### PR TITLE
Fix dark mode text color in search results

### DIFF
--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -162,6 +162,7 @@ a {
   padding: 1rem;
   background: #1a1a1a;
   border-radius: 8px;
+  color: inherit;
 }
 
 .request-info {


### PR DESCRIPTION
## Summary
- Button elements have a default black text color from the browser
- Add `color: inherit` to `.request-item` so text is visible in dark mode

## Test plan
- [x] Open the join page and search for a song
- [x] Verify song titles are readable (light text on dark background)

🤖 Generated with [Claude Code](https://claude.com/claude-code)