### PR TITLE
test: frontend coverage uplift for events and display pages

### DIFF
--- a/dashboard/app/e/[code]/display/page.test.tsx
+++ b/dashboard/app/e/[code]/display/page.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import KioskDisplayPage from './page';
 
 // Mock next/navigation
@@ -12,6 +12,16 @@ vi.mock('qrcode.react', () => ({
   QRCodeSVG: ({ value }: { value: string }) => (
     <div data-testid="qr-code" data-value={value}>QR Code</div>
   ),
+}));
+
+// Mock SSE hook
+vi.mock('@/lib/use-event-stream', () => ({
+  useEventStream: () => ({ connected: false }),
+}));
+
+// Mock RequestModal
+vi.mock('./components/RequestModal', () => ({
+  RequestModal: () => <div data-testid="request-modal">Modal</div>,
 }));
 
 // Mock API responses
@@ -70,11 +80,21 @@ vi.mock('@/lib/api', () => ({
   },
 }));
 
-import { api } from '@/lib/api';
+import { api, ApiError } from '@/lib/api';
+
+function setupDefaultMocks() {
+  vi.mocked(api.getKioskDisplay).mockResolvedValue(mockKioskDisplay);
+  vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+  vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+}
 
 describe('KioskDisplayPage', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe('Three-column layout', () => {
@@ -217,6 +237,22 @@ describe('KioskDisplayPage', () => {
       expect(screen.getByText('Requests Closed')).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /request a song/i })).not.toBeInTheDocument();
     });
