### PR TITLE
refactor: extract helpers and fix response_model types in events API

### DIFF
--- a/server/tests/test_bridge_api.py
+++ b/server/tests/test_bridge_api.py
@@ -424,10 +424,13 @@ class TestGetPublicHistory:
         assert len(data["items"]) == 3
 
     def test_limit_capped(self, client: TestClient, test_event: Event):
-        """Limit is capped at 100."""
+        """Limit is capped at 100 via Query validation."""
         response = client.get("/api/public/e/TEST01/history?limit=200")
+        assert response.status_code == 422  # FastAPI rejects limit > 100
+
+        # Valid limit at the boundary works
+        response = client.get("/api/public/e/TEST01/history?limit=100")
         assert response.status_code == 200
-        # Just verify it doesn't error - the cap is internal
 
     def test_event_not_found(self, client: TestClient):
         """Returns 404 for non-existent event."""


### PR DESCRIPTION
## Summary
- Extract `_request_to_out()` helper to eliminate duplicated `RequestOut` construction (used in `submit_request` and `get_event_requests`)
- Extract `_build_recommendation_response()` helper to deduplicate profile/suggestion building across 3 recommendation endpoints (`get_recommendations`, `get_recommendations_from_template`, `get_llm_recommendations`)
- Add proper `response_model` annotations to all 3 recommendation endpoints
- Fix `get_activity_log` response_model from bare `list` to `list[ActivityLogEntry]`
- Replace manual limit/offset clamping in `get_public_history` with `Query(ge=, le=)` for automatic 422 on invalid values
- Add FIXME comment on per-process LLM rate limit cache drift in multi-worker deployments

## Test plan
- [x] All 1316 existing tests pass
- [x] Updated `test_limit_capped` to expect 422 for `limit=200` (was 200 OK with silent clamping)
- [x] ruff check + format + bandit all pass