### PR TITLE
fix: send guest cookie on all collect/public identity endpoints

### DIFF
--- a/dashboard/app/collect/[code]/page.test.tsx
+++ b/dashboard/app/collect/[code]/page.test.tsx
@@ -132,6 +132,21 @@ describe("CollectPage", () => {
     );
   });
 
+  it("hides FeatureOptInPanel when profile returns email_verified true with nickname", async () => {
+    mockGetEvent.mockResolvedValue(COLLECTION_EVENT);
+    mockGetCollectProfile.mockResolvedValue({
+      email_verified: true,
+      nickname: "DancingQueen",
+      submission_count: 0,
+      submission_cap: 15,
+    });
+    render(<CollectPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/test event/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/make it yours/i)).not.toBeInTheDocument();
+  });
+
   it("calls submitCollectRequest and refreshes profile after track select", async () => {
     mockGetEvent.mockResolvedValue(COLLECTION_EVENT);
 

--- a/dashboard/app/join/[code]/page.tsx
+++ b/dashboard/app/join/[code]/page.tsx
@@ -70,14 +70,14 @@ export default function JoinEventPage() {
   useEffect(() => {
     if (!code) return;
     let cancelled = false;
-    api.getCollectEvent(code).then(
-      (ev) => {
-        if (!cancelled) setCollectPhase(ev.phase);
-      },
-      () => {
-        /* silently ignore — assume live */
-      }
-    );
+    Promise.allSettled([
+      api.getCollectEvent(code),
+      api.getCollectProfile(code),
+    ]).then(([evResult, profileResult]) => {
+      if (cancelled) return;
+      if (evResult.status === 'fulfilled') setCollectPhase(evResult.value.phase);
+      if (profileResult.status === 'fulfilled') setEmailVerified(profileResult.value.email_verified);
+    });
     return () => {
       cancelled = true;
     };

--- a/dashboard/lib/__tests__/collect-api.test.ts
+++ b/dashboard/lib/__tests__/collect-api.test.ts
@@ -27,7 +27,7 @@ describe("collect api client", () => {
     );
   });
 
-  it("submitCollectRequest POSTs JSON", async () => {
+  it("submitCollectRequest POSTs JSON with credentials", async () => {
     (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
       OK_RESPONSE({ id: 42 })
     );
@@ -38,7 +38,7 @@ describe("collect api client", () => {
     });
     expect(fetch).toHaveBeenCalledWith(
       expect.stringMatching(/\/api\/public\/collect\/ABC\/requests$/),
-      expect.objectContaining({ method: "POST" })
+      expect.objectContaining({ method: "POST", credentials: "include" })
     );
   });
 
@@ -68,7 +68,7 @@ describe("collect api client", () => {
     ).rejects.toThrow("You already picked this one!");
   });
 
-  it("voteCollectRequest POSTs the request_id", async () => {
+  it("voteCollectRequest POSTs the request_id with credentials", async () => {
     (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
       OK_RESPONSE({ ok: true })
     );
@@ -77,6 +77,7 @@ describe("collect api client", () => {
       expect.stringMatching(/\/api\/public\/collect\/ABC\/vote$/),
       expect.objectContaining({
         body: JSON.stringify({ request_id: 99 }),
+        credentials: "include",
       })
     );
   });
@@ -87,6 +88,61 @@ describe("collect api client", () => {
     );
     await expect(apiClient.voteCollectRequest("ABC", 99)).rejects.toThrow(
       "Can't vote on your own pick"
+    );
+  });
+
+  it("getCollectProfile sends credentials and returns profile", async () => {
+    const profile = { nickname: "DJ", email_verified: true, submission_count: 3, submission_cap: 15 };
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(OK_RESPONSE(profile));
+    const r = await apiClient.getCollectProfile("ABC");
+    expect(r.email_verified).toBe(true);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/public\/collect\/ABC\/profile$/),
+      expect.objectContaining({ method: "GET", credentials: "include" })
+    );
+  });
+
+  it("setCollectProfile POSTs with credentials", async () => {
+    const profile = { nickname: "DJ", email_verified: false, submission_count: 0, submission_cap: 15 };
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(OK_RESPONSE(profile));
+    await apiClient.setCollectProfile("ABC", { nickname: "DJ" });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/public\/collect\/ABC\/profile$/),
+      expect.objectContaining({ method: "POST", credentials: "include" })
+    );
+  });
+
+  it("getCollectMyPicks sends credentials", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      OK_RESPONSE({ submitted: [], upvoted: [], voted_request_ids: [], is_top_contributor: false, first_suggestion_ids: [] })
+    );
+    await apiClient.getCollectMyPicks("ABC");
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/public\/collect\/ABC\/profile\/me$/),
+      expect.objectContaining({ method: "GET", credentials: "include" })
+    );
+  });
+
+  it("checkHasRequested sends credentials", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      OK_RESPONSE({ has_requested: true })
+    );
+    const r = await apiClient.checkHasRequested("ABC");
+    expect(r.has_requested).toBe(true);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/public\/events\/ABC\/has-requested$/),
+      expect.objectContaining({ credentials: "include" })
+    );
+  });
+
+  it("getMyRequests sends credentials", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      OK_RESPONSE({ requests: [] })
+    );
+    await apiClient.getMyRequests("ABC");
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/public\/events\/ABC\/my-requests$/),
+      expect.objectContaining({ credentials: "include" })
     );
   });
 });

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -521,11 +521,19 @@ class ApiClient {
   }
 
   async checkHasRequested(code: string): Promise<HasRequestedResponse> {
-    return this.publicFetch(`${getApiUrl()}/api/public/events/${code}/has-requested`);
+    const res = await fetch(`${getApiUrl()}/api/public/events/${code}/has-requested`, {
+      credentials: 'include',
+    });
+    if (!res.ok) throw new ApiError(`checkHasRequested failed: ${res.status}`, res.status);
+    return res.json();
   }
 
   async getMyRequests(code: string): Promise<MyRequestsResponse> {
-    return this.publicFetch(`${getApiUrl()}/api/public/events/${code}/my-requests`);
+    const res = await fetch(`${getApiUrl()}/api/public/events/${code}/my-requests`, {
+      credentials: 'include',
+    });
+    if (!res.ok) throw new ApiError(`getMyRequests failed: ${res.status}`, res.status);
+    return res.json();
   }
 
   async getPublicRequests(code: string): Promise<GuestRequestListResponse> {
@@ -1001,7 +1009,7 @@ class ApiClient {
   async getCollectProfile(code: string): Promise<CollectProfileResponse> {
     const res = await fetch(
       `${getApiUrl()}/api/public/collect/${code}/profile`,
-      { method: 'GET', headers: { 'Content-Type': 'application/json' } },
+      { method: 'GET', headers: { 'Content-Type': 'application/json' }, credentials: 'include' },
     );
     if (!res.ok) {
       throw new ApiError(`getCollectProfile failed: ${res.status}`, res.status);
@@ -1016,6 +1024,7 @@ class ApiClient {
     const res = await fetch(`${getApiUrl()}/api/public/collect/${code}/profile`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify(data),
     });
     if (!res.ok) throw new ApiError(`setCollectProfile failed: ${res.status}`, res.status);
@@ -1026,6 +1035,7 @@ class ApiClient {
     const res = await fetch(`${getApiUrl()}/api/public/collect/${code}/profile/me`, {
       method: 'GET',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
     });
     if (!res.ok) throw new ApiError(`getCollectMyPicks failed: ${res.status}`, res.status);
     return res.json();
@@ -1046,6 +1056,7 @@ class ApiClient {
     const res = await fetch(`${getApiUrl()}/api/public/collect/${code}/requests`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify(data),
     });
     if (!res.ok) {
@@ -1059,6 +1070,7 @@ class ApiClient {
     const res = await fetch(`${getApiUrl()}/api/public/collect/${code}/vote`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify({ request_id: requestId }),
     });
     if (!res.ok) {


### PR DESCRIPTION
## Summary

- **Root cause**: `wrzdj_guest` session cookie was never sent on 7 of the collect/guest API fetch calls — `credentials: 'include'` was missing. The backend's `get_guest_id()` silently returned `None`, so `email_verified` always came back `false`, causing the \"Make it yours\" panel to re-appear on every page refresh even after a guest had verified their email.
- Added `credentials: 'include'` to `getCollectProfile`, `setCollectProfile`, `getCollectMyPicks`, `submitCollectRequest`, `voteCollectRequest`, `checkHasRequested`, and `getMyRequests`.
- Fixed the join page (`/join/[code]`) never checking email verification status on mount — `emailVerified` was hardcoded `false`, so the verify CTA always showed in the request list view for returning verified guests. Now fetches guest profile on boot via `Promise.allSettled` alongside the existing collect event check.

## Test plan

- [ ] Verify email as a guest on the collect page (`/collect/{code}`) — the \"Make it yours\" panel should disappear after verification
- [ ] Refresh the collect page in the same browser — panel should remain hidden (cookie is now sent with the profile fetch)
- [ ] Close the tab, reopen the same collect URL — panel should still be hidden
- [ ] Do the same on the live request page (`/join/{code}`) — the email verification CTA in the request list view should not show for already-verified guests
- [ ] New guest (no cookie) should still see both panels as expected
- [ ] 816 frontend tests pass (`npm test -- --run`)