### PR TITLE
fix: guest auth hardening (F1-F8 from 2026-04-27 audit)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,7 @@ This section exists because a previous OAuth token implementation stored tokens 
 - Encrypt PII and sensitive user data at rest wherever feasible. Default to encrypted; plaintext storage of sensitive fields requires explicit justification.
 - Minimize data collection — don't store data you don't need.
 - Client fingerprinting (IP-based) should not be logged in a way that creates a tracking database.
+- The `client_fingerprint` column on `requests`, `request_votes`, and `guest_profiles` is the raw client IP truncated to 64 chars. Scrub or hash this column on any export (event CSV, play-history CSV, backups, analytics dumps) — use `mask_fingerprint()` from `app.core.rate_limit`. Search for any new export endpoints that select this column and apply the same treatment.
 
 ### Dependency CVE Vigilance
 - **Before adding any new package**, check for known CVEs and recent security advisories. Do not add packages with unpatched critical or high-severity vulnerabilities.
@@ -479,24 +480,24 @@ Bridge plugins depend on community-maintained open-source projects for protocol 
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **WrzDJ** (9968 symbols, 16173 relationships, 200 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **WrzDJ** (10612 symbols, 17044 relationships, 210 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
-## Recommended
+## Always Do
 
-- **SHOULD run impact analysis before editing a non-trivial symbol.** Before modifying a function, class, or method that may have multiple callers, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **SHOULD run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
-- **SHOULD warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
 - When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
 - When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
-## Avoid
+## Never Do
 
-- AVOID editing a widely-used function, class, or method without first running `gitnexus_impact` on it.
-- AVOID ignoring HIGH or CRITICAL risk warnings from impact analysis without explaining the rationale to the user.
-- AVOID renaming symbols with find-and-replace — prefer `gitnexus_rename` which understands the call graph.
-- AVOID committing significant changes without running `gitnexus_detect_changes()` to check affected scope.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 
@@ -507,9 +508,15 @@ This project is indexed by GitNexus as **WrzDJ** (9968 symbols, 16173 relationsh
 | `gitnexus://repo/WrzDJ/processes` | All execution flows |
 | `gitnexus://repo/WrzDJ/process/{name}` | Step-by-step execution trace |
 
-## Skills
+## CLI
 
-GitNexus skills auto-load into Claude Code from `~/.claude/skills/`. Reference by name:
-`gitnexus-exploring` (architecture / "how does X work?"), `gitnexus-impact-analysis` (blast radius), `gitnexus-debugging` (trace bugs), `gitnexus-refactoring` (rename/extract/split/move), `gitnexus-guide` (tool/schema reference), `gitnexus-cli` (CLI commands), `gitnexus-pr-review` (review PRs).
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
 
 <!-- gitnexus:end -->

--- a/dashboard/app/e/[code]/display/__tests__/no-identify.test.tsx
+++ b/dashboard/app/e/[code]/display/__tests__/no-identify.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import KioskDisplayPage from '../page';
+import { api } from '@/lib/api';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ code: 'TEST01' }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+// Mock localStorage (required by page's session token logic)
+const localStorageStore: Record<string, string> = {};
+const localStorageMock = {
+  getItem: (key: string) => localStorageStore[key] ?? null,
+  setItem: (key: string, value: string) => { localStorageStore[key] = value; },
+  removeItem: (key: string) => { delete localStorageStore[key]; },
+  clear: () => { for (const key of Object.keys(localStorageStore)) delete localStorageStore[key]; },
+};
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true, configurable: true });
+
+// thumbmarkjs mock: keeps module resolution clean if useGuestIdentity is ever
+// accidentally re-imported; the hook is intentionally absent from this page.
+vi.mock('@thumbmarkjs/thumbmarkjs', () => ({
+  setOption: vi.fn(),
+  getFingerprint: vi.fn().mockResolvedValue({ hash: 'testhash', data: {} }),
+}));
+
+// Mock SSE hook
+vi.mock('@/lib/use-event-stream', () => ({
+  useEventStream: () => ({ connected: false }),
+}));
+
+// Mock QR code (uses canvas, not available in jsdom)
+vi.mock('qrcode.react', () => ({
+  QRCodeSVG: ({ value }: { value: string }) => <div data-testid="qr-code" data-value={value}>QR</div>,
+}));
+
+// Mock RequestModal
+vi.mock('../components/RequestModal', () => ({
+  RequestModal: () => <div data-testid="request-modal">Modal</div>,
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getKioskDisplay: vi.fn().mockResolvedValue({
+      event: { code: 'TEST01', name: 'Test' },
+      qr_join_url: 'http://x',
+      accepted_queue: [],
+      now_playing: null,
+      now_playing_hidden: false,
+      requests_open: true,
+      kiosk_display_only: false,
+      updated_at: new Date().toISOString(),
+      banner_url: null,
+      banner_kiosk_url: null,
+      banner_colors: null,
+    }),
+    getNowPlaying: vi.fn().mockResolvedValue(null),
+    getPlayHistory: vi.fn().mockResolvedValue({ items: [] }),
+    getKioskAssignment: vi.fn(),
+  },
+  ApiError: class extends Error { status = 0; },
+}));
+
+describe('KioskDisplayPage (F4)', () => {
+  const mockFetch = vi.fn();
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ guest_id: 1, action: 'create' }),
+      headers: { get: () => null },
+    });
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does NOT call /api/public/guest/identify (kiosk stays anonymous)', async () => {
+    render(<KioskDisplayPage />);
+    await waitFor(() => {
+      expect(api.getKioskDisplay).toHaveBeenCalled();
+    });
+    const identifyCalls = mockFetch.mock.calls.filter(([url]) =>
+      String(url).includes('/api/public/guest/identify'),
+    );
+    expect(identifyCalls).toHaveLength(0);
+  });
+});