+
+    it('hides request button in display-only mode', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        kiosk_display_only: true,
+        requests_open: true,
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Test Event');
+
+      expect(screen.queryByRole('button', { name: /request a song/i })).not.toBeInTheDocument();
+    });
   });
 
   describe('Transient error resilience', () => {
@@ -270,6 +306,527 @@ describe('KioskDisplayPage', () => {
 
       // History section should still be present (for 3-column layout consistency)
       expect(screen.getByText('Recently Played')).toBeInTheDocument();
+    });
+
+    it('shows empty history message', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue(mockKioskDisplay);
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Test Event');
+
+      expect(screen.getByText('No songs played yet.')).toBeInTheDocument();
+    });
+  });
+
+  describe('3s polling loop', () => {
+    it('calls loadDisplay on mount', async () => {
+      setupDefaultMocks();
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Test Event');
+
+      expect(api.getKioskDisplay).toHaveBeenCalledTimes(1);
+    });
+
+    it('polls every 3 seconds', async () => {
+      vi.useFakeTimers();
+      setupDefaultMocks();
+
+      render(<KioskDisplayPage />);
+      // Flush initial load
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+
+      expect(api.getKioskDisplay).toHaveBeenCalledTimes(1);
+
+      // Advance 3s — second poll
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+      expect(api.getKioskDisplay).toHaveBeenCalledTimes(2);
+
+      // Advance 3s more — third poll
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+      expect(api.getKioskDisplay).toHaveBeenCalledTimes(3);
+    });
+
+    it('stops polling on 404', async () => {
+      vi.useFakeTimers();
+      vi.mocked(api.getKioskDisplay).mockRejectedValue(new ApiError('Not found', 404));
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+
+      const callCount = vi.mocked(api.getKioskDisplay).mock.calls.length;
+
+      // Advance past several poll intervals — no more calls
+      await act(async () => { await vi.advanceTimersByTimeAsync(10000); });
+      expect(api.getKioskDisplay).toHaveBeenCalledTimes(callCount);
+    });
+
+    it('stops polling on 410', async () => {
+      vi.useFakeTimers();
+      vi.mocked(api.getKioskDisplay).mockRejectedValue(new ApiError('Expired', 410));
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+
+      const callCount = vi.mocked(api.getKioskDisplay).mock.calls.length;
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10000); });
+      expect(api.getKioskDisplay).toHaveBeenCalledTimes(callCount);
+    });
+
+    it('continues polling on transient error', async () => {
+      vi.useFakeTimers();
+      vi.mocked(api.getKioskDisplay)
+        .mockResolvedValueOnce(mockKioskDisplay) // initial
+        .mockRejectedValueOnce(new Error('Transient')) // 1st poll
+        .mockResolvedValue(mockKioskDisplay); // subsequent
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+      expect(api.getKioskDisplay).toHaveBeenCalledTimes(1);
+
+      // Error on second call
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+      expect(api.getKioskDisplay).toHaveBeenCalledTimes(2);
+
+      // Should still poll after error
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+      expect(api.getKioskDisplay).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('Sticky now-playing (10s grace)', () => {
+    it('shows now-playing immediately', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue(mockKioskDisplay);
+      vi.mocked(api.getNowPlaying).mockResolvedValue(mockNowPlaying);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Currently Playing Song');
+      expect(screen.getByText('Current Artist')).toBeInTheDocument();
+    });
+
+    it('shows LIVE badge for bridge sources', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue(mockKioskDisplay);
+      vi.mocked(api.getNowPlaying).mockResolvedValue(mockNowPlaying);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Currently Playing Song');
+      expect(screen.getByText('LIVE')).toBeInTheDocument();
+    });
+
+    it('does not show LIVE badge for manual source', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue(mockKioskDisplay);
+      vi.mocked(api.getNowPlaying).mockResolvedValue({
+        ...mockNowPlaying,
+        source: 'manual',
+      });
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Currently Playing Song');
+      expect(screen.queryByText('LIVE')).not.toBeInTheDocument();
+    });
+
+    it('keeps track visible during 10s grace period after null', async () => {
+      vi.useFakeTimers();
+      // Initial: has now playing
+      vi.mocked(api.getKioskDisplay).mockResolvedValue(mockKioskDisplay);
+      vi.mocked(api.getNowPlaying).mockResolvedValue(mockNowPlaying);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+      expect(screen.getByText('Currently Playing Song')).toBeInTheDocument();
+
+      // Now playing goes null on next poll
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+
+      // Track should still be visible during grace period
+      expect(screen.getByText('Currently Playing Song')).toBeInTheDocument();
+
+      // Should have fading class
+      const section = screen.getByText('Now Playing').closest('.now-playing-section');
+      expect(section?.classList.contains('fading')).toBe(true);
+    });
+
+    it('clears track after 10s grace period', async () => {
+      vi.useFakeTimers();
+      vi.mocked(api.getKioskDisplay).mockResolvedValue(mockKioskDisplay);
+      vi.mocked(api.getNowPlaying).mockResolvedValue(mockNowPlaying);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+      expect(screen.getByText('Currently Playing Song')).toBeInTheDocument();
+
+      // Now playing goes null
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+
+      // Advance past the 10s grace
+      await act(async () => { await vi.advanceTimersByTimeAsync(11000); });
+
+      expect(screen.queryByText('Currently Playing Song')).not.toBeInTheDocument();
+      expect(screen.queryByText('Now Playing')).not.toBeInTheDocument();
+    });
+
+    it('cancels grace timer when new track arrives', async () => {
+      vi.useFakeTimers();
+      vi.mocked(api.getKioskDisplay).mockResolvedValue(mockKioskDisplay);
+      vi.mocked(api.getNowPlaying).mockResolvedValue(mockNowPlaying);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+
+      // Now playing goes null — starts grace period
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+
+      // New track arrives within grace period
+      const newTrack = { ...mockNowPlaying, title: 'New Track', artist: 'New Artist' };
+      vi.mocked(api.getNowPlaying).mockResolvedValue(newTrack);
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+
+      expect(screen.getByText('New Track')).toBeInTheDocument();
+      expect(screen.getByText('New Artist')).toBeInTheDocument();
+
+      // Should not be fading
+      const section = screen.getByText('Now Playing').closest('.now-playing-section');
+      expect(section?.classList.contains('fading')).toBe(false);
+    });
+  });
+
+  describe('New item animation', () => {
+    it('adds queue-item-new class for new items', async () => {
+      vi.useFakeTimers();
+      // Initial: 1 item
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        accepted_queue: [{ id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, vote_count: 0 }],
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+
+      // Second poll adds a new item
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        accepted_queue: [
+          { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, vote_count: 0 },
+          { id: 3, title: 'Song 3', artist: 'Artist 3', artwork_url: null, vote_count: 0 },
+        ],
+      });
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+
+      const newItem = screen.getByText('Song 3').closest('.queue-item');
+      expect(newItem?.classList.contains('queue-item-new')).toBe(true);
+    });
+
+    it('removes animation class after 800ms', async () => {
+      vi.useFakeTimers();
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        accepted_queue: [{ id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, vote_count: 0 }],
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+
+      // Add new item
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        accepted_queue: [
+          { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, vote_count: 0 },
+          { id: 3, title: 'Song 3', artist: 'Artist 3', artwork_url: null, vote_count: 0 },
+        ],
+      });
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+
+      // Verify animation class is present
+      let newItem = screen.getByText('Song 3').closest('.queue-item');
+      expect(newItem?.classList.contains('queue-item-new')).toBe(true);
+
+      // Advance 800ms for animation timeout
+      await act(async () => { await vi.advanceTimersByTimeAsync(800); });
+
+      newItem = screen.getByText('Song 3').closest('.queue-item');
+      expect(newItem?.classList.contains('queue-item-new')).toBe(false);
+    });
+  });
+
+  describe('Vote badges', () => {
+    it('shows vote count badge for items with votes', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        accepted_queue: [
+          { id: 1, title: 'Popular Song', artist: 'Artist', artwork_url: null, vote_count: 5 },
+        ],
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Popular Song');
+      expect(screen.getByText('5 votes')).toBeInTheDocument();
+    });
+
+    it('uses singular "vote" for count of 1', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        accepted_queue: [
+          { id: 1, title: 'Song', artist: 'Artist', artwork_url: null, vote_count: 1 },
+        ],
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Song');
+      expect(screen.getByText('1 vote')).toBeInTheDocument();
+    });
+
+    it('hides badge for zero votes', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        accepted_queue: [
+          { id: 1, title: 'Song', artist: 'Artist', artwork_url: null, vote_count: 0 },
+        ],
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Song');
+      expect(screen.queryByText(/vote/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Kiosk protections', () => {
+    it('prevents context menu', async () => {
+      setupDefaultMocks();
+
+      render(<KioskDisplayPage />);
+      await screen.findByText('Test Event');
+
+      const event = new Event('contextmenu', { cancelable: true });
+      const prevented = !document.dispatchEvent(event);
+      expect(prevented).toBe(true);
+    });
+
+    it('prevents text selection', async () => {
+      setupDefaultMocks();
+
+      render(<KioskDisplayPage />);
+      await screen.findByText('Test Event');
+
+      const event = new Event('selectstart', { cancelable: true });
+      const prevented = !document.dispatchEvent(event);
+      expect(prevented).toBe(true);
+    });
+  });
+
+  describe('Banner', () => {
+    it('applies banner gradient with valid colors', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        banner_colors: ['#1a2b3c', '#4d5e6f', '#7a8b9c'],
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Test Event');
+
+      const container = screen.getByText('Test Event').closest('.kiosk-container') as HTMLElement;
+      const bgStyle = container?.style.getPropertyValue('--kiosk-bg');
+      expect(bgStyle).toContain('#1a2b3c');
+      expect(bgStyle).toContain('#4d5e6f');
+      expect(bgStyle).toContain('#7a8b9c');
+    });
+
+    it('falls back for invalid color values', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        banner_colors: ['bad', '#4d5e6f', 'nope'],
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Test Event');
+
+      const container = screen.getByText('Test Event').closest('.kiosk-container') as HTMLElement;
+      const bgStyle = container?.style.getPropertyValue('--kiosk-bg');
+      // Should use fallback for invalid colors
+      expect(bgStyle).toContain('#1a1a2e'); // fallback for first
+      expect(bgStyle).toContain('#4d5e6f'); // valid
+      expect(bgStyle).toContain('#0f3460'); // fallback for third
+    });
+
+    it('renders banner image when present', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        banner_kiosk_url: '/uploads/banners/test-kiosk.webp',
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Test Event');
+
+      const bannerBg = document.querySelector('.kiosk-banner-bg img') as HTMLImageElement;
+      expect(bannerBg).toBeInTheDocument();
+      expect(bannerBg.src).toContain('/uploads/banners/test-kiosk.webp');
+    });
+
+    it('does not render banner when no banner_kiosk_url', async () => {
+      setupDefaultMocks();
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Test Event');
+
+      expect(document.querySelector('.kiosk-banner-bg')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Error display', () => {
+    it('shows "Event Expired" for 410', async () => {
+      vi.mocked(api.getKioskDisplay).mockRejectedValue(new ApiError('Expired', 410));
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Event Expired');
+      expect(screen.getByText(/no longer accepting requests/i)).toBeInTheDocument();
+    });
+
+    it('shows "Event Not Found" for 404', async () => {
+      vi.mocked(api.getKioskDisplay).mockRejectedValue(new ApiError('Not found', 404));
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Event Not Found');
+      expect(screen.getByText(/does not exist/i)).toBeInTheDocument();
+    });
+
+    it('shows generic error for non-API errors on initial load', async () => {
+      vi.mocked(api.getKioskDisplay).mockRejectedValue(new Error('Network'));
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Error');
+    });
+  });
+
+  describe('Loading state', () => {
+    it('shows Loading while data is being fetched', () => {
+      vi.mocked(api.getKioskDisplay).mockImplementation(
+        () => new Promise(() => {}), // never resolves
+      );
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+  });
+
+  describe('Now playing from request fallback', () => {
+    it('shows request-based now_playing when no bridge now-playing', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        now_playing: { id: 1, title: 'Request Song', artist: 'Request Artist', artwork_url: null, vote_count: 0 },
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Request Song');
+      expect(screen.getByText('Request Artist')).toBeInTheDocument();
+      // Should not show LIVE badge for request-based
+      expect(screen.queryByText('LIVE')).not.toBeInTheDocument();
+    });
+
+    it('hides now-playing when now_playing_hidden is true', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        now_playing: { id: 1, title: 'Hidden Song', artist: 'Hidden Artist', artwork_url: null, vote_count: 0 },
+        now_playing_hidden: true,
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Test Event');
+
+      expect(screen.queryByText('Hidden Song')).not.toBeInTheDocument();
+      expect(screen.queryByText('Now Playing')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Artwork rendering', () => {
+    it('shows album art image when URL is present', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue(mockKioskDisplay);
+      vi.mocked(api.getNowPlaying).mockResolvedValue(mockNowPlaying);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Currently Playing Song');
+
+      const img = screen.getByAltText('Currently Playing Song') as HTMLImageElement;
+      expect(img.src).toContain('example.com/art.jpg');
+    });
+
+    it('shows placeholder when no album art', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue(mockKioskDisplay);
+      vi.mocked(api.getNowPlaying).mockResolvedValue({
+        ...mockNowPlaying,
+        album_art_url: null,
+      });
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+
+      await screen.findByText('Currently Playing Song');
+
+      expect(document.querySelector('.now-playing-placeholder')).toBeInTheDocument();
     });
   });
 });

