### PR TITLE
fix: add x64 architecture override to winget manifest update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
           Write-Host "Tag $tag -> semver $version"
           $url = "https://github.com/thewrz/WrzDJ/releases/download/${{ github.ref_name }}/WrzDJ-Bridge.exe"
           .\wingetcreate.exe update WrzDJ.WrzDJ-Bridge `
-            --urls $url `
+            --urls "$url|x64" `
             --version $version `
             --token ${{ secrets.WINGET_PAT }} `
             --submit


### PR DESCRIPTION
## Summary
- Squirrel.Windows bootstrapper `.exe` is 32-bit, causing `wingetcreate` to auto-detect it as X86
- This fails to match the existing x64 manifest entry, breaking the winget update job
- Added `|x64` URL suffix to force correct architecture detection

## Test plan
- [x] Verified existing winget manifest has `Architecture: x64`
- [ ] Re-tag after merge to trigger release and verify winget job passes