### PR TITLE
fix: Add PUT to CORS allow_methods for Tidal settings

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -12,6 +12,9 @@ from app.core.security_headers import SecurityHeadersMiddleware
 
 settings = get_settings()
 
+# Explicit CORS methods for non-wildcard origins — must include every HTTP method used by the API
+CORS_ALLOW_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+
 app = FastAPI(
     title="WrzDJ API",
     description="Song request system for DJs",
@@ -45,7 +48,7 @@ else:
         CORSMiddleware,
         allow_origins=origins,
         allow_credentials=True,
-        allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+        allow_methods=CORS_ALLOW_METHODS,
         allow_headers=["Authorization", "Content-Type"],
     )
 

--- a/server/tests/test_cors.py
+++ b/server/tests/test_cors.py
@@ -1,0 +1,39 @@
+"""Tests for CORS configuration.
+
+Regression: PUT was missing from allow_methods for non-wildcard CORS origins,
+causing preflight failures on the Tidal settings endpoint in production.
+"""
+
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.main import CORS_ALLOW_METHODS, app
+
+
+class TestCorsConfiguration:
+    """Verify CORS allows all HTTP methods used by the API."""
+
+    def test_cors_methods_cover_all_api_routes(self):
+        """Every HTTP method used by an API route must be in CORS_ALLOW_METHODS."""
+        api_methods = set()
+        for route in app.routes:
+            if hasattr(route, "methods") and route.methods:
+                api_methods.update(route.methods)
+
+        for method in api_methods:
+            if method == "HEAD":
+                continue  # HEAD is implicitly handled
+            assert method in CORS_ALLOW_METHODS, (
+                f"HTTP {method} is used by API routes but missing from CORS_ALLOW_METHODS"
+            )
+
+    def test_cors_methods_include_put(self):
+        """PUT must be allowed — required by Tidal settings endpoint."""
+        assert "PUT" in CORS_ALLOW_METHODS
+
+    def test_cors_middleware_is_configured(self):
+        """CORSMiddleware must be present in the middleware stack."""
+        cors_mw = next(
+            (m for m in app.user_middleware if m.cls is CORSMiddleware),
+            None,
+        )
+        assert cors_mw is not None, "CORSMiddleware not found on app"


### PR DESCRIPTION
## Summary
- Added `PUT` to CORS `allow_methods` for non-wildcard origins — was missing, causing preflight failures on the Tidal sync settings endpoint
- Extracted `CORS_ALLOW_METHODS` constant in `server/app/main.py` for maintainability
- Added regression tests in `server/tests/test_cors.py` that verify all API route methods are covered by CORS config

## Test plan
- [x] 3 new CORS regression tests pass
- [x] Full backend suite: 285 tests, 75% coverage
- [x] Frontend/bridge/bridge-app CI all green
- [ ] Verify Tidal sync toggle works on https://app.wrzdj.com