### PR TITLE
fix: frontend error handling — 401 interceptor, error surfacing, UX hardening

### DIFF
--- a/dashboard/app/e/[code]/display/page.tsx
+++ b/dashboard/app/e/[code]/display/page.tsx
@@ -334,6 +334,10 @@ export default function KioskDisplayPage() {
           font-weight: bold;
           color: #fff;
           margin: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          max-width: 100%;
         }
         .kiosk-qr {
           background: #fff;

--- a/dashboard/app/events/[code]/components/RequestQueueSection.tsx
+++ b/dashboard/app/events/[code]/components/RequestQueueSection.tsx
@@ -178,14 +178,14 @@ export function RequestQueueSection({
                         <button
                           className="btn btn-success btn-sm"
                           onClick={() => onUpdateStatus(request.id, 'accepted')}
-                          disabled={updating === request.id}
+                          disabled={updating !== null}
                         >
                           Accept
                         </button>
                         <button
                           className="btn btn-danger btn-sm"
                           onClick={() => onUpdateStatus(request.id, 'rejected')}
-                          disabled={updating === request.id}
+                          disabled={updating !== null}
                         >
                           Reject
                         </button>
@@ -196,14 +196,14 @@ export function RequestQueueSection({
                         <button
                           className="btn btn-primary btn-sm"
                           onClick={() => onUpdateStatus(request.id, 'playing')}
-                          disabled={updating === request.id}
+                          disabled={updating !== null}
                         >
                           Playing
                         </button>
                         <button
                           className="btn btn-danger btn-sm"
                           onClick={() => onUpdateStatus(request.id, 'rejected')}
-                          disabled={updating === request.id}
+                          disabled={updating !== null}
                         >
                           Reject
                         </button>
@@ -213,7 +213,7 @@ export function RequestQueueSection({
                       <button
                         className="btn btn-warning btn-sm"
                         onClick={() => onUpdateStatus(request.id, 'played')}
-                        disabled={updating === request.id}
+                        disabled={updating !== null}
                       >
                         Played
                       </button>

--- a/dashboard/app/events/page.tsx
+++ b/dashboard/app/events/page.tsx
@@ -14,6 +14,7 @@ export default function EventsPage() {
   const [showCreate, setShowCreate] = useState(false);
   const [newEventName, setNewEventName] = useState('');
   const [creating, setCreating] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -33,8 +34,8 @@ export default function EventsPage() {
     try {
       const data = await api.getEvents();
       setEvents(data);
-    } catch (err) {
-      console.error('Failed to load events:', err);
+    } catch {
+      setErrorMsg('Failed to load events');
     } finally {
       setLoadingEvents(false);
     }
@@ -51,7 +52,7 @@ export default function EventsPage() {
       setNewEventName('');
       setShowCreate(false);
     } catch (err) {
-      console.error('Failed to create event:', err);
+      setErrorMsg(err instanceof Error ? err.message : 'Failed to create event');
     } finally {
       setCreating(false);
     }
@@ -67,6 +68,11 @@ export default function EventsPage() {
 
   return (
     <div className="container">
+      {errorMsg && (
+        <div style={{ background: '#7f1d1d', color: '#fca5a5', padding: '0.75rem 1rem', borderRadius: '0.5rem', marginBottom: '1rem', fontSize: '0.875rem' }}>
+          {errorMsg}
+        </div>
+      )}
       <div className="header">
         <h1>My Events</h1>
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center', flexWrap: 'wrap' }}>
@@ -106,6 +112,7 @@ export default function EventsPage() {
                 placeholder="Friday Night Party"
                 value={newEventName}
                 onChange={(e) => setNewEventName(e.target.value)}
+                maxLength={100}
                 required
               />
             </div>

--- a/dashboard/app/join/[code]/page.tsx
+++ b/dashboard/app/join/[code]/page.tsx
@@ -194,7 +194,7 @@ export default function JoinEventPage() {
           </div>
         )}
         <div className="container" style={{ maxWidth: '500px', flex: 1, position: 'relative', zIndex: 1 }}>
-          <h2 style={{ marginBottom: '0.5rem' }}>{event.name}</h2>
+          <h2 style={{ marginBottom: '0.5rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '100%' }}>{event.name}</h2>
           <p style={{ color: '#9ca3af', marginBottom: '1rem' }}>
             {guestRequests.length} {guestRequests.length === 1 ? 'request' : 'requests'}
           </p>
@@ -347,7 +347,7 @@ export default function JoinEventPage() {
         )}
         <div className="container" style={{ maxWidth: '500px', position: 'relative', zIndex: 1 }}>
           <div className="card" style={{ textAlign: 'center' }}>
-            <h1 style={{ marginBottom: '0.5rem' }}>{event.name}</h1>
+            <h1 style={{ marginBottom: '0.5rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '100%' }}>{event.name}</h1>
             <p style={{ color: '#9ca3af', marginTop: '1rem' }}>
               Requests are closed for this event
             </p>
@@ -366,7 +366,7 @@ export default function JoinEventPage() {
       )}
       <div className="container" style={{ maxWidth: '500px', position: 'relative', zIndex: 1 }}>
       <div className="card">
-        <h1 style={{ marginBottom: '0.5rem' }}>{event.name}</h1>
+        <h1 style={{ marginBottom: '0.5rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '100%' }}>{event.name}</h1>
         <p style={{ color: '#9ca3af', marginBottom: '1.5rem' }}>Request a song</p>
 
         <form onSubmit={handleSearch}>

--- a/dashboard/app/pending/page.tsx
+++ b/dashboard/app/pending/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/lib/auth';
+import { api } from '@/lib/api';
 
 export default function PendingPage() {
   const { isAuthenticated, isLoading, role, logout } = useAuth();
   const router = useRouter();
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -15,6 +17,26 @@ export default function PendingPage() {
       router.push('/events');
     }
   }, [isAuthenticated, isLoading, role, router]);
+
+  // Poll for approval every 30 seconds
+  useEffect(() => {
+    if (!isAuthenticated || role !== 'pending') return;
+
+    pollRef.current = setInterval(async () => {
+      try {
+        const user = await api.getMe();
+        if (user.role !== 'pending') {
+          router.push('/events');
+        }
+      } catch {
+        // Ignore — user might be logged out or network down
+      }
+    }, 30000);
+
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [isAuthenticated, role, router]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
- **Global 401 interceptor**: When JWT expires mid-session, all authenticated API calls auto-redirect to login. Login itself (raw fetch) is not intercepted.
- **Login error differentiation**: 401→"Invalid credentials", 429→"Too many attempts", other→"Login failed. Please try again."
- **Error surfacing**: Replaced 8 console.error-only catch blocks in event detail page with auto-dismissing inline error banners. Added error display to events list page.
- **Alert() removal**: Replaced 3 alert() calls (banner upload, Tidal login) with inline actionError state.
- **Double-submit prevention**: All status buttons disabled while any request update is in-flight (not just the one being updated).
- **Long text truncation**: CSS overflow ellipsis on event name headings across join, kiosk, and event detail pages.
- **Pending page auto-detect**: Polls `/me` every 30s; auto-redirects to `/events` when role changes from `pending`.
- **maxLength=100** on event name input (matches backend schema).

## Test plan
- [x] 44 tests pass (up from 39 — 5 new tests for 401 handler and login errors)
- [x] ESLint clean
- [x] TypeScript strict clean (tsc --noEmit)
- [ ] Manual: let JWT expire, click something — should redirect to login
- [ ] Manual: create event with 100-char name, verify truncation
- [ ] Manual: try login with backend stopped, verify "Login failed" not "Invalid credentials"
- [ ] Manual: on pending page, approve user via admin, verify auto-redirect within 30s