--- a/dashboard/app/e/[code]/display/page.tsx
+++ b/dashboard/app/e/[code]/display/page.tsx
@@ -5,7 +5,6 @@ import { useParams, useRouter } from 'next/navigation';
 import { QRCodeSVG } from 'qrcode.react';
 import { api, ApiError, KioskDisplay, NowPlayingInfo, PlayHistoryItem } from '@/lib/api';
 import { useEventStream } from '@/lib/use-event-stream';
-import { useGuestIdentity } from '@/lib/use-guest-identity';
 import { usePollingLoop } from '@/lib/usePollingLoop';
 import { RequestModal } from './components/RequestModal';
 const AUTO_SCROLL_INTERVAL = 5000; // 5 seconds between auto-scrolls
@@ -21,8 +20,6 @@ export default function KioskDisplayPage() {
   const params = useParams();
   const router = useRouter();
   const code = params.code as string;
-
-  useGuestIdentity();
 
   const [display, setDisplay] = useState<KioskDisplay | null>(null);
   const [loading, setLoading] = useState(true);

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -95,6 +95,7 @@ describe('ApiClient', () => {
       const [url, options] = mockFetch.mock.calls[0];
       expect(url).toContain('/api/events/ABC123/requests');
       expect(options.method).toBe('POST');
+      expect(options.credentials).toBe('include');
 
       const body = JSON.parse(options.body);
       expect(body.artist).toBe('Artist');
@@ -1268,7 +1269,7 @@ describe('ApiClient', () => {
   // ========== Public endpoints ==========
 
   describe('eventSearch', () => {
-    it('searches via public endpoint without auth', async () => {
+    it('searches via event code with cookie credentials', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => [{ title: 'Found Song', artist: 'Found Artist' }],
@@ -2093,6 +2094,47 @@ describe('ApiClient', () => {
       });
 
       await expect(api.getKioskDisplay('BAD')).rejects.toThrow('Request failed');
+    });
+  });
+
+  describe('credentials propagation (F2)', () => {
+    it('submitRequest sends credentials: include', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 1, vote_count: 0 }),
+      });
+
+      await api.submitRequest('TEST01', 'Artist', 'Title');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.credentials).toBe('include');
+    });
+
+    it('publicVoteRequest sends credentials: include', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: 'voted', vote_count: 1, has_voted: true }),
+      });
+
+      await api.publicVoteRequest(42);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.credentials).toBe('include');
+    });
+
+    it('eventSearch sends credentials: include', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      });
+
+      await api.eventSearch('TEST01', 'foo');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.credentials).toBe('include');
     });
   });
 

