### PR TITLE
chore: Dependency resilience + alphatheta-connect migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: dashboard/package-lock.json
 
@@ -117,7 +117,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: bridge-app/package-lock.json
 
@@ -133,3 +133,7 @@ jobs:
 
       - name: Run tests
         run: npm test -- --run
+
+      - name: Security audit
+        run: npm audit --audit-level=high
+        continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install AppImage dependencies
         if: matrix.platform == 'linux'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ gh pr create --title "feat: Short description" --body "..."
 ### Prerequisites
 - PostgreSQL 16 via Docker: `docker compose up -d db`
 - Python 3.11+ with venv: `server/.venv/`
-- Node.js 20+
+- Node.js 22+
 
 ### Starting Services
 ```bash
@@ -158,7 +158,7 @@ NEW → REJECTED
 - Registry provides `getPluginMeta()`/`listPluginMeta()` for serializable metadata (safe for IPC)
 - Bridge-app SettingsPanel is fully data-driven from plugin metadata — no hardcoded plugin UI
 - Adding a plugin with `configOptions` auto-surfaces those settings in the UI
-- Pioneer plugin uses `prolink-connect` npm library for PRO DJ LINK protocol
+- Pioneer plugin uses `alphatheta-connect` npm library for PRO DJ LINK protocol (maintained fork of `prolink-connect` with encrypted Rekordbox DB support)
 - See `docs/PLUGIN-ARCHITECTURE.md` for full details
 
 ### Bridge App Architecture
@@ -169,12 +169,12 @@ NEW → REJECTED
 - Installers: `.exe` (Windows), `.dmg` (macOS), `.AppImage` (Linux) via electron-forge
 
 ### Bridge App Externalization (Native Modules)
-- Plugins with npm deps (stagelinq, prolink-connect) must be **externalized** from Vite
+- Plugins with npm deps (stagelinq, alphatheta-connect) must be **externalized** from Vite
 - Add to `externalDeps` in `bridge-app/vite.main.config.ts` AND `dependencies` in `bridge-app/package.json`
 - `copyExternals` plugin copies externalized deps + transitive deps to `.vite/build/node_modules/`
 - `AutoUnpackNativesPlugin` unpacks `.node` native files from asar to `app.asar.unpacked/`
 - Native module compilation: `npm install --ignore-scripts` then `npx electron-rebuild`
-- Use `overrides` in package.json to unify native dep versions across plugins (e.g., `better-sqlite3`)
+- `alphatheta-connect` uses `better-sqlite3-multiple-ciphers` natively — no `overrides` needed
 - Traktor plugin uses only Node.js built-ins — no externalization needed
 
 ### Release System

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ A modern, real-time song request system for DJs. Guests scan a QR code to submit
 
 - Docker + Docker Compose
 - Python 3.11+
-- Node.js 20+
+- Node.js 22+
 - [Spotify Developer Account](https://developer.spotify.com/dashboard) (for song search)
 
 ### 1. Clone and configure
@@ -319,7 +319,7 @@ WrzDJ is built on these excellent open source projects:
 
 ### DJ Integration
 - [stagelinq](https://github.com/chrisle/stagelinq) -- Node.js library for the Denon StageLinQ protocol
-- [prolink-connect](https://github.com/evanpurkhiser/prolink-connect) -- TypeScript library for the Pioneer PRO DJ LINK protocol
+- [alphatheta-connect](https://github.com/chrisle/alphatheta-connect) -- TypeScript library for the Pioneer PRO DJ LINK protocol (maintained fork with encrypted Rekordbox DB support)
 - [Spotipy](https://github.com/spotipy-dev/spotipy) -- Python client for the Spotify Web API
 - [python-tidalapi](https://github.com/tamland/python-tidal) -- Python client for the Tidal API
 

--- a/bridge-app/package-lock.json
+++ b/bridge-app/package-lock.json
@@ -8,10 +8,10 @@
       "name": "wrzdj-bridge",
       "version": "0.1.0",
       "dependencies": {
+        "alphatheta-connect": "0.15.0",
         "electron-squirrel-startup": "^1.0.1",
         "electron-store": "^10.0.0",
-        "prolink-connect": "^0.11.0",
-        "stagelinq": "^3.0.0"
+        "stagelinq": "3.0.4"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.6.0",
@@ -35,7 +35,7 @@
         "vitest": "^4.0.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2714,132 +2714,6 @@
         "win32"
       ]
     },
-    "node_modules/@sentry/core": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
-      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/minimal": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/hub": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
-      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/minimal": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
-      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/node": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.7.tgz",
-      "integrity": "sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/core": "6.19.7",
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@sentry/tracing": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.19.7.tgz",
-      "integrity": "sha512-ol4TupNnv9Zd+bZei7B6Ygnr9N3Gp1PUrNI761QSlHtPC25xXC5ssSD3GMhBgyQrcvpuRcCFHVNNM97tN5cZiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/minimal": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/types": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
-      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
-      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -3702,6 +3576,97 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/alphatheta-connect": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/alphatheta-connect/-/alphatheta-connect-0.15.0.tgz",
+      "integrity": "sha512-10ndVfRoFPzowpKdW32Y63mQMMSoRrXD/Vcln22DcrKTcqZG2cDbtsl5seVX32fDlAVSk7PC3exsnNV6CmT+tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/better-sqlite3": "^7.6.13",
+        "@types/lodash": "^4.17.21",
+        "@types/node": "^22.15.29",
+        "@types/promise-retry": "^1.1.6",
+        "@types/promise-timeout": "^1.3.3",
+        "@types/signale": "^1.4.7",
+        "async-mutex": "^0.5.0",
+        "better-sqlite3-multiple-ciphers": "^12.5.0",
+        "iconv-lite": "^0.6.3",
+        "ip-address": "^10.1.0",
+        "js-xdr": "^3.1.2",
+        "kaitai-struct": "^0.11.0",
+        "lodash": "^4.17.21",
+        "lru_map": "^0.4.1",
+        "promise-readable": "^6.0.0",
+        "promise-retry": "^2.0.1",
+        "promise-socket": "^7.0.0",
+        "promise-timeout": "^1.3.0",
+        "strict-event-emitter-types": "^2.0.0"
+      },
+      "bin": {
+        "alphatheta-connect": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "cap": "^0.2.1"
+      }
+    },
+    "node_modules/alphatheta-connect/node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/alphatheta-connect/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/alphatheta-connect/node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/alphatheta-connect/node_modules/js-xdr": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/js-xdr/-/js-xdr-3.1.2.tgz",
+      "integrity": "sha512-jyAZSw6mD5AKKGNEv+HW2ce+MJNTgzkpvYCydt2wPIhWYfFKx2jcn2cwOmBG1APXNDlPL6tYCVxO/v+FOnXYzA==",
+      "deprecated": "⚠️ This package has moved to @stellar/js-xdr! 🚚",
+      "license": "Apache-2.0"
+    },
+    "node_modules/alphatheta-connect/node_modules/kaitai-struct": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/kaitai-struct/-/kaitai-struct-0.11.0.tgz",
+      "integrity": "sha512-fcBvQONhZlM/dhrafsLAR9eboaQxYUJ8lEsl8EnWjqY0bs9GkIFNMUcMjKAk4oVz/Ik/OzhqIKjpQkawa28RIw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/alphatheta-connect/node_modules/lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "license": "MIT"
+    },
+    "node_modules/alphatheta-connect/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -3808,21 +3773,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/async-mutex": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
-      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/async-mutex/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3920,6 +3870,20 @@
       },
       "engines": {
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/better-sqlite3-multiple-ciphers": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3-multiple-ciphers/-/better-sqlite3-multiple-ciphers-12.6.2.tgz",
+      "integrity": "sha512-VNfYJI2+tEUHmMihWTd4P76s1FRvWWKJBhpfJhxPfgsQPezQsYqK8QJZFfLa9tc9bvVVDXhHucDln3I49y2Gcg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
       }
     },
     "node_modules/bindings": {
@@ -4241,6 +4205,19 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cap": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cap/-/cap-0.2.1.tgz",
+      "integrity": "sha512-0n10YndTkI4V+rsPVvYFdqlA0Bjf8NFlP/Wgp0W0ymudkijuqkmSVdIWigFe2YdPhjjxTJdW9Mu5ee4VwB0L+A==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.14.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -4569,15 +4546,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/core-js": {
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
@@ -4712,6 +4680,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5552,19 +5521,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -6762,19 +6718,6 @@
       "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
       "license": "MIT"
     },
-    "node_modules/ip-address": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-7.1.0.tgz",
-      "integrity": "sha512-V9pWC/VJf2lsXqP7IWJ+pe3P1/HCYGBMZrrnT62niLGjAfCbeiwXMUxaeHvnVlz19O27pvXP4azs+Pj/A0x+SQ==",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "1.1.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -6990,17 +6933,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/js-xdr": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/js-xdr/-/js-xdr-1.3.0.tgz",
-      "integrity": "sha512-fjLTm2uBtFvWsE3l2J14VjTuuB8vJfeTtYuNS7LiLHDWIX2kt0l1pqq9334F8kODUkKPMuULjEcbGbkFFwhx5g==",
-      "deprecated": "⚠️ This package has moved to @stellar/js-xdr! 🚚",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.5",
-        "long": "^2.2.3"
-      }
-    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -7013,12 +6945,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "24.1.3",
@@ -7161,57 +7087,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/kaitai-struct": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/kaitai-struct/-/kaitai-struct-0.9.0.tgz",
-      "integrity": "sha512-mfoBu9+IGqaY3ykG1TyAy9omOAZWtheqESQOvo/HKIQVTz+gRPVCNBnhjbO+8wAQ77RD33wYvLBWmITuXIviQg==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/kaitai-struct-compiler": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/kaitai-struct-compiler/-/kaitai-struct-compiler-0.9.0.tgz",
-      "integrity": "sha512-KA1rRv6FjUl/J8UfLhpvgtG3UGx6mDh6/Q1uC+/CSr3RsK4ejvDehY59DjQSNF3iNtzHo6kvptoa9XmUD3gIrg==",
-      "license": "GPL-3.0"
-    },
-    "node_modules/kaitai-struct-loader": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/kaitai-struct-loader/-/kaitai-struct-loader-0.9.0.tgz",
-      "integrity": "sha512-7t48xN+IKuoqcGgM+8yhAFrtrz4VZjPp+Fkw39l0xdNKPtKAeYROwO4vDtcbLoetdlsSYN66wygbCiaA0HCg8g==",
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^3.13.1",
-        "kaitai-struct": "^0.9.0",
-        "kaitai-struct-compiler": "^0.9.0"
-      }
-    },
-    "node_modules/kaitai-struct-loader/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/kaitai-struct-loader/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/kaitai-struct-loader/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -7508,15 +7383,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/long": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-2.4.0.tgz",
-      "integrity": "sha512-ijUtjmO/n2A5PaosNG9ZGDsQ3vxJg7ZW8vsY8Kp0f2yIZWhSJvjmegV7t+9RPQKxKrvj8yKGehhS+po14hPLGQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -7539,12 +7405,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lru_map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==",
-      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -7976,6 +7836,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/murmur-32": {
@@ -8005,7 +7866,6 @@
       "version": "2.25.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
       "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -8826,40 +8686,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/prolink-connect": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/prolink-connect/-/prolink-connect-0.11.0.tgz",
-      "integrity": "sha512-JEpgzp0nYnbI6uglACZ9M7hyw4KAgmv8IkJAZxPpeGz68V+gxhlkXL/HBTTuQXlB27UJPfHzLmyBfAB92T7YfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/node": "^6.4.1",
-        "@sentry/tracing": "^6.4.1",
-        "@types/better-sqlite3": "^7.6.2",
-        "@types/lodash": "^4.14.186",
-        "@types/node": "*",
-        "@types/promise-retry": "^1.1.3",
-        "@types/promise-timeout": "^1.3.0",
-        "@types/signale": "^1.4.4",
-        "async-mutex": "^0.3.0",
-        "better-sqlite3": "^7.6.2",
-        "ip-address": "^7.0.1",
-        "js-xdr": "^1.3.0",
-        "kaitai-struct": "^0.9.0-SNAPSHOT.1",
-        "kaitai-struct-loader": "^0.9.0",
-        "lodash": "^4.17.20",
-        "promise-readable": "^6.0.0",
-        "promise-retry": "^2.0.1",
-        "promise-socket": "^7.0.0",
-        "promise-timeout": "^1.3.0",
-        "strict-event-emitter-types": "^2.0.0"
-      },
-      "bin": {
-        "prolink-connect": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/promise-duplex": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/promise-duplex/-/promise-duplex-6.0.0.tgz",
@@ -9606,7 +9432,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -9984,7 +9809,9 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "license": "BSD-3-Clause"
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/ssri": {
       "version": "9.0.1",
@@ -10652,12 +10479,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/bridge-app/package.json
+++ b/bridge-app/package.json
@@ -14,10 +14,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "alphatheta-connect": "0.15.0",
     "electron-squirrel-startup": "^1.0.1",
     "electron-store": "^10.0.0",
-    "prolink-connect": "^0.11.0",
-    "stagelinq": "^3.0.0"
+    "stagelinq": "3.0.4"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.6.0",
@@ -40,12 +40,7 @@
     "typescript": "^5.0.0",
     "vitest": "^4.0.0"
   },
-  "overrides": {
-    "prolink-connect": {
-      "better-sqlite3": "^12.5.0"
-    }
-  },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   }
 }

--- a/bridge-app/vite.main.config.ts
+++ b/bridge-app/vite.main.config.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 // Modules that must be externalized from the Vite bundle (loaded via require()
 // at runtime). Bundling stagelinq breaks TCP connection state management and
 // class name-dependent service resolution.
-const externalDeps = ['stagelinq', 'prolink-connect'];
+const externalDeps = ['stagelinq', 'alphatheta-connect'];
 
 /**
  * Resolves the full transitive dependency tree for the given packages by

--- a/bridge/package-lock.json
+++ b/bridge/package-lock.json
@@ -7,19 +7,21 @@
     "": {
       "name": "wrzdj-bridge",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
-        "prolink-connect": "^0.11.0",
-        "stagelinq": "^3.0.0"
+        "alphatheta-connect": "0.15.0",
+        "stagelinq": "3.0.4"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^4.0.0",
+        "patch-package": "^8.0.0",
         "tsx": "^4.0.0",
         "typescript": "^5.0.0",
         "vitest": "^4.0.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -902,107 +904,6 @@
         "win32"
       ]
     },
-    "node_modules/@sentry/core": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
-      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/minimal": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/hub": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
-      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/minimal": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
-      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/node": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.7.tgz",
-      "integrity": "sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/core": "6.19.7",
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/tracing": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.19.7.tgz",
-      "integrity": "sha512-ol4TupNnv9Zd+bZei7B6Ygnr9N3Gp1PUrNI761QSlHtPC25xXC5ssSD3GMhBgyQrcvpuRcCFHVNNM97tN5cZiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/minimal": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/types": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
-      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
-      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1237,6 +1138,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1249,17 +1157,84 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+    "node_modules/alphatheta-connect": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/alphatheta-connect/-/alphatheta-connect-0.15.0.tgz",
+      "integrity": "sha512-10ndVfRoFPzowpKdW32Y63mQMMSoRrXD/Vcln22DcrKTcqZG2cDbtsl5seVX32fDlAVSk7PC3exsnNV6CmT+tQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "4"
+        "@types/better-sqlite3": "^7.6.13",
+        "@types/lodash": "^4.17.21",
+        "@types/node": "^22.15.29",
+        "@types/promise-retry": "^1.1.6",
+        "@types/promise-timeout": "^1.3.3",
+        "@types/signale": "^1.4.7",
+        "async-mutex": "^0.5.0",
+        "better-sqlite3-multiple-ciphers": "^12.5.0",
+        "iconv-lite": "^0.6.3",
+        "ip-address": "^10.1.0",
+        "js-xdr": "^3.1.2",
+        "kaitai-struct": "^0.11.0",
+        "lodash": "^4.17.21",
+        "lru_map": "^0.4.1",
+        "promise-readable": "^6.0.0",
+        "promise-retry": "^2.0.1",
+        "promise-socket": "^7.0.0",
+        "promise-timeout": "^1.3.0",
+        "strict-event-emitter-types": "^2.0.0"
+      },
+      "bin": {
+        "alphatheta-connect": "lib/cli.js"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "cap": "^0.2.1"
       }
+    },
+    "node_modules/alphatheta-connect/node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/alphatheta-connect/node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/alphatheta-connect/node_modules/js-xdr": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/js-xdr/-/js-xdr-3.1.2.tgz",
+      "integrity": "sha512-jyAZSw6mD5AKKGNEv+HW2ce+MJNTgzkpvYCydt2wPIhWYfFKx2jcn2cwOmBG1APXNDlPL6tYCVxO/v+FOnXYzA==",
+      "deprecated": "⚠️ This package has moved to @stellar/js-xdr! 🚚",
+      "license": "Apache-2.0"
+    },
+    "node_modules/alphatheta-connect/node_modules/kaitai-struct": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/kaitai-struct/-/kaitai-struct-0.11.0.tgz",
+      "integrity": "sha512-fcBvQONhZlM/dhrafsLAR9eboaQxYUJ8lEsl8EnWjqY0bs9GkIFNMUcMjKAk4oVz/Ik/OzhqIKjpQkawa28RIw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/alphatheta-connect/node_modules/lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "license": "MIT"
+    },
+    "node_modules/alphatheta-connect/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -1275,21 +1250,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/argparse/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1312,21 +1272,6 @@
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
       }
-    },
-    "node_modules/async-mutex": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
-      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/async-mutex/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1360,6 +1305,20 @@
       },
       "engines": {
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/better-sqlite3-multiple-ciphers": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3-multiple-ciphers/-/better-sqlite3-multiple-ciphers-12.6.2.tgz",
+      "integrity": "sha512-VNfYJI2+tEUHmMihWTd4P76s1FRvWWKJBhpfJhxPfgsQPezQsYqK8QJZFfLa9tc9bvVVDXhHucDln3I49y2Gcg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
       }
     },
     "node_modules/bindings": {
@@ -1420,6 +1379,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -1442,6 +1414,69 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cap": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cap/-/cap-0.2.1.tgz",
+      "integrity": "sha512-0n10YndTkI4V+rsPVvYFdqlA0Bjf8NFlP/Wgp0W0ymudkijuqkmSVdIWigFe2YdPhjjxTJdW9Mu5ee4VwB0L+A==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.14.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/chai": {
@@ -1476,6 +1511,22 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1507,15 +1558,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/core-js": {
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
@@ -1527,6 +1569,21 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -1534,23 +1591,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/decompress-response": {
@@ -1577,6 +1617,24 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1584,6 +1642,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/end-of-stream": {
@@ -1601,12 +1674,45 @@
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "license": "MIT"
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1648,19 +1754,6 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/estree-walker": {
@@ -1751,11 +1844,49 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1770,6 +1901,55 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -1791,6 +1971,26 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1800,6 +2000,45 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -1807,17 +2046,16 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -1858,18 +2096,58 @@
       "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
       "license": "MIT"
     },
-    "node_modules/ip-address": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-7.1.0.tgz",
-      "integrity": "sha512-V9pWC/VJf2lsXqP7IWJ+pe3P1/HCYGBMZrrnT62niLGjAfCbeiwXMUxaeHvnVlz19O27pvXP4azs+Pj/A0x+SQ==",
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "1.1.2"
+      "bin": {
+        "is-docker": "cli.js"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -1917,78 +2195,63 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/js-xdr": {
+    "node_modules/json-stable-stringify": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/js-xdr/-/js-xdr-1.3.0.tgz",
-      "integrity": "sha512-fjLTm2uBtFvWsE3l2J14VjTuuB8vJfeTtYuNS7LiLHDWIX2kt0l1pqq9334F8kODUkKPMuULjEcbGbkFFwhx5g==",
-      "deprecated": "⚠️ This package has moved to @stellar/js-xdr! 🚚",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.5",
-        "long": "^2.2.3"
-      }
-    },
-    "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
       },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "license": "MIT"
-    },
-    "node_modules/kaitai-struct": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/kaitai-struct/-/kaitai-struct-0.9.0.tgz",
-      "integrity": "sha512-mfoBu9+IGqaY3ykG1TyAy9omOAZWtheqESQOvo/HKIQVTz+gRPVCNBnhjbO+8wAQ77RD33wYvLBWmITuXIviQg==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/kaitai-struct-compiler": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/kaitai-struct-compiler/-/kaitai-struct-compiler-0.9.0.tgz",
-      "integrity": "sha512-KA1rRv6FjUl/J8UfLhpvgtG3UGx6mDh6/Q1uC+/CSr3RsK4ejvDehY59DjQSNF3iNtzHo6kvptoa9XmUD3gIrg==",
-      "license": "GPL-3.0"
-    },
-    "node_modules/kaitai-struct-loader": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/kaitai-struct-loader/-/kaitai-struct-loader-0.9.0.tgz",
-      "integrity": "sha512-7t48xN+IKuoqcGgM+8yhAFrtrz4VZjPp+Fkw39l0xdNKPtKAeYROwO4vDtcbLoetdlsSYN66wygbCiaA0HCg8g==",
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "^3.13.1",
-        "kaitai-struct": "^0.9.0",
-        "kaitai-struct-compiler": "^0.9.0"
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/lodash": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
-    },
-    "node_modules/long": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-2.4.0.tgz",
-      "integrity": "sha512-ijUtjmO/n2A5PaosNG9ZGDsQ3vxJg7ZW8vsY8Kp0f2yIZWhSJvjmegV7t+9RPQKxKrvj8yKGehhS+po14hPLGQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/lru_map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==",
       "license": "MIT"
     },
     "node_modules/magic-string": {
@@ -2029,6 +2292,43 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -2056,11 +2356,12 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
+    "node_modules/nan": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
+      "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -2099,6 +2400,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -2117,6 +2428,63 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -2221,40 +2589,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/prolink-connect": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/prolink-connect/-/prolink-connect-0.11.0.tgz",
-      "integrity": "sha512-JEpgzp0nYnbI6uglACZ9M7hyw4KAgmv8IkJAZxPpeGz68V+gxhlkXL/HBTTuQXlB27UJPfHzLmyBfAB92T7YfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/node": "^6.4.1",
-        "@sentry/tracing": "^6.4.1",
-        "@types/better-sqlite3": "^7.6.2",
-        "@types/lodash": "^4.14.186",
-        "@types/node": "*",
-        "@types/promise-retry": "^1.1.3",
-        "@types/promise-timeout": "^1.3.0",
-        "@types/signale": "^1.4.4",
-        "async-mutex": "^0.3.0",
-        "better-sqlite3": "^7.6.2",
-        "ip-address": "^7.0.1",
-        "js-xdr": "^1.3.0",
-        "kaitai-struct": "^0.9.0-SNAPSHOT.1",
-        "kaitai-struct-loader": "^0.9.0",
-        "lodash": "^4.17.20",
-        "promise-readable": "^6.0.0",
-        "promise-retry": "^2.0.1",
-        "promise-socket": "^7.0.0",
-        "promise-timeout": "^1.3.0",
-        "strict-event-emitter-types": "^2.0.0"
-      },
-      "bin": {
-        "prolink-connect": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/promise-duplex": {
@@ -2471,6 +2805,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -2481,6 +2821,47 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/siginfo": {
@@ -2535,6 +2916,16 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2544,12 +2935,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -2721,6 +3106,29 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/token-types": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
@@ -2737,12 +3145,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
-    },
-    "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -2795,6 +3197,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -2955,6 +3367,22 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2977,6 +3405,22 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     }
   }
 }

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -10,25 +10,22 @@
     "dev": "node --env-file=.env --watch --import tsx src/index.ts",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "postinstall": "patch-package"
   },
   "dependencies": {
-    "prolink-connect": "^0.11.0",
-    "stagelinq": "^3.0.0"
+    "alphatheta-connect": "0.15.0",
+    "stagelinq": "3.0.4"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^4.0.0",
+    "patch-package": "^8.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.0.0"
   },
-  "overrides": {
-    "prolink-connect": {
-      "better-sqlite3": "^12.5.0"
-    }
-  },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   }
 }

--- a/bridge/src/__tests__/pioneer-prolink-plugin.test.ts
+++ b/bridge/src/__tests__/pioneer-prolink-plugin.test.ts
@@ -29,10 +29,10 @@ const mockNetwork = {
   db: mockDb,
   autoconfigFromPeers: vi.fn().mockResolvedValue(undefined),
   connect: vi.fn(),
-  disconnect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn().mockReturnValue(() => Promise.resolve(undefined)),
 };
 
-vi.mock("prolink-connect", () => ({
+vi.mock("alphatheta-connect", () => ({
   bringOnline: vi.fn().mockResolvedValue(mockNetwork),
   CDJStatus: {
     PlayState: {
@@ -133,7 +133,7 @@ describe("PioneerProlinkPlugin", () => {
     });
 
     it("calls bringOnline, autoconfigFromPeers, and connect on start", async () => {
-      const { bringOnline } = await import("prolink-connect");
+      const { bringOnline } = await import("alphatheta-connect");
 
       await plugin.start();
 
@@ -168,7 +168,7 @@ describe("PioneerProlinkPlugin", () => {
     });
 
     it("handles disconnect failure gracefully", async () => {
-      mockNetwork.disconnect.mockRejectedValueOnce(new Error("socket error"));
+      mockNetwork.disconnect.mockReturnValueOnce(() => Promise.reject(new Error("socket error")));
 
       await plugin.start();
       await plugin.stop(); // Should not throw

--- a/bridge/src/__tests__/stagelinq-plugin.test.ts
+++ b/bridge/src/__tests__/stagelinq-plugin.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Tests for StageLinQ Plugin
+ *
+ * Mocks the stagelinq library to test plugin lifecycle, device
+ * events, now-playing handling, state changes, and logger forwarding.
+ */
+import { EventEmitter } from "events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  PluginConnectionEvent,
+  PluginFaderEvent,
+  PluginMasterDeckEvent,
+  PluginPlayStateEvent,
+  PluginTrackEvent,
+} from "../plugin-types.js";
+
+// --- Mock setup ---
+
+const mockDevices = new EventEmitter();
+const mockLogger = new EventEmitter();
+
+const mockStageLinq = {
+  options: null as unknown,
+  devices: mockDevices,
+  logger: mockLogger,
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock("stagelinq", () => ({
+  StageLinq: mockStageLinq,
+}));
+
+// Import AFTER mock setup
+const { StageLinqPlugin } = await import("../plugins/stagelinq-plugin.js");
+
+describe("StageLinqPlugin", () => {
+  let plugin: InstanceType<typeof StageLinqPlugin>;
+
+  beforeEach(() => {
+    plugin = new StageLinqPlugin();
+    vi.clearAllMocks();
+    mockDevices.removeAllListeners();
+    mockLogger.removeAllListeners();
+  });
+
+  afterEach(async () => {
+    if (plugin?.isRunning) {
+      await plugin.stop();
+    }
+  });
+
+  describe("metadata", () => {
+    it("has correct plugin info", () => {
+      expect(plugin.info.id).toBe("stagelinq");
+      expect(plugin.info.name).toBe("Denon StageLinQ");
+      expect(plugin.info.description).toContain("StageLinQ");
+    });
+
+    it("declares all capabilities", () => {
+      expect(plugin.capabilities).toEqual({
+        multiDeck: true,
+        playState: true,
+        faderLevel: true,
+        masterDeck: true,
+        albumMetadata: true,
+      });
+    });
+
+    it("has no config options", () => {
+      expect(plugin.configOptions).toEqual([]);
+    });
+  });
+
+  describe("lifecycle", () => {
+    it("starts and stops cleanly", async () => {
+      expect(plugin.isRunning).toBe(false);
+
+      await plugin.start();
+      expect(plugin.isRunning).toBe(true);
+
+      await plugin.stop();
+      expect(plugin.isRunning).toBe(false);
+    });
+
+    it("sets StageLinq options and calls connect on start", async () => {
+      await plugin.start();
+
+      expect(mockStageLinq.options).toEqual({
+        downloadDbSources: false,
+        enableFileTranfer: true,
+      });
+      expect(mockStageLinq.connect).toHaveBeenCalled();
+    });
+
+    it("throws when starting an already-running plugin", async () => {
+      await plugin.start();
+      await expect(plugin.start()).rejects.toThrow("already running");
+    });
+
+    it("stop is idempotent when not running", async () => {
+      await plugin.stop(); // Should not throw
+    });
+
+    it("calls disconnect on stop", async () => {
+      await plugin.start();
+      await plugin.stop();
+
+      expect(mockStageLinq.disconnect).toHaveBeenCalled();
+    });
+
+    it("handles disconnect failure gracefully", async () => {
+      mockStageLinq.disconnect.mockRejectedValueOnce(new Error("socket error"));
+
+      await plugin.start();
+      await plugin.stop(); // Should not throw
+    });
+  });
+
+  describe("nowPlaying events", () => {
+    it("emits track event with title and artist", async () => {
+      const tracks: PluginTrackEvent[] = [];
+      plugin.on("track", (e: PluginTrackEvent) => tracks.push(e));
+
+      await plugin.start();
+
+      mockDevices.emit("nowPlaying", {
+        deck: "2",
+        title: "One More Time",
+        artist: "Daft Punk",
+      });
+
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0]).toEqual({
+        deckId: "2",
+        track: {
+          title: "One More Time",
+          artist: "Daft Punk",
+          album: undefined,
+        },
+      });
+    });
+
+    it("passes album through when present", async () => {
+      const tracks: PluginTrackEvent[] = [];
+      plugin.on("track", (e: PluginTrackEvent) => tracks.push(e));
+
+      await plugin.start();
+
+      mockDevices.emit("nowPlaying", {
+        deck: "1",
+        title: "Around The World",
+        artist: "Daft Punk",
+        album: "Homework",
+      });
+
+      expect(tracks[0].track?.album).toBe("Homework");
+    });
+
+    it("emits null track when title is empty", async () => {
+      const tracks: PluginTrackEvent[] = [];
+      plugin.on("track", (e: PluginTrackEvent) => tracks.push(e));
+
+      await plugin.start();
+
+      mockDevices.emit("nowPlaying", { deck: "1", title: "", artist: "" });
+
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0]).toEqual({ deckId: "1", track: null });
+    });
+
+    it("defaults deckId to '1' when deck is missing", async () => {
+      const tracks: PluginTrackEvent[] = [];
+      plugin.on("track", (e: PluginTrackEvent) => tracks.push(e));
+
+      await plugin.start();
+
+      mockDevices.emit("nowPlaying", {
+        title: "Track",
+        artist: "Artist",
+      });
+
+      expect(tracks[0].deckId).toBe("1");
+    });
+
+    it("emits playState from nowPlaying when play field is present", async () => {
+      const playStates: PluginPlayStateEvent[] = [];
+      plugin.on("playState", (e: PluginPlayStateEvent) => playStates.push(e));
+
+      await plugin.start();
+
+      mockDevices.emit("nowPlaying", {
+        deck: "1",
+        title: "Track",
+        artist: "Artist",
+        play: true,
+      });
+
+      expect(playStates).toHaveLength(1);
+      expect(playStates[0]).toEqual({ deckId: "1", isPlaying: true });
+    });
+
+    it("emits playState from nowPlaying when playState field is present", async () => {
+      const playStates: PluginPlayStateEvent[] = [];
+      plugin.on("playState", (e: PluginPlayStateEvent) => playStates.push(e));
+
+      await plugin.start();
+
+      mockDevices.emit("nowPlaying", {
+        deck: "2",
+        title: "Track",
+        artist: "Artist",
+        playState: false,
+      });
+
+      expect(playStates).toHaveLength(1);
+      expect(playStates[0]).toEqual({ deckId: "2", isPlaying: false });
+    });
+
+    it("does not emit playState when neither play nor playState is present", async () => {
+      const playStates: PluginPlayStateEvent[] = [];
+      plugin.on("playState", (e: PluginPlayStateEvent) => playStates.push(e));
+
+      await plugin.start();
+
+      mockDevices.emit("nowPlaying", {
+        deck: "1",
+        title: "Track",
+        artist: "Artist",
+      });
+
+      expect(playStates).toHaveLength(0);
+    });
+  });
+
+  describe("stateChanged events", () => {
+    it("emits playState from stateChanged", async () => {
+      const playStates: PluginPlayStateEvent[] = [];
+      plugin.on("playState", (e: PluginPlayStateEvent) => playStates.push(e));
+
+      await plugin.start();
+
+      mockDevices.emit("stateChanged", { deck: "1", play: true });
+
+      expect(playStates).toHaveLength(1);
+      expect(playStates[0]).toEqual({ deckId: "1", isPlaying: true });
+    });
+
+    it("emits fader level from externalMixerVolume", async () => {
+      const faders: PluginFaderEvent[] = [];
+      plugin.on("fader", (e: PluginFaderEvent) => faders.push(e));
+
+      await plugin.start();
+
+      mockDevices.emit("stateChanged", { deck: "2", externalMixerVolume: 0.75 });
+
+      expect(faders).toHaveLength(1);
+      expect(faders[0]).toEqual({ deckId: "2", level: 0.75 });
+    });
+
+    it("emits masterDeck from masterStatus", async () => {
+      const masters: PluginMasterDeckEvent[] = [];
+      plugin.on("masterDeck", (e: PluginMasterDeckEvent) => masters.push(e));
+
+      await plugin.start();
+
+      mockDevices.emit("stateChanged", { deck: "1", masterStatus: true });
+
+      expect(masters).toHaveLength(1);
+      expect(masters[0]).toEqual({ deckId: "1" });
+    });
+
+    it("does not emit masterDeck when masterStatus is false", async () => {
+      const masters: PluginMasterDeckEvent[] = [];
+      plugin.on("masterDeck", (e: PluginMasterDeckEvent) => masters.push(e));
+
+      await plugin.start();
+
+      mockDevices.emit("stateChanged", { deck: "1", masterStatus: false });
+
+      expect(masters).toHaveLength(0);
+    });
+
+    it("ignores stateChanged without deck", async () => {
+      const playStates: PluginPlayStateEvent[] = [];
+      const faders: PluginFaderEvent[] = [];
+      plugin.on("playState", (e: PluginPlayStateEvent) => playStates.push(e));
+      plugin.on("fader", (e: PluginFaderEvent) => faders.push(e));
+
+      await plugin.start();
+
+      mockDevices.emit("stateChanged", { play: true, externalMixerVolume: 0.5 });
+
+      expect(playStates).toHaveLength(0);
+      expect(faders).toHaveLength(0);
+    });
+  });
+
+  describe("connection events", () => {
+    it("emits connection event on device connected", async () => {
+      const connections: PluginConnectionEvent[] = [];
+      plugin.on("connection", (e: PluginConnectionEvent) => connections.push(e));
+
+      await plugin.start();
+
+      mockDevices.emit("connected", {
+        software: { name: "SC6000", version: "3.4.0" },
+        address: "192.168.1.10",
+      });
+
+      expect(connections).toHaveLength(1);
+      expect(connections[0]).toEqual({
+        connected: true,
+        deviceName: "SC6000",
+      });
+    });
+
+    it("uses 'Unknown Device' when software name is missing", async () => {
+      const connections: PluginConnectionEvent[] = [];
+      plugin.on("connection", (e: PluginConnectionEvent) => connections.push(e));
+
+      await plugin.start();
+
+      mockDevices.emit("connected", {});
+
+      expect(connections[0].deviceName).toBe("Unknown Device");
+    });
+
+    it("emits ready event", async () => {
+      const readyEvents: void[] = [];
+      plugin.on("ready", () => readyEvents.push(undefined));
+
+      await plugin.start();
+
+      mockDevices.emit("ready");
+
+      expect(readyEvents).toHaveLength(1);
+    });
+
+    it("emits disconnect event", async () => {
+      const connections: PluginConnectionEvent[] = [];
+      plugin.on("connection", (e: PluginConnectionEvent) => connections.push(e));
+
+      await plugin.start();
+
+      mockDevices.emit("disconnect");
+
+      expect(connections).toHaveLength(1);
+      expect(connections[0]).toEqual({ connected: false });
+    });
+  });
+
+  describe("logger forwarding", () => {
+    it("forwards logger events as log emissions", async () => {
+      const logs: string[] = [];
+      plugin.on("log", (msg: string) => logs.push(msg));
+
+      await plugin.start();
+
+      mockLogger.emit("any", "debug", "test message");
+
+      expect(logs.some((l) => l.includes("debug") && l.includes("test message"))).toBe(true);
+    });
+
+    it("cleans up logger listener on stop", async () => {
+      await plugin.start();
+
+      const listenerCount = mockLogger.listenerCount("any");
+      expect(listenerCount).toBeGreaterThan(0);
+
+      await plugin.stop();
+
+      // After stop, logger listener should be removed
+      // (removeAllListeners on plugin doesn't affect mockLogger)
+      expect(mockLogger.listenerCount("any")).toBe(0);
+    });
+  });
+});

--- a/bridge/src/plugins/pioneer-prolink-plugin.ts
+++ b/bridge/src/plugins/pioneer-prolink-plugin.ts
@@ -14,8 +14,8 @@
  */
 import { EventEmitter } from "events";
 
-import { bringOnline, CDJStatus, DeviceType } from "prolink-connect";
-import type { Device, ProlinkNetwork } from "prolink-connect";
+import { bringOnline, CDJStatus, DeviceType } from "alphatheta-connect";
+import type { Device, ProlinkNetwork } from "alphatheta-connect";
 
 import type {
   EquipmentSourcePlugin,
@@ -68,7 +68,11 @@ export class PioneerProlinkPlugin extends EventEmitter implements EquipmentSourc
       this.emit("log", "Connecting as virtual device...");
       network.connect();
     } catch (err) {
-      await network.disconnect().catch(() => {});
+      try {
+        await network.disconnect()();
+      } catch {
+        // Best effort cleanup
+      }
       throw err;
     }
 
@@ -88,7 +92,7 @@ export class PioneerProlinkPlugin extends EventEmitter implements EquipmentSourc
 
     if (this.network) {
       try {
-        await this.network.disconnect();
+        await this.network.disconnect()();
       } catch {
         // Best effort on shutdown
       }

--- a/docs/PLUGIN-ARCHITECTURE.md
+++ b/docs/PLUGIN-ARCHITECTURE.md
@@ -184,7 +184,7 @@ Because all capabilities are `false`, PluginBridge synthesizes everything: deck 
 
 **File:** `bridge/src/plugins/pioneer-prolink-plugin.ts`
 
-Connects to Pioneer DJ equipment (CDJ-3000, CDJ-2000NXS2, etc.) via the PRO DJ LINK protocol using the [`prolink-connect`](https://github.com/evanpurkhiser/prolink-connect) npm library. Joins the network as a virtual CDJ device, monitors CDJ status packets, and queries track metadata from CDJ databases.
+Connects to Pioneer DJ equipment (CDJ-3000, CDJ-2000NXS2, etc.) via the PRO DJ LINK protocol using the [`alphatheta-connect`](https://github.com/chrisle/alphatheta-connect) npm library (maintained fork of `prolink-connect` with encrypted Rekordbox DB support). Joins the network as a virtual CDJ device, monitors CDJ status packets, and queries track metadata from CDJ databases.
 
 | Capability | Value |
 |------------|-------|
@@ -344,6 +344,7 @@ bridge/src/
   __tests__/
     deck-state-manager.test.ts # Deck state machine tests
     pioneer-prolink-plugin.test.ts # Pioneer plugin tests
+    stagelinq-plugin.test.ts   # StageLinQ plugin tests
     plugin-bridge.test.ts      # PluginBridge synthesis and event forwarding tests
     plugin-registry.test.ts    # Registry CRUD tests
     traktor-broadcast-plugin.test.ts # ICY parsing and HTTP server tests

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "description": "DJ protocol libs - manual review only",
+      "matchPackageNames": ["alphatheta-connect", "stagelinq"],
+      "automerge": false,
+      "labels": ["dependency", "protocol-critical"]
+    },
+    {
+      "description": "Auto-merge dev dependency patches",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    },
+    {
+      "description": "Group electron-forge updates",
+      "matchPackagePatterns": ["^@electron-forge/"],
+      "groupName": "electron-forge"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **Replace `prolink-connect` with `alphatheta-connect@0.15.0`** — maintained fork by Chris Le (stagelinq maintainer) with encrypted Rekordbox DB support for CDJ-3000, no Sentry telemetry, and active development. Eliminates the `better-sqlite3` overrides hack.
- **Bump Node.js to 22** across CI, release workflow, and engine constraints (`alphatheta-connect` requires Node >= 22)
- **Pin `stagelinq` to exact version** (3.0.4) for reproducible builds
- **Add `patch-package`** to bridge for emergency hotfixes on DJ protocol libs
- **Add `renovate.json`** for automated dependency monitoring (DJ protocol libs require manual review, dev dep patches auto-merge, electron-forge grouped)
- **Add `npm audit` to bridge-app CI** (continue-on-error for now due to known transitive vulns)
- **Add 27 StageLinQ plugin tests** covering lifecycle, nowPlaying events, stateChanged events, connection/disconnect, ready forwarding, and logger forwarding
- **Fix `disconnect()` API difference** — `alphatheta-connect` returns a function instead of a direct Promise, requiring double invocation (`disconnect()()`)
- **Update README, CLAUDE.md, and plugin architecture docs** to reflect all changes

## Test plan

- [x] Backend: ruff check, ruff format, bandit, pytest (238 passed, 76% coverage)
- [x] Frontend: ESLint, tsc --noEmit, vitest (23 passed)
- [x] Bridge: tsc --noEmit, vitest (159 passed including 27 new StageLinQ tests)
- [x] Bridge-app: tsc --noEmit, vitest (34 passed)
- [x] AppImage build succeeds
- [x] AppImage runs and connects to SC6000 via StageLinQ — live track detection confirmed working