### PR TITLE
chore(release): auto-sync winget-pkgs fork before submit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,6 +237,13 @@ jobs:
           ASSET_URL: https://github.com/thewrz/WrzDJ/releases/download/${{ github.ref_name }}/WrzDJ-Bridge.exe
         run: ./.github/scripts/winget/wait-for-asset.ps1 -Url $env:ASSET_URL
 
+      - name: Sync fork with upstream microsoft/winget-pkgs
+        # wingetcreate fails with "forked repository could not be synced with the
+        # upstream commits" when our fork has drifted. Sync first so submit succeeds.
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_PAT }}
+        run: gh repo sync thewrz/winget-pkgs
+
       - name: Update winget package
         shell: pwsh
         env:


### PR DESCRIPTION
## Summary

Today's v2026.05.02 release exposed a new winget submission failure mode not covered by #277: **fork drift**. `wingetcreate update --submit` aborted with:

> The forked repository could not be synced with the upstream commits. Sync your fork manually and try again.

Manifest generation itself succeeded (\`Manifest validation succeeded: True\`); only the PR-submission step failed because GitHub's auto-sync API couldn't fast-forward our \`thewrz/winget-pkgs\` fork onto upstream master. Manual fix today was a one-liner: \`gh repo sync thewrz/winget-pkgs\`.

This PR adds that sync as a step in the \`update-winget\` job so the fork self-heals on every release.

## Why not in #277

This blocker was invisible until we actually attempted a release; the audit only had visibility into past blockers that left a trail (closed winget-pkgs PRs, fix commits). Fork drift had been silently accumulating between Apr 8 and May 2.

## Diff

7 lines added to \`.github/workflows/release.yml\` between the existing \"Wait for release asset\" and \"Update winget package\" steps. Uses \`secrets.WINGET_PAT\` (already present, no new secret).

## Test plan

- [ ] CI green on this PR
- [ ] On next release tag (or via amending v2026.05.02 retroactively if useful), the new step runs and \`Update winget package\` proceeds without manual intervention