### PR TITLE
security: H-I5 image SHA pinning + H-C1 MultiFernet key rotation

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -3,7 +3,7 @@
 # NOTE: This container must run with network_mode: host (or --network host)
 # for StageLinQ UDP broadcast discovery to work.
 
-FROM node:20-alpine
+FROM node:20-alpine@sha256:f598378b5240225e6beab68fa9f356db1fb8efe55173e6d4d8153113bb8f333c
 
 WORKDIR /app
 

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:22-alpine@sha256:4d64b49e6c891c8fc821007cb1cdc6c0db7773110ac2c34bf2e6960adef62ed3 AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/deploy/dev-proxy/docker-compose.yml
+++ b/deploy/dev-proxy/docker-compose.yml
@@ -14,7 +14,7 @@
 
 services:
   proxy:
-    image: nginx:1.27-alpine
+    image: nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
     container_name: wrzdj-dev-proxy
     ports:
       - "80:80"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -12,7 +12,7 @@
 
 services:
   db:
-    image: postgres:16-alpine
+    image: postgres:16-alpine@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-wrzdj}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   db:
-    image: postgres:16-alpine
+    image: postgres:16-alpine@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416
     environment:
       POSTGRES_USER: wrzdj
       POSTGRES_PASSWORD: wrzdj

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -102,6 +102,11 @@ class Settings(BaseSettings):
     # Generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key()...)"
     token_encryption_key: str = ""
 
+    # SECURITY (H-C1): MultiFernet key rotation support.
+    # Comma-separated Fernet keys; first encrypts, all decrypt. Falls back
+    # to token_encryption_key if empty. Rotation procedure in encryption.py.
+    token_encryption_keys: str = ""
+
     # SECURITY (H-C3): legacy plaintext passthrough in EncryptedText.
     # Set to False once all OAuth tokens are encrypted (post-migration).
     # When False, decrypt_value raises DecryptionError on non-Fernet values.

--- a/server/app/core/encryption.py
+++ b/server/app/core/encryption.py
@@ -1,15 +1,22 @@
 """Fernet encryption for OAuth tokens stored in the database.
 
 Provides transparent encrypt-on-write / decrypt-on-read via a SQLAlchemy
-TypeDecorator.  The encryption key comes from the TOKEN_ENCRYPTION_KEY env var.
-In development, a key is auto-generated if not set.  In production, a missing
-key is a fatal startup error (enforced in config.py).
+TypeDecorator.  The encryption key(s) come from TOKEN_ENCRYPTION_KEYS
+(comma-separated for rotation) or TOKEN_ENCRYPTION_KEY (single key, legacy).
+In development, a key is auto-generated if none set.  In production, a
+missing key is a fatal startup error (enforced in config.py).
+
+SECURITY (H-C1): uses MultiFernet so key rotation is a config change, not
+a data migration. The first key encrypts; all keys are tried for decrypt.
+Rotation procedure: set TOKEN_ENCRYPTION_KEYS=<new>,<old>, deploy, run a
+backfill that re-encrypts existing ciphertext under the new key, then
+remove the old key from the env.
 """
 
 import logging
 
 import sqlalchemy as sa
-from cryptography.fernet import Fernet, InvalidToken
+from cryptography.fernet import Fernet, InvalidToken, MultiFernet
 
 logger = logging.getLogger(__name__)
 
