### PR TITLE
security: encrypt Beatport OAuth state columns at rest

### DIFF
--- a/server/alembic/versions/027_encrypt_beatport_oauth_state.py
+++ b/server/alembic/versions/027_encrypt_beatport_oauth_state.py
@@ -1,0 +1,58 @@
+"""Encrypt beatport OAuth state columns at rest.
+
+Changes beatport_oauth_state (String 64) and beatport_oauth_code_verifier
+(String 128) to Text to accommodate Fernet ciphertext.  Existing plaintext
+values are NULLed (they represent abandoned OAuth flows).
+
+Revision ID: 027
+Revises: 026
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "027"
+down_revision = "026"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # NULL any leftover plaintext values (abandoned OAuth flows)
+    op.execute("UPDATE users SET beatport_oauth_state = NULL, beatport_oauth_code_verifier = NULL")
+
+    # Widen columns from String(64)/String(128) to Text for Fernet ciphertext
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.alter_column(
+            "beatport_oauth_state",
+            existing_type=sa.String(64),
+            type_=sa.Text(),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            "beatport_oauth_code_verifier",
+            existing_type=sa.String(128),
+            type_=sa.Text(),
+            existing_nullable=True,
+        )
+
+
+def downgrade() -> None:
+    # NULL encrypted values before narrowing columns
+    op.execute("UPDATE users SET beatport_oauth_state = NULL, beatport_oauth_code_verifier = NULL")
+
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.alter_column(
+            "beatport_oauth_code_verifier",
+            existing_type=sa.Text(),
+            type_=sa.String(128),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            "beatport_oauth_state",
+            existing_type=sa.Text(),
+            type_=sa.String(64),
+            existing_nullable=True,
+        )

--- a/server/app/models/user.py
+++ b/server/app/models/user.py
@@ -37,8 +37,9 @@ class User(Base):
     beatport_access_token: Mapped[str | None] = mapped_column(EncryptedText, nullable=True)
     beatport_refresh_token: Mapped[str | None] = mapped_column(EncryptedText, nullable=True)
     beatport_token_expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-    beatport_oauth_state: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    beatport_oauth_code_verifier: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    # Transient PKCE values (encrypted at rest, NULLed after token exchange)
+    beatport_oauth_state: Mapped[str | None] = mapped_column(EncryptedText, nullable=True)
+    beatport_oauth_code_verifier: Mapped[str | None] = mapped_column(EncryptedText, nullable=True)
     beatport_subscription: Mapped[str | None] = mapped_column(String(50), nullable=True)
 
     # Help onboarding state (JSON array of page IDs)


### PR DESCRIPTION
## Summary

- Change `beatport_oauth_state` (String 64) and `beatport_oauth_code_verifier` (String 128) to `EncryptedText` (Fernet AES-128-CBC + HMAC) on the User model
- Alembic migration NULLs existing plaintext values (abandoned OAuth flows) and widens columns to `Text` for Fernet ciphertext
- Cleanup already exists in `save_tokens()` (sets both to None after successful exchange)
- Add FIXME comment on per-process `_llm_rate_limit_cache` documenting multi-worker limitation

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `bandit -r app` passes
- [x] `alembic upgrade head && alembic check` — no drift
- [x] `pytest --tb=short -q` — all 1316 tests pass, 88% coverage
- [ ] Manual: verify Beatport OAuth flow still works (start auth → callback → tokens saved encrypted)