### PR TITLE
refactor: consolidate ownership guards into reusable dependencies

### DIFF
--- a/server/tests/test_beatport_manual_link.py
+++ b/server/tests/test_beatport_manual_link.py
@@ -109,7 +109,7 @@ def test_link_endpoint_request_not_found(client, auth_headers, db):
 
 
 def test_link_endpoint_not_authorized(client, auth_headers, test_event, test_request, db):
-    """Link endpoint returns 403 for requests not owned by user."""
+    """Link endpoint returns 404 for requests not owned by user (avoids leaking existence)."""
     # Create another user
     from app.models.user import User
 
@@ -130,7 +130,7 @@ def test_link_endpoint_not_authorized(client, auth_headers, test_event, test_req
         json={"beatport_track_id": "12345"},
         headers=auth_headers,
     )
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
 def test_link_endpoint_no_beatport_account(client, auth_headers, test_request):


### PR DESCRIPTION
## Summary
- Add `get_owned_event_by_id(event_id)` dependency to `deps.py` for event-by-ID ownership checks
- Add `get_owned_request(request_id)` dependency for request ownership checks (validates via parent event)
- Replace 4 inline ownership checks in `tidal.py` (get/update event settings, sync request, link track)
- Replace 3 inline ownership checks in `beatport.py` (get/update event settings, link track)
- **Security improvement**: return 404 instead of 403 on ownership mismatch to avoid leaking resource existence

## Test plan
- [x] All 1316 existing tests pass
- [x] Updated `test_link_endpoint_not_authorized` to expect 404 (was 403)
- [x] ruff check + format + bandit all pass