### PR TITLE
fix: prevent duplicate song submissions and self-voting in collect flow

### DIFF
--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -27,7 +27,10 @@ export default function CollectPage() {
   // Canonical "I have voted on this request" set — covers both upvotes AND
   // votes on my own submissions (which don't appear in `upvoted` because the
   // backend dedupes that against `submitted` for display purposes).
-  const votedIds = new Set<number>(myPicks?.voted_request_ids ?? []);
+  const votedIds = new Set<number>([
+    ...(myPicks?.voted_request_ids ?? []),
+    ...(myPicks?.submitted ?? []).map((s) => s.id),
+  ]);
   const [tab, setTab] = useState<'trending' | 'all'>('all');
   const [error, setError] = useState<string | null>(null);
   const [hasEmail, setHasEmail] = useState(false);
@@ -106,7 +109,7 @@ export default function CollectPage() {
     try {
       const submitNickname =
         nickname ?? localStorage.getItem(`wrzdj_collect_nickname_${code}`) ?? undefined;
-      await apiClient.submitCollectRequest(code, {
+      const result = await apiClient.submitCollectRequest(code, {
         song_title: song.title,
         artist: song.artist,
         source: song.source as 'spotify' | 'beatport' | 'tidal' | 'manual',
@@ -114,16 +117,26 @@ export default function CollectPage() {
         artwork_url: song.album_art ?? undefined,
         nickname: submitNickname,
       });
+
+      if (result.is_duplicate) {
+        setSubmitError('Great minds think alike! Your vote has been added.');
+      }
+
       const [p, lb] = await Promise.all([
         apiClient.getCollectProfile(code),
         apiClient.getCollectLeaderboard(code, tab),
       ]);
       setProfile({ submission_count: p.submission_count, submission_cap: p.submission_cap });
       setLeaderboard(lb);
-      closeSearch();
+
+      if (!result.is_duplicate) {
+        closeSearch();
+      }
     } catch (err) {
       if (err instanceof ApiError && err.status === 429) {
         setSubmitError('Picks limit reached');
+      } else if (err instanceof ApiError && err.status === 409) {
+        setSubmitError('You already picked this one!');
       } else {
         setSubmitError('Failed to submit. Please try again.');
       }

--- a/dashboard/lib/__tests__/collect-api.test.ts
+++ b/dashboard/lib/__tests__/collect-api.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { apiClient } from "../api";
+import { apiClient, ApiError } from "../api";
 
 const OK_RESPONSE = (body: unknown) =>
   ({ ok: true, status: 200, json: async () => body }) as Response;
+
+const ERR_RESPONSE = (status: number, detail: string) =>
+  ({ ok: false, status, json: async () => ({ detail }) }) as Response;
 
 describe("collect api client", () => {
   beforeEach(() => {
@@ -39,6 +42,32 @@ describe("collect api client", () => {
     );
   });
 
+  it("submitCollectRequest returns is_duplicate flag", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      OK_RESPONSE({ id: 7, is_duplicate: true })
+    );
+    const r = await apiClient.submitCollectRequest("ABC", {
+      song_title: "T",
+      artist: "A",
+      source: "spotify",
+    });
+    expect(r.is_duplicate).toBe(true);
+    expect(r.id).toBe(7);
+  });
+
+  it("submitCollectRequest throws ApiError on 409", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      ERR_RESPONSE(409, "You already picked this one!")
+    );
+    await expect(
+      apiClient.submitCollectRequest("ABC", {
+        song_title: "T",
+        artist: "A",
+        source: "spotify",
+      })
+    ).rejects.toThrow("You already picked this one!");
+  });
+
   it("voteCollectRequest POSTs the request_id", async () => {
     (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
       OK_RESPONSE({ ok: true })
@@ -49,6 +78,15 @@ describe("collect api client", () => {
       expect.objectContaining({
         body: JSON.stringify({ request_id: 99 }),
       })
+    );
+  });
+
+  it("voteCollectRequest throws ApiError with detail on 409", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      ERR_RESPONSE(409, "Can't vote on your own pick")
+    );
+    await expect(apiClient.voteCollectRequest("ABC", 99)).rejects.toThrow(
+      "Can't vote on your own pick"
     );
   });
 });

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1042,7 +1042,7 @@ class ApiClient {
       note?: string;
       nickname?: string;
     },
-  ): Promise<{ id: number }> {
+  ): Promise<{ id: number; is_duplicate: boolean }> {
     const res = await fetch(`${getApiUrl()}/api/public/collect/${code}/requests`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -1061,7 +1061,10 @@ class ApiClient {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ request_id: requestId }),
     });
-    if (!res.ok) throw new ApiError(`Vote failed: ${res.status}`, res.status);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new ApiError(body.detail ?? `Vote failed: ${res.status}`, res.status);
+    }
   }
 
   // ========== Pre-Event Collection (DJ-authenticated) ==========

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -1,9 +1,9 @@
 """Public API endpoints for pre-event song collection (no authentication required)."""
 
