### PR TITLE
security: P0 Python CVE bumps + M-F6 open redirect + M-F7 overlay headers

### DIFF
--- a/dashboard/app/login/page.tsx
+++ b/dashboard/app/login/page.tsx
@@ -15,7 +15,13 @@ function LoginForm() {
   const { login } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const redirectTo = searchParams.get('redirect') || '/dashboard';
+  // SECURITY (M-F6): only accept same-origin paths. Reject protocol-relative
+  // URLs like "//evil.com" that Next.js router.push treats as external.
+  const rawRedirect = searchParams.get('redirect');
+  const redirectTo =
+    rawRedirect && rawRedirect.startsWith('/') && !rawRedirect.startsWith('//')
+      ? rawRedirect
+      : '/dashboard';
 
   useEffect(() => {
     api.getPublicSettings()

--- a/dashboard/next.config.js
+++ b/dashboard/next.config.js
@@ -23,19 +23,41 @@ const nextConfig = {
           { key: 'X-Content-Type-Options', value: 'nosniff' },
           { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-          { key: 'X-XSS-Protection', value: '1; mode=block' },
+          // X-XSS-Protection removed — deprecated per OWASP (see H-I8)
           {
             key: 'Strict-Transport-Security',
-            value: 'max-age=31536000; includeSubDomains',
+            value: 'max-age=63072000; includeSubDomains; preload',
           },
           { key: 'Content-Security-Policy', value: csp },
         ],
       },
       {
-        // Allow OBS/streaming tools to embed overlay pages
+        // Allow OBS/streaming tools to embed overlay pages.
+        // SECURITY (M-F7): Next.js headers() arrays REPLACE (not merge) more-specific
+        // rules. Must re-declare every other header from the general block so
+        // the overlay route isn't left naked (no HSTS / nosniff / Referrer-Policy
+        // / CSP script-src restrictions).
         source: '/e/:code/overlay',
         headers: [
-          { key: 'Content-Security-Policy', value: "frame-ancestors *" },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            key: 'Content-Security-Policy',
+            // Same CSP as general block but with frame-ancestors * for embedding
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline'",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' data: blob: https:",
+              `connect-src 'self' ${apiUrl}`,
+              "font-src 'self'",
+              "frame-ancestors *",
+            ].join('; '),
+          },
           // Remove X-Frame-Options for this route (CSP frame-ancestors takes precedence)
           { key: 'X-Frame-Options', value: '' },
         ],

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -18,8 +18,13 @@ dependencies = [
     "spotipy>=2.23.0",
     "slowapi>=0.1.9",
     "tidalapi>=0.7.0",
-    "Pillow>=10.0.0",
-    "cryptography>=42.0.0",
+    # SECURITY: minimum versions per 2026-04-08 audit P0 CVEs.
+    # Bumping transitives to direct deps to enforce floor.
+    "Pillow>=12.1.1",        # CVE-2026-25990 (banner upload)
+    "cryptography>=46.0.7",  # CVE-2026-26007, 34073, 39892 (Fernet + JWT)
+    "PyJWT>=2.12.0",         # CVE-2026-32597 (auth lib)
+    "aiohttp>=3.13.4",       # 10x CVE-2026-* (HTTP client)
+    "requests>=2.33.0",      # CVE-2026-25645 (URL parsing)
     "anthropic>=0.40.0",
     "sse-starlette>=2.0.0",
 ]


### PR DESCRIPTION
## Summary

Closes the remaining real (non-speculative, non-hygiene) security items from the 2026-04-08 audit after adversarial gut-check.

### P0 Python CVE bumps (`server/pyproject.toml`)
| Package | Current | New | CVE |
|---|---|---|---|
| Pillow | 12.1.0 | 12.2.0 | CVE-2026-25990 (banner upload) |
| cryptography | 46.0.4 | 46.0.7 | CVE-2026-26007, 34073, 39892 (Fernet + JWT) |
| PyJWT | 2.11.0 | 2.12.1 | CVE-2026-32597 (auth library) |
| aiohttp | 3.13.3 | 3.13.5 | 10x CVE-2026-* |
| requests | 2.32.5 | 2.33.1 | CVE-2026-25645 |

Transitives promoted to direct deps to enforce the floor.

### M-F6 — open redirect on `/login?redirect=`
`router.push(redirectTo)` treated protocol-relative URLs (`//evil.com`) as external. Now validated: must start with `/` and not `//`. Falls back to `/dashboard`.

### M-F7 — overlay route security headers
Next.js `headers()` replaces more-specific rules. Overlay block was shipping without HSTS/nosniff/Referrer-Policy/full CSP. Now re-declares all of them alongside `frame-ancestors *`. Nginx is authoritative in prod so this was a dev-only gap, but still correct to fix.

Also: removed deprecated `X-XSS-Protection` from Next.js config (H-I8 already dropped it from nginx) and upgraded HSTS to 2yr + preload to match H-I7.

## Why these and not the rest

Did an attacker-prerequisite filter on the remaining audit findings:
- **H-F2 / H-I3 / H-A2**: only matter if XSS/VPS compromise happens first → defense-in-depth only
- **H-C4 (email encryption)**: DB breach already leaks bcrypt hashes and encrypted tokens — plaintext email is incremental damage
- **Most MEDIUM + all LOW findings**: either already mitigated by prior PRs (M-C5, M-I8, M-F1), require prior compromise to matter, or are operator-error hygiene rather than attack vectors

Full analysis in the chat log.

## Test plan

- [x] Backend: 1690 tests passed, 87.64% coverage
- [x] ruff check + bandit clean
- [x] Frontend: 777 tests passed, tsc clean
- [ ] Remote CI green
- [ ] Manual test on production