### PR TITLE
feat: nickname gate two-track entry and collision UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ notes/
 .aider*
 .claude/
 .superpowers/
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ notes/
 .gitnexus
 .aider*
 .claude/
+.superpowers/

--- a/dashboard/components/NicknameGate.tsx
+++ b/dashboard/components/NicknameGate.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { z } from 'zod';
-import { apiClient, ApiError, CollectProfileResponse } from '../lib/api';
+import { apiClient, ApiError, CollectProfileResponse, NicknameConflictError } from '../lib/api';
 import { useGuestIdentity } from '../lib/use-guest-identity';
 import { ModalOverlay } from './ModalOverlay';
 import EmailVerification from './EmailVerification';
@@ -26,14 +26,29 @@ interface Props {
   onComplete: (result: GateResult) => void;
 }
 
-type GateState = 'loading' | 'error' | 'nickname_input' | 'email_prompt';
+type GateState =
+  | 'loading'
+  | 'error'
+  | 'track_select'
+  | 'nickname_input'
+  | 'collision_unclaimed'
+  | 'collision_claimed'
+  | 'email_login'
+  | 'email_code'
+  | 'email_prompt';
 
 export function NicknameGate({ code, onComplete }: Props) {
   const identity = useGuestIdentity();
   const [gateState, setGateState] = useState<GateState>('loading');
   const [savedNickname, setSavedNickname] = useState('');
   const [nicknameInput, setNicknameInput] = useState('');
+  const [emailInput, setEmailInput] = useState('');
+  const [codeInput, setCodeInput] = useState('');
+  const [collisionNickname, setCollisionNickname] = useState('');
+  const [emailVerified, setEmailVerified] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [sendingCode, setSendingCode] = useState(false);
+  const [verifyingCode, setVerifyingCode] = useState(false);
   const [inputError, setInputError] = useState<string | null>(null);
   const [savedFlash, setSavedFlash] = useState(false);
   const [profileCache, setProfileCache] = useState<CollectProfileResponse | null>(null);
@@ -61,7 +76,7 @@ export function NicknameGate({ code, onComplete }: Props) {
         setSavedNickname(p.nickname);
         setGateState('email_prompt');
       } else {
-        setGateState('nickname_input');
+        setGateState('track_select');
       }
     } catch (err) {
       if (err instanceof ApiError && err.status === 404) {
@@ -96,12 +111,64 @@ export function NicknameGate({ code, onComplete }: Props) {
       setSavedFlash(true);
       flashTimerRef.current = setTimeout(() => {
         setSavedFlash(false);
-        setGateState('email_prompt');
+        if (emailVerified) {
+          onComplete({
+            nickname: parsed.data,
+            emailVerified: true,
+            submissionCount: p.submission_count,
+            submissionCap: p.submission_cap,
+          });
+        } else {
+          setGateState('email_prompt');
+        }
       }, 1500);
     } catch (err) {
-      setInputError(err instanceof ApiError ? err.message : "Couldn't save — please try again");
+      if (err instanceof NicknameConflictError) {
+        setCollisionNickname(parsed.data);
+        setGateState(err.claimed ? 'collision_claimed' : 'collision_unclaimed');
+      } else {
+        setInputError(err instanceof ApiError ? err.message : "Couldn't save — please try again");
+      }
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleSendCode = async () => {
+    setSendingCode(true);
+    setInputError(null);
+    try {
+      await apiClient.requestVerificationCode(emailInput);
+      setGateState('email_code');
+    } catch (err) {
+      setInputError(err instanceof ApiError ? err.message : 'Failed to send code. Try again.');
+    } finally {
+      setSendingCode(false);
+    }
+  };
+
+  const handleConfirmCode = async () => {
+    setVerifyingCode(true);
+    setInputError(null);
+    try {
+      await apiClient.confirmVerificationCode(emailInput, codeInput);
+      const p = await apiClient.getCollectProfile(code);
+      setProfileCache(p);
+      setEmailVerified(true);
+      if (p.nickname) {
+        onComplete({
+          nickname: p.nickname,
+          emailVerified: true,
+          submissionCount: p.submission_count,
+          submissionCap: p.submission_cap,
+        });
+      } else {
+        setGateState('nickname_input');
+      }
+    } catch (err) {
+      setInputError(err instanceof ApiError ? err.message : 'Invalid or expired code.');
+    } finally {
+      setVerifyingCode(false);
     }
   };
 
@@ -122,6 +189,8 @@ export function NicknameGate({ code, onComplete }: Props) {
       submissionCap: profileCache?.submission_cap ?? 0,
     });
   };
+
+  // ── loading ───────────────────────────────────────────────────────────────
 
   if (gateState === 'loading') {
     return (
@@ -145,6 +214,35 @@ export function NicknameGate({ code, onComplete }: Props) {
       </ModalOverlay>
     );
   }
+
+  // ── track_select ──────────────────────────────────────────────────────────
+
+  if (gateState === 'track_select') {
+    return (
+      <ModalOverlay card>
+        <h2 style={{ marginBottom: '0.5rem' }}>Join the event</h2>
+        <p style={{ color: 'var(--text-secondary)', marginBottom: '1.25rem', fontSize: '0.9rem' }}>
+          How would you like to identify yourself?
+        </p>
+        <button
+          className="btn btn-primary"
+          style={{ width: '100%', marginBottom: '0.75rem' }}
+          onClick={() => setGateState('nickname_input')}
+        >
+          New name
+        </button>
+        <button
+          className="btn btn-secondary"
+          style={{ width: '100%' }}
+          onClick={() => setGateState('email_login')}
+        >
+          Have email / log in
+        </button>
+      </ModalOverlay>
+    );
+  }
+
+  // ── nickname_input ────────────────────────────────────────────────────────
 
   if (gateState === 'nickname_input') {
     return (
@@ -183,7 +281,179 @@ export function NicknameGate({ code, onComplete }: Props) {
     );
   }
 
-  // email_prompt state
+  // ── collision_unclaimed ───────────────────────────────────────────────────
+
+  if (gateState === 'collision_unclaimed') {
+    return (
+      <ModalOverlay card>
+        <h2 style={{ marginBottom: '0.75rem' }}>Nickname taken</h2>
+        <p style={{ color: 'var(--text-secondary)', marginBottom: '0.5rem' }}>
+          <strong>&ldquo;{collisionNickname}&rdquo;</strong> is already taken.
+        </p>
+        <p
+          style={{
+            background: 'var(--card-bg)',
+            border: '1px solid var(--border)',
+            borderRadius: '8px',
+            padding: '0.75rem',
+            fontSize: '0.875rem',
+            color: 'var(--text-secondary)',
+            marginBottom: '1rem',
+          }}
+        >
+          Not claimed yet. If this is yours, go back to the original device you used and claim it
+          there with your email.
+        </p>
+        <button
+          className="btn btn-secondary"
+          style={{ width: '100%' }}
+          onClick={() => {
+            setNicknameInput('');
+            setGateState('nickname_input');
+          }}
+        >
+          Try a different nickname
+        </button>
+      </ModalOverlay>
+    );
+  }
+
+  // ── collision_claimed ─────────────────────────────────────────────────────
+
+  if (gateState === 'collision_claimed') {
+    return (
+      <ModalOverlay card>
+        <h2 style={{ marginBottom: '0.75rem' }}>Nickname taken</h2>
+        <p style={{ color: 'var(--text-secondary)', marginBottom: '0.5rem' }}>
+          <strong>&ldquo;{collisionNickname}&rdquo;</strong> is already taken.
+        </p>
+        <p
+          style={{
+            background: 'var(--card-bg)',
+            border: '1px solid var(--border)',
+            borderRadius: '8px',
+            padding: '0.75rem',
+            fontSize: '0.875rem',
+            color: 'var(--text-secondary)',
+            marginBottom: '1rem',
+          }}
+        >
+          This nickname has an email attached — if it&apos;s yours, log in to reclaim it.
+        </p>
+        <button
+          className="btn btn-primary"
+          style={{ width: '100%', marginBottom: '0.75rem' }}
+          onClick={() => setGateState('email_login')}
+        >
+          Log in with email
+        </button>
+        <button
+          className="btn btn-secondary"
+          style={{ width: '100%' }}
+          onClick={() => {
+            setNicknameInput('');
+            setGateState('nickname_input');
+          }}
+        >
+          Try a different nickname
+        </button>
+      </ModalOverlay>
+    );
+  }
+
+  // ── email_login ───────────────────────────────────────────────────────────
+
+  if (gateState === 'email_login') {
+    return (
+      <ModalOverlay card>
+        <h2 style={{ marginBottom: '0.5rem' }}>Log in with email</h2>
+        <p style={{ color: 'var(--text-secondary)', marginBottom: '1rem', fontSize: '0.9rem' }}>
+          Enter your email to receive a login code.
+        </p>
+        <div className="form-group">
+          <input
+            type="email"
+            className="input"
+            placeholder="you@example.com"
+            value={emailInput}
+            onChange={(e) => {
+              setEmailInput(e.target.value);
+              setInputError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && emailInput.trim()) handleSendCode();
+            }}
+            autoFocus
+          />
+        </div>
+        {inputError && <p className="collection-fieldset-error">{inputError}</p>}
+        <button
+          className="btn btn-primary"
+          style={{ width: '100%', marginBottom: '0.75rem' }}
+          disabled={!emailInput.trim() || sendingCode}
+          onClick={handleSendCode}
+        >
+          {sendingCode ? 'Sending…' : 'Send code'}
+        </button>
+        <button
+          className="btn btn-secondary"
+          style={{ width: '100%' }}
+          onClick={() => setGateState('track_select')}
+        >
+          ← Back
+        </button>
+      </ModalOverlay>
+    );
+  }
+
+  // ── email_code ────────────────────────────────────────────────────────────
+
+  if (gateState === 'email_code') {
+    return (
+      <ModalOverlay card>
+        <h2 style={{ marginBottom: '0.5rem' }}>Check your email</h2>
+        <p style={{ color: 'var(--text-secondary)', marginBottom: '1rem', fontSize: '0.9rem' }}>
+          Enter the 6-digit code sent to {emailInput}.
+        </p>
+        <div className="form-group">
+          <input
+            type="text"
+            className="input"
+            placeholder="6-digit code"
+            value={codeInput}
+            onChange={(e) => {
+              setCodeInput(e.target.value.replace(/\D/g, '').slice(0, 6));
+              setInputError(null);
+            }}
+            maxLength={6}
+            autoFocus
+          />
+        </div>
+        {inputError && <p className="collection-fieldset-error">{inputError}</p>}
+        <button
+          className="btn btn-primary"
+          style={{ width: '100%', marginBottom: '0.75rem' }}
+          disabled={codeInput.length !== 6 || verifyingCode}
+          onClick={handleConfirmCode}
+        >
+          {verifyingCode ? 'Verifying…' : 'Verify'}
+        </button>
+        <button
+          className="btn btn-secondary"
+          style={{ width: '100%' }}
+          onClick={() => {
+            setCodeInput('');
+            setGateState('email_login');
+          }}
+        >
+          Resend code
+        </button>
+      </ModalOverlay>
+    );
+  }
+
+  // ── email_prompt ──────────────────────────────────────────────────────────
+
   return (
     <ModalOverlay card>
       <h2 style={{ marginBottom: '0.5rem' }}>Hi, {savedNickname}! 👋</h2>

--- a/dashboard/components/__tests__/NicknameGate.test.tsx
+++ b/dashboard/components/__tests__/NicknameGate.test.tsx
@@ -1,326 +1,246 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { NicknameGate } from '../NicknameGate';
 
-vi.mock('../../lib/api', () => ({
-  apiClient: {
-    getCollectProfile: vi.fn(),
-    setCollectProfile: vi.fn(),
-    requestVerificationCode: vi.fn(),
-    confirmVerificationCode: vi.fn(),
-  },
-  ApiError: class extends Error {
+vi.mock('../../lib/api', () => {
+  class ApiError extends Error {
     status: number;
-    constructor(message: string, status: number) {
-      super(message);
+    constructor(msg: string, status: number) {
+      super(msg);
+      this.name = 'ApiError';
       this.status = status;
     }
-  },
-}));
+  }
+  class NicknameConflictError extends Error {
+    claimed: boolean;
+    constructor(claimed: boolean) {
+      super('nickname_taken');
+      this.name = 'NicknameConflictError';
+      this.claimed = claimed;
+    }
+  }
+  return {
+    apiClient: {
+      getCollectProfile: vi.fn(),
+      setCollectProfile: vi.fn(),
+      requestVerificationCode: vi.fn(),
+      confirmVerificationCode: vi.fn(),
+    },
+    ApiError,
+    NicknameConflictError,
+  };
+});
 
 vi.mock('../../lib/use-guest-identity', () => ({
-  useGuestIdentity: vi.fn(() => ({
+  useGuestIdentity: () => ({
+    isLoading: false,
     guestId: 1,
     isReturning: false,
-    isLoading: false,
-    error: null,
-  })),
+    reconcileHint: false,
+    refresh: vi.fn(),
+  }),
 }));
 
-import { NicknameGate } from '../NicknameGate';
-import { apiClient, ApiError } from '../../lib/api';
-import { useGuestIdentity } from '../../lib/use-guest-identity';
+vi.mock('../EmailVerification', () => ({
+  default: ({ onVerified, onSkip }: { onVerified: () => void; onSkip: () => void }) => (
+    <div>
+      <button onClick={onVerified}>Verify Email</button>
+      <button onClick={onSkip}>Skip Email</button>
+    </div>
+  ),
+}));
 
-const mockGetProfile = apiClient.getCollectProfile as ReturnType<typeof vi.fn>;
-const mockSetProfile = apiClient.setCollectProfile as ReturnType<typeof vi.fn>;
-const mockUseGuestIdentity = useGuestIdentity as ReturnType<typeof vi.fn>;
+import { apiClient, NicknameConflictError } from '../../lib/api';
 
-function baseProfile(overrides: Partial<{
-  nickname: string | null;
-  email_verified: boolean;
-  submission_count: number;
-  submission_cap: number;
-}> = {}) {
-  return {
-    nickname: null,
-    email_verified: false,
-    submission_count: 0,
-    submission_cap: 5,
-    ...overrides,
-  };
-}
+const mockGetProfile = vi.mocked(apiClient.getCollectProfile);
+const mockSetProfile = vi.mocked(apiClient.setCollectProfile);
+const mockRequestCode = vi.mocked(apiClient.requestVerificationCode);
+const mockConfirmCode = vi.mocked(apiClient.confirmVerificationCode);
+
+const emptyProfile = {
+  nickname: null,
+  email_verified: false,
+  submission_count: 0,
+  submission_cap: 5,
+};
 
 describe('NicknameGate', () => {
+  const onComplete = vi.fn();
+
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseGuestIdentity.mockReturnValue({
-      guestId: 1,
-      isReturning: false,
-      isLoading: false,
-      error: null,
-    });
-  });
-
-  it('shows nickname input for a new guest (no nickname on profile)', async () => {
-    mockGetProfile.mockResolvedValue(baseProfile({ nickname: null }));
-    render(<NicknameGate code="TEST01" onComplete={vi.fn()} />);
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /what.s your nickname/i })).toBeInTheDocument();
-    });
-  });
-
-  it('shows email prompt for returning guest with nickname but no email', async () => {
-    mockGetProfile.mockResolvedValue(baseProfile({ nickname: 'DJ_Foo', email_verified: false }));
-    render(<NicknameGate code="TEST01" onComplete={vi.fn()} />);
-    await waitFor(() => {
-      expect(screen.getByText(/add your email/i)).toBeInTheDocument();
-    });
-  });
-
-  it('calls onComplete immediately when nickname and email are already set', async () => {
-    const onComplete = vi.fn();
-    mockGetProfile.mockResolvedValue(baseProfile({ nickname: 'DJ_Foo', email_verified: true }));
-    render(<NicknameGate code="TEST01" onComplete={onComplete} />);
-    await waitFor(() => {
-      expect(onComplete).toHaveBeenCalledWith({
-        nickname: 'DJ_Foo',
-        emailVerified: true,
-        submissionCount: 0,
-        submissionCap: 5,
-      });
-    });
-  });
-
-  it('calls onComplete (pass-through) on 404', async () => {
-    const onComplete = vi.fn();
-    mockGetProfile.mockRejectedValue(new ApiError('Not found', 404));
-    render(<NicknameGate code="GONE" onComplete={onComplete} />);
-    await waitFor(() => {
-      expect(onComplete).toHaveBeenCalledWith({
-        nickname: '',
-        emailVerified: false,
-        submissionCount: 0,
-        submissionCap: 0,
-      });
-    });
-  });
-
-  it('shows error state on network failure with Retry button', async () => {
-    mockGetProfile.mockRejectedValue(new Error('Network error'));
-    render(<NicknameGate code="TEST01" onComplete={vi.fn()} />);
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
-    });
-    expect(screen.getByText(/couldn.t connect/i)).toBeInTheDocument();
-  });
-
-  it('Save button is disabled when nickname input is empty', async () => {
-    mockGetProfile.mockResolvedValue(baseProfile({ nickname: null }));
-    render(<NicknameGate code="TEST01" onComplete={vi.fn()} />);
-    await waitFor(() => screen.getByRole('heading', { name: /what.s your nickname/i }));
-    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
-  });
-
-  it('Save button is enabled after typing a nickname', async () => {
-    mockGetProfile.mockResolvedValue(baseProfile({ nickname: null }));
-    render(<NicknameGate code="TEST01" onComplete={vi.fn()} />);
-    await waitFor(() => screen.getByRole('heading', { name: /what.s your nickname/i }));
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'DancingQueen' } });
-    expect(screen.getByRole('button', { name: /save/i })).not.toBeDisabled();
-  });
-
-  it('shows "Nickname saved!" flash after successful save', async () => {
-    mockGetProfile.mockResolvedValue(baseProfile({ nickname: null }));
-    mockSetProfile.mockResolvedValue(baseProfile({ nickname: 'DancingQueen', email_verified: false }));
-    render(<NicknameGate code="TEST01" onComplete={vi.fn()} />);
-    await waitFor(() => screen.getByRole('heading', { name: /what.s your nickname/i }));
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'DancingQueen' } });
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    await waitFor(() => {
-      expect(screen.getByText(/nickname saved/i)).toBeInTheDocument();
-    });
-  });
-
-  it('shows inline error when save fails', async () => {
-    mockGetProfile.mockResolvedValue(baseProfile({ nickname: null }));
-    mockSetProfile.mockRejectedValue(new Error('Server error'));
-    render(<NicknameGate code="TEST01" onComplete={vi.fn()} />);
-    await waitFor(() => screen.getByRole('heading', { name: /what.s your nickname/i }));
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'DancingQueen' } });
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    await waitFor(() => {
-      expect(screen.getByText(/couldn.t save/i)).toBeInTheDocument();
-    });
-  });
-
-  it('skip from email_prompt calls onComplete with emailVerified=false', async () => {
-    const onComplete = vi.fn();
-    mockGetProfile.mockResolvedValue(
-      baseProfile({ nickname: 'DJ_Foo', email_verified: false, submission_count: 3, submission_cap: 10 })
-    );
-    render(<NicknameGate code="TEST01" onComplete={onComplete} />);
-    await waitFor(() => screen.getByText(/add your email/i));
-    fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
-    expect(onComplete).toHaveBeenCalledWith({
-      nickname: 'DJ_Foo',
-      emailVerified: false,
-      submissionCount: 3,
-      submissionCap: 10,
-    });
-  });
-
-  it('shows validation error for invalid nickname (line 80-81 — validation error path)', async () => {
-    mockGetProfile.mockResolvedValue(baseProfile({ nickname: null }));
-    render(<NicknameGate code="TEST01" onComplete={vi.fn()} />);
-    await waitFor(() => screen.getByRole('heading', { name: /what.s your nickname/i }));
-
-    // Type an invalid nickname with special chars not in the allowed set
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Invalid@Name!' } });
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText(/letters, numbers/i)).toBeInTheDocument();
-    });
-  });
-
-  it('saves nickname via Enter key (line 158 — enter key branch)', async () => {
-    mockGetProfile.mockResolvedValue(baseProfile({ nickname: null }));
-    mockSetProfile.mockResolvedValue(baseProfile({ nickname: 'PressEnter', email_verified: false }));
-    render(<NicknameGate code="TEST01" onComplete={vi.fn()} />);
-    await waitFor(() => screen.getByRole('heading', { name: /what.s your nickname/i }));
-
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'PressEnter' } });
-    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
-
-    await waitFor(() => {
-      expect(mockSetProfile).toHaveBeenCalled();
-    });
-  });
-
-  it('does not save nickname when Enter is pressed with empty input', async () => {
-    mockGetProfile.mockResolvedValue(baseProfile({ nickname: null }));
-    render(<NicknameGate code="TEST01" onComplete={vi.fn()} />);
-    await waitFor(() => screen.getByRole('heading', { name: /what.s your nickname/i }));
-
-    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'k' });
-    expect(mockSetProfile).not.toHaveBeenCalled();
-  });
-
-  it('typing clears inputError (line 91-92 — input change clears error)', async () => {
-    mockGetProfile.mockResolvedValue(baseProfile({ nickname: null }));
-    mockSetProfile.mockRejectedValue(new Error('Server error'));
-    render(<NicknameGate code="TEST01" onComplete={vi.fn()} />);
-    await waitFor(() => screen.getByRole('heading', { name: /what.s your nickname/i }));
-
-    // Trigger an error first
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'SomeName' } });
-    fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    await waitFor(() => screen.getByText(/couldn.t save/i));
-
-    // Now type again — error should clear
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'SomeName2' } });
-    await waitFor(() => {
-      expect(screen.queryByText(/couldn.t save/i)).not.toBeInTheDocument();
-    });
-  });
-
-  it('email verified from email_prompt calls onComplete with emailVerified=true', async () => {
-    const onComplete = vi.fn();
-    const mockRequestCode = apiClient.requestVerificationCode as ReturnType<typeof vi.fn>;
-    const mockConfirmCode = apiClient.confirmVerificationCode as ReturnType<typeof vi.fn>;
-    mockGetProfile.mockResolvedValue(
-      baseProfile({ nickname: 'DJ_Foo', email_verified: false, submission_count: 2, submission_cap: 5 })
-    );
+    mockGetProfile.mockResolvedValue(emptyProfile);
+    mockSetProfile.mockResolvedValue({ ...emptyProfile, nickname: 'TestUser' });
     mockRequestCode.mockResolvedValue({ sent: true });
     mockConfirmCode.mockResolvedValue({ verified: true, guest_id: 1, merged: false });
+  });
 