@@ -24,15 +31,20 @@ class DecryptionError(Exception):
     """
 
 
-# Module-level Fernet instance, lazily initialised on first use.
-_fernet: Fernet | None = None
+# Module-level MultiFernet instance, lazily initialised on first use.
+_fernet: MultiFernet | None = None
 
 # Fernet ciphertexts always start with this prefix (base64 version byte).
 _FERNET_PREFIX = "gAAAAA"
 
 
-def _get_fernet() -> Fernet:
-    """Return (or create) the module-level Fernet instance."""
+def _get_fernet() -> MultiFernet:
+    """Return (or create) the module-level MultiFernet instance.
+
+    Reads keys from settings.token_encryption_keys (comma-separated) with
+    fallback to the legacy single settings.token_encryption_key. The first
+    key encrypts new data; all keys are tried for decryption.
+    """
     global _fernet  # noqa: PLW0603
     if _fernet is not None:
         return _fernet
@@ -40,14 +52,20 @@ def _get_fernet() -> Fernet:
     from app.core.config import get_settings
 
     settings = get_settings()
-    key = settings.token_encryption_key
+    keys_str = settings.token_encryption_keys or settings.token_encryption_key
 
-    if not key:
+    if not keys_str:
         # Dev/test fallback — generate an ephemeral key.
-        key = Fernet.generate_key().decode()
-        logger.warning("TOKEN_ENCRYPTION_KEY not set — using auto-generated ephemeral key")
+        keys_str = Fernet.generate_key().decode()
+        logger.warning("TOKEN_ENCRYPTION_KEYS not set — using auto-generated ephemeral key")
 
-    _fernet = Fernet(key.encode() if isinstance(key, str) else key)
+    # Parse comma-separated keys (rotation support). Strip whitespace, drop empties.
+    key_list = [k.strip() for k in keys_str.split(",") if k.strip()]
+    if not key_list:
+        raise ValueError("TOKEN_ENCRYPTION_KEYS contains no valid keys")
+
+    fernets = [Fernet(k.encode() if isinstance(k, str) else k) for k in key_list]
+    _fernet = MultiFernet(fernets)
     return _fernet
 
 

--- a/server/tests/test_encryption.py
+++ b/server/tests/test_encryption.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 import pytest
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, MultiFernet
 from sqlalchemy import Column, Integer, create_engine
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
@@ -83,6 +83,91 @@ class TestEncryptDecrypt:
     def test_unicode_round_trip(self):
         text = "token-with-unicode-\u00e9\u00e8\u00ea"
         assert decrypt_value(encrypt_value(text)) == text
+
+
+class TestMultiFernetRotation:
+    """H-C1 guard: MultiFernet supports key rotation without data migration.
+
+    Rotation model:
+    - TOKEN_ENCRYPTION_KEYS="new,old" during rotation window
+    - First key in list encrypts new data
+    - All keys tried in order for decryption
+    - Ciphertext from old key still decrypts; re-encrypting under new key
+      is an explicit backfill step, not automatic
+
+    These tests install their own _get_fernet override (inner patch) to
+    supersede the outer autouse fixture, returning a MultiFernet with the
+    configured key list.
+    """
+
+    def test_single_key_via_new_plural_field(self):
+        """MultiFernet with one key behaves like old single-key setup."""
+        key = Fernet.generate_key()
+        mf = MultiFernet([Fernet(key)])
+        with patch("app.core.encryption._get_fernet", return_value=mf):
+            ct = encrypt_value("hello")
+            assert decrypt_value(ct) == "hello"
+
+    def test_rotation_old_ciphertext_decrypts_after_rotation(self):
+        """Ciphertext encrypted under key A still decrypts when keys=[B, A]."""
+        key_a = Fernet.generate_key()
+        key_b = Fernet.generate_key()
+
+        # Encrypt under key A only
+        mf_a = MultiFernet([Fernet(key_a)])
+        with patch("app.core.encryption._get_fernet", return_value=mf_a):
+            ciphertext_a = encrypt_value("secret-payload")
+            assert ciphertext_a is not None
+
+        # Rotate: [B, A] — B encrypts new, A still decrypts old
+        mf_rotated = MultiFernet([Fernet(key_b), Fernet(key_a)])
+        with patch("app.core.encryption._get_fernet", return_value=mf_rotated):
+            assert decrypt_value(ciphertext_a) == "secret-payload"
+            new_ct = encrypt_value("new-payload")
+            assert new_ct != ciphertext_a
+            assert decrypt_value(new_ct) == "new-payload"
+
+    def test_old_ciphertext_fails_after_key_removed(self):
+        """Removing the old key from rotation makes old ciphertext undecryptable."""
+        key_a = Fernet.generate_key()
+        key_b = Fernet.generate_key()
+
+        mf_a = MultiFernet([Fernet(key_a)])
+        with patch("app.core.encryption._get_fernet", return_value=mf_a):
+            ciphertext_a = encrypt_value("secret-payload")
+
+        # Key A removed — only B remains
+        mf_b = MultiFernet([Fernet(key_b)])
+        with patch("app.core.encryption._get_fernet", return_value=mf_b):
+            with pytest.raises(DecryptionError):
+                decrypt_value(ciphertext_a)
+
+    def test_rotate_method_reencrypts_under_first_key(self):
+        """MultiFernet.rotate() re-encrypts ciphertext under the first key.
+        This is what a backfill migration would use."""
+        key_a = Fernet.generate_key()
+        key_b = Fernet.generate_key()
+
+        mf_a = MultiFernet([Fernet(key_a)])
+        with patch("app.core.encryption._get_fernet", return_value=mf_a):
+            old_ct = encrypt_value("payload")
+
+        # Rotate: [B, A]
+        mf_rotated = MultiFernet([Fernet(key_b), Fernet(key_a)])
+        with patch("app.core.encryption._get_fernet", return_value=mf_rotated):
+            # Re-encrypt under new primary key (backfill step)
+            new_ct = mf_rotated.rotate(old_ct.encode()).decode()
+            assert new_ct != old_ct
+            # Both still decrypt to original plaintext
+            assert decrypt_value(old_ct) == "payload"
+            assert decrypt_value(new_ct) == "payload"
+
+        # Key A removed — new_ct still works, old_ct does not
+        mf_b = MultiFernet([Fernet(key_b)])
+        with patch("app.core.encryption._get_fernet", return_value=mf_b):
+            assert decrypt_value(new_ct) == "payload"
+            with pytest.raises(DecryptionError):
+                decrypt_value(old_ct)
 
 
 class TestEncryptedTextTypeDecorator:


### PR DESCRIPTION
## Summary

Closes 2 of the 7 remaining HIGH-severity audit findings. Lowest-regression subset, shipped first.

### H-I5 — Docker base image SHA digest pinning
All 5 base images across 6 files pinned to `@sha256:...` digests:
- `python:3.11-slim@sha256:233de067...`
- `node:22-alpine@sha256:4d64b49e...`
- `node:20-alpine@sha256:f598378b...`
- `postgres:16-alpine@sha256:20edbde7...`
- `nginx:1.27-alpine@sha256:65645c7b...`

Dependabot `docker` ecosystem already configured — will auto-propose digest updates.

### H-C1 — MultiFernet key rotation
Swaps `Fernet` → `MultiFernet` in `server/app/core/encryption.py`. New `TOKEN_ENCRYPTION_KEYS` env (comma-separated) supports rotation. Legacy `TOKEN_ENCRYPTION_KEY` still works (fallback). First key encrypts, all keys tried for decrypt.

Rotation procedure: generate new key → `TOKEN_ENCRYPTION_KEYS=<new>,<old>` → backfill via `MultiFernet.rotate()` → remove old key.

4 new tests in `TestMultiFernetRotation` cover rotation, backfill, key removal.

## Test plan
- [x] Backend: 1690 tests passed, 87.64% coverage
- [x] ruff check + format clean
- [x] bandit clean
- [x] docker compose config --quiet — both compose files validate
- [ ] Remote CI green
- [ ] Deploy to production
- [ ] Manual smoke test (login, event flow, OAuth token round-trip)

## Remaining deferred
5 HIGH findings still open (H-I1 code signing, H-I3 nonce CSP, H-C4 email encryption, H-A2 per-event bridge tokens, H-F2 httpOnly cookie). Will land in follow-up PRs.