### PR TITLE
feat: song detail panels, vibes enrichment & collect UX polish

### DIFF
--- a/dashboard/app/collect/[code]/components/CollectDetailSheet.test.tsx
+++ b/dashboard/app/collect/[code]/components/CollectDetailSheet.test.tsx
@@ -1,0 +1,345 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import CollectDetailSheet from './CollectDetailSheet';
+import type { CollectLeaderboardRow } from '@/lib/api';
+
+const mockRow: CollectLeaderboardRow = {
+  id: 1,
+  title: 'Levels',
+  artist: 'Avicii',
+  artwork_url: null,
+  vote_count: 47,
+  nickname: null,
+  status: 'new',
+  created_at: new Date().toISOString(),
+  bpm: 128,
+  musical_key: '8A',
+  genre: 'Progressive House',
+};
+
+describe('CollectDetailSheet', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 375,
+    });
+  });
+
+  it('renders mobile sheet layout on narrow screens', async () => {
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        rank={3}
+        totalCount={10}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    expect(screen.getByText('Levels')).toBeTruthy();
+    expect(screen.getByText('PRE-EVENT · #3')).toBeTruthy();
+  });
+
+  it('renders desktop dialog layout on wide screens', async () => {
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1024,
+    });
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    expect(screen.getByText('Levels')).toBeTruthy();
+    // desktop shows rank in stats row
+    expect(screen.getByText('#1')).toBeTruthy();
+  });
+
+  it('shows BPM pill when bpm is set', async () => {
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    expect(screen.getByText('128 BPM')).toBeTruthy();
+  });
+
+  it('shows key pill when musical_key is set', async () => {
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    expect(screen.getByText('8A')).toBeTruthy();
+  });
+
+  it('hides pills when both bpm and musical_key are null', async () => {
+    const rowNoPills: CollectLeaderboardRow = { ...mockRow, bpm: null, musical_key: null };
+    render(
+      <CollectDetailSheet
+        row={rowNoPills}
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    expect(screen.queryByText(/BPM/)).toBeNull();
+    expect(screen.queryByText('8A')).toBeNull();
+  });
+
+  it('shows bpm pill but not key pill when only bpm is set', async () => {
+    const rowBpmOnly: CollectLeaderboardRow = { ...mockRow, bpm: 140, musical_key: null };
+    render(
+      <CollectDetailSheet
+        row={rowBpmOnly}
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    expect(screen.getByText('140 BPM')).toBeTruthy();
+    expect(screen.queryByText('8A')).toBeNull();
+  });
+
+  it('shows key pill but not bpm pill when only musical_key is set', async () => {
+    const rowKeyOnly: CollectLeaderboardRow = { ...mockRow, bpm: null, musical_key: '4B' };
+    render(
+      <CollectDetailSheet
+        row={rowKeyOnly}
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    expect(screen.getByText('4B')).toBeTruthy();
+    expect(screen.queryByText(/BPM/)).toBeNull();
+  });
+
+  it('shows suggested-by section when nickname is set', async () => {
+    const rowWithNickname: CollectLeaderboardRow = { ...mockRow, nickname: 'marco_b' };
+    render(
+      <CollectDetailSheet
+        row={rowWithNickname}
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    expect(screen.getByText('marco_b')).toBeTruthy();
+    expect(screen.getByText('SUGGESTED BY')).toBeTruthy();
+  });
+
+  it('hides suggested-by section when nickname is null', async () => {
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    expect(screen.queryByText('SUGGESTED BY')).toBeNull();
+  });
+
+  it('shows UPVOTE THIS TRACK button when not voted', async () => {
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    expect(screen.getByText('UPVOTE THIS TRACK')).toBeTruthy();
+  });
+
+  it('shows VOTED label when voted', async () => {
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        rank={1}
+        totalCount={5}
+        voted={true}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    expect(screen.getByText('VOTED')).toBeTruthy();
+  });
+
+  it('calls onClose when close button is clicked', async () => {
+    const onClose = vi.fn();
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+    await act(async () => {});
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls onVote when upvote button is clicked', async () => {
+    const onVote = vi.fn();
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={onVote}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    fireEvent.click(screen.getByText('UPVOTE THIS TRACK'));
+    expect(onVote).toHaveBeenCalled();
+  });
+
+  it('renders artwork image when artwork_url is set', async () => {
+    const rowWithArt: CollectLeaderboardRow = {
+      ...mockRow,
+      artwork_url: 'https://example.com/art.jpg',
+    };
+    render(
+      <CollectDetailSheet
+        row={rowWithArt}
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    const imgs = screen.getAllByRole('img');
+    expect(imgs.length).toBeGreaterThan(0);
+    expect(imgs[0].getAttribute('src')).toBe('https://example.com/art.jpg');
+  });
+
+  it('renders initials fallback when artwork_url is null', async () => {
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    // Initials = first char of title + first char of artist = "LA"
+    const initialsEls = screen.getAllByText('LA');
+    expect(initialsEls.length).toBeGreaterThan(0);
+  });
+
+  it('calls onClose when desktop backdrop is clicked', async () => {
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1024,
+    });
+    const onClose = vi.fn();
+    const { container } = render(
+      <CollectDetailSheet
+        row={mockRow}
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+    await act(async () => {});
+    // Click the outer fixed backdrop div (first child of the container's root)
+    const backdrop = container.firstChild as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('does not propagate clicks from inner dialog card to backdrop', async () => {
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1024,
+    });
+    const onClose = vi.fn();
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+    await act(async () => {});
+    // Click the title inside the card — should NOT trigger onClose
+    fireEvent.click(screen.getByText('Levels'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('displays vote count and rank in stats row', async () => {
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        rank={2}
+        totalCount={20}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    expect(screen.getByText('47')).toBeTruthy();
+    expect(screen.getByText('#2')).toBeTruthy();
+    expect(screen.getByText('of 20')).toBeTruthy();
+  });
+});

--- a/dashboard/app/collect/[code]/components/CollectDetailSheet.tsx
+++ b/dashboard/app/collect/[code]/components/CollectDetailSheet.tsx
@@ -34,7 +34,7 @@ function artGradient(seed: string) {
 export default function CollectDetailSheet({
   row, rank, totalCount, voted, onVote, onClose,
 }: Props) {
-  const [isWide, setIsWide] = useState(false);
+  const [isWide, setIsWide] = useState<boolean | null>(null);
 
   useEffect(() => {
     const check = () => setIsWide(window.innerWidth >= 640);
@@ -97,7 +97,7 @@ export default function CollectDetailSheet({
         border: voted ? `1.5px solid ${ACCENT}` : 'none',
         color: voted ? ACCENT : '#000',
         fontFamily: 'var(--font-grotesk, system-ui)', fontSize: 16.9, fontWeight: 800,
-        cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+        cursor: voted ? 'default' : 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
         transition: 'all 160ms',
         boxShadow: voted ? 'none' : `0 12px 32px -8px ${ACCENT}90`,
       }}
@@ -151,6 +151,8 @@ export default function CollectDetailSheet({
     </div>
   );
 
+  if (isWide === null) return null;
+
   /* ── Desktop: centered dialog ─────────────────────────────── */
   if (isWide) {
     return (
@@ -160,6 +162,7 @@ export default function CollectDetailSheet({
           background: 'rgba(0,0,0,0.7)',
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           padding: '20px',
+          animation: 'cds-backdrop-in 220ms ease',
         }}
         onClick={onClose}
       >
@@ -171,6 +174,7 @@ export default function CollectDetailSheet({
             boxShadow: '0 40px 100px rgba(0,0,0,0.6)',
             fontFamily: 'var(--font-grotesk, system-ui)',
             color: '#fff', overflow: 'hidden',
+            animation: 'cds-card-in 260ms cubic-bezier(.2,.8,.2,1)',
           }}
         >
           {header}

--- a/dashboard/app/collect/[code]/components/CollectDetailSheet.tsx
+++ b/dashboard/app/collect/[code]/components/CollectDetailSheet.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { CollectLeaderboardRow } from '@/lib/api';
+
+interface Props {
+  row: CollectLeaderboardRow;
+  rank: number;
+  totalCount: number;
+  voted: boolean;
+  onVote: () => void;
+  onClose: () => void;
+}
+
+const ACCENT = '#00f0ff';
+const ACCENT2 = '#ff2bd6';
+
+const GRADIENTS = [
+  'linear-gradient(135deg, #ff006e, #8338ec, #3a86ff)',
+  'linear-gradient(135deg, #ffbe0b, #fb5607)',
+  'linear-gradient(135deg, #06ffa5, #0077b6)',
+  'linear-gradient(135deg, #ff6b9d, #c44569)',
+  'linear-gradient(135deg, #f72585, #7209b7)',
+  'linear-gradient(135deg, #4cc9f0, #4361ee)',
+  'linear-gradient(135deg, #f15bb5, #fee440)',
+  'linear-gradient(135deg, #2dc653, #25a244)',
+  'linear-gradient(135deg, #ef476f, #ffd166)',
+];
+function artGradient(seed: string) {
+  const code = (seed.charCodeAt(0) || 0) + (seed.charCodeAt(1) || 0);
+  return GRADIENTS[code % GRADIENTS.length];
+}
+
+export default function CollectDetailSheet({
+  row, rank, totalCount, voted, onVote, onClose,
+}: Props) {
+  const [isWide, setIsWide] = useState(false);
+
+  useEffect(() => {
+    const check = () => setIsWide(window.innerWidth >= 640);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
+  const surface = 'rgba(255,255,255,0.05)';
+  const border = 'rgba(255,255,255,0.1)';
+  const subFg = 'rgba(255,255,255,0.55)';
+  const subFg2 = 'rgba(255,255,255,0.35)';
+  const initials = `${row.title[0] ?? '?'}${row.artist[0] ?? ''}`.toUpperCase();
+
+  const pills = (row.bpm || row.musical_key) ? (
+    <div style={{ display: 'flex', gap: 6, marginTop: 8, flexWrap: 'wrap' }}>
+      {row.bpm && (
+        <span style={{
+          fontFamily: 'var(--font-mono, monospace)', fontSize: 10.3, fontWeight: 700,
+          padding: '3px 9px', borderRadius: 6,
+          background: `${ACCENT}18`, border: `1px solid ${ACCENT}50`, color: ACCENT,
+          letterSpacing: 1,
+        }}>
+          {row.bpm} BPM
+        </span>
+      )}
+      {row.musical_key && (
+        <span style={{
+          fontFamily: 'var(--font-mono, monospace)', fontSize: 10.3, fontWeight: 700,
+          padding: '3px 9px', borderRadius: 6,
+          background: 'rgba(255,255,255,0.06)', border: `1px solid ${border}`,
+          color: 'rgba(255,255,255,0.7)', letterSpacing: 1,
+        }}>
+          {row.musical_key}
+        </span>
+      )}
+    </div>
+  ) : null;
+
+  const statsRow = (
+    <div style={{ display: 'flex', gap: 8, marginTop: 14 }}>
+      <div style={{ flex: 1, padding: 14, borderRadius: 14, background: surface, border: `1px solid ${border}`, textAlign: 'center' }}>
+        <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 10.3, color: subFg, letterSpacing: 1.5 }}>VOTES</div>
+        <div style={{ fontSize: 30, fontWeight: 800, color: ACCENT, lineHeight: 1, marginTop: 4 }}>{row.vote_count}</div>
+      </div>
+      <div style={{ flex: 1, padding: 14, borderRadius: 14, background: surface, border: `1px solid ${border}`, textAlign: 'center' }}>
+        <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 10.3, color: subFg, letterSpacing: 1.5 }}>RANK</div>
+        <div style={{ fontSize: 30, fontWeight: 800, color: '#fff', lineHeight: 1, marginTop: 4 }}>#{rank}</div>
+        <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 9.7, color: subFg2, marginTop: 2 }}>of {totalCount}</div>
+      </div>
+    </div>
+  );
+
+  const voteBtn = (
+    <button
+      onClick={onVote}
+      style={{
+        width: '100%', height: 56, borderRadius: 14, marginTop: 12,
+        background: voted ? 'transparent' : `linear-gradient(90deg, ${ACCENT}, ${ACCENT2})`,
+        border: voted ? `1.5px solid ${ACCENT}` : 'none',
+        color: voted ? ACCENT : '#000',
+        fontFamily: 'var(--font-grotesk, system-ui)', fontSize: 16.9, fontWeight: 800,
+        cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+        transition: 'all 160ms',
+        boxShadow: voted ? 'none' : `0 12px 32px -8px ${ACCENT}90`,
+      }}
+    >
+      <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
+        <path d="M2 9L7 3L12 9" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+      {voted ? 'VOTED' : 'UPVOTE THIS TRACK'}
+    </button>
+  );
+
+  const suggestedBy = row.nickname ? (
+    <div style={{
+      marginTop: 12, padding: 12, borderRadius: 12,
+      background: surface, border: `1px solid ${border}`,
+      display: 'flex', alignItems: 'center', gap: 10,
+    }}>
+      <div style={{
+        width: 36, height: 36, borderRadius: '50%', flexShrink: 0,
+        background: `linear-gradient(135deg, ${ACCENT}, ${ACCENT2})`,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontSize: 14, fontWeight: 800, color: '#000',
+      }}>
+        {row.nickname[0]?.toUpperCase() ?? '?'}
+      </div>
+      <div>
+        <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 9.7, color: subFg, letterSpacing: 1.5 }}>SUGGESTED BY</div>
+        <div style={{ fontSize: 16.4, fontWeight: 700, marginTop: 2 }}>{row.nickname}</div>
+      </div>
+    </div>
+  ) : null;
+
+  const header = (
+    <div style={{ padding: '12px 16px 6px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 10.3, color: subFg, letterSpacing: 1.5 }}>
+        PRE-EVENT · #{rank}
+      </div>
+      <button
+        onClick={onClose}
+        style={{
+          width: 40, height: 40, borderRadius: 11,
+          background: surface, border: `1px solid ${border}`, color: '#fff',
+          cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}
+        aria-label="Close"
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14">
+          <path d="M2 2l10 10M12 2L2 12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+        </svg>
+      </button>
+    </div>
+  );
+
+  /* ── Desktop: centered dialog ─────────────────────────────── */
+  if (isWide) {
+    return (
+      <div
+        style={{
+          position: 'fixed', inset: 0, zIndex: 110,
+          background: 'rgba(0,0,0,0.7)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          padding: '20px',
+        }}
+        onClick={onClose}
+      >
+        <div
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            width: '100%', maxWidth: 480, background: '#0f0f18',
+            borderRadius: 20, border: `1px solid ${border}`,
+            boxShadow: '0 40px 100px rgba(0,0,0,0.6)',
+            fontFamily: 'var(--font-grotesk, system-ui)',
+            color: '#fff', overflow: 'hidden',
+          }}
+        >
+          {header}
+          {/* Art + title side by side */}
+          <div style={{ display: 'flex', gap: 14, padding: '10px 16px 0', alignItems: 'center' }}>
+            <div style={{
+              width: 96, height: 96, borderRadius: 14, flexShrink: 0,
+              background: row.artwork_url ? undefined : artGradient(row.title + row.artist),
+              overflow: 'hidden', display: 'flex', alignItems: 'center', justifyContent: 'center',
+              boxShadow: `0 10px 30px -8px ${ACCENT}50`,
+            }}>
+              {row.artwork_url
+                ? <img src={row.artwork_url} alt={row.title} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+                : <span style={{ fontSize: 32, fontWeight: 800, color: '#fff' }}>{initials}</span>
+              }
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 22, fontWeight: 800, letterSpacing: -0.5, lineHeight: 1.1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{row.title}</div>
+              <div style={{ fontSize: 15.7, color: subFg, marginTop: 4, fontWeight: 500 }}>{row.artist}</div>
+              {pills}
+            </div>
+          </div>
+          <div style={{ padding: '0 16px 16px' }}>
+            {statsRow}
+            {suggestedBy}
+            {voteBtn}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  /* ── Mobile: full-screen bottom sheet ────────────────────── */
+  return (
+    <div className="gst-detail-sheet">
+      {/* Glow */}
+      <div style={{
+        position: 'absolute', top: 60, left: '50%', transform: 'translateX(-50%)',
+        width: '100%', maxWidth: 420, height: 260,
+        background: `radial-gradient(circle, ${ACCENT}22, transparent 65%)`,
+        filter: 'blur(50px)', pointerEvents: 'none',
+      }} />
+
+      {header}
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '8px 18px 120px', position: 'relative', zIndex: 1 }}>
+        {/* Artwork */}
+        <div style={{
+          width: 160, height: 160, borderRadius: 22, margin: '6px auto 0',
+          background: row.artwork_url ? undefined : artGradient(row.title + row.artist),
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          overflow: 'hidden',
+          boxShadow: `0 20px 50px -12px ${ACCENT}70, 0 0 0 1px ${border}`,
+        }}>
+          {row.artwork_url
+            ? <img src={row.artwork_url} alt={row.title} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            : <span style={{ fontSize: 48, fontWeight: 800, color: '#fff' }}>{initials}</span>
+          }
+        </div>
+
+        {/* Title + artist + pills */}
+        <div style={{ marginTop: 20, textAlign: 'center' }}>
+          <div style={{ fontSize: 28, fontWeight: 800, letterSpacing: -0.7, lineHeight: 1.05 }}>{row.title}</div>
+          <div style={{ fontSize: 18.2, color: subFg, marginTop: 5, fontWeight: 500 }}>{row.artist}</div>
+          {pills && <div style={{ justifyContent: 'center', display: 'flex' }}>{pills}</div>}
+        </div>
+
+        {statsRow}
+        {suggestedBy}
+      </div>
+
+      {/* Bottom vote CTA */}
+      <div style={{
+        position: 'absolute',
+        bottom: 'calc(env(safe-area-inset-bottom, 0px) + 20px)',
+        left: 14, right: 14, zIndex: 30,
+      }}>
+        {voteBtn}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import LeaderboardTabs from './LeaderboardTabs';
+import type { CollectLeaderboardRow } from '@/lib/api';
 
-const rows = [
+const rows: CollectLeaderboardRow[] = [
   {
     id: 1,
     title: 'A',
@@ -12,6 +13,9 @@ const rows = [
     nickname: 'alex',
     status: 'new' as const,
     created_at: '2026-04-21',
+    bpm: null,
+    musical_key: null,
+    genre: null,
   },
   {
     id: 2,
@@ -22,8 +26,25 @@ const rows = [
     nickname: 'jo',
     status: 'new' as const,
     created_at: '2026-04-21',
+    bpm: null,
+    musical_key: null,
+    genre: null,
   },
 ];
+
+const mockRow: CollectLeaderboardRow = {
+  id: 1,
+  title: 'Levels',
+  artist: 'Avicii',
+  artwork_url: null,
+  vote_count: 5,
+  nickname: null,
+  status: 'new',
+  created_at: new Date().toISOString(),
+  bpm: null,
+  musical_key: null,
+  genre: null,
+};
 
 describe('LeaderboardTabs', () => {
   it('renders rows and switches tabs', () => {
@@ -92,5 +113,38 @@ describe('LeaderboardTabs', () => {
     await waitFor(() => {
       expect(onVote).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('calls onRowClick when a row is clicked', () => {
+    const onRowClick = vi.fn();
+    render(
+      <LeaderboardTabs
+        rows={[mockRow]}
+        tab="all"
+        onTabChange={vi.fn()}
+        onVote={vi.fn().mockResolvedValue(undefined)}
+        votedIds={new Set()}
+        onRowClick={onRowClick}
+      />,
+    );
+    fireEvent.click(screen.getByText('Levels'));
+    expect(onRowClick).toHaveBeenCalledWith(mockRow);
+  });
+
+  it('does not call onRowClick when vote button is clicked', () => {
+    const onRowClick = vi.fn();
+    render(
+      <LeaderboardTabs
+        rows={[mockRow]}
+        tab="all"
+        onTabChange={vi.fn()}
+        onVote={vi.fn().mockResolvedValue(undefined)}
+        votedIds={new Set()}
+        onRowClick={onRowClick}
+      />,
+    );
+    const voteBtn = screen.getByRole('button', { name: /upvote/i });
+    fireEvent.click(voteBtn);
+    expect(onRowClick).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
@@ -28,9 +28,10 @@ interface Props {
   onTabChange: (tab: 'trending' | 'all') => void;
   onVote: (requestId: number) => Promise<void>;
   votedIds: ReadonlySet<number>;
+  onRowClick?: (row: CollectLeaderboardRow) => void;
 }
 
-export default function LeaderboardTabs({ rows, tab, onTabChange, onVote, votedIds }: Props) {
+export default function LeaderboardTabs({ rows, tab, onTabChange, onVote, votedIds, onRowClick }: Props) {
   const [optimistic, setOptimistic] = useState<Record<number, number>>({});
   const [justVoted, setJustVoted] = useState<ReadonlySet<number>>(new Set());
 
@@ -117,7 +118,9 @@ export default function LeaderboardTabs({ rows, tab, onTabChange, onVote, votedI
                 style={{
                   background: surface,
                   border: `1px solid ${border}`,
+                  cursor: onRowClick ? 'pointer' : 'default',
                 }}
+                onClick={() => onRowClick?.(r)}
               >
                 {/* Vote bar fill */}
                 <div style={{
@@ -191,7 +194,10 @@ export default function LeaderboardTabs({ rows, tab, onTabChange, onVote, votedI
                       aria-pressed={voted}
                       className={`gst-collect-vote-btn${voted ? ' voted' : ''}`}
                       disabled={voted}
-                      onClick={() => handleVote(r.id, r.vote_count)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleVote(r.id, r.vote_count);
+                      }}
                     >
                       <svg width="11" height="7" viewBox="0 0 11 7" fill="none">
                         <path d="M1 6L5.5 1L10 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>

--- a/dashboard/app/collect/[code]/page.test.tsx
+++ b/dashboard/app/collect/[code]/page.test.tsx
@@ -31,6 +31,7 @@ const mockGetCollectProfile = vi.fn();
 const mockGetCollectLeaderboard = vi.fn();
 const mockSubmitCollectRequest = vi.fn();
 const mockEventSearch = vi.fn();
+const mockEnrichPreview = vi.fn();
 
 vi.mock("../../../lib/api", () => ({
   ApiError: class ApiError extends Error {
@@ -51,6 +52,7 @@ vi.mock("../../../lib/api", () => ({
     eventSearch: (...a: unknown[]) => mockEventSearch(...a),
     search: vi.fn().mockResolvedValue([]),
     voteCollectRequest: vi.fn().mockResolvedValue(undefined),
+    enrichPreview: (...a: unknown[]) => mockEnrichPreview(...a),
   },
 }));
 
@@ -70,6 +72,7 @@ describe("CollectPage", () => {
   beforeEach(() => {
     mockReplace.mockClear();
     mockGetEvent.mockReset();
+    mockEnrichPreview.mockReset();
     const defaultProfile = {
       email_verified: false,
       nickname: null,
@@ -80,6 +83,7 @@ describe("CollectPage", () => {
     mockGetCollectLeaderboard.mockResolvedValue({ requests: [], total: 0 });
     mockSubmitCollectRequest.mockResolvedValue({ id: 42 });
     mockEventSearch.mockResolvedValue([]);
+    mockEnrichPreview.mockResolvedValue([]);
     vi.stubGlobal("sessionStorage", {
       getItem: vi.fn(),
       setItem: vi.fn(),
@@ -237,5 +241,303 @@ describe("CollectPage", () => {
     // The initial load is now handled by NicknameGate (mocked), so only the
     // post-submit refresh counts here.
     expect(mockGetCollectProfile.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows error message when API throws during event fetch", async () => {
+    mockGetEvent.mockRejectedValue(new Error("Network failure"));
+    render(<CollectPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/error:/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows loading state when event is not yet loaded", async () => {
+    // Never resolves so page stays in loading
+    mockGetEvent.mockReturnValue(new Promise(() => {}));
+    render(<CollectPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    });
+  });
+
+  it("redirects to /join when phase is closed", async () => {
+    mockGetEvent.mockResolvedValue({
+      code: "ABC",
+      name: "Test Event",
+      phase: "closed",
+      collection_opens_at: new Date(Date.now() - 86400_000).toISOString(),
+      live_starts_at: new Date(Date.now() - 3600_000).toISOString(),
+      submission_cap_per_guest: 15,
+      banner_filename: null,
+      registration_enabled: true,
+      expires_at: new Date(Date.now() + 86400_000).toISOString(),
+    });
+    render(<CollectPage />);
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/join/ABC");
+    });
+  });
+
+  it("shows 'Picks limit reached' when submit returns 429", async () => {
+    mockGetEvent.mockResolvedValue(COLLECTION_EVENT);
+
+    const ApiErrorClass = (await import("../../../lib/api")).ApiError;
+    mockSubmitCollectRequest.mockRejectedValue(new ApiErrorClass("rate limited", 429));
+
+    const track = {
+      artist: "Avicii",
+      title: "Levels",
+      album: null,
+      popularity: 80,
+      spotify_id: "sp-1",
+      album_art: null,
+      preview_url: null,
+      url: "https://open.spotify.com/track/sp-1",
+      source: "spotify" as const,
+      genre: null,
+      bpm: null,
+      key: null,
+      isrc: null,
+    };
+    mockEventSearch.mockResolvedValue([track]);
+
+    render(<CollectPage />);
+    await waitFor(() => expect(screen.getByText(/Request a song/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Request a song/i));
+    await waitFor(() => expect(screen.getByTestId("collect-search-input")).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId("collect-search-input"), { target: { value: "Avicii" } });
+    fireEvent.submit(screen.getByTestId("collect-search-input").closest("form")!);
+    await waitFor(() => expect(screen.getByTestId("collect-search-result")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("collect-search-result"));
+    await waitFor(() => expect(screen.getByText(/Picks limit reached/i)).toBeInTheDocument());
+  });
+
+  it("shows 'You already picked this one!' when submit returns 409", async () => {
+    mockGetEvent.mockResolvedValue(COLLECTION_EVENT);
+
+    const ApiErrorClass = (await import("../../../lib/api")).ApiError;
+    mockSubmitCollectRequest.mockRejectedValue(new ApiErrorClass("conflict", 409));
+
+    const track = {
+      artist: "Avicii",
+      title: "Levels",
+      album: null,
+      popularity: 80,
+      spotify_id: "sp-1",
+      album_art: null,
+      preview_url: null,
+      url: null,
+      source: "spotify" as const,
+      genre: null,
+      bpm: null,
+      key: null,
+      isrc: null,
+    };
+    mockEventSearch.mockResolvedValue([track]);
+
+    render(<CollectPage />);
+    await waitFor(() => expect(screen.getByText(/Request a song/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Request a song/i));
+    await waitFor(() => expect(screen.getByTestId("collect-search-input")).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId("collect-search-input"), { target: { value: "Avicii" } });
+    fireEvent.submit(screen.getByTestId("collect-search-input").closest("form")!);
+    await waitFor(() => expect(screen.getByTestId("collect-search-result")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("collect-search-result"));
+    await waitFor(() => expect(screen.getByText(/already picked/i)).toBeInTheDocument());
+  });
+
+  it("shows generic error when submit fails with unexpected error", async () => {
+    mockGetEvent.mockResolvedValue(COLLECTION_EVENT);
+    mockSubmitCollectRequest.mockRejectedValue(new Error("unexpected"));
+
+    const track = {
+      artist: "Avicii",
+      title: "Levels",
+      album: null,
+      popularity: 80,
+      spotify_id: "sp-2",
+      album_art: "https://img.example.com/art.jpg",
+      preview_url: null,
+      url: "https://open.spotify.com/track/sp-2",
+      source: "spotify" as const,
+      genre: null,
+      bpm: null,
+      key: null,
+      isrc: null,
+    };
+    mockEventSearch.mockResolvedValue([track]);
+
+    render(<CollectPage />);
+    await waitFor(() => expect(screen.getByText(/Request a song/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Request a song/i));
+    await waitFor(() => expect(screen.getByTestId("collect-search-input")).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId("collect-search-input"), { target: { value: "Avicii" } });
+    fireEvent.submit(screen.getByTestId("collect-search-input").closest("form")!);
+    await waitFor(() => expect(screen.getByTestId("collect-search-result")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("collect-search-result"));
+    await waitFor(() => expect(screen.getByText(/Failed to submit/i)).toBeInTheDocument());
+  });
+
+  it("stays open and shows message when submit is a duplicate", async () => {
+    mockGetEvent.mockResolvedValue(COLLECTION_EVENT);
+    mockSubmitCollectRequest.mockResolvedValue({ id: 99, is_duplicate: true });
+    mockGetCollectProfile.mockResolvedValue({
+      email_verified: false,
+      nickname: null,
+      submission_count: 1,
+      submission_cap: 15,
+    });
+
+    const track = {
+      artist: "Avicii",
+      title: "Levels",
+      album: null,
+      popularity: 80,
+      spotify_id: "sp-dup",
+      album_art: null,
+      preview_url: null,
+      url: null,
+      source: "spotify" as const,
+      genre: null,
+      bpm: null,
+      key: null,
+      isrc: null,
+    };
+    mockEventSearch.mockResolvedValue([track]);
+
+    render(<CollectPage />);
+    await waitFor(() => expect(screen.getByText(/Request a song/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Request a song/i));
+    await waitFor(() => expect(screen.getByTestId("collect-search-input")).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId("collect-search-input"), { target: { value: "Avicii" } });
+    fireEvent.submit(screen.getByTestId("collect-search-input").closest("form")!);
+    await waitFor(() => expect(screen.getByTestId("collect-search-result")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("collect-search-result"));
+    await waitFor(() => expect(screen.getByText(/great minds/i)).toBeInTheDocument());
+    // Search modal should remain open (not closed for duplicate)
+    expect(screen.getByTestId("collect-search-input")).toBeInTheDocument();
+  });
+
+  it("shows HIGHLIGHT BY VIBES button when search results exist", async () => {
+    mockGetEvent.mockResolvedValue(COLLECTION_EVENT);
+
+    const track = {
+      artist: "Avicii",
+      title: "Levels",
+      album: null,
+      popularity: 80,
+      spotify_id: "sp-v1",
+      album_art: null,
+      preview_url: null,
+      url: null,
+      source: "spotify" as const,
+      genre: null,
+      bpm: 128,
+      key: "8A",
+      isrc: null,
+    };
+    mockEventSearch.mockResolvedValue([track]);
+    mockEnrichPreview.mockResolvedValue([{ bpm: 128, key: "8A", genre: "House" }]);
+
+    render(<CollectPage />);
+    await waitFor(() => expect(screen.getByText(/Request a song/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Request a song/i));
+    await waitFor(() => expect(screen.getByTestId("collect-search-input")).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId("collect-search-input"), { target: { value: "Avicii" } });
+    fireEvent.submit(screen.getByTestId("collect-search-input").closest("form")!);
+    await waitFor(() => expect(screen.getByText(/HIGHLIGHT BY VIBES/i)).toBeInTheDocument());
+
+    // Toggle vibes on — track already has bpm so no enrichment call needed
+    fireEvent.click(screen.getByText(/HIGHLIGHT BY VIBES/i));
+    await waitFor(() => {
+      // The button stays rendered (vibes active)
+      expect(screen.getByText(/HIGHLIGHT BY VIBES/i)).toBeInTheDocument();
+    });
+
+    // Toggle vibes off
+    fireEvent.click(screen.getByText(/HIGHLIGHT BY VIBES/i));
+    await waitFor(() => {
+      expect(screen.getByText(/HIGHLIGHT BY VIBES/i)).toBeInTheDocument();
+    });
+  });
+
+  it("calls enrichPreview when vibes toggled and results lack bpm", async () => {
+    mockGetEvent.mockResolvedValue(COLLECTION_EVENT);
+
+    const track = {
+      artist: "Avicii",
+      title: "Levels",
+      album: null,
+      popularity: 80,
+      spotify_id: "sp-v2",
+      album_art: null,
+      preview_url: null,
+      url: "https://open.spotify.com/track/sp-v2",
+      source: "spotify" as const,
+      genre: null,
+      bpm: null,
+      key: null,
+      isrc: null,
+    };
+    mockEventSearch.mockResolvedValue([track]);
+    mockEnrichPreview.mockResolvedValue([{ bpm: 130, key: "9A", genre: "Trance" }]);
+
+    render(<CollectPage />);
+    await waitFor(() => expect(screen.getByText(/Request a song/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/Request a song/i));
+    await waitFor(() => expect(screen.getByTestId("collect-search-input")).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId("collect-search-input"), { target: { value: "Avicii" } });
+    fireEvent.submit(screen.getByTestId("collect-search-input").closest("form")!);
+    await waitFor(() => expect(screen.getByText(/HIGHLIGHT BY VIBES/i)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText(/HIGHLIGHT BY VIBES/i));
+    await waitFor(() => {
+      expect(mockEnrichPreview).toHaveBeenCalled();
+    });
+  });
+
+  it("renders pre_announce phase with collection_opens_at in the past", async () => {
+    mockGetEvent.mockResolvedValue({
+      code: "ABC",
+      name: "Past Open Event",
+      phase: "pre_announce",
+      collection_opens_at: null,
+      live_starts_at: new Date(Date.now() + 7200_000).toISOString(),
+      submission_cap_per_guest: 15,
+      banner_filename: null,
+      registration_enabled: true,
+      expires_at: new Date(Date.now() + 86400_000).toISOString(),
+    });
+    render(<CollectPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/until voting opens/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders collection phase with banner_url", async () => {
+    mockGetEvent.mockResolvedValue({
+      ...COLLECTION_EVENT,
+      banner_url: "https://example.com/banner.jpg",
+    });
+    render(<CollectPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/test event/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows event song count from leaderboard", async () => {
+    mockGetEvent.mockResolvedValue(COLLECTION_EVENT);
+    mockGetCollectLeaderboard.mockResolvedValue({
+      requests: [
+        { id: 1, title: "Unique Song Alpha", artist: "Artist A", artwork_url: null, vote_count: 5, nickname: null, status: "new", created_at: new Date().toISOString(), bpm: 128, musical_key: "8A", genre: "House" },
+        { id: 2, title: "Unique Song Beta", artist: "Artist B", artwork_url: null, vote_count: 3, nickname: null, status: "new", created_at: new Date().toISOString(), bpm: 140, musical_key: "4A", genre: "Trance" },
+      ],
+      total: 2,
+    });
+    render(<CollectPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Unique Song Alpha")).toBeInTheDocument();
+      expect(screen.getByText("Unique Song Beta")).toBeInTheDocument();
+    });
   });
 });

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useParams, useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   apiClient,
   ApiError,
@@ -67,6 +67,9 @@ export default function CollectPage() {
   const [searching, setSearching] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [sortByVibes, setSortByVibes] = useState(false);
+  const [enriching, setEnriching] = useState(false);
+  const [enrichedResults, setEnrichedResults] = useState<SearchResult[]>([]);
 
   const openSearch = () => {
     setSearchOpen(true);
@@ -80,6 +83,9 @@ export default function CollectPage() {
     setSearchQuery('');
     setSearchResults([]);
     setSubmitError(null);
+    setSortByVibes(false);
+    setEnrichedResults([]);
+    setEnriching(false);
   };
 
   const handleSearch = async (e: React.FormEvent) => {
@@ -143,6 +149,43 @@ export default function CollectPage() {
     }
   };
 
+  const handleVibesToggle = async () => {
+    if (sortByVibes) {
+      setSortByVibes(false);
+      setEnrichedResults([]);
+      return;
+    }
+    setSortByVibes(true);
+    const needsEnrich = searchResults.slice(0, 10).filter((r) => r.bpm == null);
+    if (needsEnrich.length === 0) return;
+    setEnriching(true);
+    try {
+      const results = await apiClient.enrichPreview(
+        code,
+        searchResults.slice(0, 10).map((r) => ({
+          title: r.title,
+          artist: r.artist,
+          source_url: r.url ?? undefined,
+        })),
+      );
+      const merged = searchResults.map((r, i) => {
+        const enriched = results[i];
+        if (!enriched) return r;
+        return {
+          ...r,
+          bpm: r.bpm ?? enriched.bpm ?? null,
+          key: r.key ?? enriched.key ?? null,
+          genre: r.genre ?? enriched.genre ?? null,
+        };
+      });
+      setEnrichedResults(merged as SearchResult[]);
+    } catch {
+      // swallow — vibes still works with whatever bpm data is already on results
+    } finally {
+      setEnriching(false);
+    }
+  };
+
   const redirectToJoin = () => {
     sessionStorage.setItem(`wrzdj_live_splash_${code}`, '1');
     router.replace(`/join/${code}`);
@@ -192,7 +235,33 @@ export default function CollectPage() {
       if (timer) clearTimeout(timer);
       document.removeEventListener('visibilitychange', onVisibility);
     };
-  }, [code, tab, gateComplete]);  
+  }, [code, tab, gateComplete]);
+
+  const leaderboardAvgBpm = useMemo(() => {
+    const withBpm = (leaderboard?.requests ?? []).filter((r) => r.bpm != null);
+    return withBpm.length > 0
+      ? withBpm.reduce((s, r) => s + (r.bpm ?? 0), 0) / withBpm.length
+      : 128;
+  }, [leaderboard]);
+
+  const tierInfo: Record<string, { rail: string; label: string }> = {
+    perfect: { rail: '#00f0ff', label: 'IN THE POCKET' },
+    good:    { rail: '#ff2bd6', label: 'BLENDS WELL' },
+    ok:      { rail: 'rgba(255,255,255,0.4)', label: 'SLIGHT SHIFT' },
+    far:     { rail: 'rgba(255,255,255,0.2)', label: 'TEMPO JUMP' },
+  };
+
+  const vibeScored = useMemo(() => {
+    const base = enrichedResults.length > 0 ? enrichedResults : searchResults;
+    if (!base.length) return base;
+    return base.map((r) => {
+      const dBpm = Math.abs((r.bpm ?? leaderboardAvgBpm) - leaderboardAvgBpm);
+      const score = dBpm / 8;
+      const tier: 'perfect' | 'good' | 'ok' | 'far' =
+        score <= 1 ? 'perfect' : score <= 2.5 ? 'good' : score <= 4 ? 'ok' : 'far';
+      return { ...r, _score: score, _tier: tier };
+    }).sort((a, b) => sortByVibes ? (a._score ?? 0) - (b._score ?? 0) : 0);
+  }, [searchResults, enrichedResults, sortByVibes, leaderboardAvgBpm]);
 
   if (!gateComplete) {
     return <NicknameGate code={code} onComplete={handleGateComplete} />;
@@ -441,37 +510,109 @@ export default function CollectPage() {
               </form>
             </div>
 
-            {searchResults.length > 0 && (
+            {vibeScored.length > 0 && (
               <div style={{ flex: 1, overflowY: 'auto', padding: '0 18px 80px', position: 'relative', zIndex: 1 }}>
-                {searchResults.map((result, index) => (
+                {/* Results header with vibes toggle */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 0 10px' }}>
+                  <span style={{ fontSize: 10.9, fontFamily: 'var(--font-mono, monospace)', color: 'rgba(255,255,255,0.35)', letterSpacing: 1.5 }}>
+                    {searchResults.length} RESULTS
+                  </span>
+                  <div style={{ flex: 1 }} />
                   <button
                     type="button"
-                    key={result.spotify_id ?? result.url ?? index}
-                    disabled={submitting}
-                    onClick={() => handleSelectSong(result)}
-                    data-testid="collect-search-result"
+                    onClick={handleVibesToggle}
                     style={{
-                      width: '100%', textAlign: 'left', display: 'flex', alignItems: 'center', gap: 12,
-                      padding: '11px 12px', borderRadius: 12, marginBottom: 6,
-                      background: surface, border: `1px solid ${border}`,
-                      color: '#fff', cursor: 'pointer',
+                      display: 'flex', alignItems: 'center', gap: 7,
+                      padding: '6px 11px', borderRadius: 99,
+                      background: sortByVibes ? 'rgba(0,240,255,0.12)' : 'transparent',
+                      border: `1px solid ${sortByVibes ? accent : border}`,
+                      color: sortByVibes ? accent : subFg,
+                      fontFamily: 'var(--font-mono, monospace)', fontSize: 10.9, fontWeight: 700, letterSpacing: 1.2,
+                      cursor: 'pointer',
                     }}
                   >
-                    {result.album_art ? (
-                      <img
-                        src={result.album_art}
-                        alt={result.album ?? result.title}
-                        className="collect-row-art"
-                      />
-                    ) : (
-                      <div className="collect-row-art" aria-hidden="true" />
-                    )}
-                    <div className="collect-row-info">
-                      <div className="collect-row-title">{result.title}</div>
-                      <div className="collect-row-artist">{result.artist}</div>
-                    </div>
+                    {enriching
+                      ? <><span className="vbs-scan-icon">🔍</span> READING VIBES…</>
+                      : <><span style={{
+                          width: 6, height: 6, borderRadius: '50%', flexShrink: 0,
+                          background: sortByVibes ? accent : 'transparent',
+                          border: sortByVibes ? 'none' : `1px solid ${subFg}`,
+                          boxShadow: sortByVibes ? `0 0 6px ${accent}` : 'none',
+                          display: 'inline-block',
+                        }} /> HIGHLIGHT BY VIBES</>
+                    }
                   </button>
-                ))}
+                </div>
+
+                {/* Result rows */}
+                {vibeScored.map((result, index) => {
+                  const tier = sortByVibes ? (result as SearchResult & { _tier?: string })._tier : undefined;
+                  const tc = tier ? tierInfo[tier] : null;
+
+                  return (
+                    <button
+                      type="button"
+                      key={result.spotify_id ?? result.url ?? index}
+                      disabled={submitting}
+                      onClick={() => handleSelectSong(result)}
+                      data-testid="collect-search-result"
+                      className={enriching ? 'vbs-scanning' : ''}
+                      style={{
+                        width: '100%', textAlign: 'left', display: 'flex', alignItems: 'center', gap: 0,
+                        padding: 0, borderRadius: 12, marginBottom: 6,
+                        background: surface, border: `1px solid ${border}`,
+                        color: '#fff', cursor: 'pointer', overflow: 'hidden',
+                      }}
+                    >
+                      {sortByVibes && !enriching && tc && (
+                        <div style={{ width: 4, flexShrink: 0, background: tc.rail, alignSelf: 'stretch' }} />
+                      )}
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '11px 12px', flex: 1, minWidth: 0 }}>
+                        {result.album_art ? (
+                          <img
+                            src={result.album_art}
+                            alt={result.album ?? result.title}
+                            style={{ width: 44, height: 44, borderRadius: 8, objectFit: 'cover', flexShrink: 0 }}
+                          />
+                        ) : (
+                          <div style={{
+                            width: 44, height: 44, borderRadius: 8, flexShrink: 0,
+                            background: 'linear-gradient(135deg, #ff006e, #8338ec)',
+                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                            fontSize: 13.3, fontWeight: 800, color: '#fff',
+                          }}>
+                            {`${result.title[0] ?? '?'}${result.artist[0] ?? ''}`.toUpperCase()}
+                          </div>
+                        )}
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          <div style={{ fontSize: 16.9, fontWeight: 700, letterSpacing: -0.2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                            {result.title}
+                          </div>
+                          <div style={{ fontSize: 14.5, color: 'rgba(255,255,255,0.5)', marginTop: 2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                            {result.artist}
+                          </div>
+                          {enriching ? (
+                            <div className="vbs-analyzing" style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 9.7, color: 'rgba(0,240,255,0.6)', letterSpacing: 1, marginTop: 4 }}>
+                              ANALYZING…
+                            </div>
+                          ) : sortByVibes && tc ? (
+                            <div className="vbs-tier-in" style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 9.7, color: tc.rail, letterSpacing: 1.2, marginTop: 4, fontWeight: 700 }}>
+                              {tc.label}
+                            </div>
+                          ) : null}
+                        </div>
+                        <div style={{
+                          width: enriching ? 0 : 32, height: 32, borderRadius: '50%', flexShrink: 0,
+                          background: `conic-gradient(rgba(0,240,255,0.8) ${result.popularity}%, rgba(255,255,255,0.1) ${result.popularity}%)`,
+                          display: enriching ? 'none' : 'flex', alignItems: 'center', justifyContent: 'center',
+                          fontSize: 9.7, fontFamily: 'var(--font-mono, monospace)', fontWeight: 700, color: 'rgba(255,255,255,0.5)',
+                        }} title={`Popularity: ${result.popularity}%`}>
+                          {result.popularity}
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
               </div>
             )}
           </div>

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -7,6 +7,7 @@ import {
   ApiError,
   CollectEventPreview,
   CollectLeaderboardResponse,
+  CollectLeaderboardRow,
   CollectMyPicksResponse,
   SearchResult,
 } from '../../../lib/api';
@@ -15,6 +16,7 @@ import { IdentityBar } from '../../../components/IdentityBar';
 import { NicknameGate, GateResult } from '../../../components/NicknameGate';
 import EmailRecoveryButton from '../../../components/EmailRecoveryButton';
 import EmailRecoveryModal from '../../../components/EmailRecoveryModal';
+import CollectDetailSheet from './components/CollectDetailSheet';
 import LeaderboardTabs from './components/LeaderboardTabs';
 import MyPicksPanel from './components/MyPicksPanel';
 import SubmitBar from './components/SubmitBar';
@@ -54,6 +56,9 @@ export default function CollectPage() {
     setProfile({ submission_count: result.submissionCount, submission_cap: result.submissionCap });
     setGateComplete(true);
   };
+
+  const [detailRow, setDetailRow] = useState<CollectLeaderboardRow | null>(null);
+  const [detailVoted, setDetailVoted] = useState(false);
 
   // Search modal state
   const [searchOpen, setSearchOpen] = useState(false);
@@ -315,6 +320,7 @@ export default function CollectPage() {
             onTabChange={setTab}
             onVote={(id) => apiClient.voteCollectRequest(code, id)}
             votedIds={votedIds}
+            onRowClick={setDetailRow}
           />
         </section>
 
@@ -338,6 +344,22 @@ export default function CollectPage() {
           // cookie on the next apiClient.getCollectMyPicks() call.
         }}
       />
+
+      {detailRow && (
+        <CollectDetailSheet
+          row={detailRow}
+          rank={(leaderboard?.requests ?? []).findIndex((r) => r.id === detailRow.id) + 1 || 1}
+          totalCount={leaderboard?.requests.length ?? 0}
+          voted={detailVoted || votedIds.has(detailRow.id)}
+          onVote={async () => {
+            if (!detailVoted && !votedIds.has(detailRow.id)) {
+              setDetailVoted(true);
+              await apiClient.voteCollectRequest(code, detailRow.id);
+            }
+          }}
+          onClose={() => { setDetailRow(null); setDetailVoted(false); }}
+        />
+      )}
 
       {searchOpen && (
         <div

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -379,6 +379,7 @@ export default function CollectPage() {
 
         <EmailRecoveryButton
           reconcileHint={reconcileHint}
+          emailVerified={emailVerified}
           onOpen={() => setRecoveryOpen(true)}
         />
 

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -354,7 +354,11 @@ export default function CollectPage() {
           onVote={async () => {
             if (!detailVoted && !votedIds.has(detailRow.id)) {
               setDetailVoted(true);
-              await apiClient.voteCollectRequest(code, detailRow.id);
+              try {
+                await apiClient.voteCollectRequest(code, detailRow.id);
+              } catch {
+                setDetailVoted(false);
+              }
             }
           }}
           onClose={() => { setDetailRow(null); setDetailVoted(false); }}

--- a/dashboard/app/e/[code]/display/page.test.tsx
+++ b/dashboard/app/e/[code]/display/page.test.tsx
@@ -41,8 +41,8 @@ const mockKioskDisplay = {
   event: { code: 'TEST123', name: 'Test Event' },
   qr_join_url: 'https://example.com/join/TEST123',
   accepted_queue: [
-    { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0 },
-    { id: 2, title: 'Song 2', artist: 'Artist 2', artwork_url: null, nickname: null, vote_count: 0 },
+    { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
+    { id: 2, title: 'Song 2', artist: 'Artist 2', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
   ],
   now_playing: null,
   now_playing_hidden: false,
@@ -533,7 +533,7 @@ describe('KioskDisplayPage', () => {
       // Initial: 1 item
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
-        accepted_queue: [{ id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0 }],
+        accepted_queue: [{ id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null }],
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(null);
       vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
@@ -545,8 +545,8 @@ describe('KioskDisplayPage', () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
         accepted_queue: [
-          { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0 },
-          { id: 3, title: 'Song 3', artist: 'Artist 3', artwork_url: null, nickname: null, vote_count: 0 },
+          { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
+          { id: 3, title: 'Song 3', artist: 'Artist 3', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
         ],
       });
       await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
@@ -559,7 +559,7 @@ describe('KioskDisplayPage', () => {
       vi.useFakeTimers();
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
-        accepted_queue: [{ id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0 }],
+        accepted_queue: [{ id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null }],
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(null);
       vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
@@ -571,8 +571,8 @@ describe('KioskDisplayPage', () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
         accepted_queue: [
-          { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0 },
-          { id: 3, title: 'Song 3', artist: 'Artist 3', artwork_url: null, nickname: null, vote_count: 0 },
+          { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
+          { id: 3, title: 'Song 3', artist: 'Artist 3', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
         ],
       });
       await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
@@ -594,7 +594,7 @@ describe('KioskDisplayPage', () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
         accepted_queue: [
-          { id: 1, title: 'Popular Song', artist: 'Artist', artwork_url: null, nickname: null, vote_count: 5 },
+          { id: 1, title: 'Popular Song', artist: 'Artist', artwork_url: null, nickname: null, vote_count: 5, bpm: null, musical_key: null, genre: null },
         ],
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(null);
@@ -610,7 +610,7 @@ describe('KioskDisplayPage', () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
         accepted_queue: [
-          { id: 1, title: 'Song', artist: 'Artist', artwork_url: null, nickname: null, vote_count: 1 },
+          { id: 1, title: 'Song', artist: 'Artist', artwork_url: null, nickname: null, vote_count: 1, bpm: null, musical_key: null, genre: null },
         ],
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(null);
@@ -626,7 +626,7 @@ describe('KioskDisplayPage', () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
         accepted_queue: [
-          { id: 1, title: 'Song', artist: 'Artist', artwork_url: null, nickname: null, vote_count: 0 },
+          { id: 1, title: 'Song', artist: 'Artist', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
         ],
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(null);
@@ -836,7 +836,7 @@ describe('KioskDisplayPage', () => {
     it('shows request-based now_playing when no bridge now-playing', async () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
-        now_playing: { id: 1, title: 'Request Song', artist: 'Request Artist', artwork_url: null, nickname: null, vote_count: 0 },
+        now_playing: { id: 1, title: 'Request Song', artist: 'Request Artist', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(null);
       vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
@@ -852,7 +852,7 @@ describe('KioskDisplayPage', () => {
     it('hides now-playing when now_playing_hidden is true', async () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
-        now_playing: { id: 1, title: 'Hidden Song', artist: 'Hidden Artist', artwork_url: null, nickname: null, vote_count: 0 },
+        now_playing: { id: 1, title: 'Hidden Song', artist: 'Hidden Artist', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
         now_playing_hidden: true,
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(null);

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -2337,3 +2337,14 @@ h1, .display-heading {
   color: #000;
   box-shadow: 0 0 14px #00f0ff80;
 }
+
+/* CollectDetailSheet desktop dialog animations */
+@keyframes cds-backdrop-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes cds-card-in {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: none; }
+}

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -2348,3 +2348,55 @@ h1, .display-heading {
   from { opacity: 0; transform: translateY(16px); }
   to   { opacity: 1; transform: none; }
 }
+
+/* ── Vibes enrichment scanning animation ─────────────────────── */
+.vbs-scanning {
+  position: relative;
+  overflow: hidden;
+}
+.vbs-scanning::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  top: 0;
+  background: linear-gradient(90deg, transparent, rgba(0, 240, 255, 0.8), rgba(255, 43, 214, 0.8), transparent);
+  animation: vbs-scanline 0.9s linear infinite;
+  z-index: 10;
+  pointer-events: none;
+}
+
+@keyframes vbs-scanline {
+  0% { top: 0%; opacity: 1; }
+  90% { top: 100%; opacity: 1; }
+  100% { top: 100%; opacity: 0; }
+}
+
+.vbs-analyzing {
+  animation: vbs-blink 0.6s step-end infinite;
+}
+
+@keyframes vbs-blink {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
+.vbs-tier-in {
+  animation: vbs-tier-fade 300ms ease both;
+}
+
+@keyframes vbs-tier-fade {
+  from { opacity: 0; transform: translateY(3px); }
+  to { opacity: 1; transform: none; }
+}
+
+.vbs-scan-icon {
+  display: inline-block;
+  animation: vbs-bounce 0.7s ease-in-out infinite alternate;
+}
+
+@keyframes vbs-bounce {
+  from { transform: rotate(-10deg) scale(0.9); }
+  to { transform: rotate(10deg) scale(1.1); }
+}

--- a/dashboard/app/join/[code]/components/SongDetailSheet.tsx
+++ b/dashboard/app/join/[code]/components/SongDetailSheet.tsx
@@ -76,7 +76,7 @@ export default function SongDetailSheet({
       <div style={{ flex: 1, overflowY: 'auto', padding: '8px 18px 140px', position: 'relative', zIndex: 1 }}>
         {/* Artwork */}
         <div style={{
-          width: 160, height: 160, borderRadius: 22, marginTop: 6, margin: '6px auto 0',
+          width: 160, height: 160, borderRadius: 22, margin: '6px auto 0',
           background: track.artwork_url ? undefined : artGradient(track.title + track.artist),
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           overflow: 'hidden',

--- a/dashboard/app/join/[code]/components/SongDetailSheet.tsx
+++ b/dashboard/app/join/[code]/components/SongDetailSheet.tsx
@@ -76,11 +76,11 @@ export default function SongDetailSheet({
       <div style={{ flex: 1, overflowY: 'auto', padding: '8px 18px 140px', position: 'relative', zIndex: 1 }}>
         {/* Artwork */}
         <div style={{
-          width: '100%', aspectRatio: '1', borderRadius: 22, marginTop: 6,
+          width: 160, height: 160, borderRadius: 22, marginTop: 6, margin: '6px auto 0',
           background: track.artwork_url ? undefined : artGradient(track.title + track.artist),
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           overflow: 'hidden',
-          boxShadow: `0 30px 70px -20px ${ACCENT}70, 0 0 0 1px ${border}`,
+          boxShadow: `0 20px 50px -12px ${ACCENT}70, 0 0 0 1px ${border}`,
         }}>
           {track.artwork_url ? (
             <img
@@ -90,7 +90,7 @@ export default function SongDetailSheet({
             />
           ) : (
             <span style={{
-              fontSize: 77.4, fontWeight: 800, color: '#fff', letterSpacing: 1,
+              fontSize: 48, fontWeight: 800, color: '#fff', letterSpacing: 1,
               textShadow: '0 4px 30px rgba(0,0,0,0.3)',
             }}>
               {initials}
@@ -99,13 +99,37 @@ export default function SongDetailSheet({
         </div>
 
         {/* Title + artist */}
-        <div style={{ marginTop: 22 }}>
+        <div style={{ marginTop: 22, textAlign: 'center' }}>
           <div style={{ fontSize: 33.9, fontWeight: 800, letterSpacing: -0.8, lineHeight: 1.05 }}>
             {track.title}
           </div>
           <div style={{ fontSize: 20.6, color: subFg, marginTop: 5, fontWeight: 500 }}>
             {track.artist}
           </div>
+          {(track.bpm || track.musical_key) && (
+            <div style={{ display: 'flex', gap: 6, marginTop: 10, justifyContent: 'center', flexWrap: 'wrap' }}>
+              {track.bpm && (
+                <span style={{
+                  fontFamily: 'var(--font-mono, monospace)', fontSize: 10.9, fontWeight: 700,
+                  padding: '3px 9px', borderRadius: 6,
+                  background: `${ACCENT}18`, border: `1px solid ${ACCENT}50`, color: ACCENT,
+                  letterSpacing: 1,
+                }}>
+                  {track.bpm} BPM
+                </span>
+              )}
+              {track.musical_key && (
+                <span style={{
+                  fontFamily: 'var(--font-mono, monospace)', fontSize: 10.9, fontWeight: 700,
+                  padding: '3px 9px', borderRadius: 6,
+                  background: 'rgba(255,255,255,0.06)', border: `1px solid ${border}`,
+                  color: 'rgba(255,255,255,0.7)', letterSpacing: 1,
+                }}>
+                  {track.musical_key}
+                </span>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Stats */}

--- a/dashboard/app/join/[code]/page.tsx
+++ b/dashboard/app/join/[code]/page.tsx
@@ -523,6 +523,7 @@ export default function JoinEventPage() {
         <div style={{ padding: '0 16px 6px', position: 'relative', zIndex: 1 }}>
           <EmailRecoveryButton
             reconcileHint={reconcileHint}
+            emailVerified={emailVerified}
             onOpen={() => setRecoveryOpen(true)}
           />
         </div>

--- a/dashboard/components/EmailRecoveryButton.tsx
+++ b/dashboard/components/EmailRecoveryButton.tsx
@@ -3,9 +3,12 @@
 interface Props {
   reconcileHint: boolean
   onOpen: () => void
+  emailVerified?: boolean
 }
 
-export default function EmailRecoveryButton({ reconcileHint, onOpen }: Props) {
+export default function EmailRecoveryButton({ reconcileHint, onOpen, emailVerified }: Props) {
+  if (emailVerified) return null
+
   if (reconcileHint) {
     return (
       <div

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -1201,6 +1201,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/public/collect/{code}/enrich-preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enrich Preview
+         * @description Lightweight Beatport BPM/key lookup for search-time vibes — no DB writes.
+         */
+        post: operations["enrich_preview_api_public_collect__code__enrich_preview_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/public/collect/{code}/leaderboard": {
         parameters: {
             query?: never;
@@ -1227,10 +1247,8 @@ export interface paths {
         };
         /**
          * Get Profile
-         * @description Read the calling fingerprint's profile for this event. Does NOT
-         *     create a row if none exists — returns defaults instead. Separate from
-         *     POST /profile so reads and writes have different action tags in the
-         *     fingerprint log.
+         * @description Read the calling guest's profile for this event. Anonymous callers
+         *     (no cookie) get the default empty profile — there is no IP fallback.
          */
         get: operations["get_profile_api_public_collect__code__profile_get"];
         put?: never;
@@ -1472,6 +1490,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/public/guest/identify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Identify
+         * @description Resolve guest identity via cookie token and/or browser fingerprint.
+         */
+        post: operations["identify_api_public_guest_identify_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/public/guest/verify/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Confirm Code
+         * @description Confirm a verification code. May trigger guest merge.
+         */
+        post: operations["confirm_code_api_public_guest_verify_confirm_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/public/guest/verify/request": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Request Verification Code
+         * @description Send a verification code to the provided email.
+         */
+        post: operations["request_verification_code_api_public_guest_verify_request_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/public/kiosk/pair": {
         parameters: {
             query?: never;
@@ -1588,11 +1666,15 @@ export interface paths {
         /**
          * Vote For Request
          * @description Upvote a song request. Idempotent: voting twice has no effect.
+         *
+         *     Requires a guest cookie. Anonymous callers receive 401.
          */
         post: operations["vote_for_request_api_requests__request_id__vote_post"];
         /**
          * Unvote Request
          * @description Remove vote from a song request. Idempotent.
+         *
+         *     Requires a guest cookie. Anonymous callers receive 401.
          */
         delete: operations["unvote_request_api_requests__request_id__vote_delete"];
         options?: never;
@@ -2280,13 +2362,19 @@ export interface components {
             artist: string;
             /** Artwork Url */
             artwork_url: string | null;
+            /** Bpm */
+            bpm: number | null;
             /**
              * Created At
              * Format: date-time
              */
             created_at: string;
+            /** Genre */
+            genre: string | null;
             /** Id */
             id: number;
+            /** Musical Key */
+            musical_key: string | null;
             /** Nickname */
             nickname: string | null;
             /**
@@ -2305,11 +2393,15 @@ export interface components {
             artist: string;
             /** Artwork Url */
             artwork_url: string | null;
+            /** Bpm */
+            bpm: number | null;
             /**
              * Created At
              * Format: date-time
              */
             created_at: string;
+            /** Genre */
+            genre: string | null;
             /** Id */
             id: number;
             /**
@@ -2317,6 +2409,8 @@ export interface components {
              * @enum {string}
              */
             interaction: "submitted" | "upvoted";
+            /** Musical Key */
+            musical_key: string | null;
             /** Nickname */
             nickname: string | null;
             /**
@@ -2344,15 +2438,13 @@ export interface components {
         };
         /** CollectProfileRequest */
         CollectProfileRequest: {
-            /** Email */
-            email?: string | null;
             /** Nickname */
             nickname?: string | null;
         };
         /** CollectProfileResponse */
         CollectProfileResponse: {
-            /** Has Email */
-            has_email: boolean;
+            /** Email Verified */
+            email_verified: boolean;
             /** Nickname */
             nickname: string | null;
             /** Submission Cap */
@@ -2426,6 +2518,38 @@ export interface components {
             now_playing_hidden?: boolean | null;
             /** Requests Open */
             requests_open?: boolean | null;
+        };
+        /** EnrichPreviewItem */
+        EnrichPreviewItem: {
+            /** Artist */
+            artist: string;
+            /** Source Url */
+            source_url?: string | null;
+            /** Title */
+            title: string;
+        };
+        /** EnrichPreviewRequest */
+        EnrichPreviewRequest: {
+            /** Items */
+            items: components["schemas"]["EnrichPreviewItem"][];
+        };
+        /** EnrichPreviewResponse */
+        EnrichPreviewResponse: {
+            /** Results */
+            results: components["schemas"]["EnrichPreviewResult"][];
+        };
+        /** EnrichPreviewResult */
+        EnrichPreviewResult: {
+            /** Artist */
+            artist: string;
+            /** Bpm */
+            bpm: number | null;
+            /** Genre */
+            genre: string | null;
+            /** Key */
+            key: string | null;
+            /** Title */
+            title: string;
         };
         /** EventCreate */
         EventCreate: {
@@ -2554,8 +2678,14 @@ export interface components {
             artist: string;
             /** Artwork Url */
             artwork_url: string | null;
+            /** Bpm */
+            bpm: number | null;
+            /** Genre */
+            genre: string | null;
             /** Id */
             id: number;
+            /** Musical Key */
+            musical_key: string | null;
             /** Nickname */
             nickname: string | null;
             /**
@@ -2592,6 +2722,30 @@ export interface components {
         HelpPageSeenRequest: {
             /** Page */
             page: string;
+        };
+        /** IdentifyRequest */
+        IdentifyRequest: {
+            /** Fingerprint Components */
+            fingerprint_components?: {
+                [key: string]: unknown;
+            } | null;
+            /** Fingerprint Hash */
+            fingerprint_hash: string;
+        };
+        /** IdentifyResponse */
+        IdentifyResponse: {
+            /**
+             * Action
+             * @enum {string}
+             */
+            action: "create" | "cookie_hit" | "reconcile";
+            /** Guest Id */
+            guest_id: number;
+            /**
+             * Reconcile Hint
+             * @default false
+             */
+            reconcile_hint: boolean;
         };
         /**
          * IntegrationCheckResponse
@@ -2941,8 +3095,14 @@ export interface components {
             artist: string;
             /** Artwork Url */
             artwork_url: string | null;
+            /** Bpm */
+            bpm: number | null;
+            /** Genre */
+            genre: string | null;
             /** Id */
             id: number;
+            /** Musical Key */
+            musical_key: string | null;
             /** Nickname */
             nickname: string | null;
             /** Title */
@@ -3424,6 +3584,38 @@ export interface components {
             msg: string;
             /** Error Type */
             type: string;
+        };
+        /** VerifyConfirmResponse */
+        VerifyConfirmResponse: {
+            /** Guest Id */
+            guest_id: number;
+            /** Merged */
+            merged: boolean;
+            /** Verified */
+            verified: boolean;
+        };
+        /** VerifyConfirmSchema */
+        VerifyConfirmSchema: {
+            /** Code */
+            code: string;
+            /**
+             * Email
+             * Format: email
+             */
+            email: string;
+        };
+        /** VerifyRequestResponse */
+        VerifyRequestResponse: {
+            /** Sent */
+            sent: boolean;
+        };
+        /** VerifyRequestSchema */
+        VerifyRequestSchema: {
+            /**
+             * Email
+             * Format: email
+             */
+            email: string;
         };
         /** VoteResponse */
         VoteResponse: {
@@ -5651,6 +5843,41 @@ export interface operations {
             };
         };
     };
+    enrich_preview_api_public_collect__code__enrich_preview_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                code: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EnrichPreviewRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EnrichPreviewResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     leaderboard_api_public_collect__code__leaderboard_get: {
         parameters: {
             query?: {
@@ -6089,6 +6316,105 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    identify_api_public_guest_identify_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["IdentifyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IdentifyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    confirm_code_api_public_guest_verify_confirm_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["VerifyConfirmSchema"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VerifyConfirmResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    request_verification_code_api_public_guest_verify_request_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["VerifyRequestSchema"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VerifyRequestResponse"];
                 };
             };
             /** @description Validation Error */

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1116,16 +1116,19 @@ class ApiClient {
     }
   }
 
+  // Note: returns `key` (not `musical_key`) to match EnrichPreviewResult schema —
+  // callers merging results into SearchResult use `.key`; leaderboard fields use `.musical_key`.
   async enrichPreview(
     code: string,
     items: Array<{ title: string; artist: string; source_url?: string }>,
   ): Promise<Array<{ title: string; artist: string; bpm?: number | null; key?: string | null; genre?: string | null }>> {
     try {
       const res = await fetch(
-        `${getApiUrl()}/api/public/collect/${encodeURIComponent(code)}/enrich-preview`,
+        `${getApiUrl()}/api/public/collect/${code}/enrich-preview`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          // No credentials: endpoint is stateless (best-effort BPM lookup, no guest cookie needed)
           body: JSON.stringify({ items }),
         },
       );

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -122,6 +122,9 @@ export interface CollectLeaderboardRow {
   nickname: string | null;
   status: 'new' | 'accepted' | 'playing' | 'played' | 'rejected';
   created_at: string;
+  bpm?: number | null;
+  musical_key?: string | null;
+  genre?: string | null;
 }
 
 export interface CollectLeaderboardResponse {
@@ -1110,6 +1113,27 @@ class ApiClient {
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
       throw new ApiError(body.detail ?? `Vote failed: ${res.status}`, res.status);
+    }
+  }
+
+  async enrichPreview(
+    code: string,
+    items: Array<{ title: string; artist: string; source_url?: string }>,
+  ): Promise<Array<{ title: string; artist: string; bpm?: number | null; key?: string | null; genre?: string | null }>> {
+    try {
+      const res = await fetch(
+        `${getApiUrl()}/api/public/collect/${encodeURIComponent(code)}/enrich-preview`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ items }),
+        },
+      );
+      if (!res.ok) return items.map((i) => ({ title: i.title, artist: i.artist }));
+      const data = await res.json();
+      return data.results ?? [];
+    } catch {
+      return items.map((i) => ({ title: i.title, artist: i.artist }));
     }
   }
 

--- a/docs/superpowers/plans/2026-04-30-song-detail-vibes-enrichment.md
+++ b/docs/superpowers/plans/2026-04-30-song-detail-vibes-enrichment.md
@@ -1,0 +1,1806 @@
+# Song Detail Panels, Vibes Enrichment & Collect UX — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix oversized artwork on the join detail sheet, add a tappable detail panel to the collect leaderboard (responsive: bottom sheet on mobile, centered dialog on desktop), expose enrichment fields (BPM/key/genre) in both public API responses, trigger enrichment on collect submissions, and add the "Highlight by Vibes" toggle with a scanline loading animation to collect search.
+
+**Architecture:** Backend schema changes expose existing DB columns (`bpm`, `musical_key`, `genre`) through `PublicRequestInfo` and `CollectLeaderboardRow` without migrations. A new public `enrich-preview` endpoint calls Beatport fuzzy search on-demand for search-time vibes. Frontend adds a new `CollectDetailSheet` component and ports the vibes toggle from the join page.
+
+**Tech Stack:** Python/FastAPI (Pydantic schemas, BackgroundTasks), SQLAlchemy, pytest; Next.js 16/React 19, TypeScript, vanilla CSS; openapi-typescript type generation.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-song-detail-vibes-enrichment-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `server/app/api/public.py` | Modify | Add `bpm`/`musical_key`/`genre` to `PublicRequestInfo`; populate in `get_public_requests` |
+| `server/app/schemas/collect.py` | Modify | Add same 3 fields to `CollectLeaderboardRow`; add `EnrichPreviewItem/Result/Request/Response` schemas |
+| `server/app/api/collect.py` | Modify | Populate fields in leaderboard; add `BackgroundTasks` to submit; add `enrich-preview` route |
+| `server/tests/test_public.py` | Modify | Test BPM/key/genre in public request list response |
+| `server/tests/test_collect_public.py` | Modify | Test leaderboard fields, enrichment trigger, enrich-preview endpoint |
+| `dashboard/lib/api.ts` | Modify | Add 3 fields to `CollectLeaderboardRow` interface; add `enrichPreview()` method |
+| `dashboard/app/join/[code]/components/SongDetailSheet.tsx` | Modify | Cap artwork at 160px; add BPM/key pills |
+| `dashboard/app/collect/[code]/components/CollectDetailSheet.tsx` | **Create** | Responsive detail panel (mobile sheet / desktop dialog) |
+| `dashboard/app/collect/[code]/components/LeaderboardTabs.tsx` | Modify | Add `onRowClick` prop; wire row clicks; stop-propagation on vote button |
+| `dashboard/app/collect/[code]/page.tsx` | Modify | Wire `CollectDetailSheet`; add vibes state + toggle + `enrichPreview` call |
+| `dashboard/app/globals.css` | Modify | Add `.vbs-scanning`, `.vbs-analyzing`, `.vbs-tier-in` CSS + keyframes |
+
+---
+
+## Task 1: Expose enrichment fields in PublicRequestInfo
+
+**Files:**
+- Modify: `server/app/api/public.py`
+- Test: `server/tests/test_public.py`
+
+- [ ] **Step 1: Write the failing test**
+
+In `server/tests/test_public.py`, add after the existing `TestMyRequests` class:
+
+```python
+class TestPublicRequestsEnrichmentFields:
+    """bpm/musical_key/genre are exposed in /events/{code}/requests response."""
+
+    def test_enrichment_fields_present_when_set(
+        self, client: TestClient, test_event: Event, db: Session
+    ):
+        from app.models.request import Request, RequestStatus
+
+        req = Request(
+            event_id=test_event.id,
+            song_title="Levels",
+            artist="Avicii",
+            source="beatport",
+            status=RequestStatus.NEW.value,
+            dedupe_key="levels_avicii_001",
+            bpm=128.0,
+            musical_key="8A",
+            genre="Progressive House",
+        )
+        db.add(req)
+        db.commit()
+
+        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        assert response.status_code == 200
+        requests = response.json()["requests"]
+        assert len(requests) == 1
+        assert requests[0]["bpm"] == 128
+        assert requests[0]["musical_key"] == "8A"
+        assert requests[0]["genre"] == "Progressive House"
+
+    def test_enrichment_fields_null_when_not_set(
+        self, client: TestClient, test_event: Event, db: Session
+    ):
+        from app.models.request import Request, RequestStatus
+
+        req = Request(
+            event_id=test_event.id,
+            song_title="Unknown",
+            artist="Someone",
+            source="spotify",
+            status=RequestStatus.NEW.value,
+            dedupe_key="unknown_someone_001",
+        )
+        db.add(req)
+        db.commit()
+
+        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        assert response.status_code == 200
+        requests = response.json()["requests"]
+        assert len(requests) == 1
+        assert requests[0]["bpm"] is None
+        assert requests[0]["musical_key"] is None
+        assert requests[0]["genre"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd server && .venv/bin/pytest tests/test_public.py::TestPublicRequestsEnrichmentFields -v
+```
+
+Expected: FAIL — `KeyError: 'bpm'` or assertion on missing field.
+
+- [ ] **Step 3: Add fields to PublicRequestInfo**
+
+In `server/app/api/public.py`, replace the `PublicRequestInfo` class:
+
+```python
+class PublicRequestInfo(BaseModel):
+    id: int
+    title: str
+    artist: str
+    artwork_url: str | None
+    nickname: str | None = None
+    vote_count: int = 0
+    bpm: int | None = None
+    musical_key: str | None = None
+    genre: str | None = None
+```
+
+- [ ] **Step 4: Populate fields in get_public_requests**
+
+In `server/app/api/public.py`, find the `get_public_requests` endpoint. Replace the `GuestRequestInfo(...)` constructor call in the list comprehension:
+
+```python
+return GuestRequestListResponse(
+    event=PublicEventInfo(code=event.code, name=event.name),
+    requests=[
+        GuestRequestInfo(
+            id=r.id,
+            title=r.song_title,
+            artist=r.artist,
+            artwork_url=r.artwork_url,
+            nickname=r.nickname,
+            vote_count=r.vote_count,
+            status=r.status,
+            bpm=int(r.bpm) if r.bpm is not None else None,
+            musical_key=r.musical_key,
+            genre=r.genre,
+        )
+        for r in requests_list
+    ],
+    now_playing=guest_now_playing,
+)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cd server && .venv/bin/pytest tests/test_public.py::TestPublicRequestsEnrichmentFields -v
+```
+
+Expected: PASS (both tests green).
+
+- [ ] **Step 6: Run the full public test suite**
+
+```bash
+cd server && .venv/bin/pytest tests/test_public.py -v
+```
+
+Expected: all existing tests still PASS.
+
+- [ ] **Step 7: Lint + format**
+
+```bash
+cd server && .venv/bin/ruff check app/api/public.py && .venv/bin/ruff format app/api/public.py
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git checkout -b feat/song-detail-vibes-enrichment
+git add server/app/api/public.py server/tests/test_public.py
+git commit -m "feat(api): expose bpm/musical_key/genre in PublicRequestInfo"
+```
+
+---
+
+## Task 2: Expose enrichment fields in CollectLeaderboardRow
+
+**Files:**
+- Modify: `server/app/schemas/collect.py`
+- Modify: `server/app/api/collect.py`
+- Test: `server/tests/test_collect_public.py`
+
+- [ ] **Step 1: Write the failing test**
+
+In `server/tests/test_collect_public.py`, add after the existing leaderboard tests:
+
+```python
+def test_leaderboard_row_includes_enrichment_fields(client, db, test_event: Event):
+    """Leaderboard rows expose bpm/musical_key/genre when set on the request."""
+    from app.models.request import Request, RequestStatus
+
+    _enable_collection(db, test_event)
+    req = Request(
+        event_id=test_event.id,
+        song_title="Levels",
+        artist="Avicii",
+        source="beatport",
+        status=RequestStatus.NEW.value,
+        vote_count=3,
+        dedupe_key="levels_avicii_enriched",
+        submitted_during_collection=True,
+        bpm=128.0,
+        musical_key="8A",
+        genre="Progressive House",
+    )
+    db.add(req)
+    db.commit()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all")
+    assert r.status_code == 200
+    rows = r.json()["requests"]
+    assert len(rows) == 1
+    assert rows[0]["bpm"] == 128
+    assert rows[0]["musical_key"] == "8A"
+    assert rows[0]["genre"] == "Progressive House"
+
+
+def test_leaderboard_row_enrichment_fields_null_when_missing(client, db, test_event: Event):
+    from app.models.request import Request, RequestStatus
+
+    _enable_collection(db, test_event)
+    req = Request(
+        event_id=test_event.id,
+        song_title="Unknown",
+        artist="Someone",
+        source="spotify",
+        status=RequestStatus.NEW.value,
+        dedupe_key="unknown_someone_collect",
+        submitted_during_collection=True,
+    )
+    db.add(req)
+    db.commit()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all")
+    assert r.status_code == 200
+    rows = r.json()["requests"]
+    assert len(rows) == 1
+    assert rows[0]["bpm"] is None
+    assert rows[0]["musical_key"] is None
+    assert rows[0]["genre"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd server && .venv/bin/pytest tests/test_collect_public.py::test_leaderboard_row_includes_enrichment_fields tests/test_collect_public.py::test_leaderboard_row_enrichment_fields_null_when_missing -v
+```
+
+Expected: FAIL — field missing from response.
+
+- [ ] **Step 3: Add fields to CollectLeaderboardRow schema**
+
+In `server/app/schemas/collect.py`, replace `CollectLeaderboardRow`:
+
+```python
+class CollectLeaderboardRow(BaseModel):
+    id: int
+    title: str
+    artist: str
+    artwork_url: str | None
+    vote_count: int
+    nickname: str | None
+    status: Literal["new", "accepted", "playing", "played", "rejected"]
+    created_at: datetime
+    bpm: int | None = None
+    musical_key: str | None = None
+    genre: str | None = None
+```
+
+- [ ] **Step 4: Populate fields in the leaderboard endpoint**
+
+In `server/app/api/collect.py`, find the `leaderboard` endpoint's `CollectLeaderboardRow(...)` constructor call and add the three fields:
+
+```python
+return CollectLeaderboardResponse(
+    requests=[
+        CollectLeaderboardRow(
+            id=r.id,
+            title=r.song_title,
+            artist=r.artist,
+            artwork_url=r.artwork_url,
+            vote_count=r.vote_count,
+            nickname=r.nickname,
+            status=r.status,
+            created_at=r.created_at,
+            bpm=int(r.bpm) if r.bpm is not None else None,
+            musical_key=r.musical_key,
+            genre=r.genre,
+        )
+        for r in rows
+    ],
+    total=len(rows),
+)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cd server && .venv/bin/pytest tests/test_collect_public.py::test_leaderboard_row_includes_enrichment_fields tests/test_collect_public.py::test_leaderboard_row_enrichment_fields_null_when_missing -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full collect public test suite**
+
+```bash
+cd server && .venv/bin/pytest tests/test_collect_public.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Lint + format**
+
+```bash
+cd server && .venv/bin/ruff check app/schemas/collect.py app/api/collect.py && .venv/bin/ruff format app/schemas/collect.py app/api/collect.py
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/app/schemas/collect.py server/app/api/collect.py server/tests/test_collect_public.py
+git commit -m "feat(collect): expose bpm/musical_key/genre in leaderboard response"
+```
+
+---
+
+## Task 3: Trigger enrichment on collect submit
+
+**Files:**
+- Modify: `server/app/api/collect.py`
+- Test: `server/tests/test_collect_public.py`
+
+- [ ] **Step 1: Write the failing test**
+
+In `server/tests/test_collect_public.py`, add:
+
+```python
+def test_collect_submit_triggers_enrichment(client, db, test_event: Event):
+    """Submitting a pick fires enrich_request_metadata as a background task."""
+    from unittest.mock import patch
+
+    _enable_collection(db, test_event)
+
+    with patch("app.api.collect.enrich_request_metadata") as mock_enrich:
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/requests",
+            json={
+                "song_title": "Levels",
+                "artist": "Avicii",
+                "source": "spotify",
+            },
+        )
+
+    assert r.status_code == 201
+    assert r.json()["is_duplicate"] is False
+    mock_enrich.assert_called_once()
+    _, request_id = mock_enrich.call_args[0]
+    assert isinstance(request_id, int)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd server && .venv/bin/pytest tests/test_collect_public.py::test_collect_submit_triggers_enrichment -v
+```
+
+Expected: FAIL — `mock_enrich.assert_called_once()` fails (not called).
+
+- [ ] **Step 3: Add BackgroundTasks + enrichment to submit endpoint**
+
+In `server/app/api/collect.py`:
+
+Add to the top-level imports at the top of the file:
+```python
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+```
+(Replace the existing `from fastapi import APIRouter, Depends, HTTPException, Request` line.)
+
+Add the enrichment import after the existing service imports:
+```python
+from app.services.sync.enrichment_pipeline import enrich_request_metadata
+```
+
+Find the `submit` function signature and add `background_tasks: BackgroundTasks`:
+```python
+@router.post("/{code}/requests", status_code=201)
+@limiter.limit("10/minute")
+def submit(
+    code: str,
+    payload: CollectSubmitRequest,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+):
+```
+
+After `db.refresh(row)` (line ~375), add:
+```python
+    background_tasks.add_task(enrich_request_metadata, db, row.id)
+```
+
+The full block after commit should look like:
+```python
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    background_tasks.add_task(enrich_request_metadata, db, row.id)
+    log_activity(
+        ...
+    )
+    return {"id": row.id, "is_duplicate": False}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd server && .venv/bin/pytest tests/test_collect_public.py::test_collect_submit_triggers_enrichment -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full collect test suite to check no regressions**
+
+```bash
+cd server && .venv/bin/pytest tests/test_collect_public.py tests/test_collect_service.py tests/test_collect_dj.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Lint + format**
+
+```bash
+cd server && .venv/bin/ruff check app/api/collect.py && .venv/bin/ruff format app/api/collect.py
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/app/api/collect.py server/tests/test_collect_public.py
+git commit -m "feat(collect): trigger enrichment background task on pick submit"
+```
+
+---
+
+## Task 4: Add enrich-preview endpoint
+
+**Files:**
+- Modify: `server/app/schemas/collect.py`
+- Modify: `server/app/api/collect.py`
+- Test: `server/tests/test_collect_public.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `server/tests/test_collect_public.py`, add:
+
+```python
+def test_enrich_preview_returns_nulls_without_beatport_token(client, db, test_event: Event):
+    """When the DJ has no Beatport token, all results have null bpm/key/genre."""
+    _enable_collection(db, test_event)
+    # Ensure no beatport token on the DJ user
+    dj = test_event.created_by
+    dj.beatport_access_token = None
+    db.commit()
+
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/enrich-preview",
+        json={"items": [{"title": "Levels", "artist": "Avicii"}]},
+    )
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert len(results) == 1
+    assert results[0]["title"] == "Levels"
+    assert results[0]["artist"] == "Avicii"
+    assert results[0]["bpm"] is None
+    assert results[0]["key"] is None
+    assert results[0]["genre"] is None
+
+
+def test_enrich_preview_returns_bpm_from_beatport(client, db, test_event: Event):
+    """When Beatport search returns a match, bpm/key/genre are populated."""
+    from unittest.mock import MagicMock, patch
+
+    _enable_collection(db, test_event)
+
+    dj = test_event.created_by
+    dj.beatport_access_token = "fake_token"  # nosec B106
+    db.commit()
+
+    mock_match = MagicMock()
+    mock_match.title = "Levels"
+    mock_match.artist = "Avicii"
+    mock_match.bpm = 128
+    mock_match.key = "8A"
+    mock_match.genre = "Progressive House"
+    mock_match.mix_name = "Original Mix"
+
+    with patch("app.api.collect.search_beatport_tracks", return_value=[mock_match]), \
+         patch("app.api.collect._find_best_match", return_value=mock_match):
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/enrich-preview",
+            json={"items": [{"title": "Levels", "artist": "Avicii"}]},
+        )
+
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert len(results) == 1
+    assert results[0]["bpm"] == 128
+    assert results[0]["key"] == "8A"
+    assert results[0]["genre"] == "Progressive House"
+
+
+def test_enrich_preview_caps_at_10_items(client, db, test_event: Event):
+    """Requests with >10 items are silently capped — only first 10 processed."""
+    _enable_collection(db, test_event)
+    dj = test_event.created_by
+    dj.beatport_access_token = None
+    db.commit()
+
+    items = [{"title": f"Song {i}", "artist": f"Artist {i}"} for i in range(15)]
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/enrich-preview",
+        json={"items": items},
+    )
+    assert r.status_code == 200
+    assert len(r.json()["results"]) == 10
+
+
+def test_enrich_preview_404_for_unknown_event(client):
+    r = client.post(
+        "/api/public/collect/ZZZZZZ/enrich-preview",
+        json={"items": [{"title": "X", "artist": "Y"}]},
+    )
+    assert r.status_code == 404
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd server && .venv/bin/pytest tests/test_collect_public.py::test_enrich_preview_returns_nulls_without_beatport_token tests/test_collect_public.py::test_enrich_preview_returns_bpm_from_beatport tests/test_collect_public.py::test_enrich_preview_caps_at_10_items tests/test_collect_public.py::test_enrich_preview_404_for_unknown_event -v
+```
+
+Expected: FAIL — 404 (route not found).
+
+- [ ] **Step 3: Add Pydantic schemas**
+
+In `server/app/schemas/collect.py`, add at the bottom:
+
+```python
+class EnrichPreviewItem(BaseModel):
+    title: str
+    artist: str
+    source_url: str | None = None
+
+
+class EnrichPreviewResult(BaseModel):
+    title: str
+    artist: str
+    bpm: int | None = None
+    key: str | None = None
+    genre: str | None = None
+
+
+class EnrichPreviewRequest(BaseModel):
+    items: list[EnrichPreviewItem]
+
+
+class EnrichPreviewResponse(BaseModel):
+    results: list[EnrichPreviewResult]
+```
+
+- [ ] **Step 4: Add imports to collect.py**
+
+In `server/app/api/collect.py`, replace the existing schema import block with:
+
+```python
+from app.schemas.collect import (
+    CollectLeaderboardResponse,
+    CollectLeaderboardRow,
+    CollectMyPicksItem,
+    CollectMyPicksResponse,
+    CollectProfileRequest,
+    CollectProfileResponse,
+    CollectSubmitRequest,
+    CollectVoteRequest,
+    EnrichPreviewRequest,
+    EnrichPreviewResponse,
+    EnrichPreviewResult,
+)
+```
+
+Also add these service imports after the existing service imports:
+
+```python
+from app.services.beatport import search_beatport_tracks
+from app.services.sync.enrichment_pipeline import _find_best_match
+```
+
+If a circular import occurs (unlikely given the existing import structure), move them into the function body instead.
+
+- [ ] **Step 5: Add the enrich-preview route**
+
+In `server/app/api/collect.py`, add at the end of the file (after the `vote` endpoint):
+
+```python
+@router.post("/{code}/enrich-preview", response_model=EnrichPreviewResponse)
+@limiter.limit("10/minute")
+def enrich_preview(
+    code: str,
+    payload: EnrichPreviewRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> EnrichPreviewResponse:
+    """Lightweight Beatport BPM/key lookup for search-time vibes — no DB writes."""
+    event = _get_event_or_404(db, code)
+    user = event.created_by
+    items = payload.items[:10]
+    results: list[EnrichPreviewResult] = []
+
+    for item in items:
+        bpm = None
+        key = None
+        genre = None
+
+        if user and user.beatport_access_token:
+            try:
+                matches = search_beatport_tracks(db, user, f"{item.artist} {item.title}", limit=5)
+                if matches:
+                    best = _find_best_match(matches, item.title, item.artist)
+                    if best:
+                        bpm = int(best.bpm) if best.bpm is not None else None
+                        key = best.key or None
+                        genre = best.genre or None
+            except Exception:
+                pass  # nosec B110 — best-effort, callers handle null fields
+
+        results.append(EnrichPreviewResult(
+            title=item.title,
+            artist=item.artist,
+            bpm=bpm,
+            key=key,
+            genre=genre,
+        ))
+
+    return EnrichPreviewResponse(results=results)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+cd server && .venv/bin/pytest tests/test_collect_public.py::test_enrich_preview_returns_nulls_without_beatport_token tests/test_collect_public.py::test_enrich_preview_returns_bpm_from_beatport tests/test_collect_public.py::test_enrich_preview_caps_at_10_items tests/test_collect_public.py::test_enrich_preview_404_for_unknown_event -v
+```
+
+Expected: all 4 PASS.
+
+- [ ] **Step 7: Run full backend test suite**
+
+```bash
+cd server && .venv/bin/pytest --tb=short -q
+```
+
+Expected: all PASS, coverage ≥ 70%.
+
+- [ ] **Step 8: Security scan**
+
+```bash
+cd server && .venv/bin/bandit -r app -c pyproject.toml -q
+```
+
+Expected: no new HIGH/MEDIUM issues. The `# nosec B110` in the endpoint suppresses the intentional `except/pass`.
+
+- [ ] **Step 9: Lint + format**
+
+```bash
+cd server && .venv/bin/ruff check app/schemas/collect.py app/api/collect.py && .venv/bin/ruff format app/schemas/collect.py app/api/collect.py
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add server/app/schemas/collect.py server/app/api/collect.py server/tests/test_collect_public.py
+git commit -m "feat(collect): add enrich-preview endpoint for search-time vibes BPM lookup"
+```
+
+---
+
+## Task 5: Regenerate frontend types + update CollectLeaderboardRow
+
+**Files:**
+- Modify (generated): `dashboard/lib/api-types.generated.ts`
+- Modify: `dashboard/lib/api.ts`
+
+- [ ] **Step 1: Export the updated OpenAPI schema**
+
+```bash
+cd server && .venv/bin/python scripts/export_openapi.py
+```
+
+This writes `server/openapi.json` reflecting the new `bpm`/`musical_key`/`genre` fields on `PublicRequestInfo` and `GuestRequestInfo`.
+
+- [ ] **Step 2: Regenerate TypeScript types**
+
+```bash
+cd dashboard && npm run types:generate
+```
+
+Expected: `dashboard/lib/api-types.generated.ts` updated. `GuestRequestInfo` in the generated file now includes `bpm`, `musical_key`, `genre` as optional nullable fields.
+
+- [ ] **Step 3: Verify generated type includes new fields**
+
+```bash
+grep -A 5 "GuestRequestInfo" dashboard/lib/api-types.generated.ts | head -20
+```
+
+Expected output includes lines like:
+```
+bpm?: number | null;
+musical_key?: string | null;
+genre?: string | null;
+```
+
+- [ ] **Step 4: Add fields to the manual CollectLeaderboardRow interface**
+
+In `dashboard/lib/api.ts`, find the `CollectLeaderboardRow` interface at line ~116 and replace it:
+
+```typescript
+export interface CollectLeaderboardRow {
+  id: number;
+  title: string;
+  artist: string;
+  artwork_url: string | null;
+  vote_count: number;
+  nickname: string | null;
+  status: 'new' | 'accepted' | 'playing' | 'played' | 'rejected';
+  created_at: string;
+  bpm?: number | null;
+  musical_key?: string | null;
+  genre?: string | null;
+}
+```
+
+- [ ] **Step 5: Add enrichPreview method to ApiClient**
+
+In `dashboard/lib/api.ts`, add this method to the `ApiClient` class (near other public collect methods):
+
+```typescript
+async enrichPreview(
+  code: string,
+  items: Array<{ title: string; artist: string; source_url?: string }>,
+): Promise<Array<{ title: string; artist: string; bpm?: number | null; key?: string | null; genre?: string | null }>> {
+  try {
+    const res = await fetch(
+      `${this.baseUrl}/api/public/collect/${encodeURIComponent(code)}/enrich-preview`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items }),
+      },
+    );
+    if (!res.ok) return items.map((i) => ({ title: i.title, artist: i.artist }));
+    const data = await res.json();
+    return data.results ?? [];
+  } catch {
+    return items.map((i) => ({ title: i.title, artist: i.artist }));
+  }
+}
+```
+
+- [ ] **Step 6: TypeScript check**
+
+```bash
+cd dashboard && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/lib/api-types.generated.ts dashboard/lib/api.ts server/openapi.json
+git commit -m "feat(types): regenerate frontend types with bpm/musical_key/genre; add enrichPreview method"
+```
+
+---
+
+## Task 6: Fix SongDetailSheet — artwork size + BPM/key pills
+
+**Files:**
+- Modify: `dashboard/app/join/[code]/components/SongDetailSheet.tsx`
+
+- [ ] **Step 1: Run existing join page tests to confirm current baseline**
+
+```bash
+cd dashboard && npm test -- --run app/join
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Fix artwork size**
+
+In `dashboard/app/join/[code]/components/SongDetailSheet.tsx`, find the artwork `<div>` starting at line ~78. Replace:
+
+```tsx
+        {/* Artwork */}
+        <div style={{
+          width: '100%', aspectRatio: '1', borderRadius: 22, marginTop: 6,
+          background: track.artwork_url ? undefined : artGradient(track.title + track.artist),
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          overflow: 'hidden',
+          boxShadow: `0 30px 70px -20px ${ACCENT}70, 0 0 0 1px ${border}`,
+        }}>
+```
+
+With:
+
+```tsx
+        {/* Artwork */}
+        <div style={{
+          width: 160, height: 160, borderRadius: 22, marginTop: 6, margin: '6px auto 0',
+          background: track.artwork_url ? undefined : artGradient(track.title + track.artist),
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          overflow: 'hidden',
+          boxShadow: `0 20px 50px -12px ${ACCENT}70, 0 0 0 1px ${border}`,
+        }}>
+```
+
+Also update the initials font size inside this div (it was sized for full-width art):
+
+```tsx
+            <span style={{
+              fontSize: 48, fontWeight: 800, color: '#fff', letterSpacing: 1,
+              textShadow: '0 4px 30px rgba(0,0,0,0.3)',
+            }}>
+```
+
+(was `fontSize: 77.4`)
+
+- [ ] **Step 3: Add BPM/key pills below artist name**
+
+In `SongDetailSheet.tsx`, find the title + artist block (starting around line ~101). After the artist `<div>`, add the pills row:
+
+```tsx
+        {/* Title + artist */}
+        <div style={{ marginTop: 22, textAlign: 'center' }}>
+          <div style={{ fontSize: 33.9, fontWeight: 800, letterSpacing: -0.8, lineHeight: 1.05 }}>
+            {track.title}
+          </div>
+          <div style={{ fontSize: 20.6, color: subFg, marginTop: 5, fontWeight: 500 }}>
+            {track.artist}
+          </div>
+          {(track.bpm || track.musical_key) && (
+            <div style={{ display: 'flex', gap: 6, marginTop: 10, justifyContent: 'center', flexWrap: 'wrap' }}>
+              {track.bpm && (
+                <span style={{
+                  fontFamily: 'var(--font-mono, monospace)', fontSize: 10.9, fontWeight: 700,
+                  padding: '3px 9px', borderRadius: 6,
+                  background: `${ACCENT}18`, border: `1px solid ${ACCENT}50`, color: ACCENT,
+                  letterSpacing: 1,
+                }}>
+                  {track.bpm} BPM
+                </span>
+              )}
+              {track.musical_key && (
+                <span style={{
+                  fontFamily: 'var(--font-mono, monospace)', fontSize: 10.9, fontWeight: 700,
+                  padding: '3px 9px', borderRadius: 6,
+                  background: 'rgba(255,255,255,0.06)', border: `1px solid ${border}`,
+                  color: 'rgba(255,255,255,0.7)', letterSpacing: 1,
+                }}>
+                  {track.musical_key}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+```
+
+Note: also add `textAlign: 'center'` to the outer title div (as shown above).
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+cd dashboard && npx tsc --noEmit
+```
+
+Expected: no errors. (`track.bpm` and `track.musical_key` are now on the generated `GuestRequestInfo` type.)
+
+- [ ] **Step 5: Run join tests**
+
+```bash
+cd dashboard && npm test -- --run app/join
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/app/join/[code]/components/SongDetailSheet.tsx
+git commit -m "fix(join): cap SongDetailSheet artwork at 160px and add BPM/key pills"
+```
+
+---
+
+## Task 7: New CollectDetailSheet component
+
+**Files:**
+- Create: `dashboard/app/collect/[code]/components/CollectDetailSheet.tsx`
+
+- [ ] **Step 1: Create the component file**
+
+Create `dashboard/app/collect/[code]/components/CollectDetailSheet.tsx`:
+
+```tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { CollectLeaderboardRow } from '@/lib/api';
+
+interface Props {
+  row: CollectLeaderboardRow;
+  rank: number;
+  totalCount: number;
+  voted: boolean;
+  onVote: () => void;
+  onClose: () => void;
+}
+
+const ACCENT = '#00f0ff';
+const ACCENT2 = '#ff2bd6';
+
+const GRADIENTS = [
+  'linear-gradient(135deg, #ff006e, #8338ec, #3a86ff)',
+  'linear-gradient(135deg, #ffbe0b, #fb5607)',
+  'linear-gradient(135deg, #06ffa5, #0077b6)',
+  'linear-gradient(135deg, #ff6b9d, #c44569)',
+  'linear-gradient(135deg, #f72585, #7209b7)',
+  'linear-gradient(135deg, #4cc9f0, #4361ee)',
+  'linear-gradient(135deg, #f15bb5, #fee440)',
+  'linear-gradient(135deg, #2dc653, #25a244)',
+  'linear-gradient(135deg, #ef476f, #ffd166)',
+];
+function artGradient(seed: string) {
+  const code = (seed.charCodeAt(0) || 0) + (seed.charCodeAt(1) || 0);
+  return GRADIENTS[code % GRADIENTS.length];
+}
+
+export default function CollectDetailSheet({
+  row, rank, totalCount, voted, onVote, onClose,
+}: Props) {
+  const [isWide, setIsWide] = useState(false);
+
+  useEffect(() => {
+    const check = () => setIsWide(window.innerWidth >= 640);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
+  const surface = 'rgba(255,255,255,0.05)';
+  const border = 'rgba(255,255,255,0.1)';
+  const subFg = 'rgba(255,255,255,0.55)';
+  const subFg2 = 'rgba(255,255,255,0.35)';
+  const initials = `${row.title[0] ?? '?'}${row.artist[0] ?? ''}`.toUpperCase();
+
+  const pills = (row.bpm || row.musical_key) ? (
+    <div style={{ display: 'flex', gap: 6, marginTop: 8, flexWrap: 'wrap' }}>
+      {row.bpm && (
+        <span style={{
+          fontFamily: 'var(--font-mono, monospace)', fontSize: 10.3, fontWeight: 700,
+          padding: '3px 9px', borderRadius: 6,
+          background: `${ACCENT}18`, border: `1px solid ${ACCENT}50`, color: ACCENT,
+          letterSpacing: 1,
+        }}>
+          {row.bpm} BPM
+        </span>
+      )}
+      {row.musical_key && (
+        <span style={{
+          fontFamily: 'var(--font-mono, monospace)', fontSize: 10.3, fontWeight: 700,
+          padding: '3px 9px', borderRadius: 6,
+          background: 'rgba(255,255,255,0.06)', border: `1px solid ${border}`,
+          color: 'rgba(255,255,255,0.7)', letterSpacing: 1,
+        }}>
+          {row.musical_key}
+        </span>
+      )}
+    </div>
+  ) : null;
+
+  const statsRow = (
+    <div style={{ display: 'flex', gap: 8, marginTop: 14 }}>
+      <div style={{ flex: 1, padding: 14, borderRadius: 14, background: surface, border: `1px solid ${border}`, textAlign: 'center' }}>
+        <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 10.3, color: subFg, letterSpacing: 1.5 }}>VOTES</div>
+        <div style={{ fontSize: 30, fontWeight: 800, color: ACCENT, lineHeight: 1, marginTop: 4 }}>{row.vote_count}</div>
+      </div>
+      <div style={{ flex: 1, padding: 14, borderRadius: 14, background: surface, border: `1px solid ${border}`, textAlign: 'center' }}>
+        <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 10.3, color: subFg, letterSpacing: 1.5 }}>RANK</div>
+        <div style={{ fontSize: 30, fontWeight: 800, color: '#fff', lineHeight: 1, marginTop: 4 }}>#{rank}</div>
+        <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 9.7, color: subFg2, marginTop: 2 }}>of {totalCount}</div>
+      </div>
+    </div>
+  );
+
+  const voteBtn = (
+    <button
+      onClick={onVote}
+      style={{
+        width: '100%', height: 56, borderRadius: 14, marginTop: 12,
+        background: voted ? 'transparent' : `linear-gradient(90deg, ${ACCENT}, ${ACCENT2})`,
+        border: voted ? `1.5px solid ${ACCENT}` : 'none',
+        color: voted ? ACCENT : '#000',
+        fontFamily: 'var(--font-grotesk, system-ui)', fontSize: 16.9, fontWeight: 800,
+        cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+        transition: 'all 160ms',
+        boxShadow: voted ? 'none' : `0 12px 32px -8px ${ACCENT}90`,
+      }}
+    >
+      <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
+        <path d="M2 9L7 3L12 9" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+      {voted ? 'VOTED' : 'UPVOTE THIS TRACK'}
+    </button>
+  );
+
+  const suggestedBy = row.nickname ? (
+    <div style={{
+      marginTop: 12, padding: 12, borderRadius: 12,
+      background: surface, border: `1px solid ${border}`,
+      display: 'flex', alignItems: 'center', gap: 10,
+    }}>
+      <div style={{
+        width: 36, height: 36, borderRadius: '50%', flexShrink: 0,
+        background: `linear-gradient(135deg, ${ACCENT}, ${ACCENT2})`,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontSize: 14, fontWeight: 800, color: '#000',
+      }}>
+        {row.nickname[0]?.toUpperCase() ?? '?'}
+      </div>
+      <div>
+        <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 9.7, color: subFg, letterSpacing: 1.5 }}>SUGGESTED BY</div>
+        <div style={{ fontSize: 16.4, fontWeight: 700, marginTop: 2 }}>{row.nickname}</div>
+      </div>
+    </div>
+  ) : null;
+
+  const header = (
+    <div style={{ padding: '12px 16px 6px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 10.3, color: subFg, letterSpacing: 1.5 }}>
+        PRE-EVENT · #{rank}
+      </div>
+      <button
+        onClick={onClose}
+        style={{
+          width: 40, height: 40, borderRadius: 11,
+          background: surface, border: `1px solid ${border}`, color: '#fff',
+          cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}
+        aria-label="Close"
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14">
+          <path d="M2 2l10 10M12 2L2 12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+        </svg>
+      </button>
+    </div>
+  );
+
+  /* ── Desktop: centered dialog ─────────────────────────────── */
+  if (isWide) {
+    return (
+      <div
+        style={{
+          position: 'fixed', inset: 0, zIndex: 110,
+          background: 'rgba(0,0,0,0.7)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          padding: '20px',
+        }}
+        onClick={onClose}
+      >
+        <div
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            width: '100%', maxWidth: 480, background: '#0f0f18',
+            borderRadius: 20, border: `1px solid ${border}`,
+            boxShadow: `0 40px 100px rgba(0,0,0,0.6)`,
+            fontFamily: 'var(--font-grotesk, system-ui)',
+            color: '#fff', overflow: 'hidden',
+          }}
+        >
+          {header}
+          {/* Art + title side by side */}
+          <div style={{ display: 'flex', gap: 14, padding: '10px 16px 0', alignItems: 'center' }}>
+            <div style={{
+              width: 96, height: 96, borderRadius: 14, flexShrink: 0,
+              background: row.artwork_url ? undefined : artGradient(row.title + row.artist),
+              overflow: 'hidden', display: 'flex', alignItems: 'center', justifyContent: 'center',
+              boxShadow: `0 10px 30px -8px ${ACCENT}50`,
+            }}>
+              {row.artwork_url
+                ? <img src={row.artwork_url} alt={row.title} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+                : <span style={{ fontSize: 32, fontWeight: 800, color: '#fff' }}>{initials}</span>
+              }
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 22, fontWeight: 800, letterSpacing: -0.5, lineHeight: 1.1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{row.title}</div>
+              <div style={{ fontSize: 15.7, color: subFg, marginTop: 4, fontWeight: 500 }}>{row.artist}</div>
+              {pills}
+            </div>
+          </div>
+          <div style={{ padding: '0 16px 16px' }}>
+            {statsRow}
+            {suggestedBy}
+            {voteBtn}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  /* ── Mobile: full-screen bottom sheet ────────────────────── */
+  return (
+    <div className="gst-detail-sheet">
+      {/* Glow */}
+      <div style={{
+        position: 'absolute', top: 60, left: '50%', transform: 'translateX(-50%)',
+        width: '100%', maxWidth: 420, height: 260,
+        background: `radial-gradient(circle, ${ACCENT}22, transparent 65%)`,
+        filter: 'blur(50px)', pointerEvents: 'none',
+      }} />
+
+      {header}
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '8px 18px 120px', position: 'relative', zIndex: 1 }}>
+        {/* Artwork */}
+        <div style={{
+          width: 160, height: 160, borderRadius: 22, margin: '6px auto 0',
+          background: row.artwork_url ? undefined : artGradient(row.title + row.artist),
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          overflow: 'hidden',
+          boxShadow: `0 20px 50px -12px ${ACCENT}70, 0 0 0 1px ${border}`,
+        }}>
+          {row.artwork_url
+            ? <img src={row.artwork_url} alt={row.title} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            : <span style={{ fontSize: 48, fontWeight: 800, color: '#fff' }}>{initials}</span>
+          }
+        </div>
+
+        {/* Title + artist + pills */}
+        <div style={{ marginTop: 20, textAlign: 'center' }}>
+          <div style={{ fontSize: 28, fontWeight: 800, letterSpacing: -0.7, lineHeight: 1.05 }}>{row.title}</div>
+          <div style={{ fontSize: 18.2, color: subFg, marginTop: 5, fontWeight: 500 }}>{row.artist}</div>
+          {pills && <div style={{ justifyContent: 'center', display: 'flex' }}>{pills}</div>}
+        </div>
+
+        {statsRow}
+        {suggestedBy}
+      </div>
+
+      {/* Bottom vote CTA */}
+      <div style={{
+        position: 'absolute',
+        bottom: 'calc(env(safe-area-inset-bottom, 0px) + 20px)',
+        left: 14, right: 14, zIndex: 30,
+      }}>
+        {voteBtn}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: TypeScript check**
+
+```bash
+cd dashboard && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/app/collect/[code]/components/CollectDetailSheet.tsx
+git commit -m "feat(collect): add CollectDetailSheet — responsive detail panel for leaderboard rows"
+```
+
+---
+
+## Task 8: Wire LeaderboardTabs + collect page detail sheet
+
+**Files:**
+- Modify: `dashboard/app/collect/[code]/components/LeaderboardTabs.tsx`
+- Modify: `dashboard/app/collect/[code]/page.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+In `dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx` (create if it doesn't exist):
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import LeaderboardTabs from './LeaderboardTabs';
+import type { CollectLeaderboardRow } from '@/lib/api';
+
+const mockRow: CollectLeaderboardRow = {
+  id: 1,
+  title: 'Levels',
+  artist: 'Avicii',
+  artwork_url: null,
+  vote_count: 5,
+  nickname: null,
+  status: 'new',
+  created_at: new Date().toISOString(),
+};
+
+describe('LeaderboardTabs', () => {
+  it('calls onRowClick when a row is clicked', () => {
+    const onRowClick = vi.fn();
+    render(
+      <LeaderboardTabs
+        rows={[mockRow]}
+        tab="all"
+        onTabChange={vi.fn()}
+        onVote={vi.fn().mockResolvedValue(undefined)}
+        votedIds={new Set()}
+        onRowClick={onRowClick}
+      />,
+    );
+    fireEvent.click(screen.getByText('Levels'));
+    expect(onRowClick).toHaveBeenCalledWith(mockRow);
+  });
+
+  it('does not call onRowClick when vote button is clicked', () => {
+    const onRowClick = vi.fn();
+    render(
+      <LeaderboardTabs
+        rows={[mockRow]}
+        tab="all"
+        onTabChange={vi.fn()}
+        onVote={vi.fn().mockResolvedValue(undefined)}
+        votedIds={new Set()}
+        onRowClick={onRowClick}
+      />,
+    );
+    const voteBtn = screen.getByRole('button', { name: /upvote/i });
+    fireEvent.click(voteBtn);
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd dashboard && npm test -- --run LeaderboardTabs
+```
+
+Expected: FAIL — `onRowClick` not a valid prop.
+
+- [ ] **Step 3: Add onRowClick to LeaderboardTabs**
+
+In `dashboard/app/collect/[code]/components/LeaderboardTabs.tsx`, update the `Props` interface:
+
+```typescript
+interface Props {
+  rows: CollectLeaderboardRow[];
+  tab: 'trending' | 'all';
+  onTabChange: (tab: 'trending' | 'all') => void;
+  onVote: (requestId: number) => Promise<void>;
+  votedIds: ReadonlySet<number>;
+  onRowClick?: (row: CollectLeaderboardRow) => void;
+}
+```
+
+Update the function signature:
+
+```typescript
+export default function LeaderboardTabs({ rows, tab, onTabChange, onVote, votedIds, onRowClick }: Props) {
+```
+
+On the outer row `div`, add `onClick` and `cursor: pointer`:
+
+```tsx
+              <div
+                key={r.id}
+                className="gst-collect-row"
+                style={{
+                  background: surface,
+                  border: `1px solid ${border}`,
+                  cursor: onRowClick ? 'pointer' : 'default',
+                }}
+                onClick={() => onRowClick?.(r)}
+              >
+```
+
+On the vote button, add `e.stopPropagation()`:
+
+```tsx
+                    <button
+                      type="button"
+                      aria-label={voted ? 'upvoted' : 'upvote'}
+                      aria-pressed={voted}
+                      className={`gst-collect-vote-btn${voted ? ' voted' : ''}`}
+                      disabled={voted}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleVote(r.id, r.vote_count);
+                      }}
+                    >
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd dashboard && npm test -- --run LeaderboardTabs
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Wire CollectDetailSheet into collect page**
+
+In `dashboard/app/collect/[code]/page.tsx`:
+
+Add import at the top:
+```tsx
+import CollectDetailSheet from './components/CollectDetailSheet';
+```
+
+Add state after the existing `searchOpen` state:
+```tsx
+const [detailRow, setDetailRow] = useState<import('../../../lib/api').CollectLeaderboardRow | null>(null);
+const [detailVoted, setDetailVoted] = useState(false);
+```
+
+Update the collect page's API import to include `CollectLeaderboardRow`:
+
+```tsx
+import {
+  apiClient,
+  ApiError,
+  CollectEventPreview,
+  CollectLeaderboardResponse,
+  CollectLeaderboardRow,
+  CollectMyPicksResponse,
+  SearchResult,
+} from '../../../lib/api';
+```
+
+Pass `onRowClick` to `LeaderboardTabs`:
+```tsx
+          <LeaderboardTabs
+            rows={leaderboard?.requests ?? []}
+            tab={tab}
+            onTabChange={setTab}
+            onVote={(id) => apiClient.voteCollectRequest(code, id)}
+            votedIds={votedIds}
+            onRowClick={setDetailRow}
+          />
+```
+
+Add `CollectDetailSheet` render before the closing `</main>` tag:
+```tsx
+      {detailRow && (
+        <CollectDetailSheet
+          row={detailRow}
+          rank={(leaderboard?.requests ?? []).findIndex((r) => r.id === detailRow.id) + 1 || 1}
+          totalCount={leaderboard?.requests.length ?? 0}
+          voted={detailVoted || votedIds.has(detailRow.id)}
+          onVote={async () => {
+            if (!detailVoted && !votedIds.has(detailRow.id)) {
+              setDetailVoted(true);
+              await apiClient.voteCollectRequest(code, detailRow.id);
+            }
+          }}
+          onClose={() => { setDetailRow(null); setDetailVoted(false); }}
+        />
+      )}
+```
+
+Simplify the state declarations now that `CollectLeaderboardRow` is imported:
+```tsx
+const [detailRow, setDetailRow] = useState<CollectLeaderboardRow | null>(null);
+const [detailVoted, setDetailVoted] = useState(false);
+```
+
+- [ ] **Step 6: TypeScript check**
+
+```bash
+cd dashboard && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Run frontend tests**
+
+```bash
+cd dashboard && npm test -- --run
+```
+
+Expected: all PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add dashboard/app/collect/[code]/components/LeaderboardTabs.tsx \
+        dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx \
+        dashboard/app/collect/[code]/page.tsx
+git commit -m "feat(collect): wire CollectDetailSheet — tap a leaderboard row to open detail panel"
+```
+
+---
+
+## Task 9: Collect vibes toggle + enrichment animation
+
+**Files:**
+- Modify: `dashboard/app/globals.css`
+- Modify: `dashboard/app/collect/[code]/page.tsx`
+
+- [ ] **Step 1: Add CSS animation classes to globals.css**
+
+In `dashboard/app/globals.css`, find the end of the guest/kiosk section (after the last `@keyframes` block). Add:
+
+```css
+/* ── Vibes enrichment scanning animation ─────────────────────── */
+.vbs-scanning {
+  position: relative;
+  overflow: hidden;
+}
+.vbs-scanning::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  top: 0;
+  background: linear-gradient(90deg, transparent, rgba(0, 240, 255, 0.8), rgba(255, 43, 214, 0.8), transparent);
+  animation: vbs-scanline 0.9s linear infinite;
+  z-index: 10;
+  pointer-events: none;
+}
+
+@keyframes vbs-scanline {
+  0% { top: 0%; opacity: 1; }
+  90% { top: 100%; opacity: 1; }
+  100% { top: 100%; opacity: 0; }
+}
+
+.vbs-analyzing {
+  animation: vbs-blink 0.6s step-end infinite;
+}
+
+@keyframes vbs-blink {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
+.vbs-tier-in {
+  animation: vbs-tier-fade 300ms ease both;
+}
+
+@keyframes vbs-tier-fade {
+  from { opacity: 0; transform: translateY(3px); }
+  to { opacity: 1; transform: none; }
+}
+
+.vbs-scan-icon {
+  display: inline-block;
+  animation: vbs-bounce 0.7s ease-in-out infinite alternate;
+}
+
+@keyframes vbs-bounce {
+  from { transform: rotate(-10deg) scale(0.9); }
+  to { transform: rotate(10deg) scale(1.1); }
+}
+```
+
+- [ ] **Step 2: Add vibes state and scoring to collect page**
+
+In `dashboard/app/collect/[code]/page.tsx`, add after the `searchOpen` state block:
+
+```tsx
+  // Vibes toggle
+  const [sortByVibes, setSortByVibes] = useState(false);
+  const [enriching, setEnriching] = useState(false);
+  const [enrichedResults, setEnrichedResults] = useState<SearchResult[]>([]);
+```
+
+Add the average BPM computation (after the `leaderboard` state is available, inside the component body):
+
+```tsx
+  const leaderboardAvgBpm = useMemo(() => {
+    const withBpm = (leaderboard?.requests ?? []).filter((r) => r.bpm != null);
+    return withBpm.length > 0
+      ? withBpm.reduce((s, r) => s + (r.bpm ?? 0), 0) / withBpm.length
+      : 128;
+  }, [leaderboard]);
+```
+
+Add the `vibeScored` computation:
+
+```tsx
+  const tierInfo: Record<string, { rail: string; label: string }> = {
+    perfect: { rail: '#00f0ff', label: 'IN THE POCKET' },
+    good:    { rail: '#ff2bd6', label: 'BLENDS WELL' },
+    ok:      { rail: 'rgba(255,255,255,0.4)', label: 'SLIGHT SHIFT' },
+    far:     { rail: 'rgba(255,255,255,0.2)', label: 'TEMPO JUMP' },
+  };
+
+  const vibeScored = useMemo(() => {
+    const base = enrichedResults.length > 0 ? enrichedResults : searchResults;
+    if (!base.length) return base;
+    return base.map((r) => {
+      const dBpm = Math.abs((r.bpm ?? leaderboardAvgBpm) - leaderboardAvgBpm);
+      const score = dBpm / 8;
+      const tier: 'perfect' | 'good' | 'ok' | 'far' =
+        score <= 1 ? 'perfect' : score <= 2.5 ? 'good' : score <= 4 ? 'ok' : 'far';
+      return { ...r, _score: score, _tier: tier };
+    }).sort((a, b) => sortByVibes ? (a._score ?? 0) - (b._score ?? 0) : 0);
+  }, [searchResults, enrichedResults, sortByVibes, leaderboardAvgBpm]);
+```
+
+Add the `handleVibesToggle` function (alongside the other handlers):
+
+```tsx
+  const handleVibesToggle = async () => {
+    if (sortByVibes) {
+      setSortByVibes(false);
+      setEnrichedResults([]);
+      return;
+    }
+    setSortByVibes(true);
+    const needsEnrich = searchResults.slice(0, 10).filter((r) => r.bpm == null);
+    if (needsEnrich.length === 0) return;
+    setEnriching(true);
+    try {
+      const results = await apiClient.enrichPreview(
+        code,
+        searchResults.slice(0, 10).map((r) => ({
+          title: r.title,
+          artist: r.artist,
+          source_url: r.url ?? undefined,
+        })),
+      );
+      const merged = searchResults.map((r, i) => {
+        const enriched = results[i];
+        if (!enriched) return r;
+        return {
+          ...r,
+          bpm: r.bpm ?? enriched.bpm ?? null,
+          key: r.key ?? enriched.key ?? null,
+          genre: r.genre ?? enriched.genre ?? null,
+        };
+      });
+      setEnrichedResults(merged as SearchResult[]);
+    } catch {
+      // swallow — vibes still works with whatever bpm data is already on results
+    } finally {
+      setEnriching(false);
+    }
+  };
+```
+
+Also reset vibes state when search closes:
+
+```tsx
+  const closeSearch = () => {
+    setSearchOpen(false);
+    setSearchQuery('');
+    setSearchResults([]);
+    setSubmitError(null);
+    setSortByVibes(false);
+    setEnrichedResults([]);
+    setEnriching(false);
+  };
+```
+
+- [ ] **Step 3: Add the vibes toggle button and animated result rows**
+
+In `dashboard/app/collect/[code]/page.tsx`, find the search results section (the `{searchResults.length > 0 && (` block inside `searchOpen`). Replace the entire inner block with:
+
+```tsx
+            {vibeScored.length > 0 && (
+              <div style={{ flex: 1, overflowY: 'auto', padding: '0 18px 80px', position: 'relative', zIndex: 1 }}>
+                {/* Results header with vibes toggle */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 0 10px' }}>
+                  <span style={{ fontSize: 10.9, fontFamily: 'var(--font-mono, monospace)', color: 'rgba(255,255,255,0.35)', letterSpacing: 1.5 }}>
+                    {searchResults.length} RESULTS
+                  </span>
+                  <div style={{ flex: 1 }} />
+                  <button
+                    onClick={handleVibesToggle}
+                    style={{
+                      display: 'flex', alignItems: 'center', gap: 7,
+                      padding: '6px 11px', borderRadius: 99,
+                      background: sortByVibes ? 'rgba(0,240,255,0.12)' : 'transparent',
+                      border: `1px solid ${sortByVibes ? '#00f0ff' : 'rgba(255,255,255,0.08)'}`,
+                      color: sortByVibes ? '#00f0ff' : 'rgba(255,255,255,0.5)',
+                      fontFamily: 'var(--font-mono, monospace)', fontSize: 10.9, fontWeight: 700, letterSpacing: 1.2,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {enriching
+                      ? <><span className="vbs-scan-icon">🔍</span> READING VIBES…</>
+                      : <><span style={{
+                          width: 6, height: 6, borderRadius: '50%', flexShrink: 0,
+                          background: sortByVibes ? '#00f0ff' : 'transparent',
+                          border: sortByVibes ? 'none' : '1px solid rgba(255,255,255,0.5)',
+                          boxShadow: sortByVibes ? '0 0 6px #00f0ff' : 'none',
+                          display: 'inline-block',
+                        }} /> HIGHLIGHT BY VIBES</>
+                    }
+                  </button>
+                </div>
+
+                {/* Result rows */}
+                {vibeScored.map((result, index) => {
+                  const tier = sortByVibes ? (result as SearchResult & { _tier?: string })._tier : undefined;
+                  const tc = tier ? tierInfo[tier] : null;
+
+                  return (
+                    <button
+                      type="button"
+                      key={result.spotify_id ?? result.url ?? index}
+                      disabled={submitting}
+                      onClick={() => handleSelectSong(result)}
+                      data-testid="collect-search-result"
+                      className={enriching ? 'vbs-scanning' : ''}
+                      style={{
+                        width: '100%', textAlign: 'left', display: 'flex', alignItems: 'center', gap: 0,
+                        padding: 0, borderRadius: 12, marginBottom: 6,
+                        background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)',
+                        color: '#fff', cursor: 'pointer', overflow: 'hidden',
+                      }}
+                    >
+                      {sortByVibes && !enriching && tc && (
+                        <div style={{ width: 4, flexShrink: 0, background: tc.rail, alignSelf: 'stretch' }} />
+                      )}
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '11px 12px', flex: 1, minWidth: 0 }}>
+                        {result.album_art ? (
+                          <img
+                            src={result.album_art}
+                            alt={result.album ?? result.title}
+                            style={{ width: 44, height: 44, borderRadius: 8, objectFit: 'cover', flexShrink: 0 }}
+                          />
+                        ) : (
+                          <div style={{
+                            width: 44, height: 44, borderRadius: 8, flexShrink: 0,
+                            background: 'linear-gradient(135deg, #ff006e, #8338ec)',
+                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                            fontSize: 13.3, fontWeight: 800, color: '#fff',
+                          }}>
+                            {`${result.title[0] ?? '?'}${result.artist[0] ?? ''}`.toUpperCase()}
+                          </div>
+                        )}
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          <div style={{ fontSize: 16.9, fontWeight: 700, letterSpacing: -0.2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                            {result.title}
+                          </div>
+                          <div style={{ fontSize: 14.5, color: 'rgba(255,255,255,0.5)', marginTop: 2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                            {result.artist}
+                          </div>
+                          {enriching ? (
+                            <div className="vbs-analyzing" style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 9.7, color: 'rgba(0,240,255,0.6)', letterSpacing: 1, marginTop: 4 }}>
+                              ANALYZING…
+                            </div>
+                          ) : sortByVibes && tc ? (
+                            <div className="vbs-tier-in" style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 9.7, color: tc.rail, letterSpacing: 1.2, marginTop: 4, fontWeight: 700 }}>
+                              {tc.label}
+                            </div>
+                          ) : null}
+                        </div>
+                        <div style={{
+                          width: enriching ? 0 : 32, height: 32, borderRadius: '50%', flexShrink: 0,
+                          background: `conic-gradient(rgba(0,240,255,0.8) ${result.popularity}%, rgba(255,255,255,0.1) ${result.popularity}%)`,
+                          display: enriching ? 'none' : 'flex', alignItems: 'center', justifyContent: 'center',
+                          fontSize: 9.7, fontFamily: 'var(--font-mono, monospace)', fontWeight: 700, color: 'rgba(255,255,255,0.5)',
+                        }} title={`Popularity: ${result.popularity}%`}>
+                          {result.popularity}
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+```
+
+- [ ] **Step 4: Add missing import**
+
+In `dashboard/app/collect/[code]/page.tsx`, ensure `useMemo` is in the React imports:
+
+```tsx
+import { useEffect, useState, useMemo } from 'react';
+```
+
+- [ ] **Step 5: TypeScript check**
+
+```bash
+cd dashboard && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Run frontend tests**
+
+```bash
+cd dashboard && npm test -- --run
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Run backend CI checks**
+
+```bash
+cd server && .venv/bin/ruff check . && .venv/bin/ruff format --check . && .venv/bin/bandit -r app -c pyproject.toml -q && .venv/bin/pytest --tb=short -q
+```
+
+Expected: all PASS.
+
+- [ ] **Step 8: Lint the CSS**
+
+```bash
+cd dashboard && npm run lint
+```
+
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add dashboard/app/globals.css dashboard/app/collect/[code]/page.tsx
+git commit -m "feat(collect): add vibes toggle with scanline enrichment animation to search"
+```
+
+---
+
+## Task 10: Final CI + PR
+
+- [ ] **Step 1: Run full backend CI suite**
+
+```bash
+cd server && .venv/bin/ruff check . && .venv/bin/ruff format --check . && .venv/bin/bandit -r app -c pyproject.toml -q && .venv/bin/pytest --tb=short -q
+```
+
+Expected: all PASS, coverage ≥ 70%.
+
+- [ ] **Step 2: Run full frontend CI suite**
+
+```bash
+cd dashboard && npm run lint && npx tsc --noEmit && npm test -- --run
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Run bridge CI checks**
+
+```bash
+cd bridge && npx tsc --noEmit && npm test -- --run
+cd bridge-app && npx tsc --noEmit && npm test -- --run
+```
+
+Expected: all PASS (no bridge changes, just confirming no regressions).
+
+- [ ] **Step 4: Check Alembic drift**
+
+```bash
+cd server && .venv/bin/alembic upgrade head && .venv/bin/alembic check
+```
+
+Expected: `No new upgrade operations detected.` (no migrations added).
+
+- [ ] **Step 5: Push and open PR**
+
+```bash
+git push -u origin feat/song-detail-vibes-enrichment
+gh pr create \
+  --title "feat: song detail panels, vibes enrichment & collect UX polish" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Exposes `bpm`/`musical_key`/`genre` in `PublicRequestInfo` and `CollectLeaderboardRow` API responses (fields already in DB — schema-only change, no migration)
+- Triggers `enrich_request_metadata` background task on collect picks so BPM/key/genre get populated
+- Adds `/api/public/collect/{code}/enrich-preview` for search-time Beatport BPM lookup (no DB writes, 10/min rate limit)
+- Caps `SongDetailSheet` artwork at 160px and adds BPM/key pills on the join page
+- New `CollectDetailSheet` — tapping a leaderboard row opens a bottom sheet (mobile) or centered dialog (desktop ≥640px) with BPM/key pills and a vote button
+- Adds "HIGHLIGHT BY VIBES" toggle to collect search with scanline+ANALYZING… animation during enrichment, tier labels after resolve
+
+## Test plan
+
+- [ ] Local: tap a leaderboard row on `/collect` — detail opens, art 160px, pills visible on enriched tracks
+- [ ] Local: tap a leaderboard row on `/join` — art no longer fills screen, pills show if BPM known
+- [ ] Local: search on `/collect`, click HIGHLIGHT BY VIBES — scanline animation plays, rows reorder by BPM proximity
+- [ ] Local: submit a Spotify pick on `/collect` — confirm enrichment background task fires (check server logs)
+- [ ] Desktop browser: resize to >640px on `/collect`, tap a row — centered dialog appears
+- [ ] Confirm no regressions on `/join` request sheet vibes toggle
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+

--- a/docs/superpowers/specs/2026-04-30-song-detail-vibes-enrichment-design.md
+++ b/docs/superpowers/specs/2026-04-30-song-detail-vibes-enrichment-design.md
@@ -1,0 +1,322 @@
+# Song Detail Panels, Vibes Enrichment & Collect UX — Design Spec
+
+**Date:** 2026-04-30
+**Status:** Approved
+
+## Problem Summary
+
+Five distinct issues across three layers:
+
+1. `SongDetailSheet` on `/join` renders artwork full-viewport-width (375px on iPhone) — title and stats require scrolling
+2. `/collect` leaderboard rows are not tappable — no detail panel exists
+3. `bpm`, `musical_key`, and `genre` are stripped from both `GuestRequestInfo` and `CollectLeaderboardRow` API responses — even when the DB has them
+4. `/collect` submit endpoint never calls `enrich_request_metadata` — so collect picks never get BPM/key/genre populated
+5. "HIGHLIGHT BY VIBES" toggle is missing from `/collect` search results — it exists only on `/join`
+
+---
+
+## Approach: Full Fix (Approach 2)
+
+Fix all five issues end-to-end. No shared component extraction — the join and collect detail panels differ enough in data shape and context to warrant separate components.
+
+---
+
+## Section 1 — Backend Schema Exposure
+
+**Files:** `server/app/api/public.py`, `server/app/schemas/collect.py`, `server/app/api/collect.py`
+
+Add three nullable fields to both public response schemas:
+
+```python
+bpm: int | None = None
+musical_key: str | None = None
+genre: str | None = None
+```
+
+### `PublicRequestInfo` (`server/app/api/public.py`)
+Add the three fields. They propagate automatically to `GuestRequestInfo` via inheritance.
+
+Populate in `get_public_requests` by reading `r.bpm`, `r.musical_key`, `r.genre` from the `SongRequest` model row. Same for the `now_playing` matched-request path.
+
+### `CollectLeaderboardRow` (`server/app/schemas/collect.py`)
+Add the three fields directly to the schema class.
+
+Populate in the leaderboard endpoint (`server/app/api/collect.py`) by reading the same columns from the `SongRequest` row.
+
+**No Alembic migration needed.** These columns already exist on the `SongRequest` model — this is pure schema exposure.
+
+---
+
+## Section 2 — Enrichment Trigger on Collect Submit
+
+**File:** `server/app/api/collect.py`
+
+The `submit` endpoint creates a `SongRequest` row but never fires enrichment. Add `BackgroundTasks` as a FastAPI dependency and call `enrich_request_metadata` after commit — identical to the pattern in `events.py`.
+
+```python
+# After db.commit() / db.refresh(row):
+background_tasks.add_task(enrich_request_metadata, db, row.id)
+```
+
+Import: `from app.services.sync.orchestrator import enrich_request_metadata`
+
+This fills BPM/key/genre asynchronously from Beatport/Tidal/MusicBrainz depending on source URL. Duplicate-vote path (`is_duplicate=True`) does not need enrichment — the original row already has or will have it.
+
+---
+
+## Section 3 — Enrich-Preview Endpoint
+
+**File:** `server/app/api/collect.py` (new route added to the existing collect router — event-code-scoped, keeps auth/rate-limit context consistent)
+
+New public endpoint for search-time vibes enrichment:
+
+```
+POST /api/public/collect/{code}/enrich-preview
+```
+
+**Request body:**
+```json
+[
+  { "title": "Levels", "artist": "Avicii", "source_url": "https://open.spotify.com/track/..." },
+  ...
+]
+```
+
+**Response:**
+```json
+[
+  { "title": "Levels", "artist": "Avicii", "bpm": 128, "key": "6B", "genre": "Progressive House" },
+  ...
+]
+```
+
+**Constraints:**
+- Accepts up to 10 items per request (slice server-side, ignore excess)
+- Calls Beatport fuzzy search only — no MusicBrainz (too slow for interactive use)
+- No DB writes — purely a lookup / pass-through
+- Rate-limited: 10 requests/minute per guest (`@limiter.limit("10/minute")`)
+- Returns best-effort: items with no Beatport match return `{ title, artist, bpm: null, key: null, genre: null }`
+
+---
+
+## Section 4 — Join Page: Fix `SongDetailSheet`
+
+**File:** `dashboard/app/join/[code]/components/SongDetailSheet.tsx`
+
+### Artwork size fix
+Replace:
+```tsx
+width: '100%', aspectRatio: '1'
+```
+With:
+```tsx
+width: 160, height: 160, margin: '0 auto'
+```
+Keep the existing glow, border-radius, shadow, and gradient fallback — just at fixed 160px.
+
+### BPM / key pills
+After the artist name `<div>`, add a pill row — rendered only when at least one field is non-null:
+
+```tsx
+{(track.bpm || track.musical_key) && (
+  <div style={{ display: 'flex', gap: 6, marginTop: 8, justifyContent: 'center' }}>
+    {track.bpm && (
+      <span style={/* cyan pill */}>{track.bpm} BPM</span>
+    )}
+    {track.musical_key && (
+      <span style={/* dim pill */}>{track.musical_key}</span>
+    )}
+  </div>
+)}
+```
+
+Pill styles match the WrzDJ aesthetic: cyan (`#00f0ff`) background tint with cyan border for BPM; dim white surface with dim border for key.
+
+### Type update
+`GuestRequestInfo` in `dashboard/lib/api.ts` (or generated from `api-types.ts`) gains:
+```ts
+bpm?: number | null
+musical_key?: string | null
+genre?: string | null
+```
+
+---
+
+## Section 5 — Collect Page: New `CollectDetailSheet` Component
+
+**File:** `dashboard/app/collect/[code]/components/CollectDetailSheet.tsx`
+
+### Props
+```ts
+interface Props {
+  row: CollectLeaderboardRow;
+  rank: number;
+  totalCount: number;
+  voted: boolean;
+  onVote: () => void;
+  onClose: () => void;
+}
+```
+
+### Mobile layout (< 640px)
+Full-screen bottom sheet using the existing `gst-detail-sheet` CSS class. Structure:
+- Header bar: "PRE-EVENT · #rank" label + close button
+- Artwork: 160px × 160px square, centered, same gradient fallback as SongDetailSheet
+- BPM + key pills (null-guarded, same style as Section 4)
+- Stats row: VOTES card + RANK card (side-by-side)
+- "Suggested by" row (shown only when `row.nickname` is non-null)
+- Bottom vote CTA: full-width, gradient button — disabled + outlined when already voted
+
+### Desktop layout (≥ 640px)
+Fixed-position overlay with `rgba(0,0,0,0.7)` backdrop covering the full viewport. Click backdrop to close.
+
+Centered card: `max-width: 480px`, `border-radius: 20px`, dark surface background. Inside the card:
+- Header bar (same as mobile)
+- Art (96px) side-by-side with title / artist / pills in a horizontal row
+- Stats row beneath
+- Vote button beneath stats
+
+The breakpoint is detected via a `useEffect`-tracked `isWide` boolean:
+```ts
+const [isWide, setIsWide] = useState(false);
+useEffect(() => {
+  const check = () => setIsWide(window.innerWidth >= 640);
+  check();
+  window.addEventListener('resize', check);
+  return () => window.removeEventListener('resize', check);
+}, []);
+```
+
+`isWide` switches between the two layout branches in the return statement.
+
+### Wiring into `LeaderboardTabs`
+Add optional prop: `onRowClick?: (row: CollectLeaderboardRow) => void`
+
+On the outer `div` of each leaderboard row:
+```tsx
+onClick={() => onRowClick?.(r)}
+```
+
+On the vote button inside the row:
+```tsx
+onClick={(e) => { e.stopPropagation(); handleVote(r.id, r.vote_count); }}
+```
+
+### Wiring into `collect/[code]/page.tsx`
+```ts
+const [detailRow, setDetailRow] = useState<CollectLeaderboardRow | null>(null);
+```
+- Pass `onRowClick={setDetailRow}` to `<LeaderboardTabs />`
+- Render `<CollectDetailSheet>` when `detailRow` is non-null
+
+---
+
+## Section 6 — Collect Page: "Highlight by Vibes" in Search
+
+**File:** `dashboard/app/collect/[code]/page.tsx`
+
+### State additions
+```ts
+const [sortByVibes, setSortByVibes] = useState(false);
+const [enriching, setEnriching] = useState(false);
+const [enrichedResults, setEnrichedResults] = useState<SearchResult[]>([]);
+```
+
+### Vibe scoring
+Port the `vibeScored` `useMemo` from `join/[code]/page.tsx`. Reference BPM is the leaderboard's average (computed from `leaderboard?.requests` with non-null BPM values). No `nowPlaying` reference — key distance defaults to 0 when no reference key exists, so sorting is purely BPM-proximity to the collection average. Tier thresholds, labels, and rail colors are identical to join.
+
+### Toggle behavior
+When the user clicks "HIGHLIGHT BY VIBES":
+
+1. `setSortByVibes(true)` immediately — button label changes, loading state begins
+2. `setEnriching(true)` — triggers the loading animation on all result rows
+3. Fire `POST /api/public/collect/{code}/enrich-preview` with the first 10 results (those lacking `bpm`/`key`)
+4. On response: merge by positional index (request was sent in the same order as `searchResults.slice(0, 10)`) — returned array length matches input length, so `result[i]` maps to `searchResults[i]`. Merge into `enrichedResults` state, `setEnriching(false)`
+5. `vibeScored` re-runs with merged data, rows reorder
+
+Toggling off resets `sortByVibes` and `enrichedResults`.
+
+### Loading animation (Option C — scanline)
+While `enriching === true`, each result row:
+- Gets a cyan→magenta horizontal scanline sweeping top-to-bottom (CSS `@keyframes` via inline `style` + `className`)
+- Shows `"ANALYZING…"` blinking text below artist name (replaces tier label slot)
+- Popularity ring is hidden during enrichment
+
+On resolve:
+- Scanlines and "ANALYZING…" removed
+- Rows reorder by vibe score
+- Tier labels fade in with `opacity: 0 → 1` + `translateY(3px → 0)` over 300ms
+
+Button label during enrichment: `"READING VIBES…"` with a bouncing 🔍 icon. Returns to `"HIGHLIGHT BY VIBES"` after resolve.
+
+### Toggle placement
+Right-aligned in the results header row (same position as join) — visible only once results load:
+```tsx
+<div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 0 10px' }}>
+  <span>{searchResults.length} RESULTS</span>
+  <div style={{ flex: 1 }} />
+  <button onClick={handleVibesToggle}>
+    {enriching ? '🔍 READING VIBES…' : 'HIGHLIGHT BY VIBES'}
+  </button>
+</div>
+```
+
+---
+
+## Data Flow Summary
+
+```
+Guest searches on /collect
+  └── searchResults arrive (Beatport results have bpm/key already)
+      └── Guest clicks "HIGHLIGHT BY VIBES"
+            └── POST /enrich-preview (Beatport lookup, no DB write)
+                  └── Results merged → rows reorder by vibe score
+
+Guest submits a pick on /collect
+  └── POST /public/collect/{code}/requests
+        └── SongRequest row created in DB
+            └── BackgroundTask: enrich_request_metadata(db, row.id)
+                  └── Beatport/Tidal/MusicBrainz fills bpm/musical_key/genre
+                        └── Leaderboard poll returns row with bpm/musical_key/genre
+                              └── CollectDetailSheet shows pills when guest taps row
+
+Guest taps row on /collect leaderboard
+  └── CollectDetailSheet opens
+        └── Shows bpm/key pills (if enrichment has run)
+        └── Desktop (≥640px): centered dialog; Mobile: full-screen sheet
+
+Guest taps row on /join leaderboard
+  └── SongDetailSheet opens (existing component, art now capped at 160px)
+        └── Shows bpm/key pills (from GuestRequestInfo, now exposed)
+```
+
+---
+
+## Files Changed
+
+### Backend
+| File | Change |
+|------|--------|
+| `server/app/api/public.py` | Add `bpm`/`musical_key`/`genre` to `PublicRequestInfo`; populate in endpoint |
+| `server/app/schemas/collect.py` | Add same three fields to `CollectLeaderboardRow` |
+| `server/app/api/collect.py` | Populate fields in leaderboard endpoint; add `BackgroundTasks` + `enrich_request_metadata` to submit; add `enrich-preview` route |
+
+### Frontend
+| File | Change |
+|------|--------|
+| `dashboard/lib/api.ts` | Add `bpm?`/`musical_key?`/`genre?` to `CollectLeaderboardRow` interface |
+| `dashboard/app/join/[code]/components/SongDetailSheet.tsx` | Fix art size; add BPM/key pills |
+| `dashboard/app/collect/[code]/components/CollectDetailSheet.tsx` | **New** — responsive detail panel |
+| `dashboard/app/collect/[code]/components/LeaderboardTabs.tsx` | Add `onRowClick` prop; wire row clicks |
+| `dashboard/app/collect/[code]/page.tsx` | Wire `CollectDetailSheet`; add vibes toggle + enrichment flow |
+
+No Alembic migrations. No changes to bridge, bridge-app, or kiosk.
+
+---
+
+## Out of Scope
+
+- Sharing the `SongDetailSheet` / `CollectDetailSheet` as a single component (deferred — different data shapes and context)
+- Genre display in the detail panel (genre is enrichment metadata, not display data)
+- MusicBrainz in the enrich-preview endpoint (too slow for interactive use)
+- Vibes on the join page leaderboard rows (not requested)

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -33,7 +33,7 @@ from app.services import collect as collect_service
 from app.services.activity_log import log_activity
 from app.services.collect import NicknameConflictError, upsert_profile
 from app.services.dedup import compute_dedupe_key, find_duplicate
-from app.services.sync.enrichment_pipeline import enrich_request_metadata
+from app.services.sync.orchestrator import enrich_request_metadata
 from app.services.system_settings import get_system_settings
 from app.services.vote import add_vote
 
@@ -381,7 +381,8 @@ def submit(
     db.add(row)
     db.commit()
     db.refresh(row)
-    background_tasks.add_task(enrich_request_metadata, db, row.id)
+    if not (row.genre and row.bpm and row.musical_key):
+        background_tasks.add_task(enrich_request_metadata, db, row.id)
     log_activity(
         db,
         level="info",

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -127,6 +127,9 @@ def leaderboard(
                 nickname=r.nickname,
                 status=r.status,
                 created_at=r.created_at,
+                bpm=int(r.bpm) if r.bpm is not None else None,
+                musical_key=r.musical_key,
+                genre=r.genre,
             )
             for r in rows
         ],

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -28,6 +28,7 @@ from app.schemas.collect import (
     CollectProfileResponse,
     CollectSubmitRequest,
     CollectVoteRequest,
+    EnrichPreviewItem,  # noqa: F401
     EnrichPreviewRequest,
     EnrichPreviewResponse,
     EnrichPreviewResult,

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -28,11 +28,16 @@ from app.schemas.collect import (
     CollectProfileResponse,
     CollectSubmitRequest,
     CollectVoteRequest,
+    EnrichPreviewRequest,
+    EnrichPreviewResponse,
+    EnrichPreviewResult,
 )
 from app.services import collect as collect_service
 from app.services.activity_log import log_activity
+from app.services.beatport import search_beatport_tracks
 from app.services.collect import NicknameConflictError, upsert_profile
 from app.services.dedup import compute_dedupe_key, find_duplicate
+from app.services.sync.enrichment_pipeline import _find_best_match
 from app.services.sync.orchestrator import enrich_request_metadata
 from app.services.system_settings import get_system_settings
 from app.services.vote import add_vote
@@ -427,3 +432,47 @@ def vote(
             event_code=code,
         )
     return {"ok": True}
+
+
+@router.post("/{code}/enrich-preview", response_model=EnrichPreviewResponse)
+@limiter.limit("10/minute")
+def enrich_preview(
+    code: str,
+    payload: EnrichPreviewRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> EnrichPreviewResponse:
+    """Lightweight Beatport BPM/key lookup for search-time vibes — no DB writes."""
+    event = _get_event_or_404(db, code)
+    user = event.created_by
+    items = payload.items[:10]
+    results: list[EnrichPreviewResult] = []
+
+    for item in items:
+        bpm = None
+        key = None
+        genre = None
+
+        if user and user.beatport_access_token:
+            try:
+                matches = search_beatport_tracks(db, user, f"{item.artist} {item.title}", limit=5)
+                if matches:
+                    best = _find_best_match(matches, item.title, item.artist)
+                    if best:
+                        bpm = int(best.bpm) if best.bpm is not None else None
+                        key = best.key or None
+                        genre = best.genre or None
+            except Exception:
+                pass  # nosec B110 — best-effort, callers handle null fields
+
+        results.append(
+            EnrichPreviewResult(
+                title=item.title,
+                artist=item.artist,
+                bpm=bpm,
+                key=key,
+                genre=genre,
+            )
+        )
+
+    return EnrichPreviewResponse(results=results)

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -6,7 +6,7 @@ endpoints. See docs/RECOVERY-IP-IDENTITY.md.
 
 from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy import desc, func
 from sqlalchemy.exc import IntegrityError
@@ -33,6 +33,7 @@ from app.services import collect as collect_service
 from app.services.activity_log import log_activity
 from app.services.collect import NicknameConflictError, upsert_profile
 from app.services.dedup import compute_dedupe_key, find_duplicate
+from app.services.sync.enrichment_pipeline import enrich_request_metadata
 from app.services.system_settings import get_system_settings
 from app.services.vote import add_vote
 
@@ -320,6 +321,7 @@ def submit(
     code: str,
     payload: CollectSubmitRequest,
     request: Request,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
 ):
     event = _get_event_or_404(db, code)
@@ -379,6 +381,7 @@ def submit(
     db.add(row)
     db.commit()
     db.refresh(row)
+    background_tasks.add_task(enrich_request_metadata, db, row.id)
     log_activity(
         db,
         level="info",

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -299,6 +299,9 @@ def my_picks(code: str, request: Request, db: Session = Depends(get_db)):
             status=r.status,
             created_at=r.created_at,
             interaction=interaction,
+            bpm=int(r.bpm) if r.bpm is not None else None,
+            musical_key=r.musical_key,
+            genre=r.genre,
         )
 
     submitted_ids = {s.id for s in submitted}

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -4,6 +4,7 @@ Identity is `guest_id` only — the wrzdj_guest cookie is required for write
 endpoints. See docs/RECOVERY-IP-IDENTITY.md.
 """
 
+import logging
 from typing import Literal
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
@@ -42,6 +43,8 @@ from app.services.sync.enrichment_pipeline import _find_best_match
 from app.services.sync.orchestrator import enrich_request_metadata
 from app.services.system_settings import get_system_settings
 from app.services.vote import add_vote
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -463,8 +466,13 @@ def enrich_preview(
                         bpm = int(best.bpm) if best.bpm is not None else None
                         key = best.key or None
                         genre = best.genre or None
-            except Exception:
-                pass  # nosec B110 — best-effort, callers handle null fields
+            except Exception as exc:
+                logger.warning(
+                    "enrich_preview: Beatport lookup failed for '%s' by '%s': %s",
+                    item.title,
+                    item.artist,
+                    exc,
+                )  # nosec B110 — best-effort, callers handle null fields
 
         results.append(
             EnrichPreviewResult(

--- a/server/app/api/public.py
+++ b/server/app/api/public.py
@@ -37,6 +37,9 @@ class PublicRequestInfo(BaseModel):
     artwork_url: str | None
     nickname: str | None = None
     vote_count: int = 0
+    bpm: int | None = None
+    musical_key: str | None = None
+    genre: str | None = None
 
 
 class GuestRequestInfo(PublicRequestInfo):
@@ -224,6 +227,9 @@ def get_public_requests(
                 nickname=r.nickname,
                 vote_count=r.vote_count,
                 status=r.status,
+                bpm=int(r.bpm) if r.bpm is not None else None,
+                musical_key=r.musical_key,
+                genre=r.genre,
             )
             for r in requests_list
         ],

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -67,6 +67,9 @@ class CollectLeaderboardRow(BaseModel):
     nickname: str | None
     status: Literal["new", "accepted", "playing", "played", "rejected"]
     created_at: datetime
+    bpm: int | None = None
+    musical_key: str | None = None
+    genre: str | None = None
 
 
 class CollectLeaderboardResponse(BaseModel):

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -165,3 +165,25 @@ class BulkReviewResponse(BaseModel):
     accepted: int
     rejected: int
     unchanged: int
+
+
+class EnrichPreviewItem(BaseModel):
+    title: str
+    artist: str
+    source_url: str | None = None
+
+
+class EnrichPreviewResult(BaseModel):
+    title: str
+    artist: str
+    bpm: int | None = None
+    key: str | None = None
+    genre: str | None = None
+
+
+class EnrichPreviewRequest(BaseModel):
+    items: list[EnrichPreviewItem]
+
+
+class EnrichPreviewResponse(BaseModel):
+    results: list[EnrichPreviewResult]

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1216,14 +1216,47 @@
             ],
             "title": "Artwork Url"
           },
+          "bpm": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
           "created_at": {
             "format": "date-time",
             "title": "Created At",
             "type": "string"
           },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
           "id": {
             "title": "Id",
             "type": "integer"
+          },
+          "musical_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Musical Key"
           },
           "nickname": {
             "anyOf": [
@@ -1259,8 +1292,11 @@
         "required": [
           "artist",
           "artwork_url",
+          "bpm",
           "created_at",
+          "genre",
           "id",
+          "musical_key",
           "nickname",
           "status",
           "title",
@@ -1286,10 +1322,32 @@
             ],
             "title": "Artwork Url"
           },
+          "bpm": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
           "created_at": {
             "format": "date-time",
             "title": "Created At",
             "type": "string"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
           },
           "id": {
             "title": "Id",
@@ -1302,6 +1360,17 @@
             ],
             "title": "Interaction",
             "type": "string"
+          },
+          "musical_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Musical Key"
           },
           "nickname": {
             "anyOf": [
@@ -1337,9 +1406,12 @@
         "required": [
           "artist",
           "artwork_url",
+          "bpm",
           "created_at",
+          "genre",
           "id",
           "interaction",
+          "musical_key",
           "nickname",
           "status",
           "title",
@@ -1395,23 +1467,11 @@
       },
       "CollectProfileRequest": {
         "properties": {
-          "email": {
-            "anyOf": [
-              {
-                "format": "email",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
           "nickname": {
             "anyOf": [
               {
                 "maxLength": 30,
-                "minLength": 1,
+                "minLength": 2,
                 "pattern": "^[a-zA-Z0-9 _.-]+$",
                 "type": "string"
               },
@@ -1427,8 +1487,8 @@
       },
       "CollectProfileResponse": {
         "properties": {
-          "has_email": {
-            "title": "Has Email",
+          "email_verified": {
+            "title": "Email Verified",
             "type": "boolean"
           },
           "nickname": {
@@ -1452,7 +1512,7 @@
           }
         },
         "required": [
-          "has_email",
+          "email_verified",
           "nickname",
           "submission_cap",
           "submission_count"
@@ -1484,7 +1544,7 @@
             "anyOf": [
               {
                 "maxLength": 30,
-                "minLength": 1,
+                "minLength": 2,
                 "pattern": "^[a-zA-Z0-9 _.-]+$",
                 "type": "string"
               },
@@ -1645,6 +1705,121 @@
           }
         },
         "title": "DisplaySettingsUpdate",
+        "type": "object"
+      },
+      "EnrichPreviewItem": {
+        "properties": {
+          "artist": {
+            "title": "Artist",
+            "type": "string"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "artist"
+        ],
+        "title": "EnrichPreviewItem",
+        "type": "object"
+      },
+      "EnrichPreviewRequest": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/EnrichPreviewItem"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "EnrichPreviewRequest",
+        "type": "object"
+      },
+      "EnrichPreviewResponse": {
+        "properties": {
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/EnrichPreviewResult"
+            },
+            "title": "Results",
+            "type": "array"
+          }
+        },
+        "required": [
+          "results"
+        ],
+        "title": "EnrichPreviewResponse",
+        "type": "object"
+      },
+      "EnrichPreviewResult": {
+        "properties": {
+          "artist": {
+            "title": "Artist",
+            "type": "string"
+          },
+          "bpm": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "artist",
+          "bpm",
+          "genre",
+          "key",
+          "title"
+        ],
+        "title": "EnrichPreviewResult",
         "type": "object"
       },
       "EventCreate": {
@@ -2044,9 +2219,42 @@
             ],
             "title": "Artwork Url"
           },
+          "bpm": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
           "id": {
             "title": "Id",
             "type": "integer"
+          },
+          "musical_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Musical Key"
           },
           "nickname": {
             "anyOf": [
@@ -2080,7 +2288,10 @@
         "required": [
           "artist",
           "artwork_url",
+          "bpm",
+          "genre",
           "id",
+          "musical_key",
           "nickname",
           "status",
           "title",
@@ -2163,6 +2374,62 @@
           "page"
         ],
         "title": "HelpPageSeenRequest",
+        "type": "object"
+      },
+      "IdentifyRequest": {
+        "properties": {
+          "fingerprint_components": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fingerprint Components"
+          },
+          "fingerprint_hash": {
+            "maxLength": 64,
+            "minLength": 8,
+            "title": "Fingerprint Hash",
+            "type": "string"
+          }
+        },
+        "required": [
+          "fingerprint_hash"
+        ],
+        "title": "IdentifyRequest",
+        "type": "object"
+      },
+      "IdentifyResponse": {
+        "properties": {
+          "action": {
+            "enum": [
+              "create",
+              "cookie_hit",
+              "reconcile"
+            ],
+            "title": "Action",
+            "type": "string"
+          },
+          "guest_id": {
+            "title": "Guest Id",
+            "type": "integer"
+          },
+          "reconcile_hint": {
+            "default": false,
+            "title": "Reconcile Hint",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "action",
+          "guest_id",
+          "reconcile_hint"
+        ],
+        "title": "IdentifyResponse",
         "type": "object"
       },
       "IntegrationCheckResponse": {
@@ -3153,9 +3420,42 @@
             ],
             "title": "Artwork Url"
           },
+          "bpm": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
           "id": {
             "title": "Id",
             "type": "integer"
+          },
+          "musical_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Musical Key"
           },
           "nickname": {
             "anyOf": [
@@ -3181,7 +3481,10 @@
         "required": [
           "artist",
           "artwork_url",
+          "bpm",
+          "genre",
           "id",
+          "musical_key",
           "nickname",
           "title",
           "vote_count"
@@ -4718,6 +5021,75 @@
           "type"
         ],
         "title": "ValidationError",
+        "type": "object"
+      },
+      "VerifyConfirmResponse": {
+        "properties": {
+          "guest_id": {
+            "title": "Guest Id",
+            "type": "integer"
+          },
+          "merged": {
+            "title": "Merged",
+            "type": "boolean"
+          },
+          "verified": {
+            "title": "Verified",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "guest_id",
+          "merged",
+          "verified"
+        ],
+        "title": "VerifyConfirmResponse",
+        "type": "object"
+      },
+      "VerifyConfirmSchema": {
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "email": {
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "code"
+        ],
+        "title": "VerifyConfirmSchema",
+        "type": "object"
+      },
+      "VerifyRequestResponse": {
+        "properties": {
+          "sent": {
+            "title": "Sent",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "sent"
+        ],
+        "title": "VerifyRequestResponse",
+        "type": "object"
+      },
+      "VerifyRequestSchema": {
+        "properties": {
+          "email": {
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email"
+        ],
+        "title": "VerifyRequestSchema",
         "type": "object"
       },
       "VoteResponse": {
@@ -8207,6 +8579,59 @@
         ]
       }
     },
+    "/api/public/collect/{code}/enrich-preview": {
+      "post": {
+        "description": "Lightweight Beatport BPM/key lookup for search-time vibes \u2014 no DB writes.",
+        "operationId": "enrich_preview_api_public_collect__code__enrich_preview_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnrichPreviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnrichPreviewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Enrich Preview",
+        "tags": [
+          "collect"
+        ]
+      }
+    },
     "/api/public/collect/{code}/leaderboard": {
       "get": {
         "operationId": "leaderboard_api_public_collect__code__leaderboard_get",
@@ -8265,7 +8690,7 @@
     },
     "/api/public/collect/{code}/profile": {
       "get": {
-        "description": "Read the calling fingerprint's profile for this event. Does NOT\ncreate a row if none exists \u2014 returns defaults instead. Separate from\nPOST /profile so reads and writes have different action tags in the\nfingerprint log.",
+        "description": "Read the calling guest's profile for this event. Anonymous callers\n(no cookie) get the default empty profile \u2014 there is no IP fallback.",
         "operationId": "get_profile_api_public_collect__code__profile_get",
         "parameters": [
           {
@@ -8871,6 +9296,132 @@
         ]
       }
     },
+    "/api/public/guest/identify": {
+      "post": {
+        "description": "Resolve guest identity via cookie token and/or browser fingerprint.",
+        "operationId": "identify_api_public_guest_identify_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IdentifyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IdentifyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Identify",
+        "tags": [
+          "guest"
+        ]
+      }
+    },
+    "/api/public/guest/verify/confirm": {
+      "post": {
+        "description": "Confirm a verification code. May trigger guest merge.",
+        "operationId": "confirm_code_api_public_guest_verify_confirm_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyConfirmSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyConfirmResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Confirm Code",
+        "tags": [
+          "verify"
+        ]
+      }
+    },
+    "/api/public/guest/verify/request": {
+      "post": {
+        "description": "Send a verification code to the provided email.",
+        "operationId": "request_verification_code_api_public_guest_verify_request_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyRequestSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyRequestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Request Verification Code",
+        "tags": [
+          "verify"
+        ]
+      }
+    },
     "/api/public/kiosk/pair": {
       "post": {
         "description": "Create a new kiosk pairing session.",
@@ -9104,7 +9655,7 @@
     },
     "/api/requests/{request_id}/vote": {
       "delete": {
-        "description": "Remove vote from a song request. Idempotent.",
+        "description": "Remove vote from a song request. Idempotent.\n\nRequires a guest cookie. Anonymous callers receive 401.",
         "operationId": "unvote_request_api_requests__request_id__vote_delete",
         "parameters": [
           {
@@ -9146,7 +9697,7 @@
         ]
       },
       "post": {
-        "description": "Upvote a song request. Idempotent: voting twice has no effect.",
+        "description": "Upvote a song request. Idempotent: voting twice has no effect.\n\nRequires a guest cookie. Anonymous callers receive 401.",
         "operationId": "vote_for_request_api_requests__request_id__vote_post",
         "parameters": [
           {

--- a/server/tests/test_api_contracts.py
+++ b/server/tests/test_api_contracts.py
@@ -157,7 +157,17 @@ KIOSK_DISPLAY_KEYS = {
 
 PUBLIC_EVENT_INFO_KEYS = {"code", "name"}
 
-PUBLIC_REQUEST_INFO_KEYS = {"id", "title", "artist", "artwork_url", "nickname", "vote_count"}
+PUBLIC_REQUEST_INFO_KEYS = {
+    "id",
+    "title",
+    "artist",
+    "artwork_url",
+    "nickname",
+    "vote_count",
+    "bpm",
+    "musical_key",
+    "genre",
+}
 
 GUEST_REQUEST_INFO_KEYS = PUBLIC_REQUEST_INFO_KEYS | {"status"}
 

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -867,3 +867,25 @@ def test_enrich_preview_404_for_unknown_event(client):
         json={"items": [{"title": "X", "artist": "Y"}]},
     )
     assert r.status_code == 404
+
+
+def test_enrich_preview_returns_nulls_when_beatport_raises(client, db, test_event: Event):
+    """When Beatport search raises an exception, result fields are null (best-effort)."""
+    from unittest.mock import patch
+
+    _enable_collection(db, test_event)
+    dj = test_event.created_by
+    dj.beatport_access_token = "fake_token"  # nosec B106
+    db.commit()
+
+    with patch("app.api.collect.search_beatport_tracks", side_effect=Exception("timeout")):
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/enrich-preview",
+            json={"items": [{"title": "Levels", "artist": "Avicii"}]},
+        )
+
+    assert r.status_code == 200
+    result = r.json()["results"][0]
+    assert result["bpm"] is None
+    assert result["key"] is None
+    assert result["genre"] is None

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -729,3 +729,35 @@ def test_leaderboard_row_enrichment_fields_null_when_missing(client, db, test_ev
     assert rows[0]["bpm"] is None
     assert rows[0]["musical_key"] is None
     assert rows[0]["genre"] is None
+
+
+def test_my_picks_includes_enrichment_fields(
+    client, db, test_event: Event, _default_guest_cookie: Guest
+):
+    """my_picks response populates bpm/musical_key/genre from enriched requests."""
+    from app.models.request import Request, RequestStatus
+
+    _enable_collection(db, test_event)
+    req = Request(
+        event_id=test_event.id,
+        song_title="Levels",
+        artist="Avicii",
+        source="beatport",
+        status=RequestStatus.NEW.value,
+        dedupe_key="levels_avicii_mypicks",
+        submitted_during_collection=True,
+        guest_id=_default_guest_cookie.id,
+        bpm=128.0,
+        musical_key="8A",
+        genre="Progressive House",
+    )
+    db.add(req)
+    db.commit()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/profile/me")
+    assert r.status_code == 200
+    submitted = r.json()["submitted"]
+    assert len(submitted) == 1
+    assert submitted[0]["bpm"] == 128
+    assert submitted[0]["musical_key"] == "8A"
+    assert submitted[0]["genre"] == "Progressive House"

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -731,6 +731,29 @@ def test_leaderboard_row_enrichment_fields_null_when_missing(client, db, test_ev
     assert rows[0]["genre"] is None
 
 
+def test_collect_submit_triggers_enrichment(client, db, test_event: Event):
+    """Submitting a pick fires enrich_request_metadata as a background task."""
+    from unittest.mock import patch
+
+    _enable_collection(db, test_event)
+
+    with patch("app.api.collect.enrich_request_metadata") as mock_enrich:
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/requests",
+            json={
+                "song_title": "Levels",
+                "artist": "Avicii",
+                "source": "spotify",
+            },
+        )
+
+    assert r.status_code == 201
+    assert r.json()["is_duplicate"] is False
+    mock_enrich.assert_called_once()
+    _, request_id = mock_enrich.call_args[0]
+    assert isinstance(request_id, int)
+
+
 def test_my_picks_includes_enrichment_fields(
     client, db, test_event: Event, _default_guest_cookie: Guest
 ):

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -674,3 +674,58 @@ class TestNicknameUniqueness:
             json={},
         )
         assert r.status_code == 200
+
+
+def test_leaderboard_row_includes_enrichment_fields(client, db, test_event: Event):
+    """Leaderboard rows expose bpm/musical_key/genre when set on the request."""
+    from app.models.request import Request, RequestStatus
+
+    _enable_collection(db, test_event)
+    req = Request(
+        event_id=test_event.id,
+        song_title="Levels",
+        artist="Avicii",
+        source="beatport",
+        status=RequestStatus.NEW.value,
+        vote_count=3,
+        dedupe_key="levels_avicii_enriched",
+        submitted_during_collection=True,
+        bpm=128.0,
+        musical_key="8A",
+        genre="Progressive House",
+    )
+    db.add(req)
+    db.commit()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all")
+    assert r.status_code == 200
+    rows = r.json()["requests"]
+    assert len(rows) == 1
+    assert rows[0]["bpm"] == 128
+    assert rows[0]["musical_key"] == "8A"
+    assert rows[0]["genre"] == "Progressive House"
+
+
+def test_leaderboard_row_enrichment_fields_null_when_missing(client, db, test_event: Event):
+    from app.models.request import Request, RequestStatus
+
+    _enable_collection(db, test_event)
+    req = Request(
+        event_id=test_event.id,
+        song_title="Unknown",
+        artist="Someone",
+        source="spotify",
+        status=RequestStatus.NEW.value,
+        dedupe_key="unknown_someone_collect",
+        submitted_during_collection=True,
+    )
+    db.add(req)
+    db.commit()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all")
+    assert r.status_code == 200
+    rows = r.json()["requests"]
+    assert len(rows) == 1
+    assert rows[0]["bpm"] is None
+    assert rows[0]["musical_key"] is None
+    assert rows[0]["genre"] is None

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -784,3 +784,86 @@ def test_my_picks_includes_enrichment_fields(
     assert submitted[0]["bpm"] == 128
     assert submitted[0]["musical_key"] == "8A"
     assert submitted[0]["genre"] == "Progressive House"
+
+
+# ── Enrich-preview tests ──────────────────────────────────────────────────────
+
+
+def test_enrich_preview_returns_nulls_without_beatport_token(client, db, test_event: Event):
+    """When the DJ has no Beatport token, all results have null bpm/key/genre."""
+    _enable_collection(db, test_event)
+    dj = test_event.created_by
+    dj.beatport_access_token = None
+    db.commit()
+
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/enrich-preview",
+        json={"items": [{"title": "Levels", "artist": "Avicii"}]},
+    )
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert len(results) == 1
+    assert results[0]["title"] == "Levels"
+    assert results[0]["artist"] == "Avicii"
+    assert results[0]["bpm"] is None
+    assert results[0]["key"] is None
+    assert results[0]["genre"] is None
+
+
+def test_enrich_preview_returns_bpm_from_beatport(client, db, test_event: Event):
+    """When Beatport search returns a match, bpm/key/genre are populated."""
+    from unittest.mock import MagicMock, patch
+
+    _enable_collection(db, test_event)
+
+    dj = test_event.created_by
+    dj.beatport_access_token = "fake_token"  # nosec B106
+    db.commit()
+
+    mock_match = MagicMock()
+    mock_match.title = "Levels"
+    mock_match.artist = "Avicii"
+    mock_match.bpm = 128
+    mock_match.key = "8A"
+    mock_match.genre = "Progressive House"
+    mock_match.mix_name = "Original Mix"
+
+    with (
+        patch("app.api.collect.search_beatport_tracks", return_value=[mock_match]),
+        patch("app.api.collect._find_best_match", return_value=mock_match),
+    ):
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/enrich-preview",
+            json={"items": [{"title": "Levels", "artist": "Avicii"}]},
+        )
+
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert len(results) == 1
+    assert results[0]["bpm"] == 128
+    assert results[0]["key"] == "8A"
+    assert results[0]["genre"] == "Progressive House"
+
+
+def test_enrich_preview_caps_at_10_items(client, db, test_event: Event):
+    """Requests with >10 items are silently capped — only first 10 processed."""
+    _enable_collection(db, test_event)
+    dj = test_event.created_by
+    dj.beatport_access_token = None
+    db.commit()
+
+    items = [{"title": f"Song {i}", "artist": f"Artist {i}"} for i in range(15)]
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/enrich-preview",
+        json={"items": items},
+    )
+    assert r.status_code == 200
+    assert len(r.json()["results"]) == 10
+
+
+def test_enrich_preview_404_for_unknown_event(client):
+    r = client.post(
+        "/api/public/collect/ZZZZZZ/enrich-preview",
+        json={"items": [{"title": "X", "artist": "Y"}]},
+    )
+    assert r.status_code == 404

--- a/server/tests/test_public.py
+++ b/server/tests/test_public.py
@@ -303,6 +303,61 @@ class TestGuestRequestList:
         assert data["requests"][0]["nickname"] is None
 
 
+class TestPublicRequestsEnrichmentFields:
+    """bpm/musical_key/genre are exposed in /events/{code}/requests response."""
+
+    def test_enrichment_fields_present_when_set(
+        self, client: TestClient, test_event: Event, db: Session
+    ):
+        from app.models.request import Request, RequestStatus
+
+        req = Request(
+            event_id=test_event.id,
+            song_title="Levels",
+            artist="Avicii",
+            source="beatport",
+            status=RequestStatus.NEW.value,
+            dedupe_key="levels_avicii_001",
+            bpm=128.0,
+            musical_key="8A",
+            genre="Progressive House",
+        )
+        db.add(req)
+        db.commit()
+
+        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        assert response.status_code == 200
+        requests = response.json()["requests"]
+        assert len(requests) == 1
+        assert requests[0]["bpm"] == 128
+        assert requests[0]["musical_key"] == "8A"
+        assert requests[0]["genre"] == "Progressive House"
+
+    def test_enrichment_fields_null_when_not_set(
+        self, client: TestClient, test_event: Event, db: Session
+    ):
+        from app.models.request import Request, RequestStatus
+
+        req = Request(
+            event_id=test_event.id,
+            song_title="Unknown",
+            artist="Someone",
+            source="spotify",
+            status=RequestStatus.NEW.value,
+            dedupe_key="unknown_someone_001",
+        )
+        db.add(req)
+        db.commit()
+
+        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        assert response.status_code == 200
+        requests = response.json()["requests"]
+        assert len(requests) == 1
+        assert requests[0]["bpm"] is None
+        assert requests[0]["musical_key"] is None
+        assert requests[0]["genre"] is None
+
+
 class TestSubmitRequestNickname:
     """Tests for nickname field in POST /api/events/{code}/requests."""
 


### PR DESCRIPTION
## Summary

- Exposes `bpm`/`musical_key`/`genre` in `PublicRequestInfo` and `CollectLeaderboardRow` API responses (fields already in DB — schema-only change, no migration)
- Populates enrichment fields in the `my_picks` endpoint (`_to_row` helper) so submitted/upvoted tracks show BPM and key in the detail panel
- Triggers `enrich_request_metadata` background task on collect picks (with full-metadata short-circuit) so BPM/key/genre get populated after submission
- Adds `POST /api/public/collect/{code}/enrich-preview` for search-time Beatport BPM lookup (no DB writes, best-effort with warning logs, 10/min rate limit)
- Caps `SongDetailSheet` artwork at 160px and adds BPM/key pills on the join page detail panel
- New `CollectDetailSheet` — tapping a leaderboard row opens a bottom sheet (mobile) or centered dialog (desktop ≥640px) with BPM/key pills, stats, and a vote button; uses `useState<boolean | null>(null)` null-gate to prevent hydration flash
- Adds "HIGHLIGHT BY VIBES" toggle to collect search with scanline+ANALYZING… animation during enrichment, tier labels (IN THE POCKET / BLENDS WELL / SLIGHT SHIFT / TEMPO JUMP) and color rails after resolve
- Regenerates frontend types from updated OpenAPI schema; adds `enrichPreview()` method to `ApiClient`

## Test plan

- [ ] Tap a leaderboard row on `/collect` — detail opens, artwork 160px, BPM/key pills visible on enriched tracks
- [ ] Tap a leaderboard row on `/join` — artwork no longer fills screen, BPM/key pills show if enrichment has run
- [ ] Search on `/collect`, click HIGHLIGHT BY VIBES — scanline animation plays on each row, rows reorder by BPM proximity to leaderboard average after resolve
- [ ] Submit a Spotify pick on `/collect` — confirm `enrich_request_metadata` fires (server logs show enrichment task)
- [ ] Resize browser to >640px on `/collect`, tap a row — centered dialog appears with slide-up animation
- [ ] Confirm no regressions on `/join` request sheet vibes toggle and join page leaderboard behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)