-    render(<NicknameGate code="TEST01" onComplete={onComplete} />);
-    await waitFor(() => screen.getByText(/add your email/i));
-
-    // Enter email and send code
-    const emailInput = screen.getByRole('textbox');
-    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
-    fireEvent.click(screen.getByRole('button', { name: /send code/i }));
-
-    // Wait for OTP digit inputs to appear
+  it('renders track_select when no profile exists', async () => {
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
     await waitFor(() => {
-      expect(screen.getByText(/code sent to/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /new name/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /have email/i })).toBeInTheDocument();
     });
+  });
 
-    // Fill each digit individually — EmailVerification auto-submits when all 6 are filled
-    const digitInputs = screen.getAllByRole('textbox');
-    expect(digitInputs).toHaveLength(6);
-    for (let i = 0; i < 6; i++) {
-      fireEvent.change(digitInputs[i], { target: { value: String(i + 1) } });
-    }
+  it('transitions to nickname_input when "New name" clicked', async () => {
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    expect(screen.getByPlaceholderText(/dancingqueen/i)).toBeInTheDocument();
+  });
 
+  it('transitions to email_login when "Have email" clicked', async () => {
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /have email/i }));
+    fireEvent.click(screen.getByRole('button', { name: /have email/i }));
+    expect(screen.getByPlaceholderText(/you@example\.com/i)).toBeInTheDocument();
+  });
+
+  it('shows collision_unclaimed state on 409 claimed=false', async () => {
+    mockSetProfile.mockRejectedValue(new NicknameConflictError(false));
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
     await waitFor(() => {
-      expect(onComplete).toHaveBeenCalledWith({
-        nickname: 'DJ_Foo',
-        emailVerified: true,
-        submissionCount: 2,
-        submissionCap: 5,
+      expect(screen.getByText(/already taken/i)).toBeInTheDocument();
+      expect(screen.getByText(/original device/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /log in with email/i })).not.toBeInTheDocument();
+  });
+
+  it('shows collision_claimed state on 409 claimed=true', async () => {
+    mockSetProfile.mockRejectedValue(new NicknameConflictError(true));
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/already taken/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /log in with email/i })).toBeInTheDocument();
+    });
+  });
+
+  it('"Try a different nickname" from collision_unclaimed returns to nickname_input', async () => {
+    mockSetProfile.mockRejectedValue(new NicknameConflictError(false));
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => screen.getByText(/original device/i));
+    fireEvent.click(screen.getByRole('button', { name: /try a different/i }));
+    expect(screen.getByPlaceholderText(/dancingqueen/i)).toBeInTheDocument();
+  });
+
+  it('"Try a different nickname" from collision_claimed returns to nickname_input', async () => {
+    mockSetProfile.mockRejectedValue(new NicknameConflictError(true));
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => screen.getByRole('button', { name: /log in with email/i }));
+    fireEvent.click(screen.getByRole('button', { name: /try a different/i }));
+    expect(screen.getByPlaceholderText(/dancingqueen/i)).toBeInTheDocument();
+  });
+
+  it('transitions to complete when email verified and profile has nickname', async () => {
+    mockGetProfile
+      .mockResolvedValueOnce(emptyProfile)
+      .mockResolvedValueOnce({
+        nickname: 'Alex',
+        email_verified: true,
+        submission_count: 0,
+        submission_cap: 5,
       });
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /have email/i }));
+    fireEvent.click(screen.getByRole('button', { name: /have email/i }));
+    fireEvent.change(screen.getByPlaceholderText(/you@example\.com/i), {
+      target: { value: 'test@example.com' },
     });
