### PR TITLE
refactor: decompose oversized dashboard pages and fix Tidal polling leak

### DIFF
--- a/dashboard/app/e/[code]/display/components/RequestModal.tsx
+++ b/dashboard/app/e/[code]/display/components/RequestModal.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { api, ApiError, SearchResult } from '@/lib/api';
+
+const INACTIVITY_TIMEOUT = 60000; // 60 seconds
+
+interface RequestModalProps {
+  code: string;
+  onClose: () => void;
+  onRequestsClosed: () => void;
+}
+
+export function RequestModal({ code, onClose, onRequestsClosed }: RequestModalProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [selectedSong, setSelectedSong] = useState<SearchResult | null>(null);
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [submitIsDuplicate, setSubmitIsDuplicate] = useState(false);
+  const [submitVoteCount, setSubmitVoteCount] = useState(0);
+
+  const inactivityTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const closeModal = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  // Inactivity timeout
+  const resetInactivityTimer = useCallback(() => {
+    if (inactivityTimerRef.current) {
+      clearTimeout(inactivityTimerRef.current);
+    }
+    inactivityTimerRef.current = setTimeout(() => {
+      closeModal();
+    }, INACTIVITY_TIMEOUT);
+  }, [closeModal]);
+
+  useEffect(() => {
+    resetInactivityTimer();
+
+    const handleActivity = () => resetInactivityTimer();
+    window.addEventListener('touchstart', handleActivity);
+    window.addEventListener('pointerdown', handleActivity);
+    window.addEventListener('pointermove', handleActivity);
+    window.addEventListener('keydown', handleActivity);
+    return () => {
+      window.removeEventListener('touchstart', handleActivity);
+      window.removeEventListener('pointerdown', handleActivity);
+      window.removeEventListener('pointermove', handleActivity);
+      window.removeEventListener('keydown', handleActivity);
+      if (inactivityTimerRef.current) {
+        clearTimeout(inactivityTimerRef.current);
+      }
+    };
+  }, [resetInactivityTimer]);
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!searchQuery.trim()) return;
+
+    setSearching(true);
+    setSearchResults([]);
+    try {
+      const results = await api.search(searchQuery);
+      setSearchResults(results);
+    } catch {
+      setSearchResults([]);
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!selectedSong) return;
+
+    setSubmitting(true);
+    try {
+      const result = await api.submitRequest(
+        code,
+        selectedSong.artist,
+        selectedSong.title,
+        note || undefined,
+        selectedSong.url || undefined,
+        selectedSong.album_art || undefined
+      );
+      setSubmitted(true);
+      setSubmitIsDuplicate(result.is_duplicate ?? false);
+      setSubmitVoteCount(result.vote_count);
+      // Auto-close after 2.5 seconds
+      setTimeout(() => {
+        closeModal();
+      }, 2500);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        closeModal();
+        onRequestsClosed();
+        return;
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={() => !submitting && closeModal()}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2 className="modal-title">
+            {submitted ? 'Success!' : selectedSong ? 'Confirm Request' : 'Request a Song'}
+          </h2>
+          {!submitted && (
+            <button className="modal-close" onClick={closeModal}>&times;</button>
+          )}
+        </div>
+
+        {submitted ? (
+          <div className="success-message">
+            <div className="success-icon">✓</div>
+            <p className="success-text">
+              {submitIsDuplicate ? 'Vote Added!' : 'Request Submitted!'}
+            </p>
+            {submitIsDuplicate && submitVoteCount > 0 && (
+              <p className="success-vote-count">
+                {submitVoteCount} {submitVoteCount === 1 ? 'person wants' : 'people want'} this song!
+              </p>
+            )}
+          </div>
+        ) : selectedSong ? (
+          <div className="confirm-section">
+            <div className="confirm-song">
+              <h3 className="confirm-title">{selectedSong.title}</h3>
+              <p className="confirm-artist">{selectedSong.artist}</p>
+            </div>
+            <input
+              type="text"
+              className="note-input"
+              placeholder="Add a note (optional)"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              maxLength={500}
+            />
+            <div className="confirm-buttons">
+              <button
+                className="confirm-submit"
+                onClick={handleSubmit}
+                disabled={submitting}
+              >
+                {submitting ? 'Submitting...' : 'Submit Request'}
+              </button>
+              <button className="confirm-back" onClick={() => setSelectedSong(null)}>
+                Back
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <form onSubmit={handleSearch} className="search-form">
+              <input
+                type="text"
+                className="search-input"
+                placeholder="Search for a song..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                autoFocus
+              />
+              <button type="submit" className="search-button" disabled={searching}>
+                {searching ? '...' : 'Search'}
+              </button>
+            </form>
+            {searchResults.length > 0 && (
+              <div className="search-results">
+                {searchResults.map((result, index) => (
+                  <button
+                    key={result.spotify_id || index}
+                    className="search-result-item"
+                    onClick={() => setSelectedSong(result)}
+                  >
+                    {result.album_art ? (
+                      <img
+                        src={result.album_art}
+                        alt={result.title}
+                        className="search-result-art"
+                      />
+                    ) : (
+                      <div className="search-result-placeholder">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" xmlns="http://www.w3.org/2000/svg">
+                          <path d="M20 4v8.5a3.5 3.5 0 1 1-2-3.163V6l-9 1.5v9a3.5 3.5 0 1 1-2-3.163V5l13-1Z" />
+                        </svg>
+                      </div>
+                    )}
+                    <div className="search-result-info">
+                      <div className="search-result-title">{result.title}</div>
+                      <div className="search-result-artist">{result.artist}</div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/e/[code]/display/page.tsx
+++ b/dashboard/app/e/[code]/display/page.tsx
@@ -3,9 +3,8 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useParams } from 'next/navigation';
 import { QRCodeSVG } from 'qrcode.react';
-import { api, ApiError, KioskDisplay, SearchResult, NowPlayingInfo, PlayHistoryItem } from '@/lib/api';
-
-const INACTIVITY_TIMEOUT = 60000; // 60 seconds
+import { api, ApiError, KioskDisplay, NowPlayingInfo, PlayHistoryItem } from '@/lib/api';
+import { RequestModal } from './components/RequestModal';
 const AUTO_SCROLL_INTERVAL = 5000; // 5 seconds between auto-scrolls
 const HEX_COLOR_RE = /^#[0-9a-f]{6}$/i;
 function safeColor(c: string | undefined, fallback: string): string {
@@ -38,18 +37,6 @@ export default function KioskDisplayPage() {
 
   // Request modal state
   const [showRequestModal, setShowRequestModal] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
-  const [searching, setSearching] = useState(false);
-  const [selectedSong, setSelectedSong] = useState<SearchResult | null>(null);
-  const [note, setNote] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-  const [submitted, setSubmitted] = useState(false);
-  const [submitIsDuplicate, setSubmitIsDuplicate] = useState(false);
-  const [submitVoteCount, setSubmitVoteCount] = useState(0);
-
-  // Inactivity timer
-  const inactivityTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   // Track whether initial load succeeded (ref avoids stale closure in useCallback)
   const hasLoadedRef = useRef(false);
@@ -157,39 +144,6 @@ export default function KioskDisplayPage() {
     };
   }, []);
 
-  // Inactivity timeout
-  const resetInactivityTimer = useCallback(() => {
-    if (inactivityTimerRef.current) {
-      clearTimeout(inactivityTimerRef.current);
-    }
-    if (showRequestModal) {
-      inactivityTimerRef.current = setTimeout(() => {
-        closeModal();
-      }, INACTIVITY_TIMEOUT);
-    }
-  }, [showRequestModal]);
-
-  useEffect(() => {
-    const handleActivity = () => resetInactivityTimer();
-    window.addEventListener('touchstart', handleActivity);
-    window.addEventListener('pointerdown', handleActivity);
-    window.addEventListener('pointermove', handleActivity);
-    window.addEventListener('keydown', handleActivity);
-    return () => {
-      window.removeEventListener('touchstart', handleActivity);
-      window.removeEventListener('pointerdown', handleActivity);
-      window.removeEventListener('pointermove', handleActivity);
-      window.removeEventListener('keydown', handleActivity);
-      if (inactivityTimerRef.current) {
-        clearTimeout(inactivityTimerRef.current);
-      }
-    };
-  }, [resetInactivityTimer]);
-
-  useEffect(() => {
-    resetInactivityTimer();
-  }, [showRequestModal, resetInactivityTimer]);
-
   // Kiosk mode protections
   useEffect(() => {
     const preventDefaults = (e: Event) => {
@@ -248,64 +202,6 @@ export default function KioskDisplayPage() {
 
     return () => clearInterval(interval);
   }, [display?.kiosk_display_only]);
-
-  const closeModal = () => {
-    setShowRequestModal(false);
-    setSearchQuery('');
-    setSearchResults([]);
-    setSelectedSong(null);
-    setNote('');
-    setSubmitted(false);
-    setSubmitIsDuplicate(false);
-    setSubmitVoteCount(0);
-  };
-
-  const handleSearch = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!searchQuery.trim()) return;
-
-    setSearching(true);
-    setSearchResults([]);
-    try {
-      const results = await api.search(searchQuery);
-      setSearchResults(results);
-    } catch {
-      setSearchResults([]);
-    } finally {
-      setSearching(false);
-    }
-  };
-
-  const handleSubmit = async () => {
-    if (!selectedSong) return;
-
-    setSubmitting(true);
-    try {
-      const result = await api.submitRequest(
-        code,
-        selectedSong.artist,
-        selectedSong.title,
-        note || undefined,
-        selectedSong.url || undefined,
-        selectedSong.album_art || undefined
-      );
-      setSubmitted(true);
-      setSubmitIsDuplicate(result.is_duplicate ?? false);
-      setSubmitVoteCount(result.vote_count);
-      // Auto-close after 2.5 seconds
-      setTimeout(() => {
-        closeModal();
-      }, 2500);
-    } catch (err) {
-      if (err instanceof ApiError && err.status === 403) {
-        closeModal();
-        loadDisplay();
-        return;
-      }
-    } finally {
-      setSubmitting(false);
-    }
-  };
 
   if (loading) {
     return (
@@ -1075,104 +971,11 @@ export default function KioskDisplayPage() {
       </div>
 
       {showRequestModal && (
-        <div className="modal-overlay" onClick={() => !submitting && closeModal()}>
-          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-            <div className="modal-header">
-              <h2 className="modal-title">
-                {submitted ? 'Success!' : selectedSong ? 'Confirm Request' : 'Request a Song'}
-              </h2>
-              {!submitted && (
-                <button className="modal-close" onClick={closeModal}>&times;</button>
-              )}
-            </div>
-
-            {submitted ? (
-              <div className="success-message">
-                <div className="success-icon">✓</div>
-                <p className="success-text">
-                  {submitIsDuplicate ? 'Vote Added!' : 'Request Submitted!'}
-                </p>
-                {submitIsDuplicate && submitVoteCount > 0 && (
-                  <p className="success-vote-count">
-                    {submitVoteCount} {submitVoteCount === 1 ? 'person wants' : 'people want'} this song!
-                  </p>
-                )}
-              </div>
-            ) : selectedSong ? (
-              <div className="confirm-section">
-                <div className="confirm-song">
-                  <h3 className="confirm-title">{selectedSong.title}</h3>
-                  <p className="confirm-artist">{selectedSong.artist}</p>
-                </div>
-                <input
-                  type="text"
-                  className="note-input"
-                  placeholder="Add a note (optional)"
-                  value={note}
-                  onChange={(e) => setNote(e.target.value)}
-                  maxLength={500}
-                />
-                <div className="confirm-buttons">
-                  <button
-                    className="confirm-submit"
-                    onClick={handleSubmit}
-                    disabled={submitting}
-                  >
-                    {submitting ? 'Submitting...' : 'Submit Request'}
-                  </button>
-                  <button className="confirm-back" onClick={() => setSelectedSong(null)}>
-                    Back
-                  </button>
-                </div>
-              </div>
-            ) : (
-              <>
-                <form onSubmit={handleSearch} className="search-form">
-                  <input
-                    type="text"
-                    className="search-input"
-                    placeholder="Search for a song..."
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    autoFocus
-                  />
-                  <button type="submit" className="search-button" disabled={searching}>
-                    {searching ? '...' : 'Search'}
-                  </button>
-                </form>
-                {searchResults.length > 0 && (
-                  <div className="search-results">
-                    {searchResults.map((result, index) => (
-                      <button
-                        key={result.spotify_id || index}
-                        className="search-result-item"
-                        onClick={() => setSelectedSong(result)}
-                      >
-                        {result.album_art ? (
-                          <img
-                            src={result.album_art}
-                            alt={result.title}
-                            className="search-result-art"
-                          />
-                        ) : (
-                          <div className="search-result-placeholder">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" xmlns="http://www.w3.org/2000/svg">
-                              <path d="M20 4v8.5a3.5 3.5 0 1 1-2-3.163V6l-9 1.5v9a3.5 3.5 0 1 1-2-3.163V5l13-1Z" />
-                            </svg>
-                          </div>
-                        )}
-                        <div className="search-result-info">
-                          <div className="search-result-title">{result.title}</div>
-                          <div className="search-result-artist">{result.artist}</div>
-                        </div>
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-        </div>
+        <RequestModal
+          code={code}
+          onClose={() => setShowRequestModal(false)}
+          onRequestsClosed={() => loadDisplay()}
+        />
       )}
     </>
   );

--- a/dashboard/components/EventErrorCard.tsx
+++ b/dashboard/components/EventErrorCard.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+
+interface EventErrorCardProps {
+  error: { message: string; status: number } | null;
+  fallbackMessage?: string;
+  backLink?: { href: string; label: string };
+}
+
+export function EventErrorCard({
+  error,
+  fallbackMessage = 'Event not found.',
+  backLink,
+}: EventErrorCardProps) {
+  const is410 = error?.status === 410;
+  const is404 = error?.status === 404;
+
+  return (
+    <div className="card" style={{ textAlign: 'center' }}>
+      <h2 style={{ marginBottom: '1rem' }}>
+        {is410 ? 'Event Expired' : is404 ? 'Event Not Found' : 'Error'}
+      </h2>
+      <p style={{ color: 'var(--text-secondary)', marginBottom: '1rem' }}>
+        {is410
+          ? 'This event has expired and is no longer accepting requests.'
+          : is404
+            ? 'This event does not exist.'
+            : error?.message || fallbackMessage}
+      </p>
+      {backLink && (
+        <Link href={backLink.href} className="btn btn-primary" style={{ marginTop: '1rem' }}>
+          {backLink.label}
+        </Link>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Fix Tidal auth polling leak**: Moved `setInterval`/`setTimeout` from `handleConnectTidal` into a dedicated `useEffect` keyed on `tidalLoginPolling` state. Both the poll interval and 10-minute timeout are properly cleaned up on state change or unmount.
- **Replace 7 console.error swallows** in events page handlers (`handleToggleTidalSync`, `handleConnectTidal`, `handleCancelTidalLogin`, `handleDisconnectTidal`, `handleSyncToTidal`, `handleSearchTidal`, `handleLinkTidalTrack`) with `setActionError()` calls so users see error messages.
- **Extract RequestModal** (207 lines) from `display/page.tsx` (1179→982 lines) into `display/components/RequestModal.tsx` with self-contained state, search, submission, inactivity timeout, and 403 handling.
- **Extract EventErrorCard** component for the duplicated 410/404/fallback error pattern.

## Test plan

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm test -- --run` — all 483 tests pass
- [ ] Manual: verify Tidal auth flow still works (start login → poll → complete/cancel)
- [ ] Manual: verify error messages appear for failed Tidal operations
- [ ] Manual: verify kiosk display request modal works (search, submit, auto-close)