### PR TITLE
fix: Include externalized stagelinq in packaged app

### DIFF
--- a/bridge-app/vite.main.config.ts
+++ b/bridge-app/vite.main.config.ts
@@ -1,5 +1,34 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import path from 'path';
+import fs from 'fs';
+
+// Modules that must be externalized from the Vite bundle (loaded via require()
+// at runtime). Bundling stagelinq breaks TCP connection state management and
+// class name-dependent service resolution.
+const externalDeps = ['stagelinq'];
+
+/**
+ * Copies externalized dependencies into the build output's node_modules/ so
+ * they're available at runtime in the packaged app. Required because
+ * @electron-forge/plugin-vite excludes the project's node_modules/ from the
+ * asar (it assumes Vite bundles everything).
+ */
+function copyExternals(deps: string[]): Plugin {
+  return {
+    name: 'copy-externals',
+    writeBundle(options) {
+      const outDir = options.dir;
+      if (!outDir) return;
+      for (const dep of deps) {
+        const src = path.resolve(__dirname, 'node_modules', dep);
+        const dest = path.join(outDir, 'node_modules', dep);
+        if (fs.existsSync(src)) {
+          fs.cpSync(src, dest, { recursive: true, force: true });
+        }
+      }
+    },
+  };
+}
 
 export default defineConfig({
   resolve: {
@@ -7,13 +36,10 @@ export default defineConfig({
       '@bridge': path.resolve(__dirname, '../bridge/src'),
     },
   },
+  plugins: [copyExternals(externalDeps)],
   build: {
     rollupOptions: {
-      // Externalize the stagelinq library so it's loaded via require() at
-      // runtime instead of being bundled by Vite. The CLI bridge loads it
-      // this way and it works correctly; bundling it breaks TCP connection
-      // state management and native module resolution (better-sqlite3).
-      external: ['stagelinq'],
+      external: externalDeps,
     },
   },
 });


### PR DESCRIPTION
## Summary

- Fixes `Cannot find module 'stagelinq'` crash when running the packaged AppImage (or exe/dmg)
- Root cause: `@electron-forge/plugin-vite` excludes all `node_modules/` from the asar — it assumes Vite bundles everything. But `stagelinq` must stay externalized (bundling breaks TCP state management and class name-dependent service resolution)
- Adds a Vite `writeBundle` plugin that copies externalized deps into `.vite/build/node_modules/`, which the Forge plugin's ignore function allows into the asar
- stagelinq has zero transitive dependencies, so copying just its directory is sufficient

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npm test -- --run` — 17/17 tests pass
- [x] `npx electron-forge start` — app launches, no module error
- [x] `npx electron-forge package` — builds successfully
- [x] `npx asar list` confirms `/.vite/build/node_modules/stagelinq/` is in the asar
- [ ] Download AppImage from release build and verify it launches