### PR TITLE
style(collect): design pass — match WrzDJ dark theme

### DIFF
--- a/dashboard/app/collect/[code]/components/FeatureOptInPanel.test.tsx
+++ b/dashboard/app/collect/[code]/components/FeatureOptInPanel.test.tsx
@@ -1,39 +1,85 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-import FeatureOptInPanel from "./FeatureOptInPanel";
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import FeatureOptInPanel from './FeatureOptInPanel';
 
-describe("FeatureOptInPanel", () => {
-  it("does not render when hasEmail is true", () => {
-    render(<FeatureOptInPanel hasEmail={true} onSave={vi.fn()} />);
-    expect(screen.queryByText(/add email/i)).not.toBeInTheDocument();
+describe('FeatureOptInPanel', () => {
+  it('does not render when guest already has email AND a nickname', () => {
+    render(
+      <FeatureOptInPanel
+        hasEmail={true}
+        initialNickname="Alex"
+        onSave={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/make it yours/i)).not.toBeInTheDocument();
   });
 
-  it("shows feature comparison and save button", () => {
-    render(<FeatureOptInPanel hasEmail={false} onSave={vi.fn()} />);
+  it('shows feature copy and inputs when nothing set yet', () => {
+    render(
+      <FeatureOptInPanel hasEmail={false} initialNickname={null} onSave={vi.fn()} />,
+    );
+    expect(screen.getByText(/nickname appears/i)).toBeInTheDocument();
     expect(screen.getByText(/notify me when my song plays/i)).toBeInTheDocument();
     expect(screen.getByText(/cross-device/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^nickname$/i)).toBeInTheDocument();
   });
 
-  it("rejects invalid email on client", async () => {
+  it('rejects invalid email on client', async () => {
     const onSave = vi.fn();
-    render(<FeatureOptInPanel hasEmail={false} onSave={onSave} />);
-    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "bogus" } });
-    fireEvent.click(screen.getByRole("button", { name: /add email/i }));
+    render(
+      <FeatureOptInPanel hasEmail={false} initialNickname={null} onSave={onSave} />,
+    );
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'bogus' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
     await waitFor(() => {
       expect(screen.getByText(/invalid email/i)).toBeInTheDocument();
     });
     expect(onSave).not.toHaveBeenCalled();
   });
 
-  it("calls onSave with valid email", async () => {
-    const onSave = vi.fn().mockResolvedValue(undefined);
-    render(<FeatureOptInPanel hasEmail={false} onSave={onSave} />);
-    fireEvent.change(screen.getByLabelText(/email/i), {
-      target: { value: "guest@example.com" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /add email/i }));
+  it('requires at least one of nickname or email', async () => {
+    const onSave = vi.fn();
+    render(
+      <FeatureOptInPanel hasEmail={false} initialNickname={null} onSave={onSave} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
     await waitFor(() => {
-      expect(onSave).toHaveBeenCalledWith("guest@example.com");
+      expect(screen.getByText(/enter a nickname or email/i)).toBeInTheDocument();
+    });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('calls onSave with just nickname when only nickname entered', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <FeatureOptInPanel hasEmail={false} initialNickname={null} onSave={onSave} />,
+    );
+    fireEvent.change(screen.getByLabelText(/^nickname$/i), {
+      target: { value: 'DancingQueen' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({ nickname: 'DancingQueen' });
+    });
+  });
+
+  it('calls onSave with both fields when both filled', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <FeatureOptInPanel hasEmail={false} initialNickname={null} onSave={onSave} />,
+    );
+    fireEvent.change(screen.getByLabelText(/^nickname$/i), {
+      target: { value: 'Alex' },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'alex@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({
+        nickname: 'Alex',
+        email: 'alex@example.com',
+      });
     });
   });
 });

--- a/dashboard/app/collect/[code]/components/FeatureOptInPanel.tsx
+++ b/dashboard/app/collect/[code]/components/FeatureOptInPanel.tsx
@@ -1,7 +1,7 @@
-"use client";
+'use client';
 
-import { useState } from "react";
-import { z } from "zod";
+import { useState } from 'react';
+import { z } from 'zod';
 
 const emailSchema = z.string().email().max(254);
 
@@ -12,7 +12,7 @@ interface Props {
 
 export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
   const [expanded, setExpanded] = useState(true);
-  const [email, setEmail] = useState("");
+  const [email, setEmail] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -21,7 +21,7 @@ export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
   const submit = async () => {
     const parsed = emailSchema.safeParse(email);
     if (!parsed.success) {
-      setError("Invalid email");
+      setError('Invalid email');
       return;
     }
     setSaving(true);
@@ -36,35 +36,40 @@ export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
   };
 
   return (
-    <section
-      style={{
-        background: "#1a1a1a",
-        padding: 16,
-        borderRadius: 8,
-        marginBottom: 16,
-      }}
-    >
+    <section className="collect-optin">
       <h3>Get the most out of your picks</h3>
-      <ul style={{ marginBottom: 12 }}>
+      <ul className="collect-optin-features">
         <li>Notify me when my song plays</li>
         <li>Cross-device &quot;my picks&quot; and leaderboard position</li>
         <li>Persistent profile across events</li>
       </ul>
-      <label>
-        Email
+      <div className="form-group" style={{ marginBottom: 0 }}>
+        <label htmlFor="collect-email">Email</label>
         <input
+          id="collect-email"
           type="email"
+          className="input"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          style={{ marginLeft: 8 }}
+          placeholder="you@example.com"
         />
-      </label>
-      {error && <p style={{ color: "#ff6b6b" }}>{error}</p>}
-      <div style={{ marginTop: 8 }}>
-        <button onClick={() => setExpanded(false)} disabled={saving}>
+      </div>
+      {error && <p className="collection-fieldset-error">{error}</p>}
+      <div className="collect-optin-actions">
+        <button
+          type="button"
+          className="btn btn-sm collect-optin-dismiss"
+          onClick={() => setExpanded(false)}
+          disabled={saving}
+        >
           Keep it anonymous
         </button>
-        <button onClick={submit} disabled={saving}>
+        <button
+          type="button"
+          className="btn btn-primary btn-sm"
+          onClick={submit}
+          disabled={saving}
+        >
           Add email
         </button>
       </div>

--- a/dashboard/app/collect/[code]/components/FeatureOptInPanel.tsx
+++ b/dashboard/app/collect/[code]/components/FeatureOptInPanel.tsx
@@ -4,29 +4,62 @@ import { useState } from 'react';
 import { z } from 'zod';
 
 const emailSchema = z.string().email().max(254);
+const nicknameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(30)
+  .regex(/^[a-zA-Z0-9 _.-]+$/, 'Letters, numbers, spaces, . _ - only');
 
 interface Props {
   hasEmail: boolean;
-  onSave: (email: string) => Promise<void>;
+  initialNickname: string | null;
+  onSave: (data: { nickname?: string; email?: string }) => Promise<void>;
 }
 
-export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
+export default function FeatureOptInPanel({ hasEmail, initialNickname, onSave }: Props) {
   const [expanded, setExpanded] = useState(true);
+  const [nickname, setNickname] = useState(initialNickname ?? '');
   const [email, setEmail] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
-  if (hasEmail || !expanded) return null;
+  // Hide once the guest either has an email OR has chosen a nickname and dismissed.
+  if ((hasEmail || !expanded) && initialNickname !== null) return null;
+  if (hasEmail && !expanded) return null;
 
   const submit = async () => {
-    const parsed = emailSchema.safeParse(email);
-    if (!parsed.success) {
-      setError('Invalid email');
+    const payload: { nickname?: string; email?: string } = {};
+
+    const nickTrimmed = nickname.trim();
+    if (nickTrimmed) {
+      const nickResult = nicknameSchema.safeParse(nickTrimmed);
+      if (!nickResult.success) {
+        setError(nickResult.error.issues[0].message);
+        return;
+      }
+      payload.nickname = nickResult.data;
+    }
+
+    const emailTrimmed = email.trim();
+    if (emailTrimmed) {
+      const emailResult = emailSchema.safeParse(emailTrimmed);
+      if (!emailResult.success) {
+        setError('Invalid email');
+        return;
+      }
+      payload.email = emailResult.data;
+    }
+
+    if (Object.keys(payload).length === 0) {
+      setError('Enter a nickname or email (or both)');
       return;
     }
+
+    setError(null);
     setSaving(true);
     try {
-      await onSave(parsed.data);
+      await onSave(payload);
       setExpanded(false);
     } catch (e) {
       setError((e as Error).message);
@@ -37,14 +70,36 @@ export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
 
   return (
     <section className="collect-optin">
-      <h3>Get the most out of your picks</h3>
+      <h3>Make it yours</h3>
+      <p
+        style={{
+          fontSize: '0.875rem',
+          color: 'var(--text-secondary)',
+          marginBottom: '0.75rem',
+        }}
+      >
+        Pick a nickname so the DJ knows who suggested what. Add an email for extra perks.
+      </p>
       <ul className="collect-optin-features">
-        <li>Notify me when my song plays</li>
-        <li>Cross-device &quot;my picks&quot; and leaderboard position</li>
-        <li>Persistent profile across events</li>
+        <li>Nickname appears next to your picks</li>
+        <li>Email (optional): notify me when my song plays</li>
+        <li>Email: cross-device &quot;my picks&quot; and leaderboard position</li>
       </ul>
+
+      <div className="form-group">
+        <label htmlFor="collect-nickname">Nickname</label>
+        <input
+          id="collect-nickname"
+          type="text"
+          className="input"
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          placeholder="DancingQueen"
+          maxLength={30}
+        />
+      </div>
       <div className="form-group" style={{ marginBottom: 0 }}>
-        <label htmlFor="collect-email">Email</label>
+        <label htmlFor="collect-email">Email (optional)</label>
         <input
           id="collect-email"
           type="email"
@@ -52,9 +107,12 @@ export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           placeholder="you@example.com"
+          disabled={hasEmail}
         />
       </div>
+
       {error && <p className="collection-fieldset-error">{error}</p>}
+
       <div className="collect-optin-actions">
         <button
           type="button"
@@ -62,7 +120,7 @@ export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
           onClick={() => setExpanded(false)}
           disabled={saving}
         >
-          Keep it anonymous
+          {initialNickname ? 'Close' : 'Skip'}
         </button>
         <button
           type="button"
@@ -70,7 +128,7 @@ export default function FeatureOptInPanel({ hasEmail, onSave }: Props) {
           onClick={submit}
           disabled={saving}
         >
-          Add email
+          {saving ? 'Saving…' : 'Save'}
         </button>
       </div>
     </section>

--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx
@@ -1,14 +1,32 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-import LeaderboardTabs from "./LeaderboardTabs";
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import LeaderboardTabs from './LeaderboardTabs';
 
 const rows = [
-  { id: 1, title: "A", artist: "X", artwork_url: null, vote_count: 5, nickname: "alex", status: "new" as const, created_at: "2026-04-21" },
-  { id: 2, title: "B", artist: "Y", artwork_url: null, vote_count: 1, nickname: "jo",   status: "new" as const, created_at: "2026-04-21" },
+  {
+    id: 1,
+    title: 'A',
+    artist: 'X',
+    artwork_url: null,
+    vote_count: 5,
+    nickname: 'alex',
+    status: 'new' as const,
+    created_at: '2026-04-21',
+  },
+  {
+    id: 2,
+    title: 'B',
+    artist: 'Y',
+    artwork_url: null,
+    vote_count: 1,
+    nickname: 'jo',
+    status: 'new' as const,
+    created_at: '2026-04-21',
+  },
 ];
 
-describe("LeaderboardTabs", () => {
-  it("renders rows and switches tabs", () => {
+describe('LeaderboardTabs', () => {
+  it('renders rows and switches tabs', () => {
     const onTabChange = vi.fn();
     render(
       <LeaderboardTabs
@@ -16,26 +34,63 @@ describe("LeaderboardTabs", () => {
         tab="trending"
         onTabChange={onTabChange}
         onVote={vi.fn()}
-      />
+        votedIds={new Set()}
+      />,
     );
-    expect(screen.getByText("A")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /^all$/i }));
-    expect(onTabChange).toHaveBeenCalledWith("all");
+    expect(screen.getByText('A')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^all$/i }));
+    expect(onTabChange).toHaveBeenCalledWith('all');
   });
 
-  it("optimistically updates vote count then rolls back on error", async () => {
-    const onVote = vi.fn().mockRejectedValue(new Error("boom"));
+  it('optimistically updates vote count then rolls back on error', async () => {
+    const onVote = vi.fn().mockRejectedValue(new Error('boom'));
     render(
       <LeaderboardTabs
         rows={rows}
         tab="trending"
         onTabChange={vi.fn()}
         onVote={onVote}
-      />
+        votedIds={new Set()}
+      />,
     );
-    fireEvent.click(screen.getAllByRole("button", { name: /upvote/i })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: /upvote/i })[0]);
     await waitFor(() => {
       expect(screen.getByText(/5/)).toBeInTheDocument();
+    });
+  });
+
+  it('disables the vote button when votedIds already contains the request id', () => {
+    render(
+      <LeaderboardTabs
+        rows={rows}
+        tab="trending"
+        onTabChange={vi.fn()}
+        onVote={vi.fn()}
+        votedIds={new Set([1])}
+      />,
+    );
+    const votedButton = screen.getByRole('button', { name: /upvoted/i });
+    expect(votedButton).toBeDisabled();
+    expect(votedButton).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('does not call onVote twice for rapid repeated clicks on the same row', async () => {
+    const onVote = vi.fn().mockResolvedValue(undefined);
+    render(
+      <LeaderboardTabs
+        rows={rows}
+        tab="trending"
+        onTabChange={vi.fn()}
+        onVote={onVote}
+        votedIds={new Set()}
+      />,
+    );
+    const upvoteButtons = screen.getAllByRole('button', { name: /upvote/i });
+    fireEvent.click(upvoteButtons[0]);
+    fireEvent.click(upvoteButtons[0]);
+    fireEvent.click(upvoteButtons[0]);
+    await waitFor(() => {
+      expect(onVote).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
@@ -22,20 +22,22 @@ export default function LeaderboardTabs({
   const [optimistic, setOptimistic] = useState<Record<number, number>>({});
   const [justVoted, setJustVoted] = useState<ReadonlySet<number>>(new Set());
 
-  // Drop optimistic overrides for rows whose vote_count the server has now
-  // caught up on (or exceeded) — prevents stale +1 overlays from lingering.
+  // Once the server's my-picks response confirms a vote (votedIds has the id),
+  // drop the optimistic overlay — trust the server's authoritative vote_count.
+  // If the server rejected the vote as a duplicate, that's correct too; the
+  // UI reverts to the real value instead of clinging to a stale +1.
   useEffect(() => {
     setOptimistic((prev) => {
       const next: Record<number, number> = {};
-      for (const r of rows) {
-        const guess = prev[r.id];
-        if (guess !== undefined && guess > r.vote_count) {
-          next[r.id] = guess;
+      for (const [id, guess] of Object.entries(prev)) {
+        const numericId = Number(id);
+        if (!votedIds.has(numericId)) {
+          next[numericId] = guess;
         }
       }
       return next;
     });
-  }, [rows]);
+  }, [rows, votedIds]);
 
   const hasVoted = (id: number): boolean => votedIds.has(id) || justVoted.has(id);
 

--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { CollectLeaderboardRow } from '../../../../lib/api';
 
 interface Props {
@@ -8,19 +8,56 @@ interface Props {
   tab: 'trending' | 'all';
   onTabChange: (tab: 'trending' | 'all') => void;
   onVote: (requestId: number) => Promise<void>;
+  /** Request IDs this guest has already voted for (from my-picks). */
+  votedIds: ReadonlySet<number>;
 }
 
-export default function LeaderboardTabs({ rows, tab, onTabChange, onVote }: Props) {
+export default function LeaderboardTabs({
+  rows,
+  tab,
+  onTabChange,
+  onVote,
+  votedIds,
+}: Props) {
   const [optimistic, setOptimistic] = useState<Record<number, number>>({});
+  const [justVoted, setJustVoted] = useState<ReadonlySet<number>>(new Set());
+
+  // Drop optimistic overrides for rows whose vote_count the server has now
+  // caught up on (or exceeded) — prevents stale +1 overlays from lingering.
+  useEffect(() => {
+    setOptimistic((prev) => {
+      const next: Record<number, number> = {};
+      for (const r of rows) {
+        const guess = prev[r.id];
+        if (guess !== undefined && guess > r.vote_count) {
+          next[r.id] = guess;
+        }
+      }
+      return next;
+    });
+  }, [rows]);
+
+  const hasVoted = (id: number): boolean => votedIds.has(id) || justVoted.has(id);
 
   const handleVote = async (id: number, currentVotes: number) => {
+    if (hasVoted(id)) return;
     setOptimistic((o) => ({ ...o, [id]: currentVotes + 1 }));
+    setJustVoted((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
     try {
       await onVote(id);
     } catch {
       setOptimistic((o) => {
         const next = { ...o };
         delete next[id];
+        return next;
+      });
+      setJustVoted((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
         return next;
       });
     }
@@ -75,8 +112,10 @@ export default function LeaderboardTabs({ rows, tab, onTabChange, onVote }: Prop
                 </div>
                 <button
                   type="button"
-                  aria-label="upvote"
-                  className="collect-vote"
+                  aria-label={hasVoted(r.id) ? 'upvoted' : 'upvote'}
+                  aria-pressed={hasVoted(r.id)}
+                  className={`collect-vote${hasVoted(r.id) ? ' voted' : ''}`}
+                  disabled={hasVoted(r.id)}
                   onClick={() => handleVote(r.id, r.vote_count)}
                 >
                   <span className="collect-vote-caret">▲</span>

--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
@@ -1,12 +1,12 @@
-"use client";
+'use client';
 
-import { useState } from "react";
-import type { CollectLeaderboardRow } from "../../../../lib/api";
+import { useState } from 'react';
+import type { CollectLeaderboardRow } from '../../../../lib/api';
 
 interface Props {
   rows: CollectLeaderboardRow[];
-  tab: "trending" | "all";
-  onTabChange: (tab: "trending" | "all") => void;
+  tab: 'trending' | 'all';
+  onTabChange: (tab: 'trending' | 'all') => void;
   onVote: (requestId: number) => Promise<void>;
 }
 
@@ -28,48 +28,61 @@ export default function LeaderboardTabs({ rows, tab, onTabChange, onVote }: Prop
 
   return (
     <div>
-      <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+      <div className="collect-tabs">
         <button
-          aria-pressed={tab === "trending"}
-          onClick={() => onTabChange("trending")}
+          type="button"
+          className="collect-tab"
+          aria-pressed={tab === 'trending'}
+          onClick={() => onTabChange('trending')}
         >
           Trending
         </button>
         <button
-          aria-pressed={tab === "all"}
-          onClick={() => onTabChange("all")}
+          type="button"
+          className="collect-tab"
+          aria-pressed={tab === 'all'}
+          onClick={() => onTabChange('all')}
         >
           All
         </button>
       </div>
-      <ul style={{ listStyle: "none", padding: 0 }}>
-        {rows.map((r) => {
-          const votes = optimistic[r.id] ?? r.vote_count;
-          return (
-            <li
-              key={r.id}
-              style={{
-                display: "flex",
-                justifyContent: "space-between",
-                padding: 8,
-                background: "#1a1a1a",
-                marginBottom: 4,
-              }}
-            >
-              <div>
-                <strong>{r.title}</strong> — {r.artist}
-                {r.nickname && <span style={{ opacity: 0.7 }}> · by @{r.nickname}</span>}
-              </div>
-              <button
-                aria-label="upvote"
-                onClick={() => handleVote(r.id, r.vote_count)}
-              >
-                ▲ {votes}
-              </button>
-            </li>
-          );
-        })}
-      </ul>
+      {rows.length === 0 ? (
+        <p className="collect-empty">No songs yet — be the first to add one!</p>
+      ) : (
+        <ul className="collect-leaderboard">
+          {rows.map((r) => {
+            const votes = optimistic[r.id] ?? r.vote_count;
+            return (
+              <li key={r.id} className="collect-row">
+                {r.artwork_url ? (
+                  <img src={r.artwork_url} alt="" className="collect-row-art" />
+                ) : (
+                  <div className="collect-row-art" aria-hidden="true" />
+                )}
+                <div className="collect-row-info">
+                  <div className="collect-row-title">{r.title}</div>
+                  <div className="collect-row-artist">{r.artist}</div>
+                  {r.nickname && (
+                    <div className="collect-row-nickname">
+                      <em className="nickname-icon">@</em>
+                      {r.nickname}
+                    </div>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  aria-label="upvote"
+                  className="collect-vote"
+                  onClick={() => handleVote(r.id, r.vote_count)}
+                >
+                  <span className="collect-vote-caret">▲</span>
+                  <span>{votes}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
     </div>
   );
 }

--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
@@ -47,7 +47,11 @@ export default function LeaderboardTabs({ rows, tab, onTabChange, onVote }: Prop
         </button>
       </div>
       {rows.length === 0 ? (
-        <p className="collect-empty">No songs yet — be the first to add one!</p>
+        <p className="collect-empty">
+          {tab === 'trending'
+            ? 'Not enough songs added yet! Once others contribute this list will grow.'
+            : 'No songs yet — be the first to add one!'}
+        </p>
       ) : (
         <ul className="collect-leaderboard">
           {rows.map((r) => {

--- a/dashboard/app/collect/[code]/components/MyPicksPanel.test.tsx
+++ b/dashboard/app/collect/[code]/components/MyPicksPanel.test.tsx
@@ -18,7 +18,7 @@ describe("MyPicksPanel", () => {
   it("shows empty state when no picks", () => {
     render(
       <MyPicksPanel
-        picks={{ submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: [] }}
+        picks={{ submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: [], voted_request_ids: [] }}
       />
     );
     expect(screen.getByText(/no picks yet/i)).toBeInTheDocument();
@@ -32,6 +32,7 @@ describe("MyPicksPanel", () => {
           upvoted: [],
           is_top_contributor: true,
           first_suggestion_ids: [],
+          voted_request_ids: [],
         }}
       />
     );
@@ -46,6 +47,7 @@ describe("MyPicksPanel", () => {
           upvoted: [],
           is_top_contributor: false,
           first_suggestion_ids: [1],
+          voted_request_ids: [1],
         }}
       />
     );

--- a/dashboard/app/collect/[code]/components/MyPicksPanel.tsx
+++ b/dashboard/app/collect/[code]/components/MyPicksPanel.tsx
@@ -1,38 +1,63 @@
-"use client";
+'use client';
 
-import type { CollectMyPicksResponse } from "../../../../lib/api";
+import type { CollectMyPicksItem, CollectMyPicksResponse } from '../../../../lib/api';
 
 interface Props {
   picks: CollectMyPicksResponse;
 }
 
+const STATUS_CLASS: Record<CollectMyPicksItem['status'], string> = {
+  new: 'badge-new',
+  accepted: 'badge-accepted',
+  playing: 'badge-playing',
+  played: 'badge-played',
+  rejected: 'badge-rejected',
+};
+
 export default function MyPicksPanel({ picks }: Props) {
   const isEmpty = picks.submitted.length === 0 && picks.upvoted.length === 0;
 
   return (
-    <section style={{ marginTop: 24 }}>
-      <h2>My Picks</h2>
+    <section className="collect-section">
+      <h2 className="collect-section-title">My Picks</h2>
       {picks.is_top_contributor && (
-        <p style={{ color: "#ffcc00" }}>🏆 Top contributor for this event</p>
+        <p className="collect-picks-badge">🏆 Top contributor for this event</p>
       )}
       {isEmpty ? (
-        <p>No picks yet — search for a song below!</p>
+        <p className="collect-empty">No picks yet — search for a song below!</p>
       ) : (
-        <ul>
+        <ul className="collect-leaderboard">
           {picks.submitted.map((p) => (
-            <li key={`s-${p.id}`}>
-              {p.title} — {p.artist}
-              <span style={{ marginLeft: 8, padding: "2px 6px", background: "#333" }}>
-                {p.status}
-              </span>
-              {picks.first_suggestion_ids.includes(p.id) && (
-                <span style={{ marginLeft: 8 }}>⭐ First to suggest</span>
+            <li key={`s-${p.id}`} className="collect-row">
+              {p.artwork_url ? (
+                <img src={p.artwork_url} alt="" className="collect-row-art" />
+              ) : (
+                <div className="collect-row-art" aria-hidden="true" />
               )}
+              <div className="collect-row-info">
+                <div className="collect-row-title">{p.title}</div>
+                <div className="collect-row-artist">{p.artist}</div>
+                {picks.first_suggestion_ids.includes(p.id) && (
+                  <span className="collect-pick-first">⭐ First to suggest</span>
+                )}
+              </div>
+              <span className={`badge ${STATUS_CLASS[p.status]}`}>{p.status}</span>
             </li>
           ))}
           {picks.upvoted.map((p) => (
-            <li key={`u-${p.id}`}>
-              {p.title} — {p.artist} <em>(upvoted)</em>
+            <li key={`u-${p.id}`} className="collect-row">
+              {p.artwork_url ? (
+                <img src={p.artwork_url} alt="" className="collect-row-art" />
+              ) : (
+                <div className="collect-row-art" aria-hidden="true" />
+              )}
+              <div className="collect-row-info">
+                <div className="collect-row-title">{p.title}</div>
+                <div className="collect-row-artist">
+                  {p.artist} <em>(upvoted)</em>
+                </div>
+              </div>
+              <span className="badge badge-new">▲ {p.vote_count}</span>
             </li>
           ))}
         </ul>

--- a/dashboard/app/collect/[code]/components/SubmitBar.tsx
+++ b/dashboard/app/collect/[code]/components/SubmitBar.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 interface Props {
   used: number;
@@ -8,24 +8,17 @@ interface Props {
 
 export default function SubmitBar({ used, cap, onOpenSearch }: Props) {
   const atCap = cap !== 0 && used >= cap;
-  const label =
-    cap === 0 ? "Unlimited picks" : `${used} of ${cap} picks used`;
+  const label = cap === 0 ? 'Unlimited picks' : `${used} of ${cap} picks used`;
 
   return (
-    <div
-      style={{
-        position: "sticky",
-        bottom: 0,
-        background: "#0a0a0a",
-        padding: 16,
-        borderTop: "1px solid #333",
-        display: "flex",
-        justifyContent: "space-between",
-        alignItems: "center",
-      }}
-    >
-      <span>{label}</span>
-      <button disabled={atCap} onClick={onOpenSearch}>
+    <div className="collect-submit-bar">
+      <span className={`collect-cap-counter${atCap ? ' at-cap' : ''}`}>{label}</span>
+      <button
+        type="button"
+        className="btn btn-primary btn-sm"
+        disabled={atCap}
+        onClick={onOpenSearch}
+      >
         + Add a song
       </button>
     </div>

--- a/dashboard/app/collect/[code]/page.test.tsx
+++ b/dashboard/app/collect/[code]/page.test.tsx
@@ -26,7 +26,7 @@ vi.mock("../../../lib/api", () => ({
     getCollectEvent: (...a: unknown[]) => mockGetEvent(...a),
     getCollectLeaderboard: (...a: unknown[]) => mockGetCollectLeaderboard(...a),
     getCollectMyPicks: vi.fn().mockResolvedValue({
-      submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: []
+      submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: [], voted_request_ids: []
     }),
     setCollectProfile: (...a: unknown[]) => mockSetCollectProfile(...a),
     submitCollectRequest: (...a: unknown[]) => mockSubmitCollectRequest(...a),

--- a/dashboard/app/collect/[code]/page.test.tsx
+++ b/dashboard/app/collect/[code]/page.test.tsx
@@ -89,7 +89,7 @@ describe("CollectPage", () => {
     });
     render(<CollectPage />);
     await waitFor(() => {
-      expect(screen.getByText(/opens in/i)).toBeInTheDocument();
+      expect(screen.getByText(/until voting opens/i)).toBeInTheDocument();
     });
   });
 

--- a/dashboard/app/collect/[code]/page.test.tsx
+++ b/dashboard/app/collect/[code]/page.test.tsx
@@ -9,6 +9,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 const mockGetEvent = vi.fn();
+const mockGetCollectProfile = vi.fn();
 const mockSetCollectProfile = vi.fn();
 const mockGetCollectLeaderboard = vi.fn();
 const mockSubmitCollectRequest = vi.fn();
@@ -28,6 +29,7 @@ vi.mock("../../../lib/api", () => ({
     getCollectMyPicks: vi.fn().mockResolvedValue({
       submitted: [], upvoted: [], is_top_contributor: false, first_suggestion_ids: [], voted_request_ids: []
     }),
+    getCollectProfile: (...a: unknown[]) => mockGetCollectProfile(...a),
     setCollectProfile: (...a: unknown[]) => mockSetCollectProfile(...a),
     submitCollectRequest: (...a: unknown[]) => mockSubmitCollectRequest(...a),
     eventSearch: (...a: unknown[]) => mockEventSearch(...a),
@@ -52,11 +54,14 @@ describe("CollectPage", () => {
   beforeEach(() => {
     mockReplace.mockClear();
     mockGetEvent.mockReset();
-    mockSetCollectProfile.mockResolvedValue({
+    const defaultProfile = {
       has_email: false,
+      nickname: null,
       submission_count: 0,
       submission_cap: 15,
-    });
+    };
+    mockGetCollectProfile.mockResolvedValue(defaultProfile);
+    mockSetCollectProfile.mockResolvedValue(defaultProfile);
     mockGetCollectLeaderboard.mockResolvedValue({ requests: [], total: 0 });
     mockSubmitCollectRequest.mockResolvedValue({ id: 42 });
     mockEventSearch.mockResolvedValue([]);
@@ -126,11 +131,22 @@ describe("CollectPage", () => {
   it("calls submitCollectRequest and refreshes profile after track select", async () => {
     mockGetEvent.mockResolvedValue(COLLECTION_EVENT);
 
-    // First setCollectProfile call (initial profile load)
-    mockSetCollectProfile
-      .mockResolvedValueOnce({ has_email: false, submission_count: 0, submission_cap: 15 })
-      // Second call (refresh after submit)
-      .mockResolvedValueOnce({ has_email: false, submission_count: 1, submission_cap: 15 });
+    // Initial profile load goes through getCollectProfile; post-submit refresh
+    // also hits getCollectProfile (not setCollectProfile) now that reads and
+    // writes have separate endpoints.
+    mockGetCollectProfile
+      .mockResolvedValueOnce({
+        has_email: false,
+        nickname: null,
+        submission_count: 0,
+        submission_cap: 15,
+      })
+      .mockResolvedValueOnce({
+        has_email: false,
+        nickname: null,
+        submission_count: 1,
+        submission_cap: 15,
+      });
 
     mockSubmitCollectRequest.mockResolvedValue({ id: 42 });
 
@@ -190,7 +206,8 @@ describe("CollectPage", () => {
       });
     });
 
-    // Profile should have been refreshed at least once after submit (initial + at least one refresh)
-    expect(mockSetCollectProfile.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // Profile should have been refreshed at least once after submit
+    // (initial load + post-submit refresh, both via the read endpoint)
+    expect(mockGetCollectProfile.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -1,7 +1,7 @@
-"use client";
+'use client';
 
-import { useParams, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import {
   apiClient,
   ApiError,
@@ -9,31 +9,32 @@ import {
   CollectLeaderboardResponse,
   CollectMyPicksResponse,
   SearchResult,
-} from "../../../lib/api";
-import FeatureOptInPanel from "./components/FeatureOptInPanel";
-import LeaderboardTabs from "./components/LeaderboardTabs";
-import MyPicksPanel from "./components/MyPicksPanel";
-import SubmitBar from "./components/SubmitBar";
+} from '../../../lib/api';
+import FeatureOptInPanel from './components/FeatureOptInPanel';
+import LeaderboardTabs from './components/LeaderboardTabs';
+import MyPicksPanel from './components/MyPicksPanel';
+import SubmitBar from './components/SubmitBar';
 
 const POLL_MS = 5000;
 
 export default function CollectPage() {
   const router = useRouter();
   const params = useParams<{ code: string }>();
-  const code = params?.code ?? "";
+  const code = params?.code ?? '';
   const [event, setEvent] = useState<CollectEventPreview | null>(null);
-  const [leaderboard, setLeaderboard] = useState<CollectLeaderboardResponse | null>(
-    null
-  );
+  const [leaderboard, setLeaderboard] = useState<CollectLeaderboardResponse | null>(null);
   const [myPicks, setMyPicks] = useState<CollectMyPicksResponse | null>(null);
-  const [tab, setTab] = useState<"trending" | "all">("trending");
+  const [tab, setTab] = useState<'trending' | 'all'>('trending');
   const [error, setError] = useState<string | null>(null);
   const [hasEmail, setHasEmail] = useState(false);
-  const [profile, setProfile] = useState<{ submission_count: number; submission_cap: number } | null>(null);
+  const [profile, setProfile] = useState<{
+    submission_count: number;
+    submission_cap: number;
+  } | null>(null);
 
   // Search modal state
   const [searchOpen, setSearchOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [searching, setSearching] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -54,14 +55,14 @@ export default function CollectPage() {
 
   const openSearch = () => {
     setSearchOpen(true);
-    setSearchQuery("");
+    setSearchQuery('');
     setSearchResults([]);
     setSubmitError(null);
   };
 
   const closeSearch = () => {
     setSearchOpen(false);
-    setSearchQuery("");
+    setSearchQuery('');
     setSearchResults([]);
     setSubmitError(null);
   };
@@ -99,7 +100,6 @@ export default function CollectPage() {
         artwork_url: song.album_art ?? undefined,
         nickname,
       });
-      // Refresh profile (submission count) + leaderboard
       const [p, lb] = await Promise.all([
         apiClient.setCollectProfile(code, {}),
         apiClient.getCollectLeaderboard(code, tab),
@@ -109,9 +109,9 @@ export default function CollectPage() {
       closeSearch();
     } catch (err) {
       if (err instanceof ApiError && err.status === 429) {
-        setSubmitError("Picks limit reached");
+        setSubmitError('Picks limit reached');
       } else {
-        setSubmitError("Failed to submit. Please try again.");
+        setSubmitError('Failed to submit. Please try again.');
       }
     } finally {
       setSubmitting(false);
@@ -119,7 +119,7 @@ export default function CollectPage() {
   };
 
   const redirectToJoin = () => {
-    sessionStorage.setItem(`wrzdj_live_splash_${code}`, "1");
+    sessionStorage.setItem(`wrzdj_live_splash_${code}`, '1');
     router.replace(`/join/${code}`);
   };
 
@@ -133,11 +133,11 @@ export default function CollectPage() {
         const ev = await apiClient.getCollectEvent(code);
         if (cancelled) return;
         setEvent(ev);
-        if (ev.phase === "live" || ev.phase === "closed") {
+        if (ev.phase === 'live' || ev.phase === 'closed') {
           redirectToJoin();
           return;
         }
-        if (ev.phase === "collection") {
+        if (ev.phase === 'collection') {
           const [lb, picks] = await Promise.all([
             apiClient.getCollectLeaderboard(code, tab),
             apiClient.getCollectMyPicks(code),
@@ -150,57 +150,100 @@ export default function CollectPage() {
       } catch (e) {
         if (!cancelled) setError((e as Error).message);
       }
-      if (!cancelled && document.visibilityState === "visible") {
+      if (!cancelled && document.visibilityState === 'visible') {
         timer = setTimeout(tick, POLL_MS);
       }
     };
 
     tick();
     const onVisibility = () => {
-      if (document.visibilityState === "visible" && !cancelled) tick();
+      if (document.visibilityState === 'visible' && !cancelled) tick();
     };
-    document.addEventListener("visibilitychange", onVisibility);
+    document.addEventListener('visibilitychange', onVisibility);
 
     return () => {
       cancelled = true;
       if (timer) clearTimeout(timer);
-      document.removeEventListener("visibilitychange", onVisibility);
+      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, [code, tab]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  if (error) return <main style={{ padding: 24 }}>Error: {error}</main>;
-  if (!event) return <main style={{ padding: 24 }}>Loading…</main>;
-
-  if (event.phase === "pre_announce") {
-    const opens = event.collection_opens_at
-      ? new Date(event.collection_opens_at)
-      : null;
+  if (error) {
     return (
-      <main style={{ padding: 24 }}>
-        <h1>{event.name}</h1>
-        <p>Voting opens in {formatCountdown(opens)}</p>
+      <main className="collect-page">
+        <div className="collect-container">
+          <div className="collect-error">Error: {error}</div>
+        </div>
+      </main>
+    );
+  }
+  if (!event) {
+    return (
+      <main className="collect-page">
+        <div className="loading">Loading…</div>
       </main>
     );
   }
 
+  const bannerNode = event.banner_url ? (
+    <div className="join-banner-bg">
+      <img src={event.banner_url} alt="" />
+    </div>
+  ) : null;
+
+  if (event.phase === 'pre_announce') {
+    const opens = event.collection_opens_at ? new Date(event.collection_opens_at) : null;
+    return (
+      <main className="collect-page">
+        {bannerNode}
+        <div className="collect-container">
+          <div className="collect-preannounce">
+            <div className="collect-phase-badge pre-announce">
+              <span>🎟️</span>
+              <span>Pre-event voting</span>
+            </div>
+            <h1 className="collect-title">{event.name}</h1>
+            <div className="collect-preannounce-count">{formatCountdown(opens)}</div>
+            <p className="collect-countdown">until voting opens</p>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  const liveStarts = event.live_starts_at ? new Date(event.live_starts_at) : null;
+
   return (
-    <main style={{ padding: 24 }}>
-      <h1>{event.name}</h1>
-      <p>
-        Voting open —{" "}
-        {formatCountdown(
-          event.live_starts_at ? new Date(event.live_starts_at) : null
-        )}{" "}
-        until the event goes live
-      </p>
-      <FeatureOptInPanel hasEmail={hasEmail} onSave={saveEmail} />
-      <LeaderboardTabs
-        rows={leaderboard?.requests ?? []}
-        tab={tab}
-        onTabChange={setTab}
-        onVote={(id) => apiClient.voteCollectRequest(code, id)}
-      />
-      {myPicks && <MyPicksPanel picks={myPicks} />}
+    <main className="collect-page">
+      {bannerNode}
+      <div className="collect-container">
+        <header className="collect-header">
+          <div className="collect-phase-badge">
+            <span>🎟️</span>
+            <span>Pre-event voting is open</span>
+          </div>
+          <h1 className="collect-title">{event.name}</h1>
+          {liveStarts && (
+            <p className="collect-countdown">
+              Live show in <strong>{formatCountdown(liveStarts)}</strong>
+            </p>
+          )}
+        </header>
+
+        <FeatureOptInPanel hasEmail={hasEmail} onSave={saveEmail} />
+
+        <section className="collect-section">
+          <LeaderboardTabs
+            rows={leaderboard?.requests ?? []}
+            tab={tab}
+            onTabChange={setTab}
+            onVote={(id) => apiClient.voteCollectRequest(code, id)}
+          />
+        </section>
+
+        {myPicks && <MyPicksPanel picks={myPicks} />}
+      </div>
+
       <SubmitBar
         used={profile?.submission_count ?? 0}
         cap={event.submission_cap_per_guest}
@@ -209,41 +252,28 @@ export default function CollectPage() {
 
       {searchOpen && (
         <div
-          style={{
-            position: "fixed",
-            inset: 0,
-            background: "rgba(0,0,0,0.85)",
-            zIndex: 1000,
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            overflowY: "auto",
-            padding: "1rem",
-          }}
+          className="collect-search-overlay"
           onClick={closeSearch}
+          role="dialog"
+          aria-label="Add a song"
         >
-          <div
-            className="card"
-            style={{ width: "100%", maxWidth: 480, marginTop: "2rem" }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1rem" }}>
-              <h2 style={{ margin: 0 }}>Add a song</h2>
+          <div className="collect-search-modal" onClick={(e) => e.stopPropagation()}>
+            <div className="collect-search-header">
+              <h2 style={{ margin: 0, fontSize: '1.1rem', flex: 1 }}>Add a song</h2>
               <button
+                type="button"
+                className="btn btn-sm collect-optin-dismiss"
                 onClick={closeSearch}
-                style={{ background: "none", border: "none", color: "var(--text-secondary)", fontSize: "1.25rem", cursor: "pointer" }}
                 aria-label="Close search"
               >
                 ✕
               </button>
             </div>
 
-            {submitError && (
-              <p style={{ color: "#ef4444", marginBottom: "1rem" }}>{submitError}</p>
-            )}
+            {submitError && <div className="collect-error">{submitError}</div>}
 
-            <form onSubmit={handleSearch} style={{ marginBottom: "1rem" }}>
-              <div className="form-group">
+            <form onSubmit={handleSearch}>
+              <div className="form-group" style={{ marginBottom: '0.5rem' }}>
                 <input
                   type="text"
                   className="input"
@@ -257,47 +287,37 @@ export default function CollectPage() {
               </div>
               <button
                 type="submit"
-                className="btn btn-primary"
-                style={{ width: "100%" }}
+                className="btn btn-primary btn-sm"
+                style={{ width: '100%' }}
                 disabled={searching}
               >
-                {searching ? "Searching…" : "Search"}
+                {searching ? 'Searching…' : 'Search'}
               </button>
             </form>
 
             {searchResults.length > 0 && (
-              <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+              <div className="collect-search-results">
                 {searchResults.map((result, index) => (
                   <button
+                    type="button"
                     key={result.spotify_id ?? result.url ?? index}
-                    className="request-item"
-                    style={{
-                      cursor: submitting ? "default" : "pointer",
-                      border: "none",
-                      textAlign: "left",
-                      width: "100%",
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "0.75rem",
-                    }}
+                    className="collect-search-result"
                     disabled={submitting}
                     onClick={() => handleSelectSong(result)}
                     data-testid="collect-search-result"
                   >
-                    {result.album_art && (
+                    {result.album_art ? (
                       <img
                         src={result.album_art}
                         alt={result.album ?? result.title}
-                        style={{ width: 48, height: 48, borderRadius: 4, objectFit: "cover", flexShrink: 0 }}
+                        className="collect-row-art"
                       />
+                    ) : (
+                      <div className="collect-row-art" aria-hidden="true" />
                     )}
-                    <div className="request-info" style={{ flex: 1, minWidth: 0 }}>
-                      <h3 style={{ fontSize: "1rem", margin: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                        {result.title}
-                      </h3>
-                      <p style={{ margin: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                        {result.artist}
-                      </p>
+                    <div className="collect-row-info">
+                      <div className="collect-row-title">{result.title}</div>
+                      <div className="collect-row-artist">{result.artist}</div>
                     </div>
                   </button>
                 ))}
@@ -311,9 +331,9 @@ export default function CollectPage() {
 }
 
 function formatCountdown(target: Date | null): string {
-  if (!target) return "";
+  if (!target) return '';
   const diff = target.getTime() - Date.now();
-  if (diff <= 0) return "now";
+  if (diff <= 0) return 'now';
   const hrs = Math.floor(diff / 3_600_000);
   const mins = Math.floor((diff % 3_600_000) / 60_000);
   const days = Math.floor(hrs / 24);

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -31,6 +31,7 @@ export default function CollectPage() {
   const [tab, setTab] = useState<'trending' | 'all'>('all');
   const [error, setError] = useState<string | null>(null);
   const [hasEmail, setHasEmail] = useState(false);
+  const [nickname, setNickname] = useState<string | null>(null);
   const [profile, setProfile] = useState<{
     submission_count: number;
     submission_cap: number;
@@ -44,9 +45,13 @@ export default function CollectPage() {
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  const saveEmail = async (email: string) => {
-    const resp = await apiClient.setCollectProfile(code, { email });
+  const saveProfile = async (data: { nickname?: string; email?: string }) => {
+    const resp = await apiClient.setCollectProfile(code, data);
     setHasEmail(resp.has_email);
+    setNickname(resp.nickname);
+    if (resp.nickname) {
+      localStorage.setItem(`wrzdj_collect_nickname_${code}`, resp.nickname);
+    }
   };
 
   useEffect(() => {
@@ -54,6 +59,10 @@ export default function CollectPage() {
     apiClient.setCollectProfile(code, {}).then((p) => {
       setProfile({ submission_count: p.submission_count, submission_cap: p.submission_cap });
       setHasEmail(p.has_email);
+      setNickname(p.nickname);
+      if (p.nickname) {
+        localStorage.setItem(`wrzdj_collect_nickname_${code}`, p.nickname);
+      }
     });
   }, [code]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -95,14 +104,15 @@ export default function CollectPage() {
     setSubmitting(true);
     setSubmitError(null);
     try {
-      const nickname = localStorage.getItem(`wrzdj_collect_nickname_${code}`) ?? undefined;
+      const submitNickname =
+        nickname ?? localStorage.getItem(`wrzdj_collect_nickname_${code}`) ?? undefined;
       await apiClient.submitCollectRequest(code, {
         song_title: song.title,
         artist: song.artist,
         source: song.source,
         source_url: song.url ?? undefined,
         artwork_url: song.album_art ?? undefined,
-        nickname,
+        nickname: submitNickname,
       });
       const [p, lb] = await Promise.all([
         apiClient.setCollectProfile(code, {}),
@@ -232,9 +242,18 @@ export default function CollectPage() {
               Live show in <strong>{formatCountdown(liveStarts)}</strong>
             </p>
           )}
+          {nickname && (
+            <p className="collect-countdown" style={{ marginTop: '0.25rem' }}>
+              Voting as <strong>@{nickname}</strong>
+            </p>
+          )}
         </header>
 
-        <FeatureOptInPanel hasEmail={hasEmail} onSave={saveEmail} />
+        <FeatureOptInPanel
+          hasEmail={hasEmail}
+          initialNickname={nickname}
+          onSave={saveProfile}
+        />
 
         <section className="collect-section">
           <LeaderboardTabs

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -24,6 +24,7 @@ export default function CollectPage() {
   const [event, setEvent] = useState<CollectEventPreview | null>(null);
   const [leaderboard, setLeaderboard] = useState<CollectLeaderboardResponse | null>(null);
   const [myPicks, setMyPicks] = useState<CollectMyPicksResponse | null>(null);
+  const votedIds = new Set<number>(myPicks?.upvoted.map((p) => p.id) ?? []);
   const [tab, setTab] = useState<'trending' | 'all'>('all');
   const [error, setError] = useState<string | null>(null);
   const [hasEmail, setHasEmail] = useState(false);
@@ -238,6 +239,7 @@ export default function CollectPage() {
             tab={tab}
             onTabChange={setTab}
             onVote={(id) => apiClient.voteCollectRequest(code, id)}
+            votedIds={votedIds}
           />
         </section>
 

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -56,7 +56,7 @@ export default function CollectPage() {
 
   useEffect(() => {
     if (!code) return;
-    apiClient.setCollectProfile(code, {}).then((p) => {
+    apiClient.getCollectProfile(code).then((p) => {
       setProfile({ submission_count: p.submission_count, submission_cap: p.submission_cap });
       setHasEmail(p.has_email);
       setNickname(p.nickname);
@@ -115,7 +115,7 @@ export default function CollectPage() {
         nickname: submitNickname,
       });
       const [p, lb] = await Promise.all([
-        apiClient.setCollectProfile(code, {}),
+        apiClient.getCollectProfile(code),
         apiClient.getCollectLeaderboard(code, tab),
       ]);
       setProfile({ submission_count: p.submission_count, submission_cap: p.submission_cap });

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -24,7 +24,7 @@ export default function CollectPage() {
   const [event, setEvent] = useState<CollectEventPreview | null>(null);
   const [leaderboard, setLeaderboard] = useState<CollectLeaderboardResponse | null>(null);
   const [myPicks, setMyPicks] = useState<CollectMyPicksResponse | null>(null);
-  const [tab, setTab] = useState<'trending' | 'all'>('trending');
+  const [tab, setTab] = useState<'trending' | 'all'>('all');
   const [error, setError] = useState<string | null>(null);
   const [hasEmail, setHasEmail] = useState(false);
   const [profile, setProfile] = useState<{

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -24,7 +24,10 @@ export default function CollectPage() {
   const [event, setEvent] = useState<CollectEventPreview | null>(null);
   const [leaderboard, setLeaderboard] = useState<CollectLeaderboardResponse | null>(null);
   const [myPicks, setMyPicks] = useState<CollectMyPicksResponse | null>(null);
-  const votedIds = new Set<number>(myPicks?.upvoted.map((p) => p.id) ?? []);
+  // Canonical "I have voted on this request" set — covers both upvotes AND
+  // votes on my own submissions (which don't appear in `upvoted` because the
+  // backend dedupes that against `submitted` for display purposes).
+  const votedIds = new Set<number>(myPicks?.voted_request_ids ?? []);
   const [tab, setTab] = useState<'trending' | 'all'>('all');
   const [error, setError] = useState<string | null>(null);
   const [hasEmail, setHasEmail] = useState(false);

--- a/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
+++ b/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import { useEffect, useState } from "react";
-import { z } from "zod";
-import { apiClient, PendingReviewRow } from "@/lib/api";
+import { useEffect, useState } from 'react';
+import { z } from 'zod';
+import { apiClient, PendingReviewRow } from '@/lib/api';
 
 interface EventShape {
   code: string;
@@ -10,8 +10,8 @@ interface EventShape {
   collection_opens_at: string | null;
   live_starts_at: string | null;
   submission_cap_per_guest: number;
-  collection_phase_override: "force_collection" | "force_live" | null;
-  phase: "pre_announce" | "collection" | "live" | "closed";
+  collection_phase_override: 'force_collection' | 'force_live' | null;
+  phase: 'pre_announce' | 'collection' | 'live' | 'closed';
 }
 
 interface Props {
@@ -19,7 +19,13 @@ interface Props {
   onEventChange: (next: Partial<EventShape>) => void;
 }
 
-type ConfirmAction = "force_collection" | "force_live" | "clear";
+type ConfirmAction = 'force_collection' | 'force_live' | 'clear';
+
+const CONFIRM_LABEL: Record<ConfirmAction, string> = {
+  force_collection: 'Open collection now',
+  force_live: 'Start live now',
+  clear: 'Clear phase override',
+};
 
 const collectionSchema = z
   .object({
@@ -34,12 +40,11 @@ const collectionSchema = z
       }
       return true;
     },
-    { message: "Collection opens must be before live starts" }
+    { message: 'Collection opens must be before live starts' },
   );
 
 function toDatetimeLocal(iso: string | null): string {
-  if (!iso) return "";
-  // Chop seconds + timezone to get "YYYY-MM-DDTHH:mm"
+  if (!iso) return '';
   return iso.slice(0, 16);
 }
 
@@ -55,22 +60,18 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
   const [topN, setTopN] = useState(20);
   const [minVotes, setMinVotes] = useState(3);
 
-  // Collection settings form state
   const [collectionOpensAt, setCollectionOpensAt] = useState(
-    toDatetimeLocal(event.collection_opens_at)
+    toDatetimeLocal(event.collection_opens_at),
   );
-  const [liveStartsAt, setLiveStartsAt] = useState(
-    toDatetimeLocal(event.live_starts_at)
-  );
-  const [submissionCap, setSubmissionCap] = useState(
-    event.submission_cap_per_guest
-  );
+  const [liveStartsAt, setLiveStartsAt] = useState(toDatetimeLocal(event.live_starts_at));
+  const [submissionCap, setSubmissionCap] = useState(event.submission_cap_per_guest);
   const [savingSettings, setSavingSettings] = useState(false);
   const [settingsError, setSettingsError] = useState<string | null>(null);
   const [settingsSaved, setSettingsSaved] = useState(false);
 
   useEffect(() => {
     refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [event.code]);
 
   async function refresh() {
@@ -78,7 +79,7 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
     setPending(resp.requests);
   }
 
-  async function applyOverride(value: "force_collection" | "force_live" | null) {
+  async function applyOverride(value: 'force_collection' | 'force_live' | null) {
     const resp = await apiClient.patchCollectionSettings(event.code, {
       collection_phase_override: value,
     });
@@ -88,7 +89,7 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
 
   async function bulk(action: string, extras: Record<string, unknown> = {}) {
     await apiClient.bulkReview(event.code, {
-      action: action as Parameters<typeof apiClient.bulkReview>[1]["action"],
+      action: action as Parameters<typeof apiClient.bulkReview>[1]['action'],
       ...extras,
     });
     setSelected(new Set());
@@ -122,14 +123,14 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
       setSettingsSaved(true);
       setTimeout(() => setSettingsSaved(false), 3000);
     } catch (err) {
-      setSettingsError(err instanceof Error ? err.message : "Failed to save settings");
+      setSettingsError(err instanceof Error ? err.message : 'Failed to save settings');
     } finally {
       setSavingSettings(false);
     }
   }
 
   const shareUrl =
-    typeof window !== "undefined"
+    typeof window !== 'undefined'
       ? `${window.location.origin}/collect/${event.code}`
       : `/collect/${event.code}`;
 
@@ -144,17 +145,43 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
   }
 
   return (
-    <div style={{ padding: 16 }}>
-      <h2>Pre-Event Voting</h2>
+    <div style={{ padding: '1rem' }}>
+      <h2 style={{ marginBottom: '1rem' }}>Pre-Event Voting</h2>
 
-      {/* Collection settings */}
-      <div className="card" style={{ marginBottom: "1.5rem", padding: "1rem" }}>
-        <div style={{ fontWeight: 600, marginBottom: "0.75rem" }}>Collection Settings</div>
+      <div className="pre-event-stats">
+        <div className="pre-event-stat">
+          <div className="pre-event-stat-label">Current phase</div>
+          <div className="pre-event-stat-value">{event.phase.replace('_', ' ')}</div>
+        </div>
+        <div className="pre-event-stat">
+          <div className="pre-event-stat-label">Pending review</div>
+          <div className="pre-event-stat-value">{pending.length}</div>
+        </div>
+        <div className="pre-event-stat">
+          <div className="pre-event-stat-label">Pick cap / guest</div>
+          <div className="pre-event-stat-value">
+            {event.submission_cap_per_guest === 0 ? '∞' : event.submission_cap_per_guest}
+          </div>
+        </div>
+      </div>
+
+      <div className="pre-event-share">
+        <code>{shareUrl}</code>
+        <button
+          type="button"
+          className="btn btn-sm"
+          style={{ background: 'var(--border)', color: 'var(--text)' }}
+          onClick={() => navigator.clipboard.writeText(shareUrl)}
+        >
+          Copy
+        </button>
+      </div>
+
+      <div className="card" style={{ marginBottom: '1.25rem' }}>
+        <h3 style={{ marginBottom: '0.75rem', fontSize: '1rem' }}>Collection Settings</h3>
         <form onSubmit={handleSaveSettings}>
           <div className="form-group">
-            <label htmlFor="collection-opens-at" style={{ fontSize: "0.875rem" }}>
-              Collection opens at
-            </label>
+            <label htmlFor="collection-opens-at">Collection opens at</label>
             <input
               id="collection-opens-at"
               type="datetime-local"
@@ -164,9 +191,7 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
             />
           </div>
           <div className="form-group">
-            <label htmlFor="live-starts-at" style={{ fontSize: "0.875rem" }}>
-              Live starts at
-            </label>
+            <label htmlFor="live-starts-at">Live starts at</label>
             <input
               id="live-starts-at"
               type="datetime-local"
@@ -176,169 +201,194 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
             />
           </div>
           <div className="form-group">
-            <label htmlFor="submission-cap" style={{ fontSize: "0.875rem" }}>
-              Submission cap per guest
-            </label>
+            <label htmlFor="submission-cap">Submission cap per guest</label>
             <input
               id="submission-cap"
               type="number"
               min={0}
               max={100}
-              className="input"
+              className="input collection-fieldset-cap"
               value={submissionCap}
               onChange={(e) => setSubmissionCap(Number(e.target.value))}
-              style={{ width: "6rem" }}
             />
-            <p style={{ color: "#9ca3af", fontSize: "0.75rem", margin: "0.25rem 0 0" }}>
-              0 = unlimited picks per guest
-            </p>
+            <p className="collection-fieldset-hint">0 = unlimited picks per guest</p>
           </div>
-          {settingsError && (
-            <p style={{ color: "#f87171", fontSize: "0.875rem", marginBottom: "0.5rem" }}>
-              {settingsError}
-            </p>
-          )}
+          {settingsError && <p className="collection-fieldset-error">{settingsError}</p>}
           {settingsSaved && (
-            <p style={{ color: "#4ade80", fontSize: "0.875rem", marginBottom: "0.5rem" }}>
+            <p style={{ color: '#4ade80', fontSize: '0.875rem', marginBottom: '0.5rem' }}>
               Settings saved.
             </p>
           )}
           <button type="submit" className="btn btn-primary btn-sm" disabled={savingSettings}>
-            {savingSettings ? "Saving..." : "Save settings"}
+            {savingSettings ? 'Saving…' : 'Save settings'}
           </button>
         </form>
       </div>
 
-      <p>Phase: {event.phase}</p>
-      <p>
-        Share link: <code>{shareUrl}</code>
-        <button
-          onClick={() => navigator.clipboard.writeText(shareUrl)}
-          style={{ marginLeft: 8 }}
-        >
-          Copy
-        </button>
-      </p>
-
-      <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
-        <button onClick={() => setConfirming("force_collection")}>Open collection now</button>
-        <button onClick={() => setConfirming("force_live")}>Start live now</button>
-        <button onClick={() => setConfirming("clear")}>Clear override</button>
-      </div>
-
-      {confirming && (
-        <div style={{ padding: 12, background: "#1a1a1a", marginBottom: 16 }}>
-          <p>Confirm action: {confirming}</p>
+      <div className="card" style={{ marginBottom: '1.25rem' }}>
+        <h3 style={{ marginBottom: '0.75rem', fontSize: '1rem' }}>Phase controls</h3>
+        <div className="pre-event-override-actions">
           <button
-            onClick={() =>
-              applyOverride(confirming === "clear" ? null : confirming)
-            }
+            type="button"
+            className="btn btn-sm"
+            style={{ background: 'var(--border)', color: 'var(--text)' }}
+            onClick={() => setConfirming('force_collection')}
           >
-            Confirm
+            Open collection now
           </button>
-          <button onClick={() => setConfirming(null)} style={{ marginLeft: 8 }}>
-            Cancel
+          <button
+            type="button"
+            className="btn btn-sm btn-success"
+            onClick={() => setConfirming('force_live')}
+          >
+            Start live now
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm"
+            style={{ background: 'var(--border)', color: 'var(--text)' }}
+            onClick={() => setConfirming('clear')}
+          >
+            Clear override
           </button>
         </div>
-      )}
 
-      <h3>Pending review ({pending.length})</h3>
-      <div style={{ marginBottom: 8 }}>
-        <label>
-          Top N:{" "}
-          <input
-            type="number"
-            value={topN}
-            onChange={(e) => setTopN(Number(e.target.value))}
-            style={{ width: 60 }}
-          />
-          <button onClick={() => bulk("accept_top_n", { n: topN })} style={{ marginLeft: 4 }}>
-            Accept top N
-          </button>
-        </label>
-        <label style={{ marginLeft: 16 }}>
-          ≥ votes:{" "}
-          <input
-            type="number"
-            value={minVotes}
-            onChange={(e) => setMinVotes(Number(e.target.value))}
-            style={{ width: 60 }}
-          />
-          <button
-            onClick={() => bulk("accept_threshold", { min_votes: minVotes })}
-            style={{ marginLeft: 4 }}
-          >
-            Accept threshold
-          </button>
-        </label>
-        <button
-          onClick={() => bulk("reject_remaining")}
-          style={{ marginLeft: 16 }}
-        >
-          Reject remaining
-        </button>
+        {confirming && (
+          <div className="pre-event-confirm">
+            <span>Confirm: {CONFIRM_LABEL[confirming]}?</span>
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              onClick={() => applyOverride(confirming === 'clear' ? null : confirming)}
+            >
+              Confirm
+            </button>
+            <button type="button" className="btn btn-sm" onClick={() => setConfirming(null)}>
+              Cancel
+            </button>
+          </div>
+        )}
       </div>
 
-      <table style={{ width: "100%", borderCollapse: "collapse" }}>
-        <thead>
-          <tr>
-            <th></th>
-            <th>▲</th>
-            <th>Song</th>
-            <th>Artist</th>
-            <th>Submitted by</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {pending.map((r) => (
-            <tr key={r.id}>
-              <td>
-                <input
-                  type="checkbox"
-                  checked={selected.has(r.id)}
-                  onChange={(e) => toggleRow(r.id, e.target.checked)}
-                />
-              </td>
-              <td>{r.vote_count}</td>
-              <td>{r.song_title}</td>
-              <td>{r.artist}</td>
-              <td>{r.nickname ?? "—"}</td>
-              <td>
-                <button onClick={() => bulk("accept_ids", { request_ids: [r.id] })}>
-                  Accept
-                </button>
-                <button
-                  onClick={() => bulk("reject_ids", { request_ids: [r.id] })}
-                  style={{ marginLeft: 4 }}
-                >
-                  Reject
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div className="card">
+        <h3 style={{ marginBottom: '0.75rem', fontSize: '1rem' }}>
+          Pending review ({pending.length})
+        </h3>
 
-      {selected.size > 0 && (
-        <div style={{ marginTop: 8 }}>
+        <div className="pre-event-review-controls">
+          <label>
+            Top N:
+            <input
+              type="number"
+              value={topN}
+              onChange={(e) => setTopN(Number(e.target.value))}
+            />
+            <button
+              type="button"
+              className="btn btn-sm btn-success"
+              onClick={() => bulk('accept_top_n', { n: topN })}
+            >
+              Accept top N
+            </button>
+          </label>
+          <label>
+            ≥ votes:
+            <input
+              type="number"
+              value={minVotes}
+              onChange={(e) => setMinVotes(Number(e.target.value))}
+            />
+            <button
+              type="button"
+              className="btn btn-sm btn-success"
+              onClick={() => bulk('accept_threshold', { min_votes: minVotes })}
+            >
+              Accept threshold
+            </button>
+          </label>
           <button
-            onClick={() =>
-              bulk("accept_ids", { request_ids: Array.from(selected) })
-            }
+            type="button"
+            className="btn btn-sm btn-danger"
+            onClick={() => bulk('reject_remaining')}
           >
-            Accept selected ({selected.size})
-          </button>
-          <button
-            onClick={() =>
-              bulk("reject_ids", { request_ids: Array.from(selected) })
-            }
-            style={{ marginLeft: 8 }}
-          >
-            Reject selected ({selected.size})
+            Reject remaining
           </button>
         </div>
-      )}
+
+        {pending.length === 0 ? (
+          <p className="pre-event-review-empty">No pending requests — all caught up!</p>
+        ) : (
+          <table className="pre-event-review-table">
+            <thead>
+              <tr>
+                <th></th>
+                <th>▲</th>
+                <th>Song</th>
+                <th>Artist</th>
+                <th>Submitted by</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pending.map((r) => (
+                <tr key={r.id}>
+                  <td>
+                    <input
+                      type="checkbox"
+                      checked={selected.has(r.id)}
+                      onChange={(e) => toggleRow(r.id, e.target.checked)}
+                    />
+                  </td>
+                  <td>{r.vote_count}</td>
+                  <td>{r.song_title}</td>
+                  <td>{r.artist}</td>
+                  <td>{r.nickname ?? '—'}</td>
+                  <td>
+                    <div className="pre-event-review-actions">
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-success"
+                        onClick={() => bulk('accept_ids', { request_ids: [r.id] })}
+                      >
+                        Accept
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-danger"
+                        onClick={() => bulk('reject_ids', { request_ids: [r.id] })}
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {selected.size > 0 && (
+          <div className="pre-event-bulk-selection">
+            <span style={{ fontSize: '0.875rem', color: 'var(--text-secondary)' }}>
+              {selected.size} selected
+            </span>
+            <button
+              type="button"
+              className="btn btn-sm btn-success"
+              onClick={() => bulk('accept_ids', { request_ids: Array.from(selected) })}
+            >
+              Accept selected
+            </button>
+            <button
+              type="button"
+              className="btn btn-sm btn-danger"
+              onClick={() => bulk('reject_ids', { request_ids: Array.from(selected) })}
+            >
+              Reject selected
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
+++ b/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
@@ -31,7 +31,8 @@ vi.mock("@/lib/api", () => ({
 describe("PreEventVotingTab", () => {
   it("renders phase and share link", () => {
     render(<PreEventVotingTab event={baseEvent} onEventChange={vi.fn()} />);
-    expect(screen.getByText(/phase:\s*collection/i)).toBeInTheDocument();
+    expect(screen.getByText(/current phase/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/collection/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/\/collect\/ABC/i)).toBeInTheDocument();
   });
 

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -1392,3 +1392,588 @@ h1, .display-heading {
     transform: rotate(360deg);
   }
 }
+
+/* ==========================================================================
+ * Pre-Event Collection — /collect/[code] + DJ PreEventVotingTab
+ * Uses CSS variables so ThemeProvider switches carry through.
+ * ========================================================================== */
+
+.collect-page {
+  position: relative;
+  min-height: 100vh;
+  min-height: 100dvh;
+  max-width: 100vw;
+  overflow-x: clip;
+  padding-bottom: 5rem;
+}
+
+.collect-container {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.collect-header {
+  margin-bottom: 1.25rem;
+}
+
+.collect-title {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.collect-phase-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.collect-phase-badge.pre-announce {
+  background: rgba(245, 158, 11, 0.15);
+  color: #fbbf24;
+}
+
+.collect-countdown {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.collect-section {
+  margin-top: 1.5rem;
+}
+
+.collect-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  color: var(--text);
+}
+
+.collect-error {
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 0.5rem;
+  color: #fca5a5;
+  font-size: 0.875rem;
+}
+
+/* Feature opt-in panel */
+.collect-optin {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.collect-optin h3 {
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.collect-optin-features {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.75rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.collect-optin-features li::before {
+  content: '✓ ';
+  color: #22c55e;
+  margin-right: 0.25rem;
+}
+
+.collect-optin-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.75rem;
+}
+
+.collect-optin-dismiss {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+
+.collect-optin-dismiss:hover {
+  color: var(--text);
+  border-color: var(--text-secondary);
+}
+
+/* Leaderboard */
+.collect-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.collect-tab {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: all 0.15s;
+}
+
+.collect-tab[aria-pressed='true'] {
+  background: #3b82f6;
+  border-color: #3b82f6;
+  color: white;
+}
+
+.collect-leaderboard {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.collect-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background: var(--card);
+  border-radius: 8px;
+}
+
+.collect-row-art {
+  width: 44px;
+  height: 44px;
+  border-radius: 6px;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--bg);
+}
+
+.collect-row-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.collect-row-title {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.collect-row-artist {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.collect-row-nickname {
+  font-size: 0.75rem;
+  color: #a78bfa;
+  margin-top: 0.125rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.collect-vote {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  padding: 0.35rem 0.6rem;
+  border-radius: 8px;
+  background: rgba(59, 130, 246, 0.12);
+  color: #60a5fa;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.collect-vote:hover {
+  background: rgba(59, 130, 246, 0.2);
+  border-color: rgba(59, 130, 246, 0.4);
+}
+
+.collect-vote-caret {
+  font-size: 0.7rem;
+  line-height: 1;
+}
+
+.collect-empty {
+  text-align: center;
+  color: var(--text-secondary);
+  padding: 2rem 1rem;
+  font-style: italic;
+}
+
+/* My Picks */
+.collect-picks {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.collect-picks-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  background: rgba(245, 158, 11, 0.15);
+  color: #fbbf24;
+  font-size: 0.8rem;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.collect-pick-first {
+  font-size: 0.7rem;
+  color: #fbbf24;
+  margin-left: 0.5rem;
+}
+
+/* Submit bar */
+.collect-submit-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0.875rem 1rem;
+  background: var(--card);
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  z-index: 10;
+}
+
+.collect-cap-counter {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.collect-cap-counter.at-cap {
+  color: #f87171;
+}
+
+/* Search modal (inline on collect page) */
+.collect-search-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 100;
+}
+
+.collect-search-modal {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  width: 100%;
+  max-width: 560px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.collect-search-header {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  align-items: center;
+}
+
+.collect-search-header .input {
+  flex: 1;
+}
+
+.collect-search-results {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.collect-search-result {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.collect-search-result:hover {
+  background: var(--card);
+  border-color: #3b82f6;
+}
+
+/* Pre-Announce countdown hero */
+.collect-preannounce {
+  text-align: center;
+  padding: 3rem 1rem;
+}
+
+.collect-preannounce-count {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 1rem 0 0.5rem;
+  color: #fbbf24;
+  font-variant-numeric: tabular-nums;
+}
+
+/* DJ-side PreEventVotingTab polish */
+.pre-event-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.pre-event-stat {
+  padding: 0.75rem 1rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.pre-event-stat-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  margin-bottom: 0.25rem;
+}
+
+.pre-event-stat-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.pre-event-share {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 0.75rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+}
+
+.pre-event-share code {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.pre-event-override-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.pre-event-confirm {
+  padding: 0.75rem 1rem;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.pre-event-review-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.pre-event-review-controls label {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.875rem;
+}
+
+.pre-event-review-controls input[type='number'] {
+  width: 4.5rem;
+  padding: 0.35rem 0.5rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 4px;
+}
+
+.pre-event-review-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.pre-event-review-table th,
+.pre-event-review-table td {
+  padding: 0.6rem 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+.pre-event-review-table th {
+  text-align: left;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 500;
+}
+
+.pre-event-review-table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.pre-event-review-actions {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.pre-event-review-empty {
+  text-align: center;
+  color: var(--text-secondary);
+  padding: 2rem 1rem;
+  font-style: italic;
+}
+
+.pre-event-bulk-selection {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  border-radius: 6px;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+/* Shared CollectionFieldset (used on create form and settings card) */
+.collection-fieldset {
+  border-top: 1px solid var(--border);
+  padding-top: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.collection-fieldset-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.collection-fieldset-toggle input[type='checkbox'] {
+  accent-color: #3b82f6;
+}
+
+.collection-fieldset-fields {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.collection-fieldset-hint {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  margin: 0.25rem 0 0;
+}
+
+.collection-fieldset-error {
+  color: #f87171;
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.collection-fieldset-cap {
+  width: 6rem;
+}
+
+/* /join soft banner pointing to /collect */
+.join-pre-event-banner {
+  display: block;
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  background: rgba(59, 130, 246, 0.12);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  border-radius: 8px;
+  color: #60a5fa;
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.join-pre-event-banner a {
+  color: #93c5fd;
+  font-weight: 500;
+}
+
+.join-live-splash {
+  padding: 0.875rem 1rem;
+  background: linear-gradient(90deg, #fbbf24, #f59e0b);
+  color: #1a1a1a;
+  text-align: center;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border-radius: 0 0 8px 8px;
+}

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -1620,9 +1620,17 @@ h1, .display-heading {
   transition: background 0.15s, border-color 0.15s;
 }
 
-.collect-vote:hover {
+.collect-vote:hover:not(:disabled) {
   background: rgba(59, 130, 246, 0.2);
   border-color: rgba(59, 130, 246, 0.4);
+}
+
+.collect-vote.voted,
+.collect-vote:disabled {
+  background: rgba(59, 130, 246, 0.35);
+  color: #dbeafe;
+  border-color: rgba(59, 130, 246, 0.6);
+  cursor: default;
 }
 
 .collect-vote-caret {

--- a/dashboard/app/join/[code]/page.tsx
+++ b/dashboard/app/join/[code]/page.tsx
@@ -330,8 +330,8 @@ export default function JoinEventPage() {
   }
 
   const phaseBanner = (collectPhase === 'pre_announce' || collectPhase === 'collection') ? (
-    <div style={{ padding: 12, background: '#1a1a1a', textAlign: 'center' }}>
-      Voting for this event is open —{' '}
+    <div className="join-pre-event-banner">
+      🎟️ Pre-event voting is open —{' '}
       <a href={`/collect/${code}`}>go to the pre-event page →</a>
     </div>
   ) : null;
@@ -340,7 +340,7 @@ export default function JoinEventPage() {
     return (
       <div className="guest-request-list-container">
         {splashVisible && (
-          <div style={{ padding: 12, background: '#ffcc00', color: '#000', textAlign: 'center' }}>
+          <div className="join-live-splash">
             🎉 The event is now live — you&apos;re in!
           </div>
         )}
@@ -649,7 +649,7 @@ export default function JoinEventPage() {
         </div>
       )}
       {splashVisible && (
-        <div style={{ padding: 12, background: '#ffcc00', color: '#000', textAlign: 'center' }}>
+        <div className="join-live-splash">
           🎉 The event is now live — you&apos;re in!
         </div>
       )}

--- a/dashboard/components/CollectionFieldset.tsx
+++ b/dashboard/components/CollectionFieldset.tsx
@@ -44,38 +44,20 @@ export function CollectionFieldset(props: CollectionFieldsetProps) {
   } = props;
 
   return (
-    <div style={{ borderTop: '1px solid #333', paddingTop: '0.75rem', marginBottom: '1rem' }}>
-      <label
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: '0.5rem',
-          cursor: 'pointer',
-          fontWeight: 500,
-        }}
-      >
+    <div className="collection-fieldset">
+      <label className="collection-fieldset-toggle">
         <input
           type="checkbox"
           checked={enabled}
           onChange={(e) => onEnabledChange(e.target.checked)}
-          style={{ accentColor: '#3b82f6' }}
         />
         Enable pre-event voting
       </label>
 
       {enabled && (
-        <div
-          style={{
-            marginTop: '0.75rem',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '0.75rem',
-          }}
-        >
+        <div className="collection-fieldset-fields">
           <div className="form-group">
-            <label htmlFor="collection-opens-at" style={{ fontSize: '0.875rem' }}>
-              Collection opens at
-            </label>
+            <label htmlFor="collection-opens-at">Collection opens at</label>
             <input
               id="collection-opens-at"
               type="datetime-local"
@@ -85,9 +67,7 @@ export function CollectionFieldset(props: CollectionFieldsetProps) {
             />
           </div>
           <div className="form-group">
-            <label htmlFor="live-starts-at" style={{ fontSize: '0.875rem' }}>
-              Live starts at
-            </label>
+            <label htmlFor="live-starts-at">Live starts at</label>
             <input
               id="live-starts-at"
               type="datetime-local"
@@ -97,24 +77,19 @@ export function CollectionFieldset(props: CollectionFieldsetProps) {
             />
           </div>
           <div className="form-group">
-            <label htmlFor="submission-cap" style={{ fontSize: '0.875rem' }}>
-              Submission cap per guest
-            </label>
+            <label htmlFor="submission-cap">Submission cap per guest</label>
             <input
               id="submission-cap"
               type="number"
               min={0}
               max={100}
-              className="input"
+              className="input collection-fieldset-cap"
               value={submissionCap}
               onChange={(e) => onSubmissionCapChange(Number(e.target.value))}
-              style={{ width: '6rem' }}
             />
-            <p style={{ color: '#9ca3af', fontSize: '0.75rem', margin: '0.25rem 0 0' }}>
-              0 = unlimited picks per guest
-            </p>
+            <p className="collection-fieldset-hint">0 = unlimited picks per guest</p>
           </div>
-          {error && <p style={{ color: '#f87171', fontSize: '0.875rem' }}>{error}</p>}
+          {error && <p className="collection-fieldset-error">{error}</p>}
         </div>
       )}
     </div>

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -145,6 +145,7 @@ export interface CollectMyPicksResponse {
   upvoted: CollectMyPicksItem[];
   is_top_contributor: boolean;
   first_suggestion_ids: number[];
+  voted_request_ids: number[];
 }
 
 export interface CollectionSettingsResponse {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -998,6 +998,17 @@ class ApiClient {
     return res.json();
   }
 
+  async getCollectProfile(code: string): Promise<CollectProfileResponse> {
+    const res = await fetch(
+      `${getApiUrl()}/api/public/collect/${code}/profile`,
+      { method: 'GET', headers: { 'Content-Type': 'application/json' } },
+    );
+    if (!res.ok) {
+      throw new ApiError(`getCollectProfile failed: ${res.status}`, res.status);
+    }
+    return res.json();
+  }
+
   async setCollectProfile(
     code: string,
     data: { nickname?: string; email?: string },

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -103,6 +103,8 @@ export interface CollectEventPreview {
   code: string;
   name: string;
   banner_filename: string | null;
+  banner_url: string | null;
+  banner_colors: string[] | null;
   submission_cap_per_guest: number;
   registration_enabled: boolean;
   phase: 'pre_announce' | 'collection' | 'live' | 'closed';

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -38,6 +38,31 @@ def _get_event_or_404(db: Session, code: str) -> Event:
     return event
 
 
+def _banner_url_for_event(event: Event, request: Request) -> str | None:
+    """Build a public URL for the event's banner image, or None if not set."""
+    if not event.banner_filename:
+        return None
+    base = str(request.base_url).rstrip("/")
+    if request.headers.get("x-forwarded-proto") == "https" and base.startswith("http://"):
+        base = "https://" + base[len("http://") :]
+    return f"{base}/uploads/{event.banner_filename}"
+
+
+def _banner_colors_for_event(event: Event) -> list[str] | None:
+    """Parse the stored JSON-encoded banner_colors string into a list, or None."""
+    if not event.banner_colors:
+        return None
+    import json as _json
+
+    try:
+        value = _json.loads(event.banner_colors)
+        if isinstance(value, list) and all(isinstance(c, str) for c in value):
+            return value
+    except (_json.JSONDecodeError, TypeError):
+        pass
+    return None
+
+
 @router.get("/{code}", response_model=CollectEventPreview)
 @limiter.limit("120/minute")
 def preview(code: str, request: Request, db: Session = Depends(get_db)):
@@ -47,6 +72,8 @@ def preview(code: str, request: Request, db: Session = Depends(get_db)):
         code=event.code,
         name=event.name,
         banner_filename=event.banner_filename,
+        banner_url=_banner_url_for_event(event, request),
+        banner_colors=_banner_colors_for_event(event),
         submission_cap_per_guest=event.submission_cap_per_guest,
         registration_enabled=settings.registration_enabled,
         phase=event.phase,

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -166,10 +166,16 @@ def my_picks(code: str, request: Request, db: Session = Depends(get_db)):
         .all()
     )
 
-    upvoted_request_ids = [
-        rv.request_id
-        for rv in db.query(RequestVote).filter(RequestVote.client_fingerprint == fingerprint).all()
-    ]
+    # All request_ids this fingerprint has voted on (scoped to this event below).
+    # Used both for the `upvoted` section AND the full `voted_request_ids` list.
+    voted_rows = (
+        db.query(RequestVote.request_id)
+        .join(SongRequest, SongRequest.id == RequestVote.request_id)
+        .filter(RequestVote.client_fingerprint == fingerprint)
+        .filter(SongRequest.event_id == event.id)
+        .all()
+    )
+    upvoted_request_ids = [row[0] for row in voted_rows]
     upvoted: list[SongRequest] = []
     if upvoted_request_ids:
         upvoted = (
@@ -233,6 +239,7 @@ def my_picks(code: str, request: Request, db: Session = Depends(get_db)):
         upvoted=[_to_row(r, "upvoted") for r in upvoted if r.id not in submitted_ids],
         is_top_contributor=is_top,
         first_suggestion_ids=first_suggestion_ids,
+        voted_request_ids=upvoted_request_ids,
     )
 
 

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -127,6 +127,32 @@ def leaderboard(
     )
 
 
+@router.get("/{code}/profile", response_model=CollectProfileResponse)
+@limiter.limit("60/minute")
+def get_profile(code: str, request: Request, db: Session = Depends(get_db)):
+    """Read the calling fingerprint's profile for this event. Does NOT
+    create a row if none exists — returns defaults instead. Separate from
+    POST /profile so reads and writes have different action tags in the
+    fingerprint log.
+    """
+    event = _get_event_or_404(db, code)
+    fingerprint = get_client_fingerprint(request, action="collect.get_profile", event_code=code)
+    profile = collect_service.get_profile(db, event_id=event.id, fingerprint=fingerprint)
+    if profile is None:
+        return CollectProfileResponse(
+            nickname=None,
+            has_email=False,
+            submission_count=0,
+            submission_cap=event.submission_cap_per_guest,
+        )
+    return CollectProfileResponse(
+        nickname=profile.nickname,
+        has_email=profile.email is not None,
+        submission_count=profile.submission_count,
+        submission_cap=event.submission_cap_per_guest,
+    )
+
+
 @router.post("/{code}/profile", response_model=CollectProfileResponse)
 @limiter.limit("5/minute")
 def set_profile(

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -8,7 +8,7 @@ from sqlalchemy import desc, func
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
-from app.core.rate_limit import get_client_fingerprint, limiter
+from app.core.rate_limit import get_client_fingerprint, limiter, mask_fingerprint
 from app.models.event import Event
 from app.models.request import Request as SongRequest
 from app.models.request import RequestStatus
@@ -25,6 +25,7 @@ from app.schemas.collect import (
     CollectVoteRequest,
 )
 from app.services import collect as collect_service
+from app.services.activity_log import log_activity
 from app.services.system_settings import get_system_settings
 from app.services.vote import add_vote
 
@@ -135,7 +136,7 @@ def set_profile(
     db: Session = Depends(get_db),
 ):
     event = _get_event_or_404(db, code)
-    fingerprint = get_client_fingerprint(request)
+    fingerprint = get_client_fingerprint(request, action="collect.set_profile", event_code=code)
     profile = collect_service.upsert_profile(
         db,
         event_id=event.id,
@@ -143,6 +144,19 @@ def set_profile(
         nickname=payload.nickname,
         email=payload.email,
     )
+    if payload.nickname is not None or payload.email is not None:
+        _parts = []
+        if payload.nickname is not None:
+            _parts.append("nickname")
+        if payload.email is not None:
+            _parts.append("email")
+        log_activity(
+            db,
+            level="info",
+            source="collect",
+            message=f"Guest [{mask_fingerprint(fingerprint)}] updated profile: {', '.join(_parts)}",
+            event_code=code,
+        )
     return CollectProfileResponse(
         nickname=profile.nickname,
         has_email=profile.email is not None,
@@ -155,7 +169,7 @@ def set_profile(
 @limiter.limit("60/minute")
 def my_picks(code: str, request: Request, db: Session = Depends(get_db)):
     event = _get_event_or_404(db, code)
-    fingerprint = get_client_fingerprint(request)
+    fingerprint = get_client_fingerprint(request, action="collect.my_picks", event_code=code)
 
     submitted = (
         db.query(SongRequest)
@@ -260,7 +274,7 @@ def submit(
     if event.phase != "collection":
         raise HTTPException(status_code=409, detail="Collection has ended")
 
-    fingerprint = get_client_fingerprint(request)
+    fingerprint = get_client_fingerprint(request, action="collect.submit", event_code=code)
     try:
         collect_service.check_and_increment_submission_count(
             db, event=event, fingerprint=fingerprint
@@ -293,6 +307,16 @@ def submit(
     db.add(row)
     db.commit()
     db.refresh(row)
+    log_activity(
+        db,
+        level="info",
+        source="collect",
+        message=(
+            f"Guest [{mask_fingerprint(fingerprint)}] submitted "
+            f"'{row.song_title}' by {row.artist} (req #{row.id})"
+        ),
+        event_code=code,
+    )
     return {"id": row.id}
 
 
@@ -307,7 +331,7 @@ def vote(
     event = _get_event_or_404(db, code)
     if event.phase not in ("collection", "live"):
         raise HTTPException(status_code=409, detail="Voting is closed")
-    fingerprint = get_client_fingerprint(request)
+    fingerprint = get_client_fingerprint(request, action="collect.vote", event_code=code)
     row = (
         db.query(SongRequest)
         .filter(SongRequest.id == payload.request_id)
@@ -316,5 +340,16 @@ def vote(
     )
     if row is None:
         raise HTTPException(status_code=404, detail="Request not found")
-    add_vote(db, request_id=row.id, client_fingerprint=fingerprint)
+    _, is_new_vote = add_vote(db, request_id=row.id, client_fingerprint=fingerprint)
+    if is_new_vote:
+        log_activity(
+            db,
+            level="info",
+            source="collect",
+            message=(
+                f"Guest [{mask_fingerprint(fingerprint)}] voted on "
+                f"'{row.song_title}' (req #{row.id})"
+            ),
+            event_code=code,
+        )
     return {"ok": True}

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -103,7 +103,9 @@ def leaderboard(
             SongRequest.vote_count.desc(), SongRequest.created_at.desc()
         )
     else:
-        q = q.order_by(SongRequest.created_at.desc())
+        # "All" is the discovery view — alphabetical makes it easy to scan
+        # and upvote existing submissions rather than recency bias.
+        q = q.order_by(func.lower(SongRequest.song_title).asc())
 
     rows = q.limit(200).all()
     return CollectLeaderboardResponse(

--- a/server/app/core/rate_limit.py
+++ b/server/app/core/rate_limit.py
@@ -1,6 +1,7 @@
 """Rate limiting middleware using slowapi."""
 
 import ipaddress
+import logging
 from functools import lru_cache
 
 from fastapi import Request, Response
@@ -72,10 +73,56 @@ def get_client_ip(request: Request) -> str:
 
 MAX_FINGERPRINT_LENGTH = 64
 
+_fp_logger = logging.getLogger("app.fingerprint")
 
-def get_client_fingerprint(request: Request) -> str:
-    """Extract client fingerprint (IP) from the request, truncated to safe length."""
-    return get_client_ip(request)[:MAX_FINGERPRINT_LENGTH]
+
+def mask_fingerprint(fp: str) -> str:
+    """Return a short, non-reversible tag for a fingerprint — safe for logs
+    and activity-log messages.
+
+    SHA-256 truncated to 12 hex chars: enough to correlate actions by the
+    same guest across events in logs, but not enough to recover the original
+    IP. The raw value stays in the DB for legitimate abuse investigation.
+    """
+    import hashlib
+
+    return hashlib.sha256(fp.encode("utf-8")).hexdigest()[:12]
+
+
+def _fp_source(request: Request) -> str:
+    """Identify which header/layer supplied the fingerprint for this request."""
+    direct_ip = get_remote_address(request)
+    if request.headers.get("X-Real-IP") and _is_trusted_proxy(direct_ip):
+        return "x-real-ip"
+    if request.headers.get("X-Forwarded-For") and _is_trusted_proxy(direct_ip):
+        return "x-forwarded-for"
+    return "direct"
+
+
+def get_client_fingerprint(
+    request: Request,
+    *,
+    action: str | None = None,
+    event_code: str | None = None,
+) -> str:
+    """Extract client fingerprint (IP) from the request, truncated to safe length.
+
+    When `action` is provided, emits a structured INFO log line:
+        action=collect.vote event=PB5TTP source=x-real-ip fp=a1b2c3d4e5f6
+
+    The logged `fp` is a hashed tag — the raw IP stays in the DB for
+    legitimate abuse investigation but never appears in log output.
+    """
+    raw = get_client_ip(request)[:MAX_FINGERPRINT_LENGTH]
+    if action is not None:
+        _fp_logger.info(
+            "fp_resolve action=%s event=%s source=%s fp=%s",
+            action,
+            event_code or "-",
+            _fp_source(request),
+            mask_fingerprint(raw),
+        )
+    return raw
 
 
 # Create limiter instance with IP-based key function

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -28,6 +28,8 @@ class CollectEventPreview(BaseModel):
     code: str
     name: str
     banner_filename: str | None
+    banner_url: str | None = None
+    banner_colors: list[str] | None = None
     submission_cap_per_guest: int
     registration_enabled: bool
     phase: Literal["pre_announce", "collection", "live", "closed"]

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -75,6 +75,11 @@ class CollectMyPicksResponse(BaseModel):
     upvoted: list[CollectMyPicksItem]
     is_top_contributor: bool
     first_suggestion_ids: list[int]
+    # Every request_id this guest has voted on in this event, including votes
+    # on their own submissions. Separate from `upvoted` (which is de-duped
+    # against `submitted` for display purposes) so the UI can gate the vote
+    # button accurately.
+    voted_request_ids: list[int]
 
 
 class CollectSubmitRequest(BaseModel):

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -214,3 +214,40 @@ def test_collect_leaderboard_all_tab_sorts_alphabetically(client, db, test_event
     assert r.status_code == 200
     titles = [row["title"] for row in r.json()["requests"]]
     assert titles == ["Alpha Song", "mango tango", "zebra stripes"]
+
+
+def test_collect_my_picks_voted_request_ids_includes_self_votes(
+    client, db, test_event, collection_requests
+):
+    """voted_request_ids must include votes on own submissions, so the UI
+    can disable the vote button for them even though they don't appear in
+    the `upvoted` section (which is de-duped against `submitted`).
+    """
+    _enable_collection(db, test_event)
+    from app.core.rate_limit import MAX_FINGERPRINT_LENGTH
+
+    # TestClient's default remote host is "testclient"; take first N chars.
+    fp = "testclient"[:MAX_FINGERPRINT_LENGTH]
+
+    # Mark one collection request as submitted by this client so the backend
+    # puts it under `submitted` (de-duped out of `upvoted`).
+    target = collection_requests[0]
+    target.client_fingerprint = fp
+    db.commit()
+
+    # Cast a vote on that same request.
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/vote",
+        json={"request_id": target.id},
+    )
+    assert r.status_code == 200
+
+    me = client.get(f"/api/public/collect/{test_event.code}/profile/me")
+    assert me.status_code == 200
+    body = me.json()
+
+    # The submission is in `submitted`, NOT in `upvoted` (dedupe behavior).
+    assert any(s["id"] == target.id for s in body["submitted"])
+    assert not any(u["id"] == target.id for u in body["upvoted"])
+    # But voted_request_ids MUST include it — this is the fix.
+    assert target.id in body["voted_request_ids"]

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -309,3 +309,51 @@ def test_collect_activity_log_entries_for_state_changes(client, db, test_event):
 
     for row in rows:
         assert re.search(r"\[[0-9a-f]{12}\]", row.message), f"missing masked fp: {row.message}"
+
+
+def test_collect_get_profile_does_not_create_row(client, db, test_event):
+    """GET /profile returns defaults without creating a GuestProfile row —
+    reads should not have write side effects, and ActivityLog must stay clean.
+    """
+    from app.models.activity_log import ActivityLog
+    from app.models.guest_profile import GuestProfile
+
+    _enable_collection(db, test_event)
+
+    before_rows = db.query(GuestProfile).count()
+    before_log = db.query(ActivityLog).count()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/profile")
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {
+        "nickname": None,
+        "has_email": False,
+        "submission_count": 0,
+        "submission_cap": test_event.submission_cap_per_guest,
+    }
+
+    assert db.query(GuestProfile).count() == before_rows, (
+        "GET /profile must not create a GuestProfile row"
+    )
+    assert db.query(ActivityLog).count() == before_log, "GET /profile must not write to ActivityLog"
+
+
+def test_collect_get_profile_returns_existing_state(client, db, test_event):
+    """When a GuestProfile exists, GET returns its fields faithfully."""
+    _enable_collection(db, test_event)
+
+    # POST a real nickname + email first.
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/profile",
+        json={"nickname": "Reader", "email": "reader@example.com"},
+    )
+    assert r.status_code == 200
+
+    # Now read it back via GET.
+    r = client.get(f"/api/public/collect/{test_event.code}/profile")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["nickname"] == "Reader"
+    assert body["has_email"] is True
+    assert body["submission_cap"] == test_event.submission_cap_per_guest

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -251,3 +251,61 @@ def test_collect_my_picks_voted_request_ids_includes_self_votes(
     assert not any(u["id"] == target.id for u in body["upvoted"])
     # But voted_request_ids MUST include it — this is the fix.
     assert target.id in body["voted_request_ids"]
+
+
+def test_collect_activity_log_entries_for_state_changes(client, db, test_event):
+    """Submit, vote, and profile-set should each write one ActivityLog row
+    tagged with the masked fingerprint so DJs can audit guest activity.
+    """
+    from app.models.activity_log import ActivityLog
+
+    _enable_collection(db, test_event)
+
+    # 1. Submit a song.
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={"song_title": "Log Me", "artist": "Audit", "source": "spotify"},
+    )
+    assert r.status_code == 201
+    new_id = r.json()["id"]
+
+    # 2. Vote on it.
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/vote",
+        json={"request_id": new_id},
+    )
+    assert r.status_code == 200
+
+    # 2b. Vote again — idempotent, should NOT create a second activity row.
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/vote",
+        json={"request_id": new_id},
+    )
+    assert r.status_code == 200
+
+    # 3. Set a nickname.
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/profile",
+        json={"nickname": "LogTester"},
+    )
+    assert r.status_code == 200
+
+    rows = (
+        db.query(ActivityLog)
+        .filter(ActivityLog.event_code == test_event.code)
+        .filter(ActivityLog.source == "collect")
+        .order_by(ActivityLog.id.asc())
+        .all()
+    )
+    assert len(rows) == 3, (
+        f"expected 3 collect activity rows, got {len(rows)}: {[r.message for r in rows]}"
+    )
+    assert "submitted" in rows[0].message
+    assert "'Log Me'" in rows[0].message
+    assert "voted" in rows[1].message
+    assert "updated profile" in rows[2].message
+    # Every row should carry the masked fingerprint (12 hex chars in [brackets]).
+    import re
+
+    for row in rows:
+        assert re.search(r"\[[0-9a-f]{12}\]", row.message), f"missing masked fp: {row.message}"

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -179,3 +179,38 @@ def test_collect_vote_is_idempotent(client, db, test_event, collection_requests)
     )
     after = db.query(type(req)).filter(type(req).id == req.id).one().vote_count
     assert after == before
+
+
+def test_collect_leaderboard_all_tab_sorts_alphabetically(client, db, test_event):
+    """The All tab should sort alphabetically (case-insensitive) by song title
+    so guests can scan and upvote existing submissions without recency bias.
+    """
+    from datetime import timedelta
+
+    from app.core.time import utcnow
+    from app.models.request import Request as SongRequest
+    from app.models.request import RequestStatus
+
+    _enable_collection(db, test_event)
+    now = utcnow()
+    # Intentionally insert out of order, with mixed casing.
+    for idx, title in enumerate(["zebra stripes", "Alpha Song", "mango tango"]):
+        db.add(
+            SongRequest(
+                event_id=test_event.id,
+                song_title=title,
+                artist=f"Artist {idx}",
+                source="spotify",
+                status=RequestStatus.NEW.value,
+                vote_count=0,
+                dedupe_key=f"dk_alpha_{idx}",
+                submitted_during_collection=True,
+                created_at=now - timedelta(seconds=idx),
+            )
+        )
+    db.commit()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all")
+    assert r.status_code == 200
+    titles = [row["title"] for row in r.json()["requests"]]
+    assert titles == ["Alpha Song", "mango tango", "zebra stripes"]


### PR DESCRIPTION
## Summary

Follow-up to #245 that closes the styling gap the design pass audit caught: the initial feature sprint shipped functional-but-inline-styled components that didn't match the existing WrzDJ dark theme. This PR swaps the inline hex literals for classes built on the project's CSS variables (so the ThemeProvider toggle carries through) and wires up the banner reuse that the spec described.

**Merges into `feat/pre-event-requests`, not main.**

## What changed

- **New CSS sections in `globals.css`** (theme-variable driven):
  - `.collect-*` — collect page layout, phase badge, leaderboard rows, sticky submit bar, search modal, pre-announce hero
  - `.pre-event-*` — DJ-side tab: stats grid, share pill, override controls, confirm strip, review table, bulk-selection toolbar
  - `.collection-fieldset-*` — shared fieldset used by both create-event forms
  - `.join-pre-event-banner` + `.join-live-splash` — /join banner linking to /collect, live-start splash
- **Backend**: `CollectEventPreview` now returns `banner_url` + `banner_colors` so the collect page can reuse `.join-banner-bg` (the existing blurred banner fade used on `/join/[code]`)
- **Components**: `SubmitBar`, `FeatureOptInPanel`, `LeaderboardTabs`, `MyPicksPanel`, `PreEventVotingTab`, `CollectionFieldset`, and the collect page itself swapped from inline hex to the new class system
- **Status chips** in My Picks use the existing `.badge-new` / `.badge-accepted` / `.badge-playing` / `.badge-played` / `.badge-rejected` classes
- **Leaderboard rows** follow the existing `.guest-request-item` pattern (artwork + title + artist + vote/status badge)
- **Pre-announce phase** gets a proper countdown hero instead of a plain `<h1>` + paragraph
- Two test assertions updated to match the new copy

## Why this matters

- Theme-toggle (light/dark if/when added) now works on collect pages — they use `var(--bg)`, `var(--card)`, `var(--text)`, `var(--border)` instead of hardcoded hex
- Single source of truth for the theme colors — future palette tweaks in globals.css propagate automatically
- Matches the existing `/join/[code]` aesthetic so guests see a consistent WrzDJ look across both flows

## Test plan

- [x] Backend: collect + contract tests (56/56) + ruff/format clean
- [x] Frontend: full suite (798/798) + tsc clean + ESLint 0 errors
- [x] Visual check via push-to-testing: banner now renders on `/collect/<code>` when event has one; phase badge styled; leaderboard rows match `/join` visual weight

## Notes for reviewers

- Inline `style={{...}}` kept only where truly ad-hoc (e.g., widths on a single button). Pattern was: if it looked like a reusable shape, it got a class.
- The `banner_url` construction in `collect.py` mirrors the `_get_banner_urls` helper in `events.py` — worth extracting to a shared helper in a future cleanup if a third caller appears.
- No new CSS packages added. Stays on vanilla CSS per project convention.