### PR TITLE
fix: harden nickname filter against letter-padding bypass

### DIFF
--- a/dashboard/app/collect/[code]/components/FeatureOptInPanel.tsx
+++ b/dashboard/app/collect/[code]/components/FeatureOptInPanel.tsx
@@ -7,7 +7,7 @@ import EmailVerification from '../../../../components/EmailVerification';
 const nicknameSchema = z
   .string()
   .trim()
-  .min(1)
+  .min(2, 'Nickname must be at least 2 characters')
   .max(30)
   .regex(/^[a-zA-Z0-9 _.-]+$/, 'Letters, numbers, spaces, . _ - only');
 

--- a/dashboard/components/NicknameGate.tsx
+++ b/dashboard/components/NicknameGate.tsx
@@ -9,7 +9,7 @@ import EmailVerification from './EmailVerification';
 const nicknameSchema = z
   .string()
   .trim()
-  .min(1)
+  .min(2, 'Nickname must be at least 2 characters')
   .max(30)
   .regex(/^[a-zA-Z0-9 _.-]+$/, 'Letters, numbers, spaces, . _ - only');
 

--- a/server/app/core/validation.py
+++ b/server/app/core/validation.py
@@ -120,14 +120,39 @@ _BLOCKED_SUBSTRINGS = frozenset(
 _NON_ALPHA_RE = re.compile(r"[^a-z]")
 
 
+def _distinct_ordered_alpha(text: str) -> str:
+    """Extract each unique lowercase letter exactly once, in first-occurrence
+    order.  'mmShmmImmT' -> 'mshit'.  Used to detect letter-padding bypasses
+    where a blocked word's letters are separated by repeated filler characters
+    (e.g. 'mmSmmHmmImmT' to spell out 'shit' with 'mm' padding)."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for c in text:
+        if c not in seen:
+            seen.add(c)
+            out.append(c)
+    return _NON_ALPHA_RE.sub("", "".join(out))
+
+
 def contains_profanity(text: str) -> bool:
     """Check text for profanity using word-boundary matching and substring
     matching with leetspeak normalization.  Designed for username-style input
-    where words are concatenated without spaces."""
+    where words are concatenated without spaces.
+
+    Detection layers:
+    1. better_profanity word-boundary check (catches common phrases).
+    2. Substring check on alpha-only normalized text (catches dots/numbers
+       used as separators, e.g. 's.h.i.t' or 'sh1t').
+    3. Distinct-letter skeleton check (catches alpha letter padding,
+       e.g. 'mmSmmHmmImmT' -> 'mshit' contains 'shit').
+    """
     if not text:
         return False
     if profanity.contains_profanity(text):
         return True
     normalized = text.lower().translate(_LEET_MAP)
     alpha_only = _NON_ALPHA_RE.sub("", normalized)
-    return any(word in alpha_only for word in _BLOCKED_SUBSTRINGS)
+    if any(word in alpha_only for word in _BLOCKED_SUBSTRINGS):
+        return True
+    distinct_alpha = _distinct_ordered_alpha(normalized)
+    return any(word in distinct_alpha for word in _BLOCKED_SUBSTRINGS)

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -14,17 +14,27 @@ def _check_nickname_profanity(v: str) -> str:
     return v
 
 
+def _check_note_profanity(v: str) -> str:
+    if contains_profanity(v):
+        raise ValueError("Note contains inappropriate content")
+    return v
+
+
 Nickname = Annotated[
     str,
     StringConstraints(
         strip_whitespace=True,
-        min_length=1,
+        min_length=2,
         max_length=30,
         pattern=r"^[a-zA-Z0-9 _.-]+$",
     ),
     AfterValidator(_check_nickname_profanity),
 ]
-Note = Annotated[str, StringConstraints(strip_whitespace=True, max_length=500)]
+Note = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, max_length=500),
+    AfterValidator(_check_note_profanity),
+]
 
 
 class CollectPhase(BaseModel):

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -87,7 +87,7 @@ def test_collect_profile_email_field_ignored(client, db, test_event):
     _enable_collection(db, test_event)
     r = client.post(
         f"/api/public/collect/{test_event.code}/profile",
-        json={"nickname": "A"},
+        json={"nickname": "AJ"},
     )
     assert r.status_code == 200
     assert r.json()["email_verified"] is False


### PR DESCRIPTION
## Summary
Fixes three issues discovered during systematic abuse testing of the nickname gate.

**Root cause (F1 — Critical):** `contains_profanity()` stripped non-alpha chars (dots, numbers) before substring-matching, but could not detect alpha letter padding. `mmSmmHmmImmT` → alpha-only extraction → `mmsmmhmmimmt` — "shit" is not a *consecutive* substring. Added a third detection layer: extract each unique letter exactly once in first-occurrence order (distinct-alpha skeleton), then substring-check. `mmSmmHmmImmT` → `mshit` → "shit" found. Zero false positives on 12 real-word test cases (sophisticated, scholarship, washington, etc.).

**F2 — High:** `note` field on collect submissions had no profanity validation (only max_length=500). Added `AfterValidator(_check_note_profanity)` to the `Note` type.

**F3 — Medium:** `min_length=1` allowed single-char names ("p"). Raised to 2 on server `Nickname` type and both frontend schemas (`NicknameGate.tsx`, `FeatureOptInPanel.tsx`).

## Test plan
- [ ] `mmSmmHmmImmT` → 422
- [ ] `aSaHaIaT`, `xSxHxIxT` → 422
- [ ] `shit`, `5h1t`, `s.h.i.t` → 422 (existing, must still work)
- [ ] `sophisticated`, `wrzonance`, `washington` → 200 (no false positives)
- [ ] note with profanity → 422
- [ ] 1-char nickname → 422
- [ ] `pytest` 1859 passed