### PR TITLE
fix: link orphan GuestProfile rows to verified Guest

### DIFF
--- a/server/app/api/verify.py
+++ b/server/app/api/verify.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
 from app.core.config import get_settings
-from app.core.rate_limit import get_guest_id, limiter
+from app.core.rate_limit import get_client_fingerprint, get_guest_id, limiter
 from app.schemas.verify import (
     VerifyConfirmResponse,
     VerifyConfirmSchema,
@@ -59,9 +59,14 @@ def confirm_code(
     if guest_id is None:
         raise HTTPException(status_code=400, detail="Guest identity required")
 
+    fingerprint = get_client_fingerprint(request, action="guest.verify_confirm")
     try:
         result = confirm_verification_code(
-            db, guest_id=guest_id, email=payload.email, code=payload.code
+            db,
+            guest_id=guest_id,
+            email=payload.email,
+            code=payload.code,
+            request_fingerprint=fingerprint,
         )
     except CodeInvalidError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/server/app/services/collect.py
+++ b/server/app/services/collect.py
@@ -156,20 +156,27 @@ def get_profile(
     fingerprint: str | None = None,
     guest_id: int | None = None,
 ) -> GuestProfile | None:
+    """Find a profile by guest_id, falling back to fingerprint when both
+    are provided but guest_id has no row yet (orphan case — profile was
+    created before the wrzdj_guest cookie existed)."""
     if guest_id:
-        return (
+        row = (
             db.query(GuestProfile)
             .filter(GuestProfile.event_id == event_id, GuestProfile.guest_id == guest_id)
             .one_or_none()
         )
-    return (
-        db.query(GuestProfile)
-        .filter(
-            GuestProfile.event_id == event_id,
-            GuestProfile.client_fingerprint == fingerprint,
+        if row is not None:
+            return row
+    if fingerprint:
+        return (
+            db.query(GuestProfile)
+            .filter(
+                GuestProfile.event_id == event_id,
+                GuestProfile.client_fingerprint == fingerprint,
+            )
+            .one_or_none()
         )
-        .one_or_none()
-    )
+    return None
 
 
 def upsert_profile(
@@ -190,6 +197,10 @@ def upsert_profile(
         )
         db.add(profile)
     else:
+        if profile.guest_id is None and guest_id is not None:
+            profile.guest_id = guest_id
+        if profile.client_fingerprint is None and fingerprint is not None:
+            profile.client_fingerprint = fingerprint
         if nickname is not None:
             profile.nickname = nickname
     db.commit()

--- a/server/app/services/email_verification.py
+++ b/server/app/services/email_verification.py
@@ -12,6 +12,7 @@ from app.core.rate_limit import mask_fingerprint
 from app.core.time import utcnow
 from app.models.email_verification_code import EmailVerificationCode
 from app.models.guest import Guest
+from app.models.guest_profile import GuestProfile
 from app.services.email_sender import send_verification_email
 
 _logger = logging.getLogger("app.guest.verify")
@@ -90,8 +91,45 @@ def create_verification_code(db: Session, *, guest_id: int, email: str) -> Email
     return row
 
 
-def confirm_verification_code(db: Session, *, guest_id: int, email: str, code: str) -> VerifyResult:
-    """Validate a verification code and set verified_email on the Guest."""
+def _link_orphan_profiles_to_guest(db: Session, *, fingerprint: str | None, guest_id: int) -> int:
+    """Link guest_profiles rows with matching client_fingerprint and
+    guest_id IS NULL to the verified guest. Returns count of rows updated.
+    The caller is responsible for committing.
+    """
+    if not fingerprint:
+        return 0
+    count = (
+        db.query(GuestProfile)
+        .filter(
+            GuestProfile.client_fingerprint == fingerprint,
+            GuestProfile.guest_id.is_(None),
+        )
+        .update({"guest_id": guest_id}, synchronize_session=False)
+    )
+    if count:
+        _logger.info(
+            "guest.verify action=link_orphans guest_id=%s count=%s",
+            guest_id,
+            count,
+        )
+    return count
+
+
+def confirm_verification_code(
+    db: Session,
+    *,
+    guest_id: int,
+    email: str,
+    code: str,
+    request_fingerprint: str | None = None,
+) -> VerifyResult:
+    """Validate a verification code and set verified_email on the Guest.
+
+    When `request_fingerprint` is provided, also link any orphan
+    GuestProfile rows (matching fingerprint, guest_id IS NULL) to the
+    verified guest. This closes the gap where a profile was created
+    before the wrzdj_guest cookie was set.
+    """
     eh = _hash_email(email.lower())
     now = utcnow()
 
@@ -138,6 +176,8 @@ def confirm_verification_code(db: Session, *, guest_id: int, email: str, code: s
 
     # Already verified with this email?
     if guest.email_hash == eh:
+        _link_orphan_profiles_to_guest(db, fingerprint=request_fingerprint, guest_id=guest_id)
+        db.commit()
         _logger.info(
             "guest.verify action=code_verified guest_id=%s email_hash=%s (already verified)",
             guest_id,
@@ -152,6 +192,8 @@ def confirm_verification_code(db: Session, *, guest_id: int, email: str, code: s
         from app.services.guest_merge import merge_guests
 
         merge_result = merge_guests(db, source_guest_id=guest_id, target_guest_id=existing.id)
+        _link_orphan_profiles_to_guest(db, fingerprint=request_fingerprint, guest_id=existing.id)
+        db.commit()
         _logger.info(
             "guest.verify action=merge source_guest=%s target_guest=%s email_hash=%s"
             " requests=%s votes=%s profiles=%s",
@@ -173,6 +215,7 @@ def confirm_verification_code(db: Session, *, guest_id: int, email: str, code: s
     guest.verified_email = email.lower()
     guest.email_hash = eh
     guest.email_verified_at = now
+    _link_orphan_profiles_to_guest(db, fingerprint=request_fingerprint, guest_id=guest_id)
     db.commit()
 
     _logger.info(

--- a/server/tests/test_profile_orphan_linking.py
+++ b/server/tests/test_profile_orphan_linking.py
@@ -1,0 +1,286 @@
+"""Tests for orphan GuestProfile linking after email verification.
+
+Bug context: A profile created before the wrzdj_guest cookie is set has
+guest_id=NULL. Email verification only updated guests.verified_email but
+never backfilled guest_profiles.guest_id. This left "orphan" profiles
+unlinked to the verified guest.
+
+These tests pin down the new reconciliation behavior in two layers:
+- collect.py: get_profile / upsert_profile reconcile orphans by fingerprint
+- email_verification.py: confirm_verification_code links orphans by IP
+"""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.event import Event
+from app.models.guest import Guest
+from app.models.guest_profile import GuestProfile
+from app.services import collect as collect_service
+
+# ---------------------------------------------------------------------------
+# Layer B: services/collect.py — get_profile / upsert_profile reconciliation
+# ---------------------------------------------------------------------------
+
+
+def test_get_profile_falls_back_to_fingerprint_when_guest_id_misses(db: Session, test_event: Event):
+    """When called with both guest_id and fingerprint, an orphan profile
+    keyed only by fingerprint should be returned (current code returns None).
+    """
+    orphan = GuestProfile(
+        event_id=test_event.id,
+        client_fingerprint="1.2.3.4",
+        guest_id=None,
+        nickname="alice",
+    )
+    db.add(orphan)
+    db.commit()
+    db.refresh(orphan)
+
+    result = collect_service.get_profile(
+        db, event_id=test_event.id, fingerprint="1.2.3.4", guest_id=42
+    )
+
+    assert result is not None
+    assert result.id == orphan.id
+
+
+def test_upsert_profile_backfills_guest_id_on_orphan_match(db: Session, test_event: Event):
+    """upsert_profile reuses an orphan row matched by fingerprint and
+    backfills the missing guest_id rather than creating a duplicate."""
+    orphan = GuestProfile(
+        event_id=test_event.id,
+        client_fingerprint="1.2.3.4",
+        guest_id=None,
+        nickname="alice",
+    )
+    db.add(orphan)
+    db.commit()
+    orphan_id = orphan.id
+
+    result = collect_service.upsert_profile(
+        db,
+        event_id=test_event.id,
+        fingerprint="1.2.3.4",
+        guest_id=42,
+        nickname="alice",
+    )
+
+    assert result.id == orphan_id
+    assert result.guest_id == 42
+    assert result.nickname == "alice"
+
+    total = db.query(GuestProfile).filter(GuestProfile.event_id == test_event.id).count()
+    assert total == 1
+
+
+def test_upsert_profile_does_not_overwrite_existing_guest_id(db: Session, test_event: Event):
+    """If a profile already has a non-null guest_id, upsert with a different
+    guest_id from the same fingerprint must NOT overwrite. Fingerprint
+    (IP) is approximate; guest_id is authoritative."""
+    profile = GuestProfile(
+        event_id=test_event.id,
+        client_fingerprint="1.2.3.4",
+        guest_id=42,
+        nickname="alice",
+    )
+    db.add(profile)
+    db.commit()
+
+    result = collect_service.upsert_profile(
+        db,
+        event_id=test_event.id,
+        fingerprint="1.2.3.4",
+        guest_id=99,
+    )
+
+    assert result.guest_id == 42
+
+
+# ---------------------------------------------------------------------------
+# Layer A: confirm_verification_code links orphans by request fingerprint
+# ---------------------------------------------------------------------------
+
+
+def _identify(client: TestClient, fingerprint: str) -> dict:
+    """Helper: identify a guest and return {guest_id, cookie}."""
+    client.cookies.clear()
+    resp = client.post(
+        "/api/public/guest/identify",
+        json={"fingerprint_hash": fingerprint, "fingerprint_components": {}},
+    )
+    assert resp.status_code == 200
+    return {
+        "guest_id": resp.json()["guest_id"],
+        "cookie": resp.cookies.get("wrzdj_guest"),
+    }
+
+
+def _send_and_get_code(client: TestClient, db: Session, *, guest_id: int, email: str) -> str:
+    from app.models.email_verification_code import EmailVerificationCode
+
+    with patch("app.services.email_verification.send_verification_email"):
+        resp = client.post(
+            "/api/public/guest/verify/request",
+            json={"email": email},
+        )
+    assert resp.status_code == 200, resp.text
+    row = (
+        db.query(EmailVerificationCode)
+        .filter(EmailVerificationCode.guest_id == guest_id)
+        .order_by(EmailVerificationCode.created_at.desc())
+        .first()
+    )
+    assert row is not None
+    return row.code
+
+
+def test_confirm_verification_code_backfills_orphan_profile_by_fingerprint(
+    client: TestClient, db: Session, test_event: Event
+):
+    """After /verify/confirm, an orphan profile with client_fingerprint
+    matching the request IP must be linked to the verifying guest."""
+    info = _identify(client, "fp_orphan_link_1")
+    request_ip = "testclient"  # TestClient's default direct IP
+
+    orphan = GuestProfile(
+        event_id=test_event.id,
+        client_fingerprint=request_ip,
+        guest_id=None,
+        nickname="orphana",
+    )
+    db.add(orphan)
+    db.commit()
+    orphan_id = orphan.id
+
+    client.cookies.set("wrzdj_guest", info["cookie"])
+    code = _send_and_get_code(client, db, guest_id=info["guest_id"], email="orphana@test.com")
+
+    resp = client.post(
+        "/api/public/guest/verify/confirm",
+        json={"email": "orphana@test.com", "code": code},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["verified"] is True
+
+    db.expire_all()
+    profile = db.query(GuestProfile).filter(GuestProfile.id == orphan_id).one()
+    assert profile.guest_id == info["guest_id"]
+
+    guest = db.query(Guest).filter(Guest.id == info["guest_id"]).one()
+    assert guest.email_verified_at is not None
+
+
+def test_confirm_verification_code_does_not_link_orphans_with_different_fingerprint(
+    client: TestClient, db: Session, test_event: Event
+):
+    """Only orphans with matching client_fingerprint should be linked."""
+    info = _identify(client, "fp_orphan_link_2")
+    request_ip = "testclient"
+
+    matching = GuestProfile(
+        event_id=test_event.id,
+        client_fingerprint=request_ip,
+        guest_id=None,
+        nickname="match",
+    )
+    other = GuestProfile(
+        event_id=test_event.id,
+        client_fingerprint="9.9.9.9",
+        guest_id=None,
+        nickname="other",
+    )
+    db.add_all([matching, other])
+    db.commit()
+    matching_id = matching.id
+    other_id = other.id
+
+    client.cookies.set("wrzdj_guest", info["cookie"])
+    code = _send_and_get_code(client, db, guest_id=info["guest_id"], email="onlymatch@test.com")
+
+    resp = client.post(
+        "/api/public/guest/verify/confirm",
+        json={"email": "onlymatch@test.com", "code": code},
+    )
+    assert resp.status_code == 200
+
+    db.expire_all()
+    matched_row = db.query(GuestProfile).filter(GuestProfile.id == matching_id).one()
+    other_row = db.query(GuestProfile).filter(GuestProfile.id == other_id).one()
+    assert matched_row.guest_id == info["guest_id"]
+    assert other_row.guest_id is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: full collect flow shows email_verified=True after backfill
+# ---------------------------------------------------------------------------
+
+
+def test_email_verified_flag_reflects_orphan_profile_after_verify(
+    client: TestClient, db: Session, test_event: Event
+):
+    """End-to-end: orphan profile + identify + verify -> GET /profile
+    returns email_verified=True (currently False because guest_id stays NULL)."""
+    request_ip = "testclient"
+
+    orphan = GuestProfile(
+        event_id=test_event.id,
+        client_fingerprint=request_ip,
+        guest_id=None,
+        nickname="endtoend",
+    )
+    db.add(orphan)
+    db.commit()
+
+    info = _identify(client, "fp_e2e_orphan")
+    client.cookies.set("wrzdj_guest", info["cookie"])
+
+    code = _send_and_get_code(client, db, guest_id=info["guest_id"], email="e2e@test.com")
+    confirm = client.post(
+        "/api/public/guest/verify/confirm",
+        json={"email": "e2e@test.com", "code": code},
+    )
+    assert confirm.status_code == 200
+
+    resp = client.get(f"/api/public/collect/{test_event.code}/profile")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["email_verified"] is True
+    assert body["nickname"] == "endtoend"
+
+
+def test_set_profile_post_does_not_crash_on_pre_existing_orphan(
+    client: TestClient, db: Session, test_event: Event
+):
+    """Regression: when a fingerprint-orphan exists, POST /profile from a
+    new cookie session must reuse it (no IntegrityError on the unique
+    constraint uq_guest_profile_event_fingerprint)."""
+    request_ip = "testclient"
+
+    orphan = GuestProfile(
+        event_id=test_event.id,
+        client_fingerprint=request_ip,
+        guest_id=None,
+        nickname=None,
+    )
+    db.add(orphan)
+    db.commit()
+    orphan_id = orphan.id
+
+    info = _identify(client, "fp_regression_orphan")
+    client.cookies.set("wrzdj_guest", info["cookie"])
+
+    resp = client.post(
+        f"/api/public/collect/{test_event.code}/profile",
+        json={"nickname": "linked"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    db.expire_all()
+    rows = db.query(GuestProfile).filter(GuestProfile.event_id == test_event.id).all()
+    assert len(rows) == 1
+    assert rows[0].id == orphan_id
+    assert rows[0].guest_id == info["guest_id"]
+    assert rows[0].nickname == "linked"

--- a/server/tests/test_smtp_service.py
+++ b/server/tests/test_smtp_service.py
@@ -1,58 +1,76 @@
-"""Tests for SMTP email sending service."""
+"""Tests for verification email sending via Resend API."""
 
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.services.email_sender import EmailNotConfiguredError, send_verification_email
+from app.services.email_sender import (
+    EmailNotConfiguredError,
+    EmailSendError,
+    send_verification_email,
+)
 
 
-def test_send_verification_email():
-    """SMTP called with correct from/to/subject/body."""
+def test_send_verification_email_uses_resend():
+    """Resend.Emails.send called with correct from/to/subject/body."""
     with patch("app.services.email_sender.get_settings") as mock_settings:
         mock_settings.return_value = MagicMock(
-            smtp_host="mail.example.com",
-            smtp_port=465,
-            smtp_username="noreply@example.com",
-            smtp_password="secret",
-            smtp_from_address="noreply@example.com",
+            resend_api_key="test_resend_key",
+            email_from_address="WrzDJ <noreply@send.wrzdj.com>",
         )
-        with patch("app.services.email_sender.smtplib.SMTP_SSL") as mock_smtp:
-            instance = mock_smtp.return_value.__enter__.return_value
+        with patch("app.services.email_sender.resend.Emails.send") as mock_send:
             send_verification_email("fan@gmail.com", "847293")
 
-            instance.login.assert_called_once_with("noreply@example.com", "secret")
-            instance.send_message.assert_called_once()
-            msg = instance.send_message.call_args[0][0]
-            assert msg["To"] == "fan@gmail.com"
-            assert msg["From"] == "WrzDJ <noreply@example.com>"
-            assert "847293" in msg.get_payload()
-            assert "15 minutes" in msg.get_payload()
+            mock_send.assert_called_once()
+            payload = mock_send.call_args[0][0]
+            assert payload["from"] == "WrzDJ <noreply@send.wrzdj.com>"
+            assert payload["to"] == ["fan@gmail.com"]
+            assert payload["subject"] == "Your WrzDJ verification code"
+            assert "847293" in payload["text"]
+            assert "15 minutes" in payload["text"]
 
 
-def test_smtp_not_configured_raises():
-    """Empty smtp_host -> clear error."""
+def test_email_not_configured_when_api_key_missing():
+    """Empty resend_api_key -> clear error."""
     with patch("app.services.email_sender.get_settings") as mock_settings:
-        mock_settings.return_value = MagicMock(smtp_host="", smtp_port=465)
+        mock_settings.return_value = MagicMock(resend_api_key="", email_from_address="from@x.com")
         with pytest.raises(EmailNotConfiguredError):
             send_verification_email("fan@gmail.com", "123456")
 
 
-def test_email_content_no_pii_leak():
-    """Body contains code and expiry, no other personal data."""
+def test_email_not_configured_when_from_missing():
+    """Empty email_from_address -> clear error."""
+    with patch("app.services.email_sender.get_settings") as mock_settings:
+        mock_settings.return_value = MagicMock(resend_api_key="key", email_from_address="")
+        with pytest.raises(EmailNotConfiguredError):
+            send_verification_email("fan@gmail.com", "123456")
+
+
+def test_resend_failure_wrapped_in_email_send_error():
+    """Resend exceptions get wrapped so callers can distinguish from config issues."""
     with patch("app.services.email_sender.get_settings") as mock_settings:
         mock_settings.return_value = MagicMock(
-            smtp_host="mail.example.com",
-            smtp_port=465,
-            smtp_username="noreply@example.com",
-            smtp_password="secret",
-            smtp_from_address="noreply@example.com",
+            resend_api_key="key",
+            email_from_address="from@x.com",
         )
-        with patch("app.services.email_sender.smtplib.SMTP_SSL") as mock_smtp:
-            instance = mock_smtp.return_value.__enter__.return_value
-            send_verification_email("fan@gmail.com", "999888")
+        with patch(
+            "app.services.email_sender.resend.Emails.send",
+            side_effect=RuntimeError("API down"),
+        ):
+            with pytest.raises(EmailSendError):
+                send_verification_email("fan@gmail.com", "123456")
 
-            msg = instance.send_message.call_args[0][0]
-            body = msg.get_payload()
+
+def test_email_content_no_pii_leak():
+    """Body contains code and expiry, no recipient address."""
+    with patch("app.services.email_sender.get_settings") as mock_settings:
+        mock_settings.return_value = MagicMock(
+            resend_api_key="key",
+            email_from_address="from@x.com",
+        )
+        with patch("app.services.email_sender.resend.Emails.send") as mock_send:
+            send_verification_email("fan@gmail.com", "999888")
+            payload = mock_send.call_args[0][0]
+            body = payload["text"]
             assert "999888" in body
             assert "fan@gmail.com" not in body


### PR DESCRIPTION
## Summary

- Email verification used to update `guests.verified_email` but never backfilled `guest_profiles.guest_id`. A profile created before the `wrzdj_guest` cookie was set (race in `useGuestIdentity`) stayed orphaned forever, breaking cross-device merge and the `email_verified` flag on `/collect/{code}/profile`.
- Two reconciliation layers, defense-in-depth, with 7 new tests.

## Bug Evidence (production)

```text
guest_profiles  id=3   nickname=wrzonance  client_fingerprint=104.202.14.190  guest_id=NULL  event_id=15
guests          id=2   verified_email=<encrypted djfreaq@gmail.com>  email_verified_at=2026-04-28 01:10:01
```

Both `/api/public/guest/verify/request` and `/verify/confirm` returned 200, yet the profile and the verified guest remained unlinked.

## Changes

**Layer B — `server/app/services/collect.py`**
- `get_profile`: falls back to `client_fingerprint` lookup when `guest_id` query misses, so an orphan keyed only by fingerprint becomes visible.
- `upsert_profile`: backfills `guest_id` (and `client_fingerprint`) on existing rows when the row has them as NULL — never overwrites a non-NULL `guest_id` (fingerprint is approximate; `guest_id` is authoritative). Also fixes a latent `IntegrityError` on `uq_guest_profile_event_fingerprint` when a new cookie session POSTs `/profile` and a fingerprint orphan already exists.

**Layer A — `server/app/services/email_verification.py` + `server/app/api/verify.py`**
- New `_link_orphan_profiles_to_guest(db, fingerprint, guest_id)` helper. After `confirm_verification_code` succeeds, mass-update orphan profiles whose `client_fingerprint` matches the verifying request's IP. Wired into all three branches (already-verified, cross-device merge, first verification).
- `api/verify.py` now passes `get_client_fingerprint(request)` into the service.

**Bonus cleanup**
- `tests/test_smtp_service.py` had been failing CI silently since commit `ae730f2` swapped SMTP for Resend — rewrote the 5 tests to target the Resend API.

## Test plan

- [x] 7 new tests in `server/tests/test_profile_orphan_linking.py` — RED before, GREEN after each layer
- [x] Full backend suite: `1852 passed`, 87.91% coverage (gate 85%)
- [x] `ruff check` clean, `ruff format --check` clean, `bandit` clean
- [ ] Manual end-to-end on production after deploy:
  - Verify a fresh email; query the profile in DB; expect `guest_id` non-null.
  - Re-save nickname for the existing `wrzonance` orphan; expect Layer B to backfill `guest_id`.

## Out of scope (deferred)

- Frontend race fix in `useGuestIdentity` (orphans can still be created by the same race; this PR ensures they get linked retroactively).
- SQL migration to backfill historical orphans by IP — IP is shared across NATs, so we reconcile forward only.