### PR TITLE
feat: improved fuzzy matching and macOS universal arch support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-bridge-app:
-    name: Build Bridge App (${{ matrix.platform }})
+    name: Build Bridge App (${{ matrix.platform }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }})
     strategy:
       matrix:
         include:
@@ -14,6 +14,10 @@ jobs:
             platform: linux
           - os: macos-latest
             platform: darwin
+            arch: arm64
+          - os: macos-13
+            platform: darwin
+            arch: x64
           - os: windows-latest
             platform: win32
     runs-on: ${{ matrix.os }}
@@ -47,7 +51,7 @@ jobs:
 
       - name: Build installers
         working-directory: bridge-app
-        run: npm run make
+        run: npm run make ${{ matrix.arch && format('-- --arch {0}', matrix.arch) || '' }}
 
       - name: Verify silent install (Windows)
         if: matrix.platform == 'win32'
@@ -82,7 +86,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: bridge-app-${{ matrix.platform }}
+          name: bridge-app-${{ matrix.platform }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }}
           path: bridge-app/out/make/**/*
           if-no-files-found: warn
 
@@ -145,7 +149,8 @@ jobs:
           | Platform | Artifact |
           |----------|----------|
           | Windows | \`bridge-app-win32\` |
-          | macOS | \`bridge-app-darwin\` |
+          | macOS (Apple Silicon) | \`bridge-app-darwin-arm64\` |
+          | macOS (Intel) | \`bridge-app-darwin-x64\` |
           | Linux | \`bridge-app-linux\` |
           | Deploy Scripts | \`wrzdj-deploy-scripts.tar.gz\` |
           EOF

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,14 @@ WrzDJ is a DJ song request management system with four services:
 
 ## Git Workflow
 
-**Always use feature branches and PRs — never commit directly to `main`.**
+**CRITICAL: Create a new branch BEFORE making any code changes. Never edit code while on `main`.**
+
+1. **First action** for any task: `git checkout -b <type>/short-description`
+2. Only then start writing code
+3. After work is done, push and open a PR
 
 ```bash
-# Create a feature branch before starting work
+# ALWAYS do this FIRST, before touching any code
 git checkout -b feat/short-description
 
 # After work is done, push and open a PR
@@ -23,6 +27,7 @@ gh pr create --title "feat: Short description" --body "..."
 
 - Branch naming: `feat/`, `fix/`, `refactor/`, `docs/`, `chore/` prefixes
 - PR into `main` — never push directly to `main`
+- Never commit directly to `main` — all changes go through PRs
 - Run all CI checks locally before pushing (see below)
 
 ## Local Development

--- a/bridge-app/forge.config.ts
+++ b/bridge-app/forge.config.ts
@@ -71,7 +71,8 @@ const config: ForgeConfig = {
           const oldPath = result.artifacts[i];
           const ext = path.extname(oldPath);
           if (renameExts.has(ext)) {
-            const newPath = path.join(path.dirname(oldPath), `WrzDJ-Bridge${ext}`);
+            const archSuffix = ext === '.dmg' ? `-${result.arch}` : '';
+            const newPath = path.join(path.dirname(oldPath), `WrzDJ-Bridge${archSuffix}${ext}`);
             if (oldPath !== newPath) {
               fs.renameSync(oldPath, newPath);
               result.artifacts[i] = newPath;


### PR DESCRIPTION
## Summary

- **Now-playing fuzzy matching**: Unicode normalization, accent stripping, and smarter partial matching for DJ name variations (e.g., "Tiësto" matches "Tiesto", partial artist tokens match)
- **macOS universal builds**: Release workflow now produces separate DMGs for Apple Silicon (`WrzDJ-Bridge-arm64.dmg`) and Intel (`WrzDJ-Bridge-x64.dmg`) so both Mac architectures are supported
- Updated release notes table to list both macOS variants

## Test plan

- [ ] Backend: 371 tests pass including 91 now-playing fuzzy matching tests
- [ ] Bridge-app: `forge.config.ts` postMake hook includes arch suffix for DMG only
- [ ] Release workflow: matrix includes `macos-latest` (arm64) and `macos-13` (x64)
- [ ] Verify CI passes on GitHub Actions
- [ ] On next tag push, confirm both DMG artifacts appear in the release