### PR TITLE
feat(collect): enable pre-event voting on existing events

### DIFF
--- a/dashboard/app/events/[code]/components/EventManagementTab.tsx
+++ b/dashboard/app/events/[code]/components/EventManagementTab.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import type { Event, ArchivedEvent, TidalStatus, BeatportStatus } from '@/lib/api-types';
+import type { CollectionSettingsResponse } from '@/lib/api';
 import { KioskControlsCard } from './KioskControlsCard';
 import { PairedKiosksCard } from './PairedKiosksCard';
 import { StreamOverlayCard } from './StreamOverlayCard';
 import { BridgeStatusCard } from './BridgeStatusCard';
 import { CloudProvidersCard } from './CloudProvidersCard';
 import { EventCustomizationCard } from './EventCustomizationCard';
+import { PreEventVotingCard } from './PreEventVotingCard';
 import { HelpSpot } from '@/components/help/HelpSpot';
 
 interface BridgeDetails {
@@ -51,6 +53,8 @@ interface EventManagementTabProps {
   uploadingBanner: boolean;
   onBannerSelect: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onDeleteBanner: () => void;
+  onPreEventEnabled: (next: CollectionSettingsResponse) => void;
+  onJumpToPreEventTab: () => void;
 }
 
 export function EventManagementTab(props: EventManagementTabProps) {
@@ -86,6 +90,12 @@ export function EventManagementTab(props: EventManagementTabProps) {
           onDeleteBanner={props.onDeleteBanner}
         />
       </HelpSpot>
+
+      <PreEventVotingCard
+        event={props.event}
+        onEnabled={props.onPreEventEnabled}
+        onJumpToTab={props.onJumpToPreEventTab}
+      />
 
       <HelpSpot spotId="event-stream-overlay" page="event-manage" order={3} title="Stream Overlay" description="Copy the OBS browser source URL to show currently playing track on your stream.">
         <StreamOverlayCard code={props.code} />

--- a/dashboard/app/events/[code]/components/PreEventVotingCard.tsx
+++ b/dashboard/app/events/[code]/components/PreEventVotingCard.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useState } from 'react';
+import { apiClient, type CollectionSettingsResponse } from '@/lib/api';
+import {
+  CollectionFieldset,
+  collectionSchema,
+} from '@/components/CollectionFieldset';
+import type { Event, ArchivedEvent } from '@/lib/api-types';
+
+function toIso(local: string): string | null {
+  if (!local) return null;
+  return new Date(local).toISOString();
+}
+
+function toDatetimeLocal(iso: string | null | undefined): string {
+  if (!iso) return '';
+  return iso.slice(0, 16);
+}
+
+interface Props {
+  event: Event | ArchivedEvent;
+  onEnabled: (next: CollectionSettingsResponse) => void;
+  onJumpToTab: () => void;
+}
+
+/**
+ * Lives on the Event Management tab. Two modes:
+ *   1. Voting NOT enabled (collection_opens_at is null) — surface the
+ *      "Enable pre-event voting" toggle + date form inline.
+ *   2. Voting enabled — show a status pill + button that jumps to the
+ *      dedicated Pre-Event Voting tab where the full UI lives.
+ */
+export function PreEventVotingCard({ event, onEnabled, onJumpToTab }: Props) {
+  const enabled = !!event.collection_opens_at || !!event.live_starts_at;
+
+  const [showFields, setShowFields] = useState(false);
+  const [opensAt, setOpensAt] = useState(toDatetimeLocal(event.collection_opens_at));
+  const [liveAt, setLiveAt] = useState(toDatetimeLocal(event.live_starts_at));
+  const [cap, setCap] = useState(event.submission_cap_per_guest ?? 15);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  if (enabled) {
+    return (
+      <div className="card">
+        <h3 style={{ marginBottom: '0.5rem', fontSize: '1.05rem' }}>
+          Pre-Event Voting
+        </h3>
+        <p style={{ color: 'var(--text-secondary)', marginBottom: '0.75rem', fontSize: '0.875rem' }}>
+          Voting is enabled. Manage dates, share link, phase overrides, and bulk-review
+          on the dedicated tab.
+        </p>
+        <button type="button" className="btn btn-sm btn-primary" onClick={onJumpToTab}>
+          Open Pre-Event Voting →
+        </button>
+      </div>
+    );
+  }
+
+  async function handleSave() {
+    if (!showFields) {
+      setShowFields(true);
+      return;
+    }
+    setError(null);
+    const parsed = collectionSchema.safeParse({
+      collection_opens_at: opensAt || undefined,
+      live_starts_at: liveAt || undefined,
+      submission_cap_per_guest: cap,
+    });
+    if (!parsed.success) {
+      setError(parsed.error.issues[0].message);
+      return;
+    }
+    if (!opensAt && !liveAt) {
+      setError('Set at least an "opens at" or "live starts at" date.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const resp = await apiClient.patchCollectionSettings(event.code, {
+        collection_opens_at: toIso(opensAt),
+        live_starts_at: toIso(liveAt),
+        submission_cap_per_guest: cap,
+      });
+      onEnabled(resp);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to enable pre-event voting');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="card">
+      <h3 style={{ marginBottom: '0.5rem', fontSize: '1.05rem' }}>
+        Pre-Event Voting
+      </h3>
+      <p style={{ color: 'var(--text-secondary)', marginBottom: '0.75rem', fontSize: '0.875rem' }}>
+        Let guests suggest and upvote songs in advance via a dedicated link.
+        At live-start, accepted picks flow into the regular request queue.
+      </p>
+
+      {showFields && (
+        <CollectionFieldset
+          enabled={true}
+          onEnabledChange={(v) => {
+            if (!v) setShowFields(false);
+          }}
+          collectionOpensAt={opensAt}
+          onCollectionOpensAtChange={setOpensAt}
+          liveStartsAt={liveAt}
+          onLiveStartsAtChange={setLiveAt}
+          submissionCap={cap}
+          onSubmissionCapChange={setCap}
+          error={error}
+        />
+      )}
+
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <button
+          type="button"
+          className="btn btn-sm btn-primary"
+          onClick={handleSave}
+          disabled={saving}
+        >
+          {showFields
+            ? saving
+              ? 'Enabling…'
+              : 'Enable pre-event voting'
+            : 'Set up pre-event voting'}
+        </button>
+        {showFields && (
+          <button
+            type="button"
+            className="btn btn-sm"
+            style={{ background: 'var(--border)', color: 'var(--text)' }}
+            onClick={() => setShowFields(false)}
+            disabled={saving}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
+++ b/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
@@ -148,6 +148,24 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
     <div style={{ padding: '1rem' }}>
       <h2 style={{ marginBottom: '1rem' }}>Pre-Event Voting</h2>
 
+      {!event.collection_opens_at && !event.live_starts_at && (
+        <div
+          style={{
+            padding: '0.875rem 1rem',
+            background: 'rgba(59, 130, 246, 0.12)',
+            border: '1px solid rgba(59, 130, 246, 0.25)',
+            borderRadius: 8,
+            color: '#60a5fa',
+            marginBottom: '1.25rem',
+            fontSize: '0.9rem',
+          }}
+        >
+          Pre-event voting isn&apos;t enabled yet. Set the dates below to turn it
+          on — guests can then visit the share link to suggest and upvote songs
+          ahead of the live event.
+        </div>
+      )}
+
       <div className="pre-event-stats">
         <div className="pre-event-stat">
           <div className="pre-event-stat-label">Current phase</div>

--- a/dashboard/app/events/[code]/components/__tests__/EventManagementTab.test.tsx
+++ b/dashboard/app/events/[code]/components/__tests__/EventManagementTab.test.tsx
@@ -66,6 +66,8 @@ const baseProps = {
   uploadingBanner: false,
   onBannerSelect: vi.fn(),
   onDeleteBanner: vi.fn(),
+  onPreEventEnabled: vi.fn(),
+  onJumpToPreEventTab: vi.fn(),
 };
 
 describe('EventManagementTab', () => {

--- a/dashboard/app/events/[code]/page.tsx
+++ b/dashboard/app/events/[code]/page.tsx
@@ -1027,12 +1027,17 @@ export default function EventQueuePage() {
               >
                 Event Management
               </button>
-              {event && 'collection_opens_at' in event && event.collection_opens_at != null && (
+              {event && (
                 <button
                   className={`event-tab${activeTab === 'pre-event' ? ' active' : ''}`}
                   onClick={() => setActiveTab('pre-event')}
                 >
                   Pre-Event Voting
+                  {'collection_opens_at' in event && event.collection_opens_at == null && (
+                    <span style={{ marginLeft: 6, fontSize: '0.75em', opacity: 0.7 }}>
+                      (off)
+                    </span>
+                  )}
                 </button>
               )}
             </div>
@@ -1113,6 +1118,20 @@ export default function EventQueuePage() {
               uploadingBanner={uploadingBanner}
               onBannerSelect={handleBannerSelect}
               onDeleteBanner={handleDeleteBanner}
+              onPreEventEnabled={(next) => {
+                setCollectionSettings(next);
+                if (event) {
+                  setEvent({
+                    ...event,
+                    collection_opens_at: next.collection_opens_at,
+                    live_starts_at: next.live_starts_at,
+                    submission_cap_per_guest: next.submission_cap_per_guest,
+                    collection_phase_override: next.collection_phase_override,
+                  } as typeof event);
+                }
+                setActiveTab('pre-event');
+              }}
+              onJumpToPreEventTab={() => setActiveTab('pre-event')}
             />
           </div>
 


### PR DESCRIPTION
## Summary

Pre-existing events couldn't enable pre-event voting from the UI — the toggle only existed on the create-event form, and the Pre-Event Voting tab itself only appeared once collection_opens_at was set (classic chicken-and-egg).

Two fixes:

1. **Pre-Event Voting tab is now always visible** with an \"(off)\" suffix when voting isn't enabled, plus an explanatory banner inside.
2. **New PreEventVotingCard** on the Event Management tab — DJs find it where they expect event settings. \"Set up pre-event voting\" expands to the shared CollectionFieldset; saving persists via PATCH /collection and jumps to the dedicated tab.

## Test plan

- [x] Backend: untouched (no API changes — PATCH /collection already handled this)
- [x] Frontend: 168 vitest tests pass; tsc clean; ESLint 0 errors
- [x] Existing event JAY9S3 on app.wrzdj.com is the motivating case