### PR TITLE
feat: song recommendation engine with BPM/key/genre scoring (#100)

### DIFF
--- a/dashboard/app/events/[code]/components/RecommendationsCard.tsx
+++ b/dashboard/app/events/[code]/components/RecommendationsCard.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useState } from 'react';
+import { api, ApiError } from '@/lib/api';
+import type { RecommendedTrack, EventMusicProfile, RecommendationResponse } from '@/lib/api-types';
+
+interface RecommendationsCardProps {
+  code: string;
+  hasAcceptedRequests: boolean;
+  hasConnectedServices: boolean;
+  onAcceptTrack: (track: RecommendedTrack) => Promise<void>;
+}
+
+export function RecommendationsCard({
+  code,
+  hasAcceptedRequests,
+  hasConnectedServices,
+  onAcceptTrack,
+}: RecommendationsCardProps) {
+  const [suggestions, setSuggestions] = useState<RecommendedTrack[]>([]);
+  const [profile, setProfile] = useState<EventMusicProfile | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [acceptingId, setAcceptingId] = useState<string | null>(null);
+  const [acceptingAll, setAcceptingAll] = useState(false);
+
+  const handleGenerate = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result: RecommendationResponse = await api.generateRecommendations(code);
+      setSuggestions(result.suggestions);
+      setProfile(result.profile);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to generate suggestions');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAccept = async (track: RecommendedTrack) => {
+    const trackKey = `${track.artist}-${track.title}`;
+    setAcceptingId(trackKey);
+    try {
+      await onAcceptTrack(track);
+      setSuggestions((prev) => prev.filter((s) => `${s.artist}-${s.title}` !== trackKey));
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to accept track');
+    } finally {
+      setAcceptingId(null);
+    }
+  };
+
+  const handleAcceptAll = async () => {
+    setAcceptingAll(true);
+    try {
+      for (const track of suggestions) {
+        await onAcceptTrack(track);
+      }
+      setSuggestions([]);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to accept all tracks');
+    } finally {
+      setAcceptingAll(false);
+    }
+  };
+
+  const handleClear = () => {
+    setSuggestions([]);
+    setProfile(null);
+    setError(null);
+  };
+
+  const canGenerate = hasAcceptedRequests && hasConnectedServices && !loading;
+
+  return (
+    <div className="card" style={{ marginBottom: '1rem', padding: '1rem' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.75rem' }}>
+        <span style={{ fontWeight: 600 }}>Song Suggestions</span>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          {suggestions.length > 0 && (
+            <>
+              <button
+                className="btn btn-sm"
+                style={{ background: '#10b981' }}
+                onClick={handleAcceptAll}
+                disabled={acceptingAll || loading}
+              >
+                {acceptingAll ? 'Accepting...' : 'Accept All'}
+              </button>
+              <button
+                className="btn btn-sm"
+                style={{ background: '#6b7280' }}
+                onClick={handleClear}
+                disabled={loading}
+              >
+                Clear
+              </button>
+            </>
+          )}
+          <button
+            className="btn btn-primary btn-sm"
+            onClick={handleGenerate}
+            disabled={!canGenerate}
+          >
+            {loading ? 'Generating...' : 'Generate'}
+          </button>
+        </div>
+      </div>
+
+      {!hasConnectedServices && (
+        <p style={{ color: '#9ca3af', fontSize: '0.875rem', margin: 0 }}>
+          Link Tidal or Beatport to get song suggestions.
+        </p>
+      )}
+
+      {hasConnectedServices && !hasAcceptedRequests && suggestions.length === 0 && (
+        <p style={{ color: '#9ca3af', fontSize: '0.875rem', margin: 0 }}>
+          Accept some requests first to build a music profile.
+        </p>
+      )}
+
+      {error && (
+        <div style={{ color: '#fca5a5', fontSize: '0.875rem', marginBottom: '0.5rem' }}>
+          {error}
+        </div>
+      )}
+
+      {profile && (
+        <div style={{ fontSize: '0.8rem', color: '#9ca3af', marginBottom: '0.75rem', display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+          {profile.avg_bpm && <span>~{Math.round(profile.avg_bpm)} BPM</span>}
+          {profile.dominant_keys.length > 0 && <span>{profile.dominant_keys.join(', ')}</span>}
+          {profile.dominant_genres.length > 0 && <span>{profile.dominant_genres.join(', ')}</span>}
+          <span>{profile.enriched_count}/{profile.track_count} enriched</span>
+        </div>
+      )}
+
+      {suggestions.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          {suggestions.map((track) => {
+            const trackKey = `${track.artist}-${track.title}`;
+            const isAccepting = acceptingId === trackKey;
+            return (
+              <div
+                key={trackKey}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.75rem',
+                  padding: '0.5rem',
+                  borderRadius: '0.375rem',
+                  background: '#1a1a1a',
+                }}
+              >
+                {track.cover_url && (
+                  <img
+                    src={track.cover_url}
+                    alt=""
+                    style={{ width: 40, height: 40, borderRadius: '0.25rem', objectFit: 'cover' }}
+                  />
+                )}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontWeight: 500, fontSize: '0.875rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {track.artist} &mdash; {track.title}
+                  </div>
+                  <div style={{ fontSize: '0.75rem', color: '#9ca3af', display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                    {track.bpm && <span>{track.bpm} BPM</span>}
+                    {track.key && <span>{track.key}</span>}
+                    {track.genre && <span>{track.genre}</span>}
+                    <span style={{ color: '#3b82f6' }}>Score: {track.score.toFixed(2)}</span>
+                  </div>
+                </div>
+                <button
+                  className="btn btn-sm"
+                  style={{ background: '#10b981', flexShrink: 0 }}
+                  onClick={() => handleAccept(track)}
+                  disabled={isAccepting || acceptingAll}
+                >
+                  {isAccepting ? '...' : 'Accept'}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/app/events/[code]/components/__tests__/RecommendationsCard.test.tsx
+++ b/dashboard/app/events/[code]/components/__tests__/RecommendationsCard.test.tsx
@@ -1,0 +1,188 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RecommendationsCard } from '../RecommendationsCard';
+import type { RecommendedTrack, RecommendationResponse } from '@/lib/api-types';
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  api: {
+    generateRecommendations: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+import { api } from '@/lib/api';
+
+function makeSuggestion(overrides: Partial<RecommendedTrack> = {}): RecommendedTrack {
+  return {
+    title: 'Test Track',
+    artist: 'Test Artist',
+    bpm: 128,
+    key: '8A',
+    genre: 'Tech House',
+    score: 0.92,
+    bpm_score: 1.0,
+    key_score: 1.0,
+    genre_score: 0.8,
+    source: 'beatport',
+    track_id: '12345',
+    url: 'https://beatport.com/track/test/12345',
+    cover_url: 'https://bp.com/cover.jpg',
+    duration_seconds: 360,
+    ...overrides,
+  };
+}
+
+function makeResponse(overrides: Partial<RecommendationResponse> = {}): RecommendationResponse {
+  return {
+    suggestions: [makeSuggestion()],
+    profile: {
+      avg_bpm: 128,
+      bpm_range_low: 120,
+      bpm_range_high: 136,
+      dominant_keys: ['8A', '9A'],
+      dominant_genres: ['Tech House'],
+      track_count: 5,
+      enriched_count: 5,
+    },
+    services_used: ['beatport'],
+    total_candidates_searched: 20,
+    llm_available: false,
+    ...overrides,
+  };
+}
+
+describe('RecommendationsCard', () => {
+  const defaultProps = {
+    code: 'TEST01',
+    hasAcceptedRequests: true,
+    hasConnectedServices: true,
+    onAcceptTrack: vi.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders Generate button initially', () => {
+    render(<RecommendationsCard {...defaultProps} />);
+    expect(screen.getByText('Generate')).toBeInTheDocument();
+  });
+
+  it('disables Generate when no accepted requests', () => {
+    render(<RecommendationsCard {...defaultProps} hasAcceptedRequests={false} />);
+    const btn = screen.getByText('Generate');
+    expect(btn).toBeDisabled();
+  });
+
+  it('disables Generate when no connected services', () => {
+    render(<RecommendationsCard {...defaultProps} hasConnectedServices={false} />);
+    const btn = screen.getByText('Generate');
+    expect(btn).toBeDisabled();
+    expect(screen.getByText(/link tidal or beatport/i)).toBeInTheDocument();
+  });
+
+  it('shows loading state during generation', async () => {
+    vi.mocked(api.generateRecommendations).mockResolvedValue(makeResponse());
+
+    render(<RecommendationsCard {...defaultProps} />);
+    fireEvent.click(screen.getByText('Generate'));
+
+    // After click, button text changes to loading state (may resolve quickly)
+    // Just verify the API was called and results appear
+    await waitFor(() => {
+      expect(screen.getByText(/Test Artist/)).toBeInTheDocument();
+    });
+    expect(api.generateRecommendations).toHaveBeenCalledWith('TEST01');
+  });
+
+  it('renders suggestion list after generation', async () => {
+    vi.mocked(api.generateRecommendations).mockResolvedValue(makeResponse({
+      suggestions: [
+        makeSuggestion({ title: 'Song A', artist: 'DJ A' }),
+        makeSuggestion({ title: 'Song B', artist: 'DJ B' }),
+      ],
+    }));
+
+    render(<RecommendationsCard {...defaultProps} />);
+    fireEvent.click(screen.getByText('Generate'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/DJ A/)).toBeInTheDocument();
+      expect(screen.getByText(/DJ B/)).toBeInTheDocument();
+    });
+  });
+
+  it('Accept individual removes track from list', async () => {
+    vi.mocked(api.generateRecommendations).mockResolvedValue(makeResponse({
+      suggestions: [
+        makeSuggestion({ title: 'Song A', artist: 'DJ A' }),
+        makeSuggestion({ title: 'Song B', artist: 'DJ B' }),
+      ],
+    }));
+
+    render(<RecommendationsCard {...defaultProps} />);
+    fireEvent.click(screen.getByText('Generate'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/DJ A/)).toBeInTheDocument();
+    });
+
+    const acceptButtons = screen.getAllByText('Accept');
+    fireEvent.click(acceptButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/DJ A/)).not.toBeInTheDocument();
+      expect(screen.getByText(/DJ B/)).toBeInTheDocument();
+    });
+
+    expect(defaultProps.onAcceptTrack).toHaveBeenCalledTimes(1);
+  });
+
+  it('Accept All clears the list', async () => {
+    vi.mocked(api.generateRecommendations).mockResolvedValue(makeResponse({
+      suggestions: [
+        makeSuggestion({ title: 'Song A', artist: 'DJ A' }),
+        makeSuggestion({ title: 'Song B', artist: 'DJ B' }),
+      ],
+    }));
+
+    render(<RecommendationsCard {...defaultProps} />);
+    fireEvent.click(screen.getByText('Generate'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Accept All')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Accept All'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/DJ A/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/DJ B/)).not.toBeInTheDocument();
+    });
+
+    expect(defaultProps.onAcceptTrack).toHaveBeenCalledTimes(2);
+  });
+
+  it('Clear removes suggestions without API call', async () => {
+    vi.mocked(api.generateRecommendations).mockResolvedValue(makeResponse());
+
+    render(<RecommendationsCard {...defaultProps} />);
+    fireEvent.click(screen.getByText('Generate'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Clear')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Clear'));
+
+    expect(screen.queryByText('Test Artist')).not.toBeInTheDocument();
+    expect(defaultProps.onAcceptTrack).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/app/events/[code]/page.tsx
+++ b/dashboard/app/events/[code]/page.tsx
@@ -20,6 +20,8 @@ import { BridgeStatusCard } from './components/BridgeStatusCard';
 import { CloudProvidersCard } from './components/CloudProvidersCard';
 import { SyncReportPanel } from './components/SyncReportPanel';
 import { EventCustomizationCard } from './components/EventCustomizationCard';
+import { RecommendationsCard } from './components/RecommendationsCard';
+import type { RecommendedTrack } from '@/lib/api-types';
 
 function toLocalDateTimeString(date: Date): string {
   const pad = (n: number) => n.toString().padStart(2, '0');
@@ -602,6 +604,20 @@ export default function EventQueuePage() {
     }
   };
 
+  const handleAcceptRecommendedTrack = async (track: RecommendedTrack) => {
+    await api.submitRequest(
+      code,
+      track.artist,
+      track.title,
+      undefined,
+      track.url || undefined,
+      track.cover_url || undefined,
+    );
+    // Refresh request list
+    const updatedRequests = await api.getRequests(code);
+    setRequests(updatedRequests);
+  };
+
   if (isLoading || !isAuthenticated) {
     return (
       <div className="container">
@@ -850,7 +866,17 @@ export default function EventQueuePage() {
         />
       )}
 
-      {/* 8. Event Customization */}
+      {/* 8. Song Suggestions */}
+      {!isExpiredOrArchived && (
+        <RecommendationsCard
+          code={code}
+          hasAcceptedRequests={requests.some((r) => r.status === 'accepted' || r.status === 'played')}
+          hasConnectedServices={!!(tidalStatus?.linked || beatportStatus?.linked)}
+          onAcceptTrack={handleAcceptRecommendedTrack}
+        />
+      )}
+
+      {/* 9. Event Customization */}
       {!isExpiredOrArchived && (
         <EventCustomizationCard
           event={event}

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -309,3 +309,41 @@ export interface PaginatedResponse<T> {
   page: number;
   limit: number;
 }
+
+/** Recommended track from the suggestion engine */
+export interface RecommendedTrack {
+  title: string;
+  artist: string;
+  bpm: number | null;
+  key: string | null;
+  genre: string | null;
+  score: number;
+  bpm_score: number;
+  key_score: number;
+  genre_score: number;
+  source: string;
+  track_id: string | null;
+  url: string | null;
+  cover_url: string | null;
+  duration_seconds: number | null;
+}
+
+/** Music profile of an event derived from its requests */
+export interface EventMusicProfile {
+  avg_bpm: number | null;
+  bpm_range_low: number | null;
+  bpm_range_high: number | null;
+  dominant_keys: string[];
+  dominant_genres: string[];
+  track_count: number;
+  enriched_count: number;
+}
+
+/** Response from POST /api/events/{code}/recommendations */
+export interface RecommendationResponse {
+  suggestions: RecommendedTrack[];
+  profile: EventMusicProfile;
+  services_used: string[];
+  total_candidates_searched: number;
+  llm_available: boolean;
+}

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   NowPlayingInfo,
   PaginatedResponse,
   PlayHistoryResponse,
+  RecommendationResponse,
   SearchResult,
   SongRequest,
   SystemSettings,
@@ -37,6 +38,7 @@ export type {
   CapabilityStatus,
   DisplaySettingsResponse,
   Event,
+  EventMusicProfile,
   GuestRequestInfo,
   GuestRequestListResponse,
   HasRequestedResponse,
@@ -50,6 +52,8 @@ export type {
   PlayHistoryItem,
   PlayHistoryResponse,
   PublicRequestInfo,
+  RecommendationResponse,
+  RecommendedTrack,
   SearchResult,
   ServiceCapabilities,
   SongRequest,
@@ -550,6 +554,14 @@ class ApiClient {
     return this.fetch(`/api/beatport/requests/${requestId}/link`, {
       method: 'POST',
       body: JSON.stringify({ beatport_track_id: beatportTrackId }),
+    });
+  }
+
+  // ========== Recommendations ==========
+
+  async generateRecommendations(code: string): Promise<RecommendationResponse> {
+    return this.fetch(`/api/events/${code}/recommendations`, {
+      method: 'POST',
     });
   }
 

--- a/server/app/schemas/recommendation.py
+++ b/server/app/schemas/recommendation.py
@@ -1,0 +1,38 @@
+"""Pydantic schemas for the song recommendation system."""
+
+from pydantic import BaseModel
+
+
+class RecommendedTrack(BaseModel):
+    title: str
+    artist: str
+    bpm: float | None = None
+    key: str | None = None
+    genre: str | None = None
+    score: float
+    bpm_score: float
+    key_score: float
+    genre_score: float
+    source: str
+    track_id: str | None = None
+    url: str | None = None
+    cover_url: str | None = None
+    duration_seconds: int | None = None
+
+
+class EventMusicProfile(BaseModel):
+    avg_bpm: float | None = None
+    bpm_range_low: float | None = None
+    bpm_range_high: float | None = None
+    dominant_keys: list[str] = []
+    dominant_genres: list[str] = []
+    track_count: int = 0
+    enriched_count: int = 0
+
+
+class RecommendationResponse(BaseModel):
+    suggestions: list[RecommendedTrack] = []
+    profile: EventMusicProfile
+    services_used: list[str] = []
+    total_candidates_searched: int = 0
+    llm_available: bool = False

--- a/server/app/services/recommendation/__init__.py
+++ b/server/app/services/recommendation/__init__.py
@@ -1,0 +1,5 @@
+"""Song recommendation engine.
+
+Generates track suggestions based on BPM, key (Camelot wheel),
+and genre matching from an event's accepted/played requests.
+"""

--- a/server/app/services/recommendation/camelot.py
+++ b/server/app/services/recommendation/camelot.py
@@ -1,0 +1,138 @@
+"""Camelot wheel key parsing and harmonic compatibility scoring.
+
+The Camelot wheel maps musical keys to a numbered circle (1-12) with
+inner (A = minor) and outer (B = major) rings. Adjacent positions
+on the wheel are harmonically compatible.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CamelotPosition:
+    """Position on the Camelot wheel."""
+
+    number: int  # 1-12
+    letter: str  # "A" (minor) or "B" (major)
+
+    def __str__(self) -> str:
+        return f"{self.number}{self.letter}"
+
+
+# Map of all common key representations to Camelot positions.
+# Covers: "C major", "C maj", "Cmaj", "CM", "C", standard notation,
+# Camelot codes "8B", sharps/flats, enharmonic equivalents.
+CAMELOT_MAP: dict[str, CamelotPosition] = {}
+
+# Standard key -> Camelot mapping
+_KEY_DEFINITIONS: list[tuple[int, str, list[str]]] = [
+    # (camelot_number, letter, [key_names])
+    # Minor keys (A ring)
+    (1, "A", ["A-flat minor", "Ab minor", "Ab min", "Abm", "G# minor", "G#m", "G# min"]),
+    (2, "A", ["E-flat minor", "Eb minor", "Eb min", "Ebm", "D# minor", "D#m", "D# min"]),
+    (3, "A", ["B-flat minor", "Bb minor", "Bb min", "Bbm", "A# minor", "A#m", "A# min"]),
+    (4, "A", ["F minor", "F min", "Fm"]),
+    (5, "A", ["C minor", "C min", "Cm"]),
+    (6, "A", ["G minor", "G min", "Gm"]),
+    (7, "A", ["D minor", "D min", "Dm"]),
+    (8, "A", ["A minor", "A min", "Am"]),
+    (9, "A", ["E minor", "E min", "Em"]),
+    (10, "A", ["B minor", "B min", "Bm"]),
+    (11, "A", ["F-sharp minor", "F# minor", "F# min", "F#m", "Gb minor", "Gbm", "Gb min"]),
+    (12, "A", ["D-flat minor", "Db minor", "Db min", "Dbm", "C# minor", "C#m", "C# min"]),
+    # Major keys (B ring)
+    # Note: Do NOT include "BM", "FM", etc. — lowercased they collide with
+    # minor abbreviations ("bm" = B minor, "fm" = F minor). Use "Bmaj" instead.
+    (1, "B", ["B major", "B maj", "Bmaj"]),
+    (2, "B", ["F-sharp major", "F# major", "F# maj", "F#maj", "Gb major", "Gbmaj", "Gb maj"]),
+    (3, "B", ["D-flat major", "Db major", "Db maj", "Dbmaj", "C# major", "C#maj", "C# maj"]),
+    (4, "B", ["A-flat major", "Ab major", "Ab maj", "Abmaj", "G# major", "G#maj", "G# maj"]),
+    (5, "B", ["E-flat major", "Eb major", "Eb maj", "Ebmaj", "D# major", "D#maj", "D# maj"]),
+    (6, "B", ["B-flat major", "Bb major", "Bb maj", "Bbmaj", "A# major", "A#maj", "A# maj"]),
+    (7, "B", ["F major", "F maj", "Fmaj"]),
+    (8, "B", ["C major", "C maj", "Cmaj"]),
+    (9, "B", ["G major", "G maj", "Gmaj"]),
+    (10, "B", ["D major", "D maj", "Dmaj"]),
+    (11, "B", ["A major", "A maj", "Amaj"]),
+    (12, "B", ["E major", "E maj", "Emaj"]),
+]
+
+# Build the map
+for _num, _letter, _names in _KEY_DEFINITIONS:
+    pos = CamelotPosition(number=_num, letter=_letter)
+    # Add Camelot code itself (e.g. "8A", "8B")
+    CAMELOT_MAP[f"{_num}{_letter}"] = pos
+    CAMELOT_MAP[f"{_num}{_letter.lower()}"] = pos
+    for name in _names:
+        CAMELOT_MAP[name.lower()] = pos
+
+# Clean up module namespace
+del _num, _letter, _names, pos
+
+
+def parse_key(key_str: str | None) -> CamelotPosition | None:
+    """Parse a musical key string into a Camelot wheel position.
+
+    Handles formats: "A minor", "Am", "A min", "8A", "C maj",
+    Beatport/Tidal key strings, and Camelot codes.
+
+    Returns None for unrecognizable or empty input.
+    """
+    if not key_str or not key_str.strip():
+        return None
+
+    normalized = key_str.strip().lower()
+
+    # Direct lookup
+    result = CAMELOT_MAP.get(normalized)
+    if result:
+        return result
+
+    # Try without extra whitespace
+    compressed = " ".join(normalized.split())
+    result = CAMELOT_MAP.get(compressed)
+    if result:
+        return result
+
+    # Try matching just the Camelot code pattern (e.g. "8A" or "12B")
+    stripped = normalized.replace(" ", "")
+    if len(stripped) >= 2 and stripped[-1] in ("a", "b"):
+        num_part = stripped[:-1]
+        if num_part.isdigit():
+            num = int(num_part)
+            if 1 <= num <= 12:
+                return CamelotPosition(number=num, letter=stripped[-1].upper())
+
+    return None
+
+
+def compatibility_score(a: CamelotPosition | None, b: CamelotPosition | None) -> float:
+    """Score harmonic compatibility between two Camelot positions.
+
+    Returns:
+        1.0 — same key (perfect match)
+        0.8 — adjacent on wheel (+/-1) or parallel (A<->B at same position)
+        0.5 — two positions away
+        0.0 — incompatible or either key is None
+    """
+    if a is None or b is None:
+        return 0.0
+
+    if a == b:
+        return 1.0
+
+    # Parallel key (same number, different letter)
+    if a.number == b.number and a.letter != b.letter:
+        return 0.8
+
+    # Adjacent on the wheel (same letter, +/-1 with wrap-around)
+    if a.letter == b.letter:
+        diff = abs(a.number - b.number)
+        # Handle wrap-around: 12 -> 1 is distance 1
+        circular_diff = min(diff, 12 - diff)
+        if circular_diff == 1:
+            return 0.8
+        if circular_diff == 2:
+            return 0.5
+
+    return 0.0

--- a/server/app/services/recommendation/enrichment.py
+++ b/server/app/services/recommendation/enrichment.py
@@ -1,0 +1,199 @@
+"""Track metadata enrichment from Tidal and Beatport.
+
+Enriches tracks with BPM, key, and genre by searching connected
+music services. Beatport is preferred (has genre), Tidal fills gaps.
+"""
+
+import logging
+
+import tidalapi
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+from app.services.beatport import search_beatport_tracks
+from app.services.recommendation.scorer import TrackProfile
+from app.services.tidal import get_tidal_session
+from app.services.track_normalizer import fuzzy_match_score
+
+logger = logging.getLogger(__name__)
+
+# Maximum tracks to enrich per event (limit API calls)
+MAX_ENRICH_TRACKS = 30
+
+
+def enrich_from_tidal(
+    db: Session,
+    user: User,
+    title: str,
+    artist: str,
+) -> TrackProfile | None:
+    """Search Tidal and extract BPM/key from the result.
+
+    Uses tidalapi.Track.bpm and .audio_modes directly, which
+    are not exposed by the existing _track_to_result helper.
+    """
+    session = get_tidal_session(db, user)
+    if not session:
+        return None
+
+    try:
+        query = f"{artist} {title}"
+        results = session.search(query, models=[tidalapi.media.Track], limit=5)
+        tracks = results.get("tracks", [])
+        if not tracks:
+            return None
+
+        # Find best match
+        best_track = None
+        best_score = 0.0
+        for track in tracks:
+            track_artist = track.artist.name if track.artist else ""
+            track_title = track.name or ""
+            title_score = fuzzy_match_score(title, track_title)
+            artist_score = fuzzy_match_score(artist, track_artist)
+            combined = title_score * 0.6 + artist_score * 0.4
+            if combined > best_score:
+                best_score = combined
+                best_track = track
+
+        if not best_track or best_score < 0.4:
+            return None
+
+        # Extract BPM and key directly from the tidalapi Track object
+        bpm = None
+        key = None
+        try:
+            bpm = float(best_track.bpm) if hasattr(best_track, "bpm") and best_track.bpm else None
+        except (TypeError, ValueError):
+            pass  # nosec B110
+        try:
+            key = best_track.key if hasattr(best_track, "key") and best_track.key else None
+        except (TypeError, AttributeError):
+            pass  # nosec B110
+
+        cover_url = None
+        try:
+            if best_track.album:
+                cover_url = best_track.album.image(640)
+        except Exception:  # nosec B110 — cover art is optional
+            pass
+
+        return TrackProfile(
+            title=best_track.name or title,
+            artist=best_track.artist.name if best_track.artist else artist,
+            bpm=bpm,
+            key=key,
+            source="tidal",
+            track_id=str(best_track.id),
+            url=f"https://tidal.com/browse/track/{best_track.id}",
+            cover_url=cover_url,
+            duration_seconds=best_track.duration if best_track.duration else None,
+        )
+    except Exception as e:
+        logger.error("Tidal enrichment failed for '%s - %s': %s", artist, title, type(e).__name__)
+        return None
+
+
+def enrich_from_beatport(
+    db: Session,
+    user: User,
+    title: str,
+    artist: str,
+) -> TrackProfile | None:
+    """Search Beatport and extract BPM/key/genre from the result."""
+    results = search_beatport_tracks(db, user, f"{artist} {title}", limit=5)
+    if not results:
+        return None
+
+    # Find best match
+    best_result = None
+    best_score = 0.0
+    for result in results:
+        title_score = fuzzy_match_score(title, result.title)
+        artist_score = fuzzy_match_score(artist, result.artist)
+        combined = title_score * 0.6 + artist_score * 0.4
+        if combined > best_score:
+            best_score = combined
+            best_result = result
+
+    if not best_result or best_score < 0.4:
+        return None
+
+    return TrackProfile(
+        title=best_result.title,
+        artist=best_result.artist,
+        bpm=float(best_result.bpm) if best_result.bpm else None,
+        key=best_result.key,
+        genre=best_result.genre,
+        source="beatport",
+        track_id=best_result.track_id,
+        url=best_result.beatport_url,
+        cover_url=best_result.cover_url,
+        duration_seconds=best_result.duration_seconds,
+    )
+
+
+def enrich_track(
+    db: Session,
+    user: User,
+    title: str,
+    artist: str,
+) -> TrackProfile:
+    """Enrich a track with metadata from connected services.
+
+    Tries Beatport first (has genre), fills gaps from Tidal.
+    Returns a TrackProfile with whatever metadata could be found.
+    """
+    bp_profile = None
+    tidal_profile = None
+
+    if user.beatport_access_token:
+        bp_profile = enrich_from_beatport(db, user, title, artist)
+
+    if user.tidal_access_token:
+        tidal_profile = enrich_from_tidal(db, user, title, artist)
+
+    # If both found, merge: Beatport is primary (has genre), Tidal fills gaps
+    if bp_profile and tidal_profile:
+        return TrackProfile(
+            title=bp_profile.title,
+            artist=bp_profile.artist,
+            bpm=bp_profile.bpm or tidal_profile.bpm,
+            key=bp_profile.key or tidal_profile.key,
+            genre=bp_profile.genre,
+            source="beatport",
+            track_id=bp_profile.track_id,
+            url=bp_profile.url,
+            cover_url=bp_profile.cover_url or tidal_profile.cover_url,
+            duration_seconds=bp_profile.duration_seconds or tidal_profile.duration_seconds,
+        )
+
+    if bp_profile:
+        return bp_profile
+
+    if tidal_profile:
+        return tidal_profile
+
+    # Neither service found the track — return minimal profile
+    return TrackProfile(title=title, artist=artist)
+
+
+def enrich_event_tracks(
+    db: Session,
+    user: User,
+    requests: list,
+) -> list[TrackProfile]:
+    """Enrich accepted/played requests with BPM/key/genre metadata.
+
+    Processes up to MAX_ENRICH_TRACKS most recent requests.
+    Each request object should have .song_title and .artist attributes.
+    """
+    # Limit to most recent N requests
+    to_enrich = requests[:MAX_ENRICH_TRACKS]
+
+    profiles = []
+    for req in to_enrich:
+        profile = enrich_track(db, user, req.song_title, req.artist)
+        profiles.append(profile)
+
+    return profiles

--- a/server/app/services/recommendation/llm_hooks.py
+++ b/server/app/services/recommendation/llm_hooks.py
@@ -1,0 +1,56 @@
+"""Stub hooks for future LLM-powered recommendation enhancement.
+
+Future workflow:
+1. Algorithmic engine builds EventProfile from accepted/played tracks
+2. LLM receives profile + DJ's natural language prompt
+3. LLM returns JSON: suggested search queries with target BPM/key/genre
+4. Queries run through existing search infrastructure (Tidal/Beatport)
+5. Results scored by existing algorithm and merged into suggestions list
+
+This module provides the interface stubs. Phase 3 will implement
+the actual LLM integration (Claude Haiku via Anthropic API).
+"""
+
+from dataclasses import dataclass
+
+from app.services.recommendation.scorer import EventProfile
+
+
+@dataclass(frozen=True)
+class LLMSuggestionQuery:
+    """A search query suggested by an LLM."""
+
+    search_query: str  # e.g., "deadmau5 progressive house"
+    target_bpm: float | None = None
+    target_key: str | None = None
+    target_genre: str | None = None
+    reasoning: str = ""  # LLM's explanation
+
+
+@dataclass(frozen=True)
+class LLMSuggestionResult:
+    """Result from LLM suggestion generation."""
+
+    queries: list[LLMSuggestionQuery]
+    raw_response: str  # Full LLM response for debugging
+
+
+async def generate_llm_suggestions(
+    event_profile: EventProfile,
+    prompt: str,
+    max_queries: int = 5,
+) -> LLMSuggestionResult:
+    """Generate search queries via LLM. NOT YET IMPLEMENTED.
+
+    Will call Claude Haiku to interpret DJ's prompt in context of
+    the event's musical profile, returning structured search queries
+    that feed into the existing search + scoring pipeline.
+
+    Raises NotImplementedError until Phase 3.
+    """
+    raise NotImplementedError("LLM recommendations not yet implemented. Coming in Phase 3.")
+
+
+def is_llm_available() -> bool:
+    """Check if LLM recommendations are configured and available."""
+    return False  # Will check for ANTHROPIC_API_KEY in Phase 3

--- a/server/app/services/recommendation/scorer.py
+++ b/server/app/services/recommendation/scorer.py
@@ -1,0 +1,202 @@
+"""BPM, key, and genre scoring algorithm for track recommendations.
+
+Scores candidate tracks against an event's musical profile built
+from its accepted/played requests.
+"""
+
+from collections import Counter
+from dataclasses import dataclass
+
+from app.services.recommendation.camelot import compatibility_score, parse_key
+
+
+@dataclass(frozen=True)
+class TrackProfile:
+    """A track with metadata for scoring."""
+
+    title: str
+    artist: str
+    bpm: float | None = None
+    key: str | None = None
+    genre: str | None = None
+    source: str = "unknown"
+    track_id: str | None = None
+    url: str | None = None
+    cover_url: str | None = None
+    duration_seconds: int | None = None
+
+
+@dataclass(frozen=True)
+class EventProfile:
+    """Musical profile of an event built from its requests."""
+
+    avg_bpm: float | None = None
+    bpm_range: tuple[float, float] | None = None
+    dominant_keys: list[str] = ()  # type: ignore[assignment]
+    dominant_genres: list[str] = ()  # type: ignore[assignment]
+    track_count: int = 0
+
+
+@dataclass(frozen=True)
+class ScoredTrack:
+    """A candidate track with its computed scores."""
+
+    profile: TrackProfile
+    score: float
+    bpm_score: float
+    key_score: float
+    genre_score: float
+
+
+DEFAULT_WEIGHTS: dict[str, float] = {"bpm": 0.40, "key": 0.40, "genre": 0.20}
+
+
+def build_event_profile(tracks: list[TrackProfile]) -> EventProfile:
+    """Build an EventProfile from a list of enriched tracks.
+
+    Computes average BPM, BPM range, dominant keys (top 3),
+    and dominant genres (top 3).
+    """
+    if not tracks:
+        return EventProfile(track_count=0)
+
+    bpms = [t.bpm for t in tracks if t.bpm is not None]
+    keys = [t.key for t in tracks if t.key]
+    genres = [t.genre for t in tracks if t.genre]
+
+    avg_bpm = sum(bpms) / len(bpms) if bpms else None
+    bpm_range = (min(bpms), max(bpms)) if bpms else None
+
+    # Top 3 most common keys and genres
+    dominant_keys = [k for k, _ in Counter(keys).most_common(3)]
+    dominant_genres = [g for g, _ in Counter(genres).most_common(3)]
+
+    return EventProfile(
+        avg_bpm=avg_bpm,
+        bpm_range=bpm_range,
+        dominant_keys=dominant_keys,
+        dominant_genres=dominant_genres,
+        track_count=len(tracks),
+    )
+
+
+def _score_bpm(candidate_bpm: float | None, avg_bpm: float | None) -> float:
+    """Score BPM compatibility.
+
+    1.0 within +/-2 BPM of average, linear falloff to 0.0 at +/-20.
+    0.5 if either BPM is missing.
+    """
+    if candidate_bpm is None or avg_bpm is None:
+        return 0.5
+
+    diff = abs(candidate_bpm - avg_bpm)
+    if diff <= 2.0:
+        return 1.0
+    if diff >= 20.0:
+        return 0.0
+    # Linear falloff between 2 and 20
+    return 1.0 - (diff - 2.0) / 18.0
+
+
+def _score_key(
+    candidate_key: str | None,
+    dominant_keys: list[str],
+) -> float:
+    """Score key compatibility against dominant keys.
+
+    Returns the best compatibility score against any dominant key.
+    0.5 if candidate key is missing.
+    """
+    if not candidate_key:
+        return 0.5
+
+    candidate_pos = parse_key(candidate_key)
+    if candidate_pos is None:
+        return 0.5
+
+    if not dominant_keys:
+        return 0.5
+
+    best = 0.0
+    for dk in dominant_keys:
+        dk_pos = parse_key(dk)
+        score = compatibility_score(candidate_pos, dk_pos)
+        if score > best:
+            best = score
+    return best
+
+
+def _score_genre(candidate_genre: str | None, dominant_genres: list[str]) -> float:
+    """Score genre compatibility.
+
+    1.0 = exact match, 0.5 = partial match (substring), 0.25 if missing, 0.0 if mismatch.
+    """
+    if not candidate_genre:
+        return 0.25
+
+    if not dominant_genres:
+        return 0.25
+
+    candidate_lower = candidate_genre.lower()
+
+    for dg in dominant_genres:
+        dg_lower = dg.lower()
+        if candidate_lower == dg_lower:
+            return 1.0
+
+    # Partial match: check if one contains the other
+    for dg in dominant_genres:
+        dg_lower = dg.lower()
+        if candidate_lower in dg_lower or dg_lower in candidate_lower:
+            return 0.5
+
+    return 0.0
+
+
+def _compute_weights(event_profile: EventProfile) -> dict[str, float]:
+    """Compute dynamic weights based on available data.
+
+    If no genre data, redistribute: BPM 0.50, key 0.50, genre 0.0.
+    """
+    if not event_profile.dominant_genres:
+        return {"bpm": 0.50, "key": 0.50, "genre": 0.0}
+    return dict(DEFAULT_WEIGHTS)
+
+
+def score_candidate(
+    candidate: TrackProfile,
+    event_profile: EventProfile,
+    weights: dict[str, float] | None = None,
+) -> ScoredTrack:
+    """Score a single candidate track against an event profile."""
+    if weights is None:
+        weights = _compute_weights(event_profile)
+
+    bpm_s = _score_bpm(candidate.bpm, event_profile.avg_bpm)
+    key_s = _score_key(candidate.key, event_profile.dominant_keys)
+    genre_s = _score_genre(candidate.genre, event_profile.dominant_genres)
+
+    total = weights["bpm"] * bpm_s + weights["key"] * key_s + weights["genre"] * genre_s
+
+    return ScoredTrack(
+        profile=candidate,
+        score=round(total, 4),
+        bpm_score=round(bpm_s, 4),
+        key_score=round(key_s, 4),
+        genre_score=round(genre_s, 4),
+    )
+
+
+def rank_candidates(
+    candidates: list[TrackProfile],
+    event_profile: EventProfile,
+    max_results: int = 20,
+) -> list[ScoredTrack]:
+    """Score and rank candidates, returning top N by score descending."""
+    if not candidates:
+        return []
+
+    weights = _compute_weights(event_profile)
+    scored = [score_candidate(c, event_profile, weights) for c in candidates]
+    scored.sort(key=lambda s: s.score, reverse=True)
+    return scored[:max_results]

--- a/server/app/services/recommendation/service.py
+++ b/server/app/services/recommendation/service.py
@@ -1,0 +1,258 @@
+"""Recommendation engine orchestrator.
+
+Coordinates enrichment, profiling, candidate search, scoring,
+and deduplication to generate track suggestions for an event.
+"""
+
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from app.models.event import Event
+from app.models.request import Request, RequestStatus
+from app.models.user import User
+from app.services.recommendation.enrichment import enrich_event_tracks
+from app.services.recommendation.scorer import (
+    EventProfile,
+    ScoredTrack,
+    TrackProfile,
+    build_event_profile,
+    rank_candidates,
+)
+from app.services.track_normalizer import fuzzy_match_score
+
+logger = logging.getLogger(__name__)
+
+# Maximum number of search queries per source
+MAX_SEARCH_QUERIES = 3
+# Maximum results per search query
+SEARCH_LIMIT = 10
+
+
+@dataclass
+class RecommendationResult:
+    """Result of generating recommendations for an event."""
+
+    suggestions: list[ScoredTrack]
+    event_profile: EventProfile
+    enriched_count: int
+    total_candidates_searched: int
+    services_used: list[str]
+
+
+def _get_accepted_played_requests(db: Session, event: Event) -> list[Request]:
+    """Fetch accepted and played requests for the event, most recent first."""
+    return (
+        db.query(Request)
+        .filter(
+            Request.event_id == event.id,
+            Request.status.in_([RequestStatus.ACCEPTED.value, RequestStatus.PLAYED.value]),
+        )
+        .order_by(Request.created_at.desc())
+        .all()
+    )
+
+
+def _build_search_queries(profile: EventProfile) -> list[str]:
+    """Generate search queries from an event profile.
+
+    Uses dominant genres and creates general queries that
+    should return tracks matching the event's vibe.
+    """
+    queries = []
+
+    # Genre-based queries
+    for genre in profile.dominant_genres[:MAX_SEARCH_QUERIES]:
+        queries.append(genre)
+
+    # If we have BPM info, add a BPM-targeted query
+    if profile.avg_bpm and len(queries) < MAX_SEARCH_QUERIES:
+        bpm_str = str(int(profile.avg_bpm))
+        if profile.dominant_genres:
+            queries.append(f"{profile.dominant_genres[0]} {bpm_str} bpm")
+        else:
+            queries.append(f"{bpm_str} bpm")
+
+    return queries[:MAX_SEARCH_QUERIES]
+
+
+def _search_candidates(
+    db: Session,
+    user: User,
+    queries: list[str],
+) -> tuple[list[TrackProfile], list[str], int]:
+    """Search connected services for candidate tracks.
+
+    Returns (candidates, services_used, total_searched).
+    """
+    candidates: list[TrackProfile] = []
+    services_used: set[str] = set()
+    total_searched = 0
+
+    # Search Beatport if connected
+    if user.beatport_access_token:
+        from app.services.beatport import search_beatport_tracks
+
+        for query in queries:
+            results = search_beatport_tracks(db, user, query, limit=SEARCH_LIMIT)
+            for r in results:
+                candidates.append(
+                    TrackProfile(
+                        title=r.title,
+                        artist=r.artist,
+                        bpm=float(r.bpm) if r.bpm else None,
+                        key=r.key,
+                        genre=r.genre,
+                        source="beatport",
+                        track_id=r.track_id,
+                        url=r.beatport_url,
+                        cover_url=r.cover_url,
+                        duration_seconds=r.duration_seconds,
+                    )
+                )
+            total_searched += len(results)
+            if results:
+                services_used.add("beatport")
+
+    # Search Tidal if connected
+    if user.tidal_access_token:
+        from app.services.tidal import search_tidal_tracks
+
+        for query in queries:
+            results = search_tidal_tracks(db, user, query, limit=SEARCH_LIMIT)
+            for r in results:
+                candidates.append(
+                    TrackProfile(
+                        title=r.title,
+                        artist=r.artist,
+                        source="tidal",
+                        track_id=r.track_id,
+                        url=r.tidal_url,
+                        cover_url=r.cover_url,
+                        duration_seconds=r.duration_seconds,
+                    )
+                )
+            total_searched += len(results)
+            if results:
+                services_used.add("tidal")
+
+    return candidates, sorted(services_used), total_searched
+
+
+def _deduplicate_against_requests(
+    candidates: list[TrackProfile],
+    existing_requests: list[Request],
+) -> list[TrackProfile]:
+    """Remove candidates that are already requested for this event."""
+    if not existing_requests:
+        return candidates
+
+    deduped = []
+    for candidate in candidates:
+        is_dupe = False
+        for req in existing_requests:
+            title_score = fuzzy_match_score(candidate.title, req.song_title)
+            artist_score = fuzzy_match_score(candidate.artist, req.artist)
+            combined = title_score * 0.6 + artist_score * 0.4
+            if combined >= 0.8:
+                is_dupe = True
+                break
+        if not is_dupe:
+            deduped.append(candidate)
+    return deduped
+
+
+def _deduplicate_candidates(candidates: list[TrackProfile]) -> list[TrackProfile]:
+    """Remove duplicate candidates (same track from different queries)."""
+    seen: list[TrackProfile] = []
+    for candidate in candidates:
+        is_dupe = False
+        for existing in seen:
+            title_score = fuzzy_match_score(candidate.title, existing.title)
+            artist_score = fuzzy_match_score(candidate.artist, existing.artist)
+            combined = title_score * 0.6 + artist_score * 0.4
+            if combined >= 0.8:
+                is_dupe = True
+                break
+        if not is_dupe:
+            seen.append(candidate)
+    return seen
+
+
+def generate_recommendations(
+    db: Session,
+    user: User,
+    event: Event,
+    max_results: int = 20,
+) -> RecommendationResult:
+    """Generate track recommendations for an event.
+
+    Pipeline:
+    1. Fetch accepted/played requests
+    2. Enrich with BPM/key/genre from Tidal/Beatport
+    3. Build EventProfile
+    4. Generate search queries from profile
+    5. Search connected services for candidates
+    6. Deduplicate against existing requests
+    7. Score and rank candidates
+    8. Return top N
+    """
+    # Step 1: Fetch existing requests
+    requests = _get_accepted_played_requests(db, event)
+
+    # Check if any services are connected
+    has_tidal = bool(user.tidal_access_token)
+    has_beatport = bool(user.beatport_access_token)
+
+    if not has_tidal and not has_beatport:
+        return RecommendationResult(
+            suggestions=[],
+            event_profile=EventProfile(track_count=0),
+            enriched_count=0,
+            total_candidates_searched=0,
+            services_used=[],
+        )
+
+    # Step 2: Enrich tracks
+    enriched = enrich_event_tracks(db, user, requests) if requests else []
+
+    # Step 3: Build profile
+    profile = build_event_profile(enriched)
+
+    # Step 4: Generate search queries
+    search_queries = _build_search_queries(profile)
+
+    # If no queries can be generated (no genre, no BPM), use generic queries
+    if not search_queries:
+        search_queries = ["top tracks", "popular tracks"]
+
+    # Step 5: Search for candidates
+    candidates, services_used, total_searched = _search_candidates(db, user, search_queries)
+
+    # Step 6a: Deduplicate candidates among themselves
+    candidates = _deduplicate_candidates(candidates)
+
+    # Step 6b: Deduplicate against existing requests
+    all_requests = db.query(Request).filter(Request.event_id == event.id).all()
+    candidates = _deduplicate_against_requests(candidates, all_requests)
+
+    # Step 7: Score and rank
+    ranked = rank_candidates(candidates, profile, max_results)
+
+    logger.info(
+        "Generated %d recommendations for event %s (enriched=%d, candidates=%d, searched=%d)",
+        len(ranked),
+        event.code,
+        len(enriched),
+        len(candidates),
+        total_searched,
+    )
+
+    return RecommendationResult(
+        suggestions=ranked,
+        event_profile=profile,
+        enriched_count=len(enriched),
+        total_candidates_searched=total_searched,
+        services_used=services_used,
+    )

--- a/server/tests/test_camelot.py
+++ b/server/tests/test_camelot.py
@@ -1,0 +1,224 @@
+"""Tests for Camelot wheel key parsing and compatibility scoring."""
+
+import pytest
+
+from app.services.recommendation.camelot import (
+    CamelotPosition,
+    compatibility_score,
+    parse_key,
+)
+
+
+class TestParseKey:
+    """Tests for parse_key function."""
+
+    # Standard notation: "X minor", "X major"
+    @pytest.mark.parametrize(
+        "key_str,expected",
+        [
+            ("A minor", CamelotPosition(8, "A")),
+            ("C major", CamelotPosition(8, "B")),
+            ("D minor", CamelotPosition(7, "A")),
+            ("G major", CamelotPosition(9, "B")),
+            ("F minor", CamelotPosition(4, "A")),
+            ("E major", CamelotPosition(12, "B")),
+            ("B major", CamelotPosition(1, "B")),
+            ("F# minor", CamelotPosition(11, "A")),
+            ("Bb major", CamelotPosition(6, "B")),
+            ("Eb minor", CamelotPosition(2, "A")),
+        ],
+    )
+    def test_standard_notation(self, key_str, expected):
+        assert parse_key(key_str) == expected
+
+    # Abbreviated: "Am", "Cm", "Gmaj"
+    @pytest.mark.parametrize(
+        "key_str,expected",
+        [
+            ("Am", CamelotPosition(8, "A")),
+            ("Cm", CamelotPosition(5, "A")),
+            ("Fm", CamelotPosition(4, "A")),
+            ("Cmaj", CamelotPosition(8, "B")),
+            ("Gmaj", CamelotPosition(9, "B")),
+            ("F#m", CamelotPosition(11, "A")),
+            ("Bbm", CamelotPosition(3, "A")),
+            ("Ebm", CamelotPosition(2, "A")),
+        ],
+    )
+    def test_abbreviated_notation(self, key_str, expected):
+        assert parse_key(key_str) == expected
+
+    # Beatport format: "C maj", "A min"
+    @pytest.mark.parametrize(
+        "key_str,expected",
+        [
+            ("C maj", CamelotPosition(8, "B")),
+            ("A min", CamelotPosition(8, "A")),
+            ("D min", CamelotPosition(7, "A")),
+            ("F# maj", CamelotPosition(2, "B")),
+            ("Bb min", CamelotPosition(3, "A")),
+            ("Ab maj", CamelotPosition(4, "B")),
+        ],
+    )
+    def test_beatport_format(self, key_str, expected):
+        assert parse_key(key_str) == expected
+
+    # Camelot codes: "8A", "12B"
+    @pytest.mark.parametrize(
+        "key_str,expected",
+        [
+            ("8A", CamelotPosition(8, "A")),
+            ("8B", CamelotPosition(8, "B")),
+            ("1A", CamelotPosition(1, "A")),
+            ("12B", CamelotPosition(12, "B")),
+            ("12A", CamelotPosition(12, "A")),
+            ("1B", CamelotPosition(1, "B")),
+            ("6a", CamelotPosition(6, "A")),
+            ("6b", CamelotPosition(6, "B")),
+        ],
+    )
+    def test_camelot_codes(self, key_str, expected):
+        assert parse_key(key_str) == expected
+
+    # Edge cases
+    def test_none_input(self):
+        assert parse_key(None) is None
+
+    def test_empty_string(self):
+        assert parse_key("") is None
+
+    def test_whitespace_only(self):
+        assert parse_key("   ") is None
+
+    def test_unknown_key(self):
+        assert parse_key("unknown") is None
+
+    def test_gibberish(self):
+        assert parse_key("xyz123") is None
+
+    def test_leading_trailing_whitespace(self):
+        assert parse_key("  A minor  ") == CamelotPosition(8, "A")
+
+    def test_case_insensitive(self):
+        assert parse_key("a MINOR") == CamelotPosition(8, "A")
+        assert parse_key("C MAJOR") == CamelotPosition(8, "B")
+
+    # Enharmonic equivalents
+    def test_enharmonic_sharps_flats(self):
+        # G# minor = Ab minor = 1A
+        assert parse_key("G# minor") == CamelotPosition(1, "A")
+        assert parse_key("Ab minor") == CamelotPosition(1, "A")
+        # D# minor = Eb minor = 2A
+        assert parse_key("D# minor") == CamelotPosition(2, "A")
+        assert parse_key("Eb minor") == CamelotPosition(2, "A")
+        # C# minor = Db minor = 12A
+        assert parse_key("C# minor") == CamelotPosition(12, "A")
+        assert parse_key("Db minor") == CamelotPosition(12, "A")
+
+    def test_all_12_minor_keys_parse(self):
+        """Every minor key from 1A to 12A should be parseable."""
+        for i in range(1, 13):
+            result = parse_key(f"{i}A")
+            assert result is not None
+            assert result.number == i
+            assert result.letter == "A"
+
+    def test_all_12_major_keys_parse(self):
+        """Every major key from 1B to 12B should be parseable."""
+        for i in range(1, 13):
+            result = parse_key(f"{i}B")
+            assert result is not None
+            assert result.number == i
+            assert result.letter == "B"
+
+
+class TestCompatibilityScore:
+    """Tests for compatibility_score function."""
+
+    def test_same_key_perfect_match(self):
+        a = CamelotPosition(8, "A")
+        assert compatibility_score(a, a) == 1.0
+
+    def test_same_key_different_objects(self):
+        a = CamelotPosition(8, "A")
+        b = CamelotPosition(8, "A")
+        assert compatibility_score(a, b) == 1.0
+
+    def test_adjacent_plus_one(self):
+        a = CamelotPosition(8, "A")
+        b = CamelotPosition(9, "A")
+        assert compatibility_score(a, b) == 0.8
+
+    def test_adjacent_minus_one(self):
+        a = CamelotPosition(8, "A")
+        b = CamelotPosition(7, "A")
+        assert compatibility_score(a, b) == 0.8
+
+    def test_parallel_key(self):
+        a = CamelotPosition(8, "A")
+        b = CamelotPosition(8, "B")
+        assert compatibility_score(a, b) == 0.8
+
+    def test_two_away(self):
+        a = CamelotPosition(8, "A")
+        b = CamelotPosition(10, "A")
+        assert compatibility_score(a, b) == 0.5
+
+    def test_two_away_minus(self):
+        a = CamelotPosition(8, "A")
+        b = CamelotPosition(6, "A")
+        assert compatibility_score(a, b) == 0.5
+
+    def test_incompatible(self):
+        a = CamelotPosition(8, "A")
+        b = CamelotPosition(3, "A")
+        assert compatibility_score(a, b) == 0.0
+
+    def test_none_first(self):
+        b = CamelotPosition(8, "A")
+        assert compatibility_score(None, b) == 0.0
+
+    def test_none_second(self):
+        a = CamelotPosition(8, "A")
+        assert compatibility_score(a, None) == 0.0
+
+    def test_both_none(self):
+        assert compatibility_score(None, None) == 0.0
+
+    # Wrap-around tests
+    def test_wraparound_12_to_1(self):
+        a = CamelotPosition(12, "A")
+        b = CamelotPosition(1, "A")
+        assert compatibility_score(a, b) == 0.8
+
+    def test_wraparound_1_to_12(self):
+        a = CamelotPosition(1, "A")
+        b = CamelotPosition(12, "A")
+        assert compatibility_score(a, b) == 0.8
+
+    def test_wraparound_two_away_11_to_1(self):
+        a = CamelotPosition(11, "A")
+        b = CamelotPosition(1, "A")
+        assert compatibility_score(a, b) == 0.5
+
+    def test_wraparound_two_away_1_to_11(self):
+        a = CamelotPosition(1, "A")
+        b = CamelotPosition(11, "A")
+        assert compatibility_score(a, b) == 0.5
+
+    # Cross-ring (different letter, different number) = incompatible
+    def test_different_ring_different_number(self):
+        a = CamelotPosition(8, "A")
+        b = CamelotPosition(3, "B")
+        assert compatibility_score(a, b) == 0.0
+
+    def test_major_keys_adjacent(self):
+        a = CamelotPosition(5, "B")
+        b = CamelotPosition(6, "B")
+        assert compatibility_score(a, b) == 0.8
+
+
+class TestCamelotPositionStr:
+    def test_str(self):
+        assert str(CamelotPosition(8, "A")) == "8A"
+        assert str(CamelotPosition(12, "B")) == "12B"

--- a/server/tests/test_llm_hooks.py
+++ b/server/tests/test_llm_hooks.py
@@ -1,0 +1,55 @@
+"""Tests for LLM hooks stub module."""
+
+import pytest
+
+from app.services.recommendation.llm_hooks import (
+    LLMSuggestionQuery,
+    LLMSuggestionResult,
+    generate_llm_suggestions,
+    is_llm_available,
+)
+from app.services.recommendation.scorer import EventProfile
+
+
+class TestIsLLMAvailable:
+    def test_returns_false(self):
+        assert is_llm_available() is False
+
+
+class TestGenerateLLMSuggestions:
+    @pytest.mark.asyncio
+    async def test_raises_not_implemented(self):
+        profile = EventProfile(track_count=0)
+        with pytest.raises(NotImplementedError, match="Phase 3"):
+            await generate_llm_suggestions(profile, "chill vibes")
+
+
+class TestDataClasses:
+    def test_suggestion_query_is_frozen(self):
+        q = LLMSuggestionQuery(
+            search_query="deadmau5 progressive house",
+            target_bpm=128.0,
+            target_key="8A",
+            target_genre="Progressive House",
+            reasoning="Matches event profile",
+        )
+        assert q.search_query == "deadmau5 progressive house"
+        with pytest.raises(AttributeError):
+            q.search_query = "something else"  # type: ignore[misc]
+
+    def test_suggestion_result_is_frozen(self):
+        result = LLMSuggestionResult(
+            queries=[LLMSuggestionQuery(search_query="test", reasoning="test reason")],
+            raw_response='{"queries": []}',
+        )
+        assert len(result.queries) == 1
+        assert result.raw_response == '{"queries": []}'
+        with pytest.raises(AttributeError):
+            result.raw_response = "other"  # type: ignore[misc]
+
+    def test_query_defaults(self):
+        q = LLMSuggestionQuery(search_query="test")
+        assert q.target_bpm is None
+        assert q.target_key is None
+        assert q.target_genre is None
+        assert q.reasoning == ""

--- a/server/tests/test_recommendation_api.py
+++ b/server/tests/test_recommendation_api.py
@@ -1,0 +1,230 @@
+"""Tests for the recommendations API endpoint."""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.models.event import Event
+from app.models.request import Request, RequestStatus
+from app.models.user import User
+from app.services.recommendation.scorer import EventProfile, ScoredTrack, TrackProfile
+from app.services.recommendation.service import RecommendationResult
+
+
+@pytest.fixture
+def event_with_requests(db: Session, test_user: User, test_event: Event) -> Event:
+    """Create an event with some accepted requests."""
+    for i in range(3):
+        req = Request(
+            event_id=test_event.id,
+            song_title=f"Song {i}",
+            artist=f"Artist {i}",
+            source="manual",
+            status=RequestStatus.ACCEPTED.value,
+            dedupe_key=f"dedupe_{i}_{'x' * 20}",
+        )
+        db.add(req)
+    db.commit()
+    return test_event
+
+
+@pytest.fixture
+def user_with_beatport(db: Session, test_user: User) -> User:
+    """Give the test user Beatport credentials."""
+    test_user.beatport_access_token = "fake_token"
+    test_user.beatport_refresh_token = "fake_refresh"
+    test_user.beatport_token_expires_at = utcnow() + timedelta(hours=1)
+    db.commit()
+    db.refresh(test_user)
+    return test_user
+
+
+def _mock_recommendation_result():
+    """Create a mock RecommendationResult for patching."""
+    return RecommendationResult(
+        suggestions=[
+            ScoredTrack(
+                profile=TrackProfile(
+                    title="Suggested Track",
+                    artist="Cool DJ",
+                    bpm=128.0,
+                    key="8A",
+                    genre="Tech House",
+                    source="beatport",
+                    track_id="12345",
+                    url="https://beatport.com/track/test/12345",
+                    cover_url="https://bp.com/cover.jpg",
+                    duration_seconds=360,
+                ),
+                score=0.92,
+                bpm_score=1.0,
+                key_score=1.0,
+                genre_score=0.8,
+            ),
+        ],
+        event_profile=EventProfile(
+            avg_bpm=128.0,
+            bpm_range=(120.0, 136.0),
+            dominant_keys=["8A", "9A"],
+            dominant_genres=["Tech House"],
+            track_count=3,
+        ),
+        enriched_count=3,
+        total_candidates_searched=20,
+        services_used=["beatport"],
+    )
+
+
+class TestRecommendationsEndpoint:
+    @patch("app.services.recommendation.service.generate_recommendations")
+    def test_200_with_valid_response(
+        self,
+        mock_generate,
+        client: TestClient,
+        auth_headers: dict,
+        event_with_requests: Event,
+        user_with_beatport: User,
+    ):
+        mock_generate.return_value = _mock_recommendation_result()
+
+        response = client.post(
+            f"/api/events/{event_with_requests.code}/recommendations",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "suggestions" in data
+        assert "profile" in data
+        assert len(data["suggestions"]) == 1
+        assert data["suggestions"][0]["title"] == "Suggested Track"
+        assert data["suggestions"][0]["score"] == 0.92
+        assert data["profile"]["avg_bpm"] == 128.0
+        assert data["services_used"] == ["beatport"]
+        assert data["llm_available"] is False
+
+    def test_401_without_auth(self, client: TestClient, test_event: Event):
+        response = client.post(f"/api/events/{test_event.code}/recommendations")
+        assert response.status_code == 401
+
+    def test_404_for_nonexistent_event(self, client: TestClient, auth_headers: dict):
+        response = client.post("/api/events/NONEXIST/recommendations", headers=auth_headers)
+        assert response.status_code == 404
+
+    def test_503_no_services_connected(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        event_with_requests: Event,
+    ):
+        """User has no Tidal or Beatport linked."""
+        response = client.post(
+            f"/api/events/{event_with_requests.code}/recommendations",
+            headers=auth_headers,
+        )
+        assert response.status_code == 503
+        assert "music services" in response.json()["detail"].lower()
+
+    @patch("app.services.recommendation.service.generate_recommendations")
+    def test_200_empty_suggestions_no_requests(
+        self,
+        mock_generate,
+        client: TestClient,
+        auth_headers: dict,
+        test_event: Event,
+        user_with_beatport: User,
+    ):
+        mock_generate.return_value = RecommendationResult(
+            suggestions=[],
+            event_profile=EventProfile(track_count=0),
+            enriched_count=0,
+            total_candidates_searched=0,
+            services_used=["beatport"],
+        )
+
+        response = client.post(
+            f"/api/events/{test_event.code}/recommendations",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["suggestions"] == []
+        assert data["profile"]["track_count"] == 0
+
+    def test_403_non_owner(
+        self,
+        client: TestClient,
+        db: Session,
+        test_event: Event,
+    ):
+        """Another user cannot get recommendations for someone else's event."""
+        from app.services.auth import get_password_hash
+
+        other_user = User(
+            username="otheruser",
+            password_hash=get_password_hash("otherpassword123"),
+            role="dj",
+        )
+        db.add(other_user)
+        db.commit()
+
+        login_resp = client.post(
+            "/api/auth/login",
+            data={"username": "otheruser", "password": "otherpassword123"},
+        )
+        other_headers = {"Authorization": f"Bearer {login_resp.json()['access_token']}"}
+
+        response = client.post(
+            f"/api/events/{test_event.code}/recommendations",
+            headers=other_headers,
+        )
+        assert response.status_code == 404  # get_owned_event returns 404 for non-owner
+
+    @patch("app.services.recommendation.service.generate_recommendations")
+    def test_response_schema_structure(
+        self,
+        mock_generate,
+        client: TestClient,
+        auth_headers: dict,
+        test_event: Event,
+        user_with_beatport: User,
+    ):
+        mock_generate.return_value = _mock_recommendation_result()
+
+        response = client.post(
+            f"/api/events/{test_event.code}/recommendations",
+            headers=auth_headers,
+        )
+        data = response.json()
+
+        # Verify all fields present
+        suggestion = data["suggestions"][0]
+        assert "title" in suggestion
+        assert "artist" in suggestion
+        assert "bpm" in suggestion
+        assert "key" in suggestion
+        assert "genre" in suggestion
+        assert "score" in suggestion
+        assert "bpm_score" in suggestion
+        assert "key_score" in suggestion
+        assert "genre_score" in suggestion
+        assert "source" in suggestion
+        assert "track_id" in suggestion
+        assert "url" in suggestion
+        assert "cover_url" in suggestion
+
+        profile = data["profile"]
+        assert "avg_bpm" in profile
+        assert "bpm_range_low" in profile
+        assert "bpm_range_high" in profile
+        assert "dominant_keys" in profile
+        assert "dominant_genres" in profile
+        assert "track_count" in profile
+        assert "enriched_count" in profile
+
+        assert "services_used" in data
+        assert "total_candidates_searched" in data
+        assert "llm_available" in data

--- a/server/tests/test_recommendation_enrichment.py
+++ b/server/tests/test_recommendation_enrichment.py
@@ -1,0 +1,255 @@
+"""Tests for track metadata enrichment from Tidal and Beatport."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.services.recommendation.enrichment import (
+    enrich_event_tracks,
+    enrich_from_beatport,
+    enrich_from_tidal,
+    enrich_track,
+)
+from app.services.recommendation.scorer import TrackProfile
+
+
+def _make_user(tidal=True, beatport=True):
+    user = MagicMock()
+    user.tidal_access_token = "tok" if tidal else None
+    user.tidal_refresh_token = "ref" if tidal else None
+    user.beatport_access_token = "tok" if beatport else None
+    return user
+
+
+def _make_tidal_track(name="Test Track", artist_name="Test Artist", bpm=128, key="C maj"):
+    track = MagicMock()
+    track.name = name
+    track.id = 12345
+    track.bpm = bpm
+    track.key = key
+    track.duration = 300
+    track.artist = SimpleNamespace(name=artist_name)
+    track.album = MagicMock()
+    track.album.name = "Test Album"
+    track.album.image.return_value = "https://tidal.com/cover.jpg"
+    return track
+
+
+class TestEnrichFromTidal:
+    @patch("app.services.recommendation.enrichment.get_tidal_session")
+    def test_returns_profile_on_match(self, mock_session):
+        session = MagicMock()
+        track = _make_tidal_track()
+        session.search.return_value = {"tracks": [track]}
+        mock_session.return_value = session
+
+        db = MagicMock()
+        user = _make_user()
+
+        result = enrich_from_tidal(db, user, "Test Track", "Test Artist")
+        assert result is not None
+        assert result.source == "tidal"
+        assert result.bpm == 128.0
+        assert result.track_id == "12345"
+
+    @patch("app.services.recommendation.enrichment.get_tidal_session")
+    def test_returns_none_when_no_session(self, mock_session):
+        mock_session.return_value = None
+        db = MagicMock()
+        user = _make_user()
+        assert enrich_from_tidal(db, user, "T", "A") is None
+
+    @patch("app.services.recommendation.enrichment.get_tidal_session")
+    def test_returns_none_on_no_results(self, mock_session):
+        session = MagicMock()
+        session.search.return_value = {"tracks": []}
+        mock_session.return_value = session
+        db = MagicMock()
+        user = _make_user()
+        assert enrich_from_tidal(db, user, "Nonexistent", "Nobody") is None
+
+    @patch("app.services.recommendation.enrichment.get_tidal_session")
+    def test_handles_missing_bpm(self, mock_session):
+        session = MagicMock()
+        track = _make_tidal_track(bpm=None)
+        session.search.return_value = {"tracks": [track]}
+        mock_session.return_value = session
+        db = MagicMock()
+        user = _make_user()
+
+        result = enrich_from_tidal(db, user, "Test Track", "Test Artist")
+        assert result is not None
+        assert result.bpm is None
+
+    @patch("app.services.recommendation.enrichment.get_tidal_session")
+    def test_handles_exception(self, mock_session):
+        session = MagicMock()
+        session.search.side_effect = Exception("API error")
+        mock_session.return_value = session
+        db = MagicMock()
+        user = _make_user()
+        assert enrich_from_tidal(db, user, "T", "A") is None
+
+
+class TestEnrichFromBeatport:
+    @patch("app.services.recommendation.enrichment.search_beatport_tracks")
+    def test_returns_profile_on_match(self, mock_search):
+        from app.schemas.beatport import BeatportSearchResult
+
+        mock_search.return_value = [
+            BeatportSearchResult(
+                track_id="999",
+                title="Test Track",
+                artist="Test Artist",
+                genre="Tech House",
+                bpm=126,
+                key="8A",
+                duration_seconds=360,
+                cover_url="https://bp.com/cover.jpg",
+                beatport_url="https://beatport.com/track/test/999",
+            )
+        ]
+        db = MagicMock()
+        user = _make_user()
+
+        result = enrich_from_beatport(db, user, "Test Track", "Test Artist")
+        assert result is not None
+        assert result.source == "beatport"
+        assert result.bpm == 126.0
+        assert result.genre == "Tech House"
+        assert result.key == "8A"
+
+    @patch("app.services.recommendation.enrichment.search_beatport_tracks")
+    def test_returns_none_on_no_results(self, mock_search):
+        mock_search.return_value = []
+        db = MagicMock()
+        user = _make_user()
+        assert enrich_from_beatport(db, user, "T", "A") is None
+
+    @patch("app.services.recommendation.enrichment.search_beatport_tracks")
+    def test_returns_none_on_low_match(self, mock_search):
+        from app.schemas.beatport import BeatportSearchResult
+
+        mock_search.return_value = [
+            BeatportSearchResult(
+                track_id="1",
+                title="Completely Different",
+                artist="Unknown DJ",
+            )
+        ]
+        db = MagicMock()
+        user = _make_user()
+        assert enrich_from_beatport(db, user, "My Song", "My Artist") is None
+
+
+class TestEnrichTrack:
+    @patch("app.services.recommendation.enrichment.enrich_from_beatport")
+    @patch("app.services.recommendation.enrichment.enrich_from_tidal")
+    def test_merges_both_sources(self, mock_tidal, mock_bp):
+        mock_bp.return_value = TrackProfile(
+            title="Track", artist="Artist", bpm=128.0, key=None, genre="House", source="beatport"
+        )
+        mock_tidal.return_value = TrackProfile(
+            title="Track",
+            artist="Artist",
+            bpm=127.0,
+            key="8A",
+            source="tidal",
+            cover_url="https://tidal.com/cover.jpg",
+        )
+        db = MagicMock()
+        user = _make_user()
+
+        result = enrich_track(db, user, "Track", "Artist")
+        assert result.bpm == 128.0  # Beatport preferred
+        assert result.key == "8A"  # Filled from Tidal
+        assert result.genre == "House"  # From Beatport
+
+    @patch("app.services.recommendation.enrichment.enrich_from_beatport")
+    @patch("app.services.recommendation.enrichment.enrich_from_tidal")
+    def test_beatport_only(self, mock_tidal, mock_bp):
+        mock_bp.return_value = TrackProfile(
+            title="Track", artist="Artist", bpm=128.0, genre="Techno", source="beatport"
+        )
+        mock_tidal.return_value = None
+        db = MagicMock()
+        user = _make_user()
+
+        result = enrich_track(db, user, "Track", "Artist")
+        assert result.source == "beatport"
+        assert result.bpm == 128.0
+
+    @patch("app.services.recommendation.enrichment.enrich_from_beatport")
+    @patch("app.services.recommendation.enrichment.enrich_from_tidal")
+    def test_tidal_only(self, mock_tidal, mock_bp):
+        mock_bp.return_value = None
+        mock_tidal.return_value = TrackProfile(
+            title="Track", artist="Artist", bpm=130.0, key="9A", source="tidal"
+        )
+        db = MagicMock()
+        user = _make_user()
+
+        result = enrich_track(db, user, "Track", "Artist")
+        assert result.source == "tidal"
+        assert result.bpm == 130.0
+
+    @patch("app.services.recommendation.enrichment.enrich_from_beatport")
+    @patch("app.services.recommendation.enrichment.enrich_from_tidal")
+    def test_neither_service(self, mock_tidal, mock_bp):
+        mock_bp.return_value = None
+        mock_tidal.return_value = None
+        db = MagicMock()
+        user = _make_user()
+
+        result = enrich_track(db, user, "Unknown", "Unknown")
+        assert result.title == "Unknown"
+        assert result.artist == "Unknown"
+        assert result.bpm is None
+
+    def test_skips_beatport_when_not_connected(self):
+        db = MagicMock()
+        user = _make_user(beatport=False, tidal=False)
+        with (
+            patch("app.services.recommendation.enrichment.enrich_from_beatport") as mock_bp,
+            patch("app.services.recommendation.enrichment.enrich_from_tidal") as mock_tidal,
+        ):
+            mock_bp.return_value = None
+            mock_tidal.return_value = None
+            result = enrich_track(db, user, "T", "A")
+            mock_bp.assert_not_called()
+            mock_tidal.assert_not_called()
+            assert result.title == "T"
+
+
+class TestEnrichEventTracks:
+    @patch("app.services.recommendation.enrichment.enrich_track")
+    def test_enriches_list(self, mock_enrich):
+        mock_enrich.return_value = TrackProfile(title="T", artist="A", bpm=128.0)
+        db = MagicMock()
+        user = _make_user()
+
+        requests = [
+            SimpleNamespace(song_title="Song 1", artist="Artist 1"),
+            SimpleNamespace(song_title="Song 2", artist="Artist 2"),
+        ]
+        result = enrich_event_tracks(db, user, requests)
+        assert len(result) == 2
+        assert mock_enrich.call_count == 2
+
+    @patch("app.services.recommendation.enrichment.enrich_track")
+    def test_caps_at_30(self, mock_enrich):
+        mock_enrich.return_value = TrackProfile(title="T", artist="A")
+        db = MagicMock()
+        user = _make_user()
+
+        requests = [SimpleNamespace(song_title=f"S{i}", artist=f"A{i}") for i in range(50)]
+        result = enrich_event_tracks(db, user, requests)
+        assert len(result) == 30
+        assert mock_enrich.call_count == 30
+
+    @patch("app.services.recommendation.enrichment.enrich_track")
+    def test_empty_requests(self, mock_enrich):
+        db = MagicMock()
+        user = _make_user()
+        result = enrich_event_tracks(db, user, [])
+        assert result == []
+        mock_enrich.assert_not_called()

--- a/server/tests/test_recommendation_scorer.py
+++ b/server/tests/test_recommendation_scorer.py
@@ -1,0 +1,233 @@
+"""Tests for BPM/key/genre scoring algorithm."""
+
+import pytest
+
+from app.services.recommendation.scorer import (
+    EventProfile,
+    ScoredTrack,
+    TrackProfile,
+    build_event_profile,
+    rank_candidates,
+    score_candidate,
+)
+
+
+class TestBuildEventProfile:
+    def test_empty_tracks(self):
+        profile = build_event_profile([])
+        assert profile.track_count == 0
+        assert profile.avg_bpm is None
+        assert profile.bpm_range is None
+        assert list(profile.dominant_keys) == []
+        assert list(profile.dominant_genres) == []
+
+    def test_single_track(self):
+        tracks = [TrackProfile(title="Track", artist="Artist", bpm=128.0, key="8A", genre="House")]
+        profile = build_event_profile(tracks)
+        assert profile.track_count == 1
+        assert profile.avg_bpm == 128.0
+        assert profile.bpm_range == (128.0, 128.0)
+        assert list(profile.dominant_keys) == ["8A"]
+        assert list(profile.dominant_genres) == ["House"]
+
+    def test_multiple_tracks_avg_bpm(self):
+        tracks = [
+            TrackProfile(title="T1", artist="A", bpm=120.0),
+            TrackProfile(title="T2", artist="A", bpm=130.0),
+            TrackProfile(title="T3", artist="A", bpm=140.0),
+        ]
+        profile = build_event_profile(tracks)
+        assert profile.avg_bpm == pytest.approx(130.0)
+        assert profile.bpm_range == (120.0, 140.0)
+
+    def test_bpm_range(self):
+        tracks = [
+            TrackProfile(title="T1", artist="A", bpm=100.0),
+            TrackProfile(title="T2", artist="A", bpm=150.0),
+        ]
+        profile = build_event_profile(tracks)
+        assert profile.bpm_range == (100.0, 150.0)
+
+    def test_all_none_bpms(self):
+        tracks = [
+            TrackProfile(title="T1", artist="A"),
+            TrackProfile(title="T2", artist="A"),
+        ]
+        profile = build_event_profile(tracks)
+        assert profile.avg_bpm is None
+        assert profile.bpm_range is None
+        assert profile.track_count == 2
+
+    def test_dominant_keys(self):
+        tracks = [
+            TrackProfile(title="T1", artist="A", key="8A"),
+            TrackProfile(title="T2", artist="A", key="8A"),
+            TrackProfile(title="T3", artist="A", key="9A"),
+            TrackProfile(title="T4", artist="A", key="7A"),
+            TrackProfile(title="T5", artist="A", key="8A"),
+        ]
+        profile = build_event_profile(tracks)
+        # 8A appears 3 times, should be first
+        assert profile.dominant_keys[0] == "8A"
+        assert len(profile.dominant_keys) <= 3
+
+    def test_dominant_genres(self):
+        tracks = [
+            TrackProfile(title="T1", artist="A", genre="Tech House"),
+            TrackProfile(title="T2", artist="A", genre="Tech House"),
+            TrackProfile(title="T3", artist="A", genre="Progressive House"),
+            TrackProfile(title="T4", artist="A", genre="Tech House"),
+        ]
+        profile = build_event_profile(tracks)
+        assert profile.dominant_genres[0] == "Tech House"
+
+    def test_max_three_dominant(self):
+        tracks = [
+            TrackProfile(title="T1", artist="A", genre="A"),
+            TrackProfile(title="T2", artist="A", genre="B"),
+            TrackProfile(title="T3", artist="A", genre="C"),
+            TrackProfile(title="T4", artist="A", genre="D"),
+        ]
+        profile = build_event_profile(tracks)
+        assert len(profile.dominant_genres) == 3
+
+
+class TestScoreCandidate:
+    def _make_profile(self, **kwargs):
+        defaults = {
+            "avg_bpm": 128.0,
+            "bpm_range": (120.0, 136.0),
+            "dominant_keys": ["8A"],
+            "dominant_genres": ["Tech House"],
+            "track_count": 5,
+        }
+        defaults.update(kwargs)
+        return EventProfile(**defaults)
+
+    def test_perfect_match(self):
+        """Candidate matching all criteria should score high."""
+        profile = self._make_profile()
+        candidate = TrackProfile(
+            title="Track", artist="Artist", bpm=128.0, key="8A", genre="Tech House"
+        )
+        scored = score_candidate(candidate, profile)
+        assert scored.bpm_score == 1.0
+        assert scored.key_score == 1.0
+        assert scored.genre_score == 1.0
+        assert scored.score == pytest.approx(1.0)
+
+    def test_bpm_in_range(self):
+        profile = self._make_profile()
+        candidate = TrackProfile(title="T", artist="A", bpm=129.0)
+        scored = score_candidate(candidate, profile)
+        assert scored.bpm_score == 1.0  # Within +/-2
+
+    def test_bpm_out_of_range(self):
+        profile = self._make_profile()
+        candidate = TrackProfile(title="T", artist="A", bpm=160.0)
+        scored = score_candidate(candidate, profile)
+        assert scored.bpm_score == 0.0  # More than 20 away
+
+    def test_bpm_moderate_falloff(self):
+        profile = self._make_profile()
+        candidate = TrackProfile(title="T", artist="A", bpm=138.0)
+        scored = score_candidate(candidate, profile)
+        # diff=10, falloff = 1.0 - (10-2)/18 = 1.0 - 8/18 ≈ 0.5556
+        assert 0.5 < scored.bpm_score < 0.6
+
+    def test_bpm_missing_candidate(self):
+        profile = self._make_profile()
+        candidate = TrackProfile(title="T", artist="A", bpm=None)
+        scored = score_candidate(candidate, profile)
+        assert scored.bpm_score == 0.5
+
+    def test_key_compatible(self):
+        profile = self._make_profile(dominant_keys=["8A"])
+        candidate = TrackProfile(title="T", artist="A", key="9A")  # Adjacent
+        scored = score_candidate(candidate, profile)
+        assert scored.key_score == 0.8
+
+    def test_key_incompatible(self):
+        profile = self._make_profile(dominant_keys=["8A"])
+        candidate = TrackProfile(title="T", artist="A", key="3B")
+        scored = score_candidate(candidate, profile)
+        assert scored.key_score == 0.0
+
+    def test_key_missing(self):
+        profile = self._make_profile(dominant_keys=["8A"])
+        candidate = TrackProfile(title="T", artist="A", key=None)
+        scored = score_candidate(candidate, profile)
+        assert scored.key_score == 0.5
+
+    def test_genre_exact_match(self):
+        profile = self._make_profile(dominant_genres=["Tech House"])
+        candidate = TrackProfile(title="T", artist="A", genre="Tech House")
+        scored = score_candidate(candidate, profile)
+        assert scored.genre_score == 1.0
+
+    def test_genre_partial_match(self):
+        profile = self._make_profile(dominant_genres=["Progressive House"])
+        candidate = TrackProfile(title="T", artist="A", genre="House")
+        scored = score_candidate(candidate, profile)
+        assert scored.genre_score == 0.5
+
+    def test_genre_mismatch(self):
+        profile = self._make_profile(dominant_genres=["Techno"])
+        candidate = TrackProfile(title="T", artist="A", genre="Hip Hop")
+        scored = score_candidate(candidate, profile)
+        assert scored.genre_score == 0.0
+
+    def test_genre_missing(self):
+        profile = self._make_profile(dominant_genres=["House"])
+        candidate = TrackProfile(title="T", artist="A", genre=None)
+        scored = score_candidate(candidate, profile)
+        assert scored.genre_score == 0.25
+
+    def test_no_genre_data_weights_redistribute(self):
+        """When event has no genre data, weights should be BPM 0.5, key 0.5."""
+        profile = self._make_profile(dominant_genres=[])
+        candidate = TrackProfile(title="T", artist="A", bpm=128.0, key="8A")
+        scored = score_candidate(candidate, profile)
+        # BPM=1.0 * 0.5 + Key=1.0 * 0.5 + Genre=0.25*0.0 = 1.0
+        assert scored.score == pytest.approx(1.0)
+
+
+class TestRankCandidates:
+    def _make_profile(self):
+        return EventProfile(
+            avg_bpm=128.0,
+            bpm_range=(120.0, 136.0),
+            dominant_keys=["8A"],
+            dominant_genres=["Tech House"],
+            track_count=5,
+        )
+
+    def test_correct_ordering(self):
+        profile = self._make_profile()
+        candidates = [
+            TrackProfile(title="Bad", artist="A", bpm=200.0, key="3B", genre="Hip Hop"),
+            TrackProfile(title="Perfect", artist="A", bpm=128.0, key="8A", genre="Tech House"),
+            TrackProfile(title="OK", artist="A", bpm=130.0, key="9A", genre="House"),
+        ]
+        ranked = rank_candidates(candidates, profile)
+        assert ranked[0].profile.title == "Perfect"
+        assert ranked[-1].profile.title == "Bad"
+
+    def test_max_results_cap(self):
+        profile = self._make_profile()
+        candidates = [TrackProfile(title=f"T{i}", artist="A", bpm=128.0) for i in range(50)]
+        ranked = rank_candidates(candidates, profile, max_results=10)
+        assert len(ranked) == 10
+
+    def test_empty_candidates(self):
+        profile = self._make_profile()
+        ranked = rank_candidates([], profile)
+        assert ranked == []
+
+    def test_returns_scored_tracks(self):
+        profile = self._make_profile()
+        candidates = [TrackProfile(title="T", artist="A", bpm=128.0)]
+        ranked = rank_candidates(candidates, profile)
+        assert len(ranked) == 1
+        assert isinstance(ranked[0], ScoredTrack)
+        assert ranked[0].profile.title == "T"

--- a/server/tests/test_recommendation_service.py
+++ b/server/tests/test_recommendation_service.py
@@ -1,0 +1,196 @@
+"""Tests for recommendation engine orchestrator."""
+
+from unittest.mock import MagicMock, patch
+
+from app.services.recommendation.scorer import EventProfile, TrackProfile
+from app.services.recommendation.service import (
+    RecommendationResult,
+    _build_search_queries,
+    _deduplicate_against_requests,
+    _deduplicate_candidates,
+    generate_recommendations,
+)
+
+
+def _make_user(tidal=True, beatport=True):
+    user = MagicMock()
+    user.tidal_access_token = "tok" if tidal else None
+    user.beatport_access_token = "tok" if beatport else None
+    return user
+
+
+def _make_event(code="TEST1"):
+    event = MagicMock()
+    event.id = 1
+    event.code = code
+    return event
+
+
+class TestBuildSearchQueries:
+    def test_genre_based_queries(self):
+        profile = EventProfile(
+            dominant_genres=["Tech House", "Progressive House", "Minimal"],
+            track_count=10,
+        )
+        queries = _build_search_queries(profile)
+        assert "Tech House" in queries
+        assert "Progressive House" in queries
+        assert "Minimal" in queries
+
+    def test_bpm_query_added(self):
+        profile = EventProfile(
+            avg_bpm=128.0,
+            dominant_genres=["House"],
+            track_count=5,
+        )
+        queries = _build_search_queries(profile)
+        assert any("128" in q for q in queries)
+
+    def test_empty_profile(self):
+        profile = EventProfile(track_count=0)
+        queries = _build_search_queries(profile)
+        assert queries == []
+
+    def test_max_three_queries(self):
+        profile = EventProfile(
+            avg_bpm=128.0,
+            dominant_genres=["A", "B", "C"],
+            track_count=10,
+        )
+        queries = _build_search_queries(profile)
+        assert len(queries) <= 3
+
+
+class TestDeduplicateAgainstRequests:
+    def test_removes_existing_tracks(self):
+        candidates = [
+            TrackProfile(title="Already Requested", artist="Same Artist"),
+            TrackProfile(title="New Track", artist="Different Artist"),
+        ]
+        requests = [MagicMock(song_title="Already Requested", artist="Same Artist")]
+        result = _deduplicate_against_requests(candidates, requests)
+        assert len(result) == 1
+        assert result[0].title == "New Track"
+
+    def test_empty_requests(self):
+        candidates = [TrackProfile(title="Track", artist="Artist")]
+        result = _deduplicate_against_requests(candidates, [])
+        assert len(result) == 1
+
+
+class TestDeduplicateCandidates:
+    def test_removes_duplicate_candidates(self):
+        candidates = [
+            TrackProfile(title="Same Track", artist="Same Artist", source="beatport"),
+            TrackProfile(title="Same Track", artist="Same Artist", source="tidal"),
+            TrackProfile(title="Different Track", artist="Other Artist"),
+        ]
+        result = _deduplicate_candidates(candidates)
+        assert len(result) == 2
+
+    def test_no_duplicates(self):
+        candidates = [
+            TrackProfile(title="Strobe", artist="deadmau5"),
+            TrackProfile(title="Clarity", artist="Zedd"),
+        ]
+        result = _deduplicate_candidates(candidates)
+        assert len(result) == 2
+
+
+class TestGenerateRecommendations:
+    @patch("app.services.recommendation.service._search_candidates")
+    @patch("app.services.recommendation.service.enrich_event_tracks")
+    @patch("app.services.recommendation.service._get_accepted_played_requests")
+    def test_full_pipeline(self, mock_requests, mock_enrich, mock_search):
+        mock_requests.return_value = [
+            MagicMock(song_title="Song", artist="Artist", status="accepted"),
+        ]
+        mock_enrich.return_value = [
+            TrackProfile(title="Song", artist="Artist", bpm=128.0, key="8A", genre="House"),
+        ]
+        mock_search.return_value = (
+            [
+                TrackProfile(
+                    title="Suggestion",
+                    artist="DJ",
+                    bpm=127.0,
+                    key="8A",
+                    genre="House",
+                    source="beatport",
+                ),
+            ],
+            ["beatport"],
+            1,
+        )
+
+        db = MagicMock()
+        # Mock the dedup query to return no existing requests for the candidate
+        db.query.return_value.filter.return_value.all.return_value = [
+            MagicMock(song_title="Song", artist="Artist"),
+        ]
+
+        user = _make_user(tidal=False)
+        event = _make_event()
+
+        result = generate_recommendations(db, user, event)
+        assert isinstance(result, RecommendationResult)
+        assert len(result.suggestions) > 0
+        assert result.enriched_count == 1
+        assert "beatport" in result.services_used
+
+    def test_no_services_connected(self):
+        db = MagicMock()
+        user = _make_user(tidal=False, beatport=False)
+        event = _make_event()
+
+        result = generate_recommendations(db, user, event)
+        assert result.suggestions == []
+        assert result.services_used == []
+        assert result.event_profile.track_count == 0
+
+    @patch("app.services.recommendation.service._search_candidates")
+    @patch("app.services.recommendation.service.enrich_event_tracks")
+    @patch("app.services.recommendation.service._get_accepted_played_requests")
+    def test_no_accepted_requests(self, mock_requests, mock_enrich, mock_search):
+        mock_requests.return_value = []
+        mock_search.return_value = ([], [], 0)
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = []
+        user = _make_user()
+        event = _make_event()
+
+        result = generate_recommendations(db, user, event)
+        assert result.suggestions == []
+        assert result.event_profile.track_count == 0
+        mock_enrich.assert_not_called()
+
+    @patch("app.services.recommendation.service._search_candidates")
+    @patch("app.services.recommendation.service.enrich_event_tracks")
+    @patch("app.services.recommendation.service._get_accepted_played_requests")
+    def test_dedup_excludes_existing(self, mock_requests, mock_enrich, mock_search):
+        mock_requests.return_value = [
+            MagicMock(song_title="Existing Song", artist="Existing Artist"),
+        ]
+        mock_enrich.return_value = [
+            TrackProfile(title="Existing Song", artist="Existing Artist", bpm=128.0),
+        ]
+        # Search returns the same track that already exists
+        mock_search.return_value = (
+            [
+                TrackProfile(
+                    title="Existing Song", artist="Existing Artist", bpm=128.0, source="beatport"
+                ),
+            ],
+            ["beatport"],
+            1,
+        )
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = [
+            MagicMock(song_title="Existing Song", artist="Existing Artist"),
+        ]
+        user = _make_user()
+        event = _make_event()
+
+        result = generate_recommendations(db, user, event)
+        # The existing song should be deduped out
+        assert len(result.suggestions) == 0


### PR DESCRIPTION
## Summary
- Implement PR 1 of the recommendation system (Issue #100) — algorithmic engine that suggests tracks matching an event's musical profile
- Camelot wheel key compatibility, BPM proximity, and genre matching with dynamic weight redistribution
- Enriches accepted/played requests via Tidal (BPM/key) and Beatport (BPM/key/genre), searches both services for candidates, deduplicates, scores, and returns top suggestions
- Frontend RecommendationsCard with Generate/Accept/Accept All/Clear actions
- LLM hooks stub for future Phase 3 integration
- 110 new tests (102 backend + 8 frontend), 88% backend coverage

## Test plan
- [x] Backend: 900 tests pass, 88.38% coverage
- [x] Frontend: 122 tests pass (11 test files)
- [x] ruff check/format, bandit, ESLint, tsc --noEmit all clean
- [x] Bridge and bridge-app TypeScript checks pass (no regressions)
- [ ] Manual: generate recommendations for event with accepted requests + Beatport linked
- [ ] Manual: verify Accept adds track as request, Accept All clears list
- [ ] Manual: verify 503 when no services connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)