### PR TITLE
security: add rate limits to unprotected mutation endpoints

### DIFF
--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -150,6 +150,7 @@ def _event_to_out(
 
 
 @router.post("", response_model=EventOut, status_code=status.HTTP_201_CREATED)
+@limiter.limit("10/minute")
 def create_new_event(
     event_data: EventCreate,
     request: Request,
@@ -289,6 +290,7 @@ def event_search(
 
 
 @router.patch("/{code}", response_model=EventOut)
+@limiter.limit("20/minute")
 def update_event_endpoint(
     event_data: EventUpdate,
     request: Request,
@@ -305,7 +307,9 @@ def update_event_endpoint(
 
 
 @router.delete("/{code}", status_code=status.HTTP_204_NO_CONTENT)
+@limiter.limit("5/minute")
 def delete_event_endpoint(
+    request: Request,
     event: Event = Depends(get_owned_event),
     db: Session = Depends(get_db),
 ) -> None:
@@ -314,6 +318,7 @@ def delete_event_endpoint(
 
 
 @router.post("/{code}/archive", response_model=EventOut)
+@limiter.limit("10/minute")
 def archive_event_endpoint(
     request: Request,
     event: Event = Depends(get_owned_event),
@@ -328,6 +333,7 @@ def archive_event_endpoint(
 
 
 @router.post("/{code}/unarchive", response_model=EventOut)
+@limiter.limit("10/minute")
 def unarchive_event_endpoint(
     request: Request,
     event: Event = Depends(get_owned_event),
@@ -884,6 +890,7 @@ def upload_banner(
 
 
 @router.delete("/{code}/banner", response_model=EventOut)
+@limiter.limit("10/minute")
 def delete_banner(
     request: Request,
     event: Event = Depends(get_owned_event),

--- a/server/app/core/lockout.py
+++ b/server/app/core/lockout.py
@@ -1,4 +1,11 @@
-"""Login lockout logic with escalating cooldowns."""
+"""Login lockout logic with escalating cooldowns.
+
+NOTE: LockoutManager uses an in-memory dict protected by threading.Lock.
+In a multi-worker deployment (e.g. gunicorn with multiple workers) each
+process holds its own independent lockout state, so an attacker can
+theoretically bypass lockouts by hitting different workers.  A shared
+store (Redis / DB) would be needed for strict cross-worker enforcement.
+"""
 
 import time
 from dataclasses import dataclass


### PR DESCRIPTION
## Summary

- Add `@limiter.limit()` to 6 mutation endpoints missing rate limits:
  - `POST /events` (10/min)
  - `PATCH /events/{code}` (20/min)
  - `DELETE /events/{code}` (5/min)
  - `POST /{code}/archive` (10/min)
  - `POST /{code}/unarchive` (10/min)
  - `DELETE /{code}/banner` (10/min)
- Add `request: Request` parameter to `delete_event_endpoint` (required by slowapi)
- Document single-worker limitation of `LockoutManager` in `lockout.py` module docstring

Rate limits only activate in production (`is_rate_limit_enabled`), dev tests unaffected.

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `bandit -r app` passes
- [x] `pytest --tb=short -q` — all 1316 tests pass, 88% coverage