### PR TITLE
feat(dj): Enrich All button in advanced mode to backfill BPM/key/genre

### DIFF
--- a/dashboard/app/events/[code]/components/RequestQueueSection.tsx
+++ b/dashboard/app/events/[code]/components/RequestQueueSection.tsx
@@ -31,6 +31,7 @@ interface RequestQueueSectionProps {
   onBulkDelete?: (status?: string) => Promise<void>;
   onDeleteRequest?: (requestId: number) => Promise<void>;
   onRefreshMetadata?: (requestId: number) => Promise<void>;
+  onEnrichAll?: () => Promise<{ queued: number }>;
   rejectingAll?: boolean;
   deletingRequest?: number | null;
   refreshingRequest?: number | null;
@@ -55,6 +56,7 @@ export function RequestQueueSection({
   onBulkDelete,
   onDeleteRequest,
   onRefreshMetadata,
+  onEnrichAll,
   rejectingAll,
   deletingRequest,
   refreshingRequest,
@@ -65,6 +67,7 @@ export function RequestQueueSection({
   const [advancedMode, setAdvancedMode] = useState(false);
   const [deletingAll, setDeletingAll] = useState(false);
   const [refreshingAll, setRefreshingAll] = useState(false);
+  const [enrichingAll, setEnrichingAll] = useState(false);
 
   const statusCounts = useMemo(() => {
     const counts = { all: requests.length, new: 0, accepted: 0, playing: 0, played: 0, rejected: 0 };
@@ -182,6 +185,28 @@ export function RequestQueueSection({
             )}
             {advancedMode && (
               <>
+                {onEnrichAll && (
+                  <button
+                    className="btn btn-sm"
+                    style={{ background: '#1e3a5f', fontSize: '0.7rem' }}
+                    onClick={async () => {
+                      setEnrichingAll(true);
+                      try {
+                        const { queued } = await onEnrichAll();
+                        if (queued === 0) {
+                          alert('All tracks already have BPM, key, and genre.');
+                        } else {
+                          alert(`Queued enrichment for ${queued} track${queued === 1 ? '' : 's'}. Metadata will fill in over the next minute.`);
+                        }
+                      } finally {
+                        setEnrichingAll(false);
+                      }
+                    }}
+                    disabled={enrichingAll}
+                  >
+                    {enrichingAll ? 'Queuing…' : 'Enrich All'}
+                  </button>
+                )}
                 <button
                   className="btn btn-sm"
                   style={{ background: '#374151', fontSize: '0.7rem' }}

--- a/dashboard/app/events/[code]/components/SongManagementTab.tsx
+++ b/dashboard/app/events/[code]/components/SongManagementTab.tsx
@@ -41,6 +41,7 @@ interface SongManagementTabProps {
   onBulkDelete?: (status?: string) => Promise<void>;
   onDeleteRequest?: (requestId: number) => Promise<void>;
   onRefreshMetadata?: (requestId: number) => Promise<void>;
+  onEnrichAll?: () => Promise<{ queued: number }>;
   rejectingAll?: boolean;
   deletingRequest?: number | null;
   refreshingRequest?: number | null;
@@ -84,6 +85,7 @@ export function SongManagementTab(props: SongManagementTabProps) {
         onBulkDelete={props.onBulkDelete}
         onDeleteRequest={props.onDeleteRequest}
         onRefreshMetadata={props.onRefreshMetadata}
+        onEnrichAll={props.onEnrichAll}
         rejectingAll={props.rejectingAll}
         deletingRequest={props.deletingRequest}
         refreshingRequest={props.refreshingRequest}

--- a/dashboard/app/events/[code]/page.tsx
+++ b/dashboard/app/events/[code]/page.tsx
@@ -740,6 +740,10 @@ export default function EventQueuePage() {
     }
   };
 
+  const handleEnrichAll = async () => {
+    return api.enrichAllRequests(code);
+  };
+
   const handleRejectAll = async () => {
     setRejectingAll(true);
     try {
@@ -1046,6 +1050,7 @@ export default function EventQueuePage() {
               onBulkDelete={handleBulkDelete}
               onDeleteRequest={handleDeleteRequest}
               onRefreshMetadata={handleRefreshMetadata}
+              onEnrichAll={handleEnrichAll}
               rejectingAll={rejectingAll}
               deletingRequest={deletingRequest}
               refreshingRequest={refreshingRequest}

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -457,6 +457,12 @@ class ApiClient {
     });
   }
 
+  async enrichAllRequests(code: string): Promise<{ queued: number }> {
+    return this.fetch(`/api/events/${encodeURIComponent(code)}/enrich-all`, {
+      method: 'POST',
+    });
+  }
+
   async submitRequest(
     code: string,
     artist: string,

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -1070,6 +1070,19 @@ def bulk_review(
     return BulkReviewResponse(accepted=accepted, rejected=rejected, unchanged=0)
 
 
+@router.post("/{code}/enrich-all")
+def enrich_all_requests(
+    background_tasks: BackgroundTasks,
+    event: Event = Depends(get_event_for_dj_or_admin),
+    db: Session = Depends(get_db),
+):
+    """Queue enrichment for every request on this event that is missing BPM, key, or genre."""
+    rows = [r for r in event.requests if r.bpm is None or r.musical_key is None or r.genre is None]
+    for row in rows:
+        background_tasks.add_task(enrich_request_metadata, db, row.id)
+    return {"queued": len(rows)}
+
+
 @router.delete("/{code}/banner", response_model=EventOut)
 @limiter.limit("10/minute")
 def delete_banner(


### PR DESCRIPTION
## Summary

- Adds `POST /api/events/{code}/enrich-all` endpoint (DJ-accessible) that queues `enrich_request_metadata` background tasks for every request on the event missing BPM, key, or genre
- Adds **Enrich All** button in the request queue's **Advanced** checkbox panel (alongside the existing Refresh All and Delete All buttons)
- Reports how many tracks were queued via an alert; shows "All tracks already have metadata" if nothing to do
- Useful for backfilling pre-existing collect picks that were submitted before enrichment was wired to the collect flow

## Test plan

- [ ] Open DJ dashboard → Songs tab → check Advanced → click Enrich All → confirm alert shows queued count
- [ ] Wait ~60s → refresh page → verify BPM/key/genre populated on previously bare tracks
- [ ] Click Enrich All again → confirm "All tracks already have BPM, key, and genre" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)