--- a/dashboard/app/events/[code]/__tests__/page.test.tsx
+++ b/dashboard/app/events/[code]/__tests__/page.test.tsx
@@ -1,0 +1,1001 @@
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ code: 'TEST' }),
+}));
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+// Mock qrcode.react
+vi.mock('qrcode.react', () => ({
+  QRCodeSVG: ({ value }: { value: string }) => (
+    <div data-testid="qr-code" data-value={value}>QR</div>
+  ),
+}));
+
+// Mock SSE hook
+vi.mock('@/lib/use-event-stream', () => ({
+  useEventStream: () => ({ connected: false }),
+}));
+
+// Mock help
+vi.mock('@/lib/help/HelpContext', () => ({
+  useHelp: () => ({
+    helpMode: false, onboardingActive: false, currentStep: 0, activeSpotId: null,
+    toggleHelpMode: vi.fn(), registerSpot: vi.fn(() => vi.fn()),
+    getSpotsForPage: vi.fn(() => []), startOnboarding: vi.fn(),
+    nextStep: vi.fn(), prevStep: vi.fn(), skipOnboarding: vi.fn(),
+    hasSeenPage: vi.fn(() => true),
+  }),
+}));
+vi.mock('@/components/help/HelpSpot', () => ({
+  HelpSpot: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/help/HelpButton', () => ({
+  HelpButton: () => null,
+}));
+vi.mock('@/components/help/OnboardingOverlay', () => ({
+  OnboardingOverlay: () => null,
+}));
+vi.mock('@/components/ThemeToggle', () => ({
+  ThemeToggle: () => null,
+}));
+vi.mock('@/lib/tab-title', () => ({
+  useTabTitle: () => {},
+}));
+
+// Variable-based auth mock
+let mockIsAuthenticated = true;
+let mockIsLoading = false;
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({
+    isAuthenticated: mockIsAuthenticated,
+    isLoading: mockIsLoading,
+  }),
+}));
+
+// Capture props from child components
+let capturedSongTabProps: Record<string, unknown> = {};
+let capturedManageTabProps: Record<string, unknown> = {};
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- used inside vi.mock factory
+let capturedQueueProps: Record<string, unknown> = {};
+
+vi.mock('../components/SongManagementTab', () => ({
+  SongManagementTab: (props: Record<string, unknown>) => {
+    capturedSongTabProps = props;
+    return <div data-testid="song-tab">SongTab</div>;
+  },
+}));
+vi.mock('../components/EventManagementTab', () => ({
+  EventManagementTab: (props: Record<string, unknown>) => {
+    capturedManageTabProps = props;
+    return <div data-testid="manage-tab">ManageTab</div>;
+  },
+}));
+vi.mock('../components/RequestQueueSection', () => ({
+  RequestQueueSection: (props: Record<string, unknown>) => {
+    capturedQueueProps = props;
+    return <div data-testid="queue-section">Queue</div>;
+  },
+}));
+vi.mock('../components/PlayHistorySection', () => ({
+  PlayHistorySection: () => <div data-testid="play-history">History</div>,
+}));
+vi.mock('../components/DeleteEventModal', () => ({
+  DeleteEventModal: (props: { onConfirm: () => void; onCancel: () => void }) => (
+    <div data-testid="delete-modal">
+      <button onClick={props.onConfirm}>Confirm Delete</button>
+      <button onClick={props.onCancel}>Cancel Delete</button>
+    </div>
+  ),
+}));
+vi.mock('../components/NowPlayingBadge', () => ({
+  NowPlayingBadge: () => <div data-testid="now-playing-badge">NP</div>,
+}));
+vi.mock('../components/TidalLoginModal', () => ({
+  TidalLoginModal: (props: { onCancel: () => void }) => (
+    <div data-testid="tidal-login-modal">
+      <button onClick={props.onCancel}>Cancel Tidal</button>
+    </div>
+  ),
+}));
+vi.mock('../components/BeatportLoginModal', () => ({
+  BeatportLoginModal: (props: { onSubmit: (u: string, p: string) => Promise<void>; onCancel: () => void }) => (
+    <div data-testid="beatport-login-modal">
+      <button onClick={() => props.onSubmit('user', 'pass')}>Submit BP Login</button>
+      <button onClick={props.onCancel}>Cancel BP</button>
+    </div>
+  ),
+}));
+vi.mock('../components/ServiceTrackPickerModal', () => ({
+  ServiceTrackPickerModal: () => <div data-testid="track-picker-modal">Picker</div>,
+}));
+vi.mock('@/components/EventErrorCard', () => ({
+  EventErrorCard: ({ error }: { error: { message: string; status: number } | null }) => (
+    <div data-testid="error-card">{error?.status === 410 ? 'Expired' : error?.status === 404 ? 'Not Found' : 'Error'}</div>
+  ),
+}));
+
+// Mock API
+vi.mock('@/lib/api', () => ({
+  api: {
+    getEvent: vi.fn(),
+    getRequests: vi.fn(),
+    getPlayHistory: vi.fn(),
+    getDisplaySettings: vi.fn(),
+    getTidalStatus: vi.fn(),
+    getBeatportStatus: vi.fn(),
+    getNowPlaying: vi.fn(),
+    getArchivedEvents: vi.fn(),
+    updateRequestStatus: vi.fn(),
+    acceptAllRequests: vi.fn(),
+    updateEvent: vi.fn(),
+    deleteEvent: vi.fn(),
+    exportEventCsv: vi.fn(),
+    exportPlayHistoryCsv: vi.fn(),
+    setNowPlayingVisibility: vi.fn(),
+    setAutoHideMinutes: vi.fn(),
+    setRequestsOpen: vi.fn(),
+    setKioskDisplayOnly: vi.fn(),
+    updateTidalEventSettings: vi.fn(),
+    startTidalAuth: vi.fn(),
+    checkTidalAuth: vi.fn(),
+    cancelTidalAuth: vi.fn(),
+    disconnectTidal: vi.fn(),
+    syncRequestToTidal: vi.fn(),
+    searchTidal: vi.fn(),
+    linkTidalTrack: vi.fn(),
+    updateBeatportEventSettings: vi.fn(),
+    loginBeatport: vi.fn(),
+    disconnectBeatport: vi.fn(),
+    searchBeatport: vi.fn(),
+    linkBeatportTrack: vi.fn(),
+    uploadEventBanner: vi.fn(),
+    deleteEventBanner: vi.fn(),
+    submitRequest: vi.fn(),
+    deleteRequest: vi.fn(),
+    refreshRequestMetadata: vi.fn(),
+    rejectAllRequests: vi.fn(),
+    bulkDeleteRequests: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+import { api, ApiError } from '@/lib/api';
+import type { SongRequest } from '@/lib/api';
+import EventQueuePage from '../page';
+
+function mockEvent(overrides = {}) {
+  return {
+    id: 1, code: 'TEST', name: 'Test Event',
+    created_at: '2026-01-01T00:00:00Z', expires_at: '2026-12-31T00:00:00Z',
+    is_active: true, join_url: null, requests_open: true,
+    tidal_sync_enabled: false, tidal_playlist_id: null,
+    beatport_sync_enabled: false, beatport_playlist_id: null,
+    banner_url: null, banner_kiosk_url: null, banner_colors: null,
+    ...overrides,
+  };
+}
+
+function mockRequest(overrides: Partial<SongRequest> = {}): SongRequest {
+  return {
+    id: 1, event_id: 1, song_title: 'Strobe', artist: 'deadmau5',
+    source: 'spotify', source_url: null, artwork_url: null, note: null,
+    status: 'new', created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z', raw_search_query: null,
+    sync_results_json: null, genre: null, bpm: null, musical_key: null,
+    vote_count: 0, ...overrides,
+  };
+}
+
+function setupDefaultMocks() {
+  vi.mocked(api.getEvent).mockResolvedValue(mockEvent());
+  vi.mocked(api.getRequests).mockResolvedValue([]);
+  vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+  vi.mocked(api.getDisplaySettings).mockResolvedValue({
+    status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
+    requests_open: true, kiosk_display_only: false,
+  });
+  vi.mocked(api.getTidalStatus).mockResolvedValue({
+    linked: false, user_id: null, expires_at: null, integration_enabled: true,
+  });
+  vi.mocked(api.getBeatportStatus).mockResolvedValue({
+    linked: false, expires_at: null, configured: false, subscription: null, integration_enabled: true,
+  });
+  vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+}
+
+describe('EventQueuePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAuthenticated = true;
+    mockIsLoading = false;
+    capturedSongTabProps = {};
+    capturedManageTabProps = {};
+    capturedQueueProps = {};
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('Initial loading and auth guard', () => {
+    it('redirects to /login when not authenticated', () => {
+      mockIsAuthenticated = false;
+      mockIsLoading = false;
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+
+      expect(mockPush).toHaveBeenCalledWith('/login');
+    });
+
+    it('shows Loading while auth is resolving', () => {
+      mockIsLoading = true;
+      mockIsAuthenticated = false;
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+
+    it('shows "Loading event..." during fetch', () => {
+      vi.mocked(api.getEvent).mockImplementation(() => new Promise(() => {}));
+      vi.mocked(api.getRequests).mockImplementation(() => new Promise(() => {}));
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+      vi.mocked(api.getDisplaySettings).mockResolvedValue({
+        status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
+        requests_open: true, kiosk_display_only: false,
+      });
+      vi.mocked(api.getTidalStatus).mockResolvedValue({
+        linked: false, user_id: null, expires_at: null, integration_enabled: true,
+      });
+      vi.mocked(api.getBeatportStatus).mockResolvedValue({
+        linked: false, expires_at: null, configured: false, subscription: null, integration_enabled: true,
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+
+      render(<EventQueuePage />);
+
+      expect(screen.getByText('Loading event...')).toBeInTheDocument();
+    });
+
+    it('renders event name after load', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+
+      await screen.findByText('Test Event');
+    });
+
+    it('renders QR code', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+
+      await screen.findByText('Test Event');
+      expect(screen.getByTestId('qr-code')).toBeInTheDocument();
+    });
+
+    it('renders event code', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('TEST')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Error states', () => {
+    it('shows error card on 404', async () => {
+      vi.mocked(api.getEvent).mockRejectedValue(new ApiError('Not found', 404));
+      vi.mocked(api.getRequests).mockRejectedValue(new ApiError('Not found', 404));
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+      vi.mocked(api.getDisplaySettings).mockResolvedValue({
+        status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
+        requests_open: true, kiosk_display_only: false,
+      });
+      vi.mocked(api.getTidalStatus).mockResolvedValue({
+        linked: false, user_id: null, expires_at: null, integration_enabled: true,
+      });
+      vi.mocked(api.getBeatportStatus).mockResolvedValue({
+        linked: false, expires_at: null, configured: false, subscription: null, integration_enabled: true,
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+
+      render(<EventQueuePage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('error-card')).toBeInTheDocument();
+        expect(screen.getByText('Not Found')).toBeInTheDocument();
+      });
+    });
+
+    it('shows expired state on 410 with archived data', async () => {
+      vi.mocked(api.getEvent).mockRejectedValue(new ApiError('Expired', 410));
+      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+      vi.mocked(api.getDisplaySettings).mockResolvedValue({
+        status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
+        requests_open: true, kiosk_display_only: false,
+      });
+      vi.mocked(api.getTidalStatus).mockResolvedValue({
+        linked: false, user_id: null, expires_at: null, integration_enabled: true,
+      });
+      vi.mocked(api.getBeatportStatus).mockResolvedValue({
+        linked: false, expires_at: null, configured: false, subscription: null, integration_enabled: true,
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getArchivedEvents).mockResolvedValue([{
+        ...mockEvent(), status: 'expired' as const, request_count: 1, archived_at: null,
+      }]);
+
+      render(<EventQueuePage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Event')).toBeInTheDocument();
+        expect(screen.getByText('expired')).toBeInTheDocument();
+      });
+    });
+
+    it('shows error card on 410 without archived match', async () => {
+      vi.mocked(api.getEvent).mockRejectedValue(new ApiError('Expired', 410));
+      vi.mocked(api.getRequests).mockResolvedValue([]);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+      vi.mocked(api.getDisplaySettings).mockResolvedValue({
+        status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
+        requests_open: true, kiosk_display_only: false,
+      });
+      vi.mocked(api.getTidalStatus).mockResolvedValue({
+        linked: false, user_id: null, expires_at: null, integration_enabled: true,
+      });
+      vi.mocked(api.getBeatportStatus).mockResolvedValue({
+        linked: false, expires_at: null, configured: false, subscription: null, integration_enabled: true,
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getArchivedEvents).mockResolvedValue([]); // No match
+
+      render(<EventQueuePage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('error-card')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Polling loop', () => {
+    it('polls every 3 seconds', async () => {
+      vi.useFakeTimers();
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+      expect(api.getEvent).toHaveBeenCalledTimes(1);
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+      expect(api.getEvent).toHaveBeenCalledTimes(2);
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+      expect(api.getEvent).toHaveBeenCalledTimes(3);
+    });
+
+    it('stops on 404', async () => {
+      vi.useFakeTimers();
+      vi.mocked(api.getEvent).mockRejectedValue(new ApiError('Not found', 404));
+      vi.mocked(api.getRequests).mockResolvedValue([]);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+      vi.mocked(api.getDisplaySettings).mockResolvedValue({
+        status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
+        requests_open: true, kiosk_display_only: false,
+      });
+      vi.mocked(api.getTidalStatus).mockResolvedValue({
+        linked: false, user_id: null, expires_at: null, integration_enabled: true,
+      });
+      vi.mocked(api.getBeatportStatus).mockResolvedValue({
+        linked: false, expires_at: null, configured: false, subscription: null, integration_enabled: true,
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+
+      render(<EventQueuePage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+      const callCount = vi.mocked(api.getEvent).mock.calls.length;
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10000); });
+      expect(api.getEvent).toHaveBeenCalledTimes(callCount);
+    });
+
+    it('continues on transient error', async () => {
+      vi.useFakeTimers();
+      setupDefaultMocks();
+      vi.mocked(api.getEvent)
+        .mockResolvedValueOnce(mockEvent())
+        .mockRejectedValueOnce(new Error('Transient'))
+        .mockResolvedValue(mockEvent());
+
+      render(<EventQueuePage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+      expect(api.getEvent).toHaveBeenCalledTimes(1);
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+      expect(api.getEvent).toHaveBeenCalledTimes(2);
+
+      // Should still poll after transient error
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+      expect(api.getEvent).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('Tab switching', () => {
+    it('defaults to songs tab', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      expect(screen.getByTestId('song-tab')).toBeInTheDocument();
+    });
+
+    it('switches to manage tab', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      fireEvent.click(screen.getByText('Event Management'));
+
+      expect(screen.getByTestId('manage-tab')).toBeInTheDocument();
+    });
+
+    it('switches back to songs tab', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      fireEvent.click(screen.getByText('Event Management'));
+      fireEvent.click(screen.getByText('Song Management'));
+
+      expect(screen.getByTestId('song-tab')).toBeInTheDocument();
+    });
+  });
+
+  describe('Compact mode', () => {
+    it('toggles via button and persists to localStorage', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      const container = screen.getByText('Test Event').closest('.container');
+      expect(container?.classList.contains('compact')).toBe(false);
+
+      fireEvent.click(screen.getByLabelText('Compact mode off'));
+
+      expect(container?.classList.contains('compact')).toBe(true);
+
+      // Toggle back
+      fireEvent.click(screen.getByLabelText('Compact mode on'));
+
+      expect(container?.classList.contains('compact')).toBe(false);
+    });
+  });
+
+  describe('Action error auto-dismiss', () => {
+    it('auto-dismisses after 5s', async () => {
+      vi.useFakeTimers();
+      setupDefaultMocks();
+      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.updateRequestStatus).mockRejectedValue(new ApiError('Status error', 400));
+
+      render(<EventQueuePage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+
+      // Trigger an error via the update handler
+      const onUpdateStatus = capturedSongTabProps.onUpdateStatus as (id: number, s: string) => Promise<void>;
+      await act(async () => { await onUpdateStatus(1, 'accepted'); });
+
+      expect(screen.getByText('Status error')).toBeInTheDocument();
+
+      // Advance 5s — error should dismiss
+      await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
+      expect(screen.queryByText('Status error')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Request status actions', () => {
+    it('passes onUpdateStatus to SongTab', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      expect(typeof capturedSongTabProps.onUpdateStatus).toBe('function');
+    });
+
+    it('calls updateRequestStatus via handler', async () => {
+      setupDefaultMocks();
+      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.updateRequestStatus).mockResolvedValue(mockRequest({ status: 'accepted' }));
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      const onUpdateStatus = capturedSongTabProps.onUpdateStatus as (id: number, s: string) => Promise<void>;
+      await act(async () => { await onUpdateStatus(1, 'accepted'); });
+
+      expect(api.updateRequestStatus).toHaveBeenCalledWith(1, 'accepted');
+    });
+
+    it('shows error on status update failure', async () => {
+      setupDefaultMocks();
+      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.updateRequestStatus).mockRejectedValue(new ApiError('Invalid transition', 400));
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      const onUpdateStatus = capturedSongTabProps.onUpdateStatus as (id: number, s: string) => Promise<void>;
+      await act(async () => { await onUpdateStatus(1, 'played'); });
+
+      expect(screen.getByText('Invalid transition')).toBeInTheDocument();
+    });
+  });
+
+  describe('Accept all requests', () => {
+    it('calls acceptAllRequests', async () => {
+      setupDefaultMocks();
+      vi.mocked(api.acceptAllRequests).mockResolvedValue({ status: 'ok', accepted_count: 1 });
+      vi.mocked(api.getRequests).mockResolvedValue([mockRequest({ status: 'accepted' })]);
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      const onAcceptAll = capturedSongTabProps.onAcceptAll as () => Promise<void>;
+      await act(async () => { await onAcceptAll(); });
+
+      expect(api.acceptAllRequests).toHaveBeenCalledWith('TEST');
+    });
+
+    it('shows error on failure', async () => {
+      setupDefaultMocks();
+      vi.mocked(api.acceptAllRequests).mockRejectedValue(new ApiError('No requests', 400));
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      const onAcceptAll = capturedSongTabProps.onAcceptAll as () => Promise<void>;
+      await act(async () => { await onAcceptAll(); });
+
+      expect(screen.getByText('No requests')).toBeInTheDocument();
+    });
+  });
+
+  describe('Edit expiry', () => {
+    it('shows edit form on click', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+      expect(screen.getByDisplayValue(/2026/)).toBeInTheDocument();
+    });
+
+    it('saves new expiry', async () => {
+      setupDefaultMocks();
+      vi.mocked(api.updateEvent).mockResolvedValue(mockEvent({ expires_at: '2027-06-01T00:00:00Z' }));
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+      fireEvent.change(screen.getByDisplayValue(/2026/), {
+        target: { value: '2027-06-01T00:00' },
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      });
+
+      expect(api.updateEvent).toHaveBeenCalledWith('TEST', expect.objectContaining({
+        expires_at: expect.stringContaining('2027'),
+      }));
+    });
+
+    it('cancels editing', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+      expect(screen.getByDisplayValue(/2026/)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(screen.queryByDisplayValue(/2026-12/)).not.toBeInTheDocument();
+      expect(api.updateEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Delete event', () => {
+    it('shows delete modal', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+      expect(screen.getByTestId('delete-modal')).toBeInTheDocument();
+    });
+
+    it('deletes and redirects on confirm', async () => {
+      setupDefaultMocks();
+      vi.mocked(api.deleteEvent).mockResolvedValue(undefined);
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+      await act(async () => {
+        fireEvent.click(screen.getByText('Confirm Delete'));
+      });
+
+      expect(api.deleteEvent).toHaveBeenCalledWith('TEST');
+      expect(mockPush).toHaveBeenCalledWith('/events');
+    });
+
+    it('shows error on failure', async () => {
+      setupDefaultMocks();
+      vi.mocked(api.deleteEvent).mockRejectedValue(new ApiError('Cannot delete', 400));
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+      await act(async () => {
+        fireEvent.click(screen.getByText('Confirm Delete'));
+      });
+
+      expect(screen.getByText('Cannot delete')).toBeInTheDocument();
+      expect(mockPush).not.toHaveBeenCalledWith('/events');
+    });
+  });
+
+  describe('CSV export', () => {
+    it('calls exportEventCsv', async () => {
+      setupDefaultMocks();
+      // Force expired state to show export button
+      vi.mocked(api.getEvent).mockRejectedValue(new ApiError('Expired', 410));
+      vi.mocked(api.getArchivedEvents).mockResolvedValue([{
+        ...mockEvent(), status: 'expired' as const, request_count: 1, archived_at: null,
+      }]);
+      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.exportEventCsv).mockResolvedValue(undefined);
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
+      });
+
+      expect(api.exportEventCsv).toHaveBeenCalledWith('TEST');
+    });
+  });
+
+  describe('Display settings via ManageTab', () => {
+    it('passes toggle handlers to ManageTab', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      fireEvent.click(screen.getByText('Event Management'));
+
+      expect(typeof capturedManageTabProps.onToggleRequests).toBe('function');
+      expect(typeof capturedManageTabProps.onToggleNowPlaying).toBe('function');
+      expect(typeof capturedManageTabProps.onToggleDisplayOnly).toBe('function');
+      expect(typeof capturedManageTabProps.onBannerSelect).toBe('function');
+    });
+  });
+
+  describe('Tidal auth flow', () => {
+    it('starts auth and shows modal', async () => {
+      setupDefaultMocks();
+      vi.mocked(api.startTidalAuth).mockResolvedValue({
+        verification_url: 'https://tidal.com/device',
+        user_code: 'ABCD1234',
+        message: 'ok',
+      });
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+      fireEvent.click(screen.getByText('Event Management'));
+
+      const onConnectTidal = capturedManageTabProps.onConnectTidal as () => Promise<void>;
+      await act(async () => { await onConnectTidal(); });
+
+      expect(api.startTidalAuth).toHaveBeenCalled();
+      expect(screen.getByTestId('tidal-login-modal')).toBeInTheDocument();
+    });
+
+    it('polls checkTidalAuth every 2s', async () => {
+      vi.useFakeTimers();
+      setupDefaultMocks();
+      vi.mocked(api.startTidalAuth).mockResolvedValue({
+        verification_url: 'https://tidal.com/device',
+        user_code: 'ABCD1234',
+        message: 'ok',
+      });
+      vi.mocked(api.checkTidalAuth).mockResolvedValue({ complete: false });
+
+      render(<EventQueuePage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+      fireEvent.click(screen.getByText('Event Management'));
+
+      const onConnectTidal = capturedManageTabProps.onConnectTidal as () => Promise<void>;
+      await act(async () => { await onConnectTidal(); });
+
+      // Advance 2s for first poll
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+      expect(api.checkTidalAuth).toHaveBeenCalledTimes(1);
+
+      // Advance 2s for second poll
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+      expect(api.checkTidalAuth).toHaveBeenCalledTimes(2);
+    });
+
+    it('cancels auth', async () => {
+      setupDefaultMocks();
+      vi.mocked(api.startTidalAuth).mockResolvedValue({
+        verification_url: 'https://tidal.com/device',
+        user_code: 'ABCD1234',
+        message: 'ok',
+      });
+      vi.mocked(api.cancelTidalAuth).mockResolvedValue({ status: 'ok', message: 'cancelled' });
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+      fireEvent.click(screen.getByText('Event Management'));
+
+      const onConnectTidal = capturedManageTabProps.onConnectTidal as () => Promise<void>;
+      await act(async () => { await onConnectTidal(); });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Cancel Tidal'));
+      });
+
+      expect(api.cancelTidalAuth).toHaveBeenCalled();
+    });
+  });
+
+  describe('Beatport auth flow', () => {
+    it('opens login modal', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+      fireEvent.click(screen.getByText('Event Management'));
+
+      const onConnectBeatport = capturedManageTabProps.onConnectBeatport as () => void;
+      act(() => { onConnectBeatport(); });
+
+      expect(screen.getByTestId('beatport-login-modal')).toBeInTheDocument();
+    });
+
+    it('calls loginBeatport', async () => {
+      setupDefaultMocks();
+      vi.mocked(api.loginBeatport).mockResolvedValue({ status: 'ok', message: 'logged in' });
+      vi.mocked(api.getBeatportStatus).mockResolvedValue({
+        linked: true, expires_at: null, configured: true, subscription: 'pro', integration_enabled: true,
+      });
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+      fireEvent.click(screen.getByText('Event Management'));
+
+      const onConnectBeatport = capturedManageTabProps.onConnectBeatport as () => void;
+      act(() => { onConnectBeatport(); });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Submit BP Login'));
+      });
+
+      expect(api.loginBeatport).toHaveBeenCalledWith('user', 'pass');
+    });
+  });
+
+  describe('Banner upload', () => {
+    it('passes onBannerSelect to ManageTab', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+      fireEvent.click(screen.getByText('Event Management'));
+
+      expect(typeof capturedManageTabProps.onBannerSelect).toBe('function');
+    });
+  });
+
+  describe('Now playing badge', () => {
+    it('shows badge when bridge has now-playing', async () => {
+      setupDefaultMocks();
+      vi.mocked(api.getNowPlaying).mockResolvedValue({
+        title: 'Track', artist: 'Artist', album: null, album_art_url: null,
+        spotify_uri: null, started_at: new Date().toISOString(),
+        source: 'stagelinq', matched_request_id: null, bridge_connected: true,
+      });
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      expect(screen.getByTestId('now-playing-badge')).toBeInTheDocument();
+    });
+
+    it('hides badge when expired', async () => {
+      vi.mocked(api.getEvent).mockRejectedValue(new ApiError('Expired', 410));
+      vi.mocked(api.getArchivedEvents).mockResolvedValue([{
+        ...mockEvent(), status: 'expired' as const, request_count: 0, archived_at: null,
+      }]);
+      vi.mocked(api.getRequests).mockResolvedValue([]);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+      vi.mocked(api.getDisplaySettings).mockResolvedValue({
+        status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
+        requests_open: true, kiosk_display_only: false,
+      });
+      vi.mocked(api.getTidalStatus).mockResolvedValue({
+        linked: false, user_id: null, expires_at: null, integration_enabled: true,
+      });
+      vi.mocked(api.getBeatportStatus).mockResolvedValue({
+        linked: false, expires_at: null, configured: false, subscription: null, integration_enabled: true,
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue({
+        title: 'Track', artist: 'Artist', album: null, album_art_url: null,
+        spotify_uri: null, started_at: new Date().toISOString(),
+        source: 'stagelinq', matched_request_id: null, bridge_connected: true,
+      });
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      expect(screen.queryByTestId('now-playing-badge')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Expired event features', () => {
+    it('shows RequestQueueSection directly for expired events', async () => {
+      vi.mocked(api.getEvent).mockRejectedValue(new ApiError('Expired', 410));
+      vi.mocked(api.getArchivedEvents).mockResolvedValue([{
+        ...mockEvent(), status: 'expired' as const, request_count: 1, archived_at: null,
+      }]);
+      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+      vi.mocked(api.getDisplaySettings).mockResolvedValue({
+        status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
+        requests_open: true, kiosk_display_only: false,
+      });
+      vi.mocked(api.getTidalStatus).mockResolvedValue({
+        linked: false, user_id: null, expires_at: null, integration_enabled: true,
+      });
+      vi.mocked(api.getBeatportStatus).mockResolvedValue({
+        linked: false, expires_at: null, configured: false, subscription: null, integration_enabled: true,
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      // Expired events show queue section directly, no tabs
+      expect(screen.getByTestId('queue-section')).toBeInTheDocument();
+      expect(screen.getByTestId('play-history')).toBeInTheDocument();
+      expect(screen.queryByText('Song Management')).not.toBeInTheDocument();
+    });
+
+    it('hides QR code for expired events', async () => {
+      vi.mocked(api.getEvent).mockRejectedValue(new ApiError('Expired', 410));
+      vi.mocked(api.getArchivedEvents).mockResolvedValue([{
+        ...mockEvent(), status: 'expired' as const, request_count: 0, archived_at: null,
+      }]);
+      vi.mocked(api.getRequests).mockResolvedValue([]);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+      vi.mocked(api.getDisplaySettings).mockResolvedValue({
+        status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
+        requests_open: true, kiosk_display_only: false,
+      });
+      vi.mocked(api.getTidalStatus).mockResolvedValue({
+        linked: false, user_id: null, expires_at: null, integration_enabled: true,
+      });
+      vi.mocked(api.getBeatportStatus).mockResolvedValue({
+        linked: false, expires_at: null, configured: false, subscription: null, integration_enabled: true,
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      expect(screen.queryByTestId('qr-code')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Delete request', () => {
+    it('calls deleteRequest via handler', async () => {
+      setupDefaultMocks();
+      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.deleteRequest).mockResolvedValue(undefined);
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      const onDeleteRequest = capturedSongTabProps.onDeleteRequest as (id: number) => Promise<void>;
+      await act(async () => { await onDeleteRequest(1); });
+
+      expect(api.deleteRequest).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('Refresh metadata', () => {
+    it('calls refreshRequestMetadata via handler', async () => {
+      setupDefaultMocks();
+      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.refreshRequestMetadata).mockResolvedValue(
+        mockRequest({ genre: 'Electronic', bpm: 128 }),
+      );
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      const onRefreshMetadata = capturedSongTabProps.onRefreshMetadata as (id: number) => Promise<void>;
+      await act(async () => { await onRefreshMetadata(1); });
+
+      expect(api.refreshRequestMetadata).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('Reject all', () => {
+    it('calls rejectAllRequests via handler', async () => {
+      setupDefaultMocks();
+      vi.mocked(api.rejectAllRequests).mockResolvedValue({ status: 'ok', count: 0 });
+      vi.mocked(api.getRequests).mockResolvedValue([]);
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      const onRejectAll = capturedSongTabProps.onRejectAll as () => Promise<void>;
+      await act(async () => { await onRejectAll(); });
+
+      expect(api.rejectAllRequests).toHaveBeenCalledWith('TEST');
+    });
+  });
+
+  describe('Back link', () => {
+    it('shows back link to events', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      const backLink = screen.getByText(/Back to Events/);
+      expect(backLink.closest('a')).toHaveAttribute('href', '/dashboard');
+    });
+  });
+});

--- a/dashboard/app/events/__tests__/page.test.tsx
+++ b/dashboard/app/events/__tests__/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import EventsPage from '../page';
 
@@ -26,13 +26,27 @@ vi.mock('@/lib/help/HelpContext', () => ({
   }),
 }));
 
-// Mock auth hook
+// Mock help components to simple pass-throughs
+vi.mock('@/components/help/HelpSpot', () => ({
+  HelpSpot: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/help/HelpButton', () => ({
+  HelpButton: () => null,
+}));
+vi.mock('@/components/help/OnboardingOverlay', () => ({
+  OnboardingOverlay: () => null,
+}));
+
+// Variable-based auth mock for role testing
+let mockRole = 'dj';
+let mockIsAuthenticated = true;
+let mockIsLoading = false;
 const mockLogout = vi.fn();
 vi.mock('@/lib/auth', () => ({
   useAuth: () => ({
-    isAuthenticated: true,
-    isLoading: false,
-    role: 'dj',
+    isAuthenticated: mockIsAuthenticated,
+    isLoading: mockIsLoading,
+    role: mockRole,
     logout: mockLogout,
   }),
 }));
@@ -48,9 +62,33 @@ vi.mock('@/lib/api', () => ({
 
 import { api } from '@/lib/api';
 
+function mockEvent(overrides = {}) {
+  return {
+    id: 1,
+    code: 'EVT01',
+    name: 'Friday Night',
+    created_at: '2026-01-01T00:00:00Z',
+    expires_at: '2026-01-02T00:00:00Z',
+    is_active: true,
+    join_url: null,
+    tidal_sync_enabled: false,
+    tidal_playlist_id: null,
+    beatport_sync_enabled: false,
+    beatport_playlist_id: null,
+    banner_url: null,
+    banner_kiosk_url: null,
+    banner_colors: null,
+    requests_open: true,
+    ...overrides,
+  };
+}
+
 describe('EventsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRole = 'dj';
+    mockIsAuthenticated = true;
+    mockIsLoading = false;
   });
 
   it('renders page heading and create button', async () => {
@@ -73,25 +111,7 @@ describe('EventsPage', () => {
   });
 
   it('displays events when loaded', async () => {
-    vi.mocked(api.getEvents).mockResolvedValue([
-      {
-        id: 1,
-        code: 'EVT01',
-        name: 'Friday Night',
-        created_at: '2026-01-01T00:00:00Z',
-        expires_at: '2026-01-02T00:00:00Z',
-        is_active: true,
-        join_url: null,
-        tidal_sync_enabled: false,
-        tidal_playlist_id: null,
-        beatport_sync_enabled: false,
-        beatport_playlist_id: null,
-        banner_url: null,
-        banner_kiosk_url: null,
-        banner_colors: null,
-        requests_open: true,
-      },
-    ]);
+    vi.mocked(api.getEvents).mockResolvedValue([mockEvent()]);
 
     render(<EventsPage />);
 
@@ -117,5 +137,212 @@ describe('EventsPage', () => {
     render(<EventsPage />);
 
     expect(screen.getByRole('button', { name: 'Logout' })).toBeInTheDocument();
+  });
+
+  it('shows inactive badge for inactive events', async () => {
+    vi.mocked(api.getEvents).mockResolvedValue([mockEvent({ is_active: false })]);
+
+    render(<EventsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Inactive')).toBeInTheDocument();
+    });
+  });
+
+  describe('Loading & auth redirects', () => {
+    it('shows Loading while auth is resolving', () => {
+      mockIsLoading = true;
+      mockIsAuthenticated = false;
+      vi.mocked(api.getEvents).mockResolvedValue([]);
+
+      render(<EventsPage />);
+
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+
+    it('shows "Loading events..." during fetch', async () => {
+      let resolveEvents!: (v: never[]) => void;
+      vi.mocked(api.getEvents).mockImplementation(
+        () => new Promise((r) => { resolveEvents = r; }),
+      );
+
+      render(<EventsPage />);
+
+      expect(screen.getByText('Loading events...')).toBeInTheDocument();
+
+      await act(async () => { resolveEvents([]); });
+    });
+
+    it('redirects unauthenticated users to /login', () => {
+      mockIsAuthenticated = false;
+      mockIsLoading = false;
+      vi.mocked(api.getEvents).mockResolvedValue([]);
+
+      render(<EventsPage />);
+
+      expect(mockPush).toHaveBeenCalledWith('/login');
+    });
+
+    it('redirects pending users to /pending', () => {
+      mockRole = 'pending';
+      vi.mocked(api.getEvents).mockResolvedValue([]);
+
+      render(<EventsPage />);
+
+      expect(mockPush).toHaveBeenCalledWith('/pending');
+    });
+  });
+
+  describe('Create event form', () => {
+    it('shows form when Create Event clicked', async () => {
+      vi.mocked(api.getEvents).mockResolvedValue([]);
+
+      render(<EventsPage />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Create Event' }));
+
+      expect(screen.getByLabelText('Event Name')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument();
+    });
+
+    it('creates event and adds to list', async () => {
+      vi.mocked(api.getEvents).mockResolvedValue([]);
+      const newEvent = mockEvent({ id: 2, code: 'NEW01', name: 'New Party' });
+      vi.mocked(api.createEvent).mockResolvedValue(newEvent);
+
+      render(<EventsPage />);
+      await waitFor(() => expect(screen.getByText(/No events yet/)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: 'Create Event' }));
+      fireEvent.change(screen.getByLabelText('Event Name'), { target: { value: 'New Party' } });
+      await act(async () => {
+        fireEvent.submit(screen.getByRole('button', { name: 'Create' }));
+      });
+
+      expect(api.createEvent).toHaveBeenCalledWith('New Party');
+      await waitFor(() => {
+        expect(screen.getByText('New Party')).toBeInTheDocument();
+      });
+    });
+
+    it('hides form and resets input after create', async () => {
+      vi.mocked(api.getEvents).mockResolvedValue([]);
+      vi.mocked(api.createEvent).mockResolvedValue(mockEvent());
+
+      render(<EventsPage />);
+      await waitFor(() => expect(screen.getByText(/No events yet/)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: 'Create Event' }));
+      fireEvent.change(screen.getByLabelText('Event Name'), { target: { value: 'Test' } });
+      await act(async () => {
+        fireEvent.submit(screen.getByRole('button', { name: 'Create' }));
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByLabelText('Event Name')).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows error when create fails', async () => {
+      vi.mocked(api.getEvents).mockResolvedValue([]);
+      vi.mocked(api.createEvent).mockRejectedValue(new Error('Name taken'));
+
+      render(<EventsPage />);
+      await waitFor(() => expect(screen.getByText(/No events yet/)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: 'Create Event' }));
+      fireEvent.change(screen.getByLabelText('Event Name'), { target: { value: 'Dup' } });
+      await act(async () => {
+        fireEvent.submit(screen.getByRole('button', { name: 'Create' }));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Name taken')).toBeInTheDocument();
+      });
+    });
+
+    it('disables button while creating', async () => {
+      vi.mocked(api.getEvents).mockResolvedValue([]);
+      let resolveCreate!: (v: ReturnType<typeof mockEvent>) => void;
+      vi.mocked(api.createEvent).mockImplementation(
+        () => new Promise((r) => { resolveCreate = r; }),
+      );
+
+      render(<EventsPage />);
+      await waitFor(() => expect(screen.getByText(/No events yet/)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: 'Create Event' }));
+      fireEvent.change(screen.getByLabelText('Event Name'), { target: { value: 'Test' } });
+      fireEvent.submit(screen.getByRole('button', { name: 'Create' }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Creating...' })).toBeDisabled();
+      });
+
+      await act(async () => { resolveCreate(mockEvent()); });
+    });
+
+    it('does not submit with empty name', async () => {
+      vi.mocked(api.getEvents).mockResolvedValue([]);
+
+      render(<EventsPage />);
+      await waitFor(() => expect(screen.getByText(/No events yet/)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: 'Create Event' }));
+      // Leave input empty (required attribute prevents native submit, but our handler also checks)
+      const input = screen.getByLabelText('Event Name');
+      fireEvent.change(input, { target: { value: '   ' } });
+      await act(async () => {
+        fireEvent.submit(screen.getByRole('button', { name: 'Create' }));
+      });
+
+      expect(api.createEvent).not.toHaveBeenCalled();
+    });
+
+    it('hides form on Cancel', async () => {
+      vi.mocked(api.getEvents).mockResolvedValue([]);
+
+      render(<EventsPage />);
+      await waitFor(() => expect(screen.getByText(/No events yet/)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: 'Create Event' }));
+      expect(screen.getByLabelText('Event Name')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(screen.queryByLabelText('Event Name')).not.toBeInTheDocument();
+      expect(api.createEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Logout', () => {
+    it('calls logout on Logout click', async () => {
+      vi.mocked(api.getEvents).mockResolvedValue([]);
+
+      render(<EventsPage />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Logout' }));
+
+      expect(mockLogout).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('Admin role', () => {
+    it('shows Admin button for admin role', async () => {
+      mockRole = 'admin';
+      vi.mocked(api.getEvents).mockResolvedValue([]);
+
+      render(<EventsPage />);
+
+      expect(screen.getByRole('button', { name: 'Admin' })).toBeInTheDocument();
+    });
+
+    it('hides Admin button for dj role', async () => {
+      mockRole = 'dj';
+      vi.mocked(api.getEvents).mockResolvedValue([]);
+
+      render(<EventsPage />);
+
+      expect(screen.queryByRole('button', { name: 'Admin' })).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Phase 1: `events/page.tsx` coverage 65% → **100%** (20 tests)
- Phase 2: `display/page.tsx` coverage 68% → **89%** (43 tests)
- Phase 3: `events/[code]/page.tsx` coverage 36% → **62%** (38 tests)
- Global frontend line coverage: 78.7% → **86.3%** (+7.6)
- Total frontend tests: 613 → **721** (+108)

## Test plan
- [x] All 721 frontend tests pass locally
- [x] ESLint clean (0 errors)
- [x] TypeScript strict mode clean (0 errors)
- [x] Coverage thresholds pass (85.27% stmts vs 77% threshold)
- [ ] CI passes on GitHub Actions