--- a/dashboard/lib/__tests__/use-guest-identity.test.ts
+++ b/dashboard/lib/__tests__/use-guest-identity.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+vi.mock('@thumbmarkjs/thumbmarkjs', () => ({
+  setOption: vi.fn(),
+  getFingerprint: vi.fn().mockResolvedValue({ hash: 'mock_hash_value', data: {} }),
+}));
+
+describe('useGuestIdentity (F6)', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockFetch.mockReset();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('marks isReturning=false when server returns action=create', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ guest_id: 7, action: 'create' }),
+      headers: { get: () => null },
+    });
+
+    // Dynamic import after mocks are set up — resets module-level cache
+    const { useGuestIdentity } = await import('../use-guest-identity');
+    const { result } = renderHook(() => useGuestIdentity());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.guestId).toBe(7);
+    expect(result.current.isReturning).toBe(false);
+  });
+
+  it('marks isReturning=true when server returns action=cookie_hit', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ guest_id: 8, action: 'cookie_hit' }),
+      headers: { get: () => null },
+    });
+
+    const { useGuestIdentity } = await import('../use-guest-identity');
+    const { result } = renderHook(() => useGuestIdentity());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.guestId).toBe(8);
+    expect(result.current.isReturning).toBe(true);
+  });
+});

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -457,8 +457,12 @@ class ApiClient {
     source?: string,
     nickname?: string,
   ): Promise<SongRequest> {
-    return this.fetch(`/api/events/${code}/requests`, {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.token) headers['Authorization'] = `Bearer ${this.token}`;
+    const res = await fetch(`${getApiUrl()}/api/events/${code}/requests`, {
       method: 'POST',
+      headers,
+      credentials: 'include',
       body: JSON.stringify({
         artist,
         title,
@@ -473,6 +477,14 @@ class ApiClient {
         musical_key: metadata?.musical_key,
       }),
     });
+    if (!res.ok) {
+      if (res.status === 401 && this.onUnauthorized) {
+        this.onUnauthorized();
+      }
+      const body = await res.json().catch(() => ({}));
+      throw new ApiError((body as { detail?: string }).detail ?? 'Submit failed', res.status);
+    }
+    return res.json();
   }
 
   async search(query: string): Promise<SearchResult[]> {
@@ -480,9 +492,15 @@ class ApiClient {
   }
 
   async eventSearch(code: string, query: string): Promise<SearchResult[]> {
-    return this.publicFetch(
-      `${getApiUrl()}/api/events/${code}/search?q=${encodeURIComponent(query)}`
+    const res = await fetch(
+      `${getApiUrl()}/api/events/${code}/search?q=${encodeURIComponent(query)}`,
+      { credentials: 'include' },
     );
+    if (!res.ok) {
+      const error = await res.json().catch(() => ({ detail: 'Request failed' }));
+      throw new ApiError(error.detail || 'Request failed', res.status);
+    }
+    return res.json();
   }
 
   async voteRequest(requestId: number): Promise<VoteResponse> {
@@ -494,12 +512,15 @@ class ApiClient {
   }
 
   async publicVoteRequest(requestId: number): Promise<VoteResponse> {
-    const response = await fetch(`${getApiUrl()}/api/requests/${requestId}/vote`, { method: 'POST' });
-    if (!response.ok) {
-      const error = await response.json().catch(() => ({ detail: 'Vote failed' }));
-      throw new ApiError(error.detail || 'Vote failed', response.status);
+    const res = await fetch(`${getApiUrl()}/api/requests/${requestId}/vote`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      const error = await res.json().catch(() => ({ detail: 'Vote failed' }));
+      throw new ApiError(error.detail || 'Vote failed', res.status);
     }
-    return response.json();
+    return res.json();
   }
 
   async getArchivedEvents(): Promise<ArchivedEvent[]> {

--- a/dashboard/lib/use-guest-identity.ts
+++ b/dashboard/lib/use-guest-identity.ts
@@ -50,10 +50,10 @@ export function useGuestIdentity(): GuestIdentity {
         throw new Error(`Identify failed: ${resp.status}`);
       }
 
-      const data = await resp.json();
+      const data = (await resp.json()) as { guest_id: number; action: "create" | "cookie_hit" | "reconcile" };
       const identity = {
-        guestId: data.guest_id as number,
-        isReturning: !resp.headers.get("set-cookie"),
+        guestId: data.guest_id,
+        isReturning: data.action !== "create",
       };
       cachedIdentity = identity;
       setState({ ...identity, isLoading: false, error: null });

--- a/server/alembic/versions/038_drop_request_vote_fp_unique.py
+++ b/server/alembic/versions/038_drop_request_vote_fp_unique.py
@@ -1,0 +1,28 @@
+"""Drop request_votes (request_id, client_fingerprint) unique.
+
+The legacy uq_request_vote constraint blocks legitimate votes from
+distinct cookie-identified guests behind a single NAT IP. Identity-aware
+dedup now relies on uq_request_vote_guest plus the existence check in
+services/vote.py:_find_existing_vote().
+
+Revision ID: 038
+Revises: 037
+Create Date: 2026-04-27
+"""
+
+from alembic import op
+
+revision: str = "038"
+down_revision: str | None = "037"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("request_votes") as batch_op:
+        batch_op.drop_constraint("uq_request_vote", type_="unique")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("request_votes") as batch_op:
+        batch_op.create_unique_constraint("uq_request_vote", ["request_id", "client_fingerprint"])

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -317,11 +317,11 @@ def submit(
 
     existing = find_duplicate(db, event.id, payload.artist, payload.song_title)
     if existing:
-        is_own = False
-        if guest_id and existing.guest_id:
-            is_own = existing.guest_id == guest_id
-        elif existing.client_fingerprint and fingerprint:
-            is_own = existing.client_fingerprint == fingerprint
+        is_own = (guest_id is not None and existing.guest_id == guest_id) or (
+            existing.client_fingerprint is not None
+            and fingerprint is not None
+            and existing.client_fingerprint == fingerprint
+        )
         if is_own:
             raise HTTPException(status_code=409, detail="You already picked this one!")
 
@@ -406,11 +406,11 @@ def vote(
     )
     if row is None:
         raise HTTPException(status_code=404, detail="Request not found")
-    is_own = False
-    if guest_id and row.guest_id:
-        is_own = row.guest_id == guest_id
-    elif row.client_fingerprint and row.client_fingerprint == fingerprint:
-        is_own = True
+    is_own = (guest_id is not None and row.guest_id == guest_id) or (
+        row.client_fingerprint is not None
+        and fingerprint is not None
+        and row.client_fingerprint == fingerprint
+    )
     if is_own:
         raise HTTPException(status_code=409, detail="Can't vote on your own pick")
     _, is_new_vote = add_vote(

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -24,7 +24,7 @@ from app.api.deps import (
     get_owned_event,
 )
 from app.core.config import get_settings
-from app.core.rate_limit import get_client_fingerprint, limiter
+from app.core.rate_limit import get_client_fingerprint, get_guest_id, limiter
 from app.models.event import Event
 from app.models.request import RequestStatus
 from app.models.user import User
@@ -633,6 +633,7 @@ def submit_request(
         source_url=request_data.source_url,
         artwork_url=request_data.artwork_url,
         client_fingerprint=get_client_fingerprint(request),
+        guest_id=get_guest_id(request, db),  # NEW — F1 fix
         raw_search_query=request_data.raw_search_query,
         genre=request_data.genre,
         bpm=request_data.bpm,

--- a/server/app/api/guest.py
+++ b/server/app/api/guest.py
@@ -34,7 +34,7 @@ def identify(
         user_agent=user_agent,
     )
 
-    response = JSONResponse(content={"guest_id": result.guest_id})
+    response = JSONResponse(content={"guest_id": result.guest_id, "action": result.action})
 
     if result.token:
         is_prod = get_settings().env == "production"

--- a/server/app/core/rate_limit.py
+++ b/server/app/core/rate_limit.py
@@ -113,6 +113,12 @@ def get_client_fingerprint(
 ) -> str:
     """Extract client fingerprint (IP) from the request, truncated to safe length.
 
+    The returned value is the raw client IP. It is stored in plain text in
+    the `client_fingerprint` columns of `requests`, `request_votes`, and
+    `guest_profiles`. **Any export of those tables (CSV, backup, analytics)
+    must scrub or hash this column** — `mask_fingerprint()` is the helper
+    for that.
+
     When `action` is provided, emits a structured INFO log line:
         action=collect.vote event=PB5TTP source=x-real-ip fp=a1b2c3d4e5f6
 

--- a/server/app/models/request_vote.py
+++ b/server/app/models/request_vote.py
@@ -9,10 +9,7 @@ from app.models.base import Base
 
 class RequestVote(Base):
     __tablename__ = "request_votes"
-    __table_args__ = (
-        UniqueConstraint("request_id", "client_fingerprint", name="uq_request_vote"),
-        UniqueConstraint("request_id", "guest_id", name="uq_request_vote_guest"),
-    )
+    __table_args__ = (UniqueConstraint("request_id", "guest_id", name="uq_request_vote_guest"),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
     request_id: Mapped[int] = mapped_column(

--- a/server/app/schemas/guest.py
+++ b/server/app/schemas/guest.py
@@ -1,5 +1,7 @@
 """Pydantic schemas for guest identity."""
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 
@@ -10,3 +12,4 @@ class IdentifyRequest(BaseModel):
 
 class IdentifyResponse(BaseModel):
     guest_id: int
+    action: Literal["create", "cookie_hit", "reconcile"]

--- a/server/app/services/guest_identity.py
+++ b/server/app/services/guest_identity.py
@@ -9,6 +9,7 @@ import json
 import logging
 import secrets
 from dataclasses import dataclass
+from typing import Literal
 
 from sqlalchemy.orm import Session
 
@@ -22,7 +23,7 @@ _logger = logging.getLogger("app.guest.identity")
 @dataclass
 class IdentifyResult:
     guest_id: int
-    action: str  # "create", "cookie_hit", "reconcile"
+    action: Literal["create", "cookie_hit", "reconcile"]
     token: str | None  # set only when a new cookie should be issued
 
 

--- a/server/tests/test_collect_own_pick.py
+++ b/server/tests/test_collect_own_pick.py
@@ -1,0 +1,110 @@
+"""F5 regression — 'own pick' check must survive cookie-clear.
+
+The if/elif structure used in collect.py let a guest who cleared cookies
+(new guest_id, same fingerprint) bypass the 'can't vote on own pick'
+guard and the 'you already picked this one' guard.
+"""
+
+from datetime import timedelta
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.models.event import Event
+from app.models.user import User
+from app.services.auth import get_password_hash
+
+
+@pytest.fixture
+def collection_event(db: Session) -> Event:
+    """An event in collection phase, owned by a fresh DJ user."""
+    user = User(
+        username="djowner_f5",
+        password_hash=get_password_hash("pw_f5_test_value"),
+        role="dj",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    now = utcnow()
+    event = Event(
+        code="F5COL1",
+        name="Collection Test",
+        created_by_user_id=user.id,
+        expires_at=now + timedelta(days=2),
+        collection_opens_at=now - timedelta(hours=1),
+        live_starts_at=now + timedelta(hours=12),
+    )
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+    return event
+
+
+def test_collect_vote_blocks_own_pick_after_cookie_clear(client, collection_event):
+    """Submit as guest A, clear cookies, identify as guest B (different
+    fingerprint so reconcile fails), then attempt to vote on the row.
+
+    The fingerprint is identical (TestClient host stays 'testclient'),
+    so the fp-based fallback must kick in even though guest_ids differ.
+    """
+    # Identity A — submit
+    client.post(
+        "/api/public/guest/identify",
+        json={"fingerprint_hash": "fp_owner_A", "fingerprint_components": {}},
+    )
+    submit_resp = client.post(
+        f"/api/public/collect/{collection_event.code}/requests",
+        json={"song_title": "Own Pick", "artist": "Self", "source": "manual"},
+    )
+    assert submit_resp.status_code == 201, submit_resp.json()
+    request_id = submit_resp.json()["id"]
+
+    # Force a different guest identity, but TestClient IP stays the same
+    cookie_a = client.cookies.get("wrzdj_guest")
+    client.cookies.clear()
+    client.post(
+        "/api/public/guest/identify",
+        json={"fingerprint_hash": "fp_owner_B_distinct", "fingerprint_components": {}},
+    )
+    cookie_b = client.cookies.get("wrzdj_guest")
+    assert cookie_a != cookie_b, "Expected a fresh guest identity after cookie clear"
+
+    vote_resp = client.post(
+        f"/api/public/collect/{collection_event.code}/vote",
+        json={"request_id": request_id},
+    )
+    assert vote_resp.status_code == 409, vote_resp.json()
+    assert "own" in vote_resp.json()["detail"].lower()
+
+
+def test_collect_submit_blocks_own_dup_after_cookie_clear(client, collection_event):
+    """Same scenario for submit — duplicate of your own pick must 409,
+    not silently auto-upvote your own row from a fresh guest_id."""
+    client.post(
+        "/api/public/guest/identify",
+        json={"fingerprint_hash": "fp_dup_A", "fingerprint_components": {}},
+    )
+    first = client.post(
+        f"/api/public/collect/{collection_event.code}/requests",
+        json={"song_title": "Same Song", "artist": "Same Artist", "source": "manual"},
+    )
+    assert first.status_code == 201
+
+    cookie_a = client.cookies.get("wrzdj_guest")
+    client.cookies.clear()
+    client.post(
+        "/api/public/guest/identify",
+        json={"fingerprint_hash": "fp_dup_B_distinct", "fingerprint_components": {}},
+    )
+    cookie_b = client.cookies.get("wrzdj_guest")
+    assert cookie_a != cookie_b, "Expected a fresh guest identity after cookie clear"
+
+    second = client.post(
+        f"/api/public/collect/{collection_event.code}/requests",
+        json={"song_title": "Same Song", "artist": "Same Artist", "source": "manual"},
+    )
+    assert second.status_code == 409, second.json()
+    assert "already picked" in second.json()["detail"].lower()

--- a/server/tests/test_identify_endpoint.py
+++ b/server/tests/test_identify_endpoint.py
@@ -59,6 +59,7 @@ def test_identify_without_cookie_reconciles(client: TestClient):
     guest_id_2 = resp2.json()["guest_id"]
 
     assert guest_id_1 == guest_id_2
+    assert resp2.json().get("action") == "reconcile"
 
 
 def test_identify_invalid_fingerprint_format(client: TestClient):
@@ -74,3 +75,26 @@ def test_identify_missing_body(client: TestClient):
     """No body -> 422."""
     resp = client.post("/api/public/guest/identify")
     assert resp.status_code == 422
+
+
+def test_identify_response_includes_action_create_then_cookie_hit(client):
+    """F6 — response body must carry the action so the frontend can
+    detect first-time creates without inspecting Set-Cookie (which is
+    a forbidden cross-origin response header)."""
+    first = client.post(
+        "/api/public/guest/identify",
+        json={"fingerprint_hash": "fp_action_test_1", "fingerprint_components": {}},
+    )
+    assert first.status_code == 200
+    body = first.json()
+    assert "guest_id" in body
+    assert body.get("action") == "create"
+
+    # Same client (cookie persisted) hits identify again
+    second = client.post(
+        "/api/public/guest/identify",
+        json={"fingerprint_hash": "fp_action_test_1", "fingerprint_components": {}},
+    )
+    assert second.status_code == 200
+    assert second.json().get("action") == "cookie_hit"
+    assert second.json().get("guest_id") == body["guest_id"]

--- a/server/tests/test_requests.py
+++ b/server/tests/test_requests.py
@@ -612,3 +612,39 @@ class TestMarkPlayingSingleActive:
         if np:
             assert np.title == ""
             assert np.artist == ""
+
+
+def test_live_submit_persists_guest_id_from_cookie(client, test_event, db):
+    """F1 regression: events.py submit_request() must capture guest_id from
+    the wrzdj_guest cookie and persist it on the Request row.
+
+    Before the fix, every live-event request was stored with guest_id=NULL.
+    """
+    from app.models.request import Request as SongRequest
+
+    identify_resp = client.post(
+        "/api/public/guest/identify",
+        json={
+            "fingerprint_hash": "fp_test_live_submit",
+            "fingerprint_components": {"screen": "1170x2532"},
+        },
+    )
+    assert identify_resp.status_code == 200
+    guest_id = identify_resp.json()["guest_id"]
+
+    submit_resp = client.post(
+        f"/api/events/{test_event.code}/requests",
+        json={
+            "artist": "Test Artist",
+            "title": "Test Song",
+            "source": "manual",
+        },
+    )
+    assert submit_resp.status_code == 200, submit_resp.json()
+    request_id = submit_resp.json()["id"]
+
+    row = db.query(SongRequest).filter(SongRequest.id == request_id).first()
+    assert row is not None
+    assert row.guest_id == guest_id, (
+        f"Expected guest_id={guest_id} on persisted request, got {row.guest_id}"
+    )

--- a/server/tests/test_votes.py
+++ b/server/tests/test_votes.py
@@ -1,0 +1,114 @@
+"""F3 regression — two distinct cookie-identified guests behind the
+same NAT IP must both be able to vote on the same request."""
+
+from datetime import timedelta
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.models.event import Event
+from app.models.request import Request as SongRequest
+from app.models.request import RequestStatus
+from app.models.user import User
+from app.services.auth import get_password_hash
+
+
+@pytest.fixture
+def votable_event_and_request(db: Session) -> tuple[Event, SongRequest]:
+    user = User(
+        username="dj_f3",
+        password_hash=get_password_hash("pw_f3_test_value"),
+        role="dj",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    event = Event(
+        code="F3VOTE",
+        name="NAT Vote Test",
+        created_by_user_id=user.id,
+        expires_at=utcnow() + timedelta(hours=6),
+    )
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+
+    req = SongRequest(
+        event_id=event.id,
+        song_title="Shared Song",
+        artist="Shared Artist",
+        source="manual",
+        status=RequestStatus.NEW.value,
+        dedupe_key="f3_dedupe_key_voteme",
+    )
+    db.add(req)
+    db.commit()
+    db.refresh(req)
+    return event, req
+
+
+def test_two_guests_one_nat_ip_both_vote(client, votable_event_and_request):
+    """Both guests issue the SAME fingerprint to TestClient (which always
+    reports IP='testclient'), but different cookie tokens via /identify."""
+    event, req = votable_event_and_request
+
+    # Guest A
+    client.post(
+        "/api/public/guest/identify",
+        json={"fingerprint_hash": "fp_nat_guest_A", "fingerprint_components": {}},
+    )
+    vote_a = client.post(f"/api/requests/{req.id}/vote")
+    assert vote_a.status_code == 200, vote_a.json()
+    assert vote_a.json()["vote_count"] == 1
+    assert vote_a.json()["status"] == "voted"
+
+    # Switch identity, IP stays the same — Guest B
+    client.cookies.clear()
+    client.post(
+        "/api/public/guest/identify",
+        json={"fingerprint_hash": "fp_nat_guest_B_distinct", "fingerprint_components": {}},
+    )
+    vote_b = client.post(f"/api/requests/{req.id}/vote")
+    assert vote_b.status_code == 200, vote_b.json()
+    assert vote_b.json()["vote_count"] == 2, (
+        "Two distinct cookie-identified guests on the same NAT IP must "
+        "both successfully vote — F3 regression"
+    )
+    assert vote_b.json()["status"] == "voted"
+
+
+def test_same_guest_double_vote_still_idempotent(client, votable_event_and_request):
+    """Sanity: dropping the (req, fp) unique must not weaken the
+    (req, guest_id) dedup. Same cookie voting twice = no-op second time."""
+    _, req = votable_event_and_request
+
+    client.post(
+        "/api/public/guest/identify",
+        json={"fingerprint_hash": "fp_idem_solo", "fingerprint_components": {}},
+    )
+    first = client.post(f"/api/requests/{req.id}/vote")
+    assert first.status_code == 200
+    assert first.json()["vote_count"] == 1
+    assert first.json()["status"] == "voted"
+
+    second = client.post(f"/api/requests/{req.id}/vote")
+    assert second.status_code == 200
+    assert second.json()["vote_count"] == 1
+    assert second.json()["status"] == "already_voted"
+
+
+def test_legacy_anon_vote_blocks_anon_revote_same_ip(client, votable_event_and_request):
+    """Sanity: when no cookie is involved (no /identify call), the
+    fp-only dedup still works — same IP can only vote once."""
+    _, req = votable_event_and_request
+
+    first = client.post(f"/api/requests/{req.id}/vote")
+    assert first.status_code == 200
+    assert first.json()["vote_count"] == 1
+
+    second = client.post(f"/api/requests/{req.id}/vote")
+    assert second.status_code == 200
+    assert second.json()["vote_count"] == 1, "anonymous re-vote must be a no-op"
+    assert second.json()["status"] == "already_voted"


### PR DESCRIPTION
## Summary

Pre-public-release security pass from the 2026-04-27 guest auth audit. The recently shipped server-token-first identity layer (PRs #254, #256, #257) was being bypassed on the live join-page flow — two CRITICAL bugs meant the \`wrzdj_guest\` cookie was never reaching the server on live event submissions and votes.

- **F1**: \`events.py submit_request()\` wasn't passing \`guest_id\` to \`create_request()\` — every live-event request row stored \`guest_id=NULL\`. Fixed: \`guest_id=get_guest_id(request, db)\` added.
- **F2**: \`submitRequest\`, \`publicVoteRequest\`, and \`eventSearch\` in \`api.ts\` were the only guest-facing fetches without \`credentials: 'include'\`. Browser strips cookies on cross-origin requests without it. Fixed: all three rewritten with \`credentials: 'include'\` + 401 hook preserved on \`submitRequest\`.
- **F3**: Legacy \`uq_request_vote (request_id, client_fingerprint)\` unique (migration 006) silently blocked legitimate votes from distinct cookie-identified guests behind a shared NAT IP. Fixed: dropped via migration 038; dedup now relies on \`uq_request_vote_guest (request_id, guest_id)\` + existence check.
- **F4**: Kiosk display page called \`useGuestIdentity()\`, issuing a persistent \`wrzdj_guest\` cookie on a shared terminal — all users shared one identity. Fixed: call removed; kiosk stays anonymous, fingerprint-based dedup still applies.
- **F5**: \`collect.py\` \`is_own\` checks used \`if/elif\` — when both rows had non-null but mismatched \`guest_id\`s, the fingerprint fallback branch was skipped. A cookie-clear gave a bypass. Fixed: flat \`or\` expression evaluating both signals independently.
- **F6**: \`useGuestIdentity\` read \`Set-Cookie\` to detect new vs. returning guests — forbidden response header, always null on cross-origin. \`isReturning\` was structurally always \`true\`. Fixed: server now includes \`action: create|cookie_hit|reconcile\` in identify response body; hook reads that instead.
- **F8** (info): \`client_fingerprint\` is raw IP — documented in \`rate_limit.py\` docstring and CLAUDE.md under User Data Protection.

## Test plan

- [x] Backend: \`pytest --tb=short -q\` — 1859 passed, 87.94% coverage (threshold 85%)
- [x] Backend: \`alembic upgrade head && alembic check\` — no drift
- [x] Backend: \`ruff check\`, \`ruff format --check\`, \`bandit\` — clean
- [x] Frontend: \`npm run lint\` — 0 errors
- [x] Frontend: \`npx tsc --noEmit\` — clean
- [x] Frontend: \`npm test -- --run\` — 822 passed
- [x] Bridge: \`npx tsc --noEmit\` + \`npm test -- --run\` — 342 passed
- [x] Bridge-app: \`npx tsc --noEmit\` + \`npm test -- --run\` — 72 passed
- [ ] Manual: live submit persists \`guest_id\` (DB query check)
- [ ] Manual: two browsers same machine both vote → \`vote_count = 2\`
- [ ] Manual: kiosk display page makes zero \`/identify\` calls (Network tab)
- [ ] Manual: cookie-clear can't bypass own-pick check (collect phase)