### PR TITLE
fix: use X-Forwarded-Proto for banner URLs behind TLS proxy

### DIFF
--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -93,7 +93,10 @@ def _get_base_url(request: Request | None) -> str | None:
 
 def _get_api_base_url(request: Request) -> str:
     """Get the API server's own base URL for constructing asset URLs (uploads, etc.)."""
-    return str(request.base_url).rstrip("/")
+    base = str(request.base_url).rstrip("/")
+    if request.headers.get("x-forwarded-proto") == "https" and base.startswith("http://"):
+        base = "https://" + base[len("http://") :]
+    return base
 
 
 def _get_banner_urls(event, request: Request | None) -> tuple[str | None, str | None]:

--- a/server/app/api/public.py
+++ b/server/app/api/public.py
@@ -123,6 +123,8 @@ def get_kiosk_display(
     banner_colors = None
     if event.banner_filename:
         api_base = str(request.base_url).rstrip("/")
+        if request.headers.get("x-forwarded-proto") == "https" and api_base.startswith("http://"):
+            api_base = "https://" + api_base[len("http://") :]
         banner_url = f"{api_base}/uploads/{event.banner_filename}"
         stem = event.banner_filename.rsplit(".", 1)[0]
         banner_kiosk_url = f"{api_base}/uploads/{stem}_kiosk.webp"


### PR DESCRIPTION
## Summary
- Banner URLs were constructed with `http://` scheme because uvicorn sees plain HTTP behind nginx's TLS termination
- Browsers block mixed content (`https://` page loading `http://` images), so banners failed to load on production
- Now checks `X-Forwarded-Proto` header and upgrades scheme in both `events.py` and `public.py`

## Test plan
- [x] All 1129 backend tests pass (88% coverage)
- [x] Verified on production: banner URLs now return `https://api.wrzdj.com/...`