### PR TITLE
fix: Default masterDeckPriority to true

### DIFF
--- a/bridge-app/src/shared/types.ts
+++ b/bridge-app/src/shared/types.ts
@@ -77,12 +77,12 @@ export const IPC_CHANNELS = {
   SETTINGS_UPDATE: 'settings:update',
 } as const;
 
-/** Default bridge settings (fader/master defaults off for 3rd-party mixer compat) */
+/** Default bridge settings (fader off for 3rd-party mixer compat, master deck priority on) */
 export const DEFAULT_SETTINGS: BridgeSettings = {
   liveThresholdSeconds: 15,
   pauseGraceSeconds: 3,
   nowPlayingPauseSeconds: 10,
   useFaderDetection: false,
-  masterDeckPriority: false,
+  masterDeckPriority: true,
   minPlaySeconds: 5,
 };

--- a/bridge/src/config.ts
+++ b/bridge/src/config.ts
@@ -26,8 +26,8 @@ export const config = {
   /** Whether to require fader > 0 for live detection (default: false for 3rd-party mixer compat) */
   useFaderDetection: process.env.USE_FADER_DETECTION === "true",
 
-  /** Whether to only report from master deck (default: false for 3rd-party mixer compat) */
-  masterDeckPriority: process.env.MASTER_DECK_PRIORITY === "true",
+  /** Whether to only report from master deck (default: true, opt out with MASTER_DECK_PRIORITY=false) */
+  masterDeckPriority: process.env.MASTER_DECK_PRIORITY !== "false",
 };
 
 /**


### PR DESCRIPTION
## Summary
- Default `masterDeckPriority` to `true` in both CLI bridge config and GUI bridge-app settings
- DJ explicitly selects master deck on SC6000 hardware, so only the master deck's track should be reported by default
- Opt out by setting `MASTER_DECK_PRIORITY=false` env var (CLI) or toggling the setting off (GUI)

## Changes
- `bridge/src/config.ts` — flip env var check from `=== "true"` to `!== "false"`
- `bridge-app/src/shared/types.ts` — set `DEFAULT_SETTINGS.masterDeckPriority` to `true`

## Test plan
- [x] `bridge` — tsc clean, 49/49 tests pass
- [x] `bridge-app` — tsc clean, 17/17 tests pass