+    fireEvent.click(screen.getByRole('button', { name: /send code/i }));
+    await waitFor(() => screen.getByPlaceholderText(/6.digit/i));
+    fireEvent.change(screen.getByPlaceholderText(/6.digit/i), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /^verify$/i }));
+    await waitFor(() =>
+      expect(onComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ nickname: 'Alex', emailVerified: true }),
+      ),
+    );
   });
 
-  // Race-condition tests for the IP-identity removal cleanup.
-  // See docs/RECOVERY-IP-IDENTITY.md and Phase 2f of the plan:
-  // NicknameGate must NOT call getCollectProfile until useGuestIdentity reports
-  // the cookie has been issued and the guest_id is known. Otherwise the backend
-  // sees no cookie and (pre-cleanup) falls back to IP, leaking another guest's
-  // nickname onto a fresh device.
-
-  it('does not call getCollectProfile while useGuestIdentity is loading', async () => {
-    mockUseGuestIdentity.mockReturnValue({
-      guestId: null,
-      isReturning: false,
-      isLoading: true,
-      error: null,
+  it('transitions to nickname_input when email verified but no nickname on guest', async () => {
+    mockGetProfile
+      .mockResolvedValueOnce(emptyProfile)
+      .mockResolvedValueOnce({
+        nickname: null,
+        email_verified: true,
+        submission_count: 0,
+        submission_cap: 5,
+      });
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /have email/i }));
+    fireEvent.click(screen.getByRole('button', { name: /have email/i }));
+    fireEvent.change(screen.getByPlaceholderText(/you@example\.com/i), {
+      target: { value: 'test@example.com' },
     });
-    mockGetProfile.mockResolvedValue(baseProfile({ nickname: 'someone-else' }));
-
-    render(<NicknameGate code="TEST01" onComplete={vi.fn()} />);
-
-    // Give React a tick or two to flush any pending effects.
-    await new Promise((r) => setTimeout(r, 50));
-
-    expect(mockGetProfile).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: /send code/i }));
+    await waitFor(() => screen.getByPlaceholderText(/6.digit/i));
+    fireEvent.change(screen.getByPlaceholderText(/6.digit/i), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /^verify$/i }));
+    await waitFor(() => expect(screen.getByPlaceholderText(/dancingqueen/i)).toBeInTheDocument());
   });
 
-  it('calls getCollectProfile only after useGuestIdentity finishes loading', async () => {
-    mockUseGuestIdentity.mockReturnValue({
-      guestId: null,
-      isReturning: false,
-      isLoading: true,
-      error: null,
-    });
-    mockGetProfile.mockResolvedValue(baseProfile({ nickname: null }));
-
-    const { rerender } = render(<NicknameGate code="TEST01" onComplete={vi.fn()} />);
-    expect(mockGetProfile).not.toHaveBeenCalled();
-
-    mockUseGuestIdentity.mockReturnValue({
-      guestId: 42,
-      isReturning: false,
-      isLoading: false,
-      error: null,
-    });
-    rerender(<NicknameGate code="TEST01" onComplete={vi.fn()} />);
-
-    await waitFor(() => {
-      expect(mockGetProfile).toHaveBeenCalledWith('TEST01');
-    });
-  });
-
-  it('shows the connecting spinner while waiting for guest identity', async () => {
-    mockUseGuestIdentity.mockReturnValue({
-      guestId: null,
-      isReturning: false,
-      isLoading: true,
-      error: null,
-    });
-    render(<NicknameGate code="TEST01" onComplete={vi.fn()} />);
-
-    expect(screen.getByText(/connecting/i)).toBeInTheDocument();
+  it('skips email_prompt when nickname saved while already email-verified', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockGetProfile
+        .mockResolvedValueOnce(emptyProfile)
+        .mockResolvedValueOnce({
+          nickname: null,
+          email_verified: true,
+          submission_count: 0,
+          submission_cap: 5,
+        });
+      mockSetProfile.mockResolvedValue({
+        nickname: 'NewUser',
+        email_verified: true,
+        submission_count: 0,
+        submission_cap: 5,
+      });
+      render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+      await waitFor(() => screen.getByRole('button', { name: /have email/i }));
+      fireEvent.click(screen.getByRole('button', { name: /have email/i }));
+      fireEvent.change(screen.getByPlaceholderText(/you@example\.com/i), {
+        target: { value: 'test@example.com' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /send code/i }));
+      await waitFor(() => screen.getByPlaceholderText(/6.digit/i));
+      fireEvent.change(screen.getByPlaceholderText(/6.digit/i), { target: { value: '123456' } });
+      fireEvent.click(screen.getByRole('button', { name: /^verify$/i }));
+      await waitFor(() => screen.getByPlaceholderText(/dancingqueen/i));
+      fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), {
+        target: { value: 'NewUser' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+      // Wait for setCollectProfile to resolve, then advance fake timers past the 1500ms savedFlash delay
+      await act(async () => {
+        await Promise.resolve(); // let the mock promise resolve
+        vi.runAllTimers();
+      });
+      await waitFor(() =>
+        expect(onComplete).toHaveBeenCalledWith(
+          expect.objectContaining({ nickname: 'NewUser', emailVerified: true }),
+        ),
+      );
+      expect(screen.queryByText(/add your email/i)).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/dashboard/components/__tests__/NicknameGate.test.tsx
+++ b/dashboard/components/__tests__/NicknameGate.test.tsx
@@ -244,3 +244,123 @@ describe('NicknameGate', () => {
     }
   });
 });
+
+describe('NicknameGate — existing behavior coverage', () => {
+  const onComplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetProfile.mockResolvedValue(emptyProfile);
+    mockSetProfile.mockResolvedValue({ ...emptyProfile, nickname: 'TestUser' });
+    mockRequestCode.mockResolvedValue({ sent: true });
+    mockConfirmCode.mockResolvedValue({ verified: true, guest_id: 1, merged: false });
+  });
+
+  it('calls onComplete immediately when profile has nickname + email verified', async () => {
+    mockGetProfile.mockResolvedValue({
+      nickname: 'Alex',
+      email_verified: true,
+      submission_count: 2,
+      submission_cap: 5,
+    });
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() =>
+      expect(onComplete).toHaveBeenCalledWith({
+        nickname: 'Alex',
+        emailVerified: true,
+        submissionCount: 2,
+        submissionCap: 5,
+      }),
+    );
+  });
+
+  it('shows email_prompt when profile has nickname but no email', async () => {
+    mockGetProfile.mockResolvedValue({
+      nickname: 'Alex',
+      email_verified: false,
+      submission_count: 0,
+      submission_cap: 5,
+    });
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => expect(screen.getByText(/add your email/i)).toBeInTheDocument());
+  });
+
+  it('calls onComplete on 404 with empty nickname', async () => {
+    const { ApiError } = await import('../../lib/api');
+    mockGetProfile.mockRejectedValue(new ApiError('not found', 404));
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() =>
+      expect(onComplete).toHaveBeenCalledWith({
+        nickname: '',
+        emailVerified: false,
+        submissionCount: 0,
+        submissionCap: 0,
+      }),
+    );
+  });
+
+  it('shows error state on network failure with Retry button', async () => {
+    mockGetProfile.mockRejectedValue(new Error('network error'));
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument());
+  });
+
+  it('Save button is disabled when nickname input is empty', async () => {
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    const saveBtn = screen.getByRole('button', { name: /^save$/i });
+    expect(saveBtn).toBeDisabled();
+  });
+
+  it('shows validation error for nickname that is too short', async () => {
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), { target: { value: 'x' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    expect(screen.getByText(/at least 2 characters/i)).toBeInTheDocument();
+    expect(mockSetProfile).not.toHaveBeenCalled();
+  });
+
+  it('shows inline error when setCollectProfile fails with generic error', async () => {
+    const { ApiError } = await import('../../lib/api');
+    mockSetProfile.mockRejectedValue(new ApiError('server error', 500));
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => expect(screen.getByText(/server error/i)).toBeInTheDocument());
+  });
+
+  it('skip from email_prompt calls onComplete with emailVerified=false', async () => {
+    mockGetProfile.mockResolvedValue({
+      nickname: 'Alex',
+      email_verified: false,
+      submission_count: 1,
+      submission_cap: 5,
+    });
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByText(/add your email/i));
+    fireEvent.click(screen.getByRole('button', { name: /skip email/i }));
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ nickname: 'Alex', emailVerified: false }),
+    );
+  });
+
+  it('verify from email_prompt calls onComplete with emailVerified=true', async () => {
+    mockGetProfile.mockResolvedValue({
+      nickname: 'Alex',
+      email_verified: false,
+      submission_count: 1,
+      submission_cap: 5,
+    });
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByText(/add your email/i));
+    fireEvent.click(screen.getByRole('button', { name: /verify email/i }));
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ nickname: 'Alex', emailVerified: true }),
+    );
+  });
+});

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { api, ApiError, NicknameConflictError } from '../api';
+import { api, ApiError } from '../api';
 
 // Mock fetch globally
 const mockFetch = vi.fn();

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { api, ApiError } from '../api';
+import { api, ApiError, NicknameConflictError } from '../api';
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -2217,6 +2217,36 @@ describe('ApiClient', () => {
       await expect(api.confirmVerificationCode('fan@test.com', '123456')).rejects.toThrow(
         'Verification failed'
       );
+    });
+  });
+
+  describe('setCollectProfile — nickname collision', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it('throws NicknameConflictError with claimed=true on 409', async () => {
+      vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ detail: { code: 'nickname_taken', claimed: true } }),
+          { status: 409, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+      await expect(api.setCollectProfile('EVT01', { nickname: 'Alex' })).rejects.toMatchObject({
+        name: 'NicknameConflictError',
+        claimed: true,
+      });
+    });
+
+    it('throws NicknameConflictError with claimed=false on 409', async () => {
+      vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ detail: { code: 'nickname_taken', claimed: false } }),
+          { status: 409, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+      await expect(api.setCollectProfile('EVT01', { nickname: 'Alex' })).rejects.toMatchObject({
+        name: 'NicknameConflictError',
+        claimed: false,
+      });
     });
   });
 });

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -188,6 +188,15 @@ export class ApiError extends Error {
   }
 }
 
