### PR TITLE
fix(deploy): normalize container healthchecks to 127.0.0.1

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -51,7 +51,10 @@ ENV HOSTNAME="0.0.0.0"
 EXPOSE 3000
 
 # Health check
+# Use 127.0.0.1 (not "localhost") because BusyBox wget on Alpine resolves
+# "localhost" to IPv6 ::1 first, but Next.js binds IPv4 0.0.0.0 only —
+# causing "connection refused" probe failures even when the app is serving fine.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:${PORT:-3000}/ || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:${PORT:-3000}/ || exit 1
 
 CMD ["node", "server.js"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -77,7 +77,7 @@ services:
     tmpfs:
       - /tmp
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
       interval: 10s
       timeout: 5s
       start_period: 30s

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -31,8 +31,12 @@ ENV PORT=8000
 EXPOSE 8000
 
 # Health check
+# Use 127.0.0.1 (not "localhost") so the probe targets IPv4 directly.
+# uvicorn binds 0.0.0.0; curl on "localhost" tries ::1 first and falls back,
+# wasting one connect attempt per cycle. Explicit IPv4 is cleaner and matches
+# the dashboard healthcheck pattern.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD curl -f http://localhost:${PORT:-8000}/health || exit 1
+    CMD curl -f http://127.0.0.1:${PORT:-8000}/health || exit 1
 
 # Use start script for migrations and server startup
 CMD ["./scripts/start.sh"]


### PR DESCRIPTION
## Summary

Production container \`deploy-web-1\` was reporting \`(unhealthy)\` since the last restart with FailingStreak ~890 (≈7.4h). Site itself was serving traffic fine — only the Docker healthcheck probe was failing.

## Root cause

\`\`\`
Connecting to localhost:3000 ([::1]:3000)
wget: can't connect to remote host: Connection refused
\`\`\`

BusyBox wget on Alpine resolves \`localhost\` to IPv6 \`::1\` first via getaddrinfo. Next.js standalone server binds \`0.0.0.0\` (IPv4 only). Probe hits \`::1\`, gets connection refused, marks unhealthy. Nginx upstream uses the IPv4 service address, so end-users were unaffected.

## Fix

Normalize all container healthchecks to use literal \`127.0.0.1\` instead of \`localhost\`. Bypasses DNS resolution entirely.

| File | Before | After |
|------|--------|-------|
| \`dashboard/Dockerfile\` | \`wget http://localhost:3000\` (broken — wget doesn't fall back) | \`wget http://127.0.0.1:3000\` |
| \`server/Dockerfile\` | \`curl http://localhost:8000/health\` (worked but wasted one connect attempt per probe) | \`curl http://127.0.0.1:8000/health\` |
| \`deploy/docker-compose.yml\` (api) | \`curl http://localhost:8000/health\` | \`curl http://127.0.0.1:8000/health\` |

Other \`localhost\` references in compose (CORS_ORIGINS, PUBLIC_URL, NEXT_PUBLIC_API_URL) are external-facing URLs for browsers — left alone, dual-stack handled client-side.

## Test plan

- [ ] CI green
- [ ] After merge + redeploy: \`docker inspect deploy-web-1 --format '{{.State.Health.Status}}'\` returns \`healthy\` within ~30s of container start
- [ ] API container stays healthy (no regression — same probe behavior, just one less connect attempt)