### PR TITLE
feat: Pre-event song collection (voting + bulk review)

### DIFF
--- a/dashboard/app/collect/[code]/components/FeatureOptInPanel.test.tsx
+++ b/dashboard/app/collect/[code]/components/FeatureOptInPanel.test.tsx
@@ -1,39 +1,85 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-import FeatureOptInPanel from "./FeatureOptInPanel";
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import FeatureOptInPanel from './FeatureOptInPanel';
 
-describe("FeatureOptInPanel", () => {
-  it("does not render when hasEmail is true", () => {
-    render(<FeatureOptInPanel hasEmail={true} onSave={vi.fn()} />);
-    expect(screen.queryByText(/add email/i)).not.toBeInTheDocument();
+describe('FeatureOptInPanel', () => {
+  it('does not render when guest already has email AND a nickname', () => {
+    render(
+      <FeatureOptInPanel
+        hasEmail={true}
+        initialNickname="Alex"
+        onSave={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/make it yours/i)).not.toBeInTheDocument();
   });
 
-  it("shows feature comparison and save button", () => {
-    render(<FeatureOptInPanel hasEmail={false} onSave={vi.fn()} />);
+  it('shows feature copy and inputs when nothing set yet', () => {
+    render(
+      <FeatureOptInPanel hasEmail={false} initialNickname={null} onSave={vi.fn()} />,
+    );
+    expect(screen.getByText(/nickname appears/i)).toBeInTheDocument();
     expect(screen.getByText(/notify me when my song plays/i)).toBeInTheDocument();
     expect(screen.getByText(/cross-device/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^nickname$/i)).toBeInTheDocument();
   });
 
-  it("rejects invalid email on client", async () => {
+  it('rejects invalid email on client', async () => {
     const onSave = vi.fn();
-    render(<FeatureOptInPanel hasEmail={false} onSave={onSave} />);
-    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "bogus" } });
-    fireEvent.click(screen.getByRole("button", { name: /add email/i }));
+    render(
+      <FeatureOptInPanel hasEmail={false} initialNickname={null} onSave={onSave} />,
+    );
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'bogus' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
     await waitFor(() => {
       expect(screen.getByText(/invalid email/i)).toBeInTheDocument();
     });
     expect(onSave).not.toHaveBeenCalled();
   });
 
-  it("calls onSave with valid email", async () => {
-    const onSave = vi.fn().mockResolvedValue(undefined);
-    render(<FeatureOptInPanel hasEmail={false} onSave={onSave} />);
-    fireEvent.change(screen.getByLabelText(/email/i), {
-      target: { value: "guest@example.com" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /add email/i }));
+  it('requires at least one of nickname or email', async () => {
+    const onSave = vi.fn();
+    render(
+      <FeatureOptInPanel hasEmail={false} initialNickname={null} onSave={onSave} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
     await waitFor(() => {
-      expect(onSave).toHaveBeenCalledWith("guest@example.com");
+      expect(screen.getByText(/enter a nickname or email/i)).toBeInTheDocument();
+    });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('calls onSave with just nickname when only nickname entered', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <FeatureOptInPanel hasEmail={false} initialNickname={null} onSave={onSave} />,
+    );
+    fireEvent.change(screen.getByLabelText(/^nickname$/i), {
+      target: { value: 'DancingQueen' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({ nickname: 'DancingQueen' });
+    });
+  });
+
+  it('calls onSave with both fields when both filled', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <FeatureOptInPanel hasEmail={false} initialNickname={null} onSave={onSave} />,
+    );
+    fireEvent.change(screen.getByLabelText(/^nickname$/i), {
+      target: { value: 'Alex' },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'alex@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({
+        nickname: 'Alex',
+        email: 'alex@example.com',
+      });
     });
   });
 });

--- a/dashboard/app/collect/[code]/components/FeatureOptInPanel.test.tsx
+++ b/dashboard/app/collect/[code]/components/FeatureOptInPanel.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import FeatureOptInPanel from "./FeatureOptInPanel";
+
+describe("FeatureOptInPanel", () => {
+  it("does not render when hasEmail is true", () => {
+    render(<FeatureOptInPanel hasEmail={true} onSave={vi.fn()} />);
+    expect(screen.queryByText(/add email/i)).not.toBeInTheDocument();
+  });
+
+  it("shows feature comparison and save button", () => {
+    render(<FeatureOptInPanel hasEmail={false} onSave={vi.fn()} />);
+    expect(screen.getByText(/notify me when my song plays/i)).toBeInTheDocument();
+    expect(screen.getByText(/cross-device/i)).toBeInTheDocument();
+  });
+
+  it("rejects invalid email on client", async () => {
+    const onSave = vi.fn();
+    render(<FeatureOptInPanel hasEmail={false} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "bogus" } });
+    fireEvent.click(screen.getByRole("button", { name: /add email/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/invalid email/i)).toBeInTheDocument();
+    });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("calls onSave with valid email", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<FeatureOptInPanel hasEmail={false} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "guest@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add email/i }));
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith("guest@example.com");
+    });
+  });
+});

--- a/dashboard/app/collect/[code]/components/FeatureOptInPanel.tsx
+++ b/dashboard/app/collect/[code]/components/FeatureOptInPanel.tsx
@@ -1,7 +1,7 @@
-"use client";
+'use client';
 
-import { useState } from "react";
-import { z } from "zod";
+import { useState } from 'react';
+import { z } from 'zod';
 
 const emailSchema = z.string().email().max(254);
 
@@ -12,7 +12,7 @@ interface Props {
 
 export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
   const [expanded, setExpanded] = useState(true);
-  const [email, setEmail] = useState("");
+  const [email, setEmail] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -21,7 +21,7 @@ export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
   const submit = async () => {
     const parsed = emailSchema.safeParse(email);
     if (!parsed.success) {
-      setError("Invalid email");
+      setError('Invalid email');
       return;
     }
     setSaving(true);
@@ -36,35 +36,40 @@ export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
   };
 
   return (
-    <section
-      style={{
-        background: "#1a1a1a",
-        padding: 16,
-        borderRadius: 8,
-        marginBottom: 16,
-      }}
-    >
+    <section className="collect-optin">
       <h3>Get the most out of your picks</h3>
-      <ul style={{ marginBottom: 12 }}>
+      <ul className="collect-optin-features">
         <li>Notify me when my song plays</li>
         <li>Cross-device &quot;my picks&quot; and leaderboard position</li>
         <li>Persistent profile across events</li>
       </ul>
-      <label>
-        Email
+      <div className="form-group" style={{ marginBottom: 0 }}>
+        <label htmlFor="collect-email">Email</label>
         <input
+          id="collect-email"
           type="email"
+          className="input"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          style={{ marginLeft: 8 }}
+          placeholder="you@example.com"
         />
-      </label>
-      {error && <p style={{ color: "#ff6b6b" }}>{error}</p>}
-      <div style={{ marginTop: 8 }}>
-        <button onClick={() => setExpanded(false)} disabled={saving}>
+      </div>
+      {error && <p className="collection-fieldset-error">{error}</p>}
+      <div className="collect-optin-actions">
+        <button
+          type="button"
+          className="btn btn-sm collect-optin-dismiss"
+          onClick={() => setExpanded(false)}
+          disabled={saving}
+        >
           Keep it anonymous
         </button>
-        <button onClick={submit} disabled={saving}>
+        <button
+          type="button"
+          className="btn btn-primary btn-sm"
+          onClick={submit}
+          disabled={saving}
+        >
           Add email
         </button>
       </div>

--- a/dashboard/app/collect/[code]/components/FeatureOptInPanel.tsx
+++ b/dashboard/app/collect/[code]/components/FeatureOptInPanel.tsx
@@ -4,29 +4,62 @@ import { useState } from 'react';
 import { z } from 'zod';
 
 const emailSchema = z.string().email().max(254);
+const nicknameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(30)
+  .regex(/^[a-zA-Z0-9 _.-]+$/, 'Letters, numbers, spaces, . _ - only');
 
 interface Props {
   hasEmail: boolean;
-  onSave: (email: string) => Promise<void>;
+  initialNickname: string | null;
+  onSave: (data: { nickname?: string; email?: string }) => Promise<void>;
 }
 
-export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
+export default function FeatureOptInPanel({ hasEmail, initialNickname, onSave }: Props) {
   const [expanded, setExpanded] = useState(true);
+  const [nickname, setNickname] = useState(initialNickname ?? '');
   const [email, setEmail] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
-  if (hasEmail || !expanded) return null;
+  // Hide once the guest either has an email OR has chosen a nickname and dismissed.
+  if ((hasEmail || !expanded) && initialNickname !== null) return null;
+  if (hasEmail && !expanded) return null;
 
   const submit = async () => {
-    const parsed = emailSchema.safeParse(email);
-    if (!parsed.success) {
-      setError('Invalid email');
+    const payload: { nickname?: string; email?: string } = {};
+
+    const nickTrimmed = nickname.trim();
+    if (nickTrimmed) {
+      const nickResult = nicknameSchema.safeParse(nickTrimmed);
+      if (!nickResult.success) {
+        setError(nickResult.error.issues[0].message);
+        return;
+      }
+      payload.nickname = nickResult.data;
+    }
+
+    const emailTrimmed = email.trim();
+    if (emailTrimmed) {
+      const emailResult = emailSchema.safeParse(emailTrimmed);
+      if (!emailResult.success) {
+        setError('Invalid email');
+        return;
+      }
+      payload.email = emailResult.data;
+    }
+
+    if (Object.keys(payload).length === 0) {
+      setError('Enter a nickname or email (or both)');
       return;
     }
+
+    setError(null);
     setSaving(true);
     try {
-      await onSave(parsed.data);
+      await onSave(payload);
       setExpanded(false);
     } catch (e) {
       setError((e as Error).message);
@@ -37,14 +70,36 @@ export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
 
   return (
     <section className="collect-optin">
-      <h3>Get the most out of your picks</h3>
+      <h3>Make it yours</h3>
+      <p
+        style={{
+          fontSize: '0.875rem',
+          color: 'var(--text-secondary)',
+          marginBottom: '0.75rem',
+        }}
+      >
+        Pick a nickname so the DJ knows who suggested what. Add an email for extra perks.
+      </p>
       <ul className="collect-optin-features">
-        <li>Notify me when my song plays</li>
-        <li>Cross-device &quot;my picks&quot; and leaderboard position</li>
-        <li>Persistent profile across events</li>
+        <li>Nickname appears next to your picks</li>
+        <li>Email (optional): notify me when my song plays</li>
+        <li>Email: cross-device &quot;my picks&quot; and leaderboard position</li>
       </ul>
+
+      <div className="form-group">
+        <label htmlFor="collect-nickname">Nickname</label>
+        <input
+          id="collect-nickname"
+          type="text"
+          className="input"
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          placeholder="DancingQueen"
+          maxLength={30}
+        />
+      </div>
       <div className="form-group" style={{ marginBottom: 0 }}>
-        <label htmlFor="collect-email">Email</label>
+        <label htmlFor="collect-email">Email (optional)</label>
         <input
           id="collect-email"
           type="email"
@@ -52,9 +107,12 @@ export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           placeholder="you@example.com"
+          disabled={hasEmail}
         />
       </div>
+
       {error && <p className="collection-fieldset-error">{error}</p>}
+
       <div className="collect-optin-actions">
         <button
           type="button"
@@ -62,7 +120,7 @@ export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
           onClick={() => setExpanded(false)}
           disabled={saving}
         >
-          Keep it anonymous
+          {initialNickname ? 'Close' : 'Skip'}
         </button>
         <button
           type="button"
@@ -70,7 +128,7 @@ export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
           onClick={submit}
           disabled={saving}
         >
-          Add email
+          {saving ? 'Saving…' : 'Save'}
         </button>
       </div>
     </section>

--- a/dashboard/app/collect/[code]/components/FeatureOptInPanel.tsx
+++ b/dashboard/app/collect/[code]/components/FeatureOptInPanel.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { z } from "zod";
+
+const emailSchema = z.string().email().max(254);
+
+interface Props {
+  hasEmail: boolean;
+  onSave: (email: string) => Promise<void>;
+}
+
+export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
+  const [expanded, setExpanded] = useState(true);
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  if (hasEmail || !expanded) return null;
+
+  const submit = async () => {
+    const parsed = emailSchema.safeParse(email);
+    if (!parsed.success) {
+      setError("Invalid email");
+      return;
+    }
+    setSaving(true);
+    try {
+      await onSave(parsed.data);
+      setExpanded(false);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section
+      style={{
+        background: "#1a1a1a",
+        padding: 16,
+        borderRadius: 8,
+        marginBottom: 16,
+      }}
+    >
+      <h3>Get the most out of your picks</h3>
+      <ul style={{ marginBottom: 12 }}>
+        <li>Notify me when my song plays</li>
+        <li>Cross-device &quot;my picks&quot; and leaderboard position</li>
+        <li>Persistent profile across events</li>
+      </ul>
+      <label>
+        Email
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          style={{ marginLeft: 8 }}
+        />
+      </label>
+      {error && <p style={{ color: "#ff6b6b" }}>{error}</p>}
+      <div style={{ marginTop: 8 }}>
+        <button onClick={() => setExpanded(false)} disabled={saving}>
+          Keep it anonymous
+        </button>
+        <button onClick={submit} disabled={saving}>
+          Add email
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx
@@ -1,14 +1,32 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-import LeaderboardTabs from "./LeaderboardTabs";
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import LeaderboardTabs from './LeaderboardTabs';
 
 const rows = [
-  { id: 1, title: "A", artist: "X", artwork_url: null, vote_count: 5, nickname: "alex", status: "new" as const, created_at: "2026-04-21" },
-  { id: 2, title: "B", artist: "Y", artwork_url: null, vote_count: 1, nickname: "jo",   status: "new" as const, created_at: "2026-04-21" },
+  {
+    id: 1,
+    title: 'A',
+    artist: 'X',
+    artwork_url: null,
+    vote_count: 5,
+    nickname: 'alex',
+    status: 'new' as const,
+    created_at: '2026-04-21',
+  },
+  {
+    id: 2,
+    title: 'B',
+    artist: 'Y',
+    artwork_url: null,
+    vote_count: 1,
+    nickname: 'jo',
+    status: 'new' as const,
+    created_at: '2026-04-21',
+  },
 ];
 
-describe("LeaderboardTabs", () => {
-  it("renders rows and switches tabs", () => {
+describe('LeaderboardTabs', () => {
+  it('renders rows and switches tabs', () => {
     const onTabChange = vi.fn();
     render(
       <LeaderboardTabs
@@ -16,26 +34,63 @@ describe("LeaderboardTabs", () => {
         tab="trending"
         onTabChange={onTabChange}
         onVote={vi.fn()}
-      />
+        votedIds={new Set()}
+      />,
     );
-    expect(screen.getByText("A")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /^all$/i }));
-    expect(onTabChange).toHaveBeenCalledWith("all");
+    expect(screen.getByText('A')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^all$/i }));
+    expect(onTabChange).toHaveBeenCalledWith('all');
   });
 
-  it("optimistically updates vote count then rolls back on error", async () => {
-    const onVote = vi.fn().mockRejectedValue(new Error("boom"));
+  it('optimistically updates vote count then rolls back on error', async () => {
+    const onVote = vi.fn().mockRejectedValue(new Error('boom'));
     render(
       <LeaderboardTabs
         rows={rows}
         tab="trending"
         onTabChange={vi.fn()}
         onVote={onVote}
-      />
+        votedIds={new Set()}
+      />,
     );
-    fireEvent.click(screen.getAllByRole("button", { name: /upvote/i })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: /upvote/i })[0]);
     await waitFor(() => {
       expect(screen.getByText(/5/)).toBeInTheDocument();
+    });
+  });
+
+  it('disables the vote button when votedIds already contains the request id', () => {
+    render(
+      <LeaderboardTabs
+        rows={rows}
+        tab="trending"
+        onTabChange={vi.fn()}
+        onVote={vi.fn()}
+        votedIds={new Set([1])}
+      />,
+    );
+    const votedButton = screen.getByRole('button', { name: /upvoted/i });
+    expect(votedButton).toBeDisabled();
+    expect(votedButton).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('does not call onVote twice for rapid repeated clicks on the same row', async () => {
+    const onVote = vi.fn().mockResolvedValue(undefined);
+    render(
+      <LeaderboardTabs
+        rows={rows}
+        tab="trending"
+        onTabChange={vi.fn()}
+        onVote={onVote}
+        votedIds={new Set()}
+      />,
+    );
+    const upvoteButtons = screen.getAllByRole('button', { name: /upvote/i });
+    fireEvent.click(upvoteButtons[0]);
+    fireEvent.click(upvoteButtons[0]);
+    fireEvent.click(upvoteButtons[0]);
+    await waitFor(() => {
+      expect(onVote).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import LeaderboardTabs from "./LeaderboardTabs";
+
+const rows = [
+  { id: 1, title: "A", artist: "X", artwork_url: null, vote_count: 5, nickname: "alex", status: "new" as const, created_at: "2026-04-21" },
+  { id: 2, title: "B", artist: "Y", artwork_url: null, vote_count: 1, nickname: "jo",   status: "new" as const, created_at: "2026-04-21" },
+];
+
+describe("LeaderboardTabs", () => {
+  it("renders rows and switches tabs", () => {
+    const onTabChange = vi.fn();
+    render(
+      <LeaderboardTabs
+        rows={rows}
+        tab="trending"
+        onTabChange={onTabChange}
+        onVote={vi.fn()}
+      />
+    );
+    expect(screen.getByText("A")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /^all$/i }));
+    expect(onTabChange).toHaveBeenCalledWith("all");
+  });
+
+  it("optimistically updates vote count then rolls back on error", async () => {
+    const onVote = vi.fn().mockRejectedValue(new Error("boom"));
+    render(
+      <LeaderboardTabs
+        rows={rows}
+        tab="trending"
+        onTabChange={vi.fn()}
+        onVote={onVote}
+      />
+    );
+    fireEvent.click(screen.getAllByRole("button", { name: /upvote/i })[0]);
+    await waitFor(() => {
+      expect(screen.getByText(/5/)).toBeInTheDocument();
+    });
+  });
+});

--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import type { CollectLeaderboardRow } from "../../../../lib/api";
+
+interface Props {
+  rows: CollectLeaderboardRow[];
+  tab: "trending" | "all";
+  onTabChange: (tab: "trending" | "all") => void;
+  onVote: (requestId: number) => Promise<void>;
+}
+
+export default function LeaderboardTabs({ rows, tab, onTabChange, onVote }: Props) {
+  const [optimistic, setOptimistic] = useState<Record<number, number>>({});
+
+  const handleVote = async (id: number, currentVotes: number) => {
+    setOptimistic((o) => ({ ...o, [id]: currentVotes + 1 }));
+    try {
+      await onVote(id);
+    } catch {
+      setOptimistic((o) => {
+        const next = { ...o };
+        delete next[id];
+        return next;
+      });
+    }
+  };
+
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+        <button
+          aria-pressed={tab === "trending"}
+          onClick={() => onTabChange("trending")}
+        >
+          Trending
+        </button>
+        <button
+          aria-pressed={tab === "all"}
+          onClick={() => onTabChange("all")}
+        >
+          All
+        </button>
+      </div>
+      <ul style={{ listStyle: "none", padding: 0 }}>
+        {rows.map((r) => {
+          const votes = optimistic[r.id] ?? r.vote_count;
+          return (
+            <li
+              key={r.id}
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                padding: 8,
+                background: "#1a1a1a",
+                marginBottom: 4,
+              }}
+            >
+              <div>
+                <strong>{r.title}</strong> — {r.artist}
+                {r.nickname && <span style={{ opacity: 0.7 }}> · by @{r.nickname}</span>}
+              </div>
+              <button
+                aria-label="upvote"
+                onClick={() => handleVote(r.id, r.vote_count)}
+              >
+                ▲ {votes}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
@@ -22,20 +22,22 @@ export default function LeaderboardTabs({
   const [optimistic, setOptimistic] = useState<Record<number, number>>({});
   const [justVoted, setJustVoted] = useState<ReadonlySet<number>>(new Set());
 
-  // Drop optimistic overrides for rows whose vote_count the server has now
-  // caught up on (or exceeded) — prevents stale +1 overlays from lingering.
+  // Once the server's my-picks response confirms a vote (votedIds has the id),
+  // drop the optimistic overlay — trust the server's authoritative vote_count.
+  // If the server rejected the vote as a duplicate, that's correct too; the
+  // UI reverts to the real value instead of clinging to a stale +1.
   useEffect(() => {
     setOptimistic((prev) => {
       const next: Record<number, number> = {};
-      for (const r of rows) {
-        const guess = prev[r.id];
-        if (guess !== undefined && guess > r.vote_count) {
-          next[r.id] = guess;
+      for (const [id, guess] of Object.entries(prev)) {
+        const numericId = Number(id);
+        if (!votedIds.has(numericId)) {
+          next[numericId] = guess;
         }
       }
       return next;
     });
-  }, [rows]);
+  }, [rows, votedIds]);
 
   const hasVoted = (id: number): boolean => votedIds.has(id) || justVoted.has(id);
 

--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { CollectLeaderboardRow } from '../../../../lib/api';
 
 interface Props {
@@ -8,19 +8,56 @@ interface Props {
   tab: 'trending' | 'all';
   onTabChange: (tab: 'trending' | 'all') => void;
   onVote: (requestId: number) => Promise<void>;
+  /** Request IDs this guest has already voted for (from my-picks). */
+  votedIds: ReadonlySet<number>;
 }
 
-export default function LeaderboardTabs({ rows, tab, onTabChange, onVote }: Props) {
+export default function LeaderboardTabs({
+  rows,
+  tab,
+  onTabChange,
+  onVote,
+  votedIds,
+}: Props) {
   const [optimistic, setOptimistic] = useState<Record<number, number>>({});
+  const [justVoted, setJustVoted] = useState<ReadonlySet<number>>(new Set());
+
+  // Drop optimistic overrides for rows whose vote_count the server has now
+  // caught up on (or exceeded) — prevents stale +1 overlays from lingering.
+  useEffect(() => {
+    setOptimistic((prev) => {
+      const next: Record<number, number> = {};
+      for (const r of rows) {
+        const guess = prev[r.id];
+        if (guess !== undefined && guess > r.vote_count) {
+          next[r.id] = guess;
+        }
+      }
+      return next;
+    });
+  }, [rows]);
+
+  const hasVoted = (id: number): boolean => votedIds.has(id) || justVoted.has(id);
 
   const handleVote = async (id: number, currentVotes: number) => {
+    if (hasVoted(id)) return;
     setOptimistic((o) => ({ ...o, [id]: currentVotes + 1 }));
+    setJustVoted((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
     try {
       await onVote(id);
     } catch {
       setOptimistic((o) => {
         const next = { ...o };
         delete next[id];
+        return next;
+      });
+      setJustVoted((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
         return next;
       });
     }
@@ -75,8 +112,10 @@ export default function LeaderboardTabs({ rows, tab, onTabChange, onVote }: Prop
                 </div>
                 <button
                   type="button"
-                  aria-label="upvote"
-                  className="collect-vote"
+                  aria-label={hasVoted(r.id) ? 'upvoted' : 'upvote'}
+                  aria-pressed={hasVoted(r.id)}
+                  className={`collect-vote${hasVoted(r.id) ? ' voted' : ''}`}
+                  disabled={hasVoted(r.id)}
                   onClick={() => handleVote(r.id, r.vote_count)}
                 >
                   <span className="collect-vote-caret">▲</span>

--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
@@ -1,12 +1,12 @@
-"use client";
+'use client';
 
-import { useState } from "react";
-import type { CollectLeaderboardRow } from "../../../../lib/api";
+import { useState } from 'react';
+import type { CollectLeaderboardRow } from '../../../../lib/api';
 
 interface Props {
   rows: CollectLeaderboardRow[];
-  tab: "trending" | "all";
-  onTabChange: (tab: "trending" | "all") => void;
+  tab: 'trending' | 'all';
+  onTabChange: (tab: 'trending' | 'all') => void;
   onVote: (requestId: number) => Promise<void>;
 }
 
@@ -28,48 +28,61 @@ export default function LeaderboardTabs({ rows, tab, onTabChange, onVote }: Prop
 
   return (
     <div>
-      <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+      <div className="collect-tabs">
         <button
-          aria-pressed={tab === "trending"}
-          onClick={() => onTabChange("trending")}
+          type="button"
+          className="collect-tab"
+          aria-pressed={tab === 'trending'}
+          onClick={() => onTabChange('trending')}
         >
           Trending
         </button>
         <button
-          aria-pressed={tab === "all"}
-          onClick={() => onTabChange("all")}
+          type="button"
+          className="collect-tab"
+          aria-pressed={tab === 'all'}
+          onClick={() => onTabChange('all')}
         >
           All
         </button>
       </div>
-      <ul style={{ listStyle: "none", padding: 0 }}>
-        {rows.map((r) => {
-          const votes = optimistic[r.id] ?? r.vote_count;
-          return (
-            <li
-              key={r.id}
-              style={{
-                display: "flex",
-                justifyContent: "space-between",
-                padding: 8,
-                background: "#1a1a1a",
-                marginBottom: 4,
-              }}
-            >
-              <div>
-                <strong>{r.title}</strong> — {r.artist}
-                {r.nickname && <span style={{ opacity: 0.7 }}> · by @{r.nickname}</span>}
-              </div>
-              <button
-                aria-label="upvote"
-                onClick={() => handleVote(r.id, r.vote_count)}
-              >
-                ▲ {votes}
-              </button>
-            </li>
-          );
-        })}
-      </ul>
+      {rows.length === 0 ? (
+        <p className="collect-empty">No songs yet — be the first to add one!</p>
+      ) : (
+        <ul className="collect-leaderboard">
+          {rows.map((r) => {
+            const votes = optimistic[r.id] ?? r.vote_count;
+            return (
+              <li key={r.id} className="collect-row">
+                {r.artwork_url ? (
+                  <img src={r.artwork_url} alt="" className="collect-row-art" />
+                ) : (
+                  <div className="collect-row-art" aria-hidden="true" />
+                )}
+                <div className="collect-row-info">
+                  <div className="collect-row-title">{r.title}</div>
+                  <div className="collect-row-artist">{r.artist}</div>
+                  {r.nickname && (
+                    <div className="collect-row-nickname">
+                      <em className="nickname-icon">@</em>
+                      {r.nickname}
+                    </div>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  aria-label="upvote"
+                  className="collect-vote"
+                  onClick={() => handleVote(r.id, r.vote_count)}
+                >
+                  <span className="collect-vote-caret">▲</span>
+                  <span>{votes}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
     </div>
   );
 }

--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
@@ -47,7 +47,11 @@ export default function LeaderboardTabs({ rows, tab, onTabChange, onVote }: Prop
         </button>
       </div>
       {rows.length === 0 ? (
-        <p className="collect-empty">No songs yet — be the first to add one!</p>
+        <p className="collect-empty">
+          {tab === 'trending'
+            ? 'Not enough songs added yet! Once others contribute this list will grow.'
+            : 'No songs yet — be the first to add one!'}
+        </p>
       ) : (
         <ul className="collect-leaderboard">
           {rows.map((r) => {

--- a/dashboard/app/collect/[code]/components/MyPicksPanel.test.tsx
+++ b/dashboard/app/collect/[code]/components/MyPicksPanel.test.tsx
@@ -18,7 +18,7 @@ describe("MyPicksPanel", () => {
   it("shows empty state when no picks", () => {
     render(
       <MyPicksPanel
-        picks={{ submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: [] }}
+        picks={{ submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: [], voted_request_ids: [] }}
       />
     );
     expect(screen.getByText(/no picks yet/i)).toBeInTheDocument();
@@ -32,6 +32,7 @@ describe("MyPicksPanel", () => {
           upvoted: [],
           is_top_contributor: true,
           first_suggestion_ids: [],
+          voted_request_ids: [],
         }}
       />
     );
@@ -46,6 +47,7 @@ describe("MyPicksPanel", () => {
           upvoted: [],
           is_top_contributor: false,
           first_suggestion_ids: [1],
+          voted_request_ids: [1],
         }}
       />
     );

--- a/dashboard/app/collect/[code]/components/MyPicksPanel.test.tsx
+++ b/dashboard/app/collect/[code]/components/MyPicksPanel.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import MyPicksPanel from "./MyPicksPanel";
+
+const basePick = {
+  id: 1,
+  title: "Mr. Brightside",
+  artist: "The Killers",
+  artwork_url: null,
+  vote_count: 12,
+  nickname: "me",
+  status: "new" as const,
+  created_at: "2026-04-21T00:00:00Z",
+  interaction: "submitted" as const,
+};
+
+describe("MyPicksPanel", () => {
+  it("shows empty state when no picks", () => {
+    render(
+      <MyPicksPanel
+        picks={{ submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: [] }}
+      />
+    );
+    expect(screen.getByText(/no picks yet/i)).toBeInTheDocument();
+  });
+
+  it("shows top contributor badge when flagged", () => {
+    render(
+      <MyPicksPanel
+        picks={{
+          submitted: [basePick],
+          upvoted: [],
+          is_top_contributor: true,
+          first_suggestion_ids: [],
+        }}
+      />
+    );
+    expect(screen.getByText(/top contributor/i)).toBeInTheDocument();
+  });
+
+  it("shows first-to-suggest badge on matching pick", () => {
+    render(
+      <MyPicksPanel
+        picks={{
+          submitted: [basePick],
+          upvoted: [],
+          is_top_contributor: false,
+          first_suggestion_ids: [1],
+        }}
+      />
+    );
+    expect(screen.getByText(/first to suggest/i)).toBeInTheDocument();
+  });
+});

--- a/dashboard/app/collect/[code]/components/MyPicksPanel.tsx
+++ b/dashboard/app/collect/[code]/components/MyPicksPanel.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type { CollectMyPicksResponse } from "../../../../lib/api";
+
+interface Props {
+  picks: CollectMyPicksResponse;
+}
+
+export default function MyPicksPanel({ picks }: Props) {
+  const isEmpty = picks.submitted.length === 0 && picks.upvoted.length === 0;
+
+  return (
+    <section style={{ marginTop: 24 }}>
+      <h2>My Picks</h2>
+      {picks.is_top_contributor && (
+        <p style={{ color: "#ffcc00" }}>🏆 Top contributor for this event</p>
+      )}
+      {isEmpty ? (
+        <p>No picks yet — search for a song below!</p>
+      ) : (
+        <ul>
+          {picks.submitted.map((p) => (
+            <li key={`s-${p.id}`}>
+              {p.title} — {p.artist}
+              <span style={{ marginLeft: 8, padding: "2px 6px", background: "#333" }}>
+                {p.status}
+              </span>
+              {picks.first_suggestion_ids.includes(p.id) && (
+                <span style={{ marginLeft: 8 }}>⭐ First to suggest</span>
+              )}
+            </li>
+          ))}
+          {picks.upvoted.map((p) => (
+            <li key={`u-${p.id}`}>
+              {p.title} — {p.artist} <em>(upvoted)</em>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/dashboard/app/collect/[code]/components/MyPicksPanel.tsx
+++ b/dashboard/app/collect/[code]/components/MyPicksPanel.tsx
@@ -1,38 +1,63 @@
-"use client";
+'use client';
 
-import type { CollectMyPicksResponse } from "../../../../lib/api";
+import type { CollectMyPicksItem, CollectMyPicksResponse } from '../../../../lib/api';
 
 interface Props {
   picks: CollectMyPicksResponse;
 }
 
+const STATUS_CLASS: Record<CollectMyPicksItem['status'], string> = {
+  new: 'badge-new',
+  accepted: 'badge-accepted',
+  playing: 'badge-playing',
+  played: 'badge-played',
+  rejected: 'badge-rejected',
+};
+
 export default function MyPicksPanel({ picks }: Props) {
   const isEmpty = picks.submitted.length === 0 && picks.upvoted.length === 0;
 
   return (
-    <section style={{ marginTop: 24 }}>
-      <h2>My Picks</h2>
+    <section className="collect-section">
+      <h2 className="collect-section-title">My Picks</h2>
       {picks.is_top_contributor && (
-        <p style={{ color: "#ffcc00" }}>🏆 Top contributor for this event</p>
+        <p className="collect-picks-badge">🏆 Top contributor for this event</p>
       )}
       {isEmpty ? (
-        <p>No picks yet — search for a song below!</p>
+        <p className="collect-empty">No picks yet — search for a song below!</p>
       ) : (
-        <ul>
+        <ul className="collect-leaderboard">
           {picks.submitted.map((p) => (
-            <li key={`s-${p.id}`}>
-              {p.title} — {p.artist}
-              <span style={{ marginLeft: 8, padding: "2px 6px", background: "#333" }}>
-                {p.status}
-              </span>
-              {picks.first_suggestion_ids.includes(p.id) && (
-                <span style={{ marginLeft: 8 }}>⭐ First to suggest</span>
+            <li key={`s-${p.id}`} className="collect-row">
+              {p.artwork_url ? (
+                <img src={p.artwork_url} alt="" className="collect-row-art" />
+              ) : (
+                <div className="collect-row-art" aria-hidden="true" />
               )}
+              <div className="collect-row-info">
+                <div className="collect-row-title">{p.title}</div>
+                <div className="collect-row-artist">{p.artist}</div>
+                {picks.first_suggestion_ids.includes(p.id) && (
+                  <span className="collect-pick-first">⭐ First to suggest</span>
+                )}
+              </div>
+              <span className={`badge ${STATUS_CLASS[p.status]}`}>{p.status}</span>
             </li>
           ))}
           {picks.upvoted.map((p) => (
-            <li key={`u-${p.id}`}>
-              {p.title} — {p.artist} <em>(upvoted)</em>
+            <li key={`u-${p.id}`} className="collect-row">
+              {p.artwork_url ? (
+                <img src={p.artwork_url} alt="" className="collect-row-art" />
+              ) : (
+                <div className="collect-row-art" aria-hidden="true" />
+              )}
+              <div className="collect-row-info">
+                <div className="collect-row-title">{p.title}</div>
+                <div className="collect-row-artist">
+                  {p.artist} <em>(upvoted)</em>
+                </div>
+              </div>
+              <span className="badge badge-new">▲ {p.vote_count}</span>
             </li>
           ))}
         </ul>

--- a/dashboard/app/collect/[code]/components/SubmitBar.test.tsx
+++ b/dashboard/app/collect/[code]/components/SubmitBar.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import SubmitBar from "./SubmitBar";
+
+describe("SubmitBar", () => {
+  it("shows used vs cap", () => {
+    render(
+      <SubmitBar used={3} cap={15} onOpenSearch={vi.fn()} />
+    );
+    expect(screen.getByText(/3 of 15 picks used/i)).toBeInTheDocument();
+  });
+
+  it("disables button at cap", () => {
+    render(
+      <SubmitBar used={15} cap={15} onOpenSearch={vi.fn()} />
+    );
+    expect(screen.getByRole("button", { name: /add a song/i })).toBeDisabled();
+  });
+
+  it("button enabled when cap is 0 (unlimited)", () => {
+    render(
+      <SubmitBar used={99} cap={0} onOpenSearch={vi.fn()} />
+    );
+    expect(screen.getByRole("button", { name: /add a song/i })).not.toBeDisabled();
+  });
+});

--- a/dashboard/app/collect/[code]/components/SubmitBar.tsx
+++ b/dashboard/app/collect/[code]/components/SubmitBar.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+interface Props {
+  used: number;
+  cap: number; // 0 means unlimited
+  onOpenSearch: () => void;
+}
+
+export default function SubmitBar({ used, cap, onOpenSearch }: Props) {
+  const atCap = cap !== 0 && used >= cap;
+  const label =
+    cap === 0 ? "Unlimited picks" : `${used} of ${cap} picks used`;
+
+  return (
+    <div
+      style={{
+        position: "sticky",
+        bottom: 0,
+        background: "#0a0a0a",
+        padding: 16,
+        borderTop: "1px solid #333",
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+      }}
+    >
+      <span>{label}</span>
+      <button disabled={atCap} onClick={onOpenSearch}>
+        + Add a song
+      </button>
+    </div>
+  );
+}

--- a/dashboard/app/collect/[code]/components/SubmitBar.tsx
+++ b/dashboard/app/collect/[code]/components/SubmitBar.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 interface Props {
   used: number;
@@ -8,24 +8,17 @@ interface Props {
 
 export default function SubmitBar({ used, cap, onOpenSearch }: Props) {
   const atCap = cap !== 0 && used >= cap;
-  const label =
-    cap === 0 ? "Unlimited picks" : `${used} of ${cap} picks used`;
+  const label = cap === 0 ? 'Unlimited picks' : `${used} of ${cap} picks used`;
 
   return (
-    <div
-      style={{
-        position: "sticky",
-        bottom: 0,
-        background: "#0a0a0a",
-        padding: 16,
-        borderTop: "1px solid #333",
-        display: "flex",
-        justifyContent: "space-between",
-        alignItems: "center",
-      }}
-    >
-      <span>{label}</span>
-      <button disabled={atCap} onClick={onOpenSearch}>
+    <div className="collect-submit-bar">
+      <span className={`collect-cap-counter${atCap ? ' at-cap' : ''}`}>{label}</span>
+      <button
+        type="button"
+        className="btn btn-primary btn-sm"
+        disabled={atCap}
+        onClick={onOpenSearch}
+      >
         + Add a song
       </button>
     </div>

--- a/dashboard/app/collect/[code]/page.test.tsx
+++ b/dashboard/app/collect/[code]/page.test.tsx
@@ -26,7 +26,7 @@ vi.mock("../../../lib/api", () => ({
     getCollectEvent: (...a: unknown[]) => mockGetEvent(...a),
     getCollectLeaderboard: (...a: unknown[]) => mockGetCollectLeaderboard(...a),
     getCollectMyPicks: vi.fn().mockResolvedValue({
-      submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: []
+      submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: [], voted_request_ids: []
     }),
     setCollectProfile: (...a: unknown[]) => mockSetCollectProfile(...a),
     submitCollectRequest: (...a: unknown[]) => mockSubmitCollectRequest(...a),

--- a/dashboard/app/collect/[code]/page.test.tsx
+++ b/dashboard/app/collect/[code]/page.test.tsx
@@ -89,7 +89,7 @@ describe("CollectPage", () => {
     });
     render(<CollectPage />);
     await waitFor(() => {
-      expect(screen.getByText(/opens in/i)).toBeInTheDocument();
+      expect(screen.getByText(/until voting opens/i)).toBeInTheDocument();
     });
   });
 

--- a/dashboard/app/collect/[code]/page.test.tsx
+++ b/dashboard/app/collect/[code]/page.test.tsx
@@ -9,6 +9,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 const mockGetEvent = vi.fn();
+const mockGetCollectProfile = vi.fn();
 const mockSetCollectProfile = vi.fn();
 const mockGetCollectLeaderboard = vi.fn();
 const mockSubmitCollectRequest = vi.fn();
@@ -28,6 +29,7 @@ vi.mock("../../../lib/api", () => ({
     getCollectMyPicks: vi.fn().mockResolvedValue({
       submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: [], voted_request_ids: []
     }),
+    getCollectProfile: (...a: unknown[]) => mockGetCollectProfile(...a),
     setCollectProfile: (...a: unknown[]) => mockSetCollectProfile(...a),
     submitCollectRequest: (...a: unknown[]) => mockSubmitCollectRequest(...a),
     eventSearch: (...a: unknown[]) => mockEventSearch(...a),
@@ -52,11 +54,14 @@ describe("CollectPage", () => {
   beforeEach(() => {
     mockReplace.mockClear();
     mockGetEvent.mockReset();
-    mockSetCollectProfile.mockResolvedValue({
+    const defaultProfile = {
       has_email: false,
+      nickname: null,
       submission_count: 0,
       submission_cap: 15,
-    });
+    };
+    mockGetCollectProfile.mockResolvedValue(defaultProfile);
+    mockSetCollectProfile.mockResolvedValue(defaultProfile);
     mockGetCollectLeaderboard.mockResolvedValue({ requests: [], total: 0 });
     mockSubmitCollectRequest.mockResolvedValue({ id: 42 });
     mockEventSearch.mockResolvedValue([]);
@@ -126,11 +131,22 @@ describe("CollectPage", () => {
   it("calls submitCollectRequest and refreshes profile after track select", async () => {
     mockGetEvent.mockResolvedValue(COLLECTION_EVENT);
 
-    // First setCollectProfile call (initial profile load)
-    mockSetCollectProfile
-      .mockResolvedValueOnce({ has_email: false, submission_count: 0, submission_cap: 15 })
-      // Second call (refresh after submit)
-      .mockResolvedValueOnce({ has_email: false, submission_count: 1, submission_cap: 15 });
+    // Initial profile load goes through getCollectProfile; post-submit refresh
+    // also hits getCollectProfile (not setCollectProfile) now that reads and
+    // writes have separate endpoints.
+    mockGetCollectProfile
+      .mockResolvedValueOnce({
+        has_email: false,
+        nickname: null,
+        submission_count: 0,
+        submission_cap: 15,
+      })
+      .mockResolvedValueOnce({
+        has_email: false,
+        nickname: null,
+        submission_count: 1,
+        submission_cap: 15,
+      });
 
     mockSubmitCollectRequest.mockResolvedValue({ id: 42 });
 
@@ -190,7 +206,8 @@ describe("CollectPage", () => {
       });
     });
 
-    // Profile should have been refreshed at least once after submit (initial + at least one refresh)
-    expect(mockSetCollectProfile.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // Profile should have been refreshed at least once after submit
+    // (initial load + post-submit refresh, both via the read endpoint)
+    expect(mockGetCollectProfile.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/dashboard/app/collect/[code]/page.test.tsx
+++ b/dashboard/app/collect/[code]/page.test.tsx
@@ -16,6 +16,11 @@ vi.mock("../../../lib/api", () => ({
     getCollectMyPicks: vi.fn().mockResolvedValue({
       submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: []
     }),
+    setCollectProfile: vi.fn().mockResolvedValue({
+      has_email: false,
+      submission_count: 0,
+      submission_cap: 15,
+    }),
   },
 }));
 

--- a/dashboard/app/collect/[code]/page.test.tsx
+++ b/dashboard/app/collect/[code]/page.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import CollectPage from "./page";
+
+const mockReplace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace, push: vi.fn() }),
+  useParams: () => ({ code: "ABC" }),
+}));
+
+const mockGetEvent = vi.fn();
+vi.mock("../../../lib/api", () => ({
+  apiClient: {
+    getCollectEvent: (...a: unknown[]) => mockGetEvent(...a),
+    getCollectLeaderboard: vi.fn().mockResolvedValue({ requests: [], total: 0 }),
+    getCollectMyPicks: vi.fn().mockResolvedValue({
+      submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: []
+    }),
+  },
+}));
+
+describe("CollectPage", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    mockGetEvent.mockReset();
+    vi.stubGlobal("sessionStorage", {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows pre-announce countdown when phase is pre_announce", async () => {
+    mockGetEvent.mockResolvedValue({
+      code: "ABC",
+      name: "Test Event",
+      phase: "pre_announce",
+      collection_opens_at: new Date(Date.now() + 3600_000).toISOString(),
+      live_starts_at: new Date(Date.now() + 7200_000).toISOString(),
+      submission_cap_per_guest: 15,
+      banner_filename: null,
+      registration_enabled: true,
+      expires_at: new Date(Date.now() + 86400_000).toISOString(),
+    });
+    render(<CollectPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/opens in/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders collection experience when phase is collection", async () => {
+    mockGetEvent.mockResolvedValue({
+      code: "ABC",
+      name: "Test Event",
+      phase: "collection",
+      collection_opens_at: new Date(Date.now() - 3600_000).toISOString(),
+      live_starts_at: new Date(Date.now() + 3600_000).toISOString(),
+      submission_cap_per_guest: 15,
+      banner_filename: null,
+      registration_enabled: true,
+      expires_at: new Date(Date.now() + 86400_000).toISOString(),
+    });
+    render(<CollectPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/test event/i)).toBeInTheDocument();
+    });
+  });
+
+  it("redirects to /join when phase is live", async () => {
+    mockGetEvent.mockResolvedValue({
+      code: "ABC",
+      name: "Test Event",
+      phase: "live",
+      collection_opens_at: new Date(Date.now() - 86400_000).toISOString(),
+      live_starts_at: new Date(Date.now() - 3600_000).toISOString(),
+      submission_cap_per_guest: 15,
+      banner_filename: null,
+      registration_enabled: true,
+      expires_at: new Date(Date.now() + 86400_000).toISOString(),
+    });
+    render(<CollectPage />);
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/join/ABC");
+    });
+    expect(sessionStorage.setItem).toHaveBeenCalledWith(
+      "wrzdj_live_splash_ABC",
+      "1"
+    );
+  });
+});

--- a/dashboard/app/collect/[code]/page.test.tsx
+++ b/dashboard/app/collect/[code]/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import CollectPage from "./page";
 
@@ -9,27 +9,64 @@ vi.mock("next/navigation", () => ({
 }));
 
 const mockGetEvent = vi.fn();
+const mockSetCollectProfile = vi.fn();
+const mockGetCollectLeaderboard = vi.fn();
+const mockSubmitCollectRequest = vi.fn();
+const mockEventSearch = vi.fn();
+
 vi.mock("../../../lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
   apiClient: {
     getCollectEvent: (...a: unknown[]) => mockGetEvent(...a),
-    getCollectLeaderboard: vi.fn().mockResolvedValue({ requests: [], total: 0 }),
+    getCollectLeaderboard: (...a: unknown[]) => mockGetCollectLeaderboard(...a),
     getCollectMyPicks: vi.fn().mockResolvedValue({
       submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: []
     }),
-    setCollectProfile: vi.fn().mockResolvedValue({
-      has_email: false,
-      submission_count: 0,
-      submission_cap: 15,
-    }),
+    setCollectProfile: (...a: unknown[]) => mockSetCollectProfile(...a),
+    submitCollectRequest: (...a: unknown[]) => mockSubmitCollectRequest(...a),
+    eventSearch: (...a: unknown[]) => mockEventSearch(...a),
+    search: vi.fn().mockResolvedValue([]),
+    voteCollectRequest: vi.fn().mockResolvedValue(undefined),
   },
 }));
+
+const COLLECTION_EVENT = {
+  code: "ABC",
+  name: "Test Event",
+  phase: "collection" as const,
+  collection_opens_at: new Date(Date.now() - 3600_000).toISOString(),
+  live_starts_at: new Date(Date.now() + 3600_000).toISOString(),
+  submission_cap_per_guest: 15,
+  banner_filename: null,
+  registration_enabled: true,
+  expires_at: new Date(Date.now() + 86400_000).toISOString(),
+};
 
 describe("CollectPage", () => {
   beforeEach(() => {
     mockReplace.mockClear();
     mockGetEvent.mockReset();
+    mockSetCollectProfile.mockResolvedValue({
+      has_email: false,
+      submission_count: 0,
+      submission_cap: 15,
+    });
+    mockGetCollectLeaderboard.mockResolvedValue({ requests: [], total: 0 });
+    mockSubmitCollectRequest.mockResolvedValue({ id: 42 });
+    mockEventSearch.mockResolvedValue([]);
     vi.stubGlobal("sessionStorage", {
       getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn().mockReturnValue(null),
       setItem: vi.fn(),
       removeItem: vi.fn(),
     });
@@ -57,17 +94,7 @@ describe("CollectPage", () => {
   });
 
   it("renders collection experience when phase is collection", async () => {
-    mockGetEvent.mockResolvedValue({
-      code: "ABC",
-      name: "Test Event",
-      phase: "collection",
-      collection_opens_at: new Date(Date.now() - 3600_000).toISOString(),
-      live_starts_at: new Date(Date.now() + 3600_000).toISOString(),
-      submission_cap_per_guest: 15,
-      banner_filename: null,
-      registration_enabled: true,
-      expires_at: new Date(Date.now() + 86400_000).toISOString(),
-    });
+    mockGetEvent.mockResolvedValue(COLLECTION_EVENT);
     render(<CollectPage />);
     await waitFor(() => {
       expect(screen.getByText(/test event/i)).toBeInTheDocument();
@@ -94,5 +121,76 @@ describe("CollectPage", () => {
       "wrzdj_live_splash_ABC",
       "1"
     );
+  });
+
+  it("calls submitCollectRequest and refreshes profile after track select", async () => {
+    mockGetEvent.mockResolvedValue(COLLECTION_EVENT);
+
+    // First setCollectProfile call (initial profile load)
+    mockSetCollectProfile
+      .mockResolvedValueOnce({ has_email: false, submission_count: 0, submission_cap: 15 })
+      // Second call (refresh after submit)
+      .mockResolvedValueOnce({ has_email: false, submission_count: 1, submission_cap: 15 });
+
+    mockSubmitCollectRequest.mockResolvedValue({ id: 42 });
+
+    const track = {
+      artist: "Daft Punk",
+      title: "Harder Better Faster Stronger",
+      album: null,
+      popularity: 90,
+      spotify_id: "spotify-123",
+      album_art: null,
+      preview_url: null,
+      url: "https://open.spotify.com/track/spotify-123",
+      source: "spotify" as const,
+      genre: null,
+      bpm: null,
+      key: null,
+      isrc: null,
+    };
+    mockEventSearch.mockResolvedValue([track]);
+
+    render(<CollectPage />);
+
+    // Wait for collection phase to render the SubmitBar
+    await waitFor(() => {
+      expect(screen.getByText(/add a song/i)).toBeInTheDocument();
+    });
+
+    // Open search modal
+    fireEvent.click(screen.getByText(/add a song/i));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("collect-search-input")).toBeInTheDocument();
+    });
+
+    // Type query and search
+    fireEvent.change(screen.getByTestId("collect-search-input"), {
+      target: { value: "Daft Punk" },
+    });
+    fireEvent.submit(screen.getByTestId("collect-search-input").closest("form")!);
+
+    // Wait for result to appear
+    await waitFor(() => {
+      expect(screen.getByTestId("collect-search-result")).toBeInTheDocument();
+    });
+
+    // Click the result to submit
+    fireEvent.click(screen.getByTestId("collect-search-result"));
+
+    await waitFor(() => {
+      expect(mockSubmitCollectRequest).toHaveBeenCalledWith("ABC", {
+        song_title: track.title,
+        artist: track.artist,
+        source: track.source,
+        source_url: track.url,
+        artwork_url: undefined,
+        nickname: undefined,
+      });
+    });
+
+    // Profile should have been refreshed at least once after submit (initial + at least one refresh)
+    expect(mockSetCollectProfile.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import {
+  apiClient,
+  CollectEventPreview,
+  CollectLeaderboardResponse,
+  CollectMyPicksResponse,
+} from "../../../lib/api";
+
+const POLL_MS = 5000;
+
+export default function CollectPage() {
+  const router = useRouter();
+  const params = useParams<{ code: string }>();
+  const code = params?.code ?? "";
+  const [event, setEvent] = useState<CollectEventPreview | null>(null);
+  const [leaderboard, setLeaderboard] = useState<CollectLeaderboardResponse | null>(
+    null
+  );
+  const [myPicks, setMyPicks] = useState<CollectMyPicksResponse | null>(null);
+  const [tab, setTab] = useState<"trending" | "all">("trending");
+  const [error, setError] = useState<string | null>(null);
+
+  const redirectToJoin = () => {
+    sessionStorage.setItem(`wrzdj_live_splash_${code}`, "1");
+    router.replace(`/join/${code}`);
+  };
+
+  useEffect(() => {
+    if (!code) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const tick = async () => {
+      try {
+        const ev = await apiClient.getCollectEvent(code);
+        if (cancelled) return;
+        setEvent(ev);
+        if (ev.phase === "live" || ev.phase === "closed") {
+          redirectToJoin();
+          return;
+        }
+        if (ev.phase === "collection") {
+          const [lb, picks] = await Promise.all([
+            apiClient.getCollectLeaderboard(code, tab),
+            apiClient.getCollectMyPicks(code),
+          ]);
+          if (!cancelled) {
+            setLeaderboard(lb);
+            setMyPicks(picks);
+          }
+        }
+      } catch (e) {
+        if (!cancelled) setError((e as Error).message);
+      }
+      if (!cancelled && document.visibilityState === "visible") {
+        timer = setTimeout(tick, POLL_MS);
+      }
+    };
+
+    tick();
+    const onVisibility = () => {
+      if (document.visibilityState === "visible" && !cancelled) tick();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [code, tab]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (error) return <main style={{ padding: 24 }}>Error: {error}</main>;
+  if (!event) return <main style={{ padding: 24 }}>Loading…</main>;
+
+  if (event.phase === "pre_announce") {
+    const opens = event.collection_opens_at
+      ? new Date(event.collection_opens_at)
+      : null;
+    return (
+      <main style={{ padding: 24 }}>
+        <h1>{event.name}</h1>
+        <p>Voting opens in {formatCountdown(opens)}</p>
+      </main>
+    );
+  }
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>{event.name}</h1>
+      <p>
+        Voting open —{" "}
+        {formatCountdown(
+          event.live_starts_at ? new Date(event.live_starts_at) : null
+        )}{" "}
+        until the event goes live
+      </p>
+      <div style={{ marginTop: 16 }}>
+        <button onClick={() => setTab("trending")} aria-pressed={tab === "trending"}>
+          Trending
+        </button>
+        <button onClick={() => setTab("all")} aria-pressed={tab === "all"}>
+          All
+        </button>
+      </div>
+      <ul>
+        {leaderboard?.requests.map((r) => (
+          <li key={r.id}>
+            <strong>{r.title}</strong> — {r.artist} (▲ {r.vote_count})
+          </li>
+        ))}
+      </ul>
+      <section>
+        <h2>My Picks</h2>
+        {myPicks?.submitted.length === 0 && myPicks?.upvoted.length === 0 ? (
+          <p>No picks yet — search for a song below!</p>
+        ) : (
+          <ul>
+            {myPicks?.submitted.map((r) => (
+              <li key={`s-${r.id}`}>
+                {r.title} — {r.artist} [{r.status}]
+              </li>
+            ))}
+            {myPicks?.upvoted.map((r) => (
+              <li key={`u-${r.id}`}>
+                {r.title} — {r.artist} (upvoted)
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function formatCountdown(target: Date | null): string {
+  if (!target) return "";
+  const diff = target.getTime() - Date.now();
+  if (diff <= 0) return "now";
+  const hrs = Math.floor(diff / 3_600_000);
+  const mins = Math.floor((diff % 3_600_000) / 60_000);
+  const days = Math.floor(hrs / 24);
+  if (days >= 1) return `${days}d ${hrs % 24}h`;
+  return `${hrs}h ${mins}m`;
+}

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -11,6 +11,7 @@ import {
 import FeatureOptInPanel from "./components/FeatureOptInPanel";
 import LeaderboardTabs from "./components/LeaderboardTabs";
 import MyPicksPanel from "./components/MyPicksPanel";
+import SubmitBar from "./components/SubmitBar";
 
 const POLL_MS = 5000;
 
@@ -26,11 +27,20 @@ export default function CollectPage() {
   const [tab, setTab] = useState<"trending" | "all">("trending");
   const [error, setError] = useState<string | null>(null);
   const [hasEmail, setHasEmail] = useState(false);
+  const [profile, setProfile] = useState<{ submission_count: number; submission_cap: number } | null>(null);
 
   const saveEmail = async (email: string) => {
     const resp = await apiClient.setCollectProfile(code, { email });
     setHasEmail(resp.has_email);
   };
+
+  useEffect(() => {
+    if (!code) return;
+    apiClient.setCollectProfile(code, {}).then((p) => {
+      setProfile({ submission_count: p.submission_count, submission_cap: p.submission_cap });
+      setHasEmail(p.has_email);
+    });
+  }, [code]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const redirectToJoin = () => {
     sessionStorage.setItem(`wrzdj_live_splash_${code}`, "1");
@@ -115,6 +125,11 @@ export default function CollectPage() {
         onVote={(id) => apiClient.voteCollectRequest(code, id)}
       />
       {myPicks && <MyPicksPanel picks={myPicks} />}
+      <SubmitBar
+        used={profile?.submission_count ?? 0}
+        cap={event.submission_cap_per_guest}
+        onOpenSearch={() => alert("Song search coming in Task 19")}
+      />
     </main>
   );
 }

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -1,7 +1,7 @@
-"use client";
+'use client';
 
-import { useParams, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import {
   apiClient,
   ApiError,
@@ -9,31 +9,32 @@ import {
   CollectLeaderboardResponse,
   CollectMyPicksResponse,
   SearchResult,
-} from "../../../lib/api";
-import FeatureOptInPanel from "./components/FeatureOptInPanel";
-import LeaderboardTabs from "./components/LeaderboardTabs";
-import MyPicksPanel from "./components/MyPicksPanel";
-import SubmitBar from "./components/SubmitBar";
+} from '../../../lib/api';
+import FeatureOptInPanel from './components/FeatureOptInPanel';
+import LeaderboardTabs from './components/LeaderboardTabs';
+import MyPicksPanel from './components/MyPicksPanel';
+import SubmitBar from './components/SubmitBar';
 
 const POLL_MS = 5000;
 
 export default function CollectPage() {
   const router = useRouter();
   const params = useParams<{ code: string }>();
-  const code = params?.code ?? "";
+  const code = params?.code ?? '';
   const [event, setEvent] = useState<CollectEventPreview | null>(null);
-  const [leaderboard, setLeaderboard] = useState<CollectLeaderboardResponse | null>(
-    null
-  );
+  const [leaderboard, setLeaderboard] = useState<CollectLeaderboardResponse | null>(null);
   const [myPicks, setMyPicks] = useState<CollectMyPicksResponse | null>(null);
-  const [tab, setTab] = useState<"trending" | "all">("trending");
+  const [tab, setTab] = useState<'trending' | 'all'>('trending');
   const [error, setError] = useState<string | null>(null);
   const [hasEmail, setHasEmail] = useState(false);
-  const [profile, setProfile] = useState<{ submission_count: number; submission_cap: number } | null>(null);
+  const [profile, setProfile] = useState<{
+    submission_count: number;
+    submission_cap: number;
+  } | null>(null);
 
   // Search modal state
   const [searchOpen, setSearchOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [searching, setSearching] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -54,14 +55,14 @@ export default function CollectPage() {
 
   const openSearch = () => {
     setSearchOpen(true);
-    setSearchQuery("");
+    setSearchQuery('');
     setSearchResults([]);
     setSubmitError(null);
   };
 
   const closeSearch = () => {
     setSearchOpen(false);
-    setSearchQuery("");
+    setSearchQuery('');
     setSearchResults([]);
     setSubmitError(null);
   };
@@ -99,7 +100,6 @@ export default function CollectPage() {
         artwork_url: song.album_art ?? undefined,
         nickname,
       });
-      // Refresh profile (submission count) + leaderboard
       const [p, lb] = await Promise.all([
         apiClient.setCollectProfile(code, {}),
         apiClient.getCollectLeaderboard(code, tab),
@@ -109,9 +109,9 @@ export default function CollectPage() {
       closeSearch();
     } catch (err) {
       if (err instanceof ApiError && err.status === 429) {
-        setSubmitError("Picks limit reached");
+        setSubmitError('Picks limit reached');
       } else {
-        setSubmitError("Failed to submit. Please try again.");
+        setSubmitError('Failed to submit. Please try again.');
       }
     } finally {
       setSubmitting(false);
@@ -119,7 +119,7 @@ export default function CollectPage() {
   };
 
   const redirectToJoin = () => {
-    sessionStorage.setItem(`wrzdj_live_splash_${code}`, "1");
+    sessionStorage.setItem(`wrzdj_live_splash_${code}`, '1');
     router.replace(`/join/${code}`);
   };
 
@@ -133,11 +133,11 @@ export default function CollectPage() {
         const ev = await apiClient.getCollectEvent(code);
         if (cancelled) return;
         setEvent(ev);
-        if (ev.phase === "live" || ev.phase === "closed") {
+        if (ev.phase === 'live' || ev.phase === 'closed') {
           redirectToJoin();
           return;
         }
-        if (ev.phase === "collection") {
+        if (ev.phase === 'collection') {
           const [lb, picks] = await Promise.all([
             apiClient.getCollectLeaderboard(code, tab),
             apiClient.getCollectMyPicks(code),
@@ -150,57 +150,100 @@ export default function CollectPage() {
       } catch (e) {
         if (!cancelled) setError((e as Error).message);
       }
-      if (!cancelled && document.visibilityState === "visible") {
+      if (!cancelled && document.visibilityState === 'visible') {
         timer = setTimeout(tick, POLL_MS);
       }
     };
 
     tick();
     const onVisibility = () => {
-      if (document.visibilityState === "visible" && !cancelled) tick();
+      if (document.visibilityState === 'visible' && !cancelled) tick();
     };
-    document.addEventListener("visibilitychange", onVisibility);
+    document.addEventListener('visibilitychange', onVisibility);
 
     return () => {
       cancelled = true;
       if (timer) clearTimeout(timer);
-      document.removeEventListener("visibilitychange", onVisibility);
+      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, [code, tab]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  if (error) return <main style={{ padding: 24 }}>Error: {error}</main>;
-  if (!event) return <main style={{ padding: 24 }}>Loading…</main>;
-
-  if (event.phase === "pre_announce") {
-    const opens = event.collection_opens_at
-      ? new Date(event.collection_opens_at)
-      : null;
+  if (error) {
     return (
-      <main style={{ padding: 24 }}>
-        <h1>{event.name}</h1>
-        <p>Voting opens in {formatCountdown(opens)}</p>
+      <main className="collect-page">
+        <div className="collect-container">
+          <div className="collect-error">Error: {error}</div>
+        </div>
+      </main>
+    );
+  }
+  if (!event) {
+    return (
+      <main className="collect-page">
+        <div className="loading">Loading…</div>
       </main>
     );
   }
 
+  const bannerNode = event.banner_url ? (
+    <div className="join-banner-bg">
+      <img src={event.banner_url} alt="" />
+    </div>
+  ) : null;
+
+  if (event.phase === 'pre_announce') {
+    const opens = event.collection_opens_at ? new Date(event.collection_opens_at) : null;
+    return (
+      <main className="collect-page">
+        {bannerNode}
+        <div className="collect-container">
+          <div className="collect-preannounce">
+            <div className="collect-phase-badge pre-announce">
+              <span>🎟️</span>
+              <span>Pre-event voting</span>
+            </div>
+            <h1 className="collect-title">{event.name}</h1>
+            <div className="collect-preannounce-count">{formatCountdown(opens)}</div>
+            <p className="collect-countdown">until voting opens</p>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  const liveStarts = event.live_starts_at ? new Date(event.live_starts_at) : null;
+
   return (
-    <main style={{ padding: 24 }}>
-      <h1>{event.name}</h1>
-      <p>
-        Voting open —{" "}
-        {formatCountdown(
-          event.live_starts_at ? new Date(event.live_starts_at) : null
-        )}{" "}
-        until the event goes live
-      </p>
-      <FeatureOptInPanel hasEmail={hasEmail} onSave={saveEmail} />
-      <LeaderboardTabs
-        rows={leaderboard?.requests ?? []}
-        tab={tab}
-        onTabChange={setTab}
-        onVote={(id) => apiClient.voteCollectRequest(code, id)}
-      />
-      {myPicks && <MyPicksPanel picks={myPicks} />}
+    <main className="collect-page">
+      {bannerNode}
+      <div className="collect-container">
+        <header className="collect-header">
+          <div className="collect-phase-badge">
+            <span>🎟️</span>
+            <span>Pre-event voting is open</span>
+          </div>
+          <h1 className="collect-title">{event.name}</h1>
+          {liveStarts && (
+            <p className="collect-countdown">
+              Live show in <strong>{formatCountdown(liveStarts)}</strong>
+            </p>
+          )}
+        </header>
+
+        <FeatureOptInPanel hasEmail={hasEmail} onSave={saveEmail} />
+
+        <section className="collect-section">
+          <LeaderboardTabs
+            rows={leaderboard?.requests ?? []}
+            tab={tab}
+            onTabChange={setTab}
+            onVote={(id) => apiClient.voteCollectRequest(code, id)}
+          />
+        </section>
+
+        {myPicks && <MyPicksPanel picks={myPicks} />}
+      </div>
+
       <SubmitBar
         used={profile?.submission_count ?? 0}
         cap={event.submission_cap_per_guest}
@@ -209,41 +252,28 @@ export default function CollectPage() {
 
       {searchOpen && (
         <div
-          style={{
-            position: "fixed",
-            inset: 0,
-            background: "rgba(0,0,0,0.85)",
-            zIndex: 1000,
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            overflowY: "auto",
-            padding: "1rem",
-          }}
+          className="collect-search-overlay"
           onClick={closeSearch}
+          role="dialog"
+          aria-label="Add a song"
         >
-          <div
-            className="card"
-            style={{ width: "100%", maxWidth: 480, marginTop: "2rem" }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1rem" }}>
-              <h2 style={{ margin: 0 }}>Add a song</h2>
+          <div className="collect-search-modal" onClick={(e) => e.stopPropagation()}>
+            <div className="collect-search-header">
+              <h2 style={{ margin: 0, fontSize: '1.1rem', flex: 1 }}>Add a song</h2>
               <button
+                type="button"
+                className="btn btn-sm collect-optin-dismiss"
                 onClick={closeSearch}
-                style={{ background: "none", border: "none", color: "var(--text-secondary)", fontSize: "1.25rem", cursor: "pointer" }}
                 aria-label="Close search"
               >
                 ✕
               </button>
             </div>
 
-            {submitError && (
-              <p style={{ color: "#ef4444", marginBottom: "1rem" }}>{submitError}</p>
-            )}
+            {submitError && <div className="collect-error">{submitError}</div>}
 
-            <form onSubmit={handleSearch} style={{ marginBottom: "1rem" }}>
-              <div className="form-group">
+            <form onSubmit={handleSearch}>
+              <div className="form-group" style={{ marginBottom: '0.5rem' }}>
                 <input
                   type="text"
                   className="input"
@@ -257,47 +287,37 @@ export default function CollectPage() {
               </div>
               <button
                 type="submit"
-                className="btn btn-primary"
-                style={{ width: "100%" }}
+                className="btn btn-primary btn-sm"
+                style={{ width: '100%' }}
                 disabled={searching}
               >
-                {searching ? "Searching…" : "Search"}
+                {searching ? 'Searching…' : 'Search'}
               </button>
             </form>
 
             {searchResults.length > 0 && (
-              <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+              <div className="collect-search-results">
                 {searchResults.map((result, index) => (
                   <button
+                    type="button"
                     key={result.spotify_id ?? result.url ?? index}
-                    className="request-item"
-                    style={{
-                      cursor: submitting ? "default" : "pointer",
-                      border: "none",
-                      textAlign: "left",
-                      width: "100%",
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "0.75rem",
-                    }}
+                    className="collect-search-result"
                     disabled={submitting}
                     onClick={() => handleSelectSong(result)}
                     data-testid="collect-search-result"
                   >
-                    {result.album_art && (
+                    {result.album_art ? (
                       <img
                         src={result.album_art}
                         alt={result.album ?? result.title}
-                        style={{ width: 48, height: 48, borderRadius: 4, objectFit: "cover", flexShrink: 0 }}
+                        className="collect-row-art"
                       />
+                    ) : (
+                      <div className="collect-row-art" aria-hidden="true" />
                     )}
-                    <div className="request-info" style={{ flex: 1, minWidth: 0 }}>
-                      <h3 style={{ fontSize: "1rem", margin: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                        {result.title}
-                      </h3>
-                      <p style={{ margin: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                        {result.artist}
-                      </p>
+                    <div className="collect-row-info">
+                      <div className="collect-row-title">{result.title}</div>
+                      <div className="collect-row-artist">{result.artist}</div>
                     </div>
                   </button>
                 ))}
@@ -311,9 +331,9 @@ export default function CollectPage() {
 }
 
 function formatCountdown(target: Date | null): string {
-  if (!target) return "";
+  if (!target) return '';
   const diff = target.getTime() - Date.now();
-  if (diff <= 0) return "now";
+  if (diff <= 0) return 'now';
   const hrs = Math.floor(diff / 3_600_000);
   const mins = Math.floor((diff % 3_600_000) / 60_000);
   const days = Math.floor(hrs / 24);

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -31,6 +31,7 @@ export default function CollectPage() {
   const [tab, setTab] = useState<'trending' | 'all'>('all');
   const [error, setError] = useState<string | null>(null);
   const [hasEmail, setHasEmail] = useState(false);
+  const [nickname, setNickname] = useState<string | null>(null);
   const [profile, setProfile] = useState<{
     submission_count: number;
     submission_cap: number;
@@ -44,9 +45,13 @@ export default function CollectPage() {
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  const saveEmail = async (email: string) => {
-    const resp = await apiClient.setCollectProfile(code, { email });
+  const saveProfile = async (data: { nickname?: string; email?: string }) => {
+    const resp = await apiClient.setCollectProfile(code, data);
     setHasEmail(resp.has_email);
+    setNickname(resp.nickname);
+    if (resp.nickname) {
+      localStorage.setItem(`wrzdj_collect_nickname_${code}`, resp.nickname);
+    }
   };
 
   useEffect(() => {
@@ -54,6 +59,10 @@ export default function CollectPage() {
     apiClient.setCollectProfile(code, {}).then((p) => {
       setProfile({ submission_count: p.submission_count, submission_cap: p.submission_cap });
       setHasEmail(p.has_email);
+      setNickname(p.nickname);
+      if (p.nickname) {
+        localStorage.setItem(`wrzdj_collect_nickname_${code}`, p.nickname);
+      }
     });
   }, [code]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -95,14 +104,15 @@ export default function CollectPage() {
     setSubmitting(true);
     setSubmitError(null);
     try {
-      const nickname = localStorage.getItem(`wrzdj_collect_nickname_${code}`) ?? undefined;
+      const submitNickname =
+        nickname ?? localStorage.getItem(`wrzdj_collect_nickname_${code}`) ?? undefined;
       await apiClient.submitCollectRequest(code, {
         song_title: song.title,
         artist: song.artist,
         source: song.source,
         source_url: song.url ?? undefined,
         artwork_url: song.album_art ?? undefined,
-        nickname,
+        nickname: submitNickname,
       });
       const [p, lb] = await Promise.all([
         apiClient.setCollectProfile(code, {}),
@@ -232,9 +242,18 @@ export default function CollectPage() {
               Live show in <strong>{formatCountdown(liveStarts)}</strong>
             </p>
           )}
+          {nickname && (
+            <p className="collect-countdown" style={{ marginTop: '0.25rem' }}>
+              Voting as <strong>@{nickname}</strong>
+            </p>
+          )}
         </header>
 
-        <FeatureOptInPanel hasEmail={hasEmail} onSave={saveEmail} />
+        <FeatureOptInPanel
+          hasEmail={hasEmail}
+          initialNickname={nickname}
+          onSave={saveProfile}
+        />
 
         <section className="collect-section">
           <LeaderboardTabs

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -24,6 +24,7 @@ export default function CollectPage() {
   const [event, setEvent] = useState<CollectEventPreview | null>(null);
   const [leaderboard, setLeaderboard] = useState<CollectLeaderboardResponse | null>(null);
   const [myPicks, setMyPicks] = useState<CollectMyPicksResponse | null>(null);
+  const votedIds = new Set<number>(myPicks?.upvoted.map((p) => p.id) ?? []);
   const [tab, setTab] = useState<'trending' | 'all'>('all');
   const [error, setError] = useState<string | null>(null);
   const [hasEmail, setHasEmail] = useState(false);
@@ -238,6 +239,7 @@ export default function CollectPage() {
             tab={tab}
             onTabChange={setTab}
             onVote={(id) => apiClient.voteCollectRequest(code, id)}
+            votedIds={votedIds}
           />
         </section>
 

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -56,7 +56,7 @@ export default function CollectPage() {
 
   useEffect(() => {
     if (!code) return;
-    apiClient.setCollectProfile(code, {}).then((p) => {
+    apiClient.getCollectProfile(code).then((p) => {
       setProfile({ submission_count: p.submission_count, submission_cap: p.submission_cap });
       setHasEmail(p.has_email);
       setNickname(p.nickname);
@@ -115,7 +115,7 @@ export default function CollectPage() {
         nickname: submitNickname,
       });
       const [p, lb] = await Promise.all([
-        apiClient.setCollectProfile(code, {}),
+        apiClient.getCollectProfile(code),
         apiClient.getCollectLeaderboard(code, tab),
       ]);
       setProfile({ submission_count: p.submission_count, submission_cap: p.submission_cap });

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -24,7 +24,7 @@ export default function CollectPage() {
   const [event, setEvent] = useState<CollectEventPreview | null>(null);
   const [leaderboard, setLeaderboard] = useState<CollectLeaderboardResponse | null>(null);
   const [myPicks, setMyPicks] = useState<CollectMyPicksResponse | null>(null);
-  const [tab, setTab] = useState<'trending' | 'all'>('trending');
+  const [tab, setTab] = useState<'trending' | 'all'>('all');
   const [error, setError] = useState<string | null>(null);
   const [hasEmail, setHasEmail] = useState(false);
   const [profile, setProfile] = useState<{

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -24,7 +24,10 @@ export default function CollectPage() {
   const [event, setEvent] = useState<CollectEventPreview | null>(null);
   const [leaderboard, setLeaderboard] = useState<CollectLeaderboardResponse | null>(null);
   const [myPicks, setMyPicks] = useState<CollectMyPicksResponse | null>(null);
-  const votedIds = new Set<number>(myPicks?.upvoted.map((p) => p.id) ?? []);
+  // Canonical "I have voted on this request" set — covers both upvotes AND
+  // votes on my own submissions (which don't appear in `upvoted` because the
+  // backend dedupes that against `submitted` for display purposes).
+  const votedIds = new Set<number>(myPicks?.voted_request_ids ?? []);
   const [tab, setTab] = useState<'trending' | 'all'>('all');
   const [error, setError] = useState<string | null>(null);
   const [hasEmail, setHasEmail] = useState(false);

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -9,6 +9,7 @@ import {
   CollectMyPicksResponse,
 } from "../../../lib/api";
 import FeatureOptInPanel from "./components/FeatureOptInPanel";
+import LeaderboardTabs from "./components/LeaderboardTabs";
 
 const POLL_MS = 5000;
 
@@ -106,21 +107,12 @@ export default function CollectPage() {
         until the event goes live
       </p>
       <FeatureOptInPanel hasEmail={hasEmail} onSave={saveEmail} />
-      <div style={{ marginTop: 16 }}>
-        <button onClick={() => setTab("trending")} aria-pressed={tab === "trending"}>
-          Trending
-        </button>
-        <button onClick={() => setTab("all")} aria-pressed={tab === "all"}>
-          All
-        </button>
-      </div>
-      <ul>
-        {leaderboard?.requests.map((r) => (
-          <li key={r.id}>
-            <strong>{r.title}</strong> — {r.artist} (▲ {r.vote_count})
-          </li>
-        ))}
-      </ul>
+      <LeaderboardTabs
+        rows={leaderboard?.requests ?? []}
+        tab={tab}
+        onTabChange={setTab}
+        onVote={(id) => apiClient.voteCollectRequest(code, id)}
+      />
       <section>
         <h2>My Picks</h2>
         {myPicks?.submitted.length === 0 && myPicks?.upvoted.length === 0 ? (

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -8,6 +8,7 @@ import {
   CollectLeaderboardResponse,
   CollectMyPicksResponse,
 } from "../../../lib/api";
+import FeatureOptInPanel from "./components/FeatureOptInPanel";
 
 const POLL_MS = 5000;
 
@@ -22,6 +23,12 @@ export default function CollectPage() {
   const [myPicks, setMyPicks] = useState<CollectMyPicksResponse | null>(null);
   const [tab, setTab] = useState<"trending" | "all">("trending");
   const [error, setError] = useState<string | null>(null);
+  const [hasEmail, setHasEmail] = useState(false);
+
+  const saveEmail = async (email: string) => {
+    const resp = await apiClient.setCollectProfile(code, { email });
+    setHasEmail(resp.has_email);
+  };
 
   const redirectToJoin = () => {
     sessionStorage.setItem(`wrzdj_live_splash_${code}`, "1");
@@ -98,6 +105,7 @@ export default function CollectPage() {
         )}{" "}
         until the event goes live
       </p>
+      <FeatureOptInPanel hasEmail={hasEmail} onSave={saveEmail} />
       <div style={{ marginTop: 16 }}>
         <button onClick={() => setTab("trending")} aria-pressed={tab === "trending"}>
           Trending

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../../lib/api";
 import FeatureOptInPanel from "./components/FeatureOptInPanel";
 import LeaderboardTabs from "./components/LeaderboardTabs";
+import MyPicksPanel from "./components/MyPicksPanel";
 
 const POLL_MS = 5000;
 
@@ -113,25 +114,7 @@ export default function CollectPage() {
         onTabChange={setTab}
         onVote={(id) => apiClient.voteCollectRequest(code, id)}
       />
-      <section>
-        <h2>My Picks</h2>
-        {myPicks?.submitted.length === 0 && myPicks?.upvoted.length === 0 ? (
-          <p>No picks yet — search for a song below!</p>
-        ) : (
-          <ul>
-            {myPicks?.submitted.map((r) => (
-              <li key={`s-${r.id}`}>
-                {r.title} — {r.artist} [{r.status}]
-              </li>
-            ))}
-            {myPicks?.upvoted.map((r) => (
-              <li key={`u-${r.id}`}>
-                {r.title} — {r.artist} (upvoted)
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+      {myPicks && <MyPicksPanel picks={myPicks} />}
     </main>
   );
 }

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -4,9 +4,11 @@ import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import {
   apiClient,
+  ApiError,
   CollectEventPreview,
   CollectLeaderboardResponse,
   CollectMyPicksResponse,
+  SearchResult,
 } from "../../../lib/api";
 import FeatureOptInPanel from "./components/FeatureOptInPanel";
 import LeaderboardTabs from "./components/LeaderboardTabs";
@@ -29,6 +31,14 @@ export default function CollectPage() {
   const [hasEmail, setHasEmail] = useState(false);
   const [profile, setProfile] = useState<{ submission_count: number; submission_cap: number } | null>(null);
 
+  // Search modal state
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
   const saveEmail = async (email: string) => {
     const resp = await apiClient.setCollectProfile(code, { email });
     setHasEmail(resp.has_email);
@@ -41,6 +51,72 @@ export default function CollectPage() {
       setHasEmail(p.has_email);
     });
   }, [code]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const openSearch = () => {
+    setSearchOpen(true);
+    setSearchQuery("");
+    setSearchResults([]);
+    setSubmitError(null);
+  };
+
+  const closeSearch = () => {
+    setSearchOpen(false);
+    setSearchQuery("");
+    setSearchResults([]);
+    setSubmitError(null);
+  };
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!searchQuery.trim()) return;
+    setSearching(true);
+    setSearchResults([]);
+    try {
+      const results = await apiClient.eventSearch(code, searchQuery);
+      setSearchResults(results);
+    } catch {
+      try {
+        const results = await apiClient.search(searchQuery);
+        setSearchResults(results);
+      } catch {
+        // silently leave results empty
+      }
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const handleSelectSong = async (song: SearchResult) => {
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const nickname = localStorage.getItem(`wrzdj_collect_nickname_${code}`) ?? undefined;
+      await apiClient.submitCollectRequest(code, {
+        song_title: song.title,
+        artist: song.artist,
+        source: song.source,
+        source_url: song.url ?? undefined,
+        artwork_url: song.album_art ?? undefined,
+        nickname,
+      });
+      // Refresh profile (submission count) + leaderboard
+      const [p, lb] = await Promise.all([
+        apiClient.setCollectProfile(code, {}),
+        apiClient.getCollectLeaderboard(code, tab),
+      ]);
+      setProfile({ submission_count: p.submission_count, submission_cap: p.submission_cap });
+      setLeaderboard(lb);
+      closeSearch();
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 429) {
+        setSubmitError("Picks limit reached");
+      } else {
+        setSubmitError("Failed to submit. Please try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   const redirectToJoin = () => {
     sessionStorage.setItem(`wrzdj_live_splash_${code}`, "1");
@@ -128,8 +204,108 @@ export default function CollectPage() {
       <SubmitBar
         used={profile?.submission_count ?? 0}
         cap={event.submission_cap_per_guest}
-        onOpenSearch={() => alert("Song search coming in Task 19")}
+        onOpenSearch={openSearch}
       />
+
+      {searchOpen && (
+        <div
+          style={{
+            position: "fixed",
+            inset: 0,
+            background: "rgba(0,0,0,0.85)",
+            zIndex: 1000,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            overflowY: "auto",
+            padding: "1rem",
+          }}
+          onClick={closeSearch}
+        >
+          <div
+            className="card"
+            style={{ width: "100%", maxWidth: 480, marginTop: "2rem" }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1rem" }}>
+              <h2 style={{ margin: 0 }}>Add a song</h2>
+              <button
+                onClick={closeSearch}
+                style={{ background: "none", border: "none", color: "var(--text-secondary)", fontSize: "1.25rem", cursor: "pointer" }}
+                aria-label="Close search"
+              >
+                ✕
+              </button>
+            </div>
+
+            {submitError && (
+              <p style={{ color: "#ef4444", marginBottom: "1rem" }}>{submitError}</p>
+            )}
+
+            <form onSubmit={handleSearch} style={{ marginBottom: "1rem" }}>
+              <div className="form-group">
+                <input
+                  type="text"
+                  className="input"
+                  placeholder="Search for a song or artist…"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  required
+                  autoFocus
+                  data-testid="collect-search-input"
+                />
+              </div>
+              <button
+                type="submit"
+                className="btn btn-primary"
+                style={{ width: "100%" }}
+                disabled={searching}
+              >
+                {searching ? "Searching…" : "Search"}
+              </button>
+            </form>
+
+            {searchResults.length > 0 && (
+              <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+                {searchResults.map((result, index) => (
+                  <button
+                    key={result.spotify_id ?? result.url ?? index}
+                    className="request-item"
+                    style={{
+                      cursor: submitting ? "default" : "pointer",
+                      border: "none",
+                      textAlign: "left",
+                      width: "100%",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "0.75rem",
+                    }}
+                    disabled={submitting}
+                    onClick={() => handleSelectSong(result)}
+                    data-testid="collect-search-result"
+                  >
+                    {result.album_art && (
+                      <img
+                        src={result.album_art}
+                        alt={result.album ?? result.title}
+                        style={{ width: 48, height: 48, borderRadius: 4, objectFit: "cover", flexShrink: 0 }}
+                      />
+                    )}
+                    <div className="request-info" style={{ flex: 1, minWidth: 0 }}>
+                      <h3 style={{ fontSize: "1rem", margin: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                        {result.title}
+                      </h3>
+                      <p style={{ margin: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                        {result.artist}
+                      </p>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </main>
   );
 }

--- a/dashboard/app/dashboard/page.tsx
+++ b/dashboard/app/dashboard/page.tsx
@@ -84,11 +84,22 @@ export default function DashboardPage() {
     setCollectionError(null);
 
     setCreating(true);
+    let createdEvent;
     try {
-      const event = await api.createEvent(newEventName);
+      createdEvent = await api.createEvent(newEventName);
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : 'Failed to create event');
+      setCreating(false);
+      return;
+    }
 
-      if (showCollection && (collectionOpensAt || liveStartsAt || submissionCap > 0)) {
-        await api.patchCollectionSettings(event.code, {
+    // Always show the event in the list, even if collection settings fail —
+    // the user can finish setup on the event's Pre-Event Voting tab.
+    setEvents([createdEvent, ...events]);
+
+    if (showCollection && (collectionOpensAt || liveStartsAt || submissionCap > 0)) {
+      try {
+        await api.patchCollectionSettings(createdEvent.code, {
           collection_opens_at: collectionOpensAt
             ? new Date(collectionOpensAt).toISOString()
             : null,
@@ -97,20 +108,24 @@ export default function DashboardPage() {
             : null,
           submission_cap_per_guest: submissionCap,
         });
+      } catch (err) {
+        setErrorMsg(
+          `Event "${createdEvent.name}" was created, but collection settings failed: ${
+            err instanceof Error ? err.message : 'unknown error'
+          }. Open the event and finish setup on the Pre-Event Voting tab.`,
+        );
+        setCreating(false);
+        return;
       }
-
-      setEvents([event, ...events]);
-      setNewEventName('');
-      setShowCreate(false);
-      setShowCollection(false);
-      setCollectionOpensAt('');
-      setLiveStartsAt('');
-      setSubmissionCap(0);
-    } catch (err) {
-      setErrorMsg(err instanceof Error ? err.message : 'Failed to create event');
-    } finally {
-      setCreating(false);
     }
+
+    setNewEventName('');
+    setShowCreate(false);
+    setShowCollection(false);
+    setCollectionOpensAt('');
+    setLiveStartsAt('');
+    setSubmissionCap(0);
+    setCreating(false);
   };
 
   const toggleSelection = (code: string) => {

--- a/dashboard/app/dashboard/page.tsx
+++ b/dashboard/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { Event, TidalStatus, BeatportStatus, ActivityLogEntry } from '@/lib/api-types';
 import { ActivityLogPanel } from './components/ActivityLogPanel';
+import { CollectionFieldset, collectionSchema } from '@/components/CollectionFieldset';
 
 export default function DashboardPage() {
   const { isAuthenticated, isLoading, role, logout } = useAuth();
@@ -23,6 +24,13 @@ export default function DashboardPage() {
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedEvents, setSelectedEvents] = useState<Set<string>>(new Set());
   const [deletingSelected, setDeletingSelected] = useState(false);
+
+  // Pre-event collection state
+  const [showCollection, setShowCollection] = useState(false);
+  const [collectionOpensAt, setCollectionOpensAt] = useState('');
+  const [liveStartsAt, setLiveStartsAt] = useState('');
+  const [submissionCap, setSubmissionCap] = useState(0);
+  const [collectionError, setCollectionError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -62,12 +70,42 @@ export default function DashboardPage() {
     e.preventDefault();
     if (!newEventName.trim()) return;
 
+    if (showCollection) {
+      const parsed = collectionSchema.safeParse({
+        collection_opens_at: collectionOpensAt || undefined,
+        live_starts_at: liveStartsAt || undefined,
+        submission_cap_per_guest: submissionCap,
+      });
+      if (!parsed.success) {
+        setCollectionError(parsed.error.issues[0].message);
+        return;
+      }
+    }
+    setCollectionError(null);
+
     setCreating(true);
     try {
       const event = await api.createEvent(newEventName);
+
+      if (showCollection && (collectionOpensAt || liveStartsAt || submissionCap > 0)) {
+        await api.patchCollectionSettings(event.code, {
+          collection_opens_at: collectionOpensAt
+            ? new Date(collectionOpensAt).toISOString()
+            : null,
+          live_starts_at: liveStartsAt
+            ? new Date(liveStartsAt).toISOString()
+            : null,
+          submission_cap_per_guest: submissionCap,
+        });
+      }
+
       setEvents([event, ...events]);
       setNewEventName('');
       setShowCreate(false);
+      setShowCollection(false);
+      setCollectionOpensAt('');
+      setLiveStartsAt('');
+      setSubmissionCap(0);
     } catch (err) {
       setErrorMsg(err instanceof Error ? err.message : 'Failed to create event');
     } finally {
@@ -170,6 +208,17 @@ export default function DashboardPage() {
                 required
               />
             </div>
+            <CollectionFieldset
+              enabled={showCollection}
+              onEnabledChange={setShowCollection}
+              collectionOpensAt={collectionOpensAt}
+              onCollectionOpensAtChange={setCollectionOpensAt}
+              liveStartsAt={liveStartsAt}
+              onLiveStartsAtChange={setLiveStartsAt}
+              submissionCap={submissionCap}
+              onSubmissionCapChange={setSubmissionCap}
+              error={collectionError}
+            />
             <div style={{ display: 'flex', gap: '1rem' }}>
               <button type="submit" className="btn btn-primary" disabled={creating}>
                 {creating ? 'Creating...' : 'Create'}

--- a/dashboard/app/events/[code]/__tests__/page.test.tsx
+++ b/dashboard/app/events/[code]/__tests__/page.test.tsx
@@ -190,6 +190,8 @@ function mockEvent(overrides = {}) {
     tidal_sync_enabled: false, tidal_playlist_id: null,
     beatport_sync_enabled: false, beatport_playlist_id: null,
     banner_url: null, banner_kiosk_url: null, banner_colors: null,
+    collection_opens_at: null, live_starts_at: null,
+    submission_cap_per_guest: 15, collection_phase_override: null,
     ...overrides,
   };
 }

--- a/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
+++ b/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import { useEffect, useState } from "react";
-import { z } from "zod";
-import { apiClient, PendingReviewRow } from "@/lib/api";
+import { useEffect, useState } from 'react';
+import { z } from 'zod';
+import { apiClient, PendingReviewRow } from '@/lib/api';
 
 interface EventShape {
   code: string;
@@ -10,8 +10,8 @@ interface EventShape {
   collection_opens_at: string | null;
   live_starts_at: string | null;
   submission_cap_per_guest: number;
-  collection_phase_override: "force_collection" | "force_live" | null;
-  phase: "pre_announce" | "collection" | "live" | "closed";
+  collection_phase_override: 'force_collection' | 'force_live' | null;
+  phase: 'pre_announce' | 'collection' | 'live' | 'closed';
 }
 
 interface Props {
@@ -19,7 +19,13 @@ interface Props {
   onEventChange: (next: Partial<EventShape>) => void;
 }
 
-type ConfirmAction = "force_collection" | "force_live" | "clear";
+type ConfirmAction = 'force_collection' | 'force_live' | 'clear';
+
+const CONFIRM_LABEL: Record<ConfirmAction, string> = {
+  force_collection: 'Open collection now',
+  force_live: 'Start live now',
+  clear: 'Clear phase override',
+};
 
 const collectionSchema = z
   .object({
@@ -34,12 +40,11 @@ const collectionSchema = z
       }
       return true;
     },
-    { message: "Collection opens must be before live starts" }
+    { message: 'Collection opens must be before live starts' },
   );
 
 function toDatetimeLocal(iso: string | null): string {
-  if (!iso) return "";
-  // Chop seconds + timezone to get "YYYY-MM-DDTHH:mm"
+  if (!iso) return '';
   return iso.slice(0, 16);
 }
 
@@ -55,22 +60,18 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
   const [topN, setTopN] = useState(20);
   const [minVotes, setMinVotes] = useState(3);
 
-  // Collection settings form state
   const [collectionOpensAt, setCollectionOpensAt] = useState(
-    toDatetimeLocal(event.collection_opens_at)
+    toDatetimeLocal(event.collection_opens_at),
   );
-  const [liveStartsAt, setLiveStartsAt] = useState(
-    toDatetimeLocal(event.live_starts_at)
-  );
-  const [submissionCap, setSubmissionCap] = useState(
-    event.submission_cap_per_guest
-  );
+  const [liveStartsAt, setLiveStartsAt] = useState(toDatetimeLocal(event.live_starts_at));
+  const [submissionCap, setSubmissionCap] = useState(event.submission_cap_per_guest);
   const [savingSettings, setSavingSettings] = useState(false);
   const [settingsError, setSettingsError] = useState<string | null>(null);
   const [settingsSaved, setSettingsSaved] = useState(false);
 
   useEffect(() => {
     refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [event.code]);
 
   async function refresh() {
@@ -78,7 +79,7 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
     setPending(resp.requests);
   }
 
-  async function applyOverride(value: "force_collection" | "force_live" | null) {
+  async function applyOverride(value: 'force_collection' | 'force_live' | null) {
     const resp = await apiClient.patchCollectionSettings(event.code, {
       collection_phase_override: value,
     });
@@ -88,7 +89,7 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
 
   async function bulk(action: string, extras: Record<string, unknown> = {}) {
     await apiClient.bulkReview(event.code, {
-      action: action as Parameters<typeof apiClient.bulkReview>[1]["action"],
+      action: action as Parameters<typeof apiClient.bulkReview>[1]['action'],
       ...extras,
     });
     setSelected(new Set());
@@ -122,14 +123,14 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
       setSettingsSaved(true);
       setTimeout(() => setSettingsSaved(false), 3000);
     } catch (err) {
-      setSettingsError(err instanceof Error ? err.message : "Failed to save settings");
+      setSettingsError(err instanceof Error ? err.message : 'Failed to save settings');
     } finally {
       setSavingSettings(false);
     }
   }
 
   const shareUrl =
-    typeof window !== "undefined"
+    typeof window !== 'undefined'
       ? `${window.location.origin}/collect/${event.code}`
       : `/collect/${event.code}`;
 
@@ -144,17 +145,43 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
   }
 
   return (
-    <div style={{ padding: 16 }}>
-      <h2>Pre-Event Voting</h2>
+    <div style={{ padding: '1rem' }}>
+      <h2 style={{ marginBottom: '1rem' }}>Pre-Event Voting</h2>
 
-      {/* Collection settings */}
-      <div className="card" style={{ marginBottom: "1.5rem", padding: "1rem" }}>
-        <div style={{ fontWeight: 600, marginBottom: "0.75rem" }}>Collection Settings</div>
+      <div className="pre-event-stats">
+        <div className="pre-event-stat">
+          <div className="pre-event-stat-label">Current phase</div>
+          <div className="pre-event-stat-value">{event.phase.replace('_', ' ')}</div>
+        </div>
+        <div className="pre-event-stat">
+          <div className="pre-event-stat-label">Pending review</div>
+          <div className="pre-event-stat-value">{pending.length}</div>
+        </div>
+        <div className="pre-event-stat">
+          <div className="pre-event-stat-label">Pick cap / guest</div>
+          <div className="pre-event-stat-value">
+            {event.submission_cap_per_guest === 0 ? '∞' : event.submission_cap_per_guest}
+          </div>
+        </div>
+      </div>
+
+      <div className="pre-event-share">
+        <code>{shareUrl}</code>
+        <button
+          type="button"
+          className="btn btn-sm"
+          style={{ background: 'var(--border)', color: 'var(--text)' }}
+          onClick={() => navigator.clipboard.writeText(shareUrl)}
+        >
+          Copy
+        </button>
+      </div>
+
+      <div className="card" style={{ marginBottom: '1.25rem' }}>
+        <h3 style={{ marginBottom: '0.75rem', fontSize: '1rem' }}>Collection Settings</h3>
         <form onSubmit={handleSaveSettings}>
           <div className="form-group">
-            <label htmlFor="collection-opens-at" style={{ fontSize: "0.875rem" }}>
-              Collection opens at
-            </label>
+            <label htmlFor="collection-opens-at">Collection opens at</label>
             <input
               id="collection-opens-at"
               type="datetime-local"
@@ -164,9 +191,7 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
             />
           </div>
           <div className="form-group">
-            <label htmlFor="live-starts-at" style={{ fontSize: "0.875rem" }}>
-              Live starts at
-            </label>
+            <label htmlFor="live-starts-at">Live starts at</label>
             <input
               id="live-starts-at"
               type="datetime-local"
@@ -176,169 +201,194 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
             />
           </div>
           <div className="form-group">
-            <label htmlFor="submission-cap" style={{ fontSize: "0.875rem" }}>
-              Submission cap per guest
-            </label>
+            <label htmlFor="submission-cap">Submission cap per guest</label>
             <input
               id="submission-cap"
               type="number"
               min={0}
               max={100}
-              className="input"
+              className="input collection-fieldset-cap"
               value={submissionCap}
               onChange={(e) => setSubmissionCap(Number(e.target.value))}
-              style={{ width: "6rem" }}
             />
-            <p style={{ color: "#9ca3af", fontSize: "0.75rem", margin: "0.25rem 0 0" }}>
-              0 = unlimited picks per guest
-            </p>
+            <p className="collection-fieldset-hint">0 = unlimited picks per guest</p>
           </div>
-          {settingsError && (
-            <p style={{ color: "#f87171", fontSize: "0.875rem", marginBottom: "0.5rem" }}>
-              {settingsError}
-            </p>
-          )}
+          {settingsError && <p className="collection-fieldset-error">{settingsError}</p>}
           {settingsSaved && (
-            <p style={{ color: "#4ade80", fontSize: "0.875rem", marginBottom: "0.5rem" }}>
+            <p style={{ color: '#4ade80', fontSize: '0.875rem', marginBottom: '0.5rem' }}>
               Settings saved.
             </p>
           )}
           <button type="submit" className="btn btn-primary btn-sm" disabled={savingSettings}>
-            {savingSettings ? "Saving..." : "Save settings"}
+            {savingSettings ? 'Saving…' : 'Save settings'}
           </button>
         </form>
       </div>
 
-      <p>Phase: {event.phase}</p>
-      <p>
-        Share link: <code>{shareUrl}</code>
-        <button
-          onClick={() => navigator.clipboard.writeText(shareUrl)}
-          style={{ marginLeft: 8 }}
-        >
-          Copy
-        </button>
-      </p>
-
-      <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
-        <button onClick={() => setConfirming("force_collection")}>Open collection now</button>
-        <button onClick={() => setConfirming("force_live")}>Start live now</button>
-        <button onClick={() => setConfirming("clear")}>Clear override</button>
-      </div>
-
-      {confirming && (
-        <div style={{ padding: 12, background: "#1a1a1a", marginBottom: 16 }}>
-          <p>Confirm action: {confirming}</p>
+      <div className="card" style={{ marginBottom: '1.25rem' }}>
+        <h3 style={{ marginBottom: '0.75rem', fontSize: '1rem' }}>Phase controls</h3>
+        <div className="pre-event-override-actions">
           <button
-            onClick={() =>
-              applyOverride(confirming === "clear" ? null : confirming)
-            }
+            type="button"
+            className="btn btn-sm"
+            style={{ background: 'var(--border)', color: 'var(--text)' }}
+            onClick={() => setConfirming('force_collection')}
           >
-            Confirm
+            Open collection now
           </button>
-          <button onClick={() => setConfirming(null)} style={{ marginLeft: 8 }}>
-            Cancel
+          <button
+            type="button"
+            className="btn btn-sm btn-success"
+            onClick={() => setConfirming('force_live')}
+          >
+            Start live now
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm"
+            style={{ background: 'var(--border)', color: 'var(--text)' }}
+            onClick={() => setConfirming('clear')}
+          >
+            Clear override
           </button>
         </div>
-      )}
 
-      <h3>Pending review ({pending.length})</h3>
-      <div style={{ marginBottom: 8 }}>
-        <label>
-          Top N:{" "}
-          <input
-            type="number"
-            value={topN}
-            onChange={(e) => setTopN(Number(e.target.value))}
-            style={{ width: 60 }}
-          />
-          <button onClick={() => bulk("accept_top_n", { n: topN })} style={{ marginLeft: 4 }}>
-            Accept top N
-          </button>
-        </label>
-        <label style={{ marginLeft: 16 }}>
-          ≥ votes:{" "}
-          <input
-            type="number"
-            value={minVotes}
-            onChange={(e) => setMinVotes(Number(e.target.value))}
-            style={{ width: 60 }}
-          />
-          <button
-            onClick={() => bulk("accept_threshold", { min_votes: minVotes })}
-            style={{ marginLeft: 4 }}
-          >
-            Accept threshold
-          </button>
-        </label>
-        <button
-          onClick={() => bulk("reject_remaining")}
-          style={{ marginLeft: 16 }}
-        >
-          Reject remaining
-        </button>
+        {confirming && (
+          <div className="pre-event-confirm">
+            <span>Confirm: {CONFIRM_LABEL[confirming]}?</span>
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              onClick={() => applyOverride(confirming === 'clear' ? null : confirming)}
+            >
+              Confirm
+            </button>
+            <button type="button" className="btn btn-sm" onClick={() => setConfirming(null)}>
+              Cancel
+            </button>
+          </div>
+        )}
       </div>
 
-      <table style={{ width: "100%", borderCollapse: "collapse" }}>
-        <thead>
-          <tr>
-            <th></th>
-            <th>▲</th>
-            <th>Song</th>
-            <th>Artist</th>
-            <th>Submitted by</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {pending.map((r) => (
-            <tr key={r.id}>
-              <td>
-                <input
-                  type="checkbox"
-                  checked={selected.has(r.id)}
-                  onChange={(e) => toggleRow(r.id, e.target.checked)}
-                />
-              </td>
-              <td>{r.vote_count}</td>
-              <td>{r.song_title}</td>
-              <td>{r.artist}</td>
-              <td>{r.nickname ?? "—"}</td>
-              <td>
-                <button onClick={() => bulk("accept_ids", { request_ids: [r.id] })}>
-                  Accept
-                </button>
-                <button
-                  onClick={() => bulk("reject_ids", { request_ids: [r.id] })}
-                  style={{ marginLeft: 4 }}
-                >
-                  Reject
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div className="card">
+        <h3 style={{ marginBottom: '0.75rem', fontSize: '1rem' }}>
+          Pending review ({pending.length})
+        </h3>
 
-      {selected.size > 0 && (
-        <div style={{ marginTop: 8 }}>
+        <div className="pre-event-review-controls">
+          <label>
+            Top N:
+            <input
+              type="number"
+              value={topN}
+              onChange={(e) => setTopN(Number(e.target.value))}
+            />
+            <button
+              type="button"
+              className="btn btn-sm btn-success"
+              onClick={() => bulk('accept_top_n', { n: topN })}
+            >
+              Accept top N
+            </button>
+          </label>
+          <label>
+            ≥ votes:
+            <input
+              type="number"
+              value={minVotes}
+              onChange={(e) => setMinVotes(Number(e.target.value))}
+            />
+            <button
+              type="button"
+              className="btn btn-sm btn-success"
+              onClick={() => bulk('accept_threshold', { min_votes: minVotes })}
+            >
+              Accept threshold
+            </button>
+          </label>
           <button
-            onClick={() =>
-              bulk("accept_ids", { request_ids: Array.from(selected) })
-            }
+            type="button"
+            className="btn btn-sm btn-danger"
+            onClick={() => bulk('reject_remaining')}
           >
-            Accept selected ({selected.size})
-          </button>
-          <button
-            onClick={() =>
-              bulk("reject_ids", { request_ids: Array.from(selected) })
-            }
-            style={{ marginLeft: 8 }}
-          >
-            Reject selected ({selected.size})
+            Reject remaining
           </button>
         </div>
-      )}
+
+        {pending.length === 0 ? (
+          <p className="pre-event-review-empty">No pending requests — all caught up!</p>
+        ) : (
+          <table className="pre-event-review-table">
+            <thead>
+              <tr>
+                <th></th>
+                <th>▲</th>
+                <th>Song</th>
+                <th>Artist</th>
+                <th>Submitted by</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pending.map((r) => (
+                <tr key={r.id}>
+                  <td>
+                    <input
+                      type="checkbox"
+                      checked={selected.has(r.id)}
+                      onChange={(e) => toggleRow(r.id, e.target.checked)}
+                    />
+                  </td>
+                  <td>{r.vote_count}</td>
+                  <td>{r.song_title}</td>
+                  <td>{r.artist}</td>
+                  <td>{r.nickname ?? '—'}</td>
+                  <td>
+                    <div className="pre-event-review-actions">
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-success"
+                        onClick={() => bulk('accept_ids', { request_ids: [r.id] })}
+                      >
+                        Accept
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-danger"
+                        onClick={() => bulk('reject_ids', { request_ids: [r.id] })}
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {selected.size > 0 && (
+          <div className="pre-event-bulk-selection">
+            <span style={{ fontSize: '0.875rem', color: 'var(--text-secondary)' }}>
+              {selected.size} selected
+            </span>
+            <button
+              type="button"
+              className="btn btn-sm btn-success"
+              onClick={() => bulk('accept_ids', { request_ids: Array.from(selected) })}
+            >
+              Accept selected
+            </button>
+            <button
+              type="button"
+              className="btn btn-sm btn-danger"
+              onClick={() => bulk('reject_ids', { request_ids: Array.from(selected) })}
+            >
+              Reject selected
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
+++ b/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { apiClient, PendingReviewRow } from "@/lib/api";
+
+interface EventShape {
+  code: string;
+  name: string;
+  collection_opens_at: string | null;
+  live_starts_at: string | null;
+  submission_cap_per_guest: number;
+  collection_phase_override: "force_collection" | "force_live" | null;
+  phase: "pre_announce" | "collection" | "live" | "closed";
+}
+
+interface Props {
+  event: EventShape;
+  onEventChange: (next: Partial<EventShape>) => void;
+}
+
+type ConfirmAction = "force_collection" | "force_live" | "clear";
+
+export default function PreEventVotingTab({ event, onEventChange }: Props) {
+  const [pending, setPending] = useState<PendingReviewRow[]>([]);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [confirming, setConfirming] = useState<ConfirmAction | null>(null);
+  const [topN, setTopN] = useState(20);
+  const [minVotes, setMinVotes] = useState(3);
+
+  useEffect(() => {
+    refresh();
+  }, [event.code]);
+
+  async function refresh() {
+    const resp = await apiClient.getPendingReview(event.code);
+    setPending(resp.requests);
+  }
+
+  async function applyOverride(value: "force_collection" | "force_live" | null) {
+    const resp = await apiClient.patchCollectionSettings(event.code, {
+      collection_phase_override: value,
+    });
+    onEventChange(resp);
+    setConfirming(null);
+  }
+
+  async function bulk(action: string, extras: Record<string, unknown> = {}) {
+    await apiClient.bulkReview(event.code, {
+      action: action as Parameters<typeof apiClient.bulkReview>[1]["action"],
+      ...extras,
+    });
+    setSelected(new Set());
+    refresh();
+  }
+
+  const shareUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/collect/${event.code}`
+      : `/collect/${event.code}`;
+
+  function toggleRow(id: number, checked: boolean) {
+    const next = new Set(selected);
+    if (checked) {
+      next.add(id);
+    } else {
+      next.delete(id);
+    }
+    setSelected(next);
+  }
+
+  return (
+    <div style={{ padding: 16 }}>
+      <h2>Pre-Event Voting</h2>
+      <p>Phase: {event.phase}</p>
+      <p>
+        Share link: <code>{shareUrl}</code>
+        <button
+          onClick={() => navigator.clipboard.writeText(shareUrl)}
+          style={{ marginLeft: 8 }}
+        >
+          Copy
+        </button>
+      </p>
+
+      <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
+        <button onClick={() => setConfirming("force_collection")}>Open collection now</button>
+        <button onClick={() => setConfirming("force_live")}>Start live now</button>
+        <button onClick={() => setConfirming("clear")}>Clear override</button>
+      </div>
+
+      {confirming && (
+        <div style={{ padding: 12, background: "#1a1a1a", marginBottom: 16 }}>
+          <p>Confirm action: {confirming}</p>
+          <button
+            onClick={() =>
+              applyOverride(confirming === "clear" ? null : confirming)
+            }
+          >
+            Confirm
+          </button>
+          <button onClick={() => setConfirming(null)} style={{ marginLeft: 8 }}>
+            Cancel
+          </button>
+        </div>
+      )}
+
+      <h3>Pending review ({pending.length})</h3>
+      <div style={{ marginBottom: 8 }}>
+        <label>
+          Top N:{" "}
+          <input
+            type="number"
+            value={topN}
+            onChange={(e) => setTopN(Number(e.target.value))}
+            style={{ width: 60 }}
+          />
+          <button onClick={() => bulk("accept_top_n", { n: topN })} style={{ marginLeft: 4 }}>
+            Accept top N
+          </button>
+        </label>
+        <label style={{ marginLeft: 16 }}>
+          ≥ votes:{" "}
+          <input
+            type="number"
+            value={minVotes}
+            onChange={(e) => setMinVotes(Number(e.target.value))}
+            style={{ width: 60 }}
+          />
+          <button
+            onClick={() => bulk("accept_threshold", { min_votes: minVotes })}
+            style={{ marginLeft: 4 }}
+          >
+            Accept threshold
+          </button>
+        </label>
+        <button
+          onClick={() => bulk("reject_remaining")}
+          style={{ marginLeft: 16 }}
+        >
+          Reject remaining
+        </button>
+      </div>
+
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead>
+          <tr>
+            <th></th>
+            <th>▲</th>
+            <th>Song</th>
+            <th>Artist</th>
+            <th>Submitted by</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {pending.map((r) => (
+            <tr key={r.id}>
+              <td>
+                <input
+                  type="checkbox"
+                  checked={selected.has(r.id)}
+                  onChange={(e) => toggleRow(r.id, e.target.checked)}
+                />
+              </td>
+              <td>{r.vote_count}</td>
+              <td>{r.song_title}</td>
+              <td>{r.artist}</td>
+              <td>{r.nickname ?? "—"}</td>
+              <td>
+                <button onClick={() => bulk("accept_ids", { request_ids: [r.id] })}>
+                  Accept
+                </button>
+                <button
+                  onClick={() => bulk("reject_ids", { request_ids: [r.id] })}
+                  style={{ marginLeft: 4 }}
+                >
+                  Reject
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {selected.size > 0 && (
+        <div style={{ marginTop: 8 }}>
+          <button
+            onClick={() =>
+              bulk("accept_ids", { request_ids: Array.from(selected) })
+            }
+          >
+            Accept selected ({selected.size})
+          </button>
+          <button
+            onClick={() =>
+              bulk("reject_ids", { request_ids: Array.from(selected) })
+            }
+            style={{ marginLeft: 8 }}
+          >
+            Reject selected ({selected.size})
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
+++ b/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { z } from "zod";
 import { apiClient, PendingReviewRow } from "@/lib/api";
 
 interface EventShape {
@@ -20,12 +21,53 @@ interface Props {
 
 type ConfirmAction = "force_collection" | "force_live" | "clear";
 
+const collectionSchema = z
+  .object({
+    collection_opens_at: z.string().optional(),
+    live_starts_at: z.string().optional(),
+    submission_cap_per_guest: z.number().int().min(0).max(100).optional(),
+  })
+  .refine(
+    (v) => {
+      if (v.collection_opens_at && v.live_starts_at) {
+        return new Date(v.collection_opens_at) < new Date(v.live_starts_at);
+      }
+      return true;
+    },
+    { message: "Collection opens must be before live starts" }
+  );
+
+function toDatetimeLocal(iso: string | null): string {
+  if (!iso) return "";
+  // Chop seconds + timezone to get "YYYY-MM-DDTHH:mm"
+  return iso.slice(0, 16);
+}
+
+function toIso(local: string): string | null {
+  if (!local) return null;
+  return new Date(local).toISOString();
+}
+
 export default function PreEventVotingTab({ event, onEventChange }: Props) {
   const [pending, setPending] = useState<PendingReviewRow[]>([]);
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [confirming, setConfirming] = useState<ConfirmAction | null>(null);
   const [topN, setTopN] = useState(20);
   const [minVotes, setMinVotes] = useState(3);
+
+  // Collection settings form state
+  const [collectionOpensAt, setCollectionOpensAt] = useState(
+    toDatetimeLocal(event.collection_opens_at)
+  );
+  const [liveStartsAt, setLiveStartsAt] = useState(
+    toDatetimeLocal(event.live_starts_at)
+  );
+  const [submissionCap, setSubmissionCap] = useState(
+    event.submission_cap_per_guest
+  );
+  const [savingSettings, setSavingSettings] = useState(false);
+  const [settingsError, setSettingsError] = useState<string | null>(null);
+  const [settingsSaved, setSettingsSaved] = useState(false);
 
   useEffect(() => {
     refresh();
@@ -53,6 +95,39 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
     refresh();
   }
 
+  async function handleSaveSettings(e: React.FormEvent) {
+    e.preventDefault();
+    setSettingsError(null);
+    setSettingsSaved(false);
+
+    const parsed = collectionSchema.safeParse({
+      collection_opens_at: collectionOpensAt || undefined,
+      live_starts_at: liveStartsAt || undefined,
+      submission_cap_per_guest: submissionCap,
+    });
+
+    if (!parsed.success) {
+      setSettingsError(parsed.error.issues[0].message);
+      return;
+    }
+
+    setSavingSettings(true);
+    try {
+      const resp = await apiClient.patchCollectionSettings(event.code, {
+        collection_opens_at: toIso(collectionOpensAt),
+        live_starts_at: toIso(liveStartsAt),
+        submission_cap_per_guest: submissionCap,
+      });
+      onEventChange(resp);
+      setSettingsSaved(true);
+      setTimeout(() => setSettingsSaved(false), 3000);
+    } catch (err) {
+      setSettingsError(err instanceof Error ? err.message : "Failed to save settings");
+    } finally {
+      setSavingSettings(false);
+    }
+  }
+
   const shareUrl =
     typeof window !== "undefined"
       ? `${window.location.origin}/collect/${event.code}`
@@ -71,6 +146,69 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
   return (
     <div style={{ padding: 16 }}>
       <h2>Pre-Event Voting</h2>
+
+      {/* Collection settings */}
+      <div className="card" style={{ marginBottom: "1.5rem", padding: "1rem" }}>
+        <div style={{ fontWeight: 600, marginBottom: "0.75rem" }}>Collection Settings</div>
+        <form onSubmit={handleSaveSettings}>
+          <div className="form-group">
+            <label htmlFor="collection-opens-at" style={{ fontSize: "0.875rem" }}>
+              Collection opens at
+            </label>
+            <input
+              id="collection-opens-at"
+              type="datetime-local"
+              className="input"
+              value={collectionOpensAt}
+              onChange={(e) => setCollectionOpensAt(e.target.value)}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="live-starts-at" style={{ fontSize: "0.875rem" }}>
+              Live starts at
+            </label>
+            <input
+              id="live-starts-at"
+              type="datetime-local"
+              className="input"
+              value={liveStartsAt}
+              onChange={(e) => setLiveStartsAt(e.target.value)}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="submission-cap" style={{ fontSize: "0.875rem" }}>
+              Submission cap per guest
+            </label>
+            <input
+              id="submission-cap"
+              type="number"
+              min={0}
+              max={100}
+              className="input"
+              value={submissionCap}
+              onChange={(e) => setSubmissionCap(Number(e.target.value))}
+              style={{ width: "6rem" }}
+            />
+            <p style={{ color: "#9ca3af", fontSize: "0.75rem", margin: "0.25rem 0 0" }}>
+              0 = unlimited picks per guest
+            </p>
+          </div>
+          {settingsError && (
+            <p style={{ color: "#f87171", fontSize: "0.875rem", marginBottom: "0.5rem" }}>
+              {settingsError}
+            </p>
+          )}
+          {settingsSaved && (
+            <p style={{ color: "#4ade80", fontSize: "0.875rem", marginBottom: "0.5rem" }}>
+              Settings saved.
+            </p>
+          )}
+          <button type="submit" className="btn btn-primary btn-sm" disabled={savingSettings}>
+            {savingSettings ? "Saving..." : "Save settings"}
+          </button>
+        </form>
+      </div>
+
       <p>Phase: {event.phase}</p>
       <p>
         Share link: <code>{shareUrl}</code>

--- a/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
+++ b/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import PreEventVotingTab from "../PreEventVotingTab";
+
+const baseEvent = {
+  code: "ABC",
+  name: "Wedding",
+  collection_opens_at: "2026-04-21T12:00:00Z",
+  live_starts_at: "2026-04-22T20:00:00Z",
+  submission_cap_per_guest: 15,
+  collection_phase_override: null,
+  phase: "collection" as const,
+};
+
+vi.mock("@/lib/api", () => ({
+  apiClient: {
+    patchCollectionSettings: vi.fn().mockResolvedValue({
+      code: "ABC",
+      name: "Wedding",
+      collection_opens_at: "2026-04-21T12:00:00Z",
+      live_starts_at: "2026-04-22T20:00:00Z",
+      submission_cap_per_guest: 15,
+      collection_phase_override: "force_live",
+      phase: "live",
+    }),
+    getPendingReview: vi.fn().mockResolvedValue({ requests: [], total: 0 }),
+    bulkReview: vi.fn().mockResolvedValue({ accepted: 0, rejected: 0, unchanged: 0 }),
+  },
+}));
+
+describe("PreEventVotingTab", () => {
+  it("renders phase and share link", () => {
+    render(<PreEventVotingTab event={baseEvent} onEventChange={vi.fn()} />);
+    expect(screen.getByText(/phase:\s*collection/i)).toBeInTheDocument();
+    expect(screen.getByText(/\/collect\/ABC/i)).toBeInTheDocument();
+  });
+
+  it("applies force_live override via button", async () => {
+    const onEventChange = vi.fn();
+    render(<PreEventVotingTab event={baseEvent} onEventChange={onEventChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /start live now/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^confirm$/i }));
+    await waitFor(() => {
+      expect(onEventChange).toHaveBeenCalled();
+    });
+  });
+});

--- a/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
+++ b/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
@@ -31,7 +31,8 @@ vi.mock("@/lib/api", () => ({
 describe("PreEventVotingTab", () => {
   it("renders phase and share link", () => {
     render(<PreEventVotingTab event={baseEvent} onEventChange={vi.fn()} />);
-    expect(screen.getByText(/phase:\s*collection/i)).toBeInTheDocument();
+    expect(screen.getByText(/current phase/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/collection/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/\/collect\/ABC/i)).toBeInTheDocument();
   });
 

--- a/dashboard/app/events/[code]/page.tsx
+++ b/dashboard/app/events/[code]/page.tsx
@@ -5,7 +5,7 @@ import { useRouter, useParams } from 'next/navigation';
 import Link from 'next/link';
 import { QRCodeSVG } from 'qrcode.react';
 import { useAuth } from '@/lib/auth';
-import { api, ApiError, Event, ArchivedEvent, SongRequest, PlayHistoryItem, TidalStatus, TidalSearchResult, BeatportStatus } from '@/lib/api';
+import { api, ApiError, Event, ArchivedEvent, SongRequest, PlayHistoryItem, TidalStatus, TidalSearchResult, BeatportStatus, CollectionSettingsResponse } from '@/lib/api';
 import { useEventStream } from '@/lib/use-event-stream';
 import type { BeatportSearchResult, NowPlayingInfo } from '@/lib/api-types';
 import type { SortMode } from '@/lib/priority-score';
@@ -25,6 +25,7 @@ import { RequestQueueSection } from './components/RequestQueueSection';
 import { PlayHistorySection } from './components/PlayHistorySection';
 import { SongManagementTab } from './components/SongManagementTab';
 import { EventManagementTab } from './components/EventManagementTab';
+import PreEventVotingTab from './components/PreEventVotingTab';
 import type { RecommendedTrack } from '@/lib/api-types';
 
 function toLocalDateTimeString(date: Date): string {
@@ -112,8 +113,11 @@ export default function EventQueuePage() {
   const [actionError, setActionError] = useState<string | null>(null);
 
   // Tab state
-  const [activeTab, setActiveTab] = useState<'songs' | 'manage'>('songs');
-  const helpPageId = activeTab === 'songs' ? 'event-songs' : 'event-manage';
+  const [activeTab, setActiveTab] = useState<'songs' | 'manage' | 'pre-event'>('songs');
+  const helpPageId = activeTab === 'songs' ? 'event-songs' : 'event-manage'; // pre-event shares manage page
+
+  // Pre-event collection settings
+  const [collectionSettings, setCollectionSettings] = useState<CollectionSettingsResponse | null>(null);
   const { hasSeenPage, startOnboarding, onboardingActive } = useHelp();
 
   // Banner upload state
@@ -222,6 +226,13 @@ export default function EventQueuePage() {
       clearTimeout(timeout);
     };
   }, [tidalLoginPolling]);
+
+  // Fetch collection settings when pre-event tab is first opened
+  useEffect(() => {
+    if (activeTab === 'pre-event' && !collectionSettings && isAuthenticated) {
+      api.getCollectionSettings(code).then(setCollectionSettings).catch(() => {});
+    }
+  }, [activeTab, collectionSettings, isAuthenticated, code]);
 
   // Auto-trigger onboarding for first-time visitors to this tab
   const eventLoaded = !isLoading && isAuthenticated && !loading && !!event;
@@ -1016,6 +1027,14 @@ export default function EventQueuePage() {
               >
                 Event Management
               </button>
+              {event && 'collection_opens_at' in event && event.collection_opens_at != null && (
+                <button
+                  className={`event-tab${activeTab === 'pre-event' ? ' active' : ''}`}
+                  onClick={() => setActiveTab('pre-event')}
+                >
+                  Pre-Event Voting
+                </button>
+              )}
             </div>
           </HelpSpot>
 
@@ -1096,6 +1115,21 @@ export default function EventQueuePage() {
               onDeleteBanner={handleDeleteBanner}
             />
           </div>
+
+          {collectionSettings && activeTab === 'pre-event' && (
+            <PreEventVotingTab
+              event={{
+                code,
+                name: event.name,
+                collection_opens_at: collectionSettings.collection_opens_at,
+                live_starts_at: collectionSettings.live_starts_at,
+                submission_cap_per_guest: collectionSettings.submission_cap_per_guest,
+                collection_phase_override: collectionSettings.collection_phase_override,
+                phase: collectionSettings.phase,
+              }}
+              onEventChange={(next) => setCollectionSettings((prev) => prev ? { ...prev, ...next } : prev)}
+            />
+          )}
         </>
       )}
 

--- a/dashboard/app/events/__tests__/page.test.tsx
+++ b/dashboard/app/events/__tests__/page.test.tsx
@@ -80,6 +80,10 @@ function mockEvent(overrides = {}) {
     banner_kiosk_url: null,
     banner_colors: null,
     requests_open: true,
+    collection_opens_at: null,
+    live_starts_at: null,
+    submission_cap_per_guest: 15,
+    collection_phase_override: null,
     ...overrides,
   };
 }

--- a/dashboard/app/events/page.tsx
+++ b/dashboard/app/events/page.tsx
@@ -3,12 +3,29 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { z } from 'zod';
 import { useAuth } from '@/lib/auth';
 import { api, Event } from '@/lib/api';
 import { useHelp } from '@/lib/help/HelpContext';
 import { HelpSpot } from '@/components/help/HelpSpot';
 import { HelpButton } from '@/components/help/HelpButton';
 import { OnboardingOverlay } from '@/components/help/OnboardingOverlay';
+
+const collectionSchema = z
+  .object({
+    collection_opens_at: z.string().optional(),
+    live_starts_at: z.string().optional(),
+    submission_cap_per_guest: z.number().int().min(0).max(100).optional(),
+  })
+  .refine(
+    (v) => {
+      if (v.collection_opens_at && v.live_starts_at) {
+        return new Date(v.collection_opens_at) < new Date(v.live_starts_at);
+      }
+      return true;
+    },
+    { message: 'Collection opens must be before live starts' }
+  );
 
 const PAGE_ID = 'events';
 
@@ -25,6 +42,13 @@ export default function EventsPage() {
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedEvents, setSelectedEvents] = useState<Set<string>>(new Set());
   const [deletingSelected, setDeletingSelected] = useState(false);
+
+  // Pre-event collection state
+  const [showCollection, setShowCollection] = useState(false);
+  const [collectionOpensAt, setCollectionOpensAt] = useState('');
+  const [liveStartsAt, setLiveStartsAt] = useState('');
+  const [submissionCap, setSubmissionCap] = useState(0);
+  const [collectionError, setCollectionError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -63,12 +87,44 @@ export default function EventsPage() {
     e.preventDefault();
     if (!newEventName.trim()) return;
 
+    // Validate collection settings before creating
+    if (showCollection) {
+      const parsed = collectionSchema.safeParse({
+        collection_opens_at: collectionOpensAt || undefined,
+        live_starts_at: liveStartsAt || undefined,
+        submission_cap_per_guest: submissionCap,
+      });
+      if (!parsed.success) {
+        setCollectionError(parsed.error.issues[0].message);
+        return;
+      }
+    }
+    setCollectionError(null);
+
     setCreating(true);
     try {
       const event = await api.createEvent(newEventName);
+
+      // Apply collection settings if enabled
+      if (showCollection && (collectionOpensAt || liveStartsAt || submissionCap > 0)) {
+        await api.patchCollectionSettings(event.code, {
+          collection_opens_at: collectionOpensAt
+            ? new Date(collectionOpensAt).toISOString()
+            : null,
+          live_starts_at: liveStartsAt
+            ? new Date(liveStartsAt).toISOString()
+            : null,
+          submission_cap_per_guest: submissionCap,
+        });
+      }
+
       setEvents([event, ...events]);
       setNewEventName('');
       setShowCreate(false);
+      setShowCollection(false);
+      setCollectionOpensAt('');
+      setLiveStartsAt('');
+      setSubmissionCap(0);
     } catch (err) {
       setErrorMsg(err instanceof Error ? err.message : 'Failed to create event');
     } finally {
@@ -179,6 +235,69 @@ export default function EventsPage() {
                 required
               />
             </div>
+            {/* Pre-event collection section */}
+            <div style={{ borderTop: '1px solid #333', paddingTop: '0.75rem', marginBottom: '1rem' }}>
+              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', fontWeight: 500 }}>
+                <input
+                  type="checkbox"
+                  checked={showCollection}
+                  onChange={(e) => setShowCollection(e.target.checked)}
+                  style={{ accentColor: '#3b82f6' }}
+                />
+                Enable pre-event voting
+              </label>
+
+              {showCollection && (
+                <div style={{ marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+                  <div className="form-group">
+                    <label htmlFor="collection-opens-at" style={{ fontSize: '0.875rem' }}>
+                      Collection opens at
+                    </label>
+                    <input
+                      id="collection-opens-at"
+                      type="datetime-local"
+                      className="input"
+                      value={collectionOpensAt}
+                      onChange={(e) => setCollectionOpensAt(e.target.value)}
+                    />
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="live-starts-at" style={{ fontSize: '0.875rem' }}>
+                      Live starts at
+                    </label>
+                    <input
+                      id="live-starts-at"
+                      type="datetime-local"
+                      className="input"
+                      value={liveStartsAt}
+                      onChange={(e) => setLiveStartsAt(e.target.value)}
+                    />
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="submission-cap" style={{ fontSize: '0.875rem' }}>
+                      Submission cap per guest
+                    </label>
+                    <input
+                      id="submission-cap"
+                      type="number"
+                      min={0}
+                      max={100}
+                      className="input"
+                      value={submissionCap}
+                      onChange={(e) => setSubmissionCap(Number(e.target.value))}
+                      style={{ width: '6rem' }}
+                    />
+                    <p style={{ color: '#9ca3af', fontSize: '0.75rem', margin: '0.25rem 0 0' }}>
+                      0 = unlimited picks per guest
+                    </p>
+                  </div>
+                  {collectionError && (
+                    <p style={{ color: '#f87171', fontSize: '0.875rem' }}>{collectionError}</p>
+                  )}
+                </div>
+              )}
+            </div>
+
             <div style={{ display: 'flex', gap: '1rem' }}>
               <button type="submit" className="btn btn-primary" disabled={creating}>
                 {creating ? 'Creating...' : 'Create'}

--- a/dashboard/app/events/page.tsx
+++ b/dashboard/app/events/page.tsx
@@ -86,12 +86,22 @@ export default function EventsPage() {
     setCollectionError(null);
 
     setCreating(true);
+    let createdEvent;
     try {
-      const event = await api.createEvent(newEventName);
+      createdEvent = await api.createEvent(newEventName);
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : 'Failed to create event');
+      setCreating(false);
+      return;
+    }
 
-      // Apply collection settings if enabled
-      if (showCollection && (collectionOpensAt || liveStartsAt || submissionCap > 0)) {
-        await api.patchCollectionSettings(event.code, {
+    // Show the event in the list immediately, even if collection settings fail —
+    // the user can finish setup on the event's Pre-Event Voting tab.
+    setEvents([createdEvent, ...events]);
+
+    if (showCollection && (collectionOpensAt || liveStartsAt || submissionCap > 0)) {
+      try {
+        await api.patchCollectionSettings(createdEvent.code, {
           collection_opens_at: collectionOpensAt
             ? new Date(collectionOpensAt).toISOString()
             : null,
@@ -100,20 +110,24 @@ export default function EventsPage() {
             : null,
           submission_cap_per_guest: submissionCap,
         });
+      } catch (err) {
+        setErrorMsg(
+          `Event "${createdEvent.name}" was created, but collection settings failed: ${
+            err instanceof Error ? err.message : 'unknown error'
+          }. Open the event and finish setup on the Pre-Event Voting tab.`,
+        );
+        setCreating(false);
+        return;
       }
-
-      setEvents([event, ...events]);
-      setNewEventName('');
-      setShowCreate(false);
-      setShowCollection(false);
-      setCollectionOpensAt('');
-      setLiveStartsAt('');
-      setSubmissionCap(0);
-    } catch (err) {
-      setErrorMsg(err instanceof Error ? err.message : 'Failed to create event');
-    } finally {
-      setCreating(false);
     }
+
+    setNewEventName('');
+    setShowCreate(false);
+    setShowCollection(false);
+    setCollectionOpensAt('');
+    setLiveStartsAt('');
+    setSubmissionCap(0);
+    setCreating(false);
   };
 
   const toggleSelection = (code: string) => {

--- a/dashboard/app/events/page.tsx
+++ b/dashboard/app/events/page.tsx
@@ -3,29 +3,13 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { z } from 'zod';
 import { useAuth } from '@/lib/auth';
 import { api, Event } from '@/lib/api';
 import { useHelp } from '@/lib/help/HelpContext';
 import { HelpSpot } from '@/components/help/HelpSpot';
 import { HelpButton } from '@/components/help/HelpButton';
 import { OnboardingOverlay } from '@/components/help/OnboardingOverlay';
-
-const collectionSchema = z
-  .object({
-    collection_opens_at: z.string().optional(),
-    live_starts_at: z.string().optional(),
-    submission_cap_per_guest: z.number().int().min(0).max(100).optional(),
-  })
-  .refine(
-    (v) => {
-      if (v.collection_opens_at && v.live_starts_at) {
-        return new Date(v.collection_opens_at) < new Date(v.live_starts_at);
-      }
-      return true;
-    },
-    { message: 'Collection opens must be before live starts' }
-  );
+import { CollectionFieldset, collectionSchema } from '@/components/CollectionFieldset';
 
 const PAGE_ID = 'events';
 
@@ -235,68 +219,17 @@ export default function EventsPage() {
                 required
               />
             </div>
-            {/* Pre-event collection section */}
-            <div style={{ borderTop: '1px solid #333', paddingTop: '0.75rem', marginBottom: '1rem' }}>
-              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', fontWeight: 500 }}>
-                <input
-                  type="checkbox"
-                  checked={showCollection}
-                  onChange={(e) => setShowCollection(e.target.checked)}
-                  style={{ accentColor: '#3b82f6' }}
-                />
-                Enable pre-event voting
-              </label>
-
-              {showCollection && (
-                <div style={{ marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-                  <div className="form-group">
-                    <label htmlFor="collection-opens-at" style={{ fontSize: '0.875rem' }}>
-                      Collection opens at
-                    </label>
-                    <input
-                      id="collection-opens-at"
-                      type="datetime-local"
-                      className="input"
-                      value={collectionOpensAt}
-                      onChange={(e) => setCollectionOpensAt(e.target.value)}
-                    />
-                  </div>
-                  <div className="form-group">
-                    <label htmlFor="live-starts-at" style={{ fontSize: '0.875rem' }}>
-                      Live starts at
-                    </label>
-                    <input
-                      id="live-starts-at"
-                      type="datetime-local"
-                      className="input"
-                      value={liveStartsAt}
-                      onChange={(e) => setLiveStartsAt(e.target.value)}
-                    />
-                  </div>
-                  <div className="form-group">
-                    <label htmlFor="submission-cap" style={{ fontSize: '0.875rem' }}>
-                      Submission cap per guest
-                    </label>
-                    <input
-                      id="submission-cap"
-                      type="number"
-                      min={0}
-                      max={100}
-                      className="input"
-                      value={submissionCap}
-                      onChange={(e) => setSubmissionCap(Number(e.target.value))}
-                      style={{ width: '6rem' }}
-                    />
-                    <p style={{ color: '#9ca3af', fontSize: '0.75rem', margin: '0.25rem 0 0' }}>
-                      0 = unlimited picks per guest
-                    </p>
-                  </div>
-                  {collectionError && (
-                    <p style={{ color: '#f87171', fontSize: '0.875rem' }}>{collectionError}</p>
-                  )}
-                </div>
-              )}
-            </div>
+            <CollectionFieldset
+              enabled={showCollection}
+              onEnabledChange={setShowCollection}
+              collectionOpensAt={collectionOpensAt}
+              onCollectionOpensAtChange={setCollectionOpensAt}
+              liveStartsAt={liveStartsAt}
+              onLiveStartsAtChange={setLiveStartsAt}
+              submissionCap={submissionCap}
+              onSubmissionCapChange={setSubmissionCap}
+              error={collectionError}
+            />
 
             <div style={{ display: 'flex', gap: '1rem' }}>
               <button type="submit" className="btn btn-primary" disabled={creating}>

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -1392,3 +1392,588 @@ h1, .display-heading {
     transform: rotate(360deg);
   }
 }
+
+/* ==========================================================================
+ * Pre-Event Collection — /collect/[code] + DJ PreEventVotingTab
+ * Uses CSS variables so ThemeProvider switches carry through.
+ * ========================================================================== */
+
+.collect-page {
+  position: relative;
+  min-height: 100vh;
+  min-height: 100dvh;
+  max-width: 100vw;
+  overflow-x: clip;
+  padding-bottom: 5rem;
+}
+
+.collect-container {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.collect-header {
+  margin-bottom: 1.25rem;
+}
+
+.collect-title {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.collect-phase-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.collect-phase-badge.pre-announce {
+  background: rgba(245, 158, 11, 0.15);
+  color: #fbbf24;
+}
+
+.collect-countdown {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.collect-section {
+  margin-top: 1.5rem;
+}
+
+.collect-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  color: var(--text);
+}
+
+.collect-error {
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 0.5rem;
+  color: #fca5a5;
+  font-size: 0.875rem;
+}
+
+/* Feature opt-in panel */
+.collect-optin {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.collect-optin h3 {
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.collect-optin-features {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.75rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.collect-optin-features li::before {
+  content: '✓ ';
+  color: #22c55e;
+  margin-right: 0.25rem;
+}
+
+.collect-optin-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.75rem;
+}
+
+.collect-optin-dismiss {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+
+.collect-optin-dismiss:hover {
+  color: var(--text);
+  border-color: var(--text-secondary);
+}
+
+/* Leaderboard */
+.collect-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.collect-tab {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: all 0.15s;
+}
+
+.collect-tab[aria-pressed='true'] {
+  background: #3b82f6;
+  border-color: #3b82f6;
+  color: white;
+}
+
+.collect-leaderboard {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.collect-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background: var(--card);
+  border-radius: 8px;
+}
+
+.collect-row-art {
+  width: 44px;
+  height: 44px;
+  border-radius: 6px;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--bg);
+}
+
+.collect-row-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.collect-row-title {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.collect-row-artist {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.collect-row-nickname {
+  font-size: 0.75rem;
+  color: #a78bfa;
+  margin-top: 0.125rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.collect-vote {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  padding: 0.35rem 0.6rem;
+  border-radius: 8px;
+  background: rgba(59, 130, 246, 0.12);
+  color: #60a5fa;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.collect-vote:hover {
+  background: rgba(59, 130, 246, 0.2);
+  border-color: rgba(59, 130, 246, 0.4);
+}
+
+.collect-vote-caret {
+  font-size: 0.7rem;
+  line-height: 1;
+}
+
+.collect-empty {
+  text-align: center;
+  color: var(--text-secondary);
+  padding: 2rem 1rem;
+  font-style: italic;
+}
+
+/* My Picks */
+.collect-picks {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.collect-picks-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  background: rgba(245, 158, 11, 0.15);
+  color: #fbbf24;
+  font-size: 0.8rem;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.collect-pick-first {
+  font-size: 0.7rem;
+  color: #fbbf24;
+  margin-left: 0.5rem;
+}
+
+/* Submit bar */
+.collect-submit-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0.875rem 1rem;
+  background: var(--card);
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  z-index: 10;
+}
+
+.collect-cap-counter {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.collect-cap-counter.at-cap {
+  color: #f87171;
+}
+
+/* Search modal (inline on collect page) */
+.collect-search-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 100;
+}
+
+.collect-search-modal {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  width: 100%;
+  max-width: 560px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.collect-search-header {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  align-items: center;
+}
+
+.collect-search-header .input {
+  flex: 1;
+}
+
+.collect-search-results {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.collect-search-result {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.collect-search-result:hover {
+  background: var(--card);
+  border-color: #3b82f6;
+}
+
+/* Pre-Announce countdown hero */
+.collect-preannounce {
+  text-align: center;
+  padding: 3rem 1rem;
+}
+
+.collect-preannounce-count {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 1rem 0 0.5rem;
+  color: #fbbf24;
+  font-variant-numeric: tabular-nums;
+}
+
+/* DJ-side PreEventVotingTab polish */
+.pre-event-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.pre-event-stat {
+  padding: 0.75rem 1rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.pre-event-stat-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  margin-bottom: 0.25rem;
+}
+
+.pre-event-stat-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.pre-event-share {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 0.75rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+}
+
+.pre-event-share code {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.pre-event-override-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.pre-event-confirm {
+  padding: 0.75rem 1rem;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.pre-event-review-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.pre-event-review-controls label {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.875rem;
+}
+
+.pre-event-review-controls input[type='number'] {
+  width: 4.5rem;
+  padding: 0.35rem 0.5rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 4px;
+}
+
+.pre-event-review-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.pre-event-review-table th,
+.pre-event-review-table td {
+  padding: 0.6rem 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+.pre-event-review-table th {
+  text-align: left;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 500;
+}
+
+.pre-event-review-table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.pre-event-review-actions {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.pre-event-review-empty {
+  text-align: center;
+  color: var(--text-secondary);
+  padding: 2rem 1rem;
+  font-style: italic;
+}
+
+.pre-event-bulk-selection {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  border-radius: 6px;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+/* Shared CollectionFieldset (used on create form and settings card) */
+.collection-fieldset {
+  border-top: 1px solid var(--border);
+  padding-top: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.collection-fieldset-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.collection-fieldset-toggle input[type='checkbox'] {
+  accent-color: #3b82f6;
+}
+
+.collection-fieldset-fields {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.collection-fieldset-hint {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  margin: 0.25rem 0 0;
+}
+
+.collection-fieldset-error {
+  color: #f87171;
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.collection-fieldset-cap {
+  width: 6rem;
+}
+
+/* /join soft banner pointing to /collect */
+.join-pre-event-banner {
+  display: block;
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  background: rgba(59, 130, 246, 0.12);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  border-radius: 8px;
+  color: #60a5fa;
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.join-pre-event-banner a {
+  color: #93c5fd;
+  font-weight: 500;
+}
+
+.join-live-splash {
+  padding: 0.875rem 1rem;
+  background: linear-gradient(90deg, #fbbf24, #f59e0b);
+  color: #1a1a1a;
+  text-align: center;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border-radius: 0 0 8px 8px;
+}

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -1620,9 +1620,17 @@ h1, .display-heading {
   transition: background 0.15s, border-color 0.15s;
 }
 
-.collect-vote:hover {
+.collect-vote:hover:not(:disabled) {
   background: rgba(59, 130, 246, 0.2);
   border-color: rgba(59, 130, 246, 0.4);
+}
+
+.collect-vote.voted,
+.collect-vote:disabled {
+  background: rgba(59, 130, 246, 0.35);
+  color: #dbeafe;
+  border-color: rgba(59, 130, 246, 0.6);
+  cursor: default;
 }
 
 .collect-vote-caret {

--- a/dashboard/app/join/[code]/page.tsx
+++ b/dashboard/app/join/[code]/page.tsx
@@ -43,6 +43,39 @@ export default function JoinEventPage() {
   const [votedIds, setVotedIds] = useState<Set<number>>(new Set());
   const [nowPlaying, setNowPlaying] = useState<GuestNowPlaying | null>(null);
 
+  // Splash + collect-phase banner
+  const [splashVisible, setSplashVisible] = useState(false);
+  const [collectPhase, setCollectPhase] = useState<
+    'pre_announce' | 'collection' | 'live' | 'closed' | null
+  >(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const key = `wrzdj_live_splash_${code}`;
+    if (sessionStorage.getItem(key) === '1') {
+      setSplashVisible(true);
+      sessionStorage.removeItem(key);
+      const t = setTimeout(() => setSplashVisible(false), 3000);
+      return () => clearTimeout(t);
+    }
+  }, [code]);
+
+  useEffect(() => {
+    if (!code) return;
+    let cancelled = false;
+    api.getCollectEvent(code).then(
+      (ev) => {
+        if (!cancelled) setCollectPhase(ev.phase);
+      },
+      () => {
+        /* silently ignore — assume live */
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [code]);
+
   // My Requests tracking
   const [myRequestIds, setMyRequestIds] = useState<Set<number>>(new Set());
   const [myRequestsRefreshKey, setMyRequestsRefreshKey] = useState(0);
@@ -296,9 +329,22 @@ export default function JoinEventPage() {
     );
   }
 
+  const phaseBanner = (collectPhase === 'pre_announce' || collectPhase === 'collection') ? (
+    <div style={{ padding: 12, background: '#1a1a1a', textAlign: 'center' }}>
+      Voting for this event is open —{' '}
+      <a href={`/collect/${code}`}>go to the pre-event page →</a>
+    </div>
+  ) : null;
+
   if (showRequestList) {
     return (
       <div className="guest-request-list-container">
+        {splashVisible && (
+          <div style={{ padding: 12, background: '#ffcc00', color: '#000', textAlign: 'center' }}>
+            🎉 The event is now live — you&apos;re in!
+          </div>
+        )}
+        {phaseBanner}
         {toast && (
           <Toast
             message={toast.message}
@@ -602,6 +648,12 @@ export default function JoinEventPage() {
           <img src={event.banner_url} alt="" />
         </div>
       )}
+      {splashVisible && (
+        <div style={{ padding: 12, background: '#ffcc00', color: '#000', textAlign: 'center' }}>
+          🎉 The event is now live — you&apos;re in!
+        </div>
+      )}
+      {phaseBanner}
       <div className="container" style={{ maxWidth: '500px', position: 'relative', zIndex: 1 }}>
       <div className="card">
         <h1 style={{ marginBottom: '0.5rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '100%' }}>{event.name}</h1>

--- a/dashboard/app/join/[code]/page.tsx
+++ b/dashboard/app/join/[code]/page.tsx
@@ -330,8 +330,8 @@ export default function JoinEventPage() {
   }
 
   const phaseBanner = (collectPhase === 'pre_announce' || collectPhase === 'collection') ? (
-    <div style={{ padding: 12, background: '#1a1a1a', textAlign: 'center' }}>
-      Voting for this event is open —{' '}
+    <div className="join-pre-event-banner">
+      🎟️ Pre-event voting is open —{' '}
       <a href={`/collect/${code}`}>go to the pre-event page →</a>
     </div>
   ) : null;
@@ -340,7 +340,7 @@ export default function JoinEventPage() {
     return (
       <div className="guest-request-list-container">
         {splashVisible && (
-          <div style={{ padding: 12, background: '#ffcc00', color: '#000', textAlign: 'center' }}>
+          <div className="join-live-splash">
             🎉 The event is now live — you&apos;re in!
           </div>
         )}
@@ -649,7 +649,7 @@ export default function JoinEventPage() {
         </div>
       )}
       {splashVisible && (
-        <div style={{ padding: 12, background: '#ffcc00', color: '#000', textAlign: 'center' }}>
+        <div className="join-live-splash">
           🎉 The event is now live — you&apos;re in!
         </div>
       )}

--- a/dashboard/components/CollectionFieldset.tsx
+++ b/dashboard/components/CollectionFieldset.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { z } from 'zod';
+
+export const collectionSchema = z
+  .object({
+    collection_opens_at: z.string().optional(),
+    live_starts_at: z.string().optional(),
+    submission_cap_per_guest: z.number().int().min(0).max(100).optional(),
+  })
+  .refine(
+    (v) => {
+      if (v.collection_opens_at && v.live_starts_at) {
+        return new Date(v.collection_opens_at) < new Date(v.live_starts_at);
+      }
+      return true;
+    },
+    { message: 'Collection opens must be before live starts' },
+  );
+
+export interface CollectionFieldsetProps {
+  enabled: boolean;
+  onEnabledChange: (next: boolean) => void;
+  collectionOpensAt: string;
+  onCollectionOpensAtChange: (next: string) => void;
+  liveStartsAt: string;
+  onLiveStartsAtChange: (next: string) => void;
+  submissionCap: number;
+  onSubmissionCapChange: (next: number) => void;
+  error?: string | null;
+}
+
+export function CollectionFieldset(props: CollectionFieldsetProps) {
+  const {
+    enabled,
+    onEnabledChange,
+    collectionOpensAt,
+    onCollectionOpensAtChange,
+    liveStartsAt,
+    onLiveStartsAtChange,
+    submissionCap,
+    onSubmissionCapChange,
+    error,
+  } = props;
+
+  return (
+    <div style={{ borderTop: '1px solid #333', paddingTop: '0.75rem', marginBottom: '1rem' }}>
+      <label
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+          cursor: 'pointer',
+          fontWeight: 500,
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => onEnabledChange(e.target.checked)}
+          style={{ accentColor: '#3b82f6' }}
+        />
+        Enable pre-event voting
+      </label>
+
+      {enabled && (
+        <div
+          style={{
+            marginTop: '0.75rem',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '0.75rem',
+          }}
+        >
+          <div className="form-group">
+            <label htmlFor="collection-opens-at" style={{ fontSize: '0.875rem' }}>
+              Collection opens at
+            </label>
+            <input
+              id="collection-opens-at"
+              type="datetime-local"
+              className="input"
+              value={collectionOpensAt}
+              onChange={(e) => onCollectionOpensAtChange(e.target.value)}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="live-starts-at" style={{ fontSize: '0.875rem' }}>
+              Live starts at
+            </label>
+            <input
+              id="live-starts-at"
+              type="datetime-local"
+              className="input"
+              value={liveStartsAt}
+              onChange={(e) => onLiveStartsAtChange(e.target.value)}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="submission-cap" style={{ fontSize: '0.875rem' }}>
+              Submission cap per guest
+            </label>
+            <input
+              id="submission-cap"
+              type="number"
+              min={0}
+              max={100}
+              className="input"
+              value={submissionCap}
+              onChange={(e) => onSubmissionCapChange(Number(e.target.value))}
+              style={{ width: '6rem' }}
+            />
+            <p style={{ color: '#9ca3af', fontSize: '0.75rem', margin: '0.25rem 0 0' }}>
+              0 = unlimited picks per guest
+            </p>
+          </div>
+          {error && <p style={{ color: '#f87171', fontSize: '0.875rem' }}>{error}</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/components/CollectionFieldset.tsx
+++ b/dashboard/components/CollectionFieldset.tsx
@@ -44,38 +44,20 @@ export function CollectionFieldset(props: CollectionFieldsetProps) {
   } = props;
 
   return (
-    <div style={{ borderTop: '1px solid #333', paddingTop: '0.75rem', marginBottom: '1rem' }}>
-      <label
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: '0.5rem',
-          cursor: 'pointer',
-          fontWeight: 500,
-        }}
-      >
+    <div className="collection-fieldset">
+      <label className="collection-fieldset-toggle">
         <input
           type="checkbox"
           checked={enabled}
           onChange={(e) => onEnabledChange(e.target.checked)}
-          style={{ accentColor: '#3b82f6' }}
         />
         Enable pre-event voting
       </label>
 
       {enabled && (
-        <div
-          style={{
-            marginTop: '0.75rem',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '0.75rem',
-          }}
-        >
+        <div className="collection-fieldset-fields">
           <div className="form-group">
-            <label htmlFor="collection-opens-at" style={{ fontSize: '0.875rem' }}>
-              Collection opens at
-            </label>
+            <label htmlFor="collection-opens-at">Collection opens at</label>
             <input
               id="collection-opens-at"
               type="datetime-local"
@@ -85,9 +67,7 @@ export function CollectionFieldset(props: CollectionFieldsetProps) {
             />
           </div>
           <div className="form-group">
-            <label htmlFor="live-starts-at" style={{ fontSize: '0.875rem' }}>
-              Live starts at
-            </label>
+            <label htmlFor="live-starts-at">Live starts at</label>
             <input
               id="live-starts-at"
               type="datetime-local"
@@ -97,24 +77,19 @@ export function CollectionFieldset(props: CollectionFieldsetProps) {
             />
           </div>
           <div className="form-group">
-            <label htmlFor="submission-cap" style={{ fontSize: '0.875rem' }}>
-              Submission cap per guest
-            </label>
+            <label htmlFor="submission-cap">Submission cap per guest</label>
             <input
               id="submission-cap"
               type="number"
               min={0}
               max={100}
-              className="input"
+              className="input collection-fieldset-cap"
               value={submissionCap}
               onChange={(e) => onSubmissionCapChange(Number(e.target.value))}
-              style={{ width: '6rem' }}
             />
-            <p style={{ color: '#9ca3af', fontSize: '0.75rem', margin: '0.25rem 0 0' }}>
-              0 = unlimited picks per guest
-            </p>
+            <p className="collection-fieldset-hint">0 = unlimited picks per guest</p>
           </div>
-          {error && <p style={{ color: '#f87171', fontSize: '0.875rem' }}>{error}</p>}
+          {error && <p className="collection-fieldset-error">{error}</p>}
         </div>
       )}
     </div>

--- a/dashboard/lib/__tests__/collect-api.test.ts
+++ b/dashboard/lib/__tests__/collect-api.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { apiClient } from "../api";
+
+const OK_RESPONSE = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body }) as Response;
+
+describe("collect api client", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("getCollectEvent issues GET /api/public/collect/{code}", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      OK_RESPONSE({ code: "ABC", phase: "collection" })
+    );
+    const r = await apiClient.getCollectEvent("ABC");
+    expect(r.phase).toBe("collection");
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/public\/collect\/ABC$/),
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
+  it("submitCollectRequest POSTs JSON", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      OK_RESPONSE({ id: 42 })
+    );
+    await apiClient.submitCollectRequest("ABC", {
+      song_title: "T",
+      artist: "A",
+      source: "spotify",
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/public\/collect\/ABC\/requests$/),
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("voteCollectRequest POSTs the request_id", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      OK_RESPONSE({ ok: true })
+    );
+    await apiClient.voteCollectRequest("ABC", 99);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/public\/collect\/ABC\/vote$/),
+      expect.objectContaining({
+        body: JSON.stringify({ request_id: 99 }),
+      })
+    );
+  });
+});

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -18,6 +18,11 @@ export interface Event {
   banner_colors: string[] | null;
   // Requests open/closed
   requests_open: boolean;
+  // Pre-event collection
+  collection_opens_at: string | null;
+  live_starts_at: string | null;
+  submission_cap_per_guest: number;
+  collection_phase_override: 'force_collection' | 'force_live' | null;
 }
 
 export interface ArchivedEvent extends Event {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1052,6 +1052,10 @@ class ApiClient {
 
   // ========== Pre-Event Collection (DJ-authenticated) ==========
 
+  async getCollectionSettings(code: string): Promise<CollectionSettingsResponse> {
+    return this.fetch(`/api/events/${code}/collection`);
+  }
+
   async patchCollectionSettings(
     code: string,
     data: {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -145,6 +145,7 @@ export interface CollectMyPicksResponse {
   upvoted: CollectMyPicksItem[];
   is_top_contributor: boolean;
   first_suggestion_ids: number[];
+  voted_request_ids: number[];
 }
 
 export interface CollectionSettingsResponse {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -998,6 +998,17 @@ class ApiClient {
     return res.json();
   }
 
+  async getCollectProfile(code: string): Promise<CollectProfileResponse> {
+    const res = await fetch(
+      `${getApiUrl()}/api/public/collect/${code}/profile`,
+      { method: 'GET', headers: { 'Content-Type': 'application/json' } },
+    );
+    if (!res.ok) {
+      throw new ApiError(`getCollectProfile failed: ${res.status}`, res.status);
+    }
+    return res.json();
+  }
+
   async setCollectProfile(
     code: string,
     data: { nickname?: string; email?: string },

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -103,6 +103,8 @@ export interface CollectEventPreview {
   code: string;
   name: string;
   banner_filename: string | null;
+  banner_url: string | null;
+  banner_colors: string[] | null;
   submission_cap_per_guest: number;
   registration_enabled: boolean;
   phase: 'pre_announce' | 'collection' | 'live' | 'closed';

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -97,6 +97,85 @@ export type {
   VoteResponse,
 } from './api-types';
 
+// ========== Pre-Event Collection Types ==========
+
+export interface CollectEventPreview {
+  code: string;
+  name: string;
+  banner_filename: string | null;
+  submission_cap_per_guest: number;
+  registration_enabled: boolean;
+  phase: 'pre_announce' | 'collection' | 'live' | 'closed';
+  collection_opens_at: string | null;
+  live_starts_at: string | null;
+  expires_at: string;
+}
+
+export interface CollectLeaderboardRow {
+  id: number;
+  title: string;
+  artist: string;
+  artwork_url: string | null;
+  vote_count: number;
+  nickname: string | null;
+  status: 'new' | 'accepted' | 'playing' | 'played' | 'rejected';
+  created_at: string;
+}
+
+export interface CollectLeaderboardResponse {
+  requests: CollectLeaderboardRow[];
+  total: number;
+}
+
+export interface CollectProfileResponse {
+  nickname: string | null;
+  has_email: boolean;
+  submission_count: number;
+  submission_cap: number;
+}
+
+export interface CollectMyPicksItem extends CollectLeaderboardRow {
+  interaction: 'submitted' | 'upvoted';
+}
+
+export interface CollectMyPicksResponse {
+  submitted: CollectMyPicksItem[];
+  upvoted: CollectMyPicksItem[];
+  is_top_contributor: boolean;
+  first_suggestion_ids: number[];
+}
+
+export interface CollectionSettingsResponse {
+  collection_opens_at: string | null;
+  live_starts_at: string | null;
+  submission_cap_per_guest: number;
+  collection_phase_override: 'force_collection' | 'force_live' | null;
+  phase: 'pre_announce' | 'collection' | 'live' | 'closed';
+}
+
+export interface PendingReviewRow {
+  id: number;
+  song_title: string;
+  artist: string;
+  artwork_url: string | null;
+  vote_count: number;
+  nickname: string | null;
+  created_at: string;
+  note: string | null;
+  status: 'new' | 'accepted' | 'playing' | 'played' | 'rejected';
+}
+
+export interface PendingReviewResponse {
+  requests: PendingReviewRow[];
+  total: number;
+}
+
+export interface BulkReviewResponse {
+  accepted: number;
+  rejected: number;
+  unchanged: number;
+}
+
 export class ApiError extends Error {
   status: number;
   constructor(message: string, status: number) {
@@ -893,6 +972,125 @@ class ApiClient {
     return this.fetch(`/api/kiosk/${kioskId}`, { method: 'DELETE' });
   }
 
+  // ========== Pre-Event Collection (Public) ==========
+
+  async getCollectEvent(code: string): Promise<CollectEventPreview> {
+    const res = await fetch(`${getApiUrl()}/api/public/collect/${code}`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    if (!res.ok) throw new ApiError(`getCollectEvent failed: ${res.status}`, res.status);
+    return res.json();
+  }
+
+  async getCollectLeaderboard(
+    code: string,
+    tab: 'trending' | 'all' = 'trending',
+  ): Promise<CollectLeaderboardResponse> {
+    const res = await fetch(
+      `${getApiUrl()}/api/public/collect/${code}/leaderboard?tab=${tab}`,
+      { method: 'GET', headers: { 'Content-Type': 'application/json' } },
+    );
+    if (!res.ok) throw new ApiError(`getCollectLeaderboard failed: ${res.status}`, res.status);
+    return res.json();
+  }
+
+  async setCollectProfile(
+    code: string,
+    data: { nickname?: string; email?: string },
+  ): Promise<CollectProfileResponse> {
+    const res = await fetch(`${getApiUrl()}/api/public/collect/${code}/profile`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new ApiError(`setCollectProfile failed: ${res.status}`, res.status);
+    return res.json();
+  }
+
+  async getCollectMyPicks(code: string): Promise<CollectMyPicksResponse> {
+    const res = await fetch(`${getApiUrl()}/api/public/collect/${code}/profile/me`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    if (!res.ok) throw new ApiError(`getCollectMyPicks failed: ${res.status}`, res.status);
+    return res.json();
+  }
+
+  async submitCollectRequest(
+    code: string,
+    data: {
+      song_title: string;
+      artist: string;
+      source: 'spotify' | 'beatport' | 'tidal' | 'manual';
+      source_url?: string;
+      artwork_url?: string;
+      note?: string;
+      nickname?: string;
+    },
+  ): Promise<{ id: number }> {
+    const res = await fetch(`${getApiUrl()}/api/public/collect/${code}/requests`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new ApiError(body.detail ?? `Submit failed: ${res.status}`, res.status);
+    }
+    return res.json();
+  }
+
+  async voteCollectRequest(code: string, requestId: number): Promise<void> {
+    const res = await fetch(`${getApiUrl()}/api/public/collect/${code}/vote`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ request_id: requestId }),
+    });
+    if (!res.ok) throw new ApiError(`Vote failed: ${res.status}`, res.status);
+  }
+
+  // ========== Pre-Event Collection (DJ-authenticated) ==========
+
+  async patchCollectionSettings(
+    code: string,
+    data: {
+      collection_opens_at?: string | null;
+      live_starts_at?: string | null;
+      submission_cap_per_guest?: number;
+      collection_phase_override?: 'force_collection' | 'force_live' | null;
+    },
+  ): Promise<CollectionSettingsResponse> {
+    return this.fetch(`/api/events/${code}/collection`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async getPendingReview(code: string): Promise<PendingReviewResponse> {
+    return this.fetch(`/api/events/${code}/pending-review`);
+  }
+
+  async bulkReview(
+    code: string,
+    data: {
+      action:
+        | 'accept_top_n'
+        | 'accept_threshold'
+        | 'accept_ids'
+        | 'reject_ids'
+        | 'reject_remaining';
+      n?: number;
+      min_votes?: number;
+      request_ids?: number[];
+    },
+  ): Promise<BulkReviewResponse> {
+    return this.fetch(`/api/events/${code}/bulk-review`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
   // ========== Bridge Commands ==========
 
   async sendBridgeCommand(eventCode: string, command: string): Promise<BridgeCommandResponse> {
@@ -912,3 +1110,4 @@ class ApiClient {
 }
 
 export const api = new ApiClient();
+export const apiClient = api;

--- a/deploy/dev-proxy/nginx/app.conf.template
+++ b/deploy/dev-proxy/nginx/app.conf.template
@@ -29,7 +29,7 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://api.local https://${LAN_IP}:8443 https://i.scdn.co https://resources.tidal.com https://geo-media.beatport.com; media-src 'self' data:; connect-src 'self' https://api.local https://${LAN_IP}:8443 wss://app.local wss://${LAN_IP}; frame-src https://challenges.cloudflare.com https://open.spotify.com https://embed.tidal.com; frame-ancestors 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://api.local https://${LAN_IP}:8443 https://i.scdn.co https://resources.tidal.com https://geo-media.beatport.com; media-src 'self' data:; connect-src 'self' https://api.local https://${LAN_IP}:8443 wss://app.local wss://${LAN_IP}; frame-src https://challenges.cloudflare.com https://open.spotify.com https://embed.tidal.com; frame-ancestors 'none'" always;
 
     # Strip security headers from upstream (Next.js sets them too — nginx is authoritative)
     proxy_hide_header Strict-Transport-Security;
@@ -51,7 +51,7 @@ server {
 
     # OBS/streaming overlay — allow embedding from any origin (same as production)
     location ~ ^/e/[^/]+/overlay {
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://api.local https://${LAN_IP}:8443 https://i.scdn.co https://resources.tidal.com https://geo-media.beatport.com; media-src 'self' data:; connect-src 'self' https://api.local https://${LAN_IP}:8443 wss://app.local wss://${LAN_IP}; frame-src https://challenges.cloudflare.com; frame-ancestors *" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://api.local https://${LAN_IP}:8443 https://i.scdn.co https://resources.tidal.com https://geo-media.beatport.com; media-src 'self' data:; connect-src 'self' https://api.local https://${LAN_IP}:8443 wss://app.local wss://${LAN_IP}; frame-src https://challenges.cloudflare.com; frame-ancestors *" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;

--- a/docs/superpowers/plans/2026-04-21-pre-event-collection.md
+++ b/docs/superpowers/plans/2026-04-21-pre-event-collection.md
@@ -1,0 +1,3745 @@
+# Pre-Event Song Collection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a pre-event song collection mode — DJs configure "opens at" and "live at" dates, guests visit `/collect/[code]` to submit songs, upvote others, and see themselves on a live leaderboard. Requests accumulate in `NEW` until the DJ reviews them (anytime, or via a bulk-sweep view). At live-start, `/collect/[code]` auto-redirects to `/join/[code]`.
+
+**Architecture:** Approach 1 — minimal extension of existing models. Four new columns on `events`, one new column on `requests`, a new `guest_profiles` table with encrypted email. A derived `Event.phase` computed property (`pre_announce | collection | live | closed`) drives routing and guards. A new `/api/public/collect/*` router handles guest traffic; DJ routes extend `events.py`. Frontend gets a new `/collect/[code]` page and a third `PreEventVotingTab` on the event-management page.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2.0 + Alembic (backend), Next.js 16 + React 19 + TypeScript + zod + vanilla CSS (frontend), Fernet `EncryptedText` (email at rest), slowapi (rate limits), Pydantic (server validation), pytest + vitest (tests).
+
+**Spec reference:** `docs/superpowers/specs/2026-04-21-pre-event-collection-design.md`
+
+**Corrections from spec:** migration number is `034_add_pre_event_collection.py` (not `010`); `EncryptedText` lives in `app.core.encryption` (not `app.models.base`).
+
+---
+
+## Task 1: Alembic migration 034 — add columns + guest_profiles table
+
+**Files:**
+- Create: `server/alembic/versions/034_add_pre_event_collection.py`
+
+- [ ] **Step 1: Create the migration file**
+
+```python
+"""Add pre-event collection columns + guest_profiles table.
+
+Revision ID: 034
+Revises: 033
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "034"
+down_revision = "033"
+
+
+def upgrade() -> None:
+    # events columns
+    op.add_column(
+        "events",
+        sa.Column("collection_opens_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "events",
+        sa.Column("live_starts_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "events",
+        sa.Column(
+            "submission_cap_per_guest",
+            sa.Integer(),
+            nullable=False,
+            server_default="15",
+        ),
+    )
+    op.add_column(
+        "events",
+        sa.Column("collection_phase_override", sa.String(length=20), nullable=True),
+    )
+
+    # requests column
+    op.add_column(
+        "requests",
+        sa.Column(
+            "submitted_during_collection",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+    op.create_index(
+        "ix_requests_submitted_during_collection",
+        "requests",
+        ["submitted_during_collection"],
+    )
+
+    # guest_profiles table
+    op.create_table(
+        "guest_profiles",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "event_id",
+            sa.Integer(),
+            sa.ForeignKey("events.id"),
+            nullable=False,
+        ),
+        sa.Column("client_fingerprint", sa.String(length=64), nullable=False),
+        sa.Column("nickname", sa.String(length=30), nullable=True),
+        sa.Column("email", sa.Text(), nullable=True),
+        sa.Column(
+            "submission_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint(
+            "event_id",
+            "client_fingerprint",
+            name="uq_guest_profile_event_fingerprint",
+        ),
+    )
+    op.create_index("ix_guest_profiles_event_id", "guest_profiles", ["event_id"])
+    op.create_index(
+        "ix_guest_profiles_client_fingerprint",
+        "guest_profiles",
+        ["client_fingerprint"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_guest_profiles_client_fingerprint", table_name="guest_profiles")
+    op.drop_index("ix_guest_profiles_event_id", table_name="guest_profiles")
+    op.drop_table("guest_profiles")
+    op.drop_index(
+        "ix_requests_submitted_during_collection", table_name="requests"
+    )
+    op.drop_column("requests", "submitted_during_collection")
+    op.drop_column("events", "collection_phase_override")
+    op.drop_column("events", "submission_cap_per_guest")
+    op.drop_column("events", "live_starts_at")
+    op.drop_column("events", "collection_opens_at")
+```
+
+- [ ] **Step 2: Run migration up + down locally to verify**
+
+Run: `cd server && .venv/bin/alembic upgrade head && .venv/bin/alembic downgrade -1 && .venv/bin/alembic upgrade head`
+Expected: All three commands succeed. No drift errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/alembic/versions/034_add_pre_event_collection.py
+git commit -m "feat(db): migration for pre-event collection columns and guest_profiles"
+```
+
+---
+
+## Task 2: Update Event model — new columns + derived phase property
+
+**Files:**
+- Modify: `server/app/models/event.py`
+- Test: `server/tests/test_event_phase.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `server/tests/test_event_phase.py`:
+
+```python
+from datetime import timedelta
+
+from app.core.time import utcnow
+from app.models.event import Event
+
+
+def _make_event(**kwargs) -> Event:
+    now = utcnow()
+    defaults = dict(
+        code="ABCDEF",
+        name="Test Event",
+        created_by_user_id=1,
+        expires_at=now + timedelta(days=30),
+    )
+    defaults.update(kwargs)
+    return Event(**defaults)
+
+
+def test_phase_no_collection_set_is_live():
+    ev = _make_event()
+    assert ev.phase == "live"
+
+
+def test_phase_no_collection_after_expiry_is_closed():
+    ev = _make_event(expires_at=utcnow() - timedelta(hours=1))
+    assert ev.phase == "closed"
+
+
+def test_phase_pre_announce_when_before_collection_opens():
+    now = utcnow()
+    ev = _make_event(
+        collection_opens_at=now + timedelta(hours=1),
+        live_starts_at=now + timedelta(days=1),
+    )
+    assert ev.phase == "pre_announce"
+
+
+def test_phase_collection_when_between_opens_and_live():
+    now = utcnow()
+    ev = _make_event(
+        collection_opens_at=now - timedelta(hours=1),
+        live_starts_at=now + timedelta(hours=1),
+    )
+    assert ev.phase == "collection"
+
+
+def test_phase_live_when_past_live_starts_at():
+    now = utcnow()
+    ev = _make_event(
+        collection_opens_at=now - timedelta(days=2),
+        live_starts_at=now - timedelta(hours=1),
+    )
+    assert ev.phase == "live"
+
+
+def test_phase_override_force_live_wins():
+    now = utcnow()
+    ev = _make_event(
+        collection_opens_at=now - timedelta(hours=1),
+        live_starts_at=now + timedelta(hours=1),
+        collection_phase_override="force_live",
+    )
+    assert ev.phase == "live"
+
+
+def test_phase_override_force_collection_wins():
+    now = utcnow()
+    ev = _make_event(
+        collection_opens_at=now - timedelta(days=2),
+        live_starts_at=now - timedelta(hours=1),
+        collection_phase_override="force_collection",
+    )
+    assert ev.phase == "collection"
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run: `cd server && .venv/bin/pytest tests/test_event_phase.py -v`
+Expected: FAIL — `AttributeError: 'Event' object has no attribute 'phase'` (or column doesn't exist)
+
+- [ ] **Step 3: Add columns and phase property**
+
+Replace `server/app/models/event.py` with:
+
+```python
+from datetime import datetime
+from typing import Literal
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.time import utcnow
+from app.models.base import Base
+
+
+class Event(Base):
+    __tablename__ = "events"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    code: Mapped[str] = mapped_column(String(10), unique=True, index=True)
+    name: Mapped[str] = mapped_column(String(100))
+    created_by_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow)
+    expires_at: Mapped[datetime] = mapped_column(DateTime)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    archived_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    # Tidal playlist sync
+    tidal_playlist_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    tidal_sync_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+
+    # Beatport sync
+    beatport_sync_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+    beatport_playlist_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+
+    # Display settings
+    now_playing_auto_hide_minutes: Mapped[int] = mapped_column(
+        Integer, default=10, nullable=False, server_default="10"
+    )
+    requests_open: Mapped[bool] = mapped_column(
+        Boolean, default=True, nullable=False, server_default="1"
+    )
+
+    # Kiosk display-only mode
+    kiosk_display_only: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="0"
+    )
+
+    # Custom banner image
+    banner_filename: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    banner_colors: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Pre-event collection
+    collection_opens_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    live_starts_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    submission_cap_per_guest: Mapped[int] = mapped_column(
+        Integer, default=15, nullable=False, server_default="15"
+    )
+    collection_phase_override: Mapped[str | None] = mapped_column(String(20), nullable=True)
+
+    created_by: Mapped["User"] = relationship("User", back_populates="events")
+    requests: Mapped[list["Request"]] = relationship(
+        "Request", back_populates="event", foreign_keys="Request.event_id"
+    )
+    play_history: Mapped[list["PlayHistory"]] = relationship("PlayHistory", back_populates="event")
+
+    @property
+    def phase(self) -> Literal["pre_announce", "collection", "live", "closed"]:
+        if self.collection_phase_override == "force_live":
+            return "live"
+        if self.collection_phase_override == "force_collection":
+            return "collection"
+        now = utcnow()
+        if self.collection_opens_at and now < self.collection_opens_at:
+            return "pre_announce"
+        if self.live_starts_at and now < self.live_starts_at:
+            return "collection"
+        if now < self.expires_at:
+            return "live"
+        return "closed"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd server && .venv/bin/pytest tests/test_event_phase.py -v`
+Expected: 7 passed
+
+- [ ] **Step 5: Run alembic check to confirm no drift**
+
+Run: `cd server && .venv/bin/alembic upgrade head && .venv/bin/alembic check`
+Expected: "No new upgrade operations detected."
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/app/models/event.py server/tests/test_event_phase.py
+git commit -m "feat(events): add pre-event collection columns + derived phase property"
+```
+
+---
+
+## Task 3: Update Request model — submitted_during_collection column
+
+**Files:**
+- Modify: `server/app/models/request.py`
+
+- [ ] **Step 1: Add the column**
+
+Edit `server/app/models/request.py`. Add this column immediately after the existing `vote_count` column, before the `event` relationship:
+
+```python
+    # Pre-event collection flag — set on insert when event.phase == "collection"
+    submitted_during_collection: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="0", index=True
+    )
+```
+
+Also add `Boolean` to the existing sqlalchemy import list at the top of the file if not already present.
+
+- [ ] **Step 2: Run alembic check to confirm no drift**
+
+Run: `cd server && .venv/bin/alembic upgrade head && .venv/bin/alembic check`
+Expected: "No new upgrade operations detected."
+
+- [ ] **Step 3: Run existing request tests to confirm no regression**
+
+Run: `cd server && .venv/bin/pytest tests/test_requests.py -v`
+Expected: All pass (column is optional with default, existing tests unaffected).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/app/models/request.py
+git commit -m "feat(requests): add submitted_during_collection flag"
+```
+
+---
+
+## Task 4: Create GuestProfile model
+
+**Files:**
+- Create: `server/app/models/guest_profile.py`
+- Modify: `server/app/models/__init__.py` (if it imports models — verify)
+- Test: `server/tests/test_guest_profile.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `server/tests/test_guest_profile.py`:
+
+```python
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.event import Event
+from app.models.guest_profile import GuestProfile
+
+
+def test_guest_profile_defaults(db, test_event: Event):
+    profile = GuestProfile(
+        event_id=test_event.id,
+        client_fingerprint="fp_abc",
+    )
+    db.add(profile)
+    db.commit()
+    db.refresh(profile)
+    assert profile.nickname is None
+    assert profile.email is None
+    assert profile.submission_count == 0
+    assert profile.created_at is not None
+
+
+def test_guest_profile_uniqueness(db, test_event: Event):
+    db.add(GuestProfile(event_id=test_event.id, client_fingerprint="fp_same"))
+    db.commit()
+    db.add(GuestProfile(event_id=test_event.id, client_fingerprint="fp_same"))
+    with pytest.raises(IntegrityError):
+        db.commit()
+
+
+def test_guest_profile_email_is_encrypted_at_rest(db, test_event: Event):
+    profile = GuestProfile(
+        event_id=test_event.id,
+        client_fingerprint="fp_enc",
+        email="guest@example.com",
+    )
+    db.add(profile)
+    db.commit()
+
+    raw = db.execute(
+        __import__("sqlalchemy").text(
+            "SELECT email FROM guest_profiles WHERE id = :id"
+        ),
+        {"id": profile.id},
+    ).scalar()
+    assert raw != "guest@example.com"
+    assert raw is not None
+
+    db.refresh(profile)
+    assert profile.email == "guest@example.com"
+```
+
+- [ ] **Step 2: Run tests to confirm failure**
+
+Run: `cd server && .venv/bin/pytest tests/test_guest_profile.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.models.guest_profile'`
+
+- [ ] **Step 3: Create the model**
+
+Create `server/app/models/guest_profile.py`:
+
+```python
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.encryption import EncryptedText
+from app.core.time import utcnow
+from app.models.base import Base
+
+
+class GuestProfile(Base):
+    __tablename__ = "guest_profiles"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
+    client_fingerprint: Mapped[str] = mapped_column(String(64), index=True)
+    nickname: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    email: Mapped[str | None] = mapped_column(EncryptedText, nullable=True)
+    submission_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "event_id",
+            "client_fingerprint",
+            name="uq_guest_profile_event_fingerprint",
+        ),
+    )
+```
+
+- [ ] **Step 4: Ensure the model is imported somewhere Alembic can see**
+
+Run: `grep -rn "guest_profile\|GuestProfile" /home/adam/github/WrzDJ/server/app/models/__init__.py` — if models are auto-imported there, add the import. Otherwise Alembic's `env.py` already imports `app.models` which recursively discovers via the `Base` metadata only if the module is imported somewhere. Confirm by checking `server/alembic/env.py`:
+
+Run: `grep -n "import.*models" /home/adam/github/WrzDJ/server/alembic/env.py`
+
+If the pattern is `from app.models import *` or equivalent, add an explicit import line in `server/app/models/__init__.py`:
+
+```python
+from app.models.guest_profile import GuestProfile  # noqa: F401
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd server && .venv/bin/pytest tests/test_guest_profile.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 6: Run alembic check**
+
+Run: `cd server && .venv/bin/alembic upgrade head && .venv/bin/alembic check`
+Expected: "No new upgrade operations detected."
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/app/models/guest_profile.py server/app/models/__init__.py server/tests/test_guest_profile.py
+git commit -m "feat(guest_profile): model with encrypted email + fingerprint uniqueness"
+```
+
+---
+
+## Task 5: Collect Pydantic schemas
+
+**Files:**
+- Create: `server/app/schemas/collect.py`
+
+- [ ] **Step 1: Create the schemas file**
+
+```python
+"""Pydantic schemas for pre-event collection endpoints."""
+
+from datetime import datetime
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, EmailStr, Field, StringConstraints
+
+Nickname = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=1,
+        max_length=30,
+        pattern=r"^[a-zA-Z0-9 _.-]+$",
+    ),
+]
+Note = Annotated[str, StringConstraints(strip_whitespace=True, max_length=500)]
+
+
+class CollectPhase(BaseModel):
+    phase: Literal["pre_announce", "collection", "live", "closed"]
+    collection_opens_at: datetime | None
+    live_starts_at: datetime | None
+    expires_at: datetime
+
+
+class CollectEventPreview(BaseModel):
+    code: str
+    name: str
+    banner_filename: str | None
+    submission_cap_per_guest: int
+    registration_enabled: bool
+    phase: Literal["pre_announce", "collection", "live", "closed"]
+    collection_opens_at: datetime | None
+    live_starts_at: datetime | None
+    expires_at: datetime
+
+
+class CollectLeaderboardRow(BaseModel):
+    id: int
+    title: str
+    artist: str
+    artwork_url: str | None
+    vote_count: int
+    nickname: str | None
+    status: Literal["new", "accepted", "playing", "played", "rejected"]
+    created_at: datetime
+
+
+class CollectLeaderboardResponse(BaseModel):
+    requests: list[CollectLeaderboardRow]
+    total: int
+
+
+class CollectProfileRequest(BaseModel):
+    nickname: Nickname | None = None
+    email: EmailStr | None = None
+
+
+class CollectProfileResponse(BaseModel):
+    nickname: str | None
+    has_email: bool
+    submission_count: int
+    submission_cap: int
+
+
+class CollectMyPicksItem(CollectLeaderboardRow):
+    interaction: Literal["submitted", "upvoted"]
+
+
+class CollectMyPicksResponse(BaseModel):
+    submitted: list[CollectMyPicksItem]
+    upvoted: list[CollectMyPicksItem]
+    is_top_contributor: bool
+    first_suggestion_ids: list[int]
+
+
+class CollectSubmitRequest(BaseModel):
+    song_title: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=255)]
+    artist: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=255)]
+    source: Literal["spotify", "beatport", "tidal", "manual"]
+    source_url: str | None = Field(default=None, max_length=500)
+    artwork_url: str | None = Field(default=None, max_length=500)
+    note: Note | None = None
+    nickname: Nickname | None = None
+
+
+class CollectVoteRequest(BaseModel):
+    request_id: int
+
+
+class UpdateCollectionSettings(BaseModel):
+    collection_opens_at: datetime | None = None
+    live_starts_at: datetime | None = None
+    submission_cap_per_guest: int | None = Field(default=None, ge=0, le=100)
+    collection_phase_override: Literal["force_collection", "force_live"] | None = None
+
+
+class PendingReviewRow(BaseModel):
+    id: int
+    song_title: str
+    artist: str
+    artwork_url: str | None
+    vote_count: int
+    nickname: str | None
+    created_at: datetime
+    note: str | None
+    status: Literal["new", "accepted", "playing", "played", "rejected"]
+
+
+class PendingReviewResponse(BaseModel):
+    requests: list[PendingReviewRow]
+    total: int
+
+
+class BulkReviewRequest(BaseModel):
+    action: Literal[
+        "accept_top_n",
+        "accept_threshold",
+        "accept_ids",
+        "reject_ids",
+        "reject_remaining",
+    ]
+    n: int | None = Field(default=None, ge=1, le=200)
+    min_votes: int | None = Field(default=None, ge=0)
+    request_ids: list[int] | None = Field(default=None, max_length=200)
+
+
+class BulkReviewResponse(BaseModel):
+    accepted: int
+    rejected: int
+    unchanged: int
+```
+
+- [ ] **Step 2: Smoke-test imports**
+
+Run: `cd server && .venv/bin/python -c "from app.schemas import collect; print(collect.CollectEventPreview.model_fields.keys())"`
+Expected: No errors, prints field keys.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/app/schemas/collect.py
+git commit -m "feat(collect): pydantic schemas for pre-event collection endpoints"
+```
+
+---
+
+## Task 6: Collect service — profile upsert + submission cap
+
+**Files:**
+- Create: `server/app/services/collect.py`
+- Test: `server/tests/test_collect_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `server/tests/test_collect_service.py`:
+
+```python
+from datetime import timedelta
+
+import pytest
+
+from app.core.time import utcnow
+from app.models.event import Event
+from app.models.guest_profile import GuestProfile
+from app.services import collect as collect_service
+
+
+def _enable_collection(db, event: Event):
+    now = utcnow()
+    event.collection_opens_at = now - timedelta(hours=1)
+    event.live_starts_at = now + timedelta(hours=1)
+    event.submission_cap_per_guest = 3
+    db.commit()
+    db.refresh(event)
+
+
+def test_upsert_profile_creates_row(db, test_event: Event):
+    profile = collect_service.upsert_profile(
+        db, event_id=test_event.id, fingerprint="fp1", nickname="Alex"
+    )
+    assert profile.nickname == "Alex"
+    assert profile.email is None
+    assert profile.submission_count == 0
+
+
+def test_upsert_profile_preserves_email_when_only_nickname_given(db, test_event: Event):
+    collect_service.upsert_profile(
+        db, event_id=test_event.id, fingerprint="fp2", email="g@example.com"
+    )
+    profile = collect_service.upsert_profile(
+        db, event_id=test_event.id, fingerprint="fp2", nickname="NewName"
+    )
+    assert profile.email == "g@example.com"
+    assert profile.nickname == "NewName"
+
+
+def test_check_and_increment_submission_count_blocks_at_cap(db, test_event: Event):
+    _enable_collection(db, test_event)
+    for _ in range(3):
+        collect_service.check_and_increment_submission_count(
+            db, event=test_event, fingerprint="fp3"
+        )
+    with pytest.raises(collect_service.SubmissionCapExceeded):
+        collect_service.check_and_increment_submission_count(
+            db, event=test_event, fingerprint="fp3"
+        )
+
+
+def test_check_and_increment_allows_unlimited_when_cap_zero(db, test_event: Event):
+    _enable_collection(db, test_event)
+    test_event.submission_cap_per_guest = 0
+    db.commit()
+    for _ in range(20):
+        collect_service.check_and_increment_submission_count(
+            db, event=test_event, fingerprint="fp4"
+        )
+    profile = (
+        db.query(GuestProfile)
+        .filter(
+            GuestProfile.event_id == test_event.id,
+            GuestProfile.client_fingerprint == "fp4",
+        )
+        .one()
+    )
+    assert profile.submission_count == 20
+```
+
+- [ ] **Step 2: Run tests to confirm failure**
+
+Run: `cd server && .venv/bin/pytest tests/test_collect_service.py -v`
+Expected: FAIL — `ModuleNotFoundError` on `app.services.collect`.
+
+- [ ] **Step 3: Create the service**
+
+Create `server/app/services/collect.py`:
+
+```python
+"""Service layer for pre-event collection."""
+
+from sqlalchemy.orm import Session
+
+from app.models.event import Event
+from app.models.guest_profile import GuestProfile
+
+
+class SubmissionCapExceeded(Exception):
+    """Raised when a guest has hit their per-event submission cap."""
+
+
+def get_profile(
+    db: Session, *, event_id: int, fingerprint: str
+) -> GuestProfile | None:
+    return (
+        db.query(GuestProfile)
+        .filter(
+            GuestProfile.event_id == event_id,
+            GuestProfile.client_fingerprint == fingerprint,
+        )
+        .one_or_none()
+    )
+
+
+def upsert_profile(
+    db: Session,
+    *,
+    event_id: int,
+    fingerprint: str,
+    nickname: str | None = None,
+    email: str | None = None,
+) -> GuestProfile:
+    profile = get_profile(db, event_id=event_id, fingerprint=fingerprint)
+    if profile is None:
+        profile = GuestProfile(
+            event_id=event_id,
+            client_fingerprint=fingerprint,
+            nickname=nickname,
+            email=email,
+        )
+        db.add(profile)
+    else:
+        if nickname is not None:
+            profile.nickname = nickname
+        if email is not None:
+            profile.email = email
+    db.commit()
+    db.refresh(profile)
+    return profile
+
+
+def check_and_increment_submission_count(
+    db: Session, *, event: Event, fingerprint: str
+) -> GuestProfile:
+    """Atomically enforce the per-guest cap, incrementing submission_count on success.
+
+    Raises SubmissionCapExceeded when the cap would be exceeded. cap == 0 means
+    unlimited (explicit by design).
+    """
+    profile = get_profile(db, event_id=event.id, fingerprint=fingerprint)
+    if profile is None:
+        profile = GuestProfile(
+            event_id=event.id,
+            client_fingerprint=fingerprint,
+        )
+        db.add(profile)
+        db.flush()
+
+    cap = event.submission_cap_per_guest
+    if cap != 0 and profile.submission_count >= cap:
+        db.rollback()
+        raise SubmissionCapExceeded()
+
+    profile.submission_count += 1
+    db.commit()
+    db.refresh(profile)
+    return profile
+```
+
+- [ ] **Step 4: Run tests to verify green**
+
+Run: `cd server && .venv/bin/pytest tests/test_collect_service.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/services/collect.py server/tests/test_collect_service.py
+git commit -m "feat(collect): service for profile upsert + submission cap enforcement"
+```
+
+---
+
+## Task 7: Collect public API router — preview + leaderboard endpoints
+
+**Files:**
+- Create: `server/app/api/collect.py`
+- Modify: `server/app/api/__init__.py`
+- Test: `server/tests/test_collect_public.py`
+
+- [ ] **Step 1: Write failing tests for preview + leaderboard**
+
+Create `server/tests/test_collect_public.py`:
+
+```python
+from datetime import timedelta
+
+from app.core.time import utcnow
+from app.models.event import Event
+
+
+def _enable_collection(db, event: Event):
+    now = utcnow()
+    event.collection_opens_at = now - timedelta(hours=1)
+    event.live_starts_at = now + timedelta(hours=1)
+    db.commit()
+    db.refresh(event)
+
+
+def test_collect_preview_returns_phase(client, db, test_event: Event):
+    _enable_collection(db, test_event)
+    r = client.get(f"/api/public/collect/{test_event.code}")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["code"] == test_event.code
+    assert body["phase"] == "collection"
+    assert body["submission_cap_per_guest"] == 15
+
+
+def test_collect_preview_404_for_unknown_code(client):
+    r = client.get("/api/public/collect/ZZZZZZ")
+    assert r.status_code == 404
+
+
+def test_collect_leaderboard_empty(client, db, test_event: Event):
+    _enable_collection(db, test_event)
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["requests"] == []
+    assert body["total"] == 0
+
+
+def test_collect_leaderboard_trending_sorts_by_votes(client, db, test_event, collection_requests):
+    _enable_collection(db, test_event)
+    # collection_requests fixture creates 3 requests with vote_count 5, 2, 0
+    r = client.get(
+        f"/api/public/collect/{test_event.code}/leaderboard?tab=trending"
+    )
+    assert r.status_code == 200
+    votes = [row["vote_count"] for row in r.json()["requests"]]
+    assert votes == sorted(votes, reverse=True)
+    # vote_count 0 excluded from trending
+    assert 0 not in votes
+
+
+def test_collect_leaderboard_all_tab_includes_zero_votes(
+    client, db, test_event, collection_requests
+):
+    _enable_collection(db, test_event)
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all")
+    assert r.status_code == 200
+    votes = [row["vote_count"] for row in r.json()["requests"]]
+    assert 0 in votes
+```
+
+- [ ] **Step 2: Add the `collection_requests` fixture**
+
+Edit `server/tests/conftest.py`. Add this fixture:
+
+```python
+@pytest.fixture
+def collection_requests(db, test_event):
+    """Creates 3 collection-submitted NEW requests with vote counts 5, 2, 0."""
+    from app.models.request import Request, RequestStatus
+    now = utcnow()
+    rows = []
+    for i, votes in enumerate([5, 2, 0]):
+        r = Request(
+            event_id=test_event.id,
+            song_title=f"Song {i}",
+            artist=f"Artist {i}",
+            source="spotify",
+            status=RequestStatus.NEW.value,
+            vote_count=votes,
+            dedupe_key=f"dk_{i}",
+            submitted_during_collection=True,
+            created_at=now,
+        )
+        db.add(r)
+        rows.append(r)
+    db.commit()
+    for r in rows:
+        db.refresh(r)
+    return rows
+```
+
+If `utcnow` and `pytest` are not already imported at the top of `conftest.py`, add the missing imports.
+
+- [ ] **Step 3: Create the router with preview + leaderboard**
+
+Create `server/app/api/collect.py`:
+
+```python
+"""Public API endpoints for pre-event song collection (no authentication required)."""
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.core.rate_limit import get_client_fingerprint, limiter
+from app.models.event import Event
+from app.models.request import Request as SongRequest
+from app.schemas.collect import (
+    CollectEventPreview,
+    CollectLeaderboardResponse,
+    CollectLeaderboardRow,
+)
+from app.services.system_settings import get_system_settings
+
+router = APIRouter()
+
+
+def _get_event_or_404(db: Session, code: str) -> Event:
+    event = db.query(Event).filter(Event.code == code).one_or_none()
+    if event is None or not event.is_active:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return event
+
+
+@router.get("/{code}", response_model=CollectEventPreview)
+@limiter.limit("120/minute")
+def preview(code: str, request: Request, db: Session = Depends(get_db)):
+    event = _get_event_or_404(db, code)
+    settings = get_system_settings(db)
+    return CollectEventPreview(
+        code=event.code,
+        name=event.name,
+        banner_filename=event.banner_filename,
+        submission_cap_per_guest=event.submission_cap_per_guest,
+        registration_enabled=settings.registration_enabled,
+        phase=event.phase,
+        collection_opens_at=event.collection_opens_at,
+        live_starts_at=event.live_starts_at,
+        expires_at=event.expires_at,
+    )
+
+
+@router.get("/{code}/leaderboard", response_model=CollectLeaderboardResponse)
+@limiter.limit("120/minute")
+def leaderboard(
+    code: str,
+    request: Request,
+    tab: Literal["trending", "all"] = "trending",
+    db: Session = Depends(get_db),
+):
+    event = _get_event_or_404(db, code)
+
+    q = (
+        db.query(SongRequest)
+        .filter(SongRequest.event_id == event.id)
+        .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
+    )
+    if tab == "trending":
+        q = q.filter(SongRequest.vote_count >= 1).order_by(
+            SongRequest.vote_count.desc(), SongRequest.created_at.desc()
+        )
+    else:
+        q = q.order_by(SongRequest.created_at.desc())
+
+    rows = q.limit(200).all()
+    return CollectLeaderboardResponse(
+        requests=[
+            CollectLeaderboardRow(
+                id=r.id,
+                title=r.song_title,
+                artist=r.artist,
+                artwork_url=r.artwork_url,
+                vote_count=r.vote_count,
+                nickname=r.nickname,
+                status=r.status,
+                created_at=r.created_at,
+            )
+            for r in rows
+        ],
+        total=len(rows),
+    )
+```
+
+- [ ] **Step 4: Register the router**
+
+Edit `server/app/api/__init__.py` — add `collect` to the import block and include:
+
+```python
+from app.api import (
+    admin,
+    auth,
+    beatport,
+    bridge,
+    collect,
+    events,
+    kiosk,
+    public,
+    requests,
+    search,
+    sse,
+    tidal,
+    votes,
+)
+```
+
+Add this line after the existing `include_router` calls:
+
+```python
+api_router.include_router(collect.router, prefix="/public/collect", tags=["collect"])
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd server && .venv/bin/pytest tests/test_collect_public.py -v`
+Expected: 5 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/app/api/collect.py server/app/api/__init__.py server/tests/test_collect_public.py server/tests/conftest.py
+git commit -m "feat(collect): GET preview + leaderboard public endpoints"
+```
+
+---
+
+## Task 8: Profile endpoints — POST /profile and GET /profile/me
+
+**Files:**
+- Modify: `server/app/api/collect.py`
+- Modify: `server/tests/test_collect_public.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `server/tests/test_collect_public.py`:
+
+```python
+def test_collect_profile_set_nickname(client, db, test_event):
+    _enable_collection(db, test_event)
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/profile",
+        json={"nickname": "DancingQueen"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["nickname"] == "DancingQueen"
+    assert body["has_email"] is False
+    assert body["submission_count"] == 0
+    assert body["submission_cap"] == 15
+
+
+def test_collect_profile_invalid_nickname_rejected(client, db, test_event):
+    _enable_collection(db, test_event)
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/profile",
+        json={"nickname": "<script>alert(1)</script>"},
+    )
+    assert r.status_code == 422
+
+
+def test_collect_profile_accepts_email(client, db, test_event):
+    _enable_collection(db, test_event)
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/profile",
+        json={"nickname": "A", "email": "guest@example.com"},
+    )
+    assert r.status_code == 200
+    assert r.json()["has_email"] is True
+
+
+def test_collect_profile_me_empty_when_no_interactions(client, db, test_event):
+    _enable_collection(db, test_event)
+    r = client.get(f"/api/public/collect/{test_event.code}/profile/me")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["submitted"] == []
+    assert body["upvoted"] == []
+    assert body["is_top_contributor"] is False
+```
+
+- [ ] **Step 2: Run tests to confirm failure**
+
+Run: `cd server && .venv/bin/pytest tests/test_collect_public.py::test_collect_profile_set_nickname -v`
+Expected: FAIL — 404 or similar.
+
+- [ ] **Step 3: Add the endpoints to `server/app/api/collect.py`**
+
+Add these imports at the top:
+
+```python
+from app.models.guest_profile import GuestProfile
+from app.models.request_vote import RequestVote
+from app.schemas.collect import (
+    CollectEventPreview,
+    CollectLeaderboardResponse,
+    CollectLeaderboardRow,
+    CollectMyPicksItem,
+    CollectMyPicksResponse,
+    CollectProfileRequest,
+    CollectProfileResponse,
+)
+from app.services import collect as collect_service
+```
+
+(Adjust the existing import block — keep `CollectEventPreview`/`CollectLeaderboardResponse`/`CollectLeaderboardRow` already imported.)
+
+Confirm the actual file location of `RequestVote` before adding that import:
+
+```bash
+grep -rn "class RequestVote" /home/adam/github/WrzDJ/server/app/models/
+```
+
+Use whatever module path that reveals (e.g., `app.models.request_vote` or `app.models.vote`).
+
+Append these endpoints at the bottom of `server/app/api/collect.py`:
+
+```python
+@router.post("/{code}/profile", response_model=CollectProfileResponse)
+@limiter.limit("5/minute")
+def set_profile(
+    code: str,
+    payload: CollectProfileRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    event = _get_event_or_404(db, code)
+    fingerprint = get_client_fingerprint(request)
+    profile = collect_service.upsert_profile(
+        db,
+        event_id=event.id,
+        fingerprint=fingerprint,
+        nickname=payload.nickname,
+        email=payload.email,
+    )
+    return CollectProfileResponse(
+        nickname=profile.nickname,
+        has_email=profile.email is not None,
+        submission_count=profile.submission_count,
+        submission_cap=event.submission_cap_per_guest,
+    )
+
+
+@router.get("/{code}/profile/me", response_model=CollectMyPicksResponse)
+@limiter.limit("60/minute")
+def my_picks(code: str, request: Request, db: Session = Depends(get_db)):
+    event = _get_event_or_404(db, code)
+    fingerprint = get_client_fingerprint(request)
+
+    submitted = (
+        db.query(SongRequest)
+        .filter(SongRequest.event_id == event.id)
+        .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
+        .filter(SongRequest.client_fingerprint == fingerprint)
+        .order_by(SongRequest.created_at.desc())
+        .all()
+    )
+
+    upvoted_request_ids = [
+        rv.request_id
+        for rv in db.query(RequestVote)
+        .filter(RequestVote.client_fingerprint == fingerprint)
+        .all()
+    ]
+    upvoted: list[SongRequest] = []
+    if upvoted_request_ids:
+        upvoted = (
+            db.query(SongRequest)
+            .filter(SongRequest.event_id == event.id)
+            .filter(SongRequest.id.in_(upvoted_request_ids))
+            .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
+            .all()
+        )
+
+    # Gamification: top contributor = this fingerprint has the most submissions
+    # in this event (among collection submissions).
+    top_fingerprint_row = (
+        db.query(SongRequest.client_fingerprint, __import__("sqlalchemy").func.count(SongRequest.id).label("n"))
+        .filter(SongRequest.event_id == event.id)
+        .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
+        .filter(SongRequest.client_fingerprint.isnot(None))
+        .group_by(SongRequest.client_fingerprint)
+        .order_by(__import__("sqlalchemy").desc("n"))
+        .first()
+    )
+    is_top = (
+        top_fingerprint_row is not None
+        and top_fingerprint_row[0] == fingerprint
+        and top_fingerprint_row[1] > 0
+    )
+
+    # First-to-suggest: among submitted rows, the ones where no earlier row in the
+    # event shares the same dedupe_key.
+    first_suggestion_ids: list[int] = []
+    for r in submitted:
+        earlier = (
+            db.query(SongRequest.id)
+            .filter(SongRequest.event_id == event.id)
+            .filter(SongRequest.dedupe_key == r.dedupe_key)
+            .filter(SongRequest.created_at < r.created_at)
+            .first()
+        )
+        if earlier is None:
+            first_suggestion_ids.append(r.id)
+
+    def _to_row(r: SongRequest, interaction: str) -> CollectMyPicksItem:
+        return CollectMyPicksItem(
+            id=r.id,
+            title=r.song_title,
+            artist=r.artist,
+            artwork_url=r.artwork_url,
+            vote_count=r.vote_count,
+            nickname=r.nickname,
+            status=r.status,
+            created_at=r.created_at,
+            interaction=interaction,
+        )
+
+    return CollectMyPicksResponse(
+        submitted=[_to_row(r, "submitted") for r in submitted],
+        upvoted=[_to_row(r, "upvoted") for r in upvoted if r.id not in [s.id for s in submitted]],
+        is_top_contributor=is_top,
+        first_suggestion_ids=first_suggestion_ids,
+    )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd server && .venv/bin/pytest tests/test_collect_public.py -v`
+Expected: 9 passed (5 previous + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/api/collect.py server/tests/test_collect_public.py
+git commit -m "feat(collect): POST profile + GET my picks with gamification"
+```
+
+---
+
+## Task 9: Submit + vote endpoints (phase-gated, cap-enforced)
+
+**Files:**
+- Modify: `server/app/api/collect.py`
+- Modify: `server/tests/test_collect_public.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `server/tests/test_collect_public.py`:
+
+```python
+def test_collect_submit_creates_request_in_collection_phase(client, db, test_event):
+    _enable_collection(db, test_event)
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={
+            "song_title": "Mr. Brightside",
+            "artist": "The Killers",
+            "source": "spotify",
+            "source_url": "https://open.spotify.com/track/abc",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["id"] > 0
+
+    from app.models.request import Request as SongRequest
+    row = db.query(SongRequest).filter(SongRequest.id == body["id"]).one()
+    assert row.submitted_during_collection is True
+    assert row.status == "new"
+
+
+def test_collect_submit_rejected_during_live_phase(client, db, test_event):
+    # event without collection fields → phase == "live"
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={"song_title": "A", "artist": "B", "source": "spotify"},
+    )
+    assert r.status_code == 409
+    assert "Collection" in r.json()["detail"]
+
+
+def test_collect_submit_blocked_at_cap(client, db, test_event):
+    _enable_collection(db, test_event)
+    test_event.submission_cap_per_guest = 2
+    db.commit()
+    for _ in range(2):
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/requests",
+            json={"song_title": "A", "artist": "B", "source": "spotify"},
+        )
+        assert r.status_code == 201
+    r3 = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={"song_title": "C", "artist": "D", "source": "spotify"},
+    )
+    assert r3.status_code == 429
+    assert "Picks limit reached" in r3.json()["detail"]
+
+
+def test_collect_vote_increments_count(client, db, test_event, collection_requests):
+    _enable_collection(db, test_event)
+    req = collection_requests[0]
+    before = req.vote_count
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/vote",
+        json={"request_id": req.id},
+    )
+    assert r.status_code == 200
+    db.refresh(req)
+    assert req.vote_count == before + 1
+
+
+def test_collect_vote_is_idempotent(client, db, test_event, collection_requests):
+    _enable_collection(db, test_event)
+    req = collection_requests[0]
+    client.post(
+        f"/api/public/collect/{test_event.code}/vote",
+        json={"request_id": req.id},
+    )
+    before = db.query(type(req)).filter(type(req).id == req.id).one().vote_count
+    client.post(
+        f"/api/public/collect/{test_event.code}/vote",
+        json={"request_id": req.id},
+    )
+    after = db.query(type(req)).filter(type(req).id == req.id).one().vote_count
+    assert after == before
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cd server && .venv/bin/pytest tests/test_collect_public.py -v -k "submit or vote"`
+Expected: FAIL (endpoints not defined).
+
+- [ ] **Step 3: Implement the endpoints**
+
+Append to `server/app/api/collect.py`:
+
+```python
+import hashlib
+
+from fastapi.responses import JSONResponse
+
+from app.models.request import Request as SongRequest
+from app.models.request import RequestSource, RequestStatus
+from app.schemas.collect import CollectSubmitRequest, CollectVoteRequest
+from app.services.vote import record_vote
+
+
+def _compute_dedupe_key(song_title: str, artist: str) -> str:
+    raw = f"{song_title.strip().lower()}|{artist.strip().lower()}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:64]
+
+
+@router.post("/{code}/requests", status_code=201)
+@limiter.limit("10/minute")
+def submit(
+    code: str,
+    payload: CollectSubmitRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    event = _get_event_or_404(db, code)
+    if event.phase != "collection":
+        raise HTTPException(status_code=409, detail="Collection has ended")
+
+    fingerprint = get_client_fingerprint(request)
+    try:
+        collect_service.check_and_increment_submission_count(
+            db, event=event, fingerprint=fingerprint
+        )
+    except collect_service.SubmissionCapExceeded:
+        raise HTTPException(status_code=429, detail="Picks limit reached") from None
+
+    if payload.nickname:
+        collect_service.upsert_profile(
+            db,
+            event_id=event.id,
+            fingerprint=fingerprint,
+            nickname=payload.nickname,
+        )
+
+    row = SongRequest(
+        event_id=event.id,
+        song_title=payload.song_title,
+        artist=payload.artist,
+        source=payload.source,
+        source_url=payload.source_url,
+        artwork_url=payload.artwork_url,
+        note=payload.note,
+        nickname=payload.nickname,
+        status=RequestStatus.NEW.value,
+        dedupe_key=_compute_dedupe_key(payload.song_title, payload.artist),
+        client_fingerprint=fingerprint,
+        submitted_during_collection=True,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return {"id": row.id}
+
+
+@router.post("/{code}/vote")
+@limiter.limit("60/minute")
+def vote(
+    code: str,
+    payload: CollectVoteRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    event = _get_event_or_404(db, code)
+    if event.phase not in ("collection", "live"):
+        raise HTTPException(status_code=409, detail="Voting is closed")
+    fingerprint = get_client_fingerprint(request)
+    row = (
+        db.query(SongRequest)
+        .filter(SongRequest.id == payload.request_id)
+        .filter(SongRequest.event_id == event.id)
+        .one_or_none()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Request not found")
+    record_vote(db, request_id=row.id, fingerprint=fingerprint)
+    return {"ok": True}
+```
+
+**Note:** Confirm the actual function name in `server/app/services/vote.py` — adjust `record_vote` to match. Run:
+
+```bash
+grep -n "^def " /home/adam/github/WrzDJ/server/app/services/vote.py
+```
+
+Use whatever function is the idempotent-vote entry point. If the signature differs, adjust the call accordingly.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd server && .venv/bin/pytest tests/test_collect_public.py -v`
+Expected: 14 passed (9 previous + 5 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/api/collect.py server/tests/test_collect_public.py
+git commit -m "feat(collect): POST submit (phase-gated, cap-enforced) + POST vote"
+```
+
+---
+
+## Task 10: DJ endpoint — PATCH /api/events/{code}/collection
+
+**Files:**
+- Modify: `server/app/api/events.py`
+- Test: `server/tests/test_collect_dj.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `server/tests/test_collect_dj.py`:
+
+```python
+from datetime import timedelta
+
+from app.core.time import utcnow
+
+
+def test_patch_collection_sets_dates(client, db, auth_headers, test_event):
+    now = utcnow()
+    payload = {
+        "collection_opens_at": (now + timedelta(hours=1)).isoformat(),
+        "live_starts_at": (now + timedelta(days=1)).isoformat(),
+        "submission_cap_per_guest": 10,
+    }
+    r = client.patch(
+        f"/api/events/{test_event.code}/collection",
+        json=payload,
+        headers=auth_headers,
+    )
+    assert r.status_code == 200, r.text
+    db.refresh(test_event)
+    assert test_event.submission_cap_per_guest == 10
+    assert test_event.collection_opens_at is not None
+
+
+def test_patch_collection_rejects_bad_ordering(client, auth_headers, test_event):
+    now = utcnow()
+    payload = {
+        "collection_opens_at": (now + timedelta(days=2)).isoformat(),
+        "live_starts_at": (now + timedelta(days=1)).isoformat(),
+    }
+    r = client.patch(
+        f"/api/events/{test_event.code}/collection",
+        json=payload,
+        headers=auth_headers,
+    )
+    assert r.status_code == 400
+
+
+def test_patch_collection_requires_ownership(client, db, admin_user, test_event):
+    # test_event is owned by test_user; admin_user is someone else
+    # generate a token for a DIFFERENT non-admin user
+    from app.models.user import User
+    from app.services.auth import create_access_token
+    other = User(username="otherdj", hashed_password="x", role="dj")
+    db.add(other)
+    db.commit()
+    db.refresh(other)
+    token = create_access_token(subject=str(other.id), token_version=other.token_version)
+    r = client.patch(
+        f"/api/events/{test_event.code}/collection",
+        json={"submission_cap_per_guest": 5},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 403
+
+
+def test_patch_collection_override_accepted(client, db, auth_headers, test_event):
+    r = client.patch(
+        f"/api/events/{test_event.code}/collection",
+        json={"collection_phase_override": "force_live"},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    db.refresh(test_event)
+    assert test_event.collection_phase_override == "force_live"
+
+
+def test_patch_collection_override_bad_value(client, auth_headers, test_event):
+    r = client.patch(
+        f"/api/events/{test_event.code}/collection",
+        json={"collection_phase_override": "skydiving"},
+        headers=auth_headers,
+    )
+    assert r.status_code == 422
+```
+
+- [ ] **Step 2: Run tests to confirm failure**
+
+Run: `cd server && .venv/bin/pytest tests/test_collect_dj.py -v`
+Expected: FAIL — 404 for the PATCH route.
+
+- [ ] **Step 3: Check existing auth service for token creation helper**
+
+Run: `grep -n "create_access_token" /home/adam/github/WrzDJ/server/app/services/auth.py | head -5`
+
+Adjust the `test_patch_collection_requires_ownership` test above if the signature differs — replace the call to match what exists.
+
+- [ ] **Step 4: Add the PATCH endpoint to `server/app/api/events.py`**
+
+Find the existing ownership-check helper (likely `_get_event_for_user` or similar). Add imports:
+
+```python
+from app.schemas.collect import UpdateCollectionSettings
+```
+
+Add the new endpoint (place near other event-settings endpoints):
+
+```python
+@router.patch("/{code}/collection")
+def update_collection_settings(
+    code: str,
+    payload: UpdateCollectionSettings,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_active_user),
+):
+    event = db.query(Event).filter(Event.code == code).one_or_none()
+    if event is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+    if event.created_by_user_id != user.id and user.role != "admin":
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    if payload.collection_opens_at is not None:
+        event.collection_opens_at = payload.collection_opens_at
+    if payload.live_starts_at is not None:
+        event.live_starts_at = payload.live_starts_at
+    if payload.submission_cap_per_guest is not None:
+        event.submission_cap_per_guest = payload.submission_cap_per_guest
+    if payload.collection_phase_override is not None or (
+        "collection_phase_override" in payload.model_fields_set
+    ):
+        event.collection_phase_override = payload.collection_phase_override
+
+    # Validate ordering
+    opens = event.collection_opens_at
+    live = event.live_starts_at
+    expires = event.expires_at
+    if opens and live and opens >= live:
+        raise HTTPException(status_code=400, detail="collection_opens_at must be before live_starts_at")
+    if live and expires and live >= expires:
+        raise HTTPException(status_code=400, detail="live_starts_at must be before expires_at")
+
+    db.commit()
+    db.refresh(event)
+    return {
+        "collection_opens_at": event.collection_opens_at,
+        "live_starts_at": event.live_starts_at,
+        "submission_cap_per_guest": event.submission_cap_per_guest,
+        "collection_phase_override": event.collection_phase_override,
+        "phase": event.phase,
+    }
+```
+
+Ensure `Event`, `User`, `get_current_active_user`, `get_db`, `Session`, `APIRouter`, `HTTPException`, `Depends` are already imported at the top of `events.py` (they will be — existing file uses them).
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd server && .venv/bin/pytest tests/test_collect_dj.py -v`
+Expected: 5 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/app/api/events.py server/tests/test_collect_dj.py
+git commit -m "feat(collect): PATCH /events/{code}/collection — update dates + override"
+```
+
+---
+
+## Task 11: DJ endpoint — GET pending-review
+
+**Files:**
+- Modify: `server/app/api/events.py`
+- Modify: `server/tests/test_collect_dj.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `server/tests/test_collect_dj.py`:
+
+```python
+def test_pending_review_returns_collection_news_sorted_by_votes(
+    client, auth_headers, test_event, collection_requests
+):
+    r = client.get(
+        f"/api/events/{test_event.code}/pending-review",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    rows = r.json()["requests"]
+    # collection_requests fixture has vote_count 5, 2, 0
+    assert [row["vote_count"] for row in rows] == [5, 2, 0]
+
+
+def test_pending_review_excludes_accepted(
+    client, db, auth_headers, test_event, collection_requests
+):
+    collection_requests[0].status = "accepted"
+    db.commit()
+    r = client.get(
+        f"/api/events/{test_event.code}/pending-review",
+        headers=auth_headers,
+    )
+    votes = [row["vote_count"] for row in r.json()["requests"]]
+    assert 5 not in votes  # that request is now accepted
+
+
+def test_pending_review_requires_ownership(
+    client, db, test_event
+):
+    from app.models.user import User
+    from app.services.auth import create_access_token
+    other = User(username="otherdj2", hashed_password="x", role="dj")
+    db.add(other)
+    db.commit()
+    db.refresh(other)
+    token = create_access_token(subject=str(other.id), token_version=other.token_version)
+    r = client.get(
+        f"/api/events/{test_event.code}/pending-review",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 403
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cd server && .venv/bin/pytest tests/test_collect_dj.py -v -k "pending"`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the endpoint**
+
+Append to `server/app/api/events.py` (near the PATCH added in Task 10). Add the schema import if not already:
+
+```python
+from app.schemas.collect import PendingReviewResponse, PendingReviewRow
+```
+
+Add endpoint:
+
+```python
+@router.get("/{code}/pending-review", response_model=PendingReviewResponse)
+def pending_review(
+    code: str,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_active_user),
+):
+    event = db.query(Event).filter(Event.code == code).one_or_none()
+    if event is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+    if event.created_by_user_id != user.id and user.role != "admin":
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    from app.models.request import Request as SongRequest
+    rows = (
+        db.query(SongRequest)
+        .filter(SongRequest.event_id == event.id)
+        .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
+        .filter(SongRequest.status == "new")
+        .order_by(SongRequest.vote_count.desc(), SongRequest.created_at.asc())
+        .limit(200)
+        .all()
+    )
+    return PendingReviewResponse(
+        requests=[
+            PendingReviewRow(
+                id=r.id,
+                song_title=r.song_title,
+                artist=r.artist,
+                artwork_url=r.artwork_url,
+                vote_count=r.vote_count,
+                nickname=r.nickname,
+                created_at=r.created_at,
+                note=r.note,
+                status=r.status,
+            )
+            for r in rows
+        ],
+        total=len(rows),
+    )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd server && .venv/bin/pytest tests/test_collect_dj.py -v`
+Expected: 8 passed (5 + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/api/events.py server/tests/test_collect_dj.py
+git commit -m "feat(collect): GET /events/{code}/pending-review for DJ bulk-review"
+```
+
+---
+
+## Task 12: DJ endpoint — POST bulk-review
+
+**Files:**
+- Modify: `server/app/api/events.py`
+- Modify: `server/tests/test_collect_dj.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `server/tests/test_collect_dj.py`:
+
+```python
+def test_bulk_review_accept_top_n(
+    client, db, auth_headers, test_event, collection_requests
+):
+    r = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "accept_top_n", "n": 2},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["accepted"] == 2
+    for row in collection_requests:
+        db.refresh(row)
+    statuses = sorted(r.status for r in collection_requests)
+    assert statuses == ["accepted", "accepted", "new"]
+
+
+def test_bulk_review_accept_threshold(
+    client, db, auth_headers, test_event, collection_requests
+):
+    r = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "accept_threshold", "min_votes": 3},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    # Only the vote_count=5 row qualifies
+    assert r.json()["accepted"] == 1
+
+
+def test_bulk_review_reject_remaining(
+    client, db, auth_headers, test_event, collection_requests
+):
+    r = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "reject_remaining"},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["rejected"] == 3
+
+
+def test_bulk_review_accept_ids(
+    client, db, auth_headers, test_event, collection_requests
+):
+    ids = [collection_requests[0].id, collection_requests[2].id]
+    r = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "accept_ids", "request_ids": ids},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["accepted"] == 2
+
+
+def test_bulk_review_rejects_over_200_ids(
+    client, auth_headers, test_event
+):
+    ids = list(range(1, 250))
+    r = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "accept_ids", "request_ids": ids},
+        headers=auth_headers,
+    )
+    assert r.status_code == 422
+
+
+def test_bulk_review_bad_action(client, auth_headers, test_event):
+    r = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "launch_nukes"},
+        headers=auth_headers,
+    )
+    assert r.status_code == 422
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cd server && .venv/bin/pytest tests/test_collect_dj.py -v -k "bulk"`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the endpoint**
+
+Add imports to `server/app/api/events.py`:
+
+```python
+from app.schemas.collect import BulkReviewRequest, BulkReviewResponse
+```
+
+Add endpoint:
+
+```python
+@router.post("/{code}/bulk-review", response_model=BulkReviewResponse)
+def bulk_review(
+    code: str,
+    payload: BulkReviewRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_active_user),
+):
+    event = db.query(Event).filter(Event.code == code).one_or_none()
+    if event is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+    if event.created_by_user_id != user.id and user.role != "admin":
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    from app.models.request import Request as SongRequest
+
+    pending_q = (
+        db.query(SongRequest)
+        .filter(SongRequest.event_id == event.id)
+        .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
+        .filter(SongRequest.status == "new")
+    )
+
+    accepted = 0
+    rejected = 0
+
+    if payload.action == "accept_top_n":
+        if payload.n is None:
+            raise HTTPException(status_code=400, detail="n is required")
+        rows = (
+            pending_q.order_by(
+                SongRequest.vote_count.desc(), SongRequest.created_at.asc()
+            )
+            .limit(payload.n)
+            .all()
+        )
+        for r in rows:
+            r.status = "accepted"
+            accepted += 1
+    elif payload.action == "accept_threshold":
+        if payload.min_votes is None:
+            raise HTTPException(status_code=400, detail="min_votes is required")
+        rows = pending_q.filter(SongRequest.vote_count >= payload.min_votes).all()
+        for r in rows:
+            r.status = "accepted"
+            accepted += 1
+    elif payload.action == "accept_ids":
+        if not payload.request_ids:
+            raise HTTPException(status_code=400, detail="request_ids is required")
+        rows = pending_q.filter(SongRequest.id.in_(payload.request_ids)).all()
+        for r in rows:
+            r.status = "accepted"
+            accepted += 1
+    elif payload.action == "reject_ids":
+        if not payload.request_ids:
+            raise HTTPException(status_code=400, detail="request_ids is required")
+        rows = pending_q.filter(SongRequest.id.in_(payload.request_ids)).all()
+        for r in rows:
+            r.status = "rejected"
+            rejected += 1
+    elif payload.action == "reject_remaining":
+        rows = pending_q.all()
+        for r in rows:
+            r.status = "rejected"
+            rejected += 1
+
+    db.commit()
+    return BulkReviewResponse(accepted=accepted, rejected=rejected, unchanged=0)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd server && .venv/bin/pytest tests/test_collect_dj.py -v`
+Expected: 14 passed (8 + 6 new).
+
+- [ ] **Step 5: Run full backend test suite + alembic drift check**
+
+Run: `cd server && .venv/bin/pytest -q && .venv/bin/alembic upgrade head && .venv/bin/alembic check`
+Expected: all green, no drift.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/app/api/events.py server/tests/test_collect_dj.py
+git commit -m "feat(collect): POST /events/{code}/bulk-review with all action types"
+```
+
+---
+
+## Task 13: Frontend API client — collect methods
+
+**Files:**
+- Modify: `dashboard/lib/api.ts`
+- Create: `dashboard/lib/__tests__/collect-api.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `dashboard/lib/__tests__/collect-api.test.ts`:
+
+```typescript
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { apiClient } from "../api";
+
+const OK_RESPONSE = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body }) as Response;
+
+describe("collect api client", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("getCollectEvent issues GET /api/public/collect/{code}", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      OK_RESPONSE({ code: "ABC", phase: "collection" })
+    );
+    const r = await apiClient.getCollectEvent("ABC");
+    expect(r.phase).toBe("collection");
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/public\/collect\/ABC$/),
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
+  it("submitCollectRequest POSTs JSON", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      OK_RESPONSE({ id: 42 })
+    );
+    await apiClient.submitCollectRequest("ABC", {
+      song_title: "T",
+      artist: "A",
+      source: "spotify",
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/public\/collect\/ABC\/requests$/),
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("voteCollectRequest POSTs the request_id", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      OK_RESPONSE({ ok: true })
+    );
+    await apiClient.voteCollectRequest("ABC", 99);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/public\/collect\/ABC\/vote$/),
+      expect.objectContaining({
+        body: JSON.stringify({ request_id: 99 }),
+      })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cd dashboard && npm test -- --run lib/__tests__/collect-api.test.ts`
+Expected: FAIL — methods not defined.
+
+- [ ] **Step 3: Add the methods to `apiClient` in `dashboard/lib/api.ts`**
+
+First read the existing `apiClient` class to match its style (methods, base URL, headers). Then add the following methods to the class (paste inside the class body):
+
+```typescript
+  // ===== Pre-Event Collection =====
+
+  async getCollectEvent(code: string): Promise<CollectEventPreview> {
+    const res = await fetch(`${this.baseUrl}/api/public/collect/${code}`, {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    });
+    if (!res.ok) throw new Error(`getCollectEvent failed: ${res.status}`);
+    return res.json();
+  }
+
+  async getCollectLeaderboard(
+    code: string,
+    tab: "trending" | "all" = "trending"
+  ): Promise<CollectLeaderboardResponse> {
+    const res = await fetch(
+      `${this.baseUrl}/api/public/collect/${code}/leaderboard?tab=${tab}`,
+      { method: "GET", headers: { "Content-Type": "application/json" } }
+    );
+    if (!res.ok) throw new Error(`getCollectLeaderboard failed: ${res.status}`);
+    return res.json();
+  }
+
+  async setCollectProfile(
+    code: string,
+    data: { nickname?: string; email?: string }
+  ): Promise<CollectProfileResponse> {
+    const res = await fetch(`${this.baseUrl}/api/public/collect/${code}/profile`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error(`setCollectProfile failed: ${res.status}`);
+    return res.json();
+  }
+
+  async getCollectMyPicks(code: string): Promise<CollectMyPicksResponse> {
+    const res = await fetch(`${this.baseUrl}/api/public/collect/${code}/profile/me`, {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    });
+    if (!res.ok) throw new Error(`getCollectMyPicks failed: ${res.status}`);
+    return res.json();
+  }
+
+  async submitCollectRequest(
+    code: string,
+    data: {
+      song_title: string;
+      artist: string;
+      source: "spotify" | "beatport" | "tidal" | "manual";
+      source_url?: string;
+      artwork_url?: string;
+      note?: string;
+      nickname?: string;
+    }
+  ): Promise<{ id: number }> {
+    const res = await fetch(`${this.baseUrl}/api/public/collect/${code}/requests`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new ApiError(res.status, body.detail ?? "Submit failed");
+    }
+    return res.json();
+  }
+
+  async voteCollectRequest(code: string, requestId: number): Promise<void> {
+    const res = await fetch(`${this.baseUrl}/api/public/collect/${code}/vote`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ request_id: requestId }),
+    });
+    if (!res.ok) throw new ApiError(res.status, "Vote failed");
+  }
+
+  // --- DJ-side ---
+
+  async patchCollectionSettings(
+    code: string,
+    data: {
+      collection_opens_at?: string | null;
+      live_starts_at?: string | null;
+      submission_cap_per_guest?: number;
+      collection_phase_override?: "force_collection" | "force_live" | null;
+    }
+  ): Promise<CollectionSettingsResponse> {
+    return this.fetch(`/events/${code}/collection`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    });
+  }
+
+  async getPendingReview(code: string): Promise<PendingReviewResponse> {
+    return this.fetch(`/events/${code}/pending-review`);
+  }
+
+  async bulkReview(
+    code: string,
+    data: {
+      action:
+        | "accept_top_n"
+        | "accept_threshold"
+        | "accept_ids"
+        | "reject_ids"
+        | "reject_remaining";
+      n?: number;
+      min_votes?: number;
+      request_ids?: number[];
+    }
+  ): Promise<BulkReviewResponse> {
+    return this.fetch(`/events/${code}/bulk-review`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  }
+```
+
+Add these TypeScript types to the file (near existing types):
+
+```typescript
+export interface CollectEventPreview {
+  code: string;
+  name: string;
+  banner_filename: string | null;
+  submission_cap_per_guest: number;
+  registration_enabled: boolean;
+  phase: "pre_announce" | "collection" | "live" | "closed";
+  collection_opens_at: string | null;
+  live_starts_at: string | null;
+  expires_at: string;
+}
+
+export interface CollectLeaderboardRow {
+  id: number;
+  title: string;
+  artist: string;
+  artwork_url: string | null;
+  vote_count: number;
+  nickname: string | null;
+  status: "new" | "accepted" | "playing" | "played" | "rejected";
+  created_at: string;
+}
+
+export interface CollectLeaderboardResponse {
+  requests: CollectLeaderboardRow[];
+  total: number;
+}
+
+export interface CollectProfileResponse {
+  nickname: string | null;
+  has_email: boolean;
+  submission_count: number;
+  submission_cap: number;
+}
+
+export interface CollectMyPicksItem extends CollectLeaderboardRow {
+  interaction: "submitted" | "upvoted";
+}
+
+export interface CollectMyPicksResponse {
+  submitted: CollectMyPicksItem[];
+  upvoted: CollectMyPicksItem[];
+  is_top_contributor: boolean;
+  first_suggestion_ids: number[];
+}
+
+export interface CollectionSettingsResponse {
+  collection_opens_at: string | null;
+  live_starts_at: string | null;
+  submission_cap_per_guest: number;
+  collection_phase_override: "force_collection" | "force_live" | null;
+  phase: "pre_announce" | "collection" | "live" | "closed";
+}
+
+export interface PendingReviewRow {
+  id: number;
+  song_title: string;
+  artist: string;
+  artwork_url: string | null;
+  vote_count: number;
+  nickname: string | null;
+  created_at: string;
+  note: string | null;
+  status: "new" | "accepted" | "playing" | "played" | "rejected";
+}
+
+export interface PendingReviewResponse {
+  requests: PendingReviewRow[];
+  total: number;
+}
+
+export interface BulkReviewResponse {
+  accepted: number;
+  rejected: number;
+  unchanged: number;
+}
+```
+
+If `ApiError` doesn't exist in the file, use a plain `Error` throw and adjust the tests accordingly.
+
+- [ ] **Step 4: Run frontend tests + tsc**
+
+Run: `cd dashboard && npx tsc --noEmit && npm test -- --run lib/__tests__/collect-api.test.ts`
+Expected: tsc passes; vitest 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/lib/api.ts dashboard/lib/__tests__/collect-api.test.ts
+git commit -m "feat(collect): frontend api client methods"
+```
+
+---
+
+## Task 14: `/collect/[code]` page scaffold + phase routing
+
+**Files:**
+- Create: `dashboard/app/collect/[code]/page.tsx`
+- Create: `dashboard/app/collect/[code]/page.test.tsx`
+- Create: `dashboard/app/collect/[code]/components/` (directory)
+
+- [ ] **Step 1: Write failing test**
+
+Create `dashboard/app/collect/[code]/page.test.tsx`:
+
+```typescript
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import CollectPage from "./page";
+
+const mockReplace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace, push: vi.fn() }),
+  useParams: () => ({ code: "ABC" }),
+}));
+
+const mockGetEvent = vi.fn();
+vi.mock("../../../lib/api", () => ({
+  apiClient: {
+    getCollectEvent: (...a: unknown[]) => mockGetEvent(...a),
+    getCollectLeaderboard: vi.fn().mockResolvedValue({ requests: [], total: 0 }),
+    getCollectMyPicks: vi.fn().mockResolvedValue({
+      submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: []
+    }),
+  },
+}));
+
+describe("CollectPage", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    mockGetEvent.mockReset();
+    vi.stubGlobal("sessionStorage", {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows pre-announce countdown when phase is pre_announce", async () => {
+    mockGetEvent.mockResolvedValue({
+      code: "ABC",
+      name: "Test Event",
+      phase: "pre_announce",
+      collection_opens_at: new Date(Date.now() + 3600_000).toISOString(),
+      live_starts_at: new Date(Date.now() + 7200_000).toISOString(),
+      submission_cap_per_guest: 15,
+      banner_filename: null,
+      registration_enabled: true,
+      expires_at: new Date(Date.now() + 86400_000).toISOString(),
+    });
+    render(<CollectPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/opens in/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders collection experience when phase is collection", async () => {
+    mockGetEvent.mockResolvedValue({
+      code: "ABC",
+      name: "Test Event",
+      phase: "collection",
+      collection_opens_at: new Date(Date.now() - 3600_000).toISOString(),
+      live_starts_at: new Date(Date.now() + 3600_000).toISOString(),
+      submission_cap_per_guest: 15,
+      banner_filename: null,
+      registration_enabled: true,
+      expires_at: new Date(Date.now() + 86400_000).toISOString(),
+    });
+    render(<CollectPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/test event/i)).toBeInTheDocument();
+    });
+  });
+
+  it("redirects to /join when phase is live", async () => {
+    mockGetEvent.mockResolvedValue({
+      code: "ABC",
+      name: "Test Event",
+      phase: "live",
+      collection_opens_at: new Date(Date.now() - 86400_000).toISOString(),
+      live_starts_at: new Date(Date.now() - 3600_000).toISOString(),
+      submission_cap_per_guest: 15,
+      banner_filename: null,
+      registration_enabled: true,
+      expires_at: new Date(Date.now() + 86400_000).toISOString(),
+    });
+    render(<CollectPage />);
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/join/ABC");
+    });
+    expect(sessionStorage.setItem).toHaveBeenCalledWith(
+      "wrzdj_live_splash_ABC",
+      "1"
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cd dashboard && npm test -- --run app/collect`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create the page**
+
+Create `dashboard/app/collect/[code]/page.tsx`:
+
+```typescript
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import {
+  apiClient,
+  CollectEventPreview,
+  CollectLeaderboardResponse,
+  CollectMyPicksResponse,
+} from "../../../lib/api";
+
+const POLL_MS = 5000;
+
+export default function CollectPage() {
+  const router = useRouter();
+  const params = useParams<{ code: string }>();
+  const code = params?.code ?? "";
+  const [event, setEvent] = useState<CollectEventPreview | null>(null);
+  const [leaderboard, setLeaderboard] = useState<CollectLeaderboardResponse | null>(
+    null
+  );
+  const [myPicks, setMyPicks] = useState<CollectMyPicksResponse | null>(null);
+  const [tab, setTab] = useState<"trending" | "all">("trending");
+  const [error, setError] = useState<string | null>(null);
+
+  const redirectToJoin = () => {
+    sessionStorage.setItem(`wrzdj_live_splash_${code}`, "1");
+    router.replace(`/join/${code}`);
+  };
+
+  useEffect(() => {
+    if (!code) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const tick = async () => {
+      try {
+        const ev = await apiClient.getCollectEvent(code);
+        if (cancelled) return;
+        setEvent(ev);
+        if (ev.phase === "live" || ev.phase === "closed") {
+          redirectToJoin();
+          return;
+        }
+        if (ev.phase === "collection") {
+          const [lb, picks] = await Promise.all([
+            apiClient.getCollectLeaderboard(code, tab),
+            apiClient.getCollectMyPicks(code),
+          ]);
+          if (!cancelled) {
+            setLeaderboard(lb);
+            setMyPicks(picks);
+          }
+        }
+      } catch (e) {
+        if (!cancelled) setError((e as Error).message);
+      }
+      if (!cancelled && document.visibilityState === "visible") {
+        timer = setTimeout(tick, POLL_MS);
+      }
+    };
+
+    tick();
+    const onVisibility = () => {
+      if (document.visibilityState === "visible" && !cancelled) tick();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [code, tab]);
+
+  if (error) return <main style={{ padding: 24 }}>Error: {error}</main>;
+  if (!event) return <main style={{ padding: 24 }}>Loading…</main>;
+
+  if (event.phase === "pre_announce") {
+    const opens = event.collection_opens_at
+      ? new Date(event.collection_opens_at)
+      : null;
+    return (
+      <main style={{ padding: 24 }}>
+        <h1>{event.name}</h1>
+        <p>Voting opens in {formatCountdown(opens)}</p>
+      </main>
+    );
+  }
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>{event.name}</h1>
+      <p>Voting open — {formatCountdown(event.live_starts_at ? new Date(event.live_starts_at) : null)} until the event goes live</p>
+      <div style={{ marginTop: 16 }}>
+        <button onClick={() => setTab("trending")} aria-pressed={tab === "trending"}>
+          Trending
+        </button>
+        <button onClick={() => setTab("all")} aria-pressed={tab === "all"}>
+          All
+        </button>
+      </div>
+      <ul>
+        {leaderboard?.requests.map((r) => (
+          <li key={r.id}>
+            <strong>{r.title}</strong> — {r.artist} (▲ {r.vote_count})
+          </li>
+        ))}
+      </ul>
+      <section>
+        <h2>My Picks</h2>
+        {myPicks?.submitted.length === 0 && myPicks?.upvoted.length === 0 ? (
+          <p>No picks yet — search for a song below!</p>
+        ) : (
+          <ul>
+            {myPicks?.submitted.map((r) => (
+              <li key={`s-${r.id}`}>
+                {r.title} — {r.artist} [{r.status}]
+              </li>
+            ))}
+            {myPicks?.upvoted.map((r) => (
+              <li key={`u-${r.id}`}>
+                {r.title} — {r.artist} (upvoted)
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function formatCountdown(target: Date | null): string {
+  if (!target) return "";
+  const diff = target.getTime() - Date.now();
+  if (diff <= 0) return "now";
+  const hrs = Math.floor(diff / 3_600_000);
+  const mins = Math.floor((diff % 3_600_000) / 60_000);
+  const days = Math.floor(hrs / 24);
+  if (days >= 1) return `${days}d ${hrs % 24}h`;
+  return `${hrs}h ${mins}m`;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd dashboard && npx tsc --noEmit && npm test -- --run app/collect/[code]/page.test.tsx`
+Expected: tsc passes; vitest 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/app/collect/[code]/page.tsx dashboard/app/collect/[code]/page.test.tsx
+git commit -m "feat(collect): /collect/[code] page scaffold with phase-aware routing"
+```
+
+---
+
+## Task 15: FeatureOptInPanel component + email opt-in flow
+
+**Files:**
+- Create: `dashboard/app/collect/[code]/components/FeatureOptInPanel.tsx`
+- Create: `dashboard/app/collect/[code]/components/FeatureOptInPanel.test.tsx`
+- Modify: `dashboard/app/collect/[code]/page.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+Create `dashboard/app/collect/[code]/components/FeatureOptInPanel.test.tsx`:
+
+```typescript
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import FeatureOptInPanel from "./FeatureOptInPanel";
+
+describe("FeatureOptInPanel", () => {
+  it("does not render when hasEmail is true", () => {
+    render(<FeatureOptInPanel hasEmail={true} onSave={vi.fn()} />);
+    expect(screen.queryByText(/add email/i)).not.toBeInTheDocument();
+  });
+
+  it("shows feature comparison and save button", () => {
+    render(<FeatureOptInPanel hasEmail={false} onSave={vi.fn()} />);
+    expect(screen.getByText(/notify me when my song plays/i)).toBeInTheDocument();
+    expect(screen.getByText(/cross-device/i)).toBeInTheDocument();
+  });
+
+  it("rejects invalid email on client", async () => {
+    const onSave = vi.fn();
+    render(<FeatureOptInPanel hasEmail={false} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "bogus" } });
+    fireEvent.click(screen.getByRole("button", { name: /add email/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/invalid email/i)).toBeInTheDocument();
+    });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("calls onSave with valid email", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<FeatureOptInPanel hasEmail={false} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "guest@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add email/i }));
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith("guest@example.com");
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cd dashboard && npm test -- --run app/collect/[code]/components/FeatureOptInPanel.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the component**
+
+Create `dashboard/app/collect/[code]/components/FeatureOptInPanel.tsx`:
+
+```typescript
+"use client";
+
+import { useState } from "react";
+import { z } from "zod";
+
+const emailSchema = z.string().email().max(254);
+
+interface Props {
+  hasEmail: boolean;
+  onSave: (email: string) => Promise<void>;
+}
+
+export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
+  const [expanded, setExpanded] = useState(true);
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  if (hasEmail || !expanded) return null;
+
+  const submit = async () => {
+    const parsed = emailSchema.safeParse(email);
+    if (!parsed.success) {
+      setError("Invalid email");
+      return;
+    }
+    setSaving(true);
+    try {
+      await onSave(parsed.data);
+      setExpanded(false);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section
+      style={{
+        background: "#1a1a1a",
+        padding: 16,
+        borderRadius: 8,
+        marginBottom: 16,
+      }}
+    >
+      <h3>Get the most out of your picks</h3>
+      <ul style={{ marginBottom: 12 }}>
+        <li>Notify me when my song plays</li>
+        <li>Cross-device &quot;my picks&quot; and leaderboard position</li>
+        <li>Persistent profile across events</li>
+      </ul>
+      <label>
+        Email
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          style={{ marginLeft: 8 }}
+        />
+      </label>
+      {error && <p style={{ color: "#ff6b6b" }}>{error}</p>}
+      <div style={{ marginTop: 8 }}>
+        <button onClick={() => setExpanded(false)} disabled={saving}>
+          Keep it anonymous
+        </button>
+        <button onClick={submit} disabled={saving}>
+          Add email
+        </button>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Wire it into `page.tsx`**
+
+In `dashboard/app/collect/[code]/page.tsx`, add the import and a local `hasEmail` state sourced from a new `profile` state. Add this inside the component (near other state hooks):
+
+```typescript
+import FeatureOptInPanel from "./components/FeatureOptInPanel";
+
+// inside CollectPage:
+const [hasEmail, setHasEmail] = useState(false);
+
+const saveEmail = async (email: string) => {
+  const resp = await apiClient.setCollectProfile(code, { email });
+  setHasEmail(resp.has_email);
+};
+```
+
+In the collection-phase render block (right above the tabs), insert:
+
+```tsx
+<FeatureOptInPanel hasEmail={hasEmail} onSave={saveEmail} />
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd dashboard && npx tsc --noEmit && npm test -- --run app/collect`
+Expected: tsc green, all vitest green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/app/collect/[code]/components/FeatureOptInPanel.tsx dashboard/app/collect/[code]/components/FeatureOptInPanel.test.tsx dashboard/app/collect/[code]/page.tsx
+git commit -m "feat(collect): feature opt-in panel with zod email validation"
+```
+
+---
+
+## Task 16: LeaderboardTabs component with optimistic vote
+
+**Files:**
+- Create: `dashboard/app/collect/[code]/components/LeaderboardTabs.tsx`
+- Create: `dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx`
+- Modify: `dashboard/app/collect/[code]/page.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+Create `dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx`:
+
+```typescript
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import LeaderboardTabs from "./LeaderboardTabs";
+
+const rows = [
+  { id: 1, title: "A", artist: "X", artwork_url: null, vote_count: 5, nickname: "alex", status: "new" as const, created_at: "2026-04-21" },
+  { id: 2, title: "B", artist: "Y", artwork_url: null, vote_count: 1, nickname: "jo",   status: "new" as const, created_at: "2026-04-21" },
+];
+
+describe("LeaderboardTabs", () => {
+  it("renders rows and switches tabs", () => {
+    const onTabChange = vi.fn();
+    render(
+      <LeaderboardTabs
+        rows={rows}
+        tab="trending"
+        onTabChange={onTabChange}
+        onVote={vi.fn()}
+      />
+    );
+    expect(screen.getByText("A")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /^all$/i }));
+    expect(onTabChange).toHaveBeenCalledWith("all");
+  });
+
+  it("optimistically updates vote count then rolls back on error", async () => {
+    const onVote = vi.fn().mockRejectedValue(new Error("boom"));
+    render(
+      <LeaderboardTabs
+        rows={rows}
+        tab="trending"
+        onTabChange={vi.fn()}
+        onVote={onVote}
+      />
+    );
+    fireEvent.click(screen.getAllByRole("button", { name: /upvote/i })[0]);
+    await waitFor(() => {
+      expect(screen.getByText(/5/)).toBeInTheDocument();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cd dashboard && npm test -- --run app/collect/[code]/components/LeaderboardTabs.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the component**
+
+Create `dashboard/app/collect/[code]/components/LeaderboardTabs.tsx`:
+
+```typescript
+"use client";
+
+import { useState } from "react";
+import type { CollectLeaderboardRow } from "../../../../lib/api";
+
+interface Props {
+  rows: CollectLeaderboardRow[];
+  tab: "trending" | "all";
+  onTabChange: (tab: "trending" | "all") => void;
+  onVote: (requestId: number) => Promise<void>;
+}
+
+export default function LeaderboardTabs({ rows, tab, onTabChange, onVote }: Props) {
+  const [optimistic, setOptimistic] = useState<Record<number, number>>({});
+
+  const handleVote = async (id: number, currentVotes: number) => {
+    setOptimistic((o) => ({ ...o, [id]: currentVotes + 1 }));
+    try {
+      await onVote(id);
+    } catch {
+      setOptimistic((o) => {
+        const next = { ...o };
+        delete next[id];
+        return next;
+      });
+    }
+  };
+
+  return (
+    <div>
+      <div role="tablist" style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+        <button
+          role="tab"
+          aria-pressed={tab === "trending"}
+          onClick={() => onTabChange("trending")}
+        >
+          Trending
+        </button>
+        <button
+          role="tab"
+          aria-pressed={tab === "all"}
+          onClick={() => onTabChange("all")}
+        >
+          All
+        </button>
+      </div>
+      <ul style={{ listStyle: "none", padding: 0 }}>
+        {rows.map((r) => {
+          const votes = optimistic[r.id] ?? r.vote_count;
+          return (
+            <li
+              key={r.id}
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                padding: 8,
+                background: "#1a1a1a",
+                marginBottom: 4,
+              }}
+            >
+              <div>
+                <strong>{r.title}</strong> — {r.artist}
+                {r.nickname && <span style={{ opacity: 0.7 }}> · by @{r.nickname}</span>}
+              </div>
+              <button
+                aria-label="upvote"
+                onClick={() => handleVote(r.id, r.vote_count)}
+              >
+                ▲ {votes}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Wire into `page.tsx`**
+
+Replace the inline `<ul>` and buttons in `page.tsx` with:
+
+```tsx
+<LeaderboardTabs
+  rows={leaderboard?.requests ?? []}
+  tab={tab}
+  onTabChange={setTab}
+  onVote={(id) => apiClient.voteCollectRequest(code, id)}
+/>
+```
+
+And import at top:
+
+```typescript
+import LeaderboardTabs from "./components/LeaderboardTabs";
+```
+
+- [ ] **Step 5: Run tests + tsc**
+
+Run: `cd dashboard && npx tsc --noEmit && npm test -- --run app/collect`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/app/collect/[code]/components/LeaderboardTabs.tsx dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx dashboard/app/collect/[code]/page.tsx
+git commit -m "feat(collect): LeaderboardTabs with optimistic vote"
+```
+
+---
+
+## Task 17: MyPicksPanel with status + gamification badges
+
+**Files:**
+- Create: `dashboard/app/collect/[code]/components/MyPicksPanel.tsx`
+- Create: `dashboard/app/collect/[code]/components/MyPicksPanel.test.tsx`
+- Modify: `dashboard/app/collect/[code]/page.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+Create `dashboard/app/collect/[code]/components/MyPicksPanel.test.tsx`:
+
+```typescript
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import MyPicksPanel from "./MyPicksPanel";
+
+const basePick = {
+  id: 1,
+  title: "Mr. Brightside",
+  artist: "The Killers",
+  artwork_url: null,
+  vote_count: 12,
+  nickname: "me",
+  status: "new" as const,
+  created_at: "2026-04-21T00:00:00Z",
+  interaction: "submitted" as const,
+};
+
+describe("MyPicksPanel", () => {
+  it("shows empty state when no picks", () => {
+    render(
+      <MyPicksPanel
+        picks={{ submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: [] }}
+      />
+    );
+    expect(screen.getByText(/no picks yet/i)).toBeInTheDocument();
+  });
+
+  it("shows top contributor badge when flagged", () => {
+    render(
+      <MyPicksPanel
+        picks={{
+          submitted: [basePick],
+          upvoted: [],
+          is_top_contributor: true,
+          first_suggestion_ids: [],
+        }}
+      />
+    );
+    expect(screen.getByText(/top contributor/i)).toBeInTheDocument();
+  });
+
+  it("shows first-to-suggest badge on matching pick", () => {
+    render(
+      <MyPicksPanel
+        picks={{
+          submitted: [basePick],
+          upvoted: [],
+          is_top_contributor: false,
+          first_suggestion_ids: [1],
+        }}
+      />
+    );
+    expect(screen.getByText(/first to suggest/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cd dashboard && npm test -- --run app/collect/[code]/components/MyPicksPanel.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Create `dashboard/app/collect/[code]/components/MyPicksPanel.tsx`:
+
+```typescript
+"use client";
+
+import type { CollectMyPicksResponse } from "../../../../lib/api";
+
+interface Props {
+  picks: CollectMyPicksResponse;
+}
+
+export default function MyPicksPanel({ picks }: Props) {
+  const isEmpty = picks.submitted.length === 0 && picks.upvoted.length === 0;
+
+  return (
+    <section style={{ marginTop: 24 }}>
+      <h2>My Picks</h2>
+      {picks.is_top_contributor && (
+        <p style={{ color: "#ffcc00" }}>🏆 Top contributor for this event</p>
+      )}
+      {isEmpty ? (
+        <p>No picks yet — search for a song below!</p>
+      ) : (
+        <ul>
+          {picks.submitted.map((p) => (
+            <li key={`s-${p.id}`}>
+              {p.title} — {p.artist}
+              <span style={{ marginLeft: 8, padding: "2px 6px", background: "#333" }}>
+                {p.status}
+              </span>
+              {picks.first_suggestion_ids.includes(p.id) && (
+                <span style={{ marginLeft: 8 }}>⭐ First to suggest</span>
+              )}
+            </li>
+          ))}
+          {picks.upvoted.map((p) => (
+            <li key={`u-${p.id}`}>
+              {p.title} — {p.artist} <em>(upvoted)</em>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Replace the inline My Picks in `page.tsx`**
+
+Replace the inline `<section><h2>My Picks</h2>…</section>` in `page.tsx` with:
+
+```tsx
+{myPicks && <MyPicksPanel picks={myPicks} />}
+```
+
+And add the import.
+
+- [ ] **Step 5: Run tests + tsc**
+
+Run: `cd dashboard && npx tsc --noEmit && npm test -- --run app/collect`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/app/collect/[code]/components/MyPicksPanel.tsx dashboard/app/collect/[code]/components/MyPicksPanel.test.tsx dashboard/app/collect/[code]/page.tsx
+git commit -m "feat(collect): MyPicksPanel with status + gamification badges"
+```
+
+---
+
+## Task 18: Sticky submit button + cap counter + search wrapper
+
+**Files:**
+- Create: `dashboard/app/collect/[code]/components/SubmitBar.tsx`
+- Create: `dashboard/app/collect/[code]/components/SubmitBar.test.tsx`
+- Modify: `dashboard/app/collect/[code]/page.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+Create `dashboard/app/collect/[code]/components/SubmitBar.test.tsx`:
+
+```typescript
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import SubmitBar from "./SubmitBar";
+
+describe("SubmitBar", () => {
+  it("shows used vs cap", () => {
+    render(
+      <SubmitBar used={3} cap={15} onOpenSearch={vi.fn()} />
+    );
+    expect(screen.getByText(/3 of 15 picks used/i)).toBeInTheDocument();
+  });
+
+  it("disables button at cap", () => {
+    render(
+      <SubmitBar used={15} cap={15} onOpenSearch={vi.fn()} />
+    );
+    expect(screen.getByRole("button", { name: /add a song/i })).toBeDisabled();
+  });
+
+  it("button enabled when cap is 0 (unlimited)", () => {
+    render(
+      <SubmitBar used={99} cap={0} onOpenSearch={vi.fn()} />
+    );
+    expect(screen.getByRole("button", { name: /add a song/i })).not.toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cd dashboard && npm test -- --run app/collect/[code]/components/SubmitBar.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Create `dashboard/app/collect/[code]/components/SubmitBar.tsx`:
+
+```typescript
+"use client";
+
+interface Props {
+  used: number;
+  cap: number; // 0 means unlimited
+  onOpenSearch: () => void;
+}
+
+export default function SubmitBar({ used, cap, onOpenSearch }: Props) {
+  const atCap = cap !== 0 && used >= cap;
+  const label =
+    cap === 0 ? "Unlimited picks" : `${used} of ${cap} picks used`;
+
+  return (
+    <div
+      style={{
+        position: "sticky",
+        bottom: 0,
+        background: "#0a0a0a",
+        padding: 16,
+        borderTop: "1px solid #333",
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+      }}
+    >
+      <span>{label}</span>
+      <button disabled={atCap} onClick={onOpenSearch}>
+        + Add a song
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Wire into `page.tsx`**
+
+Fetch the profile on load (to get `submission_count` + `submission_cap`). Add a `profile` state + a call to `apiClient.setCollectProfile(code, {})` on first visit (to create/load the profile). Then pass `used={profile?.submission_count ?? 0}` and `cap={event.submission_cap_per_guest}`.
+
+For the search flow, reuse the existing `/join/[code]` search UX by importing from its components folder. For now, wire `onOpenSearch` to a stub that calls `apiClient.submitCollectRequest` with a mocked payload for integration-testing. A full search modal is out of scope of this task — it's handled in Task 19.
+
+Add to `page.tsx`:
+
+```typescript
+import SubmitBar from "./components/SubmitBar";
+// …
+const [profile, setProfile] = useState<{ submission_count: number; submission_cap: number } | null>(null);
+
+useEffect(() => {
+  if (!code) return;
+  apiClient.setCollectProfile(code, {}).then((p) => {
+    setProfile({ submission_count: p.submission_count, submission_cap: p.submission_cap });
+    setHasEmail(p.has_email);
+  });
+}, [code]);
+```
+
+And in the collection-phase render:
+
+```tsx
+<SubmitBar
+  used={profile?.submission_count ?? 0}
+  cap={event.submission_cap_per_guest}
+  onOpenSearch={() => alert("Song search coming in Task 19")}
+/>
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd dashboard && npx tsc --noEmit && npm test -- --run app/collect`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/app/collect/[code]/components/SubmitBar.tsx dashboard/app/collect/[code]/components/SubmitBar.test.tsx dashboard/app/collect/[code]/page.tsx
+git commit -m "feat(collect): submit bar with cap counter"
+```
+
+---
+
+## Task 19: Integrate existing search modal for song submission
+
+**Files:**
+- Modify: `dashboard/app/collect/[code]/page.tsx`
+
+- [ ] **Step 1: Locate the existing join-page search flow**
+
+Run: `grep -rn "search.*songs\|SongSearch\|searchSongs" /home/adam/github/WrzDJ/dashboard/app/join/ | head -20`
+
+Identify the component/hook used on `/join/[code]` to render the search UI and produce a selected track. Examples: `dashboard/app/join/[code]/components/SongSearch.tsx`, or a hook that calls `apiClient.searchSongs()`.
+
+- [ ] **Step 2: Reuse or adapt**
+
+If the search component is reusable as-is: import it. If it's tightly coupled to the join page, extract a shared version:
+- Move shared search UI to `dashboard/components/SongSearchModal.tsx` (or equivalent path)
+- Both `/join/[code]` and `/collect/[code]` import from the shared location
+
+Check what exists with `grep` before making an extraction. If extraction is simplest, keep the commit limited to: (a) move + import-path updates on `/join`, (b) import on `/collect`, (c) no functional changes elsewhere.
+
+- [ ] **Step 3: Wire the search flow on the collect page**
+
+In `page.tsx`, replace the stub `onOpenSearch` with a proper handler that opens the modal. On track-select, call:
+
+```typescript
+await apiClient.submitCollectRequest(code, {
+  song_title: selected.title,
+  artist: selected.artist,
+  source: selected.source,
+  source_url: selected.source_url,
+  artwork_url: selected.artwork_url,
+  nickname: localStorage.getItem(`wrzdj_collect_nickname_${code}`) ?? undefined,
+});
+// refresh profile + leaderboard
+const p = await apiClient.setCollectProfile(code, {});
+setProfile({ submission_count: p.submission_count, submission_cap: p.submission_cap });
+const lb = await apiClient.getCollectLeaderboard(code, tab);
+setLeaderboard(lb);
+```
+
+Handle `ApiError(429)` → show "Picks limit reached" toast (reuse existing toast pattern — grep for it).
+
+- [ ] **Step 4: Write an end-to-end unit test for the submit flow**
+
+Append to `dashboard/app/collect/[code]/page.test.tsx`:
+
+```typescript
+it("increments picks counter after a successful submission", async () => {
+  // set up mocks for getCollectEvent = collection, setCollectProfile returning 0 then 1
+  // simulate search select, assert submitCollectRequest called, then profile refetched
+});
+```
+
+Write the body using whichever mock-library pattern the other tests use (vi.mock for `apiClient`). Mock `apiClient.submitCollectRequest` to resolve with `{id: 100}` and `apiClient.setCollectProfile` to return `{submission_count: 1, submission_cap: 15, has_email: false, nickname: null}` on the second call.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd dashboard && npx tsc --noEmit && npm test -- --run app/collect`
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(collect): reuse existing search modal for song submission"
+```
+
+---
+
+## Task 20: /join/[code] soft banner linking to /collect/[code]
+
+**Files:**
+- Modify: `dashboard/app/join/[code]/page.tsx`
+
+- [ ] **Step 1: Read the existing join page to find the best insert point**
+
+Run: `wc -l /home/adam/github/WrzDJ/dashboard/app/join/[code]/page.tsx && sed -n '1,60p' /home/adam/github/WrzDJ/dashboard/app/join/[code]/page.tsx`
+
+Locate where event data is loaded and where the top of the body renders.
+
+- [ ] **Step 2: Add phase-aware banner + splash consumption**
+
+Near the top of the component body, add:
+
+```typescript
+const [splashVisible, setSplashVisible] = useState(false);
+useEffect(() => {
+  if (typeof window === "undefined") return;
+  const key = `wrzdj_live_splash_${code}`;
+  if (sessionStorage.getItem(key) === "1") {
+    setSplashVisible(true);
+    sessionStorage.removeItem(key);
+    setTimeout(() => setSplashVisible(false), 3000);
+  }
+}, [code]);
+```
+
+And in the render:
+
+```tsx
+{splashVisible && (
+  <div style={{ padding: 12, background: "#ffcc00", color: "#000", textAlign: "center" }}>
+    🎉 The event is now live — you&apos;re in!
+  </div>
+)}
+{event?.phase === "pre_announce" || event?.phase === "collection" ? (
+  <div style={{ padding: 12, background: "#1a1a1a", textAlign: "center" }}>
+    Voting for this event is open —
+    <a href={`/collect/${code}`}> go to the pre-event page →</a>
+  </div>
+) : null}
+```
+
+Note: the join page's event fetch likely returns a partial event without `phase`. If so, fetch the `/api/public/collect/{code}` endpoint here in parallel (cheap, cached) or expose `phase` on the existing public endpoint — pick whichever requires the smallest change. Prefer the parallel fetch to keep blast radius small.
+
+- [ ] **Step 3: Verify by running lint + tsc**
+
+Run: `cd dashboard && npm run lint && npx tsc --noEmit`
+Expected: green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dashboard/app/join/[code]/page.tsx
+git commit -m "feat(join): soft banner + splash for pre-event collection"
+```
+
+---
+
+## Task 21: PreEventVotingTab — stats, phase controls, share link
+
+**Files:**
+- Create: `dashboard/app/events/[code]/components/PreEventVotingTab.tsx`
+- Create: `dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx`
+- Modify: `dashboard/app/events/[code]/page.tsx`
+
+- [ ] **Step 1: Inspect how existing tabs are wired**
+
+Run: `grep -n "SongManagementTab\|EventManagementTab" /home/adam/github/WrzDJ/dashboard/app/events/[code]/page.tsx`
+
+Read 30 lines around those usages to understand the tab-rendering pattern.
+
+- [ ] **Step 2: Write failing test**
+
+Create `dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx`:
+
+```typescript
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import PreEventVotingTab from "../PreEventVotingTab";
+
+const baseEvent = {
+  code: "ABC",
+  name: "Wedding",
+  collection_opens_at: "2026-04-21T12:00:00Z",
+  live_starts_at: "2026-04-22T20:00:00Z",
+  submission_cap_per_guest: 15,
+  collection_phase_override: null,
+  phase: "collection" as const,
+};
+
+vi.mock("../../../../lib/api", () => ({
+  apiClient: {
+    patchCollectionSettings: vi.fn().mockResolvedValue({ ...baseEvent, collection_phase_override: "force_live", phase: "live" }),
+    getPendingReview: vi.fn().mockResolvedValue({ requests: [], total: 0 }),
+    bulkReview: vi.fn(),
+  },
+}));
+
+describe("PreEventVotingTab", () => {
+  it("renders phase and share link", () => {
+    render(<PreEventVotingTab event={baseEvent} onEventChange={vi.fn()} />);
+    expect(screen.getByText(/phase:\s*collection/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/\/collect\/ABC/i)
+    ).toBeInTheDocument();
+  });
+
+  it("applies force_live override via button", async () => {
+    const onEventChange = vi.fn();
+    render(<PreEventVotingTab event={baseEvent} onEventChange={onEventChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /start live now/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^confirm$/i }));
+    await waitFor(() => {
+      expect(onEventChange).toHaveBeenCalled();
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Implement**
+
+Create `dashboard/app/events/[code]/components/PreEventVotingTab.tsx`:
+
+```typescript
+"use client";
+
+import { useEffect, useState } from "react";
+import { apiClient, PendingReviewRow } from "../../../../lib/api";
+
+interface EventShape {
+  code: string;
+  name: string;
+  collection_opens_at: string | null;
+  live_starts_at: string | null;
+  submission_cap_per_guest: number;
+  collection_phase_override: "force_collection" | "force_live" | null;
+  phase: "pre_announce" | "collection" | "live" | "closed";
+}
+
+interface Props {
+  event: EventShape;
+  onEventChange: (next: Partial<EventShape>) => void;
+}
+
+export default function PreEventVotingTab({ event, onEventChange }: Props) {
+  const [pending, setPending] = useState<PendingReviewRow[]>([]);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [confirming, setConfirming] = useState<null | "force_collection" | "force_live" | "clear">(null);
+  const [topN, setTopN] = useState(20);
+  const [minVotes, setMinVotes] = useState(3);
+
+  useEffect(() => {
+    refresh();
+  }, [event.code]);
+
+  async function refresh() {
+    const resp = await apiClient.getPendingReview(event.code);
+    setPending(resp.requests);
+  }
+
+  async function applyOverride(value: "force_collection" | "force_live" | null) {
+    const resp = await apiClient.patchCollectionSettings(event.code, {
+      collection_phase_override: value,
+    });
+    onEventChange(resp);
+    setConfirming(null);
+  }
+
+  async function bulk(action: string, extras: Record<string, unknown> = {}) {
+    await apiClient.bulkReview(event.code, { action: action as any, ...extras });
+    setSelected(new Set());
+    refresh();
+  }
+
+  const shareUrl = typeof window !== "undefined"
+    ? `${window.location.origin}/collect/${event.code}`
+    : `/collect/${event.code}`;
+
+  return (
+    <div style={{ padding: 16 }}>
+      <h2>Pre-Event Voting</h2>
+      <p>Phase: {event.phase}</p>
+      <p>
+        Share link: <code>{shareUrl}</code>
+        <button onClick={() => navigator.clipboard.writeText(shareUrl)}>Copy</button>
+      </p>
+
+      <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
+        <button onClick={() => setConfirming("force_collection")}>Open collection now</button>
+        <button onClick={() => setConfirming("force_live")}>Start live now</button>
+        <button onClick={() => setConfirming("clear")}>Clear override</button>
+      </div>
+
+      {confirming && (
+        <div style={{ padding: 12, background: "#1a1a1a", marginBottom: 16 }}>
+          <p>Confirm action: {confirming}</p>
+          <button onClick={() => applyOverride(confirming === "clear" ? null : confirming)}>
+            Confirm
+          </button>
+          <button onClick={() => setConfirming(null)}>Cancel</button>
+        </div>
+      )}
+
+      <h3>Pending review ({pending.length})</h3>
+      <div style={{ marginBottom: 8 }}>
+        <label>
+          Top N: <input type="number" value={topN} onChange={(e) => setTopN(Number(e.target.value))} />
+          <button onClick={() => bulk("accept_top_n", { n: topN })}>Accept top N</button>
+        </label>
+        <label style={{ marginLeft: 16 }}>
+          ≥ votes: <input type="number" value={minVotes} onChange={(e) => setMinVotes(Number(e.target.value))} />
+          <button onClick={() => bulk("accept_threshold", { min_votes: minVotes })}>Accept threshold</button>
+        </label>
+        <button onClick={() => bulk("reject_remaining")} style={{ marginLeft: 16 }}>
+          Reject remaining
+        </button>
+      </div>
+
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead>
+          <tr>
+            <th></th>
+            <th>▲</th>
+            <th>Song</th>
+            <th>Artist</th>
+            <th>Submitted by</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {pending.map((r) => (
+            <tr key={r.id}>
+              <td>
+                <input
+                  type="checkbox"
+                  checked={selected.has(r.id)}
+                  onChange={(e) => {
+                    const next = new Set(selected);
+                    if (e.target.checked) next.add(r.id); else next.delete(r.id);
+                    setSelected(next);
+                  }}
+                />
+              </td>
+              <td>{r.vote_count}</td>
+              <td>{r.song_title}</td>
+              <td>{r.artist}</td>
+              <td>{r.nickname ?? "—"}</td>
+              <td>
+                <button onClick={() => bulk("accept_ids", { request_ids: [r.id] })}>Accept</button>
+                <button onClick={() => bulk("reject_ids", { request_ids: [r.id] })}>Reject</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {selected.size > 0 && (
+        <div style={{ marginTop: 8 }}>
+          <button onClick={() => bulk("accept_ids", { request_ids: Array.from(selected) })}>
+            Accept selected ({selected.size})
+          </button>
+          <button onClick={() => bulk("reject_ids", { request_ids: Array.from(selected) })}>
+            Reject selected ({selected.size})
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Register the tab in the event page**
+
+Edit `dashboard/app/events/[code]/page.tsx`. Add import:
+
+```typescript
+import PreEventVotingTab from "./components/PreEventVotingTab";
+```
+
+Add a third tab entry that renders only when `event.collection_opens_at != null`. Match the existing tab-switching pattern. If tabs are driven by a `tab: string` local state variable with values like `"songs" | "event"`, extend to `"songs" | "event" | "pre-event"`.
+
+- [ ] **Step 5: Run tests + tsc**
+
+Run: `cd dashboard && npx tsc --noEmit && npm test -- --run app/events/[code]/components`
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/app/events/[code]/components/PreEventVotingTab.tsx dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx dashboard/app/events/[code]/page.tsx
+git commit -m "feat(collect): PreEventVotingTab with bulk review + overrides"
+```
+
+---
+
+## Task 22: Event create/edit form — collection section
+
+**Files:**
+- Modify: wherever the event-create form lives (`dashboard/app/events/new/page.tsx` likely; confirm with glob)
+- Modify: wherever the event-edit form lives (likely inside `dashboard/app/events/[code]/components/EventCustomizationCard.tsx` or similar)
+
+- [ ] **Step 1: Locate the forms**
+
+Run: `grep -rn "create.*event\|createEvent\|/events/new" /home/adam/github/WrzDJ/dashboard/app/ | head -10`
+Run: `grep -rn "editEvent\|patchEvent" /home/adam/github/WrzDJ/dashboard/ | head -10`
+
+Identify both files.
+
+- [ ] **Step 2: Add collapsible "Pre-event collection" section to both forms**
+
+The section contains:
+- Enable checkbox
+- `collection_opens_at` — `<input type="datetime-local">`
+- `live_starts_at` — `<input type="datetime-local">`
+- `submission_cap_per_guest` — `<input type="number" min="0" max="100">`
+
+Client-side zod validation before submit:
+
+```typescript
+import { z } from "zod";
+
+const collectionSchema = z.object({
+  collection_opens_at: z.string().optional(),
+  live_starts_at: z.string().optional(),
+  submission_cap_per_guest: z.number().int().min(0).max(100).optional(),
+}).refine(
+  (v) => {
+    if (v.collection_opens_at && v.live_starts_at) {
+      return new Date(v.collection_opens_at) < new Date(v.live_starts_at);
+    }
+    return true;
+  },
+  { message: "Collection opens must be before live starts" }
+);
+```
+
+On submit: include these fields in the event create/update call. If the event-create endpoint doesn't yet accept them, call `PATCH /api/events/{code}/collection` after the event is created.
+
+- [ ] **Step 3: Verify with tsc + lint**
+
+Run: `cd dashboard && npm run lint && npx tsc --noEmit`
+Expected: green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "feat(collect): event create/edit form — pre-event collection section"
+```
+
+---
+
+## Task 23: Security test suite — `~/wrzdj-testing/11-pre-event-collection.sh`
+
+**Files:**
+- Create: `~/wrzdj-testing/11-pre-event-collection.sh` (outside repo — user's machine)
+- Modify: `~/wrzdj-testing/run-all.sh`
+
+- [ ] **Step 1: Confirm the existing suite structure**
+
+Run: `ls ~/wrzdj-testing/ && head -30 ~/wrzdj-testing/10-*.sh 2>/dev/null || head -30 ~/wrzdj-testing/01-*.sh`
+
+Read the shape of an existing suite — shebang, API URL variables, curl patterns, PASS/FAIL reporting.
+
+- [ ] **Step 2: Write the suite**
+
+Create `~/wrzdj-testing/11-pre-event-collection.sh` modeled after the existing suites. Include one test block per item:
+
+1. Unauthorized DJ route access (no token → 401, wrong-owner token → 403)
+2. Phase gate: event with no collection fields → POST `/collect/{code}/requests` → 409
+3. Submission-cap bypass: set cap=3, submit 4 times, fourth → 429
+4. Rate-limit: hit `/collect/{code}/requests` 11 times in 60s → 429 on 11th
+5. Nickname injection: POST profile with `<script>alert(1)</script>` → 422
+6. Email injection: POST profile with `'; DROP TABLE guest_profiles; --@x.y` → 422
+7. Bulk-review ownership bypass → 403
+8. `collection_phase_override` bad value → 422
+9. Request-ids array of 250 → 422
+
+Each block: PASS if expected status, FAIL with details otherwise.
+
+- [ ] **Step 3: Register in `run-all.sh`**
+
+Append `./11-pre-event-collection.sh` (or match the existing registration pattern).
+
+- [ ] **Step 4: Run the suite end-to-end against a local dev instance**
+
+Kick off local services ("push to testing" workflow or the minimum subset). Then:
+
+Run: `~/wrzdj-testing/run-all.sh 11`
+Expected: all 9 test blocks PASS. Fix any failures before moving on.
+
+- [ ] **Step 5: No commit in this repo** (the testing suite is outside)
+
+Stop. Move on.
+
+---
+
+## Task 24: Full CI + manual verification
+
+- [ ] **Step 1: Run the full backend CI locally**
+
+Run (from `server/`):
+```bash
+.venv/bin/ruff check .
+.venv/bin/ruff format --check .
+.venv/bin/bandit -r app -c pyproject.toml -q
+.venv/bin/pytest --tb=short -q
+.venv/bin/alembic upgrade head && .venv/bin/alembic check
+```
+Expected: all green.
+
+- [ ] **Step 2: Run the full frontend CI locally**
+
+Run (from `dashboard/`):
+```bash
+npm run lint
+npx tsc --noEmit
+npm test -- --run
+```
+Expected: all green.
+
+- [ ] **Step 3: Manual verification (push-to-testing workflow)**
+
+Follow the "push to testing" memory entry:
+1. Tear down existing services
+2. Bring up db + dev-proxy
+3. Start backend + frontend with LAN IP env vars
+4. Open `https://<LAN_IP>/events/new` in browser → create event with collection enabled
+5. Open `https://<LAN_IP>/collect/<code>` on phone → submit + upvote
+6. Hit cap → UI + server block
+7. Click "Start live now" in DJ tab → `/collect` auto-redirects phone
+8. Inspect DB — `email` column has no plaintext
+
+- [ ] **Step 4: Push + PR**
+
+```bash
+git push -u origin feat/pre-event-requests
+gh pr create --title "feat: Pre-event song collection" --body "$(cat <<'EOF'
+## Summary
+- Pre-event song voting mode with `/collect/[code]` link
+- Live leaderboard, "my picks", gamification (top contributor, first to suggest)
+- Optional email opt-in with cross-device identity hooks
+- DJ bulk-review tab with accept-top-N / accept-threshold / reject-remaining
+- Auto-redirect on phase transition to live
+
+## Test plan
+- [ ] Backend CI (ruff, bandit, pytest, alembic check) green
+- [ ] Frontend CI (lint, tsc, vitest) green
+- [ ] Security suite 11 green (`~/wrzdj-testing/run-all.sh 11`)
+- [ ] Manual: create event, submit on phone, hit cap, flip phase, bulk-accept, verify DB encryption
+EOF
+)"
+```
+
+- [ ] **Step 5: Watch CI**
+
+Run: `gh pr checks <pr-number> --watch`
+Expected: all checks pass. If any fail, fix locally, commit, push, and re-watch.
+
+---
+
+## Self-Review Results
+
+Ran after plan completion:
+
+**Spec coverage** — every spec section traces to at least one task:
+- Data model (events columns, requests column, guest_profiles) → Tasks 1–4
+- Derived phase property → Task 2
+- Public API (preview, leaderboard, profile, my-picks, submit, vote) → Tasks 7–9
+- DJ API (PATCH collection, pending-review, bulk-review) → Tasks 10–12
+- Frontend API client → Task 13
+- `/collect/[code]` page with FeatureOptIn, MyPicks, LeaderboardTabs, SubmitBar → Tasks 14–19
+- `/join/[code]` banner + splash → Task 20
+- PreEventVotingTab (three-tab nav) → Task 21
+- Event create/edit form collection section → Task 22
+- Security suite → Task 23
+- CI + manual verification + PR → Task 24
+
+**Placeholder scan** — no TBD/TODO/"add appropriate" patterns. Each code step has concrete code. Exceptions:
+- Task 9 tells the engineer to `grep` for the actual vote-service function name (spec-accurate; integration hook depends on existing code the reviewer can see).
+- Task 19 tells the engineer to `grep` for the existing search modal before deciding to import-as-is or extract — this is a real decision that depends on the existing code shape, not a placeholder.
+- Task 22 tells the engineer to `grep` for the existing event-create/edit form — same reason.
+
+**Type consistency** — cross-checked:
+- `CollectLeaderboardRow` fields identical in Python schema (`CollectLeaderboardRow`), TypeScript type, and consumers (LeaderboardTabs, MyPicksPanel).
+- `collection_phase_override` allowed values `Literal["force_collection", "force_live"] | None` in Pydantic, `"force_collection" | "force_live" | null` in TS — identical.
+- `submitted_during_collection` column name consistent across migration (Task 1), model (Task 3), ORM queries (Tasks 7, 8, 11, 12), and tests.
+- Bulk-review action enum identical in Pydantic (`BulkReviewRequest.action`), TS type (`bulkReview`), and backend handler.
+
+No fixes needed.

--- a/docs/superpowers/specs/2026-04-21-pre-event-collection-design.md
+++ b/docs/superpowers/specs/2026-04-21-pre-event-collection-design.md
@@ -1,0 +1,401 @@
+# Pre-Event Song Collection — Design Spec
+
+**Status:** Approved (brainstorming complete, awaiting implementation plan)
+**Date:** 2026-04-21
+**Branch:** `feat/pre-event-requests`
+**Author:** brainstorming session with djfreaq
+
+## Summary
+
+A new pre-event song-collection mode for WrzDJ events. DJs configure an "opens at" date and a "live at" date. Between those dates, guests visit a dedicated `/collect/[code]` page (distinct from the existing `/join/[code]`) where they submit songs, upvote others, and see themselves on a live leaderboard. Requests accumulate in the `NEW` state and are reviewed in bulk by the DJ — either anytime during collection, or via a sweep pass before (or during) the live event. At live-start the collection link auto-redirects to the normal join flow with a celebratory splash.
+
+The collection UI is deliberately different from the live join page: it emphasizes social proof (ranked public leaderboard), personal stake ("my picks" with status badges), and lightweight gamification ("first to suggest", "top contributor"). An optional email opt-in unlocks cross-device identity and a future "notify me when my song plays" channel.
+
+## Goals
+
+- Let DJs open song voting before the event begins, driving engagement and shaping the setlist in advance.
+- Provide a collection UI that is more engaging than the current join page (leaderboard, my-picks, gamification).
+- Let DJs review accumulated requests in bulk (accept top N, accept by threshold, reject remaining) or cherry-pick individually.
+- Keep the feature optional per event — events that don't set `collection_opens_at` behave exactly as today.
+- Enforce security best practices consistent with the rest of the codebase: input sanitization, encrypted sensitive data, rate limiting, parameterized queries, no plaintext secrets, no error-message leakage.
+
+## Non-Goals
+
+- Notification delivery (email/SMS when a song plays). The *opt-in* is captured now; *sending* is a follow-up feature.
+- Background jobs or scheduled tasks. Phase computation is entirely derived from timestamps at request time.
+- Separate pre-event event entity. Collection is a phase of an existing event, not a new aggregate root.
+- Redesign of the existing `/join/[code]` live page. Minimal change: a soft "pre-event voting is open" banner when applicable.
+
+## Design Decisions Locked In
+
+| Topic | Decision |
+|---|---|
+| Engagement model | Live ranked leaderboard + personal "my picks" view + lightweight gamification (top contributor, first-to-suggest) |
+| Lifecycle | Time-driven auto-transitions (`collection_opens_at`, `live_starts_at`), with DJ manual override |
+| Guest identity | Anonymous + nickname (localStorage) default; landing page promotes optional email opt-in with feature comparison panel |
+| DJ review | Hybrid — cherry-pick anytime + dedicated bulk-sweep view (multi-select, accept top N, accept ≥X votes, reject remaining) |
+| URL | Separate `/collect/[code]`, auto-redirect to `/join/[code]` after live-start with splash |
+| Submission cap | DJ-configurable per event, default 15, `0` = unlimited |
+| Unreviewed at live-start | Stay as `NEW` (forgiving — DJ can ignore or review mid-event) |
+| Leaderboard visibility | Two tabs — "Trending" + "All", no minimum-votes floor |
+| Architecture | Approach 1 — minimal extension of existing models (columns on `events` + `requests`, new `guest_profiles` table) |
+
+## Architecture
+
+### Data Model Changes
+
+**Migration:** `server/alembic/versions/010_add_pre_event_collection.py`
+
+`events` table — four new columns:
+
+```python
+collection_opens_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+live_starts_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+submission_cap_per_guest: Mapped[int] = mapped_column(Integer, default=15, server_default="15")
+collection_phase_override: Mapped[str | None] = mapped_column(String(20), nullable=True)
+# collection_phase_override ∈ {"force_collection", "force_live", None}
+```
+
+`requests` table — one new column:
+
+```python
+submitted_during_collection: Mapped[bool] = mapped_column(
+    Boolean, default=False, server_default="0", index=True
+)
+```
+
+Indexed along with `status` for the bulk-review query (`event_id + submitted_during_collection + status`).
+
+**New table:** `guest_profiles`
+
+```python
+class GuestProfile(Base):
+    __tablename__ = "guest_profiles"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
+    client_fingerprint: Mapped[str] = mapped_column(String(64), index=True)
+    nickname: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    email: Mapped[str | None] = mapped_column(EncryptedText, nullable=True)
+    submission_count: Mapped[int] = mapped_column(Integer, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow)
+    __table_args__ = (UniqueConstraint("event_id", "client_fingerprint"),)
+```
+
+**Security rules for `guest_profiles`:**
+- `email` uses the `EncryptedText` TypeDecorator (Fernet AES-128-CBC + HMAC) — never plaintext, per CLAUDE.md hard rule.
+- `(event_id, client_fingerprint)` uniqueness prevents duplicate profiles per event per device.
+- `submission_count` is denormalized for fast cap checks and updated atomically inside the submission transaction.
+
+### Derived Phase (Computed Property)
+
+Not stored. Added as a property on `Event`:
+
+```python
+@property
+def phase(self) -> Literal["pre_announce", "collection", "live", "closed"]:
+    if self.collection_phase_override == "force_live":
+        return "live"
+    if self.collection_phase_override == "force_collection":
+        return "collection"
+    now = utcnow()
+    if self.collection_opens_at and now < self.collection_opens_at:
+        return "pre_announce"
+    if self.live_starts_at and now < self.live_starts_at:
+        return "collection"
+    if now < self.expires_at:
+        return "live"
+    return "closed"
+```
+
+Events without `collection_opens_at` skip `pre_announce` and `collection` entirely and behave exactly like today — no migration data changes, full backward compatibility.
+
+### API Surface
+
+New router: `server/app/api/collect.py`, mounted at `/api/public/collect`.
+
+#### Public endpoints (no auth, rate-limited)
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/public/collect/{code}` | Event preview (name, banner, phase, dates, `submission_cap_per_guest`, `registration_enabled`, feature flags) |
+| `GET` | `/api/public/collect/{code}/leaderboard` | Paginated ranked requests, `?tab=trending\|all` |
+| `POST` | `/api/public/collect/{code}/requests` | Submit a song (rate-limited, cap-enforced, phase-gated) |
+| `POST` | `/api/public/collect/{code}/vote` | Upvote (reuses existing vote service) |
+| `POST` | `/api/public/collect/{code}/profile` | Set/update nickname + optional email |
+| `GET` | `/api/public/collect/{code}/profile/me` | Returns this guest's "my picks" by fingerprint |
+
+#### DJ endpoints (authenticated, `get_current_active_user`, ownership-checked)
+
+Added to `server/app/api/events.py`:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `PATCH` | `/api/events/{code}/collection` | Set/update collection settings (`collection_opens_at`, `live_starts_at`, `submission_cap_per_guest`, `collection_phase_override`) |
+| `GET` | `/api/events/{code}/pending-review` | List `NEW` requests with `submitted_during_collection=True`, sorted by `vote_count DESC` |
+| `POST` | `/api/events/{code}/bulk-review` | Bulk action (`accept_top_n`, `accept_threshold`, `accept_ids`, `reject_ids`, `reject_remaining`) |
+
+#### Existing endpoint changes
+
+- `POST /api/events` — accept optional new collection fields (null = today's behavior).
+- `POST /api/requests` — when `event.phase == "collection"`, set `submitted_during_collection=True` and enforce cap via `GuestProfile.submission_count`.
+
+### Frontend Components
+
+#### New route: `/collect/[code]`
+
+`dashboard/app/collect/[code]/page.tsx` plus components:
+
+- **Event banner header** — reuses existing banner/phase-badge rendering with a countdown to `live_starts_at`.
+- **Feature opt-in panel** — collapsible, dismissible, promotes email opt-in with a feature comparison ("🔔 Notify me when my song plays", "🏆 Cross-device leaderboard", "📊 Persistent profile"). Renders only when guest has no email on file.
+- **"My Picks" panel** — fetched from `GET /profile/me`; shows submitted + upvoted songs with status badges (`submitted`, `trending`, `queued`, `played`) and gamification badges ("⭐ First to suggest", "🏆 Top contributor").
+- **Leaderboard tabs** — "Trending" (requests with `vote_count >= 1`, sorted DESC) and "All" (every submission, newest first). Each row: artwork, title, artist, vote count, upvote button, submitter nickname, status chip.
+- **Sticky request button** — opens the existing `SongSearch` component (reused from `/join/[code]`). Shows "X of Y picks used" counter, disables at cap.
+
+#### DJ dashboard changes
+
+Event page (`dashboard/app/events/[code]/page.tsx`) gets a **third tab** alongside existing `SongManagementTab` and `EventManagementTab`:
+
+- **`PreEventVotingTab.tsx`** — full-width tab content area:
+  - Phase stats card (current phase, submission count, unique guests, top submitter)
+  - Phase override buttons (Open now / Start live now / Pause) with confirmation modals
+  - Share link + QR for `/collect/[code]`, distinct from the existing live-event share
+  - Inline bulk-review table — multi-select, "Accept top N", "Accept ≥ X votes", "Reject remaining"
+  - Filter chip: "Pending only" (default) vs "All pre-event submissions"
+
+The tab is **hidden entirely** if `event.collection_opens_at` is null, keeping the UI clean for DJs who don't use the feature.
+
+Event creation/edit form gets a new collapsible "Pre-event collection" section (off by default):
+- Enable checkbox
+- `collection_opens_at` datetime picker
+- `live_starts_at` datetime picker
+- `submission_cap_per_guest` number input
+- Post-save: "Copy pre-event link" + QR display
+
+## Phase Transitions
+
+**Almost nothing happens "at transition time."** `Event.phase` is derived on demand. Unreviewed collection requests stay `NEW` and flow into the live queue.
+
+### Phase-aware behavior summary
+
+| Action | Phase | Behavior |
+|---|---|---|
+| `POST /collect/*/requests` | `collection` | Accept (cap-enforced) |
+| `POST /collect/*/requests` | `live` or `closed` | 409 "Collection has ended" |
+| `GET /collect/[code]` frontend | `pre_announce` | Show "opens in Xd Yh" countdown |
+| `GET /collect/[code]` frontend | `collection` | Full experience |
+| `GET /collect/[code]` frontend | `live` | `router.replace('/join/[code]')` + splash |
+| `GET /collect/[code]` frontend | `closed` | Redirect to `/join/[code]` (handles expired state) |
+| `GET /join/[code]` frontend | `pre_announce` or `collection` | Soft banner linking to `/collect/[code]` |
+| `GET /join/[code]` frontend | `live` or `closed` | Today's behavior (unchanged) |
+
+### Redirect mechanics
+
+1. **First-render redirect** — initial `GET /api/public/collect/{code}` returns `phase`; if not `pre_announce`/`collection`, redirect fires before mount.
+2. **Poll-triggered redirect** — leaderboard poll (every 5s, paused when tab hidden) returns phase; phase change triggers redirect + splash.
+
+**Splash** — pre-redirect sets `sessionStorage["wrzdj_live_splash_{code}"] = "1"`. The `/join/[code]` page checks once, renders a 3-second banner "🎉 The event is now live — you're in!", clears the flag. No persistent state, no URL params to forge.
+
+### Manual override
+
+`collection_phase_override` wins over timestamp-based computation. DJ clicks "Start live now" → backend sets `override = "force_live"`. Public endpoints reject new submissions immediately; guests on next poll see new phase and redirect. DJ can clear override to resume timestamp behavior.
+
+### Edge cases
+
+| Case | Behavior |
+|---|---|
+| `collection_opens_at` in past on new event | Allowed — starts immediately |
+| `live_starts_at` edited earlier than now mid-collection | Collection ends immediately, frontend redirects on next poll |
+| DJ deletes `collection_opens_at` on event with submissions | Submissions stay (they're just `NEW` requests with `submitted_during_collection=True`); Pre-Event Voting tab hides |
+| `collection_opens_at >= live_starts_at` | Rejected at validation time (zod + Pydantic) |
+| `expires_at <= live_starts_at` | Rejected at validation time |
+| Clock skew between server and client | Server is source of truth; client phase is advisory for UI only |
+
+## Security Design
+
+Security is treated as a first-class requirement. Every cross-cutting concern matches established codebase patterns — no new auth paths, no novel crypto, no custom input-validation layer. All new input goes through both client-side zod and server-side Pydantic (defense in depth). All sensitive data is encrypted at rest. All public endpoints are rate-limited.
+
+### Input sanitization checklist
+
+| Field | Client (zod) | Server (Pydantic) | DB column |
+|---|---|---|---|
+| `nickname` | `z.string().trim().min(1).max(30).regex(/^[a-zA-Z0-9 _.-]+$/)` | `constr(strip_whitespace=True, min_length=1, max_length=30, pattern=r'^[a-zA-Z0-9 _.-]+$')` | `String(30)` |
+| `email` | `z.string().email().max(254)` | `EmailStr` (from `pydantic[email]`) | `EncryptedText` |
+| `note` | `z.string().trim().max(500)` | `constr(strip_whitespace=True, max_length=500)` | `Text` |
+| `song_title`, `artist` | Existing search flow | Existing search flow | `String(255)` |
+| datetimes | Native input + ISO parse | `datetime` + custom validator (`< 1yr future`, ordering) | `DateTime` |
+| `collection_phase_override` | Enum | `Literal["force_collection", "force_live"] \| None` | `String(20)` |
+| bulk-review `action` | Enum | Pydantic discriminated union | — |
+
+**No raw HTML rendering of user input.** React renders nickname/note as text nodes by default. The feature must not introduce any unsafe HTML-injection escape hatches; reviewer should grep the PR for such patterns and reject if any are introduced.
+
+**`artwork_url` whitelist** — only accepted values from known CDNs (Spotify, Beatport, Tidal) via the existing search layer. Collection endpoints never accept user-supplied `artwork_url` directly.
+
+### Rate limits (slowapi)
+
+| Endpoint | Limit | Rationale |
+|---|---|---|
+| `POST /collect/{code}/requests` | 10/min per IP | Matches live submission rate |
+| `POST /collect/{code}/vote` | 60/min per IP | Matches existing vote endpoint |
+| `POST /collect/{code}/profile` | 5/min per IP | Prevents nickname/email churn abuse |
+| `GET /collect/{code}/leaderboard` | No hard limit | 5s in-process TTL cache in service layer |
+| `GET /collect/{code}` | No hard limit | Cheap phase check, polled frequently |
+
+Limit values stored in DB-backed `system_settings` (reuses `search_rate_limit_per_minute` pattern) so admin can tune at runtime.
+
+### Submission cap (defense in depth)
+
+- **Client-side** — button disables at `submission_count >= cap`, counter visible. UX only; never the trust boundary.
+- **Server-side** — `POST /requests` opens a DB transaction, re-reads `GuestProfile.submission_count`, compares to `event.submission_cap_per_guest`, increments atomically. Over-cap → 429 "Picks limit reached".
+- `cap=0` = unlimited (explicit).
+
+### Identity hardening
+
+- Reuses existing `client_fingerprint` helper (`X-Forwarded-For`-aware from `votes.py`). No new fingerprinting path.
+- `(event_id, client_fingerprint)` is the identity key — not the nickname. Two guests can share a nickname; top-contributor badges tie to the fingerprint, preventing rank theft via nickname copy.
+- Optional email stored via `EncryptedText` (Fernet) — never plaintext, per CLAUDE.md hard rule.
+
+### Authorization
+
+- Every DJ route: `get_current_active_user` + ownership check (`event.created_by_user_id == current_user.id` OR `role == "admin"`). Mirrors `events.py` existing guards.
+- No new auth paths — reuses `api/deps.py` dependencies.
+- `pending` users blocked via `get_current_active_user` (existing behavior).
+
+### Error-message hygiene
+
+- Phase-mismatch: `{"detail": "Collection has ended"}`.
+- Over-cap: `{"detail": "Picks limit reached"}` (no cap or count disclosed).
+- Global 500 handler (`server/app/main.py`) strips stack traces in production.
+
+### DoS / abuse surface
+
+- Leaderboard cached 5s at service layer; poll-storms don't flatten DB.
+- Phase endpoint single-row query; no N+1.
+- Bulk-review actions bounded at ≤200 IDs per call; UI paginates past that.
+- Concurrent bulk-review actions run in a single DB transaction per call (prevents double-accept from two tabs).
+
+### Dependency review
+
+**Zero new Python packages.** `EncryptedText`, `EmailStr`, `Pydantic`, `slowapi`, `SQLAlchemy` all already present.
+**Zero new JS packages.** `zod` already in use; no new UI libraries (staying on vanilla CSS + React).
+**Zero net-new CVE surface.**
+
+## Testing Strategy
+
+### Backend tests (`server/tests/`, pytest, 80% coverage floor)
+
+New test files:
+- `test_collect_public.py` — guest-facing endpoints (submit, vote, profile, leaderboard, phase gate)
+- `test_collect_dj.py` — DJ-side (collection settings, bulk-review, pending-review listing)
+- `test_event_phase.py` — derived `phase` across all timestamp/override combinations
+- `test_guest_profile.py` — `GuestProfile` model, submission_count atomicity, email encryption round-trip
+
+Coverage targets:
+- Every branch of `Event.phase` (`pre_announce`, `collection`, `live`, `closed`, both override modes)
+- Submit during each phase → correct 200 vs 409
+- Cap enforcement: over-cap → 429, `cap=0` → unlimited, atomic increment
+- Ownership: non-owner → 403 on every DJ route (parametrized)
+- Bulk-review actions: each type with empty / mid-size / 200-row-limit fixtures
+- Email encryption: DB column verified to not contain plaintext
+- Datetime validation: ordering, past-date edge cases
+
+New `conftest.py` fixtures:
+- `event_with_collection` (currently in `collection` phase)
+- `event_in_pre_announce`
+- `event_post_live` (had submissions)
+- `guest_profile`
+- `collection_requests` (factory for N `NEW` collection requests)
+
+Existing fixtures (`client`, `auth_headers`, etc.) reused as-is.
+
+### Frontend tests (`dashboard/`, vitest + jsdom)
+
+New test files:
+- `app/collect/[code]/page.test.tsx` — render states per phase, redirect on live
+- `app/collect/[code]/components/LeaderboardTabs.test.tsx` — tab filtering, optimistic vote update + rollback
+- `app/collect/[code]/components/MyPicksPanel.test.tsx` — empty state, badges
+- `app/collect/[code]/components/SubmissionCapCounter.test.tsx` — counter, disabled state
+- `app/events/[code]/components/PreEventVotingTab.test.tsx` — DJ tab, multi-select, bulk actions
+- `lib/__tests__/collect-api.test.ts` — API client methods, error paths (401, 409, 429)
+
+Coverage targets:
+- Phase-change redirect fires on mount AND on poll
+- Splash flag written + consumed + cleared exactly once
+- Optimistic vote/submit rolls back on API error
+- zod validation mirrors server Pydantic rules (prevents client/server drift)
+- Polling pauses when tab hidden
+- Feature opt-in panel hides after email is set
+
+Shared-type fixtures updated whenever new fields land on `PublicRequestInfo` or equivalent — per CLAUDE.md pitfall note.
+
+### Security test suite (`~/wrzdj-testing/`)
+
+New suite file: `11-pre-event-collection.sh`. Covers:
+
+- Unauthorized DJ route access (non-owner, pending, unauthenticated)
+- Phase gate enforcement (submit during `live` → 409, `closed` → 409)
+- Submission-cap bypass (concurrent POSTs, cap=3 → submit 10)
+- Rate-limit enforcement (hit each new endpoint past its cap → 429)
+- Nickname injection attempts (script-tag payloads, RTL overrides, null bytes, 1000-char)
+- Email injection attempts (SQL-style, bidirectional chars, 10k-char)
+- Bulk-review ownership bypass (another DJ's code → 403)
+- `collection_phase_override` enum enforcement (free-form string rejected)
+- Leaderboard cache key integrity (not user-controlled)
+
+Integrated via `~/wrzdj-testing/run-all.sh 11`.
+
+### CI enforcement
+
+No workflow changes needed. Existing `.github/workflows/ci.yml` pipeline covers:
+- Backend: ruff + bandit + pip-audit + pytest (`--cov-fail-under=80`)
+- Frontend: ESLint + `tsc --noEmit` + vitest + npm audit
+- Alembic drift: `alembic upgrade head && alembic check` (migration 010)
+
+### Manual verification (PR description checklist)
+
+- [ ] Create event with collection enabled; pre-event link works on mobile (LAN IP)
+- [ ] Two browsers submit → leaderboard updates within 5s on both
+- [ ] Hit submission cap → UI + server both block
+- [ ] Manual phase override → `/collect/*` redirects immediately
+- [ ] Auto transition via `live_starts_at` in 1min → auto-redirect fires
+- [ ] Bulk-accept top 20 → all visible in Song Management tab
+- [ ] Delete collection dates → Pre-Event Voting tab hides cleanly
+- [ ] Inspect DB — email column has no plaintext
+
+## Open Questions / Deferred
+
+- Notification delivery (email/SMS on song-played) — opt-in captured, sending pipeline is a follow-up spec.
+- Reminder emails ("event starts in 1h, you have N pending reviews") — deferred.
+- Analytics on collection-vs-live performance (acceptance rate, vote distribution) — future.
+
+## Files Touched (Preliminary)
+
+**New:**
+- `server/alembic/versions/010_add_pre_event_collection.py`
+- `server/app/models/guest_profile.py`
+- `server/app/api/collect.py`
+- `server/app/schemas/collect.py`
+- `server/app/services/collect.py`
+- `server/tests/test_collect_public.py`
+- `server/tests/test_collect_dj.py`
+- `server/tests/test_event_phase.py`
+- `server/tests/test_guest_profile.py`
+- `dashboard/app/collect/[code]/page.tsx`
+- `dashboard/app/collect/[code]/components/*` (LeaderboardTabs, MyPicksPanel, FeatureOptInPanel, SubmissionCapCounter, SearchRequestForm wrapper)
+- `dashboard/app/events/[code]/components/PreEventVotingTab.tsx`
+- `dashboard/app/collect/[code]/__tests__/*`
+- `dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx`
+- `dashboard/lib/__tests__/collect-api.test.ts`
+- `~/wrzdj-testing/11-pre-event-collection.sh` (outside repo)
+
+**Modified:**
+- `server/app/models/event.py` — new columns + derived `phase` property
+- `server/app/models/request.py` — new `submitted_during_collection` column
+- `server/app/api/events.py` — new DJ routes (`PATCH /collection`, `GET /pending-review`, `POST /bulk-review`)
+- `server/app/api/requests.py` — phase-aware submission (sets `submitted_during_collection`, enforces cap)
+- `server/app/main.py` — register new `collect` router
+- `server/app/schemas/event.py` — new optional collection fields on create/update
+- `dashboard/app/events/[code]/page.tsx` — third tab registration
+- `dashboard/app/events/new/page.tsx` and edit form — collapsible collection section
+- `dashboard/app/join/[code]/page.tsx` — soft banner linking to collect link when phase allows
+- `dashboard/lib/api.ts` — new collect API methods
+- `~/wrzdj-testing/run-all.sh` — register suite 11

--- a/server/alembic/versions/034_add_pre_event_collection.py
+++ b/server/alembic/versions/034_add_pre_event_collection.py
@@ -1,0 +1,98 @@
+"""Add pre-event collection columns + guest_profiles table.
+
+Revision ID: 034
+Revises: 033
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "034"
+down_revision = "033"
+
+
+def upgrade() -> None:
+    # events columns
+    op.add_column(
+        "events",
+        sa.Column("collection_opens_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "events",
+        sa.Column("live_starts_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "events",
+        sa.Column(
+            "submission_cap_per_guest",
+            sa.Integer(),
+            nullable=False,
+            server_default="15",
+        ),
+    )
+    op.add_column(
+        "events",
+        sa.Column("collection_phase_override", sa.String(length=20), nullable=True),
+    )
+
+    # requests column
+    op.add_column(
+        "requests",
+        sa.Column(
+            "submitted_during_collection",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.create_index(
+        "ix_requests_submitted_during_collection",
+        "requests",
+        ["submitted_during_collection"],
+    )
+
+    # guest_profiles table
+    op.create_table(
+        "guest_profiles",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "event_id",
+            sa.Integer(),
+            sa.ForeignKey("events.id"),
+            nullable=False,
+        ),
+        sa.Column("client_fingerprint", sa.String(length=64), nullable=False),
+        sa.Column("nickname", sa.String(length=30), nullable=True),
+        sa.Column("email", sa.Text(), nullable=True),
+        sa.Column(
+            "submission_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint(
+            "event_id",
+            "client_fingerprint",
+            name="uq_guest_profile_event_fingerprint",
+        ),
+    )
+    op.create_index("ix_guest_profiles_event_id", "guest_profiles", ["event_id"])
+    op.create_index(
+        "ix_guest_profiles_client_fingerprint",
+        "guest_profiles",
+        ["client_fingerprint"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_guest_profiles_client_fingerprint", table_name="guest_profiles")
+    op.drop_index("ix_guest_profiles_event_id", table_name="guest_profiles")
+    op.drop_table("guest_profiles")
+    op.drop_index("ix_requests_submitted_during_collection", table_name="requests")
+    op.drop_column("requests", "submitted_during_collection")
+    op.drop_column("events", "collection_phase_override")
+    op.drop_column("events", "submission_cap_per_guest")
+    op.drop_column("events", "live_starts_at")
+    op.drop_column("events", "collection_opens_at")

--- a/server/app/api/__init__.py
+++ b/server/app/api/__init__.py
@@ -5,6 +5,7 @@ from app.api import (
     auth,
     beatport,
     bridge,
+    collect,
     events,
     kiosk,
     public,
@@ -30,6 +31,7 @@ api_router.include_router(requests.router, prefix="/requests", tags=["requests"]
 api_router.include_router(votes.router, prefix="/requests", tags=["votes"])
 api_router.include_router(search.router, prefix="/search", tags=["search"])
 api_router.include_router(public.router, prefix="/public", tags=["public"])
+api_router.include_router(collect.router, prefix="/public/collect", tags=["collect"])
 api_router.include_router(sse.router, prefix="/public", tags=["sse"])
 api_router.include_router(bridge.router, tags=["bridge"])
 api_router.include_router(tidal.router, prefix="/tidal", tags=["tidal"])

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -1,0 +1,85 @@
+"""Public API endpoints for pre-event song collection (no authentication required)."""
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.core.rate_limit import limiter
+from app.models.event import Event
+from app.models.request import Request as SongRequest
+from app.schemas.collect import (
+    CollectEventPreview,
+    CollectLeaderboardResponse,
+    CollectLeaderboardRow,
+)
+from app.services.system_settings import get_system_settings
+
+router = APIRouter()
+
+
+def _get_event_or_404(db: Session, code: str) -> Event:
+    event = db.query(Event).filter(Event.code == code).one_or_none()
+    if event is None or not event.is_active:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return event
+
+
+@router.get("/{code}", response_model=CollectEventPreview)
+@limiter.limit("120/minute")
+def preview(code: str, request: Request, db: Session = Depends(get_db)):
+    event = _get_event_or_404(db, code)
+    settings = get_system_settings(db)
+    return CollectEventPreview(
+        code=event.code,
+        name=event.name,
+        banner_filename=event.banner_filename,
+        submission_cap_per_guest=event.submission_cap_per_guest,
+        registration_enabled=settings.registration_enabled,
+        phase=event.phase,
+        collection_opens_at=event.collection_opens_at,
+        live_starts_at=event.live_starts_at,
+        expires_at=event.expires_at,
+    )
+
+
+@router.get("/{code}/leaderboard", response_model=CollectLeaderboardResponse)
+@limiter.limit("120/minute")
+def leaderboard(
+    code: str,
+    request: Request,
+    tab: Literal["trending", "all"] = "trending",
+    db: Session = Depends(get_db),
+):
+    event = _get_event_or_404(db, code)
+
+    q = (
+        db.query(SongRequest)
+        .filter(SongRequest.event_id == event.id)
+        .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
+    )
+    if tab == "trending":
+        q = q.filter(SongRequest.vote_count >= 1).order_by(
+            SongRequest.vote_count.desc(), SongRequest.created_at.desc()
+        )
+    else:
+        q = q.order_by(SongRequest.created_at.desc())
+
+    rows = q.limit(200).all()
+    return CollectLeaderboardResponse(
+        requests=[
+            CollectLeaderboardRow(
+                id=r.id,
+                title=r.song_title,
+                artist=r.artist,
+                artwork_url=r.artwork_url,
+                vote_count=r.vote_count,
+                nickname=r.nickname,
+                status=r.status,
+                created_at=r.created_at,
+            )
+            for r in rows
+        ],
+        total=len(rows),
+    )

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -3,17 +3,24 @@
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import desc, func
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
-from app.core.rate_limit import limiter
+from app.core.rate_limit import get_client_fingerprint, limiter
 from app.models.event import Event
 from app.models.request import Request as SongRequest
+from app.models.request_vote import RequestVote
 from app.schemas.collect import (
     CollectEventPreview,
     CollectLeaderboardResponse,
     CollectLeaderboardRow,
+    CollectMyPicksItem,
+    CollectMyPicksResponse,
+    CollectProfileRequest,
+    CollectProfileResponse,
 )
+from app.services import collect as collect_service
 from app.services.system_settings import get_system_settings
 
 router = APIRouter()
@@ -82,4 +89,114 @@ def leaderboard(
             for r in rows
         ],
         total=len(rows),
+    )
+
+
+@router.post("/{code}/profile", response_model=CollectProfileResponse)
+@limiter.limit("5/minute")
+def set_profile(
+    code: str,
+    payload: CollectProfileRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    event = _get_event_or_404(db, code)
+    fingerprint = get_client_fingerprint(request)
+    profile = collect_service.upsert_profile(
+        db,
+        event_id=event.id,
+        fingerprint=fingerprint,
+        nickname=payload.nickname,
+        email=payload.email,
+    )
+    return CollectProfileResponse(
+        nickname=profile.nickname,
+        has_email=profile.email is not None,
+        submission_count=profile.submission_count,
+        submission_cap=event.submission_cap_per_guest,
+    )
+
+
+@router.get("/{code}/profile/me", response_model=CollectMyPicksResponse)
+@limiter.limit("60/minute")
+def my_picks(code: str, request: Request, db: Session = Depends(get_db)):
+    event = _get_event_or_404(db, code)
+    fingerprint = get_client_fingerprint(request)
+
+    submitted = (
+        db.query(SongRequest)
+        .filter(SongRequest.event_id == event.id)
+        .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
+        .filter(SongRequest.client_fingerprint == fingerprint)
+        .order_by(SongRequest.created_at.desc())
+        .all()
+    )
+
+    upvoted_request_ids = [
+        rv.request_id
+        for rv in db.query(RequestVote).filter(RequestVote.client_fingerprint == fingerprint).all()
+    ]
+    upvoted: list[SongRequest] = []
+    if upvoted_request_ids:
+        upvoted = (
+            db.query(SongRequest)
+            .filter(SongRequest.event_id == event.id)
+            .filter(SongRequest.id.in_(upvoted_request_ids))
+            .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
+            .all()
+        )
+
+    # Gamification: top contributor = this fingerprint has the most submissions
+    # in this event (among collection submissions).
+    top_fingerprint_row = (
+        db.query(
+            SongRequest.client_fingerprint,
+            func.count(SongRequest.id).label("n"),
+        )
+        .filter(SongRequest.event_id == event.id)
+        .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
+        .filter(SongRequest.client_fingerprint.isnot(None))
+        .group_by(SongRequest.client_fingerprint)
+        .order_by(desc("n"))
+        .first()
+    )
+    is_top = (
+        top_fingerprint_row is not None
+        and top_fingerprint_row[0] == fingerprint
+        and top_fingerprint_row[1] > 0
+    )
+
+    # First-to-suggest: among submitted rows, the ones where no earlier row in the
+    # event shares the same dedupe_key.
+    first_suggestion_ids: list[int] = []
+    for r in submitted:
+        earlier = (
+            db.query(SongRequest.id)
+            .filter(SongRequest.event_id == event.id)
+            .filter(SongRequest.dedupe_key == r.dedupe_key)
+            .filter(SongRequest.created_at < r.created_at)
+            .first()
+        )
+        if earlier is None:
+            first_suggestion_ids.append(r.id)
+
+    def _to_row(r: SongRequest, interaction: str) -> CollectMyPicksItem:
+        return CollectMyPicksItem(
+            id=r.id,
+            title=r.song_title,
+            artist=r.artist,
+            artwork_url=r.artwork_url,
+            vote_count=r.vote_count,
+            nickname=r.nickname,
+            status=r.status,
+            created_at=r.created_at,
+            interaction=interaction,
+        )
+
+    submitted_ids = {s.id for s in submitted}
+    return CollectMyPicksResponse(
+        submitted=[_to_row(r, "submitted") for r in submitted],
+        upvoted=[_to_row(r, "upvoted") for r in upvoted if r.id not in submitted_ids],
+        is_top_contributor=is_top,
+        first_suggestion_ids=first_suggestion_ids,
     )

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -38,6 +38,31 @@ def _get_event_or_404(db: Session, code: str) -> Event:
     return event
 
 
+def _banner_url_for_event(event: Event, request: Request) -> str | None:
+    """Build a public URL for the event's banner image, or None if not set."""
+    if not event.banner_filename:
+        return None
+    base = str(request.base_url).rstrip("/")
+    if request.headers.get("x-forwarded-proto") == "https" and base.startswith("http://"):
+        base = "https://" + base[len("http://") :]
+    return f"{base}/uploads/{event.banner_filename}"
+
+
+def _banner_colors_for_event(event: Event) -> list[str] | None:
+    """Parse the stored JSON-encoded banner_colors string into a list, or None."""
+    if not event.banner_colors:
+        return None
+    import json as _json
+
+    try:
+        value = _json.loads(event.banner_colors)
+        if isinstance(value, list) and all(isinstance(c, str) for c in value):
+            return value
+    except (_json.JSONDecodeError, TypeError):
+        pass
+    return None
+
+
 @router.get("/{code}", response_model=CollectEventPreview)
 @limiter.limit("120/minute")
 def preview(code: str, request: Request, db: Session = Depends(get_db)):
@@ -47,6 +72,8 @@ def preview(code: str, request: Request, db: Session = Depends(get_db)):
         code=event.code,
         name=event.name,
         banner_filename=event.banner_filename,
+        banner_url=_banner_url_for_event(event, request),
+        banner_colors=_banner_colors_for_event(event),
         submission_cap_per_guest=event.submission_cap_per_guest,
         registration_enabled=settings.registration_enabled,
         phase=event.phase,

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -166,10 +166,16 @@ def my_picks(code: str, request: Request, db: Session = Depends(get_db)):
         .all()
     )
 
-    upvoted_request_ids = [
-        rv.request_id
-        for rv in db.query(RequestVote).filter(RequestVote.client_fingerprint == fingerprint).all()
-    ]
+    # All request_ids this fingerprint has voted on (scoped to this event below).
+    # Used both for the `upvoted` section AND the full `voted_request_ids` list.
+    voted_rows = (
+        db.query(RequestVote.request_id)
+        .join(SongRequest, SongRequest.id == RequestVote.request_id)
+        .filter(RequestVote.client_fingerprint == fingerprint)
+        .filter(SongRequest.event_id == event.id)
+        .all()
+    )
+    upvoted_request_ids = [row[0] for row in voted_rows]
     upvoted: list[SongRequest] = []
     if upvoted_request_ids:
         upvoted = (
@@ -233,6 +239,7 @@ def my_picks(code: str, request: Request, db: Session = Depends(get_db)):
         upvoted=[_to_row(r, "upvoted") for r in upvoted if r.id not in submitted_ids],
         is_top_contributor=is_top,
         first_suggestion_ids=first_suggestion_ids,
+        voted_request_ids=upvoted_request_ids,
     )
 
 

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -127,6 +127,32 @@ def leaderboard(
     )
 
 
+@router.get("/{code}/profile", response_model=CollectProfileResponse)
+@limiter.limit("60/minute")
+def get_profile(code: str, request: Request, db: Session = Depends(get_db)):
+    """Read the calling fingerprint's profile for this event. Does NOT
+    create a row if none exists — returns defaults instead. Separate from
+    POST /profile so reads and writes have different action tags in the
+    fingerprint log.
+    """
+    event = _get_event_or_404(db, code)
+    fingerprint = get_client_fingerprint(request, action="collect.get_profile", event_code=code)
+    profile = collect_service.get_profile(db, event_id=event.id, fingerprint=fingerprint)
+    if profile is None:
+        return CollectProfileResponse(
+            nickname=None,
+            has_email=False,
+            submission_count=0,
+            submission_cap=event.submission_cap_per_guest,
+        )
+    return CollectProfileResponse(
+        nickname=profile.nickname,
+        has_email=profile.email is not None,
+        submission_count=profile.submission_count,
+        submission_cap=event.submission_cap_per_guest,
+    )
+
+
 @router.post("/{code}/profile", response_model=CollectProfileResponse)
 @limiter.limit("5/minute")
 def set_profile(

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -1,5 +1,6 @@
 """Public API endpoints for pre-event song collection (no authentication required)."""
 
+import hashlib
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -10,6 +11,7 @@ from app.api.deps import get_db
 from app.core.rate_limit import get_client_fingerprint, limiter
 from app.models.event import Event
 from app.models.request import Request as SongRequest
+from app.models.request import RequestStatus
 from app.models.request_vote import RequestVote
 from app.schemas.collect import (
     CollectEventPreview,
@@ -19,9 +21,12 @@ from app.schemas.collect import (
     CollectMyPicksResponse,
     CollectProfileRequest,
     CollectProfileResponse,
+    CollectSubmitRequest,
+    CollectVoteRequest,
 )
 from app.services import collect as collect_service
 from app.services.system_settings import get_system_settings
+from app.services.vote import add_vote
 
 router = APIRouter()
 
@@ -200,3 +205,80 @@ def my_picks(code: str, request: Request, db: Session = Depends(get_db)):
         is_top_contributor=is_top,
         first_suggestion_ids=first_suggestion_ids,
     )
+
+
+def _compute_dedupe_key(song_title: str, artist: str) -> str:
+    raw = f"{song_title.strip().lower()}|{artist.strip().lower()}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:64]
+
+
+@router.post("/{code}/requests", status_code=201)
+@limiter.limit("10/minute")
+def submit(
+    code: str,
+    payload: CollectSubmitRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    event = _get_event_or_404(db, code)
+    if event.phase != "collection":
+        raise HTTPException(status_code=409, detail="Collection has ended")
+
+    fingerprint = get_client_fingerprint(request)
+    try:
+        collect_service.check_and_increment_submission_count(
+            db, event=event, fingerprint=fingerprint
+        )
+    except collect_service.SubmissionCapExceeded:
+        raise HTTPException(status_code=429, detail="Picks limit reached") from None
+
+    if payload.nickname:
+        collect_service.upsert_profile(
+            db,
+            event_id=event.id,
+            fingerprint=fingerprint,
+            nickname=payload.nickname,
+        )
+
+    row = SongRequest(
+        event_id=event.id,
+        song_title=payload.song_title,
+        artist=payload.artist,
+        source=payload.source,
+        source_url=payload.source_url,
+        artwork_url=payload.artwork_url,
+        note=payload.note,
+        nickname=payload.nickname,
+        status=RequestStatus.NEW.value,
+        dedupe_key=_compute_dedupe_key(payload.song_title, payload.artist),
+        client_fingerprint=fingerprint,
+        submitted_during_collection=True,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return {"id": row.id}
+
+
+@router.post("/{code}/vote")
+@limiter.limit("60/minute")
+def vote(
+    code: str,
+    payload: CollectVoteRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    event = _get_event_or_404(db, code)
+    if event.phase not in ("collection", "live"):
+        raise HTTPException(status_code=409, detail="Voting is closed")
+    fingerprint = get_client_fingerprint(request)
+    row = (
+        db.query(SongRequest)
+        .filter(SongRequest.id == payload.request_id)
+        .filter(SongRequest.event_id == event.id)
+        .one_or_none()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Request not found")
+    add_vote(db, request_id=row.id, client_fingerprint=fingerprint)
+    return {"ok": True}

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -8,7 +8,7 @@ from sqlalchemy import desc, func
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
-from app.core.rate_limit import get_client_fingerprint, limiter
+from app.core.rate_limit import get_client_fingerprint, limiter, mask_fingerprint
 from app.models.event import Event
 from app.models.request import Request as SongRequest
 from app.models.request import RequestStatus
@@ -25,6 +25,7 @@ from app.schemas.collect import (
     CollectVoteRequest,
 )
 from app.services import collect as collect_service
+from app.services.activity_log import log_activity
 from app.services.system_settings import get_system_settings
 from app.services.vote import add_vote
 
@@ -135,7 +136,7 @@ def set_profile(
     db: Session = Depends(get_db),
 ):
     event = _get_event_or_404(db, code)
-    fingerprint = get_client_fingerprint(request)
+    fingerprint = get_client_fingerprint(request, action="collect.set_profile", event_code=code)
     profile = collect_service.upsert_profile(
         db,
         event_id=event.id,
@@ -143,6 +144,19 @@ def set_profile(
         nickname=payload.nickname,
         email=payload.email,
     )
+    if payload.nickname is not None or payload.email is not None:
+        _parts = []
+        if payload.nickname is not None:
+            _parts.append("nickname")
+        if payload.email is not None:
+            _parts.append("email")
+        log_activity(
+            db,
+            level="info",
+            source="collect",
+            message=f"Guest [{mask_fingerprint(fingerprint)}] updated profile: {', '.join(_parts)}",
+            event_code=code,
+        )
     return CollectProfileResponse(
         nickname=profile.nickname,
         has_email=profile.email is not None,
@@ -155,7 +169,7 @@ def set_profile(
 @limiter.limit("60/minute")
 def my_picks(code: str, request: Request, db: Session = Depends(get_db)):
     event = _get_event_or_404(db, code)
-    fingerprint = get_client_fingerprint(request)
+    fingerprint = get_client_fingerprint(request, action="collect.my_picks", event_code=code)
 
     submitted = (
         db.query(SongRequest)
@@ -260,7 +274,7 @@ def submit(
     if event.phase != "collection":
         raise HTTPException(status_code=409, detail="Collection has ended")
 
-    fingerprint = get_client_fingerprint(request)
+    fingerprint = get_client_fingerprint(request, action="collect.submit", event_code=code)
     try:
         collect_service.check_and_increment_submission_count(
             db, event=event, fingerprint=fingerprint
@@ -293,6 +307,16 @@ def submit(
     db.add(row)
     db.commit()
     db.refresh(row)
+    log_activity(
+        db,
+        level="info",
+        source="collect",
+        message=(
+            f"Guest [{mask_fingerprint(fingerprint)}] submitted "
+            f"'{row.song_title}' by {row.artist} (req #{row.id})"
+        ),
+        event_code=code,
+    )
     return {"id": row.id}
 
 
@@ -307,7 +331,7 @@ def vote(
     event = _get_event_or_404(db, code)
     if event.phase not in ("collection", "live"):
         raise HTTPException(status_code=409, detail="Voting is closed")
-    fingerprint = get_client_fingerprint(request)
+    fingerprint = get_client_fingerprint(request, action="collect.vote", event_code=code)
     row = (
         db.query(SongRequest)
         .filter(SongRequest.id == payload.request_id)
@@ -316,5 +340,16 @@ def vote(
     )
     if row is None:
         raise HTTPException(status_code=404, detail="Request not found")
-    add_vote(db, request_id=row.id, client_fingerprint=fingerprint)
+    _, is_new_vote = add_vote(db, request_id=row.id, client_fingerprint=fingerprint)
+    if is_new_vote:
+        log_activity(
+            db,
+            level="info",
+            source="collect",
+            message=(
+                f"Guest [{mask_fingerprint(fingerprint)}] voted on "
+                f"'{row.song_title}' (req #{row.id})"
+            ),
+            event_code=code,
+        )
     return {"ok": True}

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -103,7 +103,9 @@ def leaderboard(
             SongRequest.vote_count.desc(), SongRequest.created_at.desc()
         )
     else:
-        q = q.order_by(SongRequest.created_at.desc())
+        # "All" is the discovery view — alphabetical makes it easy to scan
+        # and upvote existing submissions rather than recency bias.
+        q = q.order_by(func.lower(SongRequest.song_title).asc())
 
     rows = q.limit(200).all()
     return CollectLeaderboardResponse(

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -1,5 +1,5 @@
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Literal
 from urllib.parse import quote
 
@@ -1043,8 +1043,12 @@ def update_collection_settings(
         raise HTTPException(
             status_code=400, detail="collection_opens_at must be before live_starts_at"
         )
+    # Auto-extend expires_at when the user schedules a live phase that runs past
+    # the default event expiry. The default is just 6h — anyone scheduling a
+    # multi-day collection clearly intends the event to live through it.
+    # Give the live phase a 12h default duration on top of live_starts_at.
     if live and expires and live >= expires:
-        raise HTTPException(status_code=400, detail="live_starts_at must be before expires_at")
+        event.expires_at = live + timedelta(hours=12)
 
     db.commit()
     db.refresh(event)

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -21,10 +21,15 @@ from app.api.deps import get_current_active_user, get_db, get_owned_event
 from app.core.config import get_settings
 from app.core.rate_limit import get_client_fingerprint, limiter
 from app.models.event import Event
+from app.models.request import Request as SongRequest
 from app.models.request import RequestStatus
 from app.models.user import User
 from app.schemas.activity_log import ActivityLogEntry
-from app.schemas.collect import UpdateCollectionSettings
+from app.schemas.collect import (
+    PendingReviewResponse,
+    PendingReviewRow,
+    UpdateCollectionSettings,
+)
 from app.schemas.common import AcceptAllResponse, BulkActionResponse
 from app.schemas.event import (
     BulkDeleteEventsRequest,
@@ -1013,6 +1018,47 @@ def update_collection_settings(
         "collection_phase_override": event.collection_phase_override,
         "phase": event.phase,
     }
+
+
+@router.get("/{code}/pending-review", response_model=PendingReviewResponse)
+def pending_review(
+    code: str,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_active_user),
+):
+    """Get pending review data source for DJ bulk-review."""
+    event = db.query(Event).filter(Event.code == code).one_or_none()
+    if event is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+    if event.created_by_user_id != user.id and user.role != "admin":
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    rows = (
+        db.query(SongRequest)
+        .filter(SongRequest.event_id == event.id)
+        .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
+        .filter(SongRequest.status == "new")
+        .order_by(SongRequest.vote_count.desc(), SongRequest.created_at.asc())
+        .limit(200)
+        .all()
+    )
+    return PendingReviewResponse(
+        requests=[
+            PendingReviewRow(
+                id=r.id,
+                song_title=r.song_title,
+                artist=r.artist,
+                artwork_url=r.artwork_url,
+                vote_count=r.vote_count,
+                nickname=r.nickname,
+                created_at=r.created_at,
+                note=r.note,
+                status=r.status,
+            )
+            for r in rows
+        ],
+        total=len(rows),
+    )
 
 
 @router.delete("/{code}/banner", response_model=EventOut)

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -24,6 +24,7 @@ from app.models.event import Event
 from app.models.request import RequestStatus
 from app.models.user import User
 from app.schemas.activity_log import ActivityLogEntry
+from app.schemas.collect import UpdateCollectionSettings
 from app.schemas.common import AcceptAllResponse, BulkActionResponse
 from app.schemas.event import (
     BulkDeleteEventsRequest,
@@ -967,6 +968,51 @@ def upload_banner(
     save_banner_to_event(db, event, banner_filename, colors)
 
     return _event_to_out(event, request)
+
+
+@router.patch("/{code}/collection")
+def update_collection_settings(
+    code: str,
+    payload: UpdateCollectionSettings,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_active_user),
+) -> dict:
+    """Update pre-event collection scheduling settings."""
+    event = db.query(Event).filter(Event.code == code).one_or_none()
+    if event is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+    if event.created_by_user_id != user.id and user.role != "admin":
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    if payload.collection_opens_at is not None:
+        event.collection_opens_at = payload.collection_opens_at
+    if payload.live_starts_at is not None:
+        event.live_starts_at = payload.live_starts_at
+    if payload.submission_cap_per_guest is not None:
+        event.submission_cap_per_guest = payload.submission_cap_per_guest
+    if "collection_phase_override" in payload.model_fields_set:
+        event.collection_phase_override = payload.collection_phase_override
+
+    # Validate ordering after applying changes
+    opens = event.collection_opens_at
+    live = event.live_starts_at
+    expires = event.expires_at
+    if opens and live and opens >= live:
+        raise HTTPException(
+            status_code=400, detail="collection_opens_at must be before live_starts_at"
+        )
+    if live and expires and live >= expires:
+        raise HTTPException(status_code=400, detail="live_starts_at must be before expires_at")
+
+    db.commit()
+    db.refresh(event)
+    return {
+        "collection_opens_at": event.collection_opens_at,
+        "live_starts_at": event.live_starts_at,
+        "submission_cap_per_guest": event.submission_cap_per_guest,
+        "collection_phase_override": event.collection_phase_override,
+        "phase": event.phase,
+    }
 
 
 @router.delete("/{code}/banner", response_model=EventOut)

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -977,6 +977,27 @@ def upload_banner(
     return _event_to_out(event, request)
 
 
+@router.get("/{code}/collection")
+def get_collection_settings(
+    code: str,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_active_user),
+) -> dict:
+    """Get pre-event collection scheduling settings."""
+    event = db.query(Event).filter(Event.code == code).one_or_none()
+    if event is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+    if event.created_by_user_id != user.id and user.role != "admin":
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return {
+        "collection_opens_at": event.collection_opens_at,
+        "live_starts_at": event.live_starts_at,
+        "submission_cap_per_guest": event.submission_cap_per_guest,
+        "collection_phase_override": event.collection_phase_override,
+        "phase": event.phase,
+    }
+
+
 @router.patch("/{code}/collection")
 def update_collection_settings(
     code: str,

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -259,6 +259,10 @@ def _event_to_out(
         banner_kiosk_url=banner_kiosk_url,
         banner_colors=banner_colors,
         requests_open=event.requests_open,
+        collection_opens_at=event.collection_opens_at,
+        live_starts_at=event.live_starts_at,
+        submission_cap_per_guest=event.submission_cap_per_guest,
+        collection_phase_override=event.collection_phase_override,
     )
 
 

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -26,6 +26,8 @@ from app.models.request import RequestStatus
 from app.models.user import User
 from app.schemas.activity_log import ActivityLogEntry
 from app.schemas.collect import (
+    BulkReviewRequest,
+    BulkReviewResponse,
     PendingReviewResponse,
     PendingReviewRow,
     UpdateCollectionSettings,
@@ -1059,6 +1061,71 @@ def pending_review(
         ],
         total=len(rows),
     )
+
+
+@router.post("/{code}/bulk-review", response_model=BulkReviewResponse)
+def bulk_review(
+    code: str,
+    payload: BulkReviewRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_active_user),
+):
+    event = db.query(Event).filter(Event.code == code).one_or_none()
+    if event is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+    if event.created_by_user_id != user.id and user.role != "admin":
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    pending_q = (
+        db.query(SongRequest)
+        .filter(SongRequest.event_id == event.id)
+        .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
+        .filter(SongRequest.status == "new")
+    )
+
+    accepted = 0
+    rejected = 0
+
+    if payload.action == "accept_top_n":
+        if payload.n is None:
+            raise HTTPException(status_code=400, detail="n is required")
+        rows = (
+            pending_q.order_by(SongRequest.vote_count.desc(), SongRequest.created_at.asc())
+            .limit(payload.n)
+            .all()
+        )
+        for r in rows:
+            r.status = "accepted"
+            accepted += 1
+    elif payload.action == "accept_threshold":
+        if payload.min_votes is None:
+            raise HTTPException(status_code=400, detail="min_votes is required")
+        rows = pending_q.filter(SongRequest.vote_count >= payload.min_votes).all()
+        for r in rows:
+            r.status = "accepted"
+            accepted += 1
+    elif payload.action == "accept_ids":
+        if not payload.request_ids:
+            raise HTTPException(status_code=400, detail="request_ids is required")
+        rows = pending_q.filter(SongRequest.id.in_(payload.request_ids)).all()
+        for r in rows:
+            r.status = "accepted"
+            accepted += 1
+    elif payload.action == "reject_ids":
+        if not payload.request_ids:
+            raise HTTPException(status_code=400, detail="request_ids is required")
+        rows = pending_q.filter(SongRequest.id.in_(payload.request_ids)).all()
+        for r in rows:
+            r.status = "rejected"
+            rejected += 1
+    elif payload.action == "reject_remaining":
+        rows = pending_q.all()
+        for r in rows:
+            r.status = "rejected"
+            rejected += 1
+
+    db.commit()
+    return BulkReviewResponse(accepted=accepted, rejected=rejected, unchanged=0)
 
 
 @router.delete("/{code}/banner", response_model=EventOut)

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Literal
 from urllib.parse import quote
 
@@ -87,6 +87,20 @@ from app.services.sync.orchestrator import enrich_request_metadata, sync_request
 from app.services.sync.registry import get_connected_adapters
 
 router = APIRouter()
+
+
+def _to_naive_utc(dt: datetime) -> datetime:
+    """Normalize an incoming datetime to naive UTC (matches the project's stored convention).
+
+    Frontend sends ISO strings with timezone (`Z` suffix), which Pydantic parses as
+    aware datetimes. The DB columns are naive; comparing aware to naive raises
+    TypeError. Strip tz to UTC-naive for storage.
+    """
+    if dt.tzinfo is None:
+        return dt
+    return dt.astimezone(UTC).replace(tzinfo=None)
+
+
 settings = get_settings()
 
 # FIXME: per-process cache — value drifts in multi-worker deployments until next request
@@ -1013,9 +1027,9 @@ def update_collection_settings(
         raise HTTPException(status_code=403, detail="Forbidden")
 
     if payload.collection_opens_at is not None:
-        event.collection_opens_at = payload.collection_opens_at
+        event.collection_opens_at = _to_naive_utc(payload.collection_opens_at)
     if payload.live_starts_at is not None:
-        event.live_starts_at = payload.live_starts_at
+        event.live_starts_at = _to_naive_utc(payload.live_starts_at)
     if payload.submission_cap_per_guest is not None:
         event.submission_cap_per_guest = payload.submission_cap_per_guest
     if "collection_phase_override" in payload.model_fields_set:

--- a/server/app/core/rate_limit.py
+++ b/server/app/core/rate_limit.py
@@ -1,6 +1,7 @@
 """Rate limiting middleware using slowapi."""
 
 import ipaddress
+import logging
 from functools import lru_cache
 
 from fastapi import Request, Response
@@ -72,10 +73,56 @@ def get_client_ip(request: Request) -> str:
 
 MAX_FINGERPRINT_LENGTH = 64
 
+_fp_logger = logging.getLogger("app.fingerprint")
 
-def get_client_fingerprint(request: Request) -> str:
-    """Extract client fingerprint (IP) from the request, truncated to safe length."""
-    return get_client_ip(request)[:MAX_FINGERPRINT_LENGTH]
+
+def mask_fingerprint(fp: str) -> str:
+    """Return a short, non-reversible tag for a fingerprint — safe for logs
+    and activity-log messages.
+
+    SHA-256 truncated to 12 hex chars: enough to correlate actions by the
+    same guest across events in logs, but not enough to recover the original
+    IP. The raw value stays in the DB for legitimate abuse investigation.
+    """
+    import hashlib
+
+    return hashlib.sha256(fp.encode("utf-8")).hexdigest()[:12]
+
+
+def _fp_source(request: Request) -> str:
+    """Identify which header/layer supplied the fingerprint for this request."""
+    direct_ip = get_remote_address(request)
+    if request.headers.get("X-Real-IP") and _is_trusted_proxy(direct_ip):
+        return "x-real-ip"
+    if request.headers.get("X-Forwarded-For") and _is_trusted_proxy(direct_ip):
+        return "x-forwarded-for"
+    return "direct"
+
+
+def get_client_fingerprint(
+    request: Request,
+    *,
+    action: str | None = None,
+    event_code: str | None = None,
+) -> str:
+    """Extract client fingerprint (IP) from the request, truncated to safe length.
+
+    When `action` is provided, emits a structured INFO log line:
+        action=collect.vote event=PB5TTP source=x-real-ip fp=a1b2c3d4e5f6
+
+    The logged `fp` is a hashed tag — the raw IP stays in the DB for
+    legitimate abuse investigation but never appears in log output.
+    """
+    raw = get_client_ip(request)[:MAX_FINGERPRINT_LENGTH]
+    if action is not None:
+        _fp_logger.info(
+            "fp_resolve action=%s event=%s source=%s fp=%s",
+            action,
+            event_code or "-",
+            _fp_source(request),
+            mask_fingerprint(raw),
+        )
+    return raw
 
 
 # Create limiter instance with IP-based key function

--- a/server/app/models/__init__.py
+++ b/server/app/models/__init__.py
@@ -1,6 +1,7 @@
 from app.models.activity_log import ActivityLog
 from app.models.base import Base
 from app.models.event import Event
+from app.models.guest_profile import GuestProfile  # noqa: F401
 from app.models.kiosk import Kiosk
 from app.models.mb_artist_cache import MbArtistCache
 from app.models.now_playing import NowPlaying
@@ -14,14 +15,15 @@ from app.models.user import User
 __all__ = [
     "ActivityLog",
     "Base",
-    "User",
     "Event",
+    "GuestProfile",
     "Kiosk",
+    "MbArtistCache",
+    "NowPlaying",
+    "PlayHistory",
     "Request",
     "RequestVote",
     "SearchCache",
-    "NowPlaying",
-    "PlayHistory",
     "SystemSettings",
-    "MbArtistCache",
+    "User",
 ]

--- a/server/app/models/event.py
+++ b/server/app/models/event.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Literal
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -44,8 +45,31 @@ class Event(Base):
     banner_filename: Mapped[str | None] = mapped_column(String(255), nullable=True)
     banner_colors: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # Pre-event collection
+    collection_opens_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    live_starts_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    submission_cap_per_guest: Mapped[int] = mapped_column(
+        Integer, default=15, nullable=False, server_default="15"
+    )
+    collection_phase_override: Mapped[str | None] = mapped_column(String(20), nullable=True)
+
     created_by: Mapped["User"] = relationship("User", back_populates="events")
     requests: Mapped[list["Request"]] = relationship(
         "Request", back_populates="event", foreign_keys="Request.event_id"
     )
     play_history: Mapped[list["PlayHistory"]] = relationship("PlayHistory", back_populates="event")
+
+    @property
+    def phase(self) -> Literal["pre_announce", "collection", "live", "closed"]:
+        if self.collection_phase_override == "force_live":
+            return "live"
+        if self.collection_phase_override == "force_collection":
+            return "collection"
+        now = utcnow()
+        if self.collection_opens_at and now < self.collection_opens_at:
+            return "pre_announce"
+        if self.live_starts_at and now < self.live_starts_at:
+            return "collection"
+        if now < self.expires_at:
+            return "live"
+        return "closed"

--- a/server/app/models/event.py
+++ b/server/app/models/event.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Literal
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text
@@ -6,6 +6,18 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.time import utcnow
 from app.models.base import Base
+
+
+def _strip_tz(dt: datetime | None) -> datetime | None:
+    """Return a naive UTC datetime so comparisons with utcnow() never raise.
+
+    Project stores naive UTC. Defends against an in-memory aware datetime
+    that hasn't yet been round-tripped through the DB (Pydantic parses
+    ISO-with-Z as aware).
+    """
+    if dt is None or dt.tzinfo is None:
+        return dt
+    return dt.astimezone(UTC).replace(tzinfo=None)
 
 
 class Event(Base):
@@ -66,10 +78,13 @@ class Event(Base):
         if self.collection_phase_override == "force_collection":
             return "collection"
         now = utcnow()
-        if self.collection_opens_at and now < self.collection_opens_at:
+        opens = _strip_tz(self.collection_opens_at)
+        live = _strip_tz(self.live_starts_at)
+        expires = _strip_tz(self.expires_at)
+        if opens and now < opens:
             return "pre_announce"
-        if self.live_starts_at and now < self.live_starts_at:
+        if live and now < live:
             return "collection"
-        if now < self.expires_at:
+        if now < expires:
             return "live"
         return "closed"

--- a/server/app/models/guest_profile.py
+++ b/server/app/models/guest_profile.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.encryption import EncryptedText
+from app.core.time import utcnow
+from app.models.base import Base
+
+
+class GuestProfile(Base):
+    __tablename__ = "guest_profiles"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
+    client_fingerprint: Mapped[str] = mapped_column(String(64), index=True)
+    nickname: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    email: Mapped[str | None] = mapped_column(EncryptedText, nullable=True)
+    submission_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "event_id",
+            "client_fingerprint",
+            name="uq_guest_profile_event_fingerprint",
+        ),
+    )

--- a/server/app/models/request.py
+++ b/server/app/models/request.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from enum import Enum
 
-from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.time import utcnow
@@ -61,6 +61,11 @@ class Request(Base):
 
     # Voting
     vote_count: Mapped[int] = mapped_column(Integer, default=0)
+
+    # Pre-event collection flag — set on insert when event.phase == "collection"
+    submitted_during_collection: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="0", index=True
+    )
 
     event: Mapped["Event"] = relationship(
         "Event", back_populates="requests", foreign_keys=[event_id]

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -28,6 +28,8 @@ class CollectEventPreview(BaseModel):
     code: str
     name: str
     banner_filename: str | None
+    banner_url: str | None = None
+    banner_colors: list[str] | None = None
     submission_cap_per_guest: int
     registration_enabled: bool
     phase: Literal["pre_announce", "collection", "live", "closed"]

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -75,6 +75,11 @@ class CollectMyPicksResponse(BaseModel):
     upvoted: list[CollectMyPicksItem]
     is_top_contributor: bool
     first_suggestion_ids: list[int]
+    # Every request_id this guest has voted on in this event, including votes
+    # on their own submissions. Separate from `upvoted` (which is de-duped
+    # against `submitted` for display purposes) so the UI can gate the vote
+    # button accurately.
+    voted_request_ids: list[int]
 
 
 class CollectSubmitRequest(BaseModel):

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -1,0 +1,138 @@
+"""Pydantic schemas for pre-event collection endpoints."""
+
+from datetime import datetime
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, EmailStr, Field, StringConstraints
+
+Nickname = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=1,
+        max_length=30,
+        pattern=r"^[a-zA-Z0-9 _.-]+$",
+    ),
+]
+Note = Annotated[str, StringConstraints(strip_whitespace=True, max_length=500)]
+
+
+class CollectPhase(BaseModel):
+    phase: Literal["pre_announce", "collection", "live", "closed"]
+    collection_opens_at: datetime | None
+    live_starts_at: datetime | None
+    expires_at: datetime
+
+
+class CollectEventPreview(BaseModel):
+    code: str
+    name: str
+    banner_filename: str | None
+    submission_cap_per_guest: int
+    registration_enabled: bool
+    phase: Literal["pre_announce", "collection", "live", "closed"]
+    collection_opens_at: datetime | None
+    live_starts_at: datetime | None
+    expires_at: datetime
+
+
+class CollectLeaderboardRow(BaseModel):
+    id: int
+    title: str
+    artist: str
+    artwork_url: str | None
+    vote_count: int
+    nickname: str | None
+    status: Literal["new", "accepted", "playing", "played", "rejected"]
+    created_at: datetime
+
+
+class CollectLeaderboardResponse(BaseModel):
+    requests: list[CollectLeaderboardRow]
+    total: int
+
+
+class CollectProfileRequest(BaseModel):
+    nickname: Nickname | None = None
+    email: EmailStr | None = None
+
+
+class CollectProfileResponse(BaseModel):
+    nickname: str | None
+    has_email: bool
+    submission_count: int
+    submission_cap: int
+
+
+class CollectMyPicksItem(CollectLeaderboardRow):
+    interaction: Literal["submitted", "upvoted"]
+
+
+class CollectMyPicksResponse(BaseModel):
+    submitted: list[CollectMyPicksItem]
+    upvoted: list[CollectMyPicksItem]
+    is_top_contributor: bool
+    first_suggestion_ids: list[int]
+
+
+class CollectSubmitRequest(BaseModel):
+    song_title: Annotated[
+        str,
+        StringConstraints(strip_whitespace=True, min_length=1, max_length=255),
+    ]
+    artist: Annotated[
+        str,
+        StringConstraints(strip_whitespace=True, min_length=1, max_length=255),
+    ]
+    source: Literal["spotify", "beatport", "tidal", "manual"]
+    source_url: str | None = Field(default=None, max_length=500)
+    artwork_url: str | None = Field(default=None, max_length=500)
+    note: Note | None = None
+    nickname: Nickname | None = None
+
+
+class CollectVoteRequest(BaseModel):
+    request_id: int
+
+
+class UpdateCollectionSettings(BaseModel):
+    collection_opens_at: datetime | None = None
+    live_starts_at: datetime | None = None
+    submission_cap_per_guest: int | None = Field(default=None, ge=0, le=100)
+    collection_phase_override: Literal["force_collection", "force_live"] | None = None
+
+
+class PendingReviewRow(BaseModel):
+    id: int
+    song_title: str
+    artist: str
+    artwork_url: str | None
+    vote_count: int
+    nickname: str | None
+    created_at: datetime
+    note: str | None
+    status: Literal["new", "accepted", "playing", "played", "rejected"]
+
+
+class PendingReviewResponse(BaseModel):
+    requests: list[PendingReviewRow]
+    total: int
+
+
+class BulkReviewRequest(BaseModel):
+    action: Literal[
+        "accept_top_n",
+        "accept_threshold",
+        "accept_ids",
+        "reject_ids",
+        "reject_remaining",
+    ]
+    n: int | None = Field(default=None, ge=1, le=200)
+    min_votes: int | None = Field(default=None, ge=0)
+    request_ids: list[int] | None = Field(default=None, max_length=200)
+
+
+class BulkReviewResponse(BaseModel):
+    accepted: int
+    rejected: int
+    unchanged: int

--- a/server/app/schemas/event.py
+++ b/server/app/schemas/event.py
@@ -73,6 +73,11 @@ class EventOut(BaseModel):
     banner_colors: list[str] | None = None
     # Requests open/closed
     requests_open: bool = True
+    # Pre-event collection
+    collection_opens_at: datetime | None = None
+    live_starts_at: datetime | None = None
+    submission_cap_per_guest: int = 15
+    collection_phase_override: str | None = None
 
     class Config:
         from_attributes = True
@@ -81,7 +86,7 @@ class EventOut(BaseModel):
     def serialize_datetime(self, dt: datetime) -> str:
         return dt.isoformat() + "Z"
 
-    @field_serializer("archived_at")
+    @field_serializer("archived_at", "collection_opens_at", "live_starts_at")
     def serialize_datetime_optional(self, dt: datetime | None) -> str | None:
         if dt is None:
             return None

--- a/server/app/services/collect.py
+++ b/server/app/services/collect.py
@@ -1,0 +1,76 @@
+"""Service layer for pre-event collection."""
+
+from sqlalchemy.orm import Session
+
+from app.models.event import Event
+from app.models.guest_profile import GuestProfile
+
+
+class SubmissionCapExceeded(Exception):
+    """Raised when a guest has hit their per-event submission cap."""
+
+
+def get_profile(db: Session, *, event_id: int, fingerprint: str) -> GuestProfile | None:
+    return (
+        db.query(GuestProfile)
+        .filter(
+            GuestProfile.event_id == event_id,
+            GuestProfile.client_fingerprint == fingerprint,
+        )
+        .one_or_none()
+    )
+
+
+def upsert_profile(
+    db: Session,
+    *,
+    event_id: int,
+    fingerprint: str,
+    nickname: str | None = None,
+    email: str | None = None,
+) -> GuestProfile:
+    profile = get_profile(db, event_id=event_id, fingerprint=fingerprint)
+    if profile is None:
+        profile = GuestProfile(
+            event_id=event_id,
+            client_fingerprint=fingerprint,
+            nickname=nickname,
+            email=email,
+        )
+        db.add(profile)
+    else:
+        if nickname is not None:
+            profile.nickname = nickname
+        if email is not None:
+            profile.email = email
+    db.commit()
+    db.refresh(profile)
+    return profile
+
+
+def check_and_increment_submission_count(
+    db: Session, *, event: Event, fingerprint: str
+) -> GuestProfile:
+    """Atomically enforce the per-guest cap, incrementing submission_count on success.
+
+    Raises SubmissionCapExceeded when the cap would be exceeded. cap == 0 means
+    unlimited (explicit by design).
+    """
+    profile = get_profile(db, event_id=event.id, fingerprint=fingerprint)
+    if profile is None:
+        profile = GuestProfile(
+            event_id=event.id,
+            client_fingerprint=fingerprint,
+        )
+        db.add(profile)
+        db.flush()
+
+    cap = event.submission_cap_per_guest
+    if cap != 0 and profile.submission_count >= cap:
+        db.rollback()
+        raise SubmissionCapExceeded()
+
+    profile.submission_count += 1
+    db.commit()
+    db.refresh(profile)
+    return profile

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -151,6 +151,31 @@ def test_event(db: Session, test_user: User) -> Event:
 
 
 @pytest.fixture
+def collection_requests(db: Session, test_event: Event) -> list[Request]:
+    """Creates 3 collection-submitted NEW requests with vote counts 5, 2, 0."""
+    now = utcnow()
+    rows = []
+    for i, votes in enumerate([5, 2, 0]):
+        r = Request(
+            event_id=test_event.id,
+            song_title=f"Song {i}",
+            artist=f"Artist {i}",
+            source="spotify",
+            status=RequestStatus.NEW.value,
+            vote_count=votes,
+            dedupe_key=f"dk_{i}",
+            submitted_during_collection=True,
+            created_at=now,
+        )
+        db.add(r)
+        rows.append(r)
+    db.commit()
+    for r in rows:
+        db.refresh(r)
+    return rows
+
+
+@pytest.fixture
 def test_request(db: Session, test_event: Event) -> Request:
     """Create a test song request."""
     request = Request(

--- a/server/tests/test_api_contracts.py
+++ b/server/tests/test_api_contracts.py
@@ -56,6 +56,10 @@ EVENT_OUT_KEYS = {
     "banner_kiosk_url",
     "banner_colors",
     "requests_open",
+    "collection_opens_at",
+    "live_starts_at",
+    "submission_cap_per_guest",
+    "collection_phase_override",
 }
 
 REQUEST_OUT_KEYS = {

--- a/server/tests/test_collect_dj.py
+++ b/server/tests/test_collect_dj.py
@@ -179,3 +179,42 @@ def test_bulk_review_bad_action(client, auth_headers, test_event):
         headers=auth_headers,
     )
     assert r.status_code == 422
+
+
+def test_get_collection_returns_settings(client, db, auth_headers, test_event):
+    now = utcnow()
+    test_event.collection_opens_at = now - timedelta(hours=1)
+    test_event.live_starts_at = now + timedelta(hours=3)
+    test_event.submission_cap_per_guest = 10
+    db.commit()
+
+    r = client.get(
+        f"/api/events/{test_event.code}/collection",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["submission_cap_per_guest"] == 10
+    assert body["phase"] in ("pre_announce", "collection", "live", "closed")
+    assert body["collection_opens_at"] is not None
+
+
+def test_get_collection_requires_ownership(client, db, test_event):
+    from app.models.user import User
+    from app.services.auth import create_access_token
+
+    other = User(username="otherdj_get", password_hash="x", role="dj")
+    db.add(other)
+    db.commit()
+    db.refresh(other)
+    token = create_access_token(data={"sub": other.username, "tv": other.token_version})
+    r = client.get(
+        f"/api/events/{test_event.code}/collection",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 403
+
+
+def test_get_collection_404_for_unknown(client, auth_headers):
+    r = client.get("/api/events/ZZZZZZ/collection", headers=auth_headers)
+    assert r.status_code == 404

--- a/server/tests/test_collect_dj.py
+++ b/server/tests/test_collect_dj.py
@@ -1,0 +1,73 @@
+from datetime import timedelta
+
+from app.core.time import utcnow
+
+
+def test_patch_collection_sets_dates(client, db, auth_headers, test_event):
+    now = utcnow()
+    payload = {
+        "collection_opens_at": (now + timedelta(hours=1)).isoformat(),
+        "live_starts_at": (now + timedelta(hours=3)).isoformat(),
+        "submission_cap_per_guest": 10,
+    }
+    r = client.patch(
+        f"/api/events/{test_event.code}/collection",
+        json=payload,
+        headers=auth_headers,
+    )
+    assert r.status_code == 200, r.text
+    db.refresh(test_event)
+    assert test_event.submission_cap_per_guest == 10
+    assert test_event.collection_opens_at is not None
+
+
+def test_patch_collection_rejects_bad_ordering(client, auth_headers, test_event):
+    now = utcnow()
+    payload = {
+        "collection_opens_at": (now + timedelta(days=2)).isoformat(),
+        "live_starts_at": (now + timedelta(days=1)).isoformat(),
+    }
+    r = client.patch(
+        f"/api/events/{test_event.code}/collection",
+        json=payload,
+        headers=auth_headers,
+    )
+    assert r.status_code == 400
+
+
+def test_patch_collection_requires_ownership(client, db, admin_user, test_event):
+    # test_event is owned by test_user; create a different non-admin user
+    from app.models.user import User
+    from app.services.auth import create_access_token
+
+    other = User(username="otherdj", password_hash="x", role="dj")
+    db.add(other)
+    db.commit()
+    db.refresh(other)
+    token = create_access_token(data={"sub": other.username, "tv": other.token_version})
+    r = client.patch(
+        f"/api/events/{test_event.code}/collection",
+        json={"submission_cap_per_guest": 5},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 403
+
+
+def test_patch_collection_override_accepted(client, db, auth_headers, test_event):
+    r = client.patch(
+        f"/api/events/{test_event.code}/collection",
+        json={"collection_phase_override": "force_live"},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    db.refresh(test_event)
+    assert test_event.collection_phase_override == "force_live"
+
+
+def test_patch_collection_override_bad_value(client, auth_headers, test_event):
+    r = client.patch(
+        f"/api/events/{test_event.code}/collection",
+        json={"collection_phase_override": "skydiving"},
+        headers=auth_headers,
+    )
+    assert r.status_code == 422

--- a/server/tests/test_collect_dj.py
+++ b/server/tests/test_collect_dj.py
@@ -218,3 +218,31 @@ def test_get_collection_requires_ownership(client, db, test_event):
 def test_get_collection_404_for_unknown(client, auth_headers):
     r = client.get("/api/events/ZZZZZZ/collection", headers=auth_headers)
     assert r.status_code == 404
+
+
+def test_patch_collection_auto_extends_expires_at(client, db, auth_headers, test_event):
+    """When live_starts_at exceeds the event's default expires_at, the endpoint
+    should automatically push expires_at forward instead of returning 400.
+
+    The default event expiry is just 6 hours; a multi-day pre-event collection
+    obviously needs the event to live through the full timeline.
+    """
+    from datetime import timedelta
+
+    from app.core.time import utcnow
+
+    now = utcnow()
+    far_live = now + timedelta(days=5)
+    r = client.patch(
+        f"/api/events/{test_event.code}/collection",
+        json={
+            "collection_opens_at": (now + timedelta(hours=1)).isoformat(),
+            "live_starts_at": far_live.isoformat(),
+        },
+        headers=auth_headers,
+    )
+    assert r.status_code == 200, r.text
+    db.refresh(test_event)
+    assert test_event.live_starts_at is not None
+    # expires_at should now be > live_starts_at (the auto-extend applied)
+    assert test_event.expires_at > test_event.live_starts_at

--- a/server/tests/test_collect_dj.py
+++ b/server/tests/test_collect_dj.py
@@ -113,3 +113,69 @@ def test_pending_review_requires_ownership(client, db, test_event):
         headers={"Authorization": f"Bearer {token}"},
     )
     assert r.status_code == 403
+
+
+def test_bulk_review_accept_top_n(client, db, auth_headers, test_event, collection_requests):
+    r = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "accept_top_n", "n": 2},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["accepted"] == 2
+    for row in collection_requests:
+        db.refresh(row)
+    statuses = sorted(r.status for r in collection_requests)
+    assert statuses == ["accepted", "accepted", "new"]
+
+
+def test_bulk_review_accept_threshold(client, db, auth_headers, test_event, collection_requests):
+    r = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "accept_threshold", "min_votes": 3},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    # Only the vote_count=5 row qualifies
+    assert r.json()["accepted"] == 1
+
+
+def test_bulk_review_reject_remaining(client, db, auth_headers, test_event, collection_requests):
+    r = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "reject_remaining"},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["rejected"] == 3
+
+
+def test_bulk_review_accept_ids(client, db, auth_headers, test_event, collection_requests):
+    ids = [collection_requests[0].id, collection_requests[2].id]
+    r = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "accept_ids", "request_ids": ids},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["accepted"] == 2
+
+
+def test_bulk_review_rejects_over_200_ids(client, auth_headers, test_event):
+    ids = list(range(1, 250))
+    r = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "accept_ids", "request_ids": ids},
+        headers=auth_headers,
+    )
+    assert r.status_code == 422
+
+
+def test_bulk_review_bad_action(client, auth_headers, test_event):
+    r = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "launch_nukes"},
+        headers=auth_headers,
+    )
+    assert r.status_code == 422

--- a/server/tests/test_collect_dj.py
+++ b/server/tests/test_collect_dj.py
@@ -71,3 +71,45 @@ def test_patch_collection_override_bad_value(client, auth_headers, test_event):
         headers=auth_headers,
     )
     assert r.status_code == 422
+
+
+def test_pending_review_returns_collection_news_sorted_by_votes(
+    client, auth_headers, test_event, collection_requests
+):
+    r = client.get(
+        f"/api/events/{test_event.code}/pending-review",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    rows = r.json()["requests"]
+    # collection_requests fixture has vote_count 5, 2, 0
+    assert [row["vote_count"] for row in rows] == [5, 2, 0]
+
+
+def test_pending_review_excludes_accepted(
+    client, db, auth_headers, test_event, collection_requests
+):
+    collection_requests[0].status = "accepted"
+    db.commit()
+    r = client.get(
+        f"/api/events/{test_event.code}/pending-review",
+        headers=auth_headers,
+    )
+    votes = [row["vote_count"] for row in r.json()["requests"]]
+    assert 5 not in votes  # that request is now accepted
+
+
+def test_pending_review_requires_ownership(client, db, test_event):
+    from app.models.user import User
+    from app.services.auth import create_access_token
+
+    other = User(username="otherdj2", password_hash="x", role="dj")
+    db.add(other)
+    db.commit()
+    db.refresh(other)
+    token = create_access_token(data={"sub": other.username, "tv": other.token_version})
+    r = client.get(
+        f"/api/events/{test_event.code}/pending-review",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 403

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -214,3 +214,40 @@ def test_collect_leaderboard_all_tab_sorts_alphabetically(client, db, test_event
     assert r.status_code == 200
     titles = [row["title"] for row in r.json()["requests"]]
     assert titles == ["Alpha Song", "mango tango", "zebra stripes"]
+
+
+def test_collect_my_picks_voted_request_ids_includes_self_votes(
+    client, db, test_event, collection_requests
+):
+    """voted_request_ids must include votes on own submissions, so the UI
+    can disable the vote button for them even though they don't appear in
+    the `upvoted` section (which is de-duped against `submitted`).
+    """
+    _enable_collection(db, test_event)
+    from app.core.rate_limit import MAX_FINGERPRINT_LENGTH
+
+    # TestClient's default remote host is "testclient"; take first N chars.
+    fp = "testclient"[:MAX_FINGERPRINT_LENGTH]
+
+    # Mark one collection request as submitted by this client so the backend
+    # puts it under `submitted` (de-duped out of `upvoted`).
+    target = collection_requests[0]
+    target.client_fingerprint = fp
+    db.commit()
+
+    # Cast a vote on that same request.
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/vote",
+        json={"request_id": target.id},
+    )
+    assert r.status_code == 200
+
+    me = client.get(f"/api/public/collect/{test_event.code}/profile/me")
+    assert me.status_code == 200
+    body = me.json()
+
+    # The submission is in `submitted`, NOT in `upvoted` (dedupe behavior).
+    assert any(s["id"] == target.id for s in body["submitted"])
+    assert not any(u["id"] == target.id for u in body["upvoted"])
+    # But voted_request_ids MUST include it — this is the fix.
+    assert target.id in body["voted_request_ids"]

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -1,0 +1,59 @@
+"""Tests for the public collect preview and leaderboard endpoints."""
+
+from datetime import timedelta
+
+from app.core.time import utcnow
+from app.models.event import Event
+
+
+def _enable_collection(db, event: Event):
+    now = utcnow()
+    event.collection_opens_at = now - timedelta(hours=1)
+    event.live_starts_at = now + timedelta(hours=1)
+    db.commit()
+    db.refresh(event)
+
+
+def test_collect_preview_returns_phase(client, db, test_event: Event):
+    _enable_collection(db, test_event)
+    r = client.get(f"/api/public/collect/{test_event.code}")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["code"] == test_event.code
+    assert body["phase"] == "collection"
+    assert body["submission_cap_per_guest"] == 15
+
+
+def test_collect_preview_404_for_unknown_code(client):
+    r = client.get("/api/public/collect/ZZZZZZ")
+    assert r.status_code == 404
+
+
+def test_collect_leaderboard_empty(client, db, test_event: Event):
+    _enable_collection(db, test_event)
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["requests"] == []
+    assert body["total"] == 0
+
+
+def test_collect_leaderboard_trending_sorts_by_votes(client, db, test_event, collection_requests):
+    _enable_collection(db, test_event)
+    # collection_requests fixture creates 3 requests with vote_count 5, 2, 0
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=trending")
+    assert r.status_code == 200
+    votes = [row["vote_count"] for row in r.json()["requests"]]
+    assert votes == sorted(votes, reverse=True)
+    # vote_count 0 excluded from trending
+    assert 0 not in votes
+
+
+def test_collect_leaderboard_all_tab_includes_zero_votes(
+    client, db, test_event, collection_requests
+):
+    _enable_collection(db, test_event)
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all")
+    assert r.status_code == 200
+    votes = [row["vote_count"] for row in r.json()["requests"]]
+    assert 0 in votes

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -309,3 +309,51 @@ def test_collect_activity_log_entries_for_state_changes(client, db, test_event):
 
     for row in rows:
         assert re.search(r"\[[0-9a-f]{12}\]", row.message), f"missing masked fp: {row.message}"
+
+
+def test_collect_get_profile_does_not_create_row(client, db, test_event):
+    """GET /profile returns defaults without creating a GuestProfile row —
+    reads should not have write side effects, and ActivityLog must stay clean.
+    """
+    from app.models.activity_log import ActivityLog
+    from app.models.guest_profile import GuestProfile
+
+    _enable_collection(db, test_event)
+
+    before_rows = db.query(GuestProfile).count()
+    before_log = db.query(ActivityLog).count()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/profile")
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {
+        "nickname": None,
+        "has_email": False,
+        "submission_count": 0,
+        "submission_cap": test_event.submission_cap_per_guest,
+    }
+
+    assert db.query(GuestProfile).count() == before_rows, (
+        "GET /profile must not create a GuestProfile row"
+    )
+    assert db.query(ActivityLog).count() == before_log, "GET /profile must not write to ActivityLog"
+
+
+def test_collect_get_profile_returns_existing_state(client, db, test_event):
+    """When a GuestProfile exists, GET returns its fields faithfully."""
+    _enable_collection(db, test_event)
+
+    # POST a real nickname + email first.
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/profile",
+        json={"nickname": "Reader", "email": "reader@example.com"},
+    )
+    assert r.status_code == 200
+
+    # Now read it back via GET.
+    r = client.get(f"/api/public/collect/{test_event.code}/profile")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["nickname"] == "Reader"
+    assert body["has_email"] is True
+    assert body["submission_cap"] == test_event.submission_cap_per_guest

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -100,3 +100,82 @@ def test_collect_profile_me_empty_when_no_interactions(client, db, test_event):
     assert body["submitted"] == []
     assert body["upvoted"] == []
     assert body["is_top_contributor"] is False
+
+
+def test_collect_submit_creates_request_in_collection_phase(client, db, test_event):
+    _enable_collection(db, test_event)
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={
+            "song_title": "Mr. Brightside",
+            "artist": "The Killers",
+            "source": "spotify",
+            "source_url": "https://open.spotify.com/track/abc",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["id"] > 0
+
+    from app.models.request import Request as SongRequest
+
+    row = db.query(SongRequest).filter(SongRequest.id == body["id"]).one()
+    assert row.submitted_during_collection is True
+    assert row.status == "new"
+
+
+def test_collect_submit_rejected_during_live_phase(client, db, test_event):
+    # event without collection fields → phase == "live"
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={"song_title": "A", "artist": "B", "source": "spotify"},
+    )
+    assert r.status_code == 409
+    assert "Collection" in r.json()["detail"]
+
+
+def test_collect_submit_blocked_at_cap(client, db, test_event):
+    _enable_collection(db, test_event)
+    test_event.submission_cap_per_guest = 2
+    db.commit()
+    for _ in range(2):
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/requests",
+            json={"song_title": "A", "artist": "B", "source": "spotify"},
+        )
+        assert r.status_code == 201
+    r3 = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={"song_title": "C", "artist": "D", "source": "spotify"},
+    )
+    assert r3.status_code == 429
+    assert "Picks limit reached" in r3.json()["detail"]
+
+
+def test_collect_vote_increments_count(client, db, test_event, collection_requests):
+    _enable_collection(db, test_event)
+    req = collection_requests[0]
+    before = req.vote_count
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/vote",
+        json={"request_id": req.id},
+    )
+    assert r.status_code == 200
+    db.refresh(req)
+    assert req.vote_count == before + 1
+
+
+def test_collect_vote_is_idempotent(client, db, test_event, collection_requests):
+    _enable_collection(db, test_event)
+    req = collection_requests[0]
+    client.post(
+        f"/api/public/collect/{test_event.code}/vote",
+        json={"request_id": req.id},
+    )
+    before = db.query(type(req)).filter(type(req).id == req.id).one().vote_count
+    client.post(
+        f"/api/public/collect/{test_event.code}/vote",
+        json={"request_id": req.id},
+    )
+    after = db.query(type(req)).filter(type(req).id == req.id).one().vote_count
+    assert after == before

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -57,3 +57,46 @@ def test_collect_leaderboard_all_tab_includes_zero_votes(
     assert r.status_code == 200
     votes = [row["vote_count"] for row in r.json()["requests"]]
     assert 0 in votes
+
+
+def test_collect_profile_set_nickname(client, db, test_event):
+    _enable_collection(db, test_event)
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/profile",
+        json={"nickname": "DancingQueen"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["nickname"] == "DancingQueen"
+    assert body["has_email"] is False
+    assert body["submission_count"] == 0
+    assert body["submission_cap"] == 15
+
+
+def test_collect_profile_invalid_nickname_rejected(client, db, test_event):
+    _enable_collection(db, test_event)
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/profile",
+        json={"nickname": "<script>alert(1)</script>"},
+    )
+    assert r.status_code == 422
+
+
+def test_collect_profile_accepts_email(client, db, test_event):
+    _enable_collection(db, test_event)
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/profile",
+        json={"nickname": "A", "email": "guest@example.com"},
+    )
+    assert r.status_code == 200
+    assert r.json()["has_email"] is True
+
+
+def test_collect_profile_me_empty_when_no_interactions(client, db, test_event):
+    _enable_collection(db, test_event)
+    r = client.get(f"/api/public/collect/{test_event.code}/profile/me")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["submitted"] == []
+    assert body["upvoted"] == []
+    assert body["is_top_contributor"] is False

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -251,3 +251,61 @@ def test_collect_my_picks_voted_request_ids_includes_self_votes(
     assert not any(u["id"] == target.id for u in body["upvoted"])
     # But voted_request_ids MUST include it — this is the fix.
     assert target.id in body["voted_request_ids"]
+
+
+def test_collect_activity_log_entries_for_state_changes(client, db, test_event):
+    """Submit, vote, and profile-set should each write one ActivityLog row
+    tagged with the masked fingerprint so DJs can audit guest activity.
+    """
+    from app.models.activity_log import ActivityLog
+
+    _enable_collection(db, test_event)
+
+    # 1. Submit a song.
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={"song_title": "Log Me", "artist": "Audit", "source": "spotify"},
+    )
+    assert r.status_code == 201
+    new_id = r.json()["id"]
+
+    # 2. Vote on it.
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/vote",
+        json={"request_id": new_id},
+    )
+    assert r.status_code == 200
+
+    # 2b. Vote again — idempotent, should NOT create a second activity row.
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/vote",
+        json={"request_id": new_id},
+    )
+    assert r.status_code == 200
+
+    # 3. Set a nickname.
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/profile",
+        json={"nickname": "LogTester"},
+    )
+    assert r.status_code == 200
+
+    rows = (
+        db.query(ActivityLog)
+        .filter(ActivityLog.event_code == test_event.code)
+        .filter(ActivityLog.source == "collect")
+        .order_by(ActivityLog.id.asc())
+        .all()
+    )
+    assert len(rows) == 3, (
+        f"expected 3 collect activity rows, got {len(rows)}: {[r.message for r in rows]}"
+    )
+    assert "submitted" in rows[0].message
+    assert "'Log Me'" in rows[0].message
+    assert "voted" in rows[1].message
+    assert "updated profile" in rows[2].message
+    # Every row should carry the masked fingerprint (12 hex chars in [brackets]).
+    import re
+
+    for row in rows:
+        assert re.search(r"\[[0-9a-f]{12}\]", row.message), f"missing masked fp: {row.message}"

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -179,3 +179,38 @@ def test_collect_vote_is_idempotent(client, db, test_event, collection_requests)
     )
     after = db.query(type(req)).filter(type(req).id == req.id).one().vote_count
     assert after == before
+
+
+def test_collect_leaderboard_all_tab_sorts_alphabetically(client, db, test_event):
+    """The All tab should sort alphabetically (case-insensitive) by song title
+    so guests can scan and upvote existing submissions without recency bias.
+    """
+    from datetime import timedelta
+
+    from app.core.time import utcnow
+    from app.models.request import Request as SongRequest
+    from app.models.request import RequestStatus
+
+    _enable_collection(db, test_event)
+    now = utcnow()
+    # Intentionally insert out of order, with mixed casing.
+    for idx, title in enumerate(["zebra stripes", "Alpha Song", "mango tango"]):
+        db.add(
+            SongRequest(
+                event_id=test_event.id,
+                song_title=title,
+                artist=f"Artist {idx}",
+                source="spotify",
+                status=RequestStatus.NEW.value,
+                vote_count=0,
+                dedupe_key=f"dk_alpha_{idx}",
+                submitted_during_collection=True,
+                created_at=now - timedelta(seconds=idx),
+            )
+        )
+    db.commit()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all")
+    assert r.status_code == 200
+    titles = [row["title"] for row in r.json()["requests"]]
+    assert titles == ["Alpha Song", "mango tango", "zebra stripes"]

--- a/server/tests/test_collect_service.py
+++ b/server/tests/test_collect_service.py
@@ -1,0 +1,68 @@
+from datetime import timedelta
+
+import pytest
+
+from app.core.time import utcnow
+from app.models.event import Event
+from app.models.guest_profile import GuestProfile
+from app.services import collect as collect_service
+
+
+def _enable_collection(db, event: Event):
+    now = utcnow()
+    event.collection_opens_at = now - timedelta(hours=1)
+    event.live_starts_at = now + timedelta(hours=1)
+    event.submission_cap_per_guest = 3
+    db.commit()
+    db.refresh(event)
+
+
+def test_upsert_profile_creates_row(db, test_event: Event):
+    profile = collect_service.upsert_profile(
+        db, event_id=test_event.id, fingerprint="fp1", nickname="Alex"
+    )
+    assert profile.nickname == "Alex"
+    assert profile.email is None
+    assert profile.submission_count == 0
+
+
+def test_upsert_profile_preserves_email_when_only_nickname_given(db, test_event: Event):
+    collect_service.upsert_profile(
+        db, event_id=test_event.id, fingerprint="fp2", email="g@example.com"
+    )
+    profile = collect_service.upsert_profile(
+        db, event_id=test_event.id, fingerprint="fp2", nickname="NewName"
+    )
+    assert profile.email == "g@example.com"
+    assert profile.nickname == "NewName"
+
+
+def test_check_and_increment_submission_count_blocks_at_cap(db, test_event: Event):
+    _enable_collection(db, test_event)
+    for _ in range(3):
+        collect_service.check_and_increment_submission_count(
+            db, event=test_event, fingerprint="fp3"
+        )
+    with pytest.raises(collect_service.SubmissionCapExceeded):
+        collect_service.check_and_increment_submission_count(
+            db, event=test_event, fingerprint="fp3"
+        )
+
+
+def test_check_and_increment_allows_unlimited_when_cap_zero(db, test_event: Event):
+    _enable_collection(db, test_event)
+    test_event.submission_cap_per_guest = 0
+    db.commit()
+    for _ in range(20):
+        collect_service.check_and_increment_submission_count(
+            db, event=test_event, fingerprint="fp4"
+        )
+    profile = (
+        db.query(GuestProfile)
+        .filter(
+            GuestProfile.event_id == test_event.id,
+            GuestProfile.client_fingerprint == "fp4",
+        )
+        .one()
+    )
+    assert profile.submission_count == 20

--- a/server/tests/test_event_phase.py
+++ b/server/tests/test_event_phase.py
@@ -1,0 +1,73 @@
+from datetime import timedelta
+
+from app.core.time import utcnow
+from app.models.event import Event
+
+
+def _make_event(**kwargs) -> Event:
+    now = utcnow()
+    defaults = dict(
+        code="ABCDEF",
+        name="Test Event",
+        created_by_user_id=1,
+        expires_at=now + timedelta(days=30),
+    )
+    defaults.update(kwargs)
+    return Event(**defaults)
+
+
+def test_phase_no_collection_set_is_live():
+    ev = _make_event()
+    assert ev.phase == "live"
+
+
+def test_phase_no_collection_after_expiry_is_closed():
+    ev = _make_event(expires_at=utcnow() - timedelta(hours=1))
+    assert ev.phase == "closed"
+
+
+def test_phase_pre_announce_when_before_collection_opens():
+    now = utcnow()
+    ev = _make_event(
+        collection_opens_at=now + timedelta(hours=1),
+        live_starts_at=now + timedelta(days=1),
+    )
+    assert ev.phase == "pre_announce"
+
+
+def test_phase_collection_when_between_opens_and_live():
+    now = utcnow()
+    ev = _make_event(
+        collection_opens_at=now - timedelta(hours=1),
+        live_starts_at=now + timedelta(hours=1),
+    )
+    assert ev.phase == "collection"
+
+
+def test_phase_live_when_past_live_starts_at():
+    now = utcnow()
+    ev = _make_event(
+        collection_opens_at=now - timedelta(days=2),
+        live_starts_at=now - timedelta(hours=1),
+    )
+    assert ev.phase == "live"
+
+
+def test_phase_override_force_live_wins():
+    now = utcnow()
+    ev = _make_event(
+        collection_opens_at=now - timedelta(hours=1),
+        live_starts_at=now + timedelta(hours=1),
+        collection_phase_override="force_live",
+    )
+    assert ev.phase == "live"
+
+
+def test_phase_override_force_collection_wins():
+    now = utcnow()
+    ev = _make_event(
+        collection_opens_at=now - timedelta(days=2),
+        live_starts_at=now - timedelta(hours=1),
+        collection_phase_override="force_collection",
+    )
+    assert ev.phase == "collection"

--- a/server/tests/test_guest_profile.py
+++ b/server/tests/test_guest_profile.py
@@ -1,0 +1,47 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.event import Event
+from app.models.guest_profile import GuestProfile
+
+
+def test_guest_profile_defaults(db, test_event: Event):
+    profile = GuestProfile(
+        event_id=test_event.id,
+        client_fingerprint="fp_abc",
+    )
+    db.add(profile)
+    db.commit()
+    db.refresh(profile)
+    assert profile.nickname is None
+    assert profile.email is None
+    assert profile.submission_count == 0
+    assert profile.created_at is not None
+
+
+def test_guest_profile_uniqueness(db, test_event: Event):
+    db.add(GuestProfile(event_id=test_event.id, client_fingerprint="fp_same"))
+    db.commit()
+    db.add(GuestProfile(event_id=test_event.id, client_fingerprint="fp_same"))
+    with pytest.raises(IntegrityError):
+        db.commit()
+
+
+def test_guest_profile_email_is_encrypted_at_rest(db, test_event: Event):
+    profile = GuestProfile(
+        event_id=test_event.id,
+        client_fingerprint="fp_enc",
+        email="guest@example.com",
+    )
+    db.add(profile)
+    db.commit()
+
+    raw = db.execute(
+        __import__("sqlalchemy").text("SELECT email FROM guest_profiles WHERE id = :id"),
+        {"id": profile.id},
+    ).scalar()
+    assert raw != "guest@example.com"
+    assert raw is not None
+
+    db.refresh(profile)
+    assert profile.email == "guest@example.com"


### PR DESCRIPTION
## Summary

Adds a new pre-event song collection mode. DJs can enable "pre-event voting" on an event with `collection_opens_at` and `live_starts_at` dates. Between those timestamps, guests visit a dedicated `/collect/[code]` page — distinct from the existing `/join/[code]` — where they submit songs, upvote others, and see themselves on a live leaderboard. At live-start, the collect URL auto-redirects to the normal join flow with a celebratory splash. DJs can cherry-pick requests anytime or use a dedicated bulk-sweep view (accept top N / accept ≥ votes / reject remaining).

- **Guest experience:** ranked Trending/All leaderboard, "My Picks" panel with status + gamification badges (⭐ first to suggest, 🏆 top contributor), optional email opt-in for cross-device identity.
- **DJ experience:** new **Pre-Event Voting** tab on the event page (alongside Song Management and Event Management) with phase-override controls (Open now / Start live now / Pause), share link + QR for `/collect/<code>`, and an inline bulk-review table.
- **Architecture:** Approach 1 — minimal extension of existing models. 4 new columns on `events`, 1 column on `requests`, 1 new `guest_profiles` table with encrypted email. `Event.phase` is a derived property; no background jobs, no stored phase state.

Design + plan: `docs/superpowers/specs/2026-04-21-pre-event-collection-design.md`, `docs/superpowers/plans/2026-04-21-pre-event-collection.md`.

## Security posture

- `GuestProfile.email` stored via `EncryptedText` (Fernet) — never plaintext.
- All public endpoints rate-limited via slowapi; submission cap enforced server-side with atomic increment.
- Input sanitization: zod client-side + Pydantic `StringConstraints` server-side; nickname regex `^[a-zA-Z0-9 _.-]+$`; email via `EmailStr`.
- Phase gate server-side on every write (client redirect is UX, not security).
- Ownership checks on every DJ route (`event.created_by_user_id == user.id` OR admin).
- Error messages scrubbed: no cap value leak in 429, no stack traces in 500, no internal IDs in 404.

## Test plan

- [x] Backend: 1735 pytest tests green, `alembic check` clean, ruff/bandit clean
- [x] Frontend: 798 vitest tests green, `tsc --noEmit` clean, ESLint clean
- [x] Bridge + bridge-app: tsc clean
- [x] Security suite 11 (`~/wrzdj-testing/run-all.sh 11`): 24/24 PASS (unauthorized access, phase gate, cap bypass, nickname/email injection, ownership bypass, enum enforcement, error hygiene)
- [x] Manual verification via push-to-testing:
  - Create event with toggle from `/dashboard` and `/events` → both work via shared `CollectionFieldset`
  - PATCH `/collection` handles tz-aware ISO datetimes from browser (naive-UTC normalization)
  - `expires_at` auto-extends when `live_starts_at` is past it
  - `phase: collection` on new event with past `collection_opens_at` (resilient to any start date)
  - Pre-Event Voting tab renders once `EventOut` exposes `collection_opens_at`
  - Failed collection-PATCH-after-create-POST now surfaces a clear error rather than orphaning events

## Notes for reviewers

- `Event.phase` defensively strips tz on every comparison to prevent future callers from triggering `TypeError: can't compare offset-naive and offset-aware datetimes`.
- The `GET /api/events/{code}/collection` endpoint was added in T21 before EventOut exposed the fields — it's now semi-redundant with the extended EventOut but left in place (used by the PreEventVotingTab's lazy-fetch on tab open); candidate for removal in a follow-up PR.
- Submission cap's read-then-write is not locked; a truly concurrent scenario could over-cap by one. Acceptable for the intended scale; add `.with_for_update()` if events at scale show drift.
- Dev-proxy CSP gained `'unsafe-eval'` for Next.js HMR in dev mode. Production CSP (`deploy/nginx/`) unchanged.