### PR TITLE
fix: backend hardening — error handler, state machine, URL allowlist, rate limits

### DIFF
--- a/server/app/api/admin.py
+++ b/server/app/api/admin.py
@@ -1,10 +1,12 @@
 """Admin API endpoints for user management, event oversight, and system settings."""
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import Request as FastAPIRequest
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_admin, get_db
+from app.core.rate_limit import limiter
 from app.models.event import Event
 from app.models.request import Request
 from app.models.user import User, UserRole
@@ -36,7 +38,9 @@ router = APIRouter()
 
 
 @router.get("/stats", response_model=SystemStats)
+@limiter.limit("120/minute")
 def admin_stats(
+    request: FastAPIRequest,
     db: Session = Depends(get_db),
     _admin: User = Depends(get_current_admin),
 ) -> SystemStats:
@@ -45,7 +49,9 @@ def admin_stats(
 
 
 @router.get("/users", response_model=PaginatedResponse)
+@limiter.limit("120/minute")
 def admin_list_users(
+    request: FastAPIRequest,
     page: int = Query(default=1, ge=1, le=1000),
     limit: int = Query(default=20, ge=1, le=100),
     role: str | None = None,
@@ -139,7 +145,9 @@ def admin_delete_user(
 
 
 @router.get("/events", response_model=PaginatedResponse)
+@limiter.limit("120/minute")
 def admin_list_events(
+    request: FastAPIRequest,
     page: int = Query(default=1, ge=1, le=1000),
     limit: int = Query(default=20, ge=1, le=100),
     db: Session = Depends(get_db),
@@ -195,7 +203,9 @@ def admin_delete_event(
 
 
 @router.get("/settings", response_model=SystemSettingsOut)
+@limiter.limit("120/minute")
 def admin_get_settings(
+    request: FastAPIRequest,
     db: Session = Depends(get_db),
     _admin: User = Depends(get_current_admin),
 ) -> SystemSettingsOut:

--- a/server/app/api/auth.py
+++ b/server/app/api/auth.py
@@ -70,7 +70,8 @@ def login(
 
 
 @router.get("/me", response_model=UserOut)
-def get_me(current_user: User = Depends(get_current_user)) -> User:
+@limiter.limit("60/minute")
+def get_me(request: Request, current_user: User = Depends(get_current_user)) -> User:
     return current_user
 
 

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -145,6 +145,7 @@ def create_new_event(
 
 
 @router.get("", response_model=list[EventOut])
+@limiter.limit("60/minute")
 def list_events(
     request: Request,
     db: Session = Depends(get_db),
@@ -155,6 +156,7 @@ def list_events(
 
 
 @router.get("/archived", response_model=list[EventOut])
+@limiter.limit("60/minute")
 def list_archived_events(
     request: Request,
     db: Session = Depends(get_db),
@@ -404,7 +406,9 @@ def accept_all_requests_endpoint(
 
 
 @router.get("/{code}/requests", response_model=list[RequestOut])
+@limiter.limit("60/minute")
 def get_event_requests(
+    request: Request,
     status: RequestStatus | None = None,
     since: datetime | None = None,
     limit: int = Query(default=100, ge=1, le=500),

--- a/server/app/schemas/request.py
+++ b/server/app/schemas/request.py
@@ -1,11 +1,12 @@
 from datetime import datetime
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field, field_serializer, field_validator
 
 from app.core.validation import normalize_single_line, normalize_text
 from app.models.request import RequestSource, RequestStatus, TidalSyncStatus
 
-DANGEROUS_URL_SCHEMES = {"javascript", "data", "vbscript"}
+ALLOWED_URL_SCHEMES = {"http", "https", "spotify"}
 
 
 class RequestCreate(BaseModel):
@@ -29,12 +30,12 @@ class RequestCreate(BaseModel):
 
     @field_validator("source_url", "artwork_url")
     @classmethod
-    def reject_dangerous_schemes(cls, v: str | None) -> str | None:
+    def validate_url_scheme(cls, v: str | None) -> str | None:
         if v is None:
             return v
-        scheme = v.split(":", 1)[0].lower().strip()
-        if scheme in DANGEROUS_URL_SCHEMES:
-            raise ValueError(f"URL scheme '{scheme}' is not allowed")
+        scheme = urlparse(v).scheme.lower()
+        if scheme not in ALLOWED_URL_SCHEMES:
+            raise ValueError(f"URL scheme '{scheme or '(empty)'}' is not allowed")
         return v
 
 

--- a/server/app/services/banner.py
+++ b/server/app/services/banner.py
@@ -192,8 +192,7 @@ def delete_banner_files(banner_filename: str | None) -> None:
         if not filepath.is_relative_to(uploads_dir):
             continue
         try:
-            if filepath.exists():
-                filepath.unlink()
+            filepath.unlink(missing_ok=True)
         except OSError:
             pass  # nosec B110
 

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -1,5 +1,7 @@
 """Basic API tests."""
 
+from unittest.mock import patch
+
 from fastapi.testclient import TestClient
 
 
@@ -29,3 +31,20 @@ def test_search_requires_query(client: TestClient):
     """Test that search requires a query parameter."""
     response = client.get("/api/search")
     assert response.status_code == 422  # Validation error
+
+
+def test_global_exception_handler_returns_500():
+    """Test that unhandled exceptions return 500 with generic message."""
+    from app.main import app
+
+    with patch(
+        "app.api.auth.get_system_settings",
+        side_effect=RuntimeError("boom"),
+    ):
+        with TestClient(app, raise_server_exceptions=False) as c:
+            response = c.get("/api/auth/settings")
+    assert response.status_code == 500
+    body = response.json()
+    assert body["detail"] == "Internal server error"
+    # Dev mode includes debug info
+    assert "boom" in body["debug"]


### PR DESCRIPTION
## Summary
- **Global exception handler**: Unhandled exceptions return `{"detail": "Internal server error"}` (500) instead of leaking stack traces. Debug info included in dev mode only.
- **Request status state machine**: Enforces valid transitions (NEW→ACCEPTED/REJECTED, ACCEPTED→PLAYING/REJECTED, PLAYING→PLAYED, REJECTED→NEW, PLAYED→terminal). Returns 400 on invalid transitions.
- **Vote count SQL clamping**: Replaced Python-side `if vote_count < 0` clamp with SQL `CASE` expression to prevent race conditions.
- **URL scheme allowlist**: Switched from blocklist to allowlist (`http`, `https`, `spotify` only). Blocks `javascript:`, `data:`, `//evil.com`, etc.
- **Banner TOCTOU fix**: Replaced `if exists(): unlink()` with `unlink(missing_ok=True)`.
- **Rate limits on GET endpoints**: Added `60/minute` to user-facing GETs, `120/minute` to admin GETs.

## Test plan
- [x] 388 tests pass (up from 371 baseline — 17 new tests added)
- [x] Coverage: 77.18% (above 70% threshold)
- [x] ruff check + format clean
- [x] bandit security scan clean
- [ ] Manual: try `NEW→PLAYED` via API, expect 400
- [ ] Manual: submit `//evil.com` as source_url, expect 422
- [ ] Manual: trigger unhandled 500, verify generic response