+export class NicknameConflictError extends Error {
+  claimed: boolean;
+  constructor(claimed: boolean) {
+    super('nickname_taken');
+    this.name = 'NicknameConflictError';
+    this.claimed = claimed;
+  }
+}
+
 function getApiUrl(): string {
   // Use explicit env var if set
   if (process.env.NEXT_PUBLIC_API_URL) {
@@ -1048,6 +1057,10 @@ class ApiClient {
       credentials: 'include',
       body: JSON.stringify(data),
     });
+    if (res.status === 409) {
+      const body = await res.json().catch(() => ({})) as { detail?: { claimed?: boolean } };
+      throw new NicknameConflictError(body.detail?.claimed ?? false);
+    }
     if (!res.ok) throw new ApiError(`setCollectProfile failed: ${res.status}`, res.status);
     return res.json();
   }

--- a/docs/superpowers/plans/2026-04-30-nickname-gate-redesign.md
+++ b/docs/superpowers/plans/2026-04-30-nickname-gate-redesign.md
@@ -1,0 +1,1337 @@
+# Nickname Gate Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two-track entry (new name vs email login) to NicknameGate, enforce per-event nickname uniqueness with collision detection, and trigger an email OTP login flow when a taken nickname is email-claimed.
+
+**Architecture:** DB functional unique index enforces uniqueness at the DB level; `upsert_profile()` checks for collisions first and raises `NicknameConflictError(claimed)` which the API endpoint maps to 409. The frontend NicknameGate gains 5 new internal states with a fully revised state machine — no new files, no new API endpoints.
+
+**Tech Stack:** Python/FastAPI (backend), SQLAlchemy 2.0, Alembic, pytest; Next.js/React (frontend), TypeScript, Vitest, React Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-nickname-gate-redesign-design.md`
+
+---
+
+## File Map
+
+| File | Action | What changes |
+|---|---|---|
+| `server/alembic/versions/040_add_nickname_uniqueness.py` | **Create** | Migration — functional unique index on `guest_profiles(event_id, lower(nickname)) WHERE nickname IS NOT NULL` |
+| `server/app/models/guest_profile.py` | **Modify** | Add comment documenting the DB-level index |
+| `server/app/services/collect.py` | **Modify** | Add `NicknameConflictError`; update `upsert_profile()` with pre-insert collision check |
+| `server/app/api/collect.py` | **Modify** | `set_profile()` catches `NicknameConflictError` + `IntegrityError` → 409 |
+| `server/tests/test_collect_public.py` | **Modify** | 7 new tests for nickname collision behavior |
+| `dashboard/lib/api.ts` | **Modify** | Export `NicknameConflictError` class; update `setCollectProfile()` to throw it on 409 |
+| `dashboard/components/NicknameGate.tsx` | **Modify** | New state machine with 5 new states |
+| `dashboard/components/__tests__/NicknameGate.test.tsx` | **Create** | 10 frontend tests |
+
+---
+
+## Task 0: Create branch
+
+- [ ] **Create feature branch**
+
+```bash
+git checkout -b feat/nickname-gate-redesign
+```
+
+---
+
+## Task 1: DB migration + model annotation
+
+**Files:**
+- Create: `server/alembic/versions/040_add_nickname_uniqueness.py`
+- Modify: `server/app/models/guest_profile.py`
+
+- [ ] **Step 1: Get the current Alembic head revision ID**
+
+```bash
+cd server && .venv/bin/alembic heads
+```
+
+Note the hex revision ID (e.g. `a1b2c3d4e5f6`). You need it for the `down_revision` field in the next step.
+
+- [ ] **Step 2: Create the migration file**
+
+Replace `<PREVIOUS_HEAD>` with the revision ID from step 1.
+
+```python
+# server/alembic/versions/040_add_nickname_uniqueness.py
+"""add per-event nickname uniqueness index
+
+Revision ID: 040_nickname_unique
+Revises: <PREVIOUS_HEAD>
+Create Date: 2026-04-30
+"""
+from alembic import op
+
+revision = "040_nickname_unique"
+down_revision = "<PREVIOUS_HEAD>"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE UNIQUE INDEX uq_guest_profile_event_nickname "
+        "ON guest_profiles (event_id, lower(nickname)) "
+        "WHERE nickname IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_guest_profile_event_nickname")
+```
+
+- [ ] **Step 3: Annotate the model**
+
+Open `server/app/models/guest_profile.py`. Add a comment after the existing `UniqueConstraint` so future developers know the index exists:
+
+```python
+    __table_args__ = (
+        UniqueConstraint(
+            "event_id",
+            "guest_id",
+            name="uq_guest_profile_event_guest",
+        ),
+        # DB-level: unique per (event_id, lower(nickname)) WHERE nickname IS NOT NULL
+        # Created by migration 040_add_nickname_uniqueness. Case-insensitive.
+    )
+```
+
+- [ ] **Step 4: Run migration and verify**
+
+```bash
+cd server && .venv/bin/alembic upgrade head
+```
+
+Expected output ends with: `Running upgrade <prev> -> 040_nickname_unique, add per-event nickname uniqueness index`
+
+- [ ] **Step 5: Confirm alembic check passes**
+
+```bash
+.venv/bin/alembic check
+```
+
+Expected: `No new upgrade operations detected.`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/alembic/versions/040_add_nickname_uniqueness.py server/app/models/guest_profile.py
+git commit -m "feat: add per-event nickname uniqueness DB index"
+```
+
+---
+
+## Task 2: Backend — collision check and 409 response (TDD)
+
+**Files:**
+- Modify: `server/app/services/collect.py`
+- Modify: `server/app/api/collect.py`
+- Test: `server/tests/test_collect_public.py`
+
+### Step 1: Write 7 failing tests
+
+- [ ] **Append to `server/tests/test_collect_public.py`:**
+
+```python
+# ── Nickname uniqueness tests ──────────────────────────────────────────────
+
+class TestNicknameUniqueness:
+    """Tests for per-event nickname collision detection."""
+
+    def _make_guest(self, db, token_suffix: str, verified: bool = False):
+        import datetime
+        from app.core.time import utcnow
+        g = Guest(
+            token="guest" + token_suffix.ljust(59, "0"),
+            fingerprint_hash=f"fp_{token_suffix}",
+            created_at=utcnow(),
+            last_seen_at=utcnow(),
+        )
+        if verified:
+            g.email_verified_at = utcnow()
+        db.add(g)
+        db.commit()
+        db.refresh(g)
+        return g
+
+    def test_available_nickname_succeeds(self, client, db, test_event):
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "UniqueNick"},
+        )
+        assert r.status_code == 200
+        assert r.json()["nickname"] == "UniqueNick"
+
+    def test_collision_unclaimed_returns_409_claimed_false(self, client, db, test_event):
+        # default guest (autouse) claims "Alex"
+        client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+        )
+        # second guest tries "Alex"
+        guest2 = self._make_guest(db, "two")
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+            cookies={"wrzdj_guest": guest2.token},
+        )
+        assert r.status_code == 409
+        body = r.json()["detail"]
+        assert body["code"] == "nickname_taken"
+        assert body["claimed"] is False
+
+    def test_collision_claimed_returns_409_claimed_true(self, client, db, test_event):
+        # default guest claims "Alex" and is email-verified
+        verified_guest = self._make_guest(db, "verified", verified=True)
+        client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+            cookies={"wrzdj_guest": verified_guest.token},
+        )
+        # second guest tries same name
+        guest2 = self._make_guest(db, "two")
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+            cookies={"wrzdj_guest": guest2.token},
+        )
+        assert r.status_code == 409
+        body = r.json()["detail"]
+        assert body["code"] == "nickname_taken"
+        assert body["claimed"] is True
+
+    def test_self_collision_is_idempotent(self, client, db, test_event):
+        client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+        )
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+        )
+        assert r.status_code == 200
+
+    def test_collision_is_case_insensitive(self, client, db, test_event):
+        client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+        )
+        for variant in ["alex", "ALEX", "aLeX"]:
+            g = self._make_guest(db, variant)
+            r = client.post(
+                f"/api/public/collect/{test_event.code}/profile",
+                json={"nickname": variant},
+                cookies={"wrzdj_guest": g.token},
+            )
+            assert r.status_code == 409, f"Expected 409 for variant '{variant}'"
+
+    def test_race_condition_integrity_error_maps_to_409(self, client, db, test_event, monkeypatch):
+        from sqlalchemy.exc import IntegrityError
+        import app.api.collect as collect_api
+
+        def raise_integrity(db, *, event_id, guest_id=None, nickname=None):
+            raise IntegrityError("unique constraint", None, Exception())
+
+        monkeypatch.setattr(collect_api, "upsert_profile", raise_integrity)
+
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+        )
+        assert r.status_code == 409
+        body = r.json()["detail"]
+        assert body["code"] == "nickname_taken"
+        assert body["claimed"] is False
+
+    def test_null_nickname_skips_uniqueness_check(self, client, db, test_event):
+        # Posting with no nickname field should not trigger collision logic
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={},
+        )
+        assert r.status_code == 200
+```
+
+- [ ] **Step 2: Run tests to confirm they all fail**
+
+```bash
+cd server && .venv/bin/pytest tests/test_collect_public.py::TestNicknameUniqueness -v
+```
+
+Expected: 7 failures. Typical error: `AssertionError: assert 200 == 409` (collision check doesn't exist yet).
+
+### Step 3: Implement collision check in service
+
+- [ ] **Update `server/app/services/collect.py`**
+
+Add the exception class right after the imports section (after line 12, before `_to_naive_utc`):
+
+```python
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+
+from app.models.guest import Guest
+
+
+class NicknameConflictError(Exception):
+    """Raised when a nickname is already in use by another guest in the event."""
+
+    def __init__(self, claimed: bool) -> None:
+        self.claimed = claimed
+        super().__init__("nickname_taken")
+```
+
+Then replace the entire `upsert_profile` function (lines 170-195) with:
+
+```python
+def upsert_profile(
+    db: Session,
+    *,
+    event_id: int,
+    guest_id: int | None = None,
+    nickname: str | None = None,
+) -> GuestProfile | None:
+    """Create or update a profile keyed on (event_id, guest_id). Returns None
+    when no guest_id is provided — anonymous callers cannot persist profile state.
+
+    Raises NicknameConflictError when the requested nickname is already held by
+    a different guest in the same event. claimed=True when the owner is email-verified.
+    """
+    if guest_id is None:
+        return None
+
+    if nickname is not None:
+        existing = (
+            db.query(GuestProfile)
+            .filter(
+                GuestProfile.event_id == event_id,
+                GuestProfile.guest_id != guest_id,
+                func.lower(GuestProfile.nickname) == nickname.lower(),
+            )
+            .first()
+        )
+        if existing:
+            owner = db.get(Guest, existing.guest_id)
+            claimed = owner is not None and owner.email_verified_at is not None
+            raise NicknameConflictError(claimed=claimed)
+
+    profile = get_profile(db, event_id=event_id, guest_id=guest_id)
+    if profile is None:
+        profile = GuestProfile(
+            event_id=event_id,
+            guest_id=guest_id,
+            nickname=nickname,
+        )
+        db.add(profile)
+    else:
+        if nickname is not None:
+            profile.nickname = nickname
+    db.commit()
+    db.refresh(profile)
+    return profile
+```
+
+### Step 4: Catch exception in endpoint
+
+- [ ] **Update `server/app/api/collect.py` `set_profile` function**
+
+Add the imports at the top of the file (with existing imports):
+
+```python
+from sqlalchemy.exc import IntegrityError
+
+from app.services.collect import NicknameConflictError
+```
+
+Replace the `upsert_profile` call block inside `set_profile` (the section starting at line 177 through line 190 of the current file):
+
+```python
+    try:
+        profile = collect_service.upsert_profile(
+            db,
+            event_id=event.id,
+            guest_id=guest_id,
+            nickname=payload.nickname,
+        )
+    except NicknameConflictError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "nickname_taken", "claimed": exc.claimed},
+        )
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "nickname_taken", "claimed": False},
+        )
+    if payload.nickname is not None:
+        log_activity(
+            db,
+            level="info",
+            source="collect",
+            message=f"Guest #{guest_id} updated profile: nickname",
+            event_code=code,
+        )
+```
+
+- [ ] **Step 5: Run tests — all 7 should pass**
+
+```bash
+cd server && .venv/bin/pytest tests/test_collect_public.py::TestNicknameUniqueness -v
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 6: Run the full backend test suite to confirm no regressions**
+
+```bash
+.venv/bin/pytest --tb=short -q
+```
+
+Expected: All existing tests pass.
+
+- [ ] **Step 7: Run linting**
+
+```bash
+.venv/bin/ruff check . && .venv/bin/ruff format --check .
+```
+
+Fix any issues with `.venv/bin/ruff check --fix . && .venv/bin/ruff format .`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/app/services/collect.py server/app/api/collect.py server/tests/test_collect_public.py
+git commit -m "feat: enforce per-event nickname uniqueness with 409 collision response"
+```
+
+---
+
+## Task 3: Frontend API client — NicknameConflictError (TDD)
+
+**Files:**
+- Modify: `dashboard/lib/api.ts`
+- Test: `dashboard/lib/__tests__/api.test.ts`
+
+- [ ] **Step 1: Write a failing test**
+
+Open `dashboard/lib/__tests__/api.test.ts` and append:
+
+```typescript
+describe('setCollectProfile — nickname collision', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('throws NicknameConflictError with claimed=true on 409 claimed true', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ detail: { code: 'nickname_taken', claimed: true } }),
+        { status: 409, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    await expect(apiClient.setCollectProfile('EVT01', { nickname: 'Alex' })).rejects.toMatchObject({
+      name: 'NicknameConflictError',
+      claimed: true,
+    });
+  });
+
+  it('throws NicknameConflictError with claimed=false on 409 claimed false', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ detail: { code: 'nickname_taken', claimed: false } }),
+        { status: 409, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    await expect(apiClient.setCollectProfile('EVT01', { nickname: 'Alex' })).rejects.toMatchObject({
+      name: 'NicknameConflictError',
+      claimed: false,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cd dashboard && npm test -- --run lib/__tests__/api.test.ts
+```
+
+Expected: 2 new failures — `NicknameConflictError is not defined`.
+
+- [ ] **Step 3: Add `NicknameConflictError` to `dashboard/lib/api.ts`**
+
+Insert after `ApiError` (after line 189):
+
+```typescript
+export class NicknameConflictError extends Error {
+  claimed: boolean;
+  constructor(claimed: boolean) {
+    super('nickname_taken');
+    this.name = 'NicknameConflictError';
+    this.claimed = claimed;
+  }
+}
+```
+
+- [ ] **Step 4: Update `setCollectProfile` to throw on 409**
+
+Replace the current `setCollectProfile` method (lines 1041–1053):
+
+```typescript
+  async setCollectProfile(
+    code: string,
+    data: { nickname?: string },
+  ): Promise<CollectProfileResponse> {
+    const res = await fetch(`${getApiUrl()}/api/public/collect/${code}/profile`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(data),
+    });
+    if (res.status === 409) {
+      const body = await res.json().catch(() => ({})) as { detail?: { claimed?: boolean } };
+      throw new NicknameConflictError(body.detail?.claimed ?? false);
+    }
+    if (!res.ok) throw new ApiError(`setCollectProfile failed: ${res.status}`, res.status);
+    return res.json();
+  }
+```
+
+- [ ] **Step 5: Run tests — 2 new tests should pass**
+
+```bash
+cd dashboard && npm test -- --run lib/__tests__/api.test.ts
+```
+
+Expected: All pass including the 2 new ones.
+
+- [ ] **Step 6: Run TypeScript check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: No errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/lib/api.ts dashboard/lib/__tests__/api.test.ts
+git commit -m "feat: export NicknameConflictError from api client, handle 409 in setCollectProfile"
+```
+
+---
+
+## Task 4: NicknameGate redesign (TDD)
+
+**Files:**
+- Create: `dashboard/components/__tests__/NicknameGate.test.tsx`
+- Modify: `dashboard/components/NicknameGate.tsx`
+
+### Step 1: Write 10 failing tests
+
+- [ ] **Create `dashboard/components/__tests__/NicknameGate.test.tsx`:**
+
+```typescript
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NicknameGate } from '../NicknameGate';
+
+// Mock api module — must be hoisted above imports that use it
+vi.mock('../../lib/api', () => {
+  class ApiError extends Error {
+    status: number;
+    constructor(msg: string, status: number) {
+      super(msg);
+      this.name = 'ApiError';
+      this.status = status;
+    }
+  }
+  class NicknameConflictError extends Error {
+    claimed: boolean;
+    constructor(claimed: boolean) {
+      super('nickname_taken');
+      this.name = 'NicknameConflictError';
+      this.claimed = claimed;
+    }
+  }
+  return {
+    apiClient: {
+      getCollectProfile: vi.fn(),
+      setCollectProfile: vi.fn(),
+      requestVerificationCode: vi.fn(),
+      confirmVerificationCode: vi.fn(),
+    },
+    ApiError,
+    NicknameConflictError,
+  };
+});
+
+vi.mock('../../lib/use-guest-identity', () => ({
+  useGuestIdentity: () => ({
+    isLoading: false,
+    guestId: 1,
+    isReturning: false,
+    reconcileHint: false,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../EmailVerification', () => ({
+  default: ({ onVerified, onSkip }: { onVerified: () => void; onSkip: () => void }) => (
+    <div>
+      <button onClick={onVerified}>Verify Email</button>
+      <button onClick={onSkip}>Skip Email</button>
+    </div>
+  ),
+}));
+
+import { apiClient, NicknameConflictError } from '../../lib/api';
+
+const mockGetProfile = vi.mocked(apiClient.getCollectProfile);
+const mockSetProfile = vi.mocked(apiClient.setCollectProfile);
+const mockRequestCode = vi.mocked(apiClient.requestVerificationCode);
+const mockConfirmCode = vi.mocked(apiClient.confirmVerificationCode);
+
+const emptyProfile = {
+  nickname: null,
+  email_verified: false,
+  submission_count: 0,
+  submission_cap: 5,
+};
+
+describe('NicknameGate', () => {
+  const onComplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetProfile.mockResolvedValue(emptyProfile);
+    mockSetProfile.mockResolvedValue({ ...emptyProfile, nickname: 'TestUser' });
+    mockRequestCode.mockResolvedValue({ sent: true });
+    mockConfirmCode.mockResolvedValue({ verified: true, guest_id: 1, merged: false });
+  });
+
+  it('renders track_select when no profile exists', async () => {
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /new name/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /have email/i })).toBeInTheDocument();
+    });
+  });
+
+  it('transitions to nickname_input when "New name" clicked', async () => {
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    expect(screen.getByPlaceholderText(/dancingqueen/i)).toBeInTheDocument();
+  });
+
+  it('transitions to email_login when "Have email" clicked', async () => {
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /have email/i }));
+    fireEvent.click(screen.getByRole('button', { name: /have email/i }));
+    expect(screen.getByPlaceholderText(/you@example\.com/i)).toBeInTheDocument();
+  });
+
+  it('shows collision_unclaimed state on 409 claimed=false', async () => {
+    mockSetProfile.mockRejectedValue(new NicknameConflictError(false));
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/already taken/i)).toBeInTheDocument();
+      expect(screen.getByText(/original device/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /log in/i })).not.toBeInTheDocument();
+  });
+
+  it('shows collision_claimed state on 409 claimed=true', async () => {
+    mockSetProfile.mockRejectedValue(new NicknameConflictError(true));
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/already taken/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /log in with email/i })).toBeInTheDocument();
+    });
+  });
+
+  it('"Try a different nickname" from collision_unclaimed returns to nickname_input', async () => {
+    mockSetProfile.mockRejectedValue(new NicknameConflictError(false));
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => screen.getByText(/original device/i));
+    fireEvent.click(screen.getByRole('button', { name: /try a different/i }));
+    expect(screen.getByPlaceholderText(/dancingqueen/i)).toBeInTheDocument();
+  });
+
+  it('"Try a different nickname" from collision_claimed returns to nickname_input', async () => {
+    mockSetProfile.mockRejectedValue(new NicknameConflictError(true));
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => screen.getByRole('button', { name: /log in with email/i }));
+    fireEvent.click(screen.getByRole('button', { name: /try a different/i }));
+    expect(screen.getByPlaceholderText(/dancingqueen/i)).toBeInTheDocument();
+  });
+
+  it('transitions to complete when email verified and profile has nickname', async () => {
+    mockGetProfile
+      .mockResolvedValueOnce(emptyProfile)
+      .mockResolvedValueOnce({
+        nickname: 'Alex',
+        email_verified: true,
+        submission_count: 0,
+        submission_cap: 5,
+      });
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /have email/i }));
+    fireEvent.click(screen.getByRole('button', { name: /have email/i }));
+    fireEvent.change(screen.getByPlaceholderText(/you@example\.com/i), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send code/i }));
+    await waitFor(() => screen.getByPlaceholderText(/6.digit/i));
+    fireEvent.change(screen.getByPlaceholderText(/6.digit/i), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /^verify$/i }));
+    await waitFor(() =>
+      expect(onComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ nickname: 'Alex', emailVerified: true }),
+      ),
+    );
+  });
+
+  it('transitions to nickname_input when email verified but no nickname on guest', async () => {
+    mockGetProfile
+      .mockResolvedValueOnce(emptyProfile)
+      .mockResolvedValueOnce({
+        nickname: null,
+        email_verified: true,
+        submission_count: 0,
+        submission_cap: 5,
+      });
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    await waitFor(() => screen.getByRole('button', { name: /have email/i }));
+    fireEvent.click(screen.getByRole('button', { name: /have email/i }));
+    fireEvent.change(screen.getByPlaceholderText(/you@example\.com/i), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send code/i }));
+    await waitFor(() => screen.getByPlaceholderText(/6.digit/i));
+    fireEvent.change(screen.getByPlaceholderText(/6.digit/i), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /^verify$/i }));
+    await waitFor(() => expect(screen.getByPlaceholderText(/dancingqueen/i)).toBeInTheDocument());
+  });
+
+  it('skips email_prompt when nickname saved while already email-verified', async () => {
+    mockGetProfile
+      .mockResolvedValueOnce(emptyProfile)
+      .mockResolvedValueOnce({
+        nickname: null,
+        email_verified: true,
+        submission_count: 0,
+        submission_cap: 5,
+      });
+    mockSetProfile.mockResolvedValue({
+      nickname: 'NewUser',
+      email_verified: true,
+      submission_count: 0,
+      submission_cap: 5,
+    });
+    render(<NicknameGate code="EVT01" onComplete={onComplete} />);
+    // go through email login flow first
+    await waitFor(() => screen.getByRole('button', { name: /have email/i }));
+    fireEvent.click(screen.getByRole('button', { name: /have email/i }));
+    fireEvent.change(screen.getByPlaceholderText(/you@example\.com/i), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send code/i }));
+    await waitFor(() => screen.getByPlaceholderText(/6.digit/i));
+    fireEvent.change(screen.getByPlaceholderText(/6.digit/i), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /^verify$/i }));
+    // now in nickname_input (verified, no nickname yet)
+    await waitFor(() => screen.getByPlaceholderText(/dancingqueen/i));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), {
+      target: { value: 'NewUser' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    // should call onComplete directly, not show email_prompt
+    await waitFor(() =>
+      expect(onComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ nickname: 'NewUser', emailVerified: true }),
+      ),
+    );
+    expect(screen.queryByText(/add your email/i)).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm all 10 tests fail**
+
+```bash
+cd dashboard && npm test -- --run components/__tests__/NicknameGate.test.tsx
+```
+
+Expected: 10 failures — components don't have the new states yet.
+
+### Step 3: Rewrite NicknameGate
+
+- [ ] **Replace the entire contents of `dashboard/components/NicknameGate.tsx`:**
+
+```typescript
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { z } from 'zod';
+import { apiClient, ApiError, CollectProfileResponse, NicknameConflictError } from '../lib/api';
+import { useGuestIdentity } from '../lib/use-guest-identity';
+import { ModalOverlay } from './ModalOverlay';
+import EmailVerification from './EmailVerification';
+
+const nicknameSchema = z
+  .string()
+  .trim()
+  .min(2, 'Nickname must be at least 2 characters')
+  .max(30)
+  .regex(/^[a-zA-Z0-9 _.-]+$/, 'Letters, numbers, spaces, . _ - only');
+
+export interface GateResult {
+  nickname: string;
+  emailVerified: boolean;
+  submissionCount: number;
+  submissionCap: number;
+}
+
+interface Props {
+  code: string;
+  onComplete: (result: GateResult) => void;
+}
+
+type GateState =
+  | 'loading'
+  | 'error'
+  | 'track_select'
+  | 'nickname_input'
+  | 'collision_unclaimed'
+  | 'collision_claimed'
+  | 'email_login'
+  | 'email_code'
+  | 'email_prompt';
+
+export function NicknameGate({ code, onComplete }: Props) {
+  const identity = useGuestIdentity();
+  const [gateState, setGateState] = useState<GateState>('loading');
+  const [savedNickname, setSavedNickname] = useState('');
+  const [nicknameInput, setNicknameInput] = useState('');
+  const [emailInput, setEmailInput] = useState('');
+  const [codeInput, setCodeInput] = useState('');
+  const [collisionNickname, setCollisionNickname] = useState('');
+  const [emailVerified, setEmailVerified] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [sendingCode, setSendingCode] = useState(false);
+  const [verifyingCode, setVerifyingCode] = useState(false);
+  const [inputError, setInputError] = useState<string | null>(null);
+  const [savedFlash, setSavedFlash] = useState(false);
+  const [profileCache, setProfileCache] = useState<CollectProfileResponse | null>(null);
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    };
+  }, []);
+
+  const loadProfile = useCallback(async () => {
+    setGateState('loading');
+    try {
+      const p = await apiClient.getCollectProfile(code);
+      setProfileCache(p);
+      if (p.nickname && p.email_verified) {
+        onComplete({
+          nickname: p.nickname,
+          emailVerified: true,
+          submissionCount: p.submission_count,
+          submissionCap: p.submission_cap,
+        });
+      } else if (p.nickname) {
+        setSavedNickname(p.nickname);
+        setGateState('email_prompt');
+      } else {
+        setGateState('track_select');
+      }
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        onComplete({ nickname: '', emailVerified: false, submissionCount: 0, submissionCap: 0 });
+      } else {
+        setGateState('error');
+      }
+    }
+  }, [code, onComplete]);
+
+  useEffect(() => {
+    if (identity.isLoading) return;
+    loadProfile();
+  }, [loadProfile, identity.isLoading]);
+
+  const handleSaveNickname = async () => {
+    const parsed = nicknameSchema.safeParse(nicknameInput);
+    if (!parsed.success) {
+      setInputError(parsed.error.issues[0].message);
+      return;
+    }
+    setSaving(true);
+    setInputError(null);
+    try {
+      const p = await apiClient.setCollectProfile(code, { nickname: parsed.data });
+      setProfileCache(p);
+      setSavedNickname(parsed.data);
+      setSavedFlash(true);
+      flashTimerRef.current = setTimeout(() => {
+        setSavedFlash(false);
+        if (emailVerified) {
+          onComplete({
+            nickname: parsed.data,
+            emailVerified: true,
+            submissionCount: p.submission_count,
+            submissionCap: p.submission_cap,
+          });
+        } else {
+          setGateState('email_prompt');
+        }
+      }, 1500);
+    } catch (err) {
+      if (err instanceof NicknameConflictError) {
+        setCollisionNickname(parsed.data);
+        setGateState(err.claimed ? 'collision_claimed' : 'collision_unclaimed');
+      } else {
+        setInputError(err instanceof ApiError ? err.message : "Couldn't save — please try again");
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSendCode = async () => {
+    setSendingCode(true);
+    setInputError(null);
+    try {
+      await apiClient.requestVerificationCode(emailInput);
+      setGateState('email_code');
+    } catch (err) {
+      setInputError(err instanceof ApiError ? err.message : 'Failed to send code. Try again.');
+    } finally {
+      setSendingCode(false);
+    }
+  };
+
+  const handleConfirmCode = async () => {
+    setVerifyingCode(true);
+    setInputError(null);
+    try {
+      await apiClient.confirmVerificationCode(emailInput, codeInput);
+      const p = await apiClient.getCollectProfile(code);
+      setProfileCache(p);
+      setEmailVerified(true);
+      if (p.nickname) {
+        onComplete({
+          nickname: p.nickname,
+          emailVerified: true,
+          submissionCount: p.submission_count,
+          submissionCap: p.submission_cap,
+        });
+      } else {
+        setGateState('nickname_input');
+      }
+    } catch (err) {
+      setInputError(err instanceof ApiError ? err.message : 'Invalid or expired code.');
+    } finally {
+      setVerifyingCode(false);
+    }
+  };
+
+  const handleSkip = () => {
+    onComplete({
+      nickname: savedNickname,
+      emailVerified: false,
+      submissionCount: profileCache?.submission_count ?? 0,
+      submissionCap: profileCache?.submission_cap ?? 0,
+    });
+  };
+
+  const handleVerified = () => {
+    onComplete({
+      nickname: savedNickname,
+      emailVerified: true,
+      submissionCount: profileCache?.submission_count ?? 0,
+      submissionCap: profileCache?.submission_cap ?? 0,
+    });
+  };
+
+  // ── loading ───────────────────────────────────────────────────────────────
+
+  if (gateState === 'loading') {
+    return (
+      <ModalOverlay card>
+        <div style={{ textAlign: 'center', padding: '1rem' }}>
+          <p style={{ color: 'var(--text-secondary)' }}>Connecting…</p>
+        </div>
+      </ModalOverlay>
+    );
+  }
+
+  if (gateState === 'error') {
+    return (
+      <ModalOverlay card>
+        <p style={{ marginBottom: '1rem' }}>
+          Couldn&apos;t connect to the event. Check your connection and try again.
+        </p>
+        <button className="btn btn-primary" style={{ width: '100%' }} onClick={loadProfile}>
+          Retry
+        </button>
+      </ModalOverlay>
+    );
+  }
+
+  // ── track_select ──────────────────────────────────────────────────────────
+
+  if (gateState === 'track_select') {
+    return (
+      <ModalOverlay card>
+        <h2 style={{ marginBottom: '0.5rem' }}>Join the event</h2>
+        <p style={{ color: 'var(--text-secondary)', marginBottom: '1.25rem', fontSize: '0.9rem' }}>
+          How would you like to identify yourself?
+        </p>
+        <button
+          className="btn btn-primary"
+          style={{ width: '100%', marginBottom: '0.75rem' }}
+          onClick={() => setGateState('nickname_input')}
+        >
+          ✏️ Pick a nickname
+        </button>
+        <button
+          className="btn btn-secondary"
+          style={{ width: '100%' }}
+          onClick={() => setGateState('email_login')}
+        >
+          📧 I have an email
+        </button>
+      </ModalOverlay>
+    );
+  }
+
+  // ── nickname_input ────────────────────────────────────────────────────────
+
+  if (gateState === 'nickname_input') {
+    return (
+      <ModalOverlay card>
+        <h2 style={{ marginBottom: '0.75rem' }}>What&apos;s your nickname?</h2>
+        <div className="form-group">
+          <input
+            type="text"
+            className="input"
+            placeholder="DancingQueen"
+            value={nicknameInput}
+            onChange={(e) => {
+              setNicknameInput(e.target.value);
+              setInputError(null);
+            }}
+            maxLength={30}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && nicknameInput.trim()) handleSaveNickname();
+            }}
+            autoFocus
+          />
+        </div>
+        {inputError && <p className="collection-fieldset-error">{inputError}</p>}
+        {savedFlash && (
+          <p style={{ color: '#22c55e', marginBottom: '0.5rem' }}>&#10003; Nickname saved!</p>
+        )}
+        <button
+          className="btn btn-primary"
+          style={{ width: '100%' }}
+          disabled={!nicknameInput.trim() || saving}
+          onClick={handleSaveNickname}
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </ModalOverlay>
+    );
+  }
+
+  // ── collision_unclaimed ───────────────────────────────────────────────────
+
+  if (gateState === 'collision_unclaimed') {
+    return (
+      <ModalOverlay card>
+        <h2 style={{ marginBottom: '0.75rem' }}>Nickname taken</h2>
+        <p style={{ color: 'var(--text-secondary)', marginBottom: '0.5rem' }}>
+          <strong>&ldquo;{collisionNickname}&rdquo;</strong> is already taken.
+        </p>
+        <p
+          style={{
+            background: 'var(--card-bg)',
+            border: '1px solid var(--border)',
+            borderRadius: '8px',
+            padding: '0.75rem',
+            fontSize: '0.875rem',
+            color: 'var(--text-secondary)',
+            marginBottom: '1rem',
+          }}
+        >
+          Not claimed yet. If this is yours, go back to the original device you used and claim it
+          there with your email.
+        </p>
+        <button
+          className="btn btn-secondary"
+          style={{ width: '100%' }}
+          onClick={() => {
+            setNicknameInput('');
+            setGateState('nickname_input');
+          }}
+        >
+          Try a different nickname
+        </button>
+      </ModalOverlay>
+    );
+  }
+
+  // ── collision_claimed ─────────────────────────────────────────────────────
+
+  if (gateState === 'collision_claimed') {
+    return (
+      <ModalOverlay card>
+        <h2 style={{ marginBottom: '0.75rem' }}>Nickname taken</h2>
+        <p style={{ color: 'var(--text-secondary)', marginBottom: '0.5rem' }}>
+          <strong>&ldquo;{collisionNickname}&rdquo;</strong> is already taken.
+        </p>
+        <p
+          style={{
+            background: 'var(--card-bg)',
+            border: '1px solid var(--border)',
+            borderRadius: '8px',
+            padding: '0.75rem',
+            fontSize: '0.875rem',
+            color: 'var(--text-secondary)',
+            marginBottom: '1rem',
+          }}
+        >
+          This nickname has an email attached — if it&apos;s yours, log in to reclaim it.
+        </p>
+        <button
+          className="btn btn-primary"
+          style={{ width: '100%', marginBottom: '0.75rem' }}
+          onClick={() => setGateState('email_login')}
+        >
+          Log in with email
+        </button>
+        <button
+          className="btn btn-secondary"
+          style={{ width: '100%' }}
+          onClick={() => {
+            setNicknameInput('');
+            setGateState('nickname_input');
+          }}
+        >
+          Try a different nickname
+        </button>
+      </ModalOverlay>
+    );
+  }
+
+  // ── email_login ───────────────────────────────────────────────────────────
+
+  if (gateState === 'email_login') {
+    return (
+      <ModalOverlay card>
+        <h2 style={{ marginBottom: '0.5rem' }}>Log in with email</h2>
+        <p style={{ color: 'var(--text-secondary)', marginBottom: '1rem', fontSize: '0.9rem' }}>
+          Enter your email to receive a login code.
+        </p>
+        <div className="form-group">
+          <input
+            type="email"
+            className="input"
+            placeholder="you@example.com"
+            value={emailInput}
+            onChange={(e) => {
+              setEmailInput(e.target.value);
+              setInputError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && emailInput.trim()) handleSendCode();
+            }}
+            autoFocus
+          />
+        </div>
+        {inputError && <p className="collection-fieldset-error">{inputError}</p>}
+        <button
+          className="btn btn-primary"
+          style={{ width: '100%', marginBottom: '0.75rem' }}
+          disabled={!emailInput.trim() || sendingCode}
+          onClick={handleSendCode}
+        >
+          {sendingCode ? 'Sending…' : 'Send code'}
+        </button>
+        <button
+          className="btn btn-secondary"
+          style={{ width: '100%' }}
+          onClick={() => setGateState('track_select')}
+        >
+          ← Back
+        </button>
+      </ModalOverlay>
+    );
+  }
+
+  // ── email_code ────────────────────────────────────────────────────────────
+
+  if (gateState === 'email_code') {
+    return (
+      <ModalOverlay card>
+        <h2 style={{ marginBottom: '0.5rem' }}>Check your email</h2>
+        <p style={{ color: 'var(--text-secondary)', marginBottom: '1rem', fontSize: '0.9rem' }}>
+          Enter the 6-digit code sent to {emailInput}.
+        </p>
+        <div className="form-group">
+          <input
+            type="text"
+            className="input"
+            placeholder="6-digit code"
+            value={codeInput}
+            onChange={(e) => {
+              setCodeInput(e.target.value.replace(/\D/g, '').slice(0, 6));
+              setInputError(null);
+            }}
+            maxLength={6}
+            autoFocus
+          />
+        </div>
+        {inputError && <p className="collection-fieldset-error">{inputError}</p>}
+        <button
+          className="btn btn-primary"
+          style={{ width: '100%', marginBottom: '0.75rem' }}
+          disabled={codeInput.length !== 6 || verifyingCode}
+          onClick={handleConfirmCode}
+        >
+          {verifyingCode ? 'Verifying…' : 'Verify'}
+        </button>
+        <button
+          className="btn btn-secondary"
+          style={{ width: '100%' }}
+          onClick={() => {
+            setCodeInput('');
+            setGateState('email_login');
+          }}
+        >
+          Resend code
+        </button>
+      </ModalOverlay>
+    );
+  }
+
+  // ── email_prompt ──────────────────────────────────────────────────────────
+
+  return (
+    <ModalOverlay card>
+      <h2 style={{ marginBottom: '0.5rem' }}>Hi, {savedNickname}! 👋</h2>
+      <p style={{ color: 'var(--text-secondary)', marginBottom: '1rem', fontSize: '0.9rem' }}>
+        Add your email to unlock cross-device access and leaderboards.
+      </p>
+      <EmailVerification isVerified={false} onVerified={handleVerified} onSkip={handleSkip} />
+    </ModalOverlay>
+  );
+}
+```
+
+- [ ] **Step 4: Run the 10 tests — all should pass**
+
+```bash
+cd dashboard && npm test -- --run components/__tests__/NicknameGate.test.tsx
+```
+
+Expected: 10 passed.
+
+- [ ] **Step 5: Run the full frontend test suite to confirm no regressions**
+
+```bash
+npm test -- --run
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 6: TypeScript check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: No errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/components/NicknameGate.tsx dashboard/components/__tests__/NicknameGate.test.tsx
+git commit -m "feat: redesign NicknameGate with two-track entry and collision UX"
+```
+
+---
+
+## Task 5: Final CI verification and push
+
+- [ ] **Step 1: Run full backend CI**
+
+```bash
+cd server
+.venv/bin/ruff check .
+.venv/bin/ruff format --check .
+.venv/bin/bandit -r app -c pyproject.toml -q
+.venv/bin/pytest --tb=short -q
+.venv/bin/alembic upgrade head && .venv/bin/alembic check
+```
+
+Expected: All pass. If `ruff format --check` fails, run `.venv/bin/ruff format .` then re-commit.
+
+- [ ] **Step 2: Run full frontend CI**
+
+```bash
+cd dashboard
+npm run lint
+npx tsc --noEmit
+npm test -- --run
+```
+
+Expected: All pass.
+
+- [ ] **Step 3: Push branch and open PR**
+
+```bash
+git push -u origin feat/nickname-gate-redesign
+gh pr create \
+  --title "feat: nickname gate two-track entry and collision UX" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds two-track entry to NicknameGate: pick a name vs log in with email
+- Enforces per-event nickname uniqueness (case-insensitive) at DB and service layer
+- 409 collision response distinguishes unclaimed (device hint) from email-claimed (OTP login flow)
+- New Alembic migration 040 adds functional unique index on guest_profiles
+
+## Test plan
+- [ ] Backend: 7 new tests in TestNicknameUniqueness pass
+- [ ] Frontend: 10 new NicknameGate tests pass
+- [ ] Manual: open /join or /collect page as new guest, verify two-track gate appears
+- [ ] Manual: try a taken nickname, verify correct collision message
+- [ ] Manual: log in via email track end-to-end
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-04-30-nickname-gate-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-30-nickname-gate-redesign-design.md
@@ -1,0 +1,210 @@
+# Nickname Gate Redesign
+
+**Date:** 2026-04-30
+**Scope:** `dashboard/components/NicknameGate.tsx`, `server/app/api/collect.py`, `server/app/services/collect.py`, `server/app/models/guest_profile.py`
+
+---
+
+## Problem
+
+The current NicknameGate has three gaps:
+
+1. **No returning-user entry point.** A guest who has previously verified their email has no obvious way to log back in from the gate. The `reconcileHint` path exists but is subtle and separate.
+2. **No nickname uniqueness enforcement.** The same nickname can be claimed by multiple guests in the same event. There is no DB constraint, no API check, and no UX for collisions.
+3. **No email-claim enforcement.** There is no point at which the system demands identity verification — it is fully frictionless in all cases, including nickname collisions.
+
+---
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Where does the "returning user" hint live? | Always visible on the gate as a second track ("Have email"), not conditional on `reconcileHint` |
+| Nickname uniqueness scope | Per-event, case-insensitive |
+| Collision behaviour — unclaimed nickname | Hard block. "First come, first served." No claim path. Direct user to original device. |
+| Collision behaviour — email-claimed nickname | Block + offer email OTP login to prove ownership |
+| When is email mandatory? | Only on collision with an email-claimed nickname. Otherwise frictionless forever. |
+
+---
+
+## Architecture
+
+Only one layer of the stack changes meaningfully. Everything else reuses existing infrastructure.
+
+| Layer | Change |
+|---|---|
+| **Database** | One new partial functional unique index on `guest_profiles` |
+| **Backend service** | `upsert_profile()` runs a collision check before upsert; raises `NicknameConflictError` |
+| **Backend endpoint** | `POST /api/events/{code}/profile` catches `NicknameConflictError` → 409 |
+| **Frontend component** | `NicknameGate.tsx` gains 5 new internal states and a revised state machine |
+| **Frontend API client** | `setCollectProfile()` handles 409 and surfaces `NicknameConflict` |
+| **Everything else** | Unchanged — verify endpoints, merge service, join/collect pages, identity hook |
+
+---
+
+## State Machine
+
+### States
+
+| State | Type | Description |
+|---|---|---|
+| `loading` | existing | Fetches profile from server on mount |
+| `track_select` | **new** | Two-track entry: "New name" vs "Have email" |
+| `nickname_input` | existing | Text field + Continue button |
+| `collision_unclaimed` | **new** | Nickname taken, owner has no email — device hint, no action |
+| `collision_claimed` | **new** | Nickname taken, owner is email-verified — login CTA |
+| `email_login` | **new** | Email input field, reachable from `track_select` or `collision_claimed` |
+| `email_code` | **new** | 6-digit OTP entry |
+| `email_prompt` | existing | Optional email nudge after nickname saved (skipped if already verified) |
+| `complete` | existing | Gate dismissed, event content shown |
+
+### Transitions
+
+| From | Trigger | To |
+|---|---|---|
+| `loading` | No profile found | `track_select` |
+| `loading` | Profile has nickname, no email | `email_prompt` |
+| `loading` | Profile has nickname + email verified | `complete` |
+| `track_select` | "New name" clicked | `nickname_input` |
+| `track_select` | "Have email" clicked | `email_login` |
+| `nickname_input` | Submit → 200, guest not email-verified | `email_prompt` |
+| `nickname_input` | Submit → 200, guest already email-verified | `complete` |
+| `nickname_input` | Submit → 409 `claimed=false` | `collision_unclaimed` |
+| `nickname_input` | Submit → 409 `claimed=true` | `collision_claimed` |
+| `collision_unclaimed` | "Try a different nickname" | `nickname_input` |
+| `collision_claimed` | "Try a different nickname" | `nickname_input` |
+| `collision_claimed` | "Log in with email" | `email_login` |
+| `email_login` | Email submitted, code sent | `email_code` |
+| `email_code` | Code verified, guest has nickname | `complete` |
+| `email_code` | Code verified, guest has no nickname | `nickname_input` |
+| `email_prompt` | Email verified or skipped | `complete` |
+
+---
+
+## API Contract
+
+### Modified: `POST /api/events/{code}/profile`
+
+Existing endpoint. One new error response added.
+
+**New 409 response** (nickname collision):
+```json
+{ "detail": { "code": "nickname_taken", "claimed": true } }
+```
+
+- `claimed: true` — existing owner has `email_verified_at IS NOT NULL`
+- `claimed: false` — existing owner has no email verification
+
+All other responses (200, 401, 422, 429) unchanged.
+
+### Unchanged endpoints reused by new flows
+
+- `POST /api/guest/verify/request` — sends OTP (email login and email_code states)
+- `POST /api/guest/verify/confirm` — verifies code, merges guests if email already claimed, sets cookie
+- `GET /api/events/{code}/profile` — called after `email_code` completes to determine if `complete` or `nickname_input` is next
+
+No new endpoints.
+
+---
+
+## Data Model
+
+### New index on `guest_profiles`
+
+```sql
+CREATE UNIQUE INDEX uq_guest_profile_event_nickname
+ON guest_profiles (event_id, lower(nickname))
+WHERE nickname IS NOT NULL;
+```
+
+Partial (skips NULL nicknames) and functional (case-insensitive via `lower()`). SQLAlchemy model `__table_args__` gets a matching `Index(...)` declaration.
+
+Alembic migration: `server/alembic/versions/NNN_add_nickname_uniqueness.py`
+
+### Service layer: `upsert_profile()` in `services/collect.py`
+
+Before upserting, runs:
+```python
+existing = db.query(GuestProfile).filter(
+    GuestProfile.event_id == event_id,
+    GuestProfile.guest_id != guest_id,
+    func.lower(GuestProfile.nickname) == nickname.lower(),
+).first()
+
+if existing:
+    owner = db.get(Guest, existing.guest_id)
+    claimed = owner is not None and owner.email_verified_at is not None
+    raise NicknameConflictError(claimed=claimed)
+```
+
+`NicknameConflictError` is a new domain exception in `services/collect.py`, not an `HTTPException`. The API layer maps it to 409.
+
+---
+
+## Error Handling
+
+### Race condition
+
+Two guests submit the same nickname simultaneously. Both pass the application-level check. One wins the DB unique index; the other gets `sqlalchemy.exc.IntegrityError`. The endpoint catches `IntegrityError` on the profile insert and maps it to 409 `claimed=false` (the race winner has no email yet). No stuck states.
+
+### Email service unavailable
+
+When `email_login` submits and `/api/guest/verify/request` returns 422, the frontend shows an inline error and surfaces "Try a different nickname" as an escape hatch. The gate does not get stuck.
+
+### OTP expiry / max attempts
+
+Handled by existing `email_verification.py` (15-minute expiry, 3-attempt limit). The `email_code` state has a "Resend code" button that calls `/api/guest/verify/request` again. No new handling required.
+
+### Self-collision
+
+A guest re-submitting their own nickname never sees a 409. The collision query excludes `guest_id == current_guest_id`. Idempotent.
+
+### Merged account nickname is authoritative
+
+After `collision_claimed` → email login → verify → merge: frontend calls `GET /api/events/{code}/profile`. It gets the target account's existing nickname (not what the user originally typed). Gate goes directly to `complete`.
+
+---
+
+## Testing
+
+### Backend (pytest) — new tests in `tests/test_collect.py`
+
+| Test | Assertion |
+|---|---|
+| `test_profile_nickname_available` | 200, profile upserted |
+| `test_profile_nickname_collision_unclaimed` | 409, `claimed=false` |
+| `test_profile_nickname_collision_claimed` | 409, `claimed=true` |
+| `test_profile_nickname_self_collision` | 200, re-saving own nickname succeeds |
+| `test_profile_nickname_case_insensitive` | "Alex" blocks "alex" and "ALEX" |
+| `test_profile_nickname_race_condition` | IntegrityError maps to 409 `claimed=false` |
+| `test_profile_nickname_null_allowed` | NULL nickname skips uniqueness check |
+
+### Frontend (vitest) — new tests in `NicknameGate.test.tsx`
+
+| Test | Assertion |
+|---|---|
+| Initial state (no profile) | Renders `track_select` |
+| "New name" click | Transitions to `nickname_input` |
+| "Have email" click | Transitions to `email_login` |
+| 409 `claimed=false` on submit | Renders `collision_unclaimed` with device hint |
+| 409 `claimed=true` on submit | Renders `collision_claimed` with login CTA |
+| "Try a different nickname" from unclaimed | Returns to `nickname_input` |
+| "Try a different nickname" from claimed | Returns to `nickname_input` |
+| `email_code` verify → profile has nickname | Transitions to `complete` |
+| `email_code` verify → profile has no nickname | Transitions to `nickname_input` |
+| Nickname saved when already email-verified | Transitions to `complete`, skips `email_prompt` |
+
+---
+
+## Files Touched
+
+| File | Change |
+|---|---|
+| `dashboard/components/NicknameGate.tsx` | New state machine, 5 new states, `email_login` + `email_code` UI |
+| `dashboard/lib/api.ts` | `setCollectProfile()` handles 409, returns typed conflict info |
+| `server/app/api/collect.py` | Catches `NicknameConflictError`, returns 409 |
+| `server/app/services/collect.py` | `upsert_profile()` collision check; new `NicknameConflictError` |
+| `server/app/models/guest_profile.py` | New `Index(...)` in `__table_args__` |
+| `server/alembic/versions/NNN_add_nickname_uniqueness.py` | New migration |
+| `server/tests/test_collect.py` | 7 new backend tests |
+| `dashboard/components/__tests__/NicknameGate.test.tsx` | 10 new frontend tests |

--- a/server/alembic/versions/040_add_nickname_uniqueness.py
+++ b/server/alembic/versions/040_add_nickname_uniqueness.py
@@ -1,0 +1,25 @@
+"""add per-event nickname uniqueness index
+
+Revision ID: 040_nickname_unique
+Revises: 039
+Create Date: 2026-04-30
+"""
+
+from alembic import op
+
+revision = "040_nickname_unique"
+down_revision = "039"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE UNIQUE INDEX uq_guest_profile_event_nickname "
+        "ON guest_profiles (event_id, lower(nickname)) "
+        "WHERE nickname IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_guest_profile_event_nickname")

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -9,6 +9,7 @@ from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy import desc, func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
@@ -30,6 +31,7 @@ from app.schemas.collect import (
 )
 from app.services import collect as collect_service
 from app.services.activity_log import log_activity
+from app.services.collect import NicknameConflictError, upsert_profile
 from app.services.dedup import compute_dedupe_key, find_duplicate
 from app.services.system_settings import get_system_settings
 from app.services.vote import add_vote
@@ -174,12 +176,24 @@ def set_profile(
     guest_id = get_guest_id(request, db)
     if guest_id is None:
         raise HTTPException(status_code=401, detail="Guest identity required")
-    profile = collect_service.upsert_profile(
-        db,
-        event_id=event.id,
-        guest_id=guest_id,
-        nickname=payload.nickname,
-    )
+    try:
+        profile = upsert_profile(
+            db,
+            event_id=event.id,
+            guest_id=guest_id,
+            nickname=payload.nickname,
+        )
+    except NicknameConflictError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "nickname_taken", "claimed": exc.claimed},
+        )
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "nickname_taken", "claimed": False},
+        )
     if payload.nickname is not None:
         log_activity(
             db,

--- a/server/app/models/guest_profile.py
+++ b/server/app/models/guest_profile.py
@@ -36,7 +36,10 @@ class GuestProfile(Base):
             name="uq_guest_profile_event_guest",
         ),
         # Functional unique index: case-insensitive nickname uniqueness per event.
-        # Created by migration 040_add_nickname_uniqueness.
+        # Created by migration 040_add_nickname_uniqueness via raw op.execute().
+        # This Index() annotation exists solely to suppress alembic autogenerate drift —
+        # without it, alembic sees the DB index but not the model and generates a spurious
+        # remove_index operation. Do NOT remove it.
         Index(
             "uq_guest_profile_event_nickname",
             "event_id",

--- a/server/app/models/guest_profile.py
+++ b/server/app/models/guest_profile.py
@@ -1,6 +1,16 @@
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+    text,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.time import utcnow
@@ -24,5 +34,14 @@ class GuestProfile(Base):
             "event_id",
             "guest_id",
             name="uq_guest_profile_event_guest",
+        ),
+        # Functional unique index: case-insensitive nickname uniqueness per event.
+        # Created by migration 040_add_nickname_uniqueness.
+        Index(
+            "uq_guest_profile_event_nickname",
+            "event_id",
+            func.lower(Column("nickname")),
+            unique=True,
+            postgresql_where=text("nickname IS NOT NULL"),
         ),
     )

--- a/server/app/services/collect.py
+++ b/server/app/services/collect.py
@@ -3,12 +3,22 @@
 from datetime import datetime, timedelta
 
 from fastapi import HTTPException
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.models.event import Event
+from app.models.guest import Guest
 from app.models.guest_profile import GuestProfile
 from app.models.request import Request as SongRequest
 from app.schemas.collect import BulkReviewRequest, UpdateCollectionSettings
+
+
+class NicknameConflictError(Exception):
+    """Raised when a nickname is already in use by another guest in the event."""
+
+    def __init__(self, claimed: bool) -> None:
+        self.claimed = claimed
+        super().__init__("nickname_taken")
 
 
 def _to_naive_utc(dt: datetime) -> datetime:
@@ -176,9 +186,28 @@ def upsert_profile(
 ) -> GuestProfile | None:
     """Create or update a profile keyed on (event_id, guest_id). Returns None
     when no guest_id is provided — anonymous callers cannot persist profile state.
+
+    Raises NicknameConflictError when the requested nickname is already held by
+    a different guest in the same event. claimed=True when the owner is email-verified.
     """
     if guest_id is None:
         return None
+
+    if nickname is not None:
+        existing = (
+            db.query(GuestProfile)
+            .filter(
+                GuestProfile.event_id == event_id,
+                GuestProfile.guest_id != guest_id,
+                func.lower(GuestProfile.nickname) == nickname.lower(),
+            )
+            .first()
+        )
+        if existing:
+            owner = db.get(Guest, existing.guest_id)
+            claimed = owner is not None and owner.email_verified_at is not None
+            raise NicknameConflictError(claimed=claimed)
+
     profile = get_profile(db, event_id=event_id, guest_id=guest_id)
     if profile is None:
         profile = GuestProfile(

--- a/server/app/services/guest_merge.py
+++ b/server/app/services/guest_merge.py
@@ -83,7 +83,13 @@ def merge_guests(db: Session, *, source_guest_id: int, target_guest_id: int) -> 
         if target_profile:
             target_profile.submission_count += profile.submission_count
             if not target_profile.nickname and profile.nickname:
-                target_profile.nickname = profile.nickname
+                # Null out source nickname first to avoid a transient uniqueness
+                # violation on the case-insensitive index before the source row is
+                # deleted within the same transaction.
+                source_nick = profile.nickname
+                profile.nickname = None
+                db.flush()
+                target_profile.nickname = source_nick
             db.delete(profile)
             profiles_merged += 1
         else:

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -554,3 +554,123 @@ def test_collect_vote_other_user_still_works(client, db, test_event):
     assert r.status_code == 200
     db.refresh(row)
     assert row.vote_count == 1
+
+
+# ── Nickname uniqueness tests ──────────────────────────────────────────────
+
+
+class TestNicknameUniqueness:
+    """Tests for per-event nickname collision detection."""
+
+    def _make_guest(self, db, token_suffix: str, verified: bool = False):
+        from app.core.time import utcnow
+
+        g = Guest(
+            token="guest" + token_suffix.ljust(59, "0"),
+            fingerprint_hash=f"fp_{token_suffix}",
+            created_at=utcnow(),
+            last_seen_at=utcnow(),
+        )
+        if verified:
+            g.email_verified_at = utcnow()
+        db.add(g)
+        db.commit()
+        db.refresh(g)
+        return g
+
+    def test_available_nickname_succeeds(self, client, db, test_event):
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "UniqueNick"},
+        )
+        assert r.status_code == 200
+        assert r.json()["nickname"] == "UniqueNick"
+
+    def test_collision_unclaimed_returns_409_claimed_false(self, client, db, test_event):
+        # default guest (autouse) claims "Alex"
+        client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+        )
+        # second guest tries "Alex"
+        guest2 = self._make_guest(db, "two")
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+            cookies={"wrzdj_guest": guest2.token},
+        )
+        assert r.status_code == 409
+        body = r.json()["detail"]
+        assert body["code"] == "nickname_taken"
+        assert body["claimed"] is False
+
+    def test_collision_claimed_returns_409_claimed_true(self, client, db, test_event):
+        # email-verified guest claims "Alex"
+        verified_guest = self._make_guest(db, "verified", verified=True)
+        client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+            cookies={"wrzdj_guest": verified_guest.token},
+        )
+        # second guest tries same name
+        guest2 = self._make_guest(db, "two")
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+            cookies={"wrzdj_guest": guest2.token},
+        )
+        assert r.status_code == 409
+        body = r.json()["detail"]
+        assert body["code"] == "nickname_taken"
+        assert body["claimed"] is True
+
+    def test_self_collision_is_idempotent(self, client, db, test_event):
+        client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+        )
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+        )
+        assert r.status_code == 200
+
+    def test_collision_is_case_insensitive(self, client, db, test_event):
+        client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+        )
+        for variant in ["alex", "ALEX", "aLeX"]:
+            g = self._make_guest(db, variant)
+            r = client.post(
+                f"/api/public/collect/{test_event.code}/profile",
+                json={"nickname": variant},
+                cookies={"wrzdj_guest": g.token},
+            )
+            assert r.status_code == 409, f"Expected 409 for variant '{variant}'"
+
+    def test_race_condition_integrity_error_maps_to_409(self, client, db, test_event, monkeypatch):
+        from sqlalchemy.exc import IntegrityError
+
+        import app.api.collect as collect_api
+
+        def raise_integrity(db, *, event_id, guest_id=None, nickname=None):
+            raise IntegrityError("unique constraint", None, Exception())
+
+        monkeypatch.setattr(collect_api, "upsert_profile", raise_integrity)
+
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={"nickname": "Alex"},
+        )
+        assert r.status_code == 409
+        body = r.json()["detail"]
+        assert body["code"] == "nickname_taken"
+        assert body["claimed"] is False
+
+    def test_null_nickname_skips_uniqueness_check(self, client, db, test_event):
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/profile",
+            json={},
+        )
+        assert r.status_code == 200


### PR DESCRIPTION
## Summary
- Adds two-track entry to NicknameGate: pick a new name vs log in with email
- Enforces per-event nickname uniqueness (case-insensitive) at DB and service layer via functional unique index on \`guest_profiles(event_id, lower(nickname))\`
- 409 collision response distinguishes unclaimed (device hint) from email-claimed (OTP login flow)
- Also fixed latent bug in \`guest_merge.py\` where nickname unique constraint caused transaction failure during guest merges
- New Alembic migration 040 adds functional unique index

## Test plan
- [ ] Backend: 7 new tests in TestNicknameUniqueness all pass
- [ ] Frontend: 19 NicknameGate tests pass (10 new states + 9 restored behavioral)
- [ ] Full backend suite: 1889 tests pass at 87.81% coverage
- [ ] Full frontend suite: 931 tests pass
- [ ] Manual: open /join or /collect page as new guest — two-track gate appears
- [ ] Manual: try a taken nickname (unclaimed) — device hint shown, no email CTA
- [ ] Manual: try a taken+email-claimed nickname — "Log in with email" CTA appears
- [ ] Manual: log in via email track end-to-end