### PR TITLE
fix: add arch suffix to macOS zip filenames

### DIFF
--- a/bridge-app/forge.config.ts
+++ b/bridge-app/forge.config.ts
@@ -71,7 +71,7 @@ const config: ForgeConfig = {
           const oldPath = result.artifacts[i];
           const ext = path.extname(oldPath);
           if (renameExts.has(ext)) {
-            const archSuffix = ext === '.dmg' ? `-${result.arch}` : '';
+            const archSuffix = ext === '.dmg' || ext === '.zip' ? `-${result.arch}` : '';
             const newPath = path.join(path.dirname(oldPath), `WrzDJ-Bridge${archSuffix}${ext}`);
             if (oldPath !== newPath) {
               fs.renameSync(oldPath, newPath);


### PR DESCRIPTION
## Summary
- Both darwin-arm64 and darwin-x64 builds produce `WrzDJ-Bridge.zip`, causing the GitHub Release upload to fail with a "Not Found" error when the second file tries to overwrite the first
- Extends the existing arch suffix logic in `forge.config.ts` `postMake` hook (already used for `.dmg` → `-arm64.dmg` / `-x64.dmg`) to also apply to `.zip` files → `-arm64.zip` / `-x64.zip`

## Test plan
- [ ] Verify `tsc --noEmit` passes
- [ ] Verify bridge-app tests pass
- [ ] Next release tag should produce uniquely-named zip artifacts