### PR TITLE
fix: replace deprecated macos-13 runner with macos-15-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           - os: macos-latest
             platform: darwin
             arch: arm64
-          - os: macos-13
+          - os: macos-15-intel
             platform: darwin
             arch: x64
           - os: windows-latest


### PR DESCRIPTION
## Summary
- `macos-13` runners were fully removed from GitHub Actions in Dec 2025
- Replace with `macos-15-intel` for x64 Darwin bridge-app builds
- This was blocking the v2026.02.11 release (darwin-x64 job failed)

## Test plan
- [ ] Re-tag after merge to verify darwin-x64 build succeeds