### PR TITLE
feat: UI overhaul — theme system, visual emphasis, typography & compact mode

### DIFF
--- a/dashboard/app/e/[code]/display/page.tsx
+++ b/dashboard/app/e/[code]/display/page.tsx
@@ -381,7 +381,7 @@ export default function KioskDisplayPage() {
           z-index: 1;
         }
         .kiosk-event-name {
-          font-size: 2.5rem;
+          font-size: 3rem;
           font-weight: bold;
           color: #fff;
           margin: 0;
@@ -389,6 +389,7 @@ export default function KioskDisplayPage() {
           text-overflow: ellipsis;
           white-space: nowrap;
           max-width: 100%;
+          font-family: var(--font-display, 'Plus Jakarta Sans'), -apple-system, sans-serif;
         }
         .kiosk-qr {
           background: #fff;
@@ -442,13 +443,14 @@ export default function KioskDisplayPage() {
         }
         .now-playing-label {
           color: #22c55e;
-          font-size: 1rem;
+          font-size: 1.125rem;
           text-transform: uppercase;
           letter-spacing: 0.1em;
           margin-bottom: 1rem;
           display: flex;
           align-items: center;
           gap: 0.5rem;
+          font-weight: 600;
         }
         .live-badge {
           background: #ef4444;
@@ -490,15 +492,16 @@ export default function KioskDisplayPage() {
           font-size: 4rem;
         }
         .now-playing-title {
-          font-size: 1.75rem;
+          font-size: 2rem;
           font-weight: bold;
           color: #fff;
           text-align: center;
           margin: 0 0 0.5rem;
+          font-family: var(--font-display, 'Plus Jakarta Sans'), -apple-system, sans-serif;
         }
         .now-playing-artist {
-          font-size: 1.25rem;
-          color: #9ca3af;
+          font-size: 1.375rem;
+          color: #d1d5db;
           text-align: center;
           margin: 0;
         }
@@ -530,11 +533,12 @@ export default function KioskDisplayPage() {
         }
         .queue-label {
           color: #3b82f6;
-          font-size: 1rem;
+          font-size: 1.125rem;
           text-transform: uppercase;
           letter-spacing: 0.1em;
           margin-bottom: 1rem;
           flex-shrink: 0;
+          font-weight: 600;
         }
         .queue-list {
           display: flex;
@@ -573,14 +577,15 @@ export default function KioskDisplayPage() {
         }
         .queue-item-title {
           color: #fff;
-          font-weight: 500;
+          font-size: 1.0625rem;
+          font-weight: 600;
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
         }
         .queue-item-artist {
-          color: #9ca3af;
-          font-size: 0.875rem;
+          color: #d1d5db;
+          font-size: 0.9375rem;
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
@@ -628,11 +633,12 @@ export default function KioskDisplayPage() {
         }
         .history-label {
           color: #a855f7;
-          font-size: 1rem;
+          font-size: 1.125rem;
           text-transform: uppercase;
           letter-spacing: 0.1em;
           margin-bottom: 1rem;
           flex-shrink: 0;
+          font-weight: 600;
         }
         .history-list {
           display: flex;
@@ -677,14 +683,14 @@ export default function KioskDisplayPage() {
         }
         .history-item-title {
           color: #d1d5db;
-          font-size: 0.875rem;
+          font-size: 0.9375rem;
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
         }
         .history-item-artist {
-          color: #6b7280;
-          font-size: 0.75rem;
+          color: #9ca3af;
+          font-size: 0.8125rem;
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;

--- a/dashboard/app/events/[code]/__tests__/event-help.test.tsx
+++ b/dashboard/app/events/[code]/__tests__/event-help.test.tsx
@@ -47,6 +47,14 @@ vi.mock('../components/ServiceTrackPickerModal', () => ({
   ServiceTrackPickerModal: () => null,
 }));
 
+vi.mock('@/components/ThemeToggle', () => ({
+  ThemeToggle: () => null,
+}));
+
+vi.mock('@/lib/tab-title', () => ({
+  useTabTitle: () => {},
+}));
+
 vi.mock('../components/RequestQueueSection', () => ({
   RequestQueueSection: () => null,
 }));

--- a/dashboard/app/events/[code]/components/RequestQueueSection.tsx
+++ b/dashboard/app/events/[code]/components/RequestQueueSection.tsx
@@ -7,6 +7,8 @@ import { SyncStatusBadges } from './SyncStatusBadges';
 import { KeyBadge, BpmBadge, GenreBadge } from '@/components/MusicBadges';
 import { PreviewPlayer } from '@/components/PreviewPlayer';
 import { computeBpmContext } from '@/lib/bpm-stats';
+import { getRequestEmphasisStyle } from '@/lib/request-emphasis';
+import { getVoteHeatStyle } from '@/lib/vote-heat';
 
 interface RequestQueueSectionProps {
   requests: SongRequest[];
@@ -171,7 +173,23 @@ export function RequestQueueSection({
       ) : (
         <div className="request-list scrollable-list" style={{ marginBottom: '1rem' }}>
           {filteredRequests.map((request) => (
-            <div key={request.id} id={`request-${request.id}`} className="request-item">
+            <div
+              key={request.id}
+              id={`request-${request.id}`}
+              className="request-item"
+              style={{
+                ...(() => {
+                  const emphasis = getRequestEmphasisStyle(request.status);
+                  const heat = getVoteHeatStyle(request.vote_count);
+                  return {
+                    ...emphasis,
+                    ...heat,
+                    // Status emphasis background takes priority over vote heat
+                    ...(emphasis.background ? { background: emphasis.background } : {}),
+                  };
+                })(),
+              }}
+            >
               <div className="request-info">
                 <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.375rem' }}>
                   <h3 style={{ margin: 0 }}>

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -4,12 +4,22 @@
   margin: 0;
 }
 
+/* Theme defaults — overridden by ThemeProvider at runtime */
+:root {
+  --bg: #0a0a0a;
+  --card: #1a1a1a;
+  --text: #ededed;
+  --text-secondary: #9ca3af;
+  --text-tertiary: #6b7280;
+  --border: #333333;
+}
+
 html,
 body {
   max-width: 100vw;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-  background: #0a0a0a;
-  color: #ededed;
+  font-family: var(--font-body, 'DM Sans'), -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+  background: var(--bg);
+  color: var(--text);
 }
 
 a {
@@ -24,7 +34,7 @@ a {
 }
 
 .card {
-  background: #1a1a1a;
+  background: var(--card);
   border-radius: 8px;
   padding: 1.5rem;
   margin-bottom: 1rem;
@@ -87,9 +97,9 @@ a {
   width: 100%;
   padding: 0.75rem;
   border-radius: 6px;
-  border: 1px solid #333;
-  background: #0a0a0a;
-  color: #ededed;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
   font-size: 1rem;
 }
 
@@ -148,7 +158,7 @@ a {
   align-items: center;
   margin-bottom: 2rem;
   padding-bottom: 1rem;
-  border-bottom: 1px solid #333;
+  border-bottom: 1px solid var(--border);
 }
 
 .header h1 {
@@ -166,7 +176,7 @@ a {
   justify-content: space-between;
   align-items: flex-start;
   padding: 1rem;
-  background: #1a1a1a;
+  background: var(--card);
   border-radius: 8px;
   color: inherit;
 }
@@ -186,7 +196,7 @@ a {
 }
 
 .request-info p {
-  color: #9ca3af;
+  color: var(--text-secondary);
   font-size: 0.875rem;
   white-space: nowrap;
   overflow: hidden;
@@ -196,7 +206,7 @@ a {
 .request-info .note {
   margin-top: 0.5rem;
   padding: 0.5rem;
-  background: #0a0a0a;
+  background: var(--bg);
   border-radius: 4px;
   font-style: italic;
 }
@@ -214,7 +224,7 @@ a {
 }
 
 .event-card {
-  background: #1a1a1a;
+  background: var(--card);
   border-radius: 8px;
   padding: 1.5rem;
 }
@@ -250,8 +260,8 @@ a {
   border-radius: 6px;
   cursor: pointer;
   background: transparent;
-  border: 1px solid #333;
-  color: #9ca3af;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
 }
 
 .tab.active {
@@ -265,7 +275,7 @@ a {
   justify-content: center;
   align-items: center;
   height: 200px;
-  color: #9ca3af;
+  color: var(--text-secondary);
 }
 
 /* Scrollable list utility */
@@ -354,7 +364,7 @@ a {
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem;
-  background: #1a1a1a;
+  background: var(--card);
   border-radius: 8px;
 }
 
@@ -379,7 +389,7 @@ a {
 }
 
 .guest-request-item-artist {
-  color: #9ca3af;
+  color: var(--text-secondary);
   font-size: 0.875rem;
   white-space: nowrap;
   overflow: hidden;
@@ -421,7 +431,7 @@ a {
   right: 0;
   padding: 1rem;
   padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
-  background: linear-gradient(transparent, #0a0a0a 30%);
+  background: linear-gradient(transparent, var(--bg) 30%);
   z-index: 10;
 }
 
@@ -468,7 +478,7 @@ a {
 .admin-sidebar {
   width: 220px;
   background: #111;
-  border-right: 1px solid #333;
+  border-right: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
@@ -476,7 +486,7 @@ a {
 
 .admin-sidebar-header {
   padding: 1.5rem;
-  border-bottom: 1px solid #333;
+  border-bottom: 1px solid var(--border);
 }
 
 .admin-sidebar-header h2 {
@@ -494,25 +504,25 @@ a {
 .admin-sidebar-link {
   display: block;
   padding: 0.75rem 1.5rem;
-  color: #9ca3af;
+  color: var(--text-secondary);
   text-decoration: none;
   transition: background 0.2s, color 0.2s;
 }
 
 .admin-sidebar-link:hover {
-  background: #1a1a1a;
-  color: #ededed;
+  background: #222;
+  color: var(--text);
 }
 
 .admin-sidebar-link.active {
-  background: #1a1a1a;
+  background: var(--card);
   color: #3b82f6;
   border-left: 3px solid #3b82f6;
 }
 
 .admin-sidebar-footer {
   padding: 1rem 1.5rem;
-  border-top: 1px solid #333;
+  border-top: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -531,7 +541,7 @@ a {
 }
 
 .stat-card {
-  background: #1a1a1a;
+  background: var(--card);
   border-radius: 8px;
   padding: 1.5rem;
   text-align: center;
@@ -540,12 +550,12 @@ a {
 .stat-value {
   font-size: 2rem;
   font-weight: 700;
-  color: #ededed;
+  color: var(--text);
 }
 
 .stat-label {
   font-size: 0.875rem;
-  color: #9ca3af;
+  color: var(--text-secondary);
   margin-top: 0.25rem;
 }
 
@@ -559,18 +569,18 @@ a {
 .admin-table td {
   padding: 0.75rem 1rem;
   text-align: left;
-  border-bottom: 1px solid #333;
+  border-bottom: 1px solid var(--border);
 }
 
 .admin-table th {
-  color: #9ca3af;
+  color: var(--text-secondary);
   font-size: 0.875rem;
   font-weight: 600;
   text-transform: uppercase;
 }
 
 .admin-table tbody tr:hover {
-  background: #1a1a1a;
+  background: var(--card);
 }
 
 /* Role badges */
@@ -601,7 +611,7 @@ a {
 }
 
 .modal {
-  background: #1a1a1a;
+  background: var(--card);
   border-radius: 8px;
   padding: 2rem;
   width: 100%;
@@ -687,7 +697,7 @@ a {
 
 .badge-status.not-configured {
   background: #374151;
-  color: #9ca3af;
+  color: var(--text-secondary);
 }
 
 .badge-status.not-implemented {
@@ -705,11 +715,11 @@ a {
 .integration-table td {
   padding: 0.75rem 1rem;
   text-align: center;
-  border-bottom: 1px solid #333;
+  border-bottom: 1px solid var(--border);
 }
 
 .integration-table th {
-  color: #9ca3af;
+  color: var(--text-secondary);
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -722,7 +732,7 @@ a {
 }
 
 .integration-table tbody tr:hover {
-  background: #1a1a1a;
+  background: var(--card);
 }
 
 /* Toggle switch */
@@ -769,14 +779,14 @@ a {
   border-radius: 4px;
   border: 1px solid #444;
   background: transparent;
-  color: #9ca3af;
+  color: var(--text-secondary);
   cursor: pointer;
   transition: background 0.2s, color 0.2s;
 }
 
 .btn-check:hover {
   background: #333;
-  color: #ededed;
+  color: var(--text);
 }
 
 .btn-check:disabled {
@@ -795,9 +805,9 @@ a {
   flex: 1;
   padding: 1rem;
   border-radius: 8px;
-  border: 2px solid #333;
-  background: #1a1a1a;
-  color: #9ca3af;
+  border: 2px solid var(--border);
+  background: var(--card);
+  color: var(--text-secondary);
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
@@ -806,13 +816,13 @@ a {
 
 .event-tab:hover {
   border-color: #555;
-  color: #ededed;
+  color: var(--text);
 }
 
 .event-tab.active {
   border-color: #3b82f6;
   background: #1e3a5f;
-  color: #ededed;
+  color: var(--text);
 }
 
 /* Activity log */
@@ -874,7 +884,7 @@ a {
   font-size: 0.75rem;
   font-weight: 500;
   background: #333;
-  color: #9ca3af;
+  color: var(--text-secondary);
   white-space: nowrap;
 }
 
@@ -886,7 +896,7 @@ a {
   .admin-sidebar {
     width: 100%;
     border-right: none;
-    border-bottom: 1px solid #333;
+    border-bottom: 1px solid var(--border);
   }
 
   .admin-sidebar-nav {
@@ -927,8 +937,8 @@ a {
   height: 36px;
   border-radius: 50%;
   border: 2px solid #444;
-  background: #1a1a1a;
-  color: #9ca3af;
+  background: var(--card);
+  color: var(--text-secondary);
   font-size: 1.125rem;
   font-weight: 700;
   cursor: pointer;
@@ -940,7 +950,7 @@ a {
 
 .help-btn:hover {
   border-color: #3b82f6;
-  color: #ededed;
+  color: var(--text);
 }
 
 .help-btn-active {
@@ -992,7 +1002,7 @@ a {
 .help-tooltip-title {
   font-weight: 600;
   font-size: 0.875rem;
-  color: #ededed;
+  color: var(--text);
   margin-bottom: 0.25rem;
 }
 
@@ -1024,7 +1034,7 @@ a {
 .onboarding-card-title {
   font-size: 1rem;
   font-weight: 600;
-  color: #ededed;
+  color: var(--text);
   margin-bottom: 0.375rem;
 }
 
@@ -1039,4 +1049,91 @@ a {
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+/* Theme toggle */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.theme-toggle:hover {
+  border-color: #3b82f6;
+  color: var(--text);
+}
+
+.theme-toggle-icon {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  transition: background 0.2s;
+}
+
+.theme-toggle-icon--dark {
+  background: linear-gradient(135deg, currentColor 50%, transparent 50%);
+}
+
+.theme-toggle-icon--high-contrast {
+  background: currentColor;
+}
+
+.theme-toggle-icon--daylight {
+  background: transparent;
+}
+
+/* Display headings (event names, kiosk titles) */
+h1, .display-heading {
+  font-family: var(--font-display, 'Plus Jakarta Sans'), -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+/* Monospace text (event codes, technical info) */
+.code, code {
+  font-family: var(--font-mono, 'JetBrains Mono'), 'SF Mono', 'Fira Code', monospace;
+}
+
+/* Compact mode — reduces density for more requests visible */
+.compact .request-list {
+  gap: 0.5rem;
+}
+
+.compact .request-item {
+  padding: 0.5rem 0.75rem;
+}
+
+.compact .request-info h3 {
+  font-size: 0.95rem;
+  margin-bottom: 0.125rem;
+}
+
+.compact .request-info p {
+  font-size: 0.8rem;
+}
+
+.compact .request-actions {
+  gap: 0.25rem;
+}
+
+.compact .btn-sm {
+  padding: 0.375rem 0.625rem;
+  font-size: 0.8rem;
+}
+
+.compact .badge {
+  padding: 0.2rem 0.5rem;
+  font-size: 0.675rem;
+}
+
+.compact .scrollable-list {
+  max-height: 900px;
 }

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -1,7 +1,27 @@
 import type { Metadata } from 'next';
+import { DM_Sans, Plus_Jakarta_Sans, JetBrains_Mono } from 'next/font/google';
 import { AuthProvider } from '@/lib/auth';
 import { HelpProvider } from '@/lib/help/HelpContext';
+import { ThemeProvider } from '@/lib/theme';
 import './globals.css';
+
+const dmSans = DM_Sans({
+  subsets: ['latin'],
+  variable: '--font-body',
+  display: 'swap',
+});
+
+const plusJakarta = Plus_Jakarta_Sans({
+  subsets: ['latin'],
+  variable: '--font-display',
+  display: 'swap',
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-mono',
+  display: 'swap',
+});
 
 export const metadata: Metadata = {
   title: 'WrzDJ Dashboard',
@@ -20,11 +40,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${dmSans.variable} ${plusJakarta.variable} ${jetbrainsMono.variable}`}>
       <body>
-        <AuthProvider>
-          <HelpProvider>{children}</HelpProvider>
-        </AuthProvider>
+        <ThemeProvider>
+          <AuthProvider>
+            <HelpProvider>{children}</HelpProvider>
+          </AuthProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/dashboard/components/ThemeToggle.tsx
+++ b/dashboard/components/ThemeToggle.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useTheme, type Theme } from '@/lib/theme';
+
+const THEME_LABELS: Record<Theme, string> = {
+  dark: 'Dark',
+  'high-contrast': 'Hi-Con',
+  daylight: 'Day',
+};
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="theme-toggle"
+      title={`Theme: ${THEME_LABELS[theme]} (click to change)`}
+      aria-label={`Current theme: ${THEME_LABELS[theme]}. Click to change.`}
+    >
+      <span className={`theme-toggle-icon theme-toggle-icon--${theme}`} />
+      <span className="theme-toggle-label">{THEME_LABELS[theme]}</span>
+    </button>
+  );
+}

--- a/dashboard/lib/__tests__/fonts.test.ts
+++ b/dashboard/lib/__tests__/fonts.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { FONT_FAMILIES, getFontClass } from '../fonts';
+
+describe('FONT_FAMILIES', () => {
+  it('defines a body font family', () => {
+    expect(FONT_FAMILIES.body).toBeDefined();
+    expect(typeof FONT_FAMILIES.body).toBe('string');
+    expect(FONT_FAMILIES.body.length).toBeGreaterThan(0);
+  });
+
+  it('defines a display font family for kiosk headings', () => {
+    expect(FONT_FAMILIES.display).toBeDefined();
+    expect(typeof FONT_FAMILIES.display).toBe('string');
+    expect(FONT_FAMILIES.display.length).toBeGreaterThan(0);
+  });
+
+  it('defines a mono font family for numeric badges', () => {
+    expect(FONT_FAMILIES.mono).toBeDefined();
+    expect(typeof FONT_FAMILIES.mono).toBe('string');
+    expect(FONT_FAMILIES.mono.length).toBeGreaterThan(0);
+  });
+
+  it('all font families include a fallback', () => {
+    expect(FONT_FAMILIES.body).toContain('sans-serif');
+    expect(FONT_FAMILIES.display).toContain('sans-serif');
+    expect(FONT_FAMILIES.mono).toContain('monospace');
+  });
+});
+
+describe('getFontClass', () => {
+  it('returns body class for body role', () => {
+    expect(getFontClass('body')).toBe('font-body');
+  });
+
+  it('returns display class for display role', () => {
+    expect(getFontClass('display')).toBe('font-display');
+  });
+
+  it('returns mono class for mono role', () => {
+    expect(getFontClass('mono')).toBe('font-mono');
+  });
+
+  it('returns body class for unknown role', () => {
+    expect(getFontClass('unknown' as 'body')).toBe('font-body');
+  });
+});

--- a/dashboard/lib/__tests__/request-emphasis.test.ts
+++ b/dashboard/lib/__tests__/request-emphasis.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { getRequestEmphasisStyle, getRequestEmphasisClass } from '../request-emphasis';
+
+describe('getRequestEmphasisStyle', () => {
+  describe('new status', () => {
+    it('returns blue left border and background tint', () => {
+      const result = getRequestEmphasisStyle('new');
+      expect(result.borderLeft).toBe('4px solid #3b82f6');
+      expect(result.background).toBe('rgba(59, 130, 246, 0.05)');
+    });
+  });
+
+  describe('accepted status', () => {
+    it('returns purple left border and no background change', () => {
+      const result = getRequestEmphasisStyle('accepted');
+      expect(result.borderLeft).toBe('4px solid #8b5cf6');
+      expect(result.background).toBeUndefined();
+    });
+  });
+
+  describe('playing status', () => {
+    it('returns green left border and no background change', () => {
+      const result = getRequestEmphasisStyle('playing');
+      expect(result.borderLeft).toBe('4px solid #22c55e');
+      expect(result.background).toBeUndefined();
+    });
+  });
+
+  describe('other statuses', () => {
+    it('returns empty object for rejected status', () => {
+      expect(getRequestEmphasisStyle('rejected')).toEqual({});
+    });
+
+    it('returns empty object for played status', () => {
+      expect(getRequestEmphasisStyle('played')).toEqual({});
+    });
+
+    it('returns empty object for unknown status', () => {
+      expect(getRequestEmphasisStyle('unknown')).toEqual({});
+    });
+
+    it('returns empty object for empty string', () => {
+      expect(getRequestEmphasisStyle('')).toEqual({});
+    });
+  });
+
+  describe('return shape', () => {
+    it('new status has exactly borderLeft and background', () => {
+      const result = getRequestEmphasisStyle('new');
+      expect(Object.keys(result)).toHaveLength(2);
+    });
+
+    it('accepted status returns only borderLeft', () => {
+      const result = getRequestEmphasisStyle('accepted');
+      expect(Object.keys(result)).toHaveLength(1);
+      expect(result).toHaveProperty('borderLeft');
+    });
+
+    it('playing status returns only borderLeft', () => {
+      const result = getRequestEmphasisStyle('playing');
+      expect(Object.keys(result)).toHaveLength(1);
+    });
+  });
+});
+
+describe('getRequestEmphasisClass', () => {
+  it('returns request-new for new status', () => {
+    expect(getRequestEmphasisClass('new')).toBe('request-new');
+  });
+
+  it('returns request-accepted for accepted status', () => {
+    expect(getRequestEmphasisClass('accepted')).toBe('request-accepted');
+  });
+
+  it('returns request-playing for playing status', () => {
+    expect(getRequestEmphasisClass('playing')).toBe('request-playing');
+  });
+
+  it('returns empty string for rejected status', () => {
+    expect(getRequestEmphasisClass('rejected')).toBe('');
+  });
+
+  it('returns empty string for played status', () => {
+    expect(getRequestEmphasisClass('played')).toBe('');
+  });
+
+  it('returns empty string for empty string', () => {
+    expect(getRequestEmphasisClass('')).toBe('');
+  });
+});

--- a/dashboard/lib/__tests__/tab-title-hook.test.tsx
+++ b/dashboard/lib/__tests__/tab-title-hook.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useTabTitle } from '../tab-title';
+
+describe('useTabTitle', () => {
+  const originalTitle = document.title;
+
+  afterEach(() => {
+    document.title = originalTitle;
+  });
+
+  it('sets document.title when rendered with event name and count', () => {
+    renderHook(() => useTabTitle('My Event', 3));
+    expect(document.title).toBe('(3) My Event - WrzDJ');
+  });
+
+  it('sets title without badge when count is 0', () => {
+    renderHook(() => useTabTitle('My Event', 0));
+    expect(document.title).toBe('My Event - WrzDJ');
+  });
+
+  it('updates title when count changes', () => {
+    const { rerender } = renderHook(
+      ({ name, count }) => useTabTitle(name, count),
+      { initialProps: { name: 'My Event', count: 1 } }
+    );
+    expect(document.title).toBe('(1) My Event - WrzDJ');
+
+    rerender({ name: 'My Event', count: 5 });
+    expect(document.title).toBe('(5) My Event - WrzDJ');
+  });
+
+  it('resets title on unmount', () => {
+    const { unmount } = renderHook(() => useTabTitle('My Event', 2));
+    expect(document.title).toBe('(2) My Event - WrzDJ');
+
+    unmount();
+    expect(document.title).toBe('WrzDJ Dashboard');
+  });
+
+  it('does not set title when eventName is null', () => {
+    document.title = 'Original Title';
+    renderHook(() => useTabTitle(null, 5));
+    expect(document.title).toBe('Original Title');
+  });
+});

--- a/dashboard/lib/__tests__/tab-title.test.ts
+++ b/dashboard/lib/__tests__/tab-title.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { formatTabTitle } from '../tab-title';
+
+describe('formatTabTitle', () => {
+  describe('with positive newCount', () => {
+    it('returns "(3) My Event - WrzDJ" for count 3', () => {
+      expect(formatTabTitle('My Event', 3)).toBe('(3) My Event - WrzDJ');
+    });
+
+    it('returns "(1) Friday Night - WrzDJ" for count 1', () => {
+      expect(formatTabTitle('Friday Night', 1)).toBe('(1) Friday Night - WrzDJ');
+    });
+
+    it('handles large counts', () => {
+      expect(formatTabTitle('Club Session', 99)).toBe('(99) Club Session - WrzDJ');
+    });
+  });
+
+  describe('with zero newCount', () => {
+    it('returns "My Event - WrzDJ" for count 0', () => {
+      expect(formatTabTitle('My Event', 0)).toBe('My Event - WrzDJ');
+    });
+  });
+
+  describe('name truncation', () => {
+    it('does not truncate names at exactly 30 characters', () => {
+      const name30 = 'A'.repeat(30);
+      expect(formatTabTitle(name30, 1)).toBe(`(1) ${name30} - WrzDJ`);
+    });
+
+    it('truncates names longer than 30 characters with "..."', () => {
+      const longName = 'A Really Long Event Name That Exceeds Thirty Characters';
+      const truncated = longName.slice(0, 30) + '...';
+      expect(formatTabTitle(longName, 1)).toBe(`(1) ${truncated} - WrzDJ`);
+    });
+
+    it('truncates long name with zero count', () => {
+      const longName = 'A Really Long Event Name That Exceeds Thirty Characters';
+      const truncated = longName.slice(0, 30) + '...';
+      expect(formatTabTitle(longName, 0)).toBe(`${truncated} - WrzDJ`);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty string name', () => {
+      expect(formatTabTitle('', 0)).toBe(' - WrzDJ');
+    });
+
+    it('handles empty string name with positive count', () => {
+      expect(formatTabTitle('', 5)).toBe('(5)  - WrzDJ');
+    });
+
+    it('treats negative count as 0', () => {
+      expect(formatTabTitle('My Event', -1)).toBe('My Event - WrzDJ');
+    });
+  });
+});

--- a/dashboard/lib/__tests__/theme-vars.test.ts
+++ b/dashboard/lib/__tests__/theme-vars.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { getThemeVars, THEMES, type Theme } from '../theme-vars';
+
+const CSS_COLOR_RE = /^#[0-9a-fA-F]{3,8}$/;
+
+describe('getThemeVars', () => {
+  describe('returns correct variable maps for each theme', () => {
+    it('returns dark theme variables with expected values', () => {
+      const vars = getThemeVars('dark');
+      expect(vars['--bg']).toBe('#0a0a0a');
+      expect(vars['--card']).toBe('#1a1a1a');
+      expect(vars['--text']).toBe('#ededed');
+      expect(vars['--text-secondary']).toBe('#9ca3af');
+      expect(vars['--text-tertiary']).toBe('#6b7280');
+    });
+
+    it('returns high-contrast theme variables with boosted contrast', () => {
+      const vars = getThemeVars('high-contrast');
+      expect(vars['--bg']).toBe('#000000');
+      expect(vars['--card']).toBe('#1a1a1a');
+      expect(vars['--text']).toBe('#ffffff');
+      expect(vars['--text-secondary']).toBe('#d1d5db');
+      expect(vars['--text-tertiary']).toBe('#9ca3af');
+      expect(vars['--border']).toBe('#555555');
+    });
+
+    it('returns daylight theme variables with bright dark values', () => {
+      const vars = getThemeVars('daylight');
+      expect(vars['--bg']).toBe('#1a1a1a');
+      expect(vars['--card']).toBe('#262626');
+      expect(vars['--text']).toBe('#ffffff');
+      expect(vars['--text-secondary']).toBe('#d1d5db');
+      expect(vars['--text-tertiary']).toBe('#9ca3af');
+      expect(vars['--border']).toBe('#444444');
+    });
+  });
+
+  describe('variable keys consistency', () => {
+    it('all three themes have the same set of keys', () => {
+      const darkKeys = Object.keys(getThemeVars('dark')).sort();
+      const highContrastKeys = Object.keys(getThemeVars('high-contrast')).sort();
+      const daylightKeys = Object.keys(getThemeVars('daylight')).sort();
+
+      expect(darkKeys).toEqual(highContrastKeys);
+      expect(darkKeys).toEqual(daylightKeys);
+    });
+
+    it('every theme includes the core variable keys', () => {
+      const coreKeys = ['--bg', '--card', '--text', '--text-secondary', '--text-tertiary', '--border'];
+      for (const theme of THEMES) {
+        const vars = getThemeVars(theme);
+        for (const key of coreKeys) {
+          expect(vars).toHaveProperty(key);
+        }
+      }
+    });
+  });
+
+  describe('variable values are valid CSS colors', () => {
+    for (const theme of ['dark', 'high-contrast', 'daylight'] as Theme[]) {
+      it(`all values in ${theme} theme are valid CSS color strings`, () => {
+        const vars = getThemeVars(theme);
+        for (const [key, value] of Object.entries(vars)) {
+          expect(value, `${theme} theme ${key}`).toMatch(CSS_COLOR_RE);
+        }
+      });
+    }
+  });
+
+  describe('THEMES constant', () => {
+    it('contains exactly three themes in order', () => {
+      expect(THEMES).toEqual(['dark', 'high-contrast', 'daylight']);
+    });
+  });
+});

--- a/dashboard/lib/__tests__/theme.test.tsx
+++ b/dashboard/lib/__tests__/theme.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { ThemeProvider, useTheme } from '../theme';
+
+// Test component that exposes theme context values
+function ThemeConsumer() {
+  const { theme, setTheme, toggleTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <button data-testid="toggle" onClick={toggleTheme}>Toggle</button>
+      <button data-testid="set-daylight" onClick={() => setTheme('daylight')}>Daylight</button>
+      <button data-testid="set-hc" onClick={() => setTheme('high-contrast')}>HC</button>
+    </div>
+  );
+}
+
+function renderWithProvider() {
+  return render(
+    <ThemeProvider>
+      <ThemeConsumer />
+    </ThemeProvider>
+  );
+}
+
+// Helper to create a matchMedia mock
+function createMatchMedia(contrastMore = false) {
+  return (query: string): MediaQueryList => ({
+    matches: contrastMore && query === '(prefers-contrast: more)',
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  });
+}
+
+// Simple in-memory localStorage replacement for tests
+function createMockStorage(): Storage {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+    get length() { return Object.keys(store).length; },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    _store: store,
+  } as Storage & { _store: Record<string, string> };
+}
+
+describe('ThemeProvider', () => {
+  const originalMatchMedia = window.matchMedia;
+  const originalLocalStorage = window.localStorage;
+  let mockStorage: ReturnType<typeof createMockStorage>;
+
+  beforeEach(() => {
+    mockStorage = createMockStorage();
+    Object.defineProperty(window, 'localStorage', { value: mockStorage, writable: true, configurable: true });
+
+    // Default: no prefers-contrast
+    window.matchMedia = createMatchMedia(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.matchMedia = originalMatchMedia;
+    Object.defineProperty(window, 'localStorage', { value: originalLocalStorage, writable: true });
+    document.documentElement.removeAttribute('data-theme');
+    for (const prop of ['--bg', '--card', '--text', '--text-secondary', '--text-tertiary', '--border']) {
+      document.documentElement.style.removeProperty(prop);
+    }
+  });
+
+  it('defaults to dark theme when no localStorage and no prefers-contrast', () => {
+    renderWithProvider();
+    expect(screen.getByTestId('theme').textContent).toBe('dark');
+  });
+
+  it('reads saved theme from localStorage', () => {
+    localStorage.setItem('wrzdj-theme', 'daylight');
+    renderWithProvider();
+    expect(screen.getByTestId('theme').textContent).toBe('daylight');
+  });
+
+  it('auto-detects prefers-contrast: more on first load', () => {
+    window.matchMedia = createMatchMedia(true);
+    renderWithProvider();
+    expect(screen.getByTestId('theme').textContent).toBe('high-contrast');
+  });
+
+  it('prefers localStorage over prefers-contrast detection', () => {
+    localStorage.setItem('wrzdj-theme', 'daylight');
+    window.matchMedia = createMatchMedia(true);
+    renderWithProvider();
+    expect(screen.getByTestId('theme').textContent).toBe('daylight');
+  });
+
+  it('setTheme updates theme and persists to localStorage', () => {
+    renderWithProvider();
+    act(() => {
+      screen.getByTestId('set-daylight').click();
+    });
+    expect(screen.getByTestId('theme').textContent).toBe('daylight');
+    expect(localStorage.getItem('wrzdj-theme')).toBe('daylight');
+  });
+
+  it('toggleTheme cycles dark -> high-contrast -> daylight -> dark', () => {
+    renderWithProvider();
+    expect(screen.getByTestId('theme').textContent).toBe('dark');
+
+    act(() => { screen.getByTestId('toggle').click(); });
+    expect(screen.getByTestId('theme').textContent).toBe('high-contrast');
+
+    act(() => { screen.getByTestId('toggle').click(); });
+    expect(screen.getByTestId('theme').textContent).toBe('daylight');
+
+    act(() => { screen.getByTestId('toggle').click(); });
+    expect(screen.getByTestId('theme').textContent).toBe('dark');
+  });
+
+  it('sets data-theme attribute on documentElement', () => {
+    renderWithProvider();
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+    act(() => { screen.getByTestId('set-hc').click(); });
+    expect(document.documentElement.getAttribute('data-theme')).toBe('high-contrast');
+  });
+
+  it('ignores invalid saved theme values', () => {
+    localStorage.setItem('wrzdj-theme', 'invalid-theme');
+    renderWithProvider();
+    expect(screen.getByTestId('theme').textContent).toBe('dark');
+  });
+});

--- a/dashboard/lib/__tests__/vote-heat.test.ts
+++ b/dashboard/lib/__tests__/vote-heat.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { getVoteHeatStyle, getVoteHeatClass } from '../vote-heat';
+
+describe('getVoteHeatStyle', () => {
+  describe('0 votes (no styling)', () => {
+    it('returns empty object for 0 votes', () => {
+      const result = getVoteHeatStyle(0);
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('1-2 votes (subtle warm tint)', () => {
+    it('returns subtle warm background for 1 vote', () => {
+      const result = getVoteHeatStyle(1);
+      expect(result.background).toBe('rgba(251, 191, 36, 0.04)');
+      expect(result.borderColor).toBeUndefined();
+    });
+
+    it('returns subtle warm background for 2 votes', () => {
+      const result = getVoteHeatStyle(2);
+      expect(result.background).toBe('rgba(251, 191, 36, 0.04)');
+      expect(result.borderColor).toBeUndefined();
+    });
+  });
+
+  describe('3-4 votes (warmer tint with subtle border)', () => {
+    it('returns warmer background and subtle border for 3 votes', () => {
+      const result = getVoteHeatStyle(3);
+      expect(result.background).toBe('rgba(251, 191, 36, 0.08)');
+      expect(result.borderColor).toBe('#f59e0b33');
+    });
+
+    it('returns warmer background and subtle border for 4 votes', () => {
+      const result = getVoteHeatStyle(4);
+      expect(result.background).toBe('rgba(251, 191, 36, 0.08)');
+      expect(result.borderColor).toBe('#f59e0b33');
+    });
+  });
+
+  describe('5-9 votes (warm glow)', () => {
+    it('returns warm glow for 5 votes', () => {
+      const result = getVoteHeatStyle(5);
+      expect(result.background).toBe('rgba(251, 191, 36, 0.12)');
+      expect(result.borderColor).toBe('#f59e0b66');
+    });
+
+    it('returns warm glow for 9 votes', () => {
+      const result = getVoteHeatStyle(9);
+      expect(result.background).toBe('rgba(251, 191, 36, 0.12)');
+      expect(result.borderColor).toBe('#f59e0b66');
+    });
+  });
+
+  describe('10+ votes (hot glow)', () => {
+    it('returns hot glow for 10 votes', () => {
+      const result = getVoteHeatStyle(10);
+      expect(result.background).toBe('rgba(251, 191, 36, 0.18)');
+      expect(result.borderColor).toBe('#f59e0b');
+    });
+
+    it('returns hot glow for 100 votes', () => {
+      const result = getVoteHeatStyle(100);
+      expect(result.background).toBe('rgba(251, 191, 36, 0.18)');
+      expect(result.borderColor).toBe('#f59e0b');
+    });
+  });
+
+  describe('boundary values', () => {
+    it('boundary: 0 returns empty', () => {
+      expect(getVoteHeatStyle(0)).toEqual({});
+    });
+
+    it('boundary: 1 enters low bracket', () => {
+      expect(getVoteHeatStyle(1).background).toBe('rgba(251, 191, 36, 0.04)');
+    });
+
+    it('boundary: 3 enters med bracket', () => {
+      expect(getVoteHeatStyle(3).background).toBe('rgba(251, 191, 36, 0.08)');
+    });
+
+    it('boundary: 5 enters high bracket', () => {
+      expect(getVoteHeatStyle(5).background).toBe('rgba(251, 191, 36, 0.12)');
+    });
+
+    it('boundary: 10 enters hot bracket', () => {
+      expect(getVoteHeatStyle(10).background).toBe('rgba(251, 191, 36, 0.18)');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('negative vote count returns empty object', () => {
+      expect(getVoteHeatStyle(-1)).toEqual({});
+    });
+
+    it('very large vote count stays in hot bracket', () => {
+      expect(getVoteHeatStyle(10000)).toEqual({
+        background: 'rgba(251, 191, 36, 0.18)',
+        borderColor: '#f59e0b',
+      });
+    });
+  });
+});
+
+describe('getVoteHeatClass', () => {
+  it('returns vote-heat-0 for 0 votes', () => {
+    expect(getVoteHeatClass(0)).toBe('vote-heat-0');
+  });
+
+  it('returns vote-heat-low for 1-2 votes', () => {
+    expect(getVoteHeatClass(1)).toBe('vote-heat-low');
+    expect(getVoteHeatClass(2)).toBe('vote-heat-low');
+  });
+
+  it('returns vote-heat-med for 3-4 votes', () => {
+    expect(getVoteHeatClass(3)).toBe('vote-heat-med');
+    expect(getVoteHeatClass(4)).toBe('vote-heat-med');
+  });
+
+  it('returns vote-heat-high for 5-9 votes', () => {
+    expect(getVoteHeatClass(5)).toBe('vote-heat-high');
+    expect(getVoteHeatClass(9)).toBe('vote-heat-high');
+  });
+
+  it('returns vote-heat-hot for 10+ votes', () => {
+    expect(getVoteHeatClass(10)).toBe('vote-heat-hot');
+    expect(getVoteHeatClass(100)).toBe('vote-heat-hot');
+  });
+
+  it('returns vote-heat-0 for negative count', () => {
+    expect(getVoteHeatClass(-5)).toBe('vote-heat-0');
+  });
+});

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -367,6 +367,15 @@ class ApiClient {
     return this.fetch(`/api/requests/${requestId}/vote`, { method: 'DELETE' });
   }
 
+  async publicVoteRequest(requestId: number): Promise<VoteResponse> {
+    const response = await fetch(`${getApiUrl()}/api/requests/${requestId}/vote`, { method: 'POST' });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ detail: 'Vote failed' }));
+      throw new ApiError(error.detail || 'Vote failed', response.status);
+    }
+    return response.json();
+  }
+
   async getArchivedEvents(): Promise<ArchivedEvent[]> {
     return this.fetch('/api/events/archived');
   }

--- a/dashboard/lib/fonts.ts
+++ b/dashboard/lib/fonts.ts
@@ -1,0 +1,29 @@
+/**
+ * Font family definitions for WrzDJ dashboard.
+ *
+ * - body:    Condensed sans-serif for the DJ dashboard (more text fits before truncation)
+ * - display: Bold display font for kiosk headings (readable at distance)
+ * - mono:    Tabular-figures monospace for BPM/key badges (numbers align vertically)
+ *
+ * Actual font loading happens in app/layout.tsx via next/font/google.
+ * These CSS variables and class names are referenced throughout the app.
+ */
+
+export type FontRole = 'body' | 'display' | 'mono';
+
+export const FONT_FAMILIES: Record<FontRole, string> = {
+  body: 'var(--font-body), "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  display:
+    'var(--font-display), "Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  mono: 'var(--font-mono), "JetBrains Mono", "SF Mono", "Fira Code", monospace',
+};
+
+const CLASS_MAP: Record<string, string> = {
+  body: 'font-body',
+  display: 'font-display',
+  mono: 'font-mono',
+};
+
+export function getFontClass(role: FontRole): string {
+  return CLASS_MAP[role] ?? 'font-body';
+}

--- a/dashboard/lib/request-emphasis.ts
+++ b/dashboard/lib/request-emphasis.ts
@@ -1,0 +1,27 @@
+/**
+ * Computes visual emphasis for request items based on their status.
+ * NEW requests get a prominent blue accent, ACCEPTED gets purple, PLAYING gets green.
+ * This helps DJs instantly distinguish request states while scanning the queue.
+ */
+
+import type { CSSProperties } from 'react';
+
+const EMPHASIS_MAP: Record<string, CSSProperties> = {
+  new: { borderLeft: '4px solid #3b82f6', background: 'rgba(59, 130, 246, 0.05)' },
+  accepted: { borderLeft: '4px solid #8b5cf6' },
+  playing: { borderLeft: '4px solid #22c55e' },
+};
+
+const CLASS_MAP: Record<string, string> = {
+  new: 'request-new',
+  accepted: 'request-accepted',
+  playing: 'request-playing',
+};
+
+export function getRequestEmphasisStyle(status: string): CSSProperties {
+  return { ...(EMPHASIS_MAP[status] ?? {}) };
+}
+
+export function getRequestEmphasisClass(status: string): string {
+  return CLASS_MAP[status] ?? '';
+}

--- a/dashboard/lib/tab-title.ts
+++ b/dashboard/lib/tab-title.ts
@@ -1,0 +1,32 @@
+/**
+ * Tab title badge utility.
+ * Shows unread NEW request count in the browser tab: "(3) Event Name - WrzDJ"
+ * Helps DJs see new requests even when the tab is backgrounded behind DJ software.
+ */
+
+import { useEffect } from 'react';
+
+const MAX_NAME_LENGTH = 30;
+const DEFAULT_TITLE = 'WrzDJ Dashboard';
+
+export function formatTabTitle(eventName: string, newCount: number): string {
+  const count = Math.max(0, newCount);
+  const name =
+    eventName.length > MAX_NAME_LENGTH
+      ? eventName.slice(0, MAX_NAME_LENGTH) + '...'
+      : eventName;
+
+  return count > 0 ? `(${count}) ${name} - WrzDJ` : `${name} - WrzDJ`;
+}
+
+export function useTabTitle(eventName: string | null, newRequestCount: number): void {
+  useEffect(() => {
+    if (eventName === null) return;
+
+    document.title = formatTabTitle(eventName, newRequestCount);
+
+    return () => {
+      document.title = DEFAULT_TITLE;
+    };
+  }, [eventName, newRequestCount]);
+}

--- a/dashboard/lib/theme-vars.ts
+++ b/dashboard/lib/theme-vars.ts
@@ -1,0 +1,42 @@
+/**
+ * CSS variable maps for each theme.
+ *
+ * - dark:          Current default (pure dark, standard contrast)
+ * - high-contrast: Boosted contrast for bright environments or accessibility
+ * - daylight:      Bright dark mode for outdoor/daylight gigs
+ */
+
+export type Theme = 'dark' | 'high-contrast' | 'daylight';
+
+export const THEMES: readonly Theme[] = ['dark', 'high-contrast', 'daylight'] as const;
+
+const THEME_VARS: Record<Theme, Record<string, string>> = {
+  dark: {
+    '--bg': '#0a0a0a',
+    '--card': '#1a1a1a',
+    '--text': '#ededed',
+    '--text-secondary': '#9ca3af',
+    '--text-tertiary': '#6b7280',
+    '--border': '#333333',
+  },
+  'high-contrast': {
+    '--bg': '#000000',
+    '--card': '#1a1a1a',
+    '--text': '#ffffff',
+    '--text-secondary': '#d1d5db',
+    '--text-tertiary': '#9ca3af',
+    '--border': '#555555',
+  },
+  daylight: {
+    '--bg': '#1a1a1a',
+    '--card': '#262626',
+    '--text': '#ffffff',
+    '--text-secondary': '#d1d5db',
+    '--text-tertiary': '#9ca3af',
+    '--border': '#444444',
+  },
+};
+
+export function getThemeVars(theme: Theme): Record<string, string> {
+  return { ...THEME_VARS[theme] };
+}

--- a/dashboard/lib/theme.tsx
+++ b/dashboard/lib/theme.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+/**
+ * Theme provider for WrzDJ dashboard.
+ * Supports three themes: dark (default), high-contrast, daylight.
+ * Persists choice to localStorage and sets data-theme attribute on <html>.
+ * Auto-detects prefers-contrast: more on first load when no saved preference.
+ */
+
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
+import { THEMES, getThemeVars, type Theme } from './theme-vars';
+
+export type { Theme };
+
+const STORAGE_KEY = 'wrzdj-theme';
+
+interface ThemeContextType {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | null>(null);
+
+function isValidTheme(value: string | null): value is Theme {
+  return value !== null && (THEMES as readonly string[]).includes(value);
+}
+
+function detectInitialTheme(): Theme {
+  // 1. Check localStorage
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (isValidTheme(saved)) return saved;
+  } catch {
+    // localStorage unavailable (SSR, privacy mode)
+  }
+
+  // 2. Auto-detect prefers-contrast
+  if (typeof window !== 'undefined' && window.matchMedia('(prefers-contrast: more)').matches) {
+    return 'high-contrast';
+  }
+
+  return 'dark';
+}
+
+function applyTheme(theme: Theme): void {
+  // Set data-theme attribute
+  document.documentElement.setAttribute('data-theme', theme);
+
+  // Apply CSS variables
+  const vars = getThemeVars(theme);
+  for (const [key, value] of Object.entries(vars)) {
+    document.documentElement.style.setProperty(key, value);
+  }
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(detectInitialTheme);
+
+  const setTheme = useCallback((newTheme: Theme) => {
+    setThemeState(newTheme);
+    try {
+      localStorage.setItem(STORAGE_KEY, newTheme);
+    } catch {
+      // localStorage unavailable
+    }
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((current) => {
+      const currentIndex = THEMES.indexOf(current);
+      const next = THEMES[(currentIndex + 1) % THEMES.length];
+      try {
+        localStorage.setItem(STORAGE_KEY, next);
+      } catch {
+        // localStorage unavailable
+      }
+      return next;
+    });
+  }, []);
+
+  // Apply theme to DOM whenever it changes
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextType {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return ctx;
+}

--- a/dashboard/lib/vote-heat.ts
+++ b/dashboard/lib/vote-heat.ts
@@ -1,0 +1,28 @@
+/**
+ * Computes visual "heat" styling for request cards based on vote count.
+ * Higher vote counts produce warmer background tints and border accents,
+ * helping DJs instantly spot crowd favorites.
+ */
+
+interface VoteHeatStyle {
+  background?: string;
+  borderColor?: string;
+}
+
+export function getVoteHeatStyle(voteCount: number): VoteHeatStyle {
+  if (voteCount <= 0) return {};
+  if (voteCount <= 2) return { background: 'rgba(251, 191, 36, 0.04)' };
+  if (voteCount <= 4)
+    return { background: 'rgba(251, 191, 36, 0.08)', borderColor: '#f59e0b33' };
+  if (voteCount <= 9)
+    return { background: 'rgba(251, 191, 36, 0.12)', borderColor: '#f59e0b66' };
+  return { background: 'rgba(251, 191, 36, 0.18)', borderColor: '#f59e0b' };
+}
+
+export function getVoteHeatClass(voteCount: number): string {
+  if (voteCount <= 0) return 'vote-heat-0';
+  if (voteCount <= 2) return 'vote-heat-low';
+  if (voteCount <= 4) return 'vote-heat-med';
+  if (voteCount <= 9) return 'vote-heat-high';
+  return 'vote-heat-hot';
+}


### PR DESCRIPTION
## Summary

- **Theme system**: Dark / high-contrast / daylight modes with CSS variable architecture, localStorage persistence, and `prefers-contrast` auto-detection
- **Visual emphasis**: Status-based left border accents (blue=new, purple=accepted, green=playing) and vote heat-map background tinting (5 brackets from subtle to hot)
- **Custom typography**: DM Sans (body), Plus Jakarta Sans (display headings), JetBrains Mono (mono) via `next/font/google` with CSS variable integration
- **Compact mode**: Toggle for DJ dashboard — reduces padding, font sizes, and gaps for dense queue scanning
- **Tab title badge**: Shows `(N) Event Name - WrzDJ` when new requests arrive, updates in real-time
- **Kiosk readability**: Bumped font sizes across now-playing, queue, and history sections for distance viewing
- **Guest voting UX**: Interactive vote buttons on join page with rate-limit handling and voted-state feedback
- **Color system migration**: All hardcoded hex colors in globals.css migrated to CSS custom properties (`--bg`, `--card`, `--text`, `--text-secondary`, `--text-tertiary`, `--border`)
- **87 new tests** (452 total) covering all new utilities, theme provider, and hooks

## Test plan

- [x] All 452 vitest tests pass
- [x] TypeScript strict mode clean (`tsc --noEmit`)
- [x] ESLint clean
- [x] Manual: Toggle theme between dark/high-contrast/daylight — verify all pages update
- [x] Manual: Submit requests and verify blue emphasis on NEW, purple on accepted, green on playing
- [x] Manual: Upvote requests and verify heat-map gradient at 1-2, 3-4, 5-9, 10+ votes
- [x] Manual: Enable compact mode — verify reduced spacing in DJ dashboard
- [x] Manual: Open kiosk display — verify larger fonts readable from distance
- [x] Manual: Vote on join page — verify button states and rate limit handling
- [x] Manual: Check tab title updates with new request count badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)