### PR TITLE
fix: Use bash shell for version injection step on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Set version from tag
         working-directory: bridge-app
+        shell: bash
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           npm version "$VERSION" --no-git-tag-version --allow-same-version


### PR DESCRIPTION
## Summary

- The `Set version from tag` step uses bash syntax (`${GITHUB_REF_NAME#v}`) but Windows runners default to PowerShell, causing the win32 build to fail
- Fix: add `shell: bash` to the step

## Test plan

- [ ] Re-tag after merge and confirm the Windows build passes