### PR TITLE
fix(enrich-all): batch limit + fresh DB session per task

### DIFF
--- a/dashboard/app/events/[code]/components/RequestQueueSection.tsx
+++ b/dashboard/app/events/[code]/components/RequestQueueSection.tsx
@@ -31,7 +31,7 @@ interface RequestQueueSectionProps {
   onBulkDelete?: (status?: string) => Promise<void>;
   onDeleteRequest?: (requestId: number) => Promise<void>;
   onRefreshMetadata?: (requestId: number) => Promise<void>;
-  onEnrichAll?: () => Promise<{ queued: number }>;
+  onEnrichAll?: () => Promise<{ queued: number; remaining: number }>;
   rejectingAll?: boolean;
   deletingRequest?: number | null;
   refreshingRequest?: number | null;
@@ -192,9 +192,11 @@ export function RequestQueueSection({
                     onClick={async () => {
                       setEnrichingAll(true);
                       try {
-                        const { queued } = await onEnrichAll();
+                        const { queued, remaining } = await onEnrichAll();
                         if (queued === 0) {
                           alert('All tracks already have BPM, key, and genre.');
+                        } else if (remaining > 0) {
+                          alert(`Queued ${queued} tracks. ${remaining} more remaining — wait ~1 min for these to finish, then click again.`);
                         } else {
                           alert(`Queued enrichment for ${queued} track${queued === 1 ? '' : 's'}. Metadata will fill in over the next minute.`);
                         }

--- a/dashboard/app/events/[code]/components/SongManagementTab.tsx
+++ b/dashboard/app/events/[code]/components/SongManagementTab.tsx
@@ -41,7 +41,7 @@ interface SongManagementTabProps {
   onBulkDelete?: (status?: string) => Promise<void>;
   onDeleteRequest?: (requestId: number) => Promise<void>;
   onRefreshMetadata?: (requestId: number) => Promise<void>;
-  onEnrichAll?: () => Promise<{ queued: number }>;
+  onEnrichAll?: () => Promise<{ queued: number; remaining: number }>;
   rejectingAll?: boolean;
   deletingRequest?: number | null;
   refreshingRequest?: number | null;

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -457,7 +457,7 @@ class ApiClient {
     });
   }
 
-  async enrichAllRequests(code: string): Promise<{ queued: number }> {
+  async enrichAllRequests(code: string): Promise<{ queued: number; remaining: number }> {
     return this.fetch(`/api/events/${encodeURIComponent(code)}/enrich-all`, {
       method: 'POST',
     });

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -1070,17 +1070,43 @@ def bulk_review(
     return BulkReviewResponse(accepted=accepted, rejected=rejected, unchanged=0)
 
 
+ENRICH_ALL_BATCH_LIMIT = 25
+
+
+def _enrich_with_fresh_session(request_id: int) -> None:
+    """Run enrichment in its own DB session.
+
+    The request-scoped `db` from `get_db` stays open until all background tasks finish — for a
+    large batch this exhausts the SQLAlchemy connection pool. A fresh `SessionLocal()` per task
+    releases its connection as soon as the task ends.
+    """
+    from app.db.session import SessionLocal
+
+    session = SessionLocal()
+    try:
+        enrich_request_metadata(session, request_id)
+    finally:
+        session.close()
+
+
 @router.post("/{code}/enrich-all")
 def enrich_all_requests(
     background_tasks: BackgroundTasks,
     event: Event = Depends(get_event_for_dj_or_admin),
-    db: Session = Depends(get_db),
+    db: Session = Depends(get_db),  # noqa: ARG001 — kept for auth dependency consistency
 ):
-    """Queue enrichment for every request on this event that is missing BPM, key, or genre."""
-    rows = [r for r in event.requests if r.bpm is None or r.musical_key is None or r.genre is None]
-    for row in rows:
-        background_tasks.add_task(enrich_request_metadata, db, row.id)
-    return {"queued": len(rows)}
+    """Queue enrichment for up to ENRICH_ALL_BATCH_LIMIT requests missing BPM, key, or genre.
+
+    Batched to avoid exhausting the connection pool when many tracks need enrichment.
+    Returns `remaining` so the caller can re-invoke until 0.
+    """
+    candidates = [
+        r for r in event.requests if r.bpm is None or r.musical_key is None or r.genre is None
+    ]
+    batch = candidates[:ENRICH_ALL_BATCH_LIMIT]
+    for row in batch:
+        background_tasks.add_task(_enrich_with_fresh_session, row.id)
+    return {"queued": len(batch), "remaining": max(0, len(candidates) - len(batch))}
 
 
 @router.delete("/{code}/banner", response_model=EventOut)


### PR DESCRIPTION
## Problem

Production API went down (502s, "Service temporarily unavailable") shortly after deploying the **Enrich All** button. Root cause:

```
sqlalchemy.exc.TimeoutError: QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00
```

The endpoint queued *every* unenriched request as a `BackgroundTask` sharing the request's pooled DB session. With ~hundreds of tasks each making slow Beatport/MusicBrainz/Tidal calls, the request stayed open until all tasks finished, holding the connection. Concurrent requests then starved.

## Fix

1. **Batch cap** at 25 requests per call. Endpoint returns `{ queued, remaining }` so caller can re-invoke until 0.
2. **Fresh `SessionLocal()` per task** via `_enrich_with_fresh_session` helper — connection released as soon as the task completes, instead of being held by the request scope.
3. Frontend alert tells the DJ how many remain and to click again after ~1 minute.

## Test plan

- [ ] Click Enrich All on event with >25 unenriched tracks → alert says "Queued 25, X more remaining"
- [ ] Wait ~1 min, click again → continues until 0
- [ ] API health stays green throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)