### PR TITLE
security: add CSP header and fix plaintext token fallback

### DIFF
--- a/dashboard/next.config.js
+++ b/dashboard/next.config.js
@@ -1,4 +1,17 @@
 /** @type {import('next').NextConfig} */
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+const csp = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  `connect-src 'self' ${apiUrl}`,
+  "font-src 'self'",
+  "frame-ancestors 'none'",
+].join('; ');
+
 const nextConfig = {
   output: 'standalone',
   allowedDevOrigins: ['192.168.*.*'],
@@ -15,6 +28,7 @@ const nextConfig = {
             key: 'Strict-Transport-Security',
             value: 'max-age=31536000; includeSubDomains',
           },
+          { key: 'Content-Security-Policy', value: csp },
         ],
       },
       {


### PR DESCRIPTION
## Summary

**Dashboard (next.config.js):**
- Add `Content-Security-Policy` header to all routes:
  - `default-src 'self'`
  - `script-src 'self' 'unsafe-inline'` (required by Next.js hydration)
  - `style-src 'self' 'unsafe-inline'`
  - `img-src 'self' data: blob: https:` (album art from external CDNs)
  - `connect-src 'self' ${NEXT_PUBLIC_API_URL}` (API calls)
  - `font-src 'self'`
  - `frame-ancestors 'none'` (clickjacking protection)
- Overlay route retains its existing `frame-ancestors *` override for OBS/streaming embedding

**Bridge-app (store.ts):**
- When `safeStorage.isEncryptionAvailable()` is false, store auth token in-memory only (module-level `sessionToken` variable) instead of writing plaintext to disk
- User must re-authenticate on next app launch when encryption is unavailable
- Emit `console.warn` so the condition is visible in logs

## Test plan

- [x] Dashboard: `npm run lint` + `npx tsc --noEmit` + `npm test -- --run` (483 tests pass)
- [x] Bridge-app: `npx tsc --noEmit` + `npm test -- --run` (58 tests pass)
- [ ] Manual: verify CSP doesn't break album art display, API calls, or kiosk overlay embedding
- [ ] Manual: verify bridge-app login works on systems with/without keychain access