-import hashlib
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
 from sqlalchemy import desc, func
 from sqlalchemy.orm import Session
 
@@ -26,6 +26,7 @@ from app.schemas.collect import (
 )
 from app.services import collect as collect_service
 from app.services.activity_log import log_activity
+from app.services.dedup import compute_dedupe_key, find_duplicate
 from app.services.system_settings import get_system_settings
 from app.services.vote import add_vote
 
@@ -283,11 +284,6 @@ def my_picks(code: str, request: Request, db: Session = Depends(get_db)):
     )
 
 
-def _compute_dedupe_key(song_title: str, artist: str) -> str:
-    raw = f"{song_title.strip().lower()}|{artist.strip().lower()}"
-    return hashlib.sha256(raw.encode()).hexdigest()[:64]
-
-
 @router.post("/{code}/requests", status_code=201)
 @limiter.limit("10/minute")
 def submit(
@@ -301,6 +297,29 @@ def submit(
         raise HTTPException(status_code=409, detail="Collection has ended")
 
     fingerprint = get_client_fingerprint(request, action="collect.submit", event_code=code)
+
+    existing = find_duplicate(db, event.id, payload.artist, payload.song_title)
+    if existing:
+        if (
+            existing.client_fingerprint
+            and fingerprint
+            and existing.client_fingerprint == fingerprint
+        ):
+            raise HTTPException(status_code=409, detail="You already picked this one!")
+
+        add_vote(db, existing.id, fingerprint)
+        log_activity(
+            db,
+            level="info",
+            source="collect",
+            message=(
+                f"Guest [{mask_fingerprint(fingerprint)}] duplicate-voted "
+                f"'{existing.song_title}' by {existing.artist} (req #{existing.id})"
+            ),
+            event_code=code,
+        )
+        return JSONResponse({"id": existing.id, "is_duplicate": True}, status_code=200)
+
     try:
         collect_service.check_and_increment_submission_count(
             db, event=event, fingerprint=fingerprint
@@ -326,7 +345,7 @@ def submit(
         note=payload.note,
         nickname=payload.nickname,
         status=RequestStatus.NEW.value,
-        dedupe_key=_compute_dedupe_key(payload.song_title, payload.artist),
+        dedupe_key=compute_dedupe_key(payload.artist, payload.song_title),
         client_fingerprint=fingerprint,
         submitted_during_collection=True,
     )
@@ -343,7 +362,7 @@ def submit(
         ),
         event_code=code,
     )
-    return {"id": row.id}
+    return {"id": row.id, "is_duplicate": False}
 
 
 @router.post("/{code}/vote")

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -385,6 +385,8 @@ def vote(
     )
     if row is None:
         raise HTTPException(status_code=404, detail="Request not found")
+    if row.client_fingerprint and row.client_fingerprint == fingerprint:
+        raise HTTPException(status_code=409, detail="Can't vote on your own pick")
     _, is_new_vote = add_vote(db, request_id=row.id, client_fingerprint=fingerprint)
     if is_new_vote:
         log_activity(

--- a/server/app/services/dedup.py
+++ b/server/app/services/dedup.py
@@ -1,0 +1,40 @@
+"""Shared deduplication service for song requests.
+
+Single source of truth for dedupe key computation and duplicate detection.
+Both the join-page (request.py) and collect (collect.py) flows import from here.
+"""
+
+import hashlib
+from datetime import timedelta
+
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.models.request import Request
+
+
+def compute_dedupe_key(artist: str, title: str) -> str:
+    """Compute a deduplication key from normalized artist and title."""
+    normalized = f"{artist.lower().strip()}:{title.lower().strip()}"
+    return hashlib.sha256(normalized.encode()).hexdigest()[:32]
+
+
+def find_duplicate(
+    db: Session,
+    event_id: int,
+    artist: str,
+    title: str,
+    window_hours: int = 6,
+) -> Request | None:
+    """Find an existing request with the same artist+title within the time window."""
+    dedupe_key = compute_dedupe_key(artist, title)
+    cutoff = utcnow() - timedelta(hours=window_hours)
+    return (
+        db.query(Request)
+        .filter(
+            Request.event_id == event_id,
+            Request.dedupe_key == dedupe_key,
+            Request.created_at > cutoff,
+        )
+        .first()
+    )

--- a/server/app/services/request.py
+++ b/server/app/services/request.py
@@ -1,11 +1,11 @@
-import hashlib
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from sqlalchemy.orm import Session
 
 from app.core.time import utcnow
 from app.models.event import Event
 from app.models.request import Request, RequestStatus
+from app.services.dedup import compute_dedupe_key, find_duplicate
 from app.services.recommendation.camelot import parse_key
 from app.services.vote import add_vote
 
@@ -35,12 +35,6 @@ def normalize_key(key_str: str | None) -> str | None:
     return str(pos) if pos else None
 
 
-def compute_dedupe_key(artist: str, title: str) -> str:
-    """Compute a deduplication key from normalized artist and title."""
-    normalized = f"{artist.lower().strip()}:{title.lower().strip()}"
-    return hashlib.sha256(normalized.encode()).hexdigest()[:32]
-
-
 def create_request(
     db: Session,
     event: Event,
@@ -62,18 +56,7 @@ def create_request(
     Returns (request, is_duplicate).
     """
     dedupe_key = compute_dedupe_key(artist, title)
-
-    # Check for duplicate in last 6 hours
-    six_hours_ago = utcnow() - timedelta(hours=6)
-    existing = (
-        db.query(Request)
-        .filter(
-            Request.event_id == event.id,
-            Request.dedupe_key == dedupe_key,
-            Request.created_at > six_hours_ago,
-        )
-        .first()
-    )
+    existing = find_duplicate(db, event.id, artist, title)
 
     if existing:
         # Auto-vote for the existing request when a duplicate is submitted

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -216,41 +216,32 @@ def test_collect_leaderboard_all_tab_sorts_alphabetically(client, db, test_event
     assert titles == ["Alpha Song", "mango tango", "zebra stripes"]
 
 
-def test_collect_my_picks_voted_request_ids_includes_self_votes(
-    client, db, test_event, collection_requests
-):
-    """voted_request_ids must include votes on own submissions, so the UI
-    can disable the vote button for them even though they don't appear in
-    the `upvoted` section (which is de-duped against `submitted`).
+def test_collect_self_vote_blocked_not_in_voted_ids(client, db, test_event):
+    """Self-voting is blocked, so voted_request_ids should not include
+    own submissions (since the vote was rejected).
     """
     _enable_collection(db, test_event)
-    from app.core.rate_limit import MAX_FINGERPRINT_LENGTH
 
-    # TestClient's default remote host is "testclient"; take first N chars.
-    fp = "testclient"[:MAX_FINGERPRINT_LENGTH]
+    target = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={"song_title": "My Song", "artist": "My Artist", "source": "spotify"},
+    )
+    assert target.status_code == 201
+    target_id = target.json()["id"]
 
-    # Mark one collection request as submitted by this client so the backend
-    # puts it under `submitted` (de-duped out of `upvoted`).
-    target = collection_requests[0]
-    target.client_fingerprint = fp
-    db.commit()
-
-    # Cast a vote on that same request.
+    # Self-vote should be rejected.
     r = client.post(
         f"/api/public/collect/{test_event.code}/vote",
-        json={"request_id": target.id},
+        json={"request_id": target_id},
     )
-    assert r.status_code == 200
+    assert r.status_code == 409
 
     me = client.get(f"/api/public/collect/{test_event.code}/profile/me")
     assert me.status_code == 200
     body = me.json()
 
-    # The submission is in `submitted`, NOT in `upvoted` (dedupe behavior).
-    assert any(s["id"] == target.id for s in body["submitted"])
-    assert not any(u["id"] == target.id for u in body["upvoted"])
-    # But voted_request_ids MUST include it — this is the fix.
-    assert target.id in body["voted_request_ids"]
+    assert any(s["id"] == target_id for s in body["submitted"])
+    assert target_id not in body["voted_request_ids"]
 
 
 def test_collect_activity_log_entries_for_state_changes(client, db, test_event):
@@ -258,6 +249,8 @@ def test_collect_activity_log_entries_for_state_changes(client, db, test_event):
     tagged with the masked fingerprint so DJs can audit guest activity.
     """
     from app.models.activity_log import ActivityLog
+    from app.models.request import Request as SongRequest
+    from app.services.dedup import compute_dedupe_key
 
     _enable_collection(db, test_event)
 
@@ -267,19 +260,33 @@ def test_collect_activity_log_entries_for_state_changes(client, db, test_event):
         json={"song_title": "Log Me", "artist": "Audit", "source": "spotify"},
     )
     assert r.status_code == 201
-    new_id = r.json()["id"]
 
-    # 2. Vote on it.
+    # 2. Vote on a DIFFERENT request (not our own — self-voting is blocked).
+    key = compute_dedupe_key("Other", "Song")
+    other_row = SongRequest(
+        event_id=test_event.id,
+        song_title="Song",
+        artist="Other",
+        source="spotify",
+        status="new",
+        dedupe_key=key,
+        client_fingerprint="someone-else",
+        submitted_during_collection=True,
+    )
+    db.add(other_row)
+    db.commit()
+    db.refresh(other_row)
+
     r = client.post(
         f"/api/public/collect/{test_event.code}/vote",
-        json={"request_id": new_id},
+        json={"request_id": other_row.id},
     )
     assert r.status_code == 200
 
     # 2b. Vote again — idempotent, should NOT create a second activity row.
     r = client.post(
         f"/api/public/collect/{test_event.code}/vote",
-        json={"request_id": new_id},
+        json={"request_id": other_row.id},
     )
     assert r.status_code == 200
 
@@ -304,7 +311,6 @@ def test_collect_activity_log_entries_for_state_changes(client, db, test_event):
     assert "'Log Me'" in rows[0].message
     assert "voted" in rows[1].message
     assert "updated profile" in rows[2].message
-    # Every row should carry the masked fingerprint (12 hex chars in [brackets]).
     import re
 
     for row in rows:
@@ -475,3 +481,54 @@ def test_collect_submit_new_request_returns_is_duplicate_false(client, db, test_
     assert r.status_code == 201
     body = r.json()
     assert body["is_duplicate"] is False
+
+
+# ── Self-vote tests ──────────────────────────────────────────────────────────
+
+
+def test_collect_vote_self_vote_blocked(client, db, test_event):
+    """Submitter cannot vote on their own request → 409."""
+    _enable_collection(db, test_event)
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={"song_title": "My Song", "artist": "My Artist", "source": "spotify"},
+    )
+    assert r.status_code == 201
+    request_id = r.json()["id"]
+
+    r2 = client.post(
+        f"/api/public/collect/{test_event.code}/vote",
+        json={"request_id": request_id},
+    )
+    assert r2.status_code == 409
+    assert "own" in r2.json()["detail"].lower()
+
+
+def test_collect_vote_other_user_still_works(client, db, test_event):
+    """Voting on someone else's request still works normally."""
+    _enable_collection(db, test_event)
+    from app.models.request import Request as SongRequest
+    from app.services.dedup import compute_dedupe_key
+
+    key = compute_dedupe_key("Other Artist", "Other Song")
+    row = SongRequest(
+        event_id=test_event.id,
+        song_title="Other Song",
+        artist="Other Artist",
+        source="spotify",
+        status="new",
+        dedupe_key=key,
+        client_fingerprint="different-user",
+        submitted_during_collection=True,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/vote",
+        json={"request_id": row.id},
+    )
+    assert r.status_code == 200
+    db.refresh(row)
+    assert row.vote_count == 1

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -138,15 +138,15 @@ def test_collect_submit_blocked_at_cap(client, db, test_event):
     _enable_collection(db, test_event)
     test_event.submission_cap_per_guest = 2
     db.commit()
-    for _ in range(2):
+    for i in range(2):
         r = client.post(
             f"/api/public/collect/{test_event.code}/requests",
-            json={"song_title": "A", "artist": "B", "source": "spotify"},
+            json={"song_title": f"Song {i}", "artist": f"Artist {i}", "source": "spotify"},
         )
         assert r.status_code == 201
     r3 = client.post(
         f"/api/public/collect/{test_event.code}/requests",
-        json={"song_title": "C", "artist": "D", "source": "spotify"},
+        json={"song_title": "Song 99", "artist": "Artist 99", "source": "spotify"},
     )
     assert r3.status_code == 429
     assert "Picks limit reached" in r3.json()["detail"]
@@ -357,3 +357,121 @@ def test_collect_get_profile_returns_existing_state(client, db, test_event):
     assert body["nickname"] == "Reader"
     assert body["has_email"] is True
     assert body["submission_cap"] == test_event.submission_cap_per_guest
+
+
+# ── Dedup tests ──────────────────────────────────────────────────────────────
+
+
+def test_collect_submit_same_user_duplicate_returns_409(client, db, test_event):
+    """Same fingerprint submitting the same song twice → 409."""
+    _enable_collection(db, test_event)
+    payload = {"song_title": "Mr. Brightside", "artist": "The Killers", "source": "spotify"}
+    r1 = client.post(f"/api/public/collect/{test_event.code}/requests", json=payload)
+    assert r1.status_code == 201
+
+    r2 = client.post(f"/api/public/collect/{test_event.code}/requests", json=payload)
+    assert r2.status_code == 409
+    assert "already" in r2.json()["detail"].lower()
+
+
+def test_collect_submit_same_user_duplicate_case_insensitive(client, db, test_event):
+    """Dedup is case-insensitive: 'The Killers' == 'the killers'."""
+    _enable_collection(db, test_event)
+    r1 = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={"song_title": "Mr. Brightside", "artist": "The Killers", "source": "spotify"},
+    )
+    assert r1.status_code == 201
+
+    r2 = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={"song_title": "mr. brightside", "artist": "the killers", "source": "spotify"},
+    )
+    assert r2.status_code == 409
+
+
+def test_collect_submit_different_user_duplicate_auto_votes(client, db, test_event):
+    """Different fingerprint submitting the same song → 200, is_duplicate=true, vote added."""
+    _enable_collection(db, test_event)
+    from app.models.request import Request as SongRequest
+    from app.services.dedup import compute_dedupe_key
+
+    key = compute_dedupe_key("The Killers", "Mr. Brightside")
+    row = SongRequest(
+        event_id=test_event.id,
+        song_title="Mr. Brightside",
+        artist="The Killers",
+        source="spotify",
+        status="new",
+        dedupe_key=key,
+        client_fingerprint="other-user-ip",
+        submitted_during_collection=True,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    original_votes = row.vote_count
+
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={"song_title": "Mr. Brightside", "artist": "The Killers", "source": "spotify"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["is_duplicate"] is True
+    assert body["id"] == row.id
+
+    db.refresh(row)
+    assert row.vote_count == original_votes + 1
+
+
+def test_collect_submit_different_user_duplicate_no_pick_slot(client, db, test_event):
+    """Duplicate submission by different user must NOT consume a pick slot."""
+    _enable_collection(db, test_event)
+    test_event.submission_cap_per_guest = 1
+    db.commit()
+
+    from app.models.request import Request as SongRequest
+    from app.services.dedup import compute_dedupe_key
+
+    key = compute_dedupe_key("The Killers", "Mr. Brightside")
+    db.add(
+        SongRequest(
+            event_id=test_event.id,
+            song_title="Mr. Brightside",
+            artist="The Killers",
+            source="spotify",
+            status="new",
+            dedupe_key=key,
+            client_fingerprint="other-user-ip",
+            submitted_during_collection=True,
+        )
+    )
+    db.commit()
+
+    # This is a duplicate → should not consume the only pick slot
+    r1 = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={"song_title": "Mr. Brightside", "artist": "The Killers", "source": "spotify"},
+    )
+    assert r1.status_code == 200
+    assert r1.json()["is_duplicate"] is True
+
+    # Now submit a genuinely new song → should succeed (pick slot still available)
+    r2 = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={"song_title": "Somebody Told Me", "artist": "The Killers", "source": "spotify"},
+    )
+    assert r2.status_code == 201
+
+
+def test_collect_submit_new_request_returns_is_duplicate_false(client, db, test_event):
+    """Fresh submission returns is_duplicate=false."""
+    _enable_collection(db, test_event)
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/requests",
+        json={"song_title": "New Song", "artist": "New Artist", "source": "spotify"},
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["is_duplicate"] is False

--- a/server/tests/test_dedup.py
+++ b/server/tests/test_dedup.py
@@ -1,0 +1,139 @@
+"""Tests for the shared deduplication service."""
+
+import hashlib
+from datetime import timedelta
+
+from app.core.time import utcnow
+from app.models.event import Event
+from app.models.request import Request as SongRequest
+from app.models.request import RequestStatus
+from app.services.dedup import compute_dedupe_key, find_duplicate
+
+
+class TestComputeDedupeKey:
+    def test_consistent_hash(self):
+        key1 = compute_dedupe_key("Artist", "Title")
+        key2 = compute_dedupe_key("Artist", "Title")
+        assert key1 == key2
+
+    def test_case_insensitive(self):
+        key1 = compute_dedupe_key("THE KILLERS", "Mr. Brightside")
+        key2 = compute_dedupe_key("the killers", "mr. brightside")
+        assert key1 == key2
+
+    def test_trims_whitespace(self):
+        key1 = compute_dedupe_key("  Artist  ", "  Title  ")
+        key2 = compute_dedupe_key("Artist", "Title")
+        assert key1 == key2
+
+    def test_returns_32_hex_chars(self):
+        key = compute_dedupe_key("Artist", "Title")
+        assert len(key) == 32
+        int(key, 16)  # raises ValueError if not hex
+
+    def test_different_songs_differ(self):
+        key1 = compute_dedupe_key("Artist", "Song A")
+        key2 = compute_dedupe_key("Artist", "Song B")
+        assert key1 != key2
+
+    def test_format_matches_expected(self):
+        normalized = "artist:title"
+        expected = hashlib.sha256(normalized.encode()).hexdigest()[:32]
+        assert compute_dedupe_key("Artist", "Title") == expected
+
+
+class TestFindDuplicate:
+    def test_finds_existing_match(self, db, test_event):
+        key = compute_dedupe_key("The Killers", "Mr. Brightside")
+        db.add(
+            SongRequest(
+                event_id=test_event.id,
+                song_title="Mr. Brightside",
+                artist="The Killers",
+                source="spotify",
+                status=RequestStatus.NEW.value,
+                dedupe_key=key,
+                client_fingerprint="user-a",
+            )
+        )
+        db.commit()
+        result = find_duplicate(db, test_event.id, "The Killers", "Mr. Brightside")
+        assert result is not None
+        assert result.song_title == "Mr. Brightside"
+
+    def test_case_insensitive_match(self, db, test_event):
+        key = compute_dedupe_key("The Killers", "Mr. Brightside")
+        db.add(
+            SongRequest(
+                event_id=test_event.id,
+                song_title="Mr. Brightside",
+                artist="The Killers",
+                source="spotify",
+                status=RequestStatus.NEW.value,
+                dedupe_key=key,
+                client_fingerprint="user-a",
+            )
+        )
+        db.commit()
+        result = find_duplicate(db, test_event.id, "THE KILLERS", "MR. BRIGHTSIDE")
+        assert result is not None
+
+    def test_no_match_different_song(self, db, test_event):
+        key = compute_dedupe_key("The Killers", "Mr. Brightside")
+        db.add(
+            SongRequest(
+                event_id=test_event.id,
+                song_title="Mr. Brightside",
+                artist="The Killers",
+                source="spotify",
+                status=RequestStatus.NEW.value,
+                dedupe_key=key,
+                client_fingerprint="user-a",
+            )
+        )
+        db.commit()
+        result = find_duplicate(db, test_event.id, "The Killers", "Somebody Told Me")
+        assert result is None
+
+    def test_no_match_outside_window(self, db, test_event):
+        key = compute_dedupe_key("The Killers", "Mr. Brightside")
+        old_request = SongRequest(
+            event_id=test_event.id,
+            song_title="Mr. Brightside",
+            artist="The Killers",
+            source="spotify",
+            status=RequestStatus.NEW.value,
+            dedupe_key=key,
+            client_fingerprint="user-a",
+            created_at=utcnow() - timedelta(hours=7),
+        )
+        db.add(old_request)
+        db.commit()
+        result = find_duplicate(db, test_event.id, "The Killers", "Mr. Brightside")
+        assert result is None
+
+    def test_no_match_different_event(self, db, test_event, test_user):
+        other_event = Event(
+            code="OTHER1",
+            name="Other Event",
+            created_by_user_id=test_user.id,
+            expires_at=utcnow() + timedelta(hours=6),
+        )
+        db.add(other_event)
+        db.commit()
+        db.refresh(other_event)
+        key = compute_dedupe_key("The Killers", "Mr. Brightside")
+        db.add(
+            SongRequest(
+                event_id=other_event.id,
+                song_title="Mr. Brightside",
+                artist="The Killers",
+                source="spotify",
+                status=RequestStatus.NEW.value,
+                dedupe_key=key,
+                client_fingerprint="user-a",
+            )
+        )
+        db.commit()
+        result = find_duplicate(db, test_event.id, "The Killers", "Mr. Brightside")
+        assert result is None


### PR DESCRIPTION
## Summary

- **Extract shared dedup service** (`server/app/services/dedup.py`) — `compute_dedupe_key()` and `find_duplicate()` are now a single source of truth, imported by both the join-page (`request.py`) and collect (`collect.py`) flows. Fixes the format divergence where collect used `title|artist` (64 hex) while request.py used `artist:title` (32 hex).
- **Fix collect submit endpoint** — `POST /api/public/collect/{code}/requests` now checks for duplicates before inserting. Same user submitting same song → 409 "You already picked this one!". Different user submitting same song → auto-upvote existing request, return `is_duplicate: true`, no pick slot consumed.
- **Block self-voting** — `POST /api/public/collect/{code}/vote` returns 409 "Can't vote on your own pick" when the voter's fingerprint matches the request submitter.
- **Frontend UX** — Collect page handles 409 (self-duplicate) and `is_duplicate` (cross-user duplicate) responses with distinct messages. Vote button is hidden on own submissions.

**Production evidence:** Event ELZ2G2 had 11 identical copies of the same song from the same IP, submitted every 5-6 seconds. All returned 201. Zero dedup rejections in logs.

## Test plan

- [x] 11 new backend tests (dedup service unit tests + collect endpoint integration tests)
- [x] 3 existing tests updated for new self-vote behavior
- [x] Full backend suite: 1756 passed, 87.64% coverage
- [x] Frontend: tsc clean, 802 vitest tests pass
- [x] Ruff lint/format clean, bandit clean
- [ ] Manual test: submit same song twice from collect page → "You already picked this one!"
- [ ] Manual test: two devices submit same song → second gets "Great minds think alike!"
- [ ] Manual test: vote button disabled on own submissions in leaderboard
- [ ] Post-deploy: clean up ELZ2G2 duplicate rows (SQL in plan doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)