### PR TITLE
chore: make releases draft by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,7 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: "WrzDJ ${{ github.ref_name }}"
           body_path: release_notes.md
-          draft: false
+          draft: true
           prerelease: false
           files: |
             artifacts/**/*


### PR DESCRIPTION
## Summary
- Changes release workflow to create **draft** releases instead of publishing immediately
- Allows downloading and testing all platform artifacts (.exe, .dmg x64/arm64, .AppImage) before publishing

## Test plan
- [x] One-line change: `draft: false` → `draft: true`
- [ ] Next tag push creates a draft release — manually publish after testing artifacts