### PR TITLE
feat: embedded audio previews in DJ request cards

### DIFF
--- a/dashboard/app/events/[code]/components/RequestQueueSection.tsx
+++ b/dashboard/app/events/[code]/components/RequestQueueSection.tsx
@@ -5,6 +5,7 @@ import { SongRequest } from '@/lib/api';
 import { StatusFilter } from './types';
 import { SyncStatusBadges } from './SyncStatusBadges';
 import { KeyBadge, BpmBadge, GenreBadge } from '@/components/MusicBadges';
+import { PreviewPlayer } from '@/components/PreviewPlayer';
 import { computeBpmContext } from '@/lib/bpm-stats';
 
 interface RequestQueueSectionProps {
@@ -201,6 +202,10 @@ export function RequestQueueSection({
                   </div>
                 )}
                 {request.note && <div className="note">{request.note}</div>}
+                <PreviewPlayer data={{
+                  source: request.source,
+                  sourceUrl: request.source_url,
+                }} />
                 <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.5rem' }}>
                   <p style={{ fontSize: '0.75rem', margin: 0 }}>
                     {new Date(request.created_at).toLocaleTimeString()}

--- a/dashboard/components/PreviewPlayer.tsx
+++ b/dashboard/components/PreviewPlayer.tsx
@@ -1,44 +1,98 @@
 'use client';
 
-import { canEmbed, getEmbedUrl, type PreviewData } from '@/lib/preview-embed';
+import { useState } from 'react';
+import { canEmbed, getEmbedUrl, getPreviewSource, type PreviewData } from '@/lib/preview-embed';
 
 /**
  * Embeddable audio preview player for song cards.
  *
- * Renders a source-specific iframe embed (Spotify or Tidal) when available.
- * Falls back to nothing if the source doesn't support embedding.
- *
- * This is the framework stub for issue #128 — the full implementation will
- * add expand/collapse behavior, loading states, and Beatport fallback.
+ * Three render paths:
+ * 1. Spotify/Tidal: toggle button → collapsible iframe embed
+ * 2. Beatport: small "Open in Beatport" link (no embed API)
+ * 3. Everything else: renders nothing
  */
 export function PreviewPlayer({ data }: { data: PreviewData }) {
+  const [expanded, setExpanded] = useState(false);
+  const source = getPreviewSource(data);
+
+  // Beatport: link-button fallback (no embed support)
+  if (source === 'beatport' && data.sourceUrl && /^https?:\/\//.test(data.sourceUrl)) {
+    return (
+      <a
+        href={data.sourceUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Open in Beatport (opens in new tab)"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '0.25rem',
+          fontSize: '0.7rem',
+          color: '#9ca3af',
+          textDecoration: 'none',
+          marginTop: '0.375rem',
+        }}
+      >
+        Open in Beatport ↗
+      </a>
+    );
+  }
+
+  // Only render toggle for embeddable sources
   if (!canEmbed(data)) return null;
 
   const embedUrl = getEmbedUrl(data);
   if (!embedUrl) return null;
 
+  const sourceLabel = source === 'spotify' ? 'Spotify' : 'Tidal';
+
   return (
-    <div
-      style={{
-        width: '100%',
-        borderRadius: '0.5rem',
-        overflow: 'hidden',
-        marginTop: '0.5rem',
-      }}
-    >
-      <iframe
-        src={embedUrl}
-        width="100%"
-        height="80"
-        frameBorder="0"
-        allow="encrypted-media"
-        loading="lazy"
-        title="Audio preview"
+    <div style={{ marginTop: '0.375rem' }}>
+      <button
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-label={`${expanded ? 'Hide' : 'Show'} ${sourceLabel} preview`}
+        aria-expanded={expanded}
         style={{
-          borderRadius: '0.5rem',
-          border: 'none',
+          background: 'none',
+          border: '1px solid #374151',
+          borderRadius: '0.375rem',
+          color: '#9ca3af',
+          fontSize: '0.7rem',
+          padding: '0.125rem 0.5rem',
+          cursor: 'pointer',
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '0.25rem',
         }}
-      />
+      >
+        {expanded ? '▼' : '▶'} Preview
+      </button>
+      {expanded && (
+        <div
+          style={{
+            width: '100%',
+            borderRadius: '0.5rem',
+            overflow: 'hidden',
+            marginTop: '0.5rem',
+            backgroundColor: '#1a1a1a',
+          }}
+        >
+          <iframe
+            src={embedUrl}
+            width="100%"
+            height="152"
+            allow="encrypted-media"
+            sandbox="allow-scripts allow-same-origin allow-popups"
+            loading="lazy"
+            title={`${sourceLabel} audio preview`}
+            style={{
+              borderRadius: '0.5rem',
+              border: 'none',
+              display: 'block',
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/dashboard/components/__tests__/PreviewPlayer.test.tsx
+++ b/dashboard/components/__tests__/PreviewPlayer.test.tsx
@@ -1,0 +1,216 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PreviewPlayer } from '../PreviewPlayer';
+
+describe('PreviewPlayer', () => {
+  describe('rendering rules', () => {
+    it('renders nothing when sourceUrl is null', () => {
+      const { container } = render(
+        <PreviewPlayer data={{ source: 'spotify', sourceUrl: null }} />
+      );
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders nothing for unknown/unsupported sources', () => {
+      const { container } = render(
+        <PreviewPlayer data={{ source: 'shazam', sourceUrl: 'https://shazam.com/track/123' }} />
+      );
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders nothing for manual source', () => {
+      const { container } = render(
+        <PreviewPlayer data={{ source: 'manual', sourceUrl: null }} />
+      );
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders a toggle button for Spotify source', () => {
+      render(
+        <PreviewPlayer data={{ source: 'spotify', sourceUrl: 'https://open.spotify.com/track/abc' }} />
+      );
+      expect(screen.getByRole('button')).toBeDefined();
+    });
+
+    it('renders a toggle button for Tidal source', () => {
+      render(
+        <PreviewPlayer data={{ source: 'tidal', sourceUrl: 'https://tidal.com/browse/track/123' }} />
+      );
+      expect(screen.getByRole('button')).toBeDefined();
+    });
+
+    it('renders a link for Beatport source (no toggle)', () => {
+      render(
+        <PreviewPlayer data={{ source: 'beatport', sourceUrl: 'https://beatport.com/track/x/1' }} />
+      );
+      const link = screen.getByRole('link');
+      expect(link).toBeDefined();
+      // Should not have a toggle button
+      expect(screen.queryByRole('button')).toBeNull();
+    });
+  });
+
+  describe('toggle behavior (Spotify/Tidal)', () => {
+    it('starts collapsed — no iframe in DOM', () => {
+      const { container } = render(
+        <PreviewPlayer data={{ source: 'spotify', sourceUrl: 'https://open.spotify.com/track/abc' }} />
+      );
+      expect(container.querySelector('iframe')).toBeNull();
+    });
+
+    it('click toggle → iframe appears', () => {
+      const { container } = render(
+        <PreviewPlayer data={{ source: 'spotify', sourceUrl: 'https://open.spotify.com/track/abc' }} />
+      );
+      fireEvent.click(screen.getByRole('button'));
+      expect(container.querySelector('iframe')).not.toBeNull();
+    });
+
+    it('click toggle again → iframe removed from DOM', () => {
+      const { container } = render(
+        <PreviewPlayer data={{ source: 'spotify', sourceUrl: 'https://open.spotify.com/track/abc' }} />
+      );
+      const button = screen.getByRole('button');
+      fireEvent.click(button); // expand
+      fireEvent.click(button); // collapse
+      expect(container.querySelector('iframe')).toBeNull();
+    });
+
+    it('button aria-label updates to reflect expanded state', () => {
+      render(
+        <PreviewPlayer data={{ source: 'spotify', sourceUrl: 'https://open.spotify.com/track/abc' }} />
+      );
+      const button = screen.getByRole('button');
+      expect(button.getAttribute('aria-expanded')).toBe('false');
+      fireEvent.click(button);
+      expect(button.getAttribute('aria-expanded')).toBe('true');
+    });
+  });
+
+  describe('iframe correctness', () => {
+    it('Spotify iframe has correct embed src', () => {
+      const { container } = render(
+        <PreviewPlayer data={{ source: 'spotify', sourceUrl: 'https://open.spotify.com/track/abc123' }} />
+      );
+      fireEvent.click(screen.getByRole('button'));
+      const iframe = container.querySelector('iframe');
+      expect(iframe?.getAttribute('src')).toBe('https://open.spotify.com/embed/track/abc123');
+    });
+
+    it('Tidal iframe has correct embed src', () => {
+      const { container } = render(
+        <PreviewPlayer data={{ source: 'tidal', sourceUrl: 'https://tidal.com/browse/track/456789' }} />
+      );
+      fireEvent.click(screen.getByRole('button'));
+      const iframe = container.querySelector('iframe');
+      expect(iframe?.getAttribute('src')).toBe('https://embed.tidal.com/tracks/456789');
+    });
+
+    it('iframe has title attribute for accessibility', () => {
+      const { container } = render(
+        <PreviewPlayer data={{ source: 'spotify', sourceUrl: 'https://open.spotify.com/track/abc' }} />
+      );
+      fireEvent.click(screen.getByRole('button'));
+      const iframe = container.querySelector('iframe');
+      expect(iframe?.getAttribute('title')).toBeTruthy();
+    });
+
+    it('iframe has allow="encrypted-media"', () => {
+      const { container } = render(
+        <PreviewPlayer data={{ source: 'spotify', sourceUrl: 'https://open.spotify.com/track/abc' }} />
+      );
+      fireEvent.click(screen.getByRole('button'));
+      const iframe = container.querySelector('iframe');
+      expect(iframe?.getAttribute('allow')).toContain('encrypted-media');
+    });
+
+    it('iframe has loading="lazy"', () => {
+      const { container } = render(
+        <PreviewPlayer data={{ source: 'spotify', sourceUrl: 'https://open.spotify.com/track/abc' }} />
+      );
+      fireEvent.click(screen.getByRole('button'));
+      const iframe = container.querySelector('iframe');
+      expect(iframe?.getAttribute('loading')).toBe('lazy');
+    });
+
+    it('iframe has sandbox for defense-in-depth', () => {
+      const { container } = render(
+        <PreviewPlayer data={{ source: 'spotify', sourceUrl: 'https://open.spotify.com/track/abc' }} />
+      );
+      fireEvent.click(screen.getByRole('button'));
+      const iframe = container.querySelector('iframe');
+      const sandbox = iframe?.getAttribute('sandbox') ?? '';
+      expect(sandbox).toContain('allow-scripts');
+      expect(sandbox).toContain('allow-same-origin');
+    });
+  });
+
+  describe('Beatport fallback', () => {
+    it('renders an <a> element with the source URL', () => {
+      render(
+        <PreviewPlayer data={{ source: 'beatport', sourceUrl: 'https://beatport.com/track/x/1' }} />
+      );
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('href')).toBe('https://beatport.com/track/x/1');
+    });
+
+    it('opens in new tab with security attrs', () => {
+      render(
+        <PreviewPlayer data={{ source: 'beatport', sourceUrl: 'https://beatport.com/track/x/1' }} />
+      );
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('target')).toBe('_blank');
+      expect(link.getAttribute('rel')).toContain('noopener');
+      expect(link.getAttribute('rel')).toContain('noreferrer');
+    });
+
+    it('renders nothing for Beatport with null sourceUrl', () => {
+      const { container } = render(
+        <PreviewPlayer data={{ source: 'beatport', sourceUrl: null }} />
+      );
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders nothing for Beatport with non-http sourceUrl', () => {
+      const { container } = render(
+        <PreviewPlayer data={{ source: 'beatport', sourceUrl: 'javascript:alert(1)' }} />
+      );
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('link text includes Beatport label', () => {
+      render(
+        <PreviewPlayer data={{ source: 'beatport', sourceUrl: 'https://beatport.com/track/x/1' }} />
+      );
+      const link = screen.getByRole('link');
+      expect(link.textContent).toContain('Beatport');
+    });
+
+    it('link has aria-label for screen readers', () => {
+      render(
+        <PreviewPlayer data={{ source: 'beatport', sourceUrl: 'https://beatport.com/track/x/1' }} />
+      );
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('aria-label')).toBeTruthy();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('toggle button has aria-label', () => {
+      render(
+        <PreviewPlayer data={{ source: 'spotify', sourceUrl: 'https://open.spotify.com/track/abc' }} />
+      );
+      const button = screen.getByRole('button');
+      expect(button.getAttribute('aria-label')).toBeTruthy();
+    });
+
+    it('iframe has descriptive title', () => {
+      const { container } = render(
+        <PreviewPlayer data={{ source: 'tidal', sourceUrl: 'https://tidal.com/browse/track/123' }} />
+      );
+      fireEvent.click(screen.getByRole('button'));
+      const iframe = container.querySelector('iframe');
+      expect(iframe?.getAttribute('title')).toMatch(/preview/i);
+    });
+  });
+});

--- a/dashboard/lib/__tests__/preview-embed.test.ts
+++ b/dashboard/lib/__tests__/preview-embed.test.ts
@@ -4,6 +4,7 @@ import {
   getTidalEmbedUrl,
   getPreviewSource,
   canEmbed,
+  getEmbedUrl,
   type PreviewData,
 } from '../preview-embed';
 
@@ -91,5 +92,35 @@ describe('canEmbed', () => {
 
   it('returns false when sourceUrl is null', () => {
     expect(canEmbed({ source: 'spotify', sourceUrl: null })).toBe(false);
+  });
+});
+
+describe('getEmbedUrl', () => {
+  it('returns Spotify embed URL for Spotify source', () => {
+    expect(
+      getEmbedUrl({ source: 'spotify', sourceUrl: 'https://open.spotify.com/track/abc' })
+    ).toBe('https://open.spotify.com/embed/track/abc');
+  });
+
+  it('returns Tidal embed URL for Tidal source', () => {
+    expect(
+      getEmbedUrl({ source: 'tidal', sourceUrl: 'https://tidal.com/browse/track/123' })
+    ).toBe('https://embed.tidal.com/tracks/123');
+  });
+
+  it('returns null for Beatport source (no embed support)', () => {
+    expect(
+      getEmbedUrl({ source: 'beatport', sourceUrl: 'https://beatport.com/track/x/1' })
+    ).toBeNull();
+  });
+
+  it('returns null when sourceUrl is null', () => {
+    expect(getEmbedUrl({ source: 'spotify', sourceUrl: null })).toBeNull();
+  });
+
+  it('returns null for unknown source', () => {
+    expect(
+      getEmbedUrl({ source: 'shazam', sourceUrl: 'https://shazam.com/track/123' })
+    ).toBeNull();
   });
 });

--- a/deploy/dev-proxy/nginx/app.conf.template
+++ b/deploy/dev-proxy/nginx/app.conf.template
@@ -29,7 +29,7 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://api.local https://${LAN_IP}:8443 https://i.scdn.co https://resources.tidal.com https://geo-media.beatport.com; media-src 'self' data:; connect-src 'self' https://api.local https://${LAN_IP}:8443 wss://app.local wss://${LAN_IP}; frame-src https://challenges.cloudflare.com; frame-ancestors 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://api.local https://${LAN_IP}:8443 https://i.scdn.co https://resources.tidal.com https://geo-media.beatport.com; media-src 'self' data:; connect-src 'self' https://api.local https://${LAN_IP}:8443 wss://app.local wss://${LAN_IP}; frame-src https://challenges.cloudflare.com https://open.spotify.com https://embed.tidal.com; frame-ancestors 'none'" always;
 
     # Strip security headers from upstream (Next.js sets them too — nginx is authoritative)
     proxy_hide_header Strict-Transport-Security;

--- a/deploy/nginx/app.conf.template
+++ b/deploy/nginx/app.conf.template
@@ -43,7 +43,7 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://${API_DOMAIN} https://i.scdn.co https://resources.tidal.com https://geo-media.beatport.com; media-src 'self' data:; connect-src 'self' https://${API_DOMAIN}; frame-src https://challenges.cloudflare.com; frame-ancestors 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://${API_DOMAIN} https://i.scdn.co https://resources.tidal.com https://geo-media.beatport.com; media-src 'self' data:; connect-src 'self' https://${API_DOMAIN}; frame-src https://challenges.cloudflare.com https://open.spotify.com https://embed.tidal.com; frame-ancestors 'none'" always;
 
     # Strip security headers from upstream (Next.js sets them too — nginx is authoritative)
     proxy_hide_header Strict-Transport-Security;


### PR DESCRIPTION
## Summary
- Adds inline Spotify/Tidal iframe embeds with toggle button (collapsed by default) to DJ request cards
- Beatport cards get a subtle "Open in Beatport" link-out since Beatport has no embed API
- Updates CSP `frame-src` to allow `open.spotify.com` and `embed.tidal.com` (main route only, not overlay)

## Details
- `PreviewPlayer` component: three render paths (embeddable toggle, Beatport link, null for unsupported)
- Defense-in-depth: `sandbox` attribute on iframes, protocol validation on Beatport links
- Accessibility: `aria-expanded`, `aria-label` on toggle and links, descriptive `title` on iframes
- 24 new component tests + 5 new utility tests (281 total passing)

Closes #128

## Test plan
- [ ] Open event with Spotify requests — verify toggle button appears, expands/collapses iframe
- [ ] Open event with Tidal requests — verify same toggle behavior with Tidal embed
- [ ] Open event with Beatport requests — verify "Open in Beatport" link (no toggle)
- [ ] Verify manual/unknown source cards show no preview UI
- [ ] Check browser console for CSP violations (should be none)
- [ ] Test on mobile via LAN IP