### PR TITLE
fix: Use correct winget package identifier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
           $version = "$y.$($m * 100 + $d).$r"
           Write-Host "Tag $tag -> semver $version"
           $url = "https://github.com/thewrz/WrzDJ/releases/download/${{ github.ref_name }}/WrzDJ-Bridge.exe"
-          .\wingetcreate.exe update TheWrz.WrzDJ-Bridge `
+          .\wingetcreate.exe update WrzDJ.WrzDJ-Bridge `
             --urls $url `
             --version $version `
             --token ${{ secrets.WINGET_PAT }} `


### PR DESCRIPTION
## Summary

The winget manifest was submitted as `WrzDJ.WrzDJ-Bridge` but the release workflow had `TheWrz.WrzDJ-Bridge`. Updated to match the actual submission.

## Test plan

- [ ] Next release tag triggers `update-winget` job with correct identifier