### PR TITLE
fix: strip duplicate security headers from nginx upstream

### DIFF
--- a/deploy/nginx/api.conf.template
+++ b/deploy/nginx/api.conf.template
@@ -45,6 +45,14 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Content-Security-Policy "default-src 'none'; frame-ancestors 'none'" always;
 
+    # Strip security headers from upstream (FastAPI sets them too — nginx is authoritative)
+    proxy_hide_header Strict-Transport-Security;
+    proxy_hide_header X-Content-Type-Options;
+    proxy_hide_header X-Frame-Options;
+    proxy_hide_header X-XSS-Protection;
+    proxy_hide_header Referrer-Policy;
+    proxy_hide_header Content-Security-Policy;
+
     # Proxy settings
     proxy_http_version 1.1;
     proxy_set_header Host $host;

--- a/deploy/nginx/app.conf.template
+++ b/deploy/nginx/app.conf.template
@@ -45,7 +45,13 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://${API_DOMAIN} https://i.scdn.co https://resources.tidal.com; media-src 'self' data:; connect-src 'self' https://${API_DOMAIN}; frame-src https://challenges.cloudflare.com; frame-ancestors 'none'" always;
 
-    # Hide X-Powered-By header from Next.js
+    # Strip security headers from upstream (Next.js sets them too — nginx is authoritative)
+    proxy_hide_header Strict-Transport-Security;
+    proxy_hide_header X-Content-Type-Options;
+    proxy_hide_header X-Frame-Options;
+    proxy_hide_header X-XSS-Protection;
+    proxy_hide_header Referrer-Policy;
+    proxy_hide_header Content-Security-Policy;
     proxy_hide_header X-Powered-By;
 
     # Proxy settings


### PR DESCRIPTION
## Summary
- Both FastAPI middleware and Next.js `headers()` emit security headers for local dev defense-in-depth
- In production, nginx `add_header` stacks a second copy on top of the upstream headers
- Added `proxy_hide_header` directives to both nginx templates so nginx is the single authority
- Already applied live on VPS and verified — all headers now appear exactly once

## Test plan
- [x] Verified `curl -sI https://api.wrzdj.com/health` returns single headers
- [x] Verified `curl -sI https://app.wrzdj.com/` returns single headers
- [x] `nginx -t` passed on VPS
- [x] No code changes — config templates only