### PR TITLE
fix: Show/hide now playing toggle not persisting

### DIFF
--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -39,8 +39,8 @@ from app.services.export import (
     generate_play_history_export_filename,
 )
 from app.services.now_playing import (
+    get_manual_hide_setting,
     get_play_history,
-    is_now_playing_hidden,
     set_now_playing_visibility,
 )
 from app.services.request import accept_all_new_requests, create_request, get_requests_for_event
@@ -250,7 +250,7 @@ def get_display_settings(
     if not event:
         raise HTTPException(status_code=404, detail="Event not found")
 
-    hidden = is_now_playing_hidden(db, event.id)
+    hidden = get_manual_hide_setting(db, event.id)
 
     return DisplaySettingsResponse(
         status="ok",

--- a/server/app/services/now_playing.py
+++ b/server/app/services/now_playing.py
@@ -76,6 +76,19 @@ def is_now_playing_hidden(db: Session, event_id: int) -> bool:
     return False
 
 
+def get_manual_hide_setting(db: Session, event_id: int) -> bool:
+    """
+    Get the DJ's manual hide/show preference (not the computed kiosk state).
+
+    Returns the manual_hide_now_playing flag, ignoring auto-hide and track status.
+    Used by the dashboard toggle to reflect the DJ's intent.
+    """
+    now_playing = get_now_playing(db, event_id)
+    if not now_playing:
+        return False
+    return now_playing.manual_hide_now_playing
+
+
 def set_now_playing_visibility(db: Session, event_id: int, hidden: bool) -> bool:
     """
     Set manual visibility for now playing on kiosk.


### PR DESCRIPTION
## Summary
- `GET /display-settings` was using `is_now_playing_hidden()` which returns `True` when no track is playing (empty title) or after auto-hide timeout — causing the dashboard toggle to revert to "Hidden" on every 3-second poll
- Replaced with new `get_manual_hide_setting()` that returns only the DJ's manual preference (`manual_hide_now_playing` field)
- Kiosk display endpoint still uses `is_now_playing_hidden()` for the full computed state

## Test plan
- [x] 6 new tests (3 unit, 3 integration regression tests)
- [x] All 238 tests pass, 76% coverage
- [x] Lint clean (ruff check + format)
- [ ] Manual: toggle now playing visibility on dashboard, confirm it persists across page polls
- [ ] Manual: verify kiosk display still hides now playing when no track is active