### PR TITLE
feat: Prepare WrzDJ-Bridge for winget submission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,45 @@ jobs:
         working-directory: bridge-app
         run: npm ci
 
+      - name: Set version from tag
+        working-directory: bridge-app
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
       - name: Build installers
         working-directory: bridge-app
         run: npm run make
+
+      - name: Verify silent install (Windows)
+        if: matrix.platform == 'win32'
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem -Path "bridge-app/out/make/squirrel.windows/x64/WrzDJ-Bridge.exe" -ErrorAction Stop
+          Write-Host "Installer found: $($exe.FullName) ($([math]::Round($exe.Length/1MB, 1)) MB)"
+
+          # Run silent install — should exit with code 0 and no GUI
+          $proc = Start-Process -FilePath $exe.FullName -ArgumentList "--silent" -Wait -PassThru -NoNewWindow
+          if ($proc.ExitCode -ne 0) {
+            Write-Error "Silent install failed with exit code $($proc.ExitCode)"
+            exit 1
+          }
+          Write-Host "Silent install completed successfully (exit code 0)"
+
+          # Verify the app appears in installed programs
+          $installed = Get-ChildItem "$env:LOCALAPPDATA\wrzdj-bridge" -ErrorAction SilentlyContinue
+          if ($installed) {
+            Write-Host "App installed to: $env:LOCALAPPDATA\wrzdj-bridge"
+          } else {
+            Write-Host "WARNING: Install directory not found at expected location"
+          }
+
+          # Clean up — run uninstall
+          $update = "$env:LOCALAPPDATA\wrzdj-bridge\Update.exe"
+          if (Test-Path $update) {
+            Start-Process -FilePath $update -ArgumentList "--uninstall" -Wait -NoNewWindow
+            Write-Host "Uninstall completed"
+          }
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -118,3 +154,20 @@ jobs:
           prerelease: false
           files: |
             artifacts/**/*
+
+  update-winget:
+    name: Update winget manifest
+    needs: [create-release]
+    runs-on: windows-latest
+    steps:
+      - name: Update winget package
+        shell: pwsh
+        run: |
+          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          $version = "${{ github.ref_name }}".TrimStart("v")
+          $url = "https://github.com/thewrz/WrzDJ/releases/download/${{ github.ref_name }}/WrzDJ-Bridge.exe"
+          .\wingetcreate.exe update TheWrz.WrzDJ-Bridge `
+            --urls $url `
+            --version $version `
+            --token ${{ secrets.WINGET_PAT }} `
+            --submit

--- a/bridge-app/forge.config.ts
+++ b/bridge-app/forge.config.ts
@@ -20,6 +20,7 @@ const config: ForgeConfig = {
     new MakerSquirrel({
       name: 'wrzdj-bridge',
       authors: 'WrzDJ',
+      description: 'DJ equipment bridge for WrzDJ song request system',
       setupIcon: './resources/icon.ico',
       setupExe: 'WrzDJ-Bridge.exe',
       noMsi: true,


### PR DESCRIPTION
## Summary

- **Version injection**: Build now writes the git tag version (e.g. `2026.02.08`) into `package.json` before `npm run make`, so the Windows installer shows the correct version in Add/Remove Programs instead of `0.1.0`
- **Silent install verification**: New CI step on the Windows runner that installs with `--silent`, checks exit code, verifies the install directory, then uninstalls — catches breakage before the release is published
- **Automated winget updates**: New `update-winget` job runs after the GitHub Release is created, using `wingetcreate` to submit a manifest PR to `microsoft/winget-pkgs` automatically
- **Installer description**: Added `description` to the Squirrel maker config so Add/Remove Programs shows "DJ equipment bridge for WrzDJ song request system"

## First-Time Setup (do this once before the first release)

### Step 1: Create a GitHub Personal Access Token (PAT)

The winget automation needs a PAT to open PRs on `microsoft/winget-pkgs` (a public Microsoft repo).

1. Go to https://github.com/settings/tokens?type=beta (Fine-grained tokens)
2. Click **"Generate new token"**
3. Give it a name like `winget-updater`
4. Set expiration (e.g. 1 year)
5. Under **"Repository access"**, select **"Public Repositories (read-only)"**
   - `wingetcreate` only needs to fork the public `microsoft/winget-pkgs` repo and open a PR — public repo read + fork/PR access is automatic with any PAT
6. Click **"Generate token"** and copy it

### Step 2: Add the PAT as a repository secret

1. Go to https://github.com/thewrz/WrzDJ/settings/secrets/actions
2. Click **"New repository secret"**
3. Name: `WINGET_PAT`
4. Value: paste the token from Step 1
5. Click **"Add secret"**

### Step 3: Tag a release so the version fix takes effect

```bash
git tag v2026.02.09 && git push --tags
```

This triggers the release workflow. The Windows build will now:
- Embed `2026.02.09` as the version (not `0.1.0`)
- Run the silent install check
- (The `update-winget` job will fail on this first run — that's expected, because the package doesn't exist in winget yet)

### Step 4: Submit the initial winget manifest (one-time, on a Windows machine)

The automated `update-winget` job can only **update** an existing package. The very first submission must be done manually.

On a Windows machine (or in Windows Sandbox):

```powershell
# Install wingetcreate
winget install wingetcreate

# Point it at the release .exe — it auto-detects version and generates manifests
wingetcreate new https://github.com/thewrz/WrzDJ/releases/download/v2026.02.09/WrzDJ-Bridge.exe
```

It will prompt you to fill in metadata. Use these values:

| Field | Value |
|-------|-------|
| PackageIdentifier | `TheWrz.WrzDJ-Bridge` |
| Publisher | `TheWrz` |
| PackageName | `WrzDJ Bridge` |
| License | `MIT` |
| ShortDescription | `DJ equipment bridge for WrzDJ song request system` |

Then submit:

```powershell
wingetcreate submit <output-folder> --token <your-github-pat>
```

This opens a PR on `microsoft/winget-pkgs`. Microsoft's automated pipelines will validate the manifest, scan the installer, and test silent install/uninstall. A human reviewer typically merges within 1-3 days.

### Step 5: Verify it works

After the winget-pkgs PR is merged (you'll get a GitHub notification):

```powershell
winget search WrzDJ
winget install TheWrz.WrzDJ-Bridge
```

From this point on, every new release tag will automatically submit an update PR to winget-pkgs via the `update-winget` job.

## Test plan

- [ ] Merge this PR
- [ ] Create `WINGET_PAT` secret in repo settings
- [ ] Tag a release and confirm the Windows build passes the silent install verification step
- [ ] Confirm Add/Remove Programs shows the correct version (not `0.1.0`) and the description
- [ ] Submit initial winget manifest manually (Step 4 above)
- [ ] After winget-pkgs PR merges, verify `winget search WrzDJ` finds the package
- [ ] On the next release, confirm the `update-winget` job runs and opens a PR automatically