### PR TITLE
feat: show verified badge next to nicknames in request lists

### DIFF
--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx
@@ -16,6 +16,7 @@ const rows: CollectLeaderboardRow[] = [
     bpm: null,
     musical_key: null,
     genre: null,
+    requester_verified: true,
   },
   {
     id: 2,
@@ -146,5 +147,20 @@ describe('LeaderboardTabs', () => {
     const voteBtn = screen.getByRole('button', { name: /upvote/i });
     fireEvent.click(voteBtn);
     expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('renders verified badge for verified requester', () => {
+    render(
+      <LeaderboardTabs
+        rows={rows}
+        tab="trending"
+        onTabChange={vi.fn()}
+        onVote={vi.fn()}
+        votedIds={new Set()}
+      />,
+    );
+    const badge = screen.getByText('✓');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveStyle({ color: '#22c55e' });
   });
 });

--- a/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
+++ b/dashboard/app/collect/[code]/components/LeaderboardTabs.tsx
@@ -170,6 +170,7 @@ export default function LeaderboardTabs({ rows, tab, onTabChange, onVote, votedI
                     {r.nickname && (
                       <div className="collect-row-nickname">
                         <em className="nickname-icon">@</em>{r.nickname}
+                        {r.requester_verified && <span style={{ color: '#22c55e', marginLeft: 4, fontStyle: 'normal' }}>✓</span>}
                       </div>
                     )}
                   </div>

--- a/dashboard/app/join/[code]/page.tsx
+++ b/dashboard/app/join/[code]/page.tsx
@@ -681,6 +681,7 @@ export default function JoinEventPage() {
                       {req.nickname && (
                         <div style={{ fontSize: 12.1, color: subFg2, marginTop: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                           Requested by {req.nickname}
+                          {req.requester_verified && <span style={{ color: '#22c55e', marginLeft: 4 }}>✓</span>}
                         </div>
                       )}
                     </div>

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -22,8 +22,8 @@ type Schemas = components['schemas'];
 
 export type Event = Schemas['EventOut'];
 export type SongRequest = Schemas['RequestOut'];
-export type PublicRequestInfo = Schemas['PublicRequestInfo'];
-export type GuestRequestInfo = Schemas['GuestRequestInfo'];
+export type PublicRequestInfo = Schemas['PublicRequestInfo'] & { requester_verified?: boolean };
+export type GuestRequestInfo = Schemas['GuestRequestInfo'] & { requester_verified?: boolean };
 export type GuestNowPlaying = Schemas['GuestNowPlaying'];
 export type GuestRequestListResponse = Schemas['GuestRequestListResponse'];
 export type MyRequestInfo = Schemas['MyRequestInfo'];

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -125,6 +125,7 @@ export interface CollectLeaderboardRow {
   bpm?: number | null;
   musical_key?: string | null;
   genre?: string | null;
+  requester_verified?: boolean;
 }
 
 export interface CollectLeaderboardResponse {

--- a/docs/superpowers/plans/2026-05-04-verified-badge-in-lists.md
+++ b/docs/superpowers/plans/2026-05-04-verified-badge-in-lists.md
@@ -1,0 +1,589 @@
+# Verified Badge in Request Lists — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a green checkmark next to verified users' nicknames in the join-page and collect-page request lists.
+
+**Architecture:** Outer-join `guests` table in two query sites (leaderboard endpoint, public requests endpoint). Derive `requester_verified` from `Guest.email_verified_at IS NOT NULL`. Frontend renders `✓` inline with existing nickname display. No migration needed.
+
+**Tech Stack:** Python/FastAPI (SQLAlchemy outer join), Next.js/React (inline styles), Vitest + pytest (tests)
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Modify | `server/app/api/public.py:33-46` | Add `requester_verified` to `PublicRequestInfo` schema |
+| Modify | `server/app/api/public.py:184-234` | Outer-join Guest in `get_public_requests()` |
+| Modify | `server/app/schemas/collect.py:61-72` | Add `requester_verified` to `CollectLeaderboardRow` |
+| Modify | `server/app/api/collect.py:114-147` | Outer-join Guest in `leaderboard()` |
+| Modify | `dashboard/lib/api.ts:116-128` | Add `requester_verified` to TS `CollectLeaderboardRow` |
+| Modify | `dashboard/app/collect/[code]/components/LeaderboardTabs.tsx:170-174` | Render ✓ badge |
+| Modify | `dashboard/app/join/[code]/page.tsx:681-684` | Render ✓ badge |
+| Modify | `server/tests/test_collect_public.py` | Test `requester_verified` in leaderboard |
+| Modify | `server/tests/test_public.py` | Test `requester_verified` in guest request list |
+| Modify | `dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx` | Update fixtures |
+
+---
+
+### Task 1: Backend — Add `requester_verified` to Pydantic schemas
+
+**Files:**
+- Modify: `server/app/api/public.py:33-41` (PublicRequestInfo)
+- Modify: `server/app/schemas/collect.py:61-72` (CollectLeaderboardRow)
+
+- [ ] **Step 1: Add field to `PublicRequestInfo`**
+
+In `server/app/api/public.py`, add to class `PublicRequestInfo`:
+
+```python
+class PublicRequestInfo(BaseModel):
+    id: int
+    title: str
+    artist: str
+    artwork_url: str | None
+    nickname: str | None = None
+    vote_count: int = 0
+    bpm: int | None = None
+    musical_key: str | None = None
+    genre: str | None = None
+    requester_verified: bool = False
+```
+
+- [ ] **Step 2: Add field to `CollectLeaderboardRow`**
+
+In `server/app/schemas/collect.py`, add to class `CollectLeaderboardRow`:
+
+```python
+class CollectLeaderboardRow(BaseModel):
+    id: int
+    title: str
+    artist: str
+    artwork_url: str | None
+    vote_count: int
+    nickname: str | None
+    status: Literal["new", "accepted", "playing", "played", "rejected"]
+    created_at: datetime
+    bpm: int | None = None
+    musical_key: str | None = None
+    genre: str | None = None
+    requester_verified: bool = False
+```
+
+- [ ] **Step 3: Verify schemas compile**
+
+Run: `cd /home/adam/github/WrzDJ/server && .venv/bin/python -c "from app.api.public import PublicRequestInfo; from app.schemas.collect import CollectLeaderboardRow; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/app/api/public.py server/app/schemas/collect.py
+git commit -m "feat: add requester_verified field to public request schemas"
+```
+
+---
+
+### Task 2: Backend — Outer-join Guest in leaderboard endpoint
+
+**Files:**
+- Modify: `server/app/api/collect.py:104-147`
+- Test: `server/tests/test_collect_public.py`
+
+- [ ] **Step 1: Write failing test — verified guest in leaderboard**
+
+Append to `server/tests/test_collect_public.py`:
+
+```python
+def test_leaderboard_row_requester_verified_true(client, db, test_event: Event):
+    """requester_verified is True when guest has email_verified_at set."""
+    from app.models.guest import Guest
+    from app.models.request import Request, RequestStatus
+
+    _enable_collection(db, test_event)
+    guest = Guest(
+        token="verified_leaderboard_test",
+        email_verified_at=datetime(2026, 5, 1),
+    )
+    db.add(guest)
+    db.flush()
+    req = Request(
+        event_id=test_event.id,
+        song_title="Verified Track",
+        artist="Verified Artist",
+        source="spotify",
+        status=RequestStatus.NEW.value,
+        vote_count=2,
+        dedupe_key="verified_lb_test",
+        submitted_during_collection=True,
+        guest_id=guest.id,
+        nickname="VerifiedUser",
+    )
+    db.add(req)
+    db.commit()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all")
+    assert r.status_code == 200
+    rows = r.json()["requests"]
+    assert len(rows) == 1
+    assert rows[0]["requester_verified"] is True
+
+
+def test_leaderboard_row_requester_verified_false_no_guest(client, db, test_event: Event):
+    """requester_verified is False when request has no guest_id."""
+    from app.models.request import Request, RequestStatus
+
+    _enable_collection(db, test_event)
+    req = Request(
+        event_id=test_event.id,
+        song_title="Anon Track",
+        artist="Anon Artist",
+        source="spotify",
+        status=RequestStatus.NEW.value,
+        vote_count=1,
+        dedupe_key="anon_lb_test",
+        submitted_during_collection=True,
+    )
+    db.add(req)
+    db.commit()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all")
+    assert r.status_code == 200
+    rows = r.json()["requests"]
+    assert len(rows) == 1
+    assert rows[0]["requester_verified"] is False
+```
+
+- [ ] **Step 2: Run test — verify it fails**
+
+Run: `cd /home/adam/github/WrzDJ/server && .venv/bin/pytest tests/test_collect_public.py::test_leaderboard_row_requester_verified_true -v`
+Expected: FAIL (field not populated yet)
+
+- [ ] **Step 3: Implement outer-join in `leaderboard()` endpoint**
+
+In `server/app/api/collect.py`, update the `leaderboard()` function. Add import at top of file:
+
+```python
+from app.models.guest import Guest
+```
+
+Replace the query section (lines ~114–147):
+
+```python
+    q = (
+        db.query(SongRequest, Guest.email_verified_at)
+        .outerjoin(Guest, SongRequest.guest_id == Guest.id)
+        .filter(SongRequest.event_id == event.id)
+        .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
+    )
+    if tab == "trending":
+        q = q.filter(SongRequest.vote_count >= 1).order_by(
+            SongRequest.vote_count.desc(), SongRequest.created_at.desc()
+        )
+    else:
+        q = q.order_by(func.lower(SongRequest.song_title).asc())
+
+    rows = q.limit(200).all()
+    return CollectLeaderboardResponse(
+        requests=[
+            CollectLeaderboardRow(
+                id=r.id,
+                title=r.song_title,
+                artist=r.artist,
+                artwork_url=r.artwork_url,
+                vote_count=r.vote_count,
+                nickname=r.nickname,
+                status=r.status,
+                created_at=r.created_at,
+                bpm=int(r.bpm) if r.bpm is not None else None,
+                musical_key=r.musical_key,
+                genre=r.genre,
+                requester_verified=email_verified_at is not None,
+            )
+            for r, email_verified_at in rows
+        ],
+        total=len(rows),
+    )
+```
+
+- [ ] **Step 4: Run tests — verify pass**
+
+Run: `cd /home/adam/github/WrzDJ/server && .venv/bin/pytest tests/test_collect_public.py -v -k "leaderboard"`
+Expected: All leaderboard tests PASS (existing + new)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/api/collect.py server/tests/test_collect_public.py
+git commit -m "feat: populate requester_verified in collect leaderboard endpoint"
+```
+
+---
+
+### Task 3: Backend — Outer-join Guest in public requests endpoint
+
+**Files:**
+- Modify: `server/app/api/public.py:184-234`
+- Test: `server/tests/test_public.py`
+
+- [ ] **Step 1: Write failing test — verified guest in public request list**
+
+Append to `server/tests/test_public.py` (inside or after `TestGuestRequestList` class, or as a new class):
+
+```python
+class TestRequesterVerifiedField:
+    """requester_verified field in GET /api/public/events/{code}/requests."""
+
+    def test_verified_guest_shows_badge(self, client: TestClient, test_event: Event, db: Session):
+        from app.models.guest import Guest
+
+        guest = Guest(token="verified_public_test", email_verified_at=datetime(2026, 5, 1))
+        db.add(guest)
+        db.flush()
+        req = Request(
+            event_id=test_event.id,
+            song_title="Badge Song",
+            artist="Badge Artist",
+            source="spotify",
+            status=RequestStatus.NEW.value,
+            dedupe_key="badge_test_001",
+            guest_id=guest.id,
+            nickname="Verified",
+        )
+        db.add(req)
+        db.commit()
+
+        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["requests"][0]["requester_verified"] is True
+
+    def test_no_guest_shows_false(self, client: TestClient, test_event: Event, db: Session):
+        req = Request(
+            event_id=test_event.id,
+            song_title="Orphan Song",
+            artist="Orphan Artist",
+            source="spotify",
+            status=RequestStatus.NEW.value,
+            dedupe_key="orphan_test_001",
+        )
+        db.add(req)
+        db.commit()
+
+        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["requests"][0]["requester_verified"] is False
+
+    def test_unverified_guest_shows_false(self, client: TestClient, test_event: Event, db: Session):
+        from app.models.guest import Guest
+
+        guest = Guest(token="unverified_public_test", email_verified_at=None)
+        db.add(guest)
+        db.flush()
+        req = Request(
+            event_id=test_event.id,
+            song_title="Unverified Song",
+            artist="Unverified Artist",
+            source="spotify",
+            status=RequestStatus.NEW.value,
+            dedupe_key="unverified_test_001",
+            guest_id=guest.id,
+        )
+        db.add(req)
+        db.commit()
+
+        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["requests"][0]["requester_verified"] is False
+```
+
+Ensure `from datetime import datetime` is imported at top of test file.
+
+- [ ] **Step 2: Run test — verify it fails**
+
+Run: `cd /home/adam/github/WrzDJ/server && .venv/bin/pytest tests/test_public.py::TestRequesterVerifiedField -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement outer-join in `get_public_requests()` endpoint**
+
+In `server/app/api/public.py`, add import near top:
+
+```python
+from app.models.guest import Guest
+```
+
+Replace the request-fetching + response construction in `get_public_requests()` (lines ~203–234). Instead of calling `get_guest_visible_requests(db, event)`, inline the query with an outer join:
+
+```python
+    requests_with_verified = (
+        db.query(SongRequest, Guest.email_verified_at)
+        .outerjoin(Guest, SongRequest.guest_id == Guest.id)
+        .filter(
+            SongRequest.event_id == event.id,
+            SongRequest.status.in_([RequestStatus.NEW.value, RequestStatus.ACCEPTED.value]),
+        )
+        .order_by(SongRequest.vote_count.desc(), SongRequest.created_at.desc())
+        .limit(50)
+        .all()
+    )
+
+    # Include now-playing if not hidden
+    guest_now_playing = None
+    if not is_now_playing_hidden(
+        db, event.id, auto_hide_minutes=event.now_playing_auto_hide_minutes
+    ):
+        np = get_now_playing(db, event.id)
+        if np:
+            guest_now_playing = GuestNowPlaying(
+                title=np.title,
+                artist=np.artist,
+                album_art_url=np.album_art_url,
+                source=np.source,
+            )
+
+    return GuestRequestListResponse(
+        event=PublicEventInfo(code=event.code, name=event.name),
+        requests=[
+            GuestRequestInfo(
+                id=r.id,
+                title=r.song_title,
+                artist=r.artist,
+                artwork_url=r.artwork_url,
+                nickname=r.nickname,
+                vote_count=r.vote_count,
+                status=r.status,
+                bpm=int(r.bpm) if r.bpm is not None else None,
+                musical_key=r.musical_key,
+                genre=r.genre,
+                requester_verified=email_verified_at is not None,
+            )
+            for r, email_verified_at in requests_with_verified
+        ],
+        now_playing=guest_now_playing,
+    )
+```
+
+Note: The `get_guest_visible_requests` import can be removed from the top if no other caller uses it in this file (check first — it's still imported for use in kiosk display, keep it if so).
+
+- [ ] **Step 4: Run tests — verify pass**
+
+Run: `cd /home/adam/github/WrzDJ/server && .venv/bin/pytest tests/test_public.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Run full backend CI**
+
+Run: `cd /home/adam/github/WrzDJ/server && .venv/bin/ruff check . && .venv/bin/pytest --tb=short -q`
+Expected: No lint errors, all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/app/api/public.py server/tests/test_public.py
+git commit -m "feat: populate requester_verified in public guest request list"
+```
+
+---
+
+### Task 4: Frontend — Add `requester_verified` to TypeScript types
+
+**Files:**
+- Modify: `dashboard/lib/api.ts:116-128`
+
+- [ ] **Step 1: Add field to `CollectLeaderboardRow`**
+
+In `dashboard/lib/api.ts`, add to the `CollectLeaderboardRow` interface:
+
+```typescript
+export interface CollectLeaderboardRow {
+  id: number;
+  title: string;
+  artist: string;
+  artwork_url: string | null;
+  vote_count: number;
+  nickname: string | null;
+  status: 'new' | 'accepted' | 'playing' | 'played' | 'rejected';
+  created_at: string;
+  bpm?: number | null;
+  musical_key?: string | null;
+  genre?: string | null;
+  requester_verified?: boolean;
+}
+```
+
+Note: `PublicRequestInfo` and `GuestRequestInfo` are auto-generated from the OpenAPI spec (in `api-types.generated.ts`). After running `npm run types:generate`, the field will appear there automatically. The hand-crafted `CollectLeaderboardRow` in `api.ts` needs manual update.
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd /home/adam/github/WrzDJ/dashboard && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/lib/api.ts
+git commit -m "feat: add requester_verified to CollectLeaderboardRow type"
+```
+
+---
+
+### Task 5: Frontend — Render verified badge in LeaderboardTabs
+
+**Files:**
+- Modify: `dashboard/app/collect/[code]/components/LeaderboardTabs.tsx:170-174`
+- Modify: `dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx`
+
+- [ ] **Step 1: Update test fixture with `requester_verified` field**
+
+In `dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx`, add a test case for the verified badge. First, add `requester_verified: true` to one fixture row:
+
+Change the first row in the `rows` array (line 6):
+```typescript
+const rows: CollectLeaderboardRow[] = [
+  {
+    id: 1,
+    title: 'A',
+    artist: 'X',
+    artwork_url: null,
+    vote_count: 5,
+    nickname: 'alex',
+    status: 'new' as const,
+    created_at: '2026-04-21',
+    bpm: null,
+    musical_key: null,
+    genre: null,
+    requester_verified: true,
+  },
+  ...
+```
+
+Add a test:
+```typescript
+it('renders verified badge for verified requester', () => {
+  render(
+    <LeaderboardTabs
+      rows={rows}
+      tab="trending"
+      onTabChange={vi.fn()}
+      onVote={vi.fn()}
+      votedIds={new Set()}
+    />,
+  );
+  const badge = screen.getByText('✓');
+  expect(badge).toBeInTheDocument();
+  expect(badge).toHaveStyle({ color: '#22c55e' });
+});
+```
+
+- [ ] **Step 2: Run test — verify it fails**
+
+Run: `cd /home/adam/github/WrzDJ/dashboard && npx vitest run app/collect/\\[code\\]/components/LeaderboardTabs.test.tsx`
+Expected: FAIL — ✓ not rendered yet
+
+- [ ] **Step 3: Render badge in LeaderboardTabs**
+
+In `dashboard/app/collect/[code]/components/LeaderboardTabs.tsx`, find the nickname rendering block (~line 170–174):
+
+```tsx
+{r.nickname && (
+  <div className="collect-row-nickname">
+    <em className="nickname-icon">@</em>{r.nickname}
+  </div>
+)}
+```
+
+Replace with:
+
+```tsx
+{r.nickname && (
+  <div className="collect-row-nickname">
+    <em className="nickname-icon">@</em>{r.nickname}
+    {r.requester_verified && <span style={{ color: '#22c55e', marginLeft: 4, fontStyle: 'normal' }}>✓</span>}
+  </div>
+)}
+```
+
+- [ ] **Step 4: Run test — verify pass**
+
+Run: `cd /home/adam/github/WrzDJ/dashboard && npx vitest run app/collect/\\[code\\]/components/LeaderboardTabs.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/app/collect/[code]/components/LeaderboardTabs.tsx dashboard/app/collect/[code]/components/LeaderboardTabs.test.tsx
+git commit -m "feat: render verified badge in collect leaderboard"
+```
+
+---
+
+### Task 6: Frontend — Render verified badge in join page
+
+**Files:**
+- Modify: `dashboard/app/join/[code]/page.tsx:681-684`
+
+- [ ] **Step 1: Render badge in join page request list**
+
+In `dashboard/app/join/[code]/page.tsx`, find the nickname line (~line 681–684):
+
+```tsx
+{req.nickname && (
+  <div style={{ fontSize: 12.1, color: subFg2, marginTop: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+    Requested by {req.nickname}
+  </div>
+)}
+```
+
+Replace with:
+
+```tsx
+{req.nickname && (
+  <div style={{ fontSize: 12.1, color: subFg2, marginTop: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+    Requested by {req.nickname}
+    {req.requester_verified && <span style={{ color: '#22c55e', marginLeft: 4 }}>✓</span>}
+  </div>
+)}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd /home/adam/github/WrzDJ/dashboard && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/app/join/[code]/page.tsx
+git commit -m "feat: render verified badge in join page request list"
+```
+
+---
+
+### Task 7: Regenerate OpenAPI types + final validation
+
+**Files:**
+- Regenerate: `dashboard/lib/api-types.generated.ts`
+
+- [ ] **Step 1: Regenerate frontend types from backend OpenAPI spec**
+
+Run: `cd /home/adam/github/WrzDJ/dashboard && npm run types:generate`
+Expected: `api-types.generated.ts` updated with `requester_verified` in `PublicRequestInfo` and `GuestRequestInfo` schemas.
+
+- [ ] **Step 2: Run full frontend CI**
+
+Run: `cd /home/adam/github/WrzDJ/dashboard && npm run lint && npx tsc --noEmit && npx vitest run`
+Expected: All pass
+
+- [ ] **Step 3: Run full backend CI**
+
+Run: `cd /home/adam/github/WrzDJ/server && .venv/bin/ruff check . && .venv/bin/ruff format --check . && .venv/bin/bandit -r app -c pyproject.toml -q && .venv/bin/pytest --tb=short -q`
+Expected: All pass
+
+- [ ] **Step 4: Commit regenerated types (if changed)**
+
+```bash
+git add dashboard/lib/api-types.generated.ts
+git commit -m "chore: regenerate OpenAPI types with requester_verified field"
+```

--- a/docs/superpowers/specs/2026-05-04-verified-badge-in-lists-design.md
+++ b/docs/superpowers/specs/2026-05-04-verified-badge-in-lists-design.md
@@ -1,0 +1,71 @@
+# Verified Badge in Request Lists
+
+**Date**: 2026-05-04
+**Author**: thewrz
+**Status**: Approved
+
+## Goal
+
+Show a green checkmark next to verified users' nicknames in the request lists on both the `join` and `collect` pages. Matches the existing verified badge style in IdentityBar (`✓`, `#22c55e`).
+
+## Approach
+
+Outer-join the `guests` table when querying requests. Derive `requester_verified = guest.email_verified_at IS NOT NULL`. No migration needed — computed from existing columns.
+
+## Backend
+
+### Schema Changes
+
+**`server/app/api/public.py` — `PublicRequestInfo`**
+Add: `requester_verified: bool = False`
+
+This propagates to `GuestRequestInfo` (extends `PublicRequestInfo`).
+
+**`server/app/schemas/collect.py` — `CollectLeaderboardRow`**
+Add: `requester_verified: bool = False`
+
+### Query Changes
+
+**`server/app/api/collect.py` — `leaderboard()` endpoint (line 114)**
+- Join `Guest` on `SongRequest.guest_id == Guest.id` (outer join, since `guest_id` is nullable)
+- Select `Guest.email_verified_at` alongside request columns
+- Derive `requester_verified` in response construction
+
+**`server/app/api/public.py` — `get_public_requests()` endpoint (line 184)**
+- Either modify `get_guest_visible_requests()` in `services/request.py` to return tuples with verification status, or inline the join in the endpoint
+- Same outer join pattern as collect
+
+## Frontend
+
+### Type Changes
+
+**`dashboard/lib/api.ts` — `CollectLeaderboardRow`**
+Add: `requester_verified?: boolean`
+
+**`dashboard/lib/api-types.ts` — `GuestRequestInfo` (or `PublicRequestInfo`)**
+Add: `requester_verified?: boolean`
+
+### Rendering
+
+**`dashboard/app/collect/[code]/components/LeaderboardTabs.tsx` ~line 170**
+After nickname text, conditionally render:
+```tsx
+{r.requester_verified && <span style={{ color: '#22c55e', marginLeft: 4 }}>✓</span>}
+```
+
+**`dashboard/app/join/[code]/page.tsx` ~line 683**
+Same pattern — append `✓` after "Requested by {nickname}" when `req.requester_verified` is true.
+
+## Non-Goals
+
+- No migration (no new DB columns)
+- No changes to IdentityBar or existing badge
+- No verified badge on kiosk display page
+- No admin-side changes
+
+## Testing
+
+- Backend: add `requester_verified` field to existing test fixtures for `GuestRequestInfo` and `CollectLeaderboardRow`
+- Verify field is `true` when guest has `email_verified_at` set, `false` otherwise
+- Verify field is `false` when `guest_id` is null (orphaned request)
+- Frontend: update existing component tests if they assert on rendered nickname rows

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 from app.api.deps import get_db, require_verified_human_soft
 from app.core.rate_limit import get_guest_id, limiter
 from app.models.event import Event
+from app.models.guest import Guest
 from app.models.request import Request as SongRequest
 from app.models.request import RequestStatus
 from app.models.request_vote import RequestVote
@@ -112,7 +113,8 @@ def leaderboard(
     event = _get_event_or_404(db, code)
 
     q = (
-        db.query(SongRequest)
+        db.query(SongRequest, Guest.email_verified_at)
+        .outerjoin(Guest, SongRequest.guest_id == Guest.id)
         .filter(SongRequest.event_id == event.id)
         .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
     )
@@ -140,8 +142,9 @@ def leaderboard(
                 bpm=int(r.bpm) if r.bpm is not None else None,
                 musical_key=r.musical_key,
                 genre=r.genre,
+                requester_verified=email_verified_at is not None,
             )
-            for r in rows
+            for r, email_verified_at in rows
         ],
         total=len(rows),
     )

--- a/server/app/api/public.py
+++ b/server/app/api/public.py
@@ -40,6 +40,7 @@ class PublicRequestInfo(BaseModel):
     bpm: int | None = None
     musical_key: str | None = None
     genre: str | None = None
+    requester_verified: bool = False
 
 
 class GuestRequestInfo(PublicRequestInfo):

--- a/server/app/api/public.py
+++ b/server/app/api/public.py
@@ -12,14 +12,12 @@ from app.api.deps import get_db
 from app.core.config import get_settings
 from app.core.rate_limit import get_guest_id, limiter
 from app.core.time import utcnow
+from app.models.guest import Guest
 from app.models.request import Request as SongRequest
 from app.models.request import RequestStatus
 from app.services.event import EventLookupResult, get_event_by_code_with_status
 from app.services.now_playing import get_now_playing, is_now_playing_hidden
-from app.services.request import (
-    get_guest_visible_requests,
-    get_requests_by_guest,
-)
+from app.services.request import get_requests_by_guest
 
 router = APIRouter()
 settings = get_settings()
@@ -201,7 +199,17 @@ def get_public_requests(
     if lookup_result == EventLookupResult.ARCHIVED:
         raise HTTPException(status_code=410, detail="Event has been archived")
 
-    requests_list = get_guest_visible_requests(db, event)
+    requests_with_verified = (
+        db.query(SongRequest, Guest.email_verified_at)
+        .outerjoin(Guest, SongRequest.guest_id == Guest.id)
+        .filter(
+            SongRequest.event_id == event.id,
+            SongRequest.status.in_([RequestStatus.NEW.value, RequestStatus.ACCEPTED.value]),
+        )
+        .order_by(SongRequest.vote_count.desc(), SongRequest.created_at.desc())
+        .limit(50)
+        .all()
+    )
 
     # Include now-playing if not hidden
     guest_now_playing = None
@@ -231,8 +239,9 @@ def get_public_requests(
                 bpm=int(r.bpm) if r.bpm is not None else None,
                 musical_key=r.musical_key,
                 genre=r.genre,
+                requester_verified=email_verified_at is not None,
             )
-            for r in requests_list
+            for r, email_verified_at in requests_with_verified
         ],
         now_playing=guest_now_playing,
     )

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -70,6 +70,7 @@ class CollectLeaderboardRow(BaseModel):
     bpm: int | None = None
     musical_key: str | None = None
     genre: str | None = None
+    requester_verified: bool = False
 
 
 class CollectLeaderboardResponse(BaseModel):

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1,23 +1,5251 @@
 {
+  "openapi": "3.1.0",
+  "info": {
+    "title": "WrzDJ API",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/health": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Api Health Check",
+        "description": "Health check endpoint for monitoring and load balancers.",
+        "operationId": "api_health_check_api_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Login",
+        "operationId": "login_api_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_login_api_auth_login_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Token"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Logout",
+        "description": "Invalidate all outstanding JWTs for the current user.\n\nSECURITY (CRIT-2): bumps token_version so every previously-issued JWT\nfor this user fails the version check in get_current_user.",
+        "operationId": "logout_api_auth_logout_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/auth/me": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Get Me",
+        "operationId": "get_me_api_auth_me_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOut"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/auth/help-seen": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Mark Help Page Seen",
+        "description": "Mark a help page as seen for the current user.",
+        "operationId": "mark_help_page_seen_api_auth_help_seen_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HelpPageSeenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/auth/settings": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Get Public Settings",
+        "description": "Public endpoint returning registration status and Turnstile site key.",
+        "operationId": "get_public_settings_api_auth_settings_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/register": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Register",
+        "description": "Register a new user (pending approval).",
+        "operationId": "register_api_auth_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "List Events",
+        "operationId": "list_events_api_events_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/EventOut"
+                  },
+                  "type": "array",
+                  "title": "Response List Events Api Events Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Create New Event",
+        "operationId": "create_new_event_api_events_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/events/archived": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "List Archived Events",
+        "description": "List all archived and expired events for the current user.",
+        "operationId": "list_archived_events_api_events_archived_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/EventOut"
+                  },
+                  "type": "array",
+                  "title": "Response List Archived Events Api Events Archived Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/events/activity": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Get Activity Log",
+        "description": "Get recent activity log entries for the current user's events.",
+        "operationId": "get_activity_log_api_events_activity_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "event_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Event Code"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActivityLogEntry"
+                  },
+                  "title": "Response Get Activity Log Api Events Activity Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Get Event",
+        "operationId": "get_event_api_events__code__get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Update Event Endpoint",
+        "operationId": "update_event_endpoint_api_events__code__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Delete Event Endpoint",
+        "description": "Delete an event and all its requests.",
+        "operationId": "delete_event_endpoint_api_events__code__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/search": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Event Search",
+        "description": "Public search endpoint for event guests.\n\nPriority: Tidal (primary) \u2192 Spotify (fallback) \u2192 Beatport (event toggle).\nResults are filtered for junk, deduplicated by ISRC, and sorted by popularity.",
+        "operationId": "event_search_api_events__code__search_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200,
+              "title": "Q"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SearchResult"
+                  },
+                  "title": "Response Event Search Api Events  Code  Search Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/bulk-delete": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Bulk Delete Events Endpoint",
+        "description": "Bulk delete multiple events owned by the current user.",
+        "operationId": "bulk_delete_events_endpoint_api_events_bulk_delete_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkDeleteEventsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkActionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/events/{code}/archive": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Archive Event Endpoint",
+        "description": "Archive an event.",
+        "operationId": "archive_event_endpoint_api_events__code__archive_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/unarchive": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Unarchive Event Endpoint",
+        "description": "Unarchive an event.",
+        "operationId": "unarchive_event_endpoint_api_events__code__unarchive_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/display-settings": {
+      "patch": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Update Display Settings",
+        "description": "Update display settings for an event (e.g., hide/show now playing on kiosk).",
+        "operationId": "update_display_settings_api_events__code__display_settings_patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisplaySettingsUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DisplaySettingsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Get Display Settings",
+        "description": "Get current display settings for an event.",
+        "operationId": "get_display_settings_api_events__code__display_settings_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DisplaySettingsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/export/csv": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Export Event Csv",
+        "description": "Export event requests as CSV. Owner can export regardless of event status.",
+        "operationId": "export_event_csv_api_events__code__export_csv_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/export/play-history/csv": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Export Play History Csv",
+        "description": "Export play history as CSV. Owner can export regardless of event status.",
+        "operationId": "export_play_history_csv_api_events__code__export_play_history_csv_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/requests": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Submit Request",
+        "operationId": "submit_request_api_events__code__requests_post",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RequestCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Get Event Requests",
+        "operationId": "get_event_requests_api_events__code__requests_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/RequestStatus"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Since"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "chronological",
+                "priority"
+              ],
+              "type": "string",
+              "default": "chronological",
+              "title": "Sort"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RequestOut"
+                  },
+                  "title": "Response Get Event Requests Api Events  Code  Requests Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/requests/accept-all": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Accept All Requests Endpoint",
+        "description": "Accept all NEW requests for an event in one operation.",
+        "operationId": "accept_all_requests_endpoint_api_events__code__requests_accept_all_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptAllResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/requests/reject-all": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Reject All Requests Endpoint",
+        "description": "Reject all NEW requests for an event in one operation.",
+        "operationId": "reject_all_requests_endpoint_api_events__code__requests_reject_all_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkActionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/requests/bulk": {
+      "delete": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Bulk Delete Requests Endpoint",
+        "description": "Bulk delete requests for an event, optionally filtered by status.",
+        "operationId": "bulk_delete_requests_endpoint_api_events__code__requests_bulk_delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkActionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/recommendations": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Get Recommendations",
+        "description": "Generate song recommendations based on the event's musical profile.",
+        "operationId": "get_recommendations_api_events__code__recommendations_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecommendationResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/playlists": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Get Playlists",
+        "description": "List the DJ's playlists from connected music services.",
+        "operationId": "get_playlists_api_events__code__playlists_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/recommendations/from-template": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Get Recommendations From Template",
+        "description": "Generate recommendations using a template playlist.",
+        "operationId": "get_recommendations_from_template_api_events__code__recommendations_from_template_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TemplatePlaylistRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecommendationResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/recommendations/llm": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Get Llm Recommendations",
+        "description": "Generate song recommendations from an LLM-interpreted DJ prompt.",
+        "operationId": "get_llm_recommendations_api_events__code__recommendations_llm_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LLMPromptRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/banner": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Upload Banner",
+        "description": "Upload a custom banner image for the event.",
+        "operationId": "upload_banner_api_events__code__banner_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_banner_api_events__code__banner_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Delete Banner",
+        "description": "Delete the event's custom banner image.",
+        "operationId": "delete_banner_api_events__code__banner_delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/collection": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Get Collection Settings",
+        "description": "Get pre-event collection scheduling settings.",
+        "operationId": "get_collection_settings_api_events__code__collection_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Collection Settings Api Events  Code  Collection Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Update Collection Settings Endpoint",
+        "description": "Update pre-event collection scheduling settings.",
+        "operationId": "update_collection_settings_endpoint_api_events__code__collection_patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCollectionSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Update Collection Settings Endpoint Api Events  Code  Collection Patch"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/pending-review": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Pending Review",
+        "description": "Get pending review data source for DJ bulk-review.",
+        "operationId": "pending_review_api_events__code__pending_review_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PendingReviewResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/bulk-review": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Bulk Review",
+        "operationId": "bulk_review_api_events__code__bulk_review_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkReviewRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkReviewResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{code}/enrich-all": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Enrich All Requests",
+        "description": "Queue enrichment for up to ENRICH_ALL_BATCH_LIMIT requests missing BPM, key, or genre.\n\nBatched to avoid exhausting the connection pool when many tracks need enrichment.\nReturns `remaining` so the caller can re-invoke until 0.",
+        "operationId": "enrich_all_requests_api_events__code__enrich_all_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/requests/{request_id}": {
+      "patch": {
+        "tags": [
+          "requests"
+        ],
+        "summary": "Update Request",
+        "operationId": "update_request_api_requests__request_id__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Request Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RequestUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "requests"
+        ],
+        "summary": "Delete Request Endpoint",
+        "description": "Delete a single request. Ownership verified via event.",
+        "operationId": "delete_request_endpoint_api_requests__request_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Request Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/requests/{request_id}/refresh-metadata": {
+      "post": {
+        "tags": [
+          "requests"
+        ],
+        "summary": "Refresh Request Metadata",
+        "description": "Clear existing metadata and re-enrich from external services.",
+        "operationId": "refresh_request_metadata_api_requests__request_id__refresh_metadata_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Request Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/requests/{request_id}/vote": {
+      "post": {
+        "tags": [
+          "votes"
+        ],
+        "summary": "Vote For Request",
+        "description": "Upvote a song request. Idempotent: voting twice has no effect.\n\nRequires a guest cookie. Anonymous callers receive 401.",
+        "operationId": "vote_for_request_api_requests__request_id__vote_post",
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "title": "Request Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VoteResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "votes"
+        ],
+        "summary": "Unvote Request",
+        "description": "Remove vote from a song request. Idempotent.\n\nRequires a guest cookie. Anonymous callers receive 401.",
+        "operationId": "unvote_request_api_requests__request_id__vote_delete",
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "title": "Request Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VoteResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/search": {
+      "get": {
+        "tags": [
+          "search"
+        ],
+        "summary": "Search",
+        "description": "DJ search endpoint. Tidal primary, Spotify fallback.",
+        "operationId": "search_api_search_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200,
+              "title": "Q"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SearchResult"
+                  },
+                  "title": "Response Search Api Search Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/search/cache": {
+      "delete": {
+        "tags": [
+          "search"
+        ],
+        "summary": "Clear Search Cache",
+        "description": "Clear all cached search results (admin only).",
+        "operationId": "clear_search_cache_api_search_cache_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CacheClearResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/public/events/{code}/display": {
+      "get": {
+        "tags": [
+          "public"
+        ],
+        "summary": "Get Kiosk Display",
+        "description": "Get public kiosk display data for an event.",
+        "operationId": "get_kiosk_display_api_public_events__code__display_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskDisplayResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/events/{code}/requests": {
+      "get": {
+        "tags": [
+          "public"
+        ],
+        "summary": "Get Public Requests",
+        "description": "Get publicly visible requests for an event (NEW and ACCEPTED only).",
+        "operationId": "get_public_requests_api_public_events__code__requests_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GuestRequestListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/events/{code}/has-requested": {
+      "get": {
+        "tags": [
+          "public"
+        ],
+        "summary": "Check Has Requested",
+        "description": "Check if the current client has submitted any requests for this event.",
+        "operationId": "check_has_requested_api_public_events__code__has_requested_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HasRequestedResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/events/{code}/my-requests": {
+      "get": {
+        "tags": [
+          "public"
+        ],
+        "summary": "Get My Requests",
+        "description": "Get all requests submitted by the current client for this event.",
+        "operationId": "get_my_requests_api_public_events__code__my_requests_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MyRequestsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/guest/identify": {
+      "post": {
+        "tags": [
+          "guest"
+        ],
+        "summary": "Identify",
+        "description": "Resolve guest identity via cookie token and/or browser fingerprint.",
+        "operationId": "identify_api_public_guest_identify_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IdentifyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IdentifyResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/guest/verify-human": {
+      "post": {
+        "tags": [
+          "guest"
+        ],
+        "summary": "Verify Human",
+        "description": "Validate a Turnstile token and issue a wrzdj_human session cookie.",
+        "operationId": "verify_human_api_public_guest_verify_human_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyHumanRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyHumanResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/guest/verify/request": {
+      "post": {
+        "tags": [
+          "verify"
+        ],
+        "summary": "Request Verification Code",
+        "description": "Send a verification code to the provided email.\n\nRequires a fresh Turnstile token (separate from the session cookie) to\nprotect against email-cost / sender-reputation abuse.",
+        "operationId": "request_verification_code_api_public_guest_verify_request_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyRequestSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyRequestResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/guest/verify/confirm": {
+      "post": {
+        "tags": [
+          "verify"
+        ],
+        "summary": "Confirm Code",
+        "description": "Confirm a verification code. May trigger guest merge.",
+        "operationId": "confirm_code_api_public_guest_verify_confirm_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyConfirmSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyConfirmResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/collect/{code}": {
+      "get": {
+        "tags": [
+          "collect"
+        ],
+        "summary": "Preview",
+        "operationId": "preview_api_public_collect__code__get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectEventPreview"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/collect/{code}/leaderboard": {
+      "get": {
+        "tags": [
+          "collect"
+        ],
+        "summary": "Leaderboard",
+        "operationId": "leaderboard_api_public_collect__code__leaderboard_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          },
+          {
+            "name": "tab",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "trending",
+                "all"
+              ],
+              "type": "string",
+              "default": "trending",
+              "title": "Tab"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectLeaderboardResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/collect/{code}/profile": {
+      "get": {
+        "tags": [
+          "collect"
+        ],
+        "summary": "Get Profile",
+        "description": "Read the calling guest's profile for this event. Anonymous callers\n(no cookie) get the default empty profile \u2014 there is no IP fallback.",
+        "operationId": "get_profile_api_public_collect__code__profile_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectProfileResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "collect"
+        ],
+        "summary": "Set Profile",
+        "operationId": "set_profile_api_public_collect__code__profile_post",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollectProfileRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectProfileResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/collect/{code}/profile/me": {
+      "get": {
+        "tags": [
+          "collect"
+        ],
+        "summary": "My Picks",
+        "operationId": "my_picks_api_public_collect__code__profile_me_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectMyPicksResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/collect/{code}/requests": {
+      "post": {
+        "tags": [
+          "collect"
+        ],
+        "summary": "Submit",
+        "operationId": "submit_api_public_collect__code__requests_post",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollectSubmitRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/collect/{code}/vote": {
+      "post": {
+        "tags": [
+          "collect"
+        ],
+        "summary": "Vote",
+        "operationId": "vote_api_public_collect__code__vote_post",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollectVoteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/collect/{code}/enrich-preview": {
+      "post": {
+        "tags": [
+          "collect"
+        ],
+        "summary": "Enrich Preview",
+        "description": "Lightweight Beatport BPM/key lookup for search-time vibes \u2014 no DB writes.",
+        "operationId": "enrich_preview_api_public_collect__code__enrich_preview_post",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnrichPreviewRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnrichPreviewResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/events/{code}/stream": {
+      "get": {
+        "tags": [
+          "sse"
+        ],
+        "summary": "Event Stream",
+        "description": "Public SSE endpoint for real-time event updates.\n\nSECURITY (CRIT-5): rate-limited and existence-checked. Before this fix,\nthe endpoint had no rate limit and no existence check, allowing\nunauthenticated DoS (unlimited long-lived connections exhausting FDs)\nand passive eavesdropping via 6-char event-code brute force.\n\nEvent types:\n- request_created: New request submitted\n- request_status_changed: Request status update\n- now_playing_changed: Now-playing track update\n- requests_bulk_update: Batch accept/reject\n- bridge_status_changed: Bridge connect/disconnect",
+        "operationId": "event_stream_api_public_events__code__stream_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/bridge/apikey": {
+      "get": {
+        "tags": [
+          "bridge"
+        ],
+        "summary": "Get Bridge Api Key",
+        "description": "Return the server's bridge API key to an admin user.\n\nThe GUI uses this so the DJ doesn't have to manually paste the key.\nRestricted to admins to prevent non-owners from impersonating the bridge.",
+        "operationId": "get_bridge_api_key_api_bridge_apikey_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BridgeApiKeyResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/bridge/nowplaying": {
+      "post": {
+        "tags": [
+          "bridge"
+        ],
+        "summary": "Post Now Playing",
+        "description": "Bridge reports a new track playing.\n\nCalled when the DJ loads/plays a new track on their equipment.\nArchives the previous track to play history and updates now_playing.\nRate limited to 60 requests per minute.",
+        "operationId": "post_now_playing_api_bridge_nowplaying_post",
+        "parameters": [
+          {
+            "name": "x-bridge-api-key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Bridge-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NowPlayingBridgePayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/bridge/status": {
+      "post": {
+        "tags": [
+          "bridge"
+        ],
+        "summary": "Post Bridge Status",
+        "description": "Bridge reports connection status.\n\nCalled when bridge connects/disconnects from DJ equipment.\nRate limited to 30 requests per minute.",
+        "operationId": "post_bridge_status_api_bridge_status_post",
+        "parameters": [
+          {
+            "name": "x-bridge-api-key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Bridge-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BridgeStatusPayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/bridge/nowplaying/{code}": {
+      "delete": {
+        "tags": [
+          "bridge"
+        ],
+        "summary": "Delete Now Playing",
+        "description": "Bridge signals track ended / deck cleared.\n\nArchives current track to history and clears now_playing.\nRate limited to 60 requests per minute.",
+        "operationId": "delete_now_playing_api_bridge_nowplaying__code__delete",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 10,
+              "title": "Code"
+            }
+          },
+          {
+            "name": "x-bridge-api-key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Bridge-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/e/{code}/nowplaying": {
+      "get": {
+        "tags": [
+          "bridge"
+        ],
+        "summary": "Get Public Now Playing",
+        "description": "Get current now-playing track for public display.\n\nReturns the track currently playing from StageLinQ, or None if nothing playing.",
+        "operationId": "get_public_now_playing_api_public_e__code__nowplaying_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/NowPlayingResponse"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "title": "Response Get Public Now Playing Api Public E  Code  Nowplaying Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/e/{code}/bridge-status": {
+      "get": {
+        "tags": [
+          "bridge"
+        ],
+        "summary": "Get Public Bridge Status",
+        "description": "Get bridge connection status for public display.\n\nIndependent of track data \u2014 returns bridge connectivity even when\nno track is currently playing.",
+        "operationId": "get_public_bridge_status_api_public_e__code__bridge_status_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BridgeStatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/e/{code}/history": {
+      "get": {
+        "tags": [
+          "bridge"
+        ],
+        "summary": "Get Public History",
+        "description": "Get play history for public display.\n\nReturns the list of tracks played during the event, newest first.",
+        "operationId": "get_public_history_api_public_e__code__history_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlayHistoryResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/bridge/commands/{code}": {
+      "post": {
+        "tags": [
+          "bridge"
+        ],
+        "summary": "Post Bridge Command",
+        "description": "Queue a command for the bridge to pick up.\n\nRequires JWT auth. The user must own the event or be an admin.\nRate limited to 10 requests per minute.",
+        "operationId": "post_bridge_command_api_bridge_commands__code__post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 10,
+              "title": "Code"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BridgeCommandRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BridgeCommandResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "bridge"
+        ],
+        "summary": "Get Bridge Commands",
+        "description": "Poll and clear pending commands for the bridge.\n\nRequires bridge API key auth. Returns all pending commands and clears the queue.\nRate limited to 30 requests per minute.",
+        "operationId": "get_bridge_commands_api_bridge_commands__code__get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 10,
+              "title": "Code"
+            }
+          },
+          {
+            "name": "x-bridge-api-key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Bridge-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BridgeCommandsPollResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tidal/auth/start": {
+      "post": {
+        "tags": [
+          "tidal"
+        ],
+        "summary": "Start Auth",
+        "description": "Start Tidal device login flow.\n\nReturns a URL and code for the user to visit and authorize.\nThe frontend should poll /auth/check to wait for completion.",
+        "operationId": "start_auth_api_tidal_auth_start_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TidalAuthStartResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/tidal/auth/check": {
+      "get": {
+        "tags": [
+          "tidal"
+        ],
+        "summary": "Check Auth",
+        "description": "Check if device login is complete.\n\nReturns:\n- complete: true if login succeeded\n- pending: true if still waiting for user\n- error: error message if login failed",
+        "operationId": "check_auth_api_tidal_auth_check_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TidalAuthCheckResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/tidal/auth/cancel": {
+      "post": {
+        "tags": [
+          "tidal"
+        ],
+        "summary": "Cancel Auth",
+        "description": "Cancel pending device login.",
+        "operationId": "cancel_auth_api_tidal_auth_cancel_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/tidal/status": {
+      "get": {
+        "tags": [
+          "tidal"
+        ],
+        "summary": "Get Status",
+        "description": "Check if current user has linked Tidal account.",
+        "operationId": "get_status_api_tidal_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TidalStatus"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/tidal/disconnect": {
+      "post": {
+        "tags": [
+          "tidal"
+        ],
+        "summary": "Disconnect",
+        "description": "Unlink Tidal account from current user.",
+        "operationId": "disconnect_api_tidal_disconnect_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/tidal/search": {
+      "get": {
+        "tags": [
+          "tidal"
+        ],
+        "summary": "Search",
+        "description": "Search Tidal for tracks.",
+        "operationId": "search_api_tidal_search_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "title": "Q"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 50,
+              "minimum": 1,
+              "default": 10,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TidalSearchResult"
+                  },
+                  "title": "Response Search Api Tidal Search Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tidal/events/{event_id}/settings": {
+      "get": {
+        "tags": [
+          "tidal"
+        ],
+        "summary": "Get Event Settings",
+        "description": "Get Tidal sync settings for an event.",
+        "operationId": "get_event_settings_api_tidal_events__event_id__settings_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "event_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Event Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TidalEventSettings"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "tidal"
+        ],
+        "summary": "Update Event Settings",
+        "description": "Update Tidal sync settings for an event.",
+        "operationId": "update_event_settings_api_tidal_events__event_id__settings_put",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "event_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Event Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TidalEventSettingsUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TidalEventSettings"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tidal/requests/{request_id}/sync": {
+      "post": {
+        "tags": [
+          "tidal"
+        ],
+        "summary": "Sync Request",
+        "description": "Manually trigger Tidal sync for a request.",
+        "operationId": "sync_request_api_tidal_requests__request_id__sync_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Request Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TidalSyncResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tidal/requests/{request_id}/link": {
+      "post": {
+        "tags": [
+          "tidal"
+        ],
+        "summary": "Link Track",
+        "description": "Manually link a Tidal track to a request.",
+        "operationId": "link_track_api_tidal_requests__request_id__link_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Request Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TidalManualLink"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TidalSyncResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/beatport/auth/login": {
+      "post": {
+        "tags": [
+          "beatport"
+        ],
+        "summary": "Login Beatport",
+        "description": "Authenticate with Beatport using username/password.\n\nThe backend logs in to Beatport server-side, obtains an authorization\ncode, exchanges it for tokens, and stores them on the user.",
+        "operationId": "login_beatport_api_beatport_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BeatportLogin"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/beatport/status": {
+      "get": {
+        "tags": [
+          "beatport"
+        ],
+        "summary": "Get Status",
+        "description": "Check if current user has linked Beatport account.",
+        "operationId": "get_status_api_beatport_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeatportStatus"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/beatport/disconnect": {
+      "post": {
+        "tags": [
+          "beatport"
+        ],
+        "summary": "Disconnect",
+        "description": "Unlink Beatport account from current user.",
+        "operationId": "disconnect_api_beatport_disconnect_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/beatport/search": {
+      "get": {
+        "tags": [
+          "beatport"
+        ],
+        "summary": "Search",
+        "description": "Search Beatport for tracks.",
+        "operationId": "search_api_beatport_search_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200,
+              "title": "Q"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 50,
+              "minimum": 1,
+              "default": 10,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BeatportSearchResult"
+                  },
+                  "title": "Response Search Api Beatport Search Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/beatport/events/{event_id}/settings": {
+      "get": {
+        "tags": [
+          "beatport"
+        ],
+        "summary": "Get Event Settings",
+        "description": "Get Beatport sync settings for an event.",
+        "operationId": "get_event_settings_api_beatport_events__event_id__settings_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "event_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Event Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeatportEventSettings"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "beatport"
+        ],
+        "summary": "Update Event Settings",
+        "description": "Update Beatport sync settings for an event.",
+        "operationId": "update_event_settings_api_beatport_events__event_id__settings_put",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "event_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Event Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BeatportEventSettingsUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeatportEventSettings"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/beatport/requests/{request_id}/link": {
+      "post": {
+        "tags": [
+          "beatport"
+        ],
+        "summary": "Link Track",
+        "description": "Manually link a Beatport track to a request.\n\nVerifies the track exists on Beatport, then stores the\nBeatport URL and metadata in sync_results_json.",
+        "operationId": "link_track_api_beatport_requests__request_id__link_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Request Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BeatportManualLink"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/kiosk/pair-challenge": {
+      "get": {
+        "tags": [
+          "kiosk"
+        ],
+        "summary": "Get Pair Challenge",
+        "description": "Issue a one-time IP-bound nonce required for kiosk pairing.",
+        "operationId": "get_pair_challenge_api_public_kiosk_pair_challenge_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskPairChallengeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/kiosk/pair": {
+      "post": {
+        "tags": [
+          "kiosk"
+        ],
+        "summary": "Create Pairing",
+        "description": "Create a new kiosk pairing session.\n\nRequires a valid X-Pair-Nonce header obtained from /pair-challenge,\nbound to the same client IP. Nonce is consumed on use.",
+        "operationId": "create_pairing_api_public_kiosk_pair_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskPairResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/kiosk/pair/{pair_code}/status": {
+      "get": {
+        "tags": [
+          "kiosk"
+        ],
+        "summary": "Get Pair Status",
+        "description": "Poll the status of a pairing code.",
+        "operationId": "get_pair_status_api_public_kiosk_pair__pair_code__status_get",
+        "parameters": [
+          {
+            "name": "pair_code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Pair Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskPairStatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/kiosk/session/assignment": {
+      "get": {
+        "tags": [
+          "kiosk"
+        ],
+        "summary": "Get Session Assignment",
+        "description": "Poll the kiosk's current event assignment. Updates last_seen_at.\n\nSession token must be sent in the X-Kiosk-Session header (not in the URL path)\nto prevent token leakage in access logs.",
+        "operationId": "get_session_assignment_api_public_kiosk_session_assignment_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskSessionResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kiosk/pair/{pair_code}/complete": {
+      "post": {
+        "tags": [
+          "kiosk"
+        ],
+        "summary": "Complete Kiosk Pairing",
+        "description": "Complete a kiosk pairing by assigning an event.",
+        "operationId": "complete_kiosk_pairing_api_kiosk_pair__pair_code__complete_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "pair_code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Pair Code"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KioskCompletePairingRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kiosk/mine": {
+      "get": {
+        "tags": [
+          "kiosk"
+        ],
+        "summary": "List My Kiosks",
+        "description": "List all kiosks paired by the current user.",
+        "operationId": "list_my_kiosks_api_kiosk_mine_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/KioskOut"
+                  },
+                  "type": "array",
+                  "title": "Response List My Kiosks Api Kiosk Mine Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/kiosk/{kiosk_id}/assign": {
+      "patch": {
+        "tags": [
+          "kiosk"
+        ],
+        "summary": "Assign Kiosk",
+        "description": "Change which event a kiosk displays.",
+        "operationId": "assign_kiosk_api_kiosk__kiosk_id__assign_patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "kiosk_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Kiosk Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KioskAssignRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kiosk/{kiosk_id}": {
+      "patch": {
+        "tags": [
+          "kiosk"
+        ],
+        "summary": "Rename Kiosk Endpoint",
+        "description": "Rename a kiosk.",
+        "operationId": "rename_kiosk_endpoint_api_kiosk__kiosk_id__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "kiosk_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Kiosk Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KioskRenameRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "kiosk"
+        ],
+        "summary": "Delete Kiosk Endpoint",
+        "description": "Unpair and delete a kiosk.",
+        "operationId": "delete_kiosk_endpoint_api_kiosk__kiosk_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "kiosk_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Kiosk Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/stats": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin Stats",
+        "operationId": "admin_stats_api_admin_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemStats"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/users": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin List Users",
+        "operationId": "admin_list_users_api_admin_users_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "role",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Role"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin Create User",
+        "operationId": "admin_create_user_api_admin_users_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminUserCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminUserOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/users/{user_id}": {
+      "patch": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin Update User",
+        "operationId": "admin_update_user_api_admin_users__user_id__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminUserUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminUserOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin Delete User",
+        "operationId": "admin_delete_user_api_admin_users__user_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/events": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin List Events",
+        "operationId": "admin_list_events_api_admin_events_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/events/{code}": {
+      "patch": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin Update Event",
+        "description": "Admin can edit any event (not just their own).",
+        "operationId": "admin_update_event_api_admin_events__code__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminEventOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin Delete Event",
+        "description": "Admin can delete any event.",
+        "operationId": "admin_delete_event_api_admin_events__code__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/events/bulk-delete": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin Bulk Delete Events",
+        "description": "Admin can bulk delete events from any owner.",
+        "operationId": "admin_bulk_delete_events_api_admin_events_bulk_delete_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkDeleteEventsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkActionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/settings": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin Get Settings",
+        "operationId": "admin_get_settings_api_admin_settings_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemSettingsOut"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin Update Settings",
+        "operationId": "admin_update_settings_api_admin_settings_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SystemSettingsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemSettingsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/integrations": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin Get Integrations",
+        "description": "Get status of all external integrations (no active health checks).",
+        "operationId": "admin_get_integrations_api_admin_integrations_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationHealthResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/integrations/{service}": {
+      "patch": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin Toggle Integration",
+        "description": "Enable or disable a specific integration.",
+        "operationId": "admin_toggle_integration_api_admin_integrations__service__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "service",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Service"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IntegrationToggleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationToggleResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/integrations/{service}/check": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin Check Integration",
+        "description": "Run an active health check for a specific service (rate limited).",
+        "operationId": "admin_check_integration_api_admin_integrations__service__check_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "service",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Service"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationCheckResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/ai/models": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin Get Ai Models",
+        "description": "List available AI models.",
+        "operationId": "admin_get_ai_models_api_admin_ai_models_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AIModelsResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/ai/settings": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin Get Ai Settings",
+        "description": "Get AI/LLM configuration.",
+        "operationId": "admin_get_ai_settings_api_admin_ai_settings_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AISettingsOut"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Admin Update Ai Settings",
+        "description": "Update AI/LLM configuration.",
+        "operationId": "admin_update_ai_settings_api_admin_ai_settings_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AISettingsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AISettingsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Health Check",
+        "operationId": "health_check_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "components": {
     "schemas": {
       "AIModelInfo": {
         "properties": {
           "id": {
-            "title": "Id",
-            "type": "string"
+            "type": "string",
+            "title": "Id"
           },
           "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "string",
+            "title": "Name"
           }
         },
+        "type": "object",
         "required": [
           "id",
           "name"
         ],
-        "title": "AIModelInfo",
-        "type": "object"
+        "title": "AIModelInfo"
       },
       "AIModelsResponse": {
         "properties": {
@@ -25,48 +5253,48 @@
             "items": {
               "$ref": "#/components/schemas/AIModelInfo"
             },
-            "title": "Models",
-            "type": "array"
+            "type": "array",
+            "title": "Models"
           }
         },
+        "type": "object",
         "required": [
           "models"
         ],
-        "title": "AIModelsResponse",
-        "type": "object"
+        "title": "AIModelsResponse"
       },
       "AISettingsOut": {
         "properties": {
-          "api_key_configured": {
-            "title": "Api Key Configured",
-            "type": "boolean"
-          },
-          "api_key_masked": {
-            "title": "Api Key Masked",
-            "type": "string"
-          },
           "llm_enabled": {
-            "title": "Llm Enabled",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Llm Enabled"
           },
           "llm_model": {
-            "title": "Llm Model",
-            "type": "string"
+            "type": "string",
+            "title": "Llm Model"
           },
           "llm_rate_limit_per_minute": {
-            "title": "Llm Rate Limit Per Minute",
-            "type": "integer"
+            "type": "integer",
+            "title": "Llm Rate Limit Per Minute"
+          },
+          "api_key_configured": {
+            "type": "boolean",
+            "title": "Api Key Configured"
+          },
+          "api_key_masked": {
+            "type": "string",
+            "title": "Api Key Masked"
           }
         },
+        "type": "object",
         "required": [
-          "api_key_configured",
-          "api_key_masked",
           "llm_enabled",
           "llm_model",
-          "llm_rate_limit_per_minute"
+          "llm_rate_limit_per_minute",
+          "api_key_configured",
+          "api_key_masked"
         ],
-        "title": "AISettingsOut",
-        "type": "object"
+        "title": "AISettingsOut"
       },
       "AISettingsUpdate": {
         "properties": {
@@ -95,9 +5323,9 @@
           "llm_rate_limit_per_minute": {
             "anyOf": [
               {
+                "type": "integer",
                 "maximum": 30.0,
-                "minimum": 1.0,
-                "type": "integer"
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -106,32 +5334,48 @@
             "title": "Llm Rate Limit Per Minute"
           }
         },
-        "title": "AISettingsUpdate",
-        "type": "object"
+        "type": "object",
+        "title": "AISettingsUpdate"
       },
       "AcceptAllResponse": {
         "properties": {
-          "accepted_count": {
-            "title": "Accepted Count",
-            "type": "integer"
-          },
           "status": {
-            "title": "Status",
-            "type": "string"
+            "type": "string",
+            "title": "Status"
+          },
+          "accepted_count": {
+            "type": "integer",
+            "title": "Accepted Count"
           }
         },
+        "type": "object",
         "required": [
-          "accepted_count",
-          "status"
+          "status",
+          "accepted_count"
         ],
-        "title": "AcceptAllResponse",
-        "type": "object"
+        "title": "AcceptAllResponse"
       },
       "ActivityLogEntry": {
         "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
           "created_at": {
-            "title": "Created At",
-            "type": "string"
+            "type": "string",
+            "title": "Created At"
+          },
+          "level": {
+            "type": "string",
+            "title": "Level"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
           },
           "event_code": {
             "anyOf": [
@@ -143,160 +5387,152 @@
               }
             ],
             "title": "Event Code"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "level": {
-            "title": "Level",
-            "type": "string"
-          },
-          "message": {
-            "title": "Message",
-            "type": "string"
-          },
-          "source": {
-            "title": "Source",
-            "type": "string"
           }
         },
+        "type": "object",
         "required": [
-          "created_at",
-          "event_code",
           "id",
+          "created_at",
           "level",
-          "message",
-          "source"
+          "source",
+          "message"
         ],
-        "title": "ActivityLogEntry",
-        "type": "object"
+        "title": "ActivityLogEntry"
       },
       "AdminEventOut": {
         "properties": {
-          "code": {
-            "title": "Code",
-            "type": "string"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "expires_at": {
-            "format": "date-time",
-            "title": "Expires At",
-            "type": "string"
-          },
           "id": {
-            "title": "Id",
-            "type": "integer"
+            "type": "integer",
+            "title": "Id"
           },
-          "is_active": {
-            "title": "Is Active",
-            "type": "boolean"
+          "code": {
+            "type": "string",
+            "title": "Code"
           },
           "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "owner_id": {
-            "title": "Owner Id",
-            "type": "integer"
+            "type": "string",
+            "title": "Name"
           },
           "owner_username": {
-            "title": "Owner Username",
-            "type": "string"
+            "type": "string",
+            "title": "Owner Username"
+          },
+          "owner_id": {
+            "type": "integer",
+            "title": "Owner Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expires At"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
           },
           "request_count": {
-            "default": 0,
+            "type": "integer",
             "title": "Request Count",
-            "type": "integer"
+            "default": 0
           }
         },
+        "type": "object",
         "required": [
+          "id",
           "code",
+          "name",
+          "owner_username",
+          "owner_id",
           "created_at",
           "expires_at",
-          "id",
-          "is_active",
-          "name",
-          "owner_id",
-          "owner_username",
-          "request_count"
+          "is_active"
         ],
-        "title": "AdminEventOut",
-        "type": "object"
+        "title": "AdminEventOut"
       },
       "AdminUserCreate": {
         "properties": {
-          "password": {
-            "maxLength": 128,
-            "minLength": 8,
-            "title": "Password",
-            "type": "string"
-          },
-          "role": {
-            "default": "dj",
-            "title": "Role",
-            "type": "string"
-          },
           "username": {
+            "type": "string",
             "maxLength": 50,
             "minLength": 3,
-            "title": "Username",
-            "type": "string"
+            "title": "Username"
+          },
+          "password": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 8,
+            "title": "Password"
+          },
+          "role": {
+            "type": "string",
+            "title": "Role",
+            "default": "dj"
           }
         },
+        "type": "object",
         "required": [
           "username",
           "password"
         ],
-        "title": "AdminUserCreate",
-        "type": "object"
+        "title": "AdminUserCreate"
       },
       "AdminUserOut": {
         "properties": {
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "event_count": {
-            "default": 0,
-            "title": "Event Count",
-            "type": "integer"
-          },
           "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "is_active": {
-            "title": "Is Active",
-            "type": "boolean"
-          },
-          "role": {
-            "title": "Role",
-            "type": "string"
+            "type": "integer",
+            "title": "Id"
           },
           "username": {
-            "title": "Username",
-            "type": "string"
+            "type": "string",
+            "title": "Username"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "role": {
+            "type": "string",
+            "title": "Role"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "event_count": {
+            "type": "integer",
+            "title": "Event Count",
+            "default": 0
           }
         },
+        "type": "object",
         "required": [
-          "created_at",
-          "event_count",
           "id",
+          "username",
           "is_active",
           "role",
-          "username"
+          "created_at"
         ],
-        "title": "AdminUserOut",
-        "type": "object"
+        "title": "AdminUserOut"
       },
       "AdminUserUpdate": {
         "properties": {
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          },
           "is_active": {
             "anyOf": [
               {
@@ -311,182 +5547,101 @@
           "password": {
             "anyOf": [
               {
+                "type": "string",
                 "maxLength": 128,
-                "minLength": 8,
-                "type": "string"
+                "minLength": 8
               },
               {
                 "type": "null"
               }
             ],
             "title": "Password"
-          },
-          "role": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Role"
           }
         },
-        "title": "AdminUserUpdate",
-        "type": "object"
+        "type": "object",
+        "title": "AdminUserUpdate"
       },
       "BeatportEventSettings": {
-        "description": "Beatport sync settings for an event.",
         "properties": {
           "beatport_sync_enabled": {
-            "title": "Beatport Sync Enabled",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Beatport Sync Enabled"
           }
         },
+        "type": "object",
         "required": [
           "beatport_sync_enabled"
         ],
         "title": "BeatportEventSettings",
-        "type": "object"
+        "description": "Beatport sync settings for an event."
       },
       "BeatportEventSettingsUpdate": {
-        "description": "Update Beatport sync settings for an event.",
         "properties": {
           "beatport_sync_enabled": {
-            "title": "Beatport Sync Enabled",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Beatport Sync Enabled"
           }
         },
+        "type": "object",
         "required": [
           "beatport_sync_enabled"
         ],
         "title": "BeatportEventSettingsUpdate",
-        "type": "object"
+        "description": "Update Beatport sync settings for an event."
       },
       "BeatportLogin": {
-        "description": "Login request with Beatport credentials.",
         "properties": {
-          "password": {
-            "maxLength": 200,
-            "minLength": 1,
-            "title": "Password",
-            "type": "string"
-          },
           "username": {
+            "type": "string",
             "maxLength": 200,
             "minLength": 1,
-            "title": "Username",
-            "type": "string"
+            "title": "Username"
+          },
+          "password": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Password"
           }
         },
+        "type": "object",
         "required": [
           "username",
           "password"
         ],
         "title": "BeatportLogin",
-        "type": "object"
+        "description": "Login request with Beatport credentials."
       },
       "BeatportManualLink": {
-        "description": "Manual Beatport track linking request.",
         "properties": {
           "beatport_track_id": {
+            "type": "string",
             "maxLength": 100,
             "minLength": 1,
             "pattern": "^[0-9]+$",
-            "title": "Beatport Track Id",
-            "type": "string"
+            "title": "Beatport Track Id"
           }
         },
+        "type": "object",
         "required": [
           "beatport_track_id"
         ],
         "title": "BeatportManualLink",
-        "type": "object"
+        "description": "Manual Beatport track linking request."
       },
       "BeatportSearchResult": {
-        "description": "Track result from Beatport search.",
         "properties": {
+          "track_id": {
+            "type": "string",
+            "title": "Track Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
           "artist": {
-            "title": "Artist",
-            "type": "string"
-          },
-          "beatport_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Beatport Url"
-          },
-          "bpm": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bpm"
-          },
-          "cover_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cover Url"
-          },
-          "duration_seconds": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Duration Seconds"
-          },
-          "genre": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
-          },
-          "key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Key"
-          },
-          "label": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Label"
+            "type": "string",
+            "title": "Artist"
           },
           "mix_name": {
             "anyOf": [
@@ -499,6 +5654,83 @@
             ],
             "title": "Mix Name"
           },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "bpm": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "duration_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Seconds"
+          },
+          "cover_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Url"
+          },
+          "beatport_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Beatport Url"
+          },
           "release_date": {
             "anyOf": [
               {
@@ -509,40 +5741,22 @@
               }
             ],
             "title": "Release Date"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "track_id": {
-            "title": "Track Id",
-            "type": "string"
           }
         },
+        "type": "object",
         "required": [
-          "artist",
-          "beatport_url",
-          "bpm",
-          "cover_url",
-          "duration_seconds",
-          "genre",
-          "key",
-          "label",
-          "mix_name",
-          "release_date",
+          "track_id",
           "title",
-          "track_id"
+          "artist"
         ],
         "title": "BeatportSearchResult",
-        "type": "object"
+        "description": "Track result from Beatport search."
       },
       "BeatportStatus": {
-        "description": "Current Beatport account linking status.",
         "properties": {
-          "configured": {
-            "default": true,
-            "title": "Configured",
-            "type": "boolean"
+          "linked": {
+            "type": "boolean",
+            "title": "Linked"
           },
           "expires_at": {
             "anyOf": [
@@ -555,14 +5769,10 @@
             ],
             "title": "Expires At"
           },
-          "integration_enabled": {
-            "default": true,
-            "title": "Integration Enabled",
-            "type": "boolean"
-          },
-          "linked": {
-            "title": "Linked",
-            "type": "boolean"
+          "configured": {
+            "type": "boolean",
+            "title": "Configured",
+            "default": true
           },
           "subscription": {
             "anyOf": [
@@ -574,20 +5784,48 @@
               }
             ],
             "title": "Subscription"
+          },
+          "integration_enabled": {
+            "type": "boolean",
+            "title": "Integration Enabled",
+            "default": true
           }
         },
+        "type": "object",
         "required": [
-          "configured",
-          "expires_at",
-          "integration_enabled",
-          "linked",
-          "subscription"
+          "linked"
         ],
         "title": "BeatportStatus",
-        "type": "object"
+        "description": "Current Beatport account linking status."
       },
       "Body_login_api_auth_login_post": {
         "properties": {
+          "grant_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^password$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grant Type"
+          },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "password": {
+            "type": "string",
+            "format": "password",
+            "title": "Password"
+          },
+          "scope": {
+            "type": "string",
+            "title": "Scope",
+            "default": ""
+          },
           "client_id": {
             "anyOf": [
               {
@@ -610,73 +5848,46 @@
             ],
             "format": "password",
             "title": "Client Secret"
-          },
-          "grant_type": {
-            "anyOf": [
-              {
-                "pattern": "^password$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Grant Type"
-          },
-          "password": {
-            "format": "password",
-            "title": "Password",
-            "type": "string"
-          },
-          "scope": {
-            "default": "",
-            "title": "Scope",
-            "type": "string"
-          },
-          "username": {
-            "title": "Username",
-            "type": "string"
           }
         },
+        "type": "object",
         "required": [
           "username",
           "password"
         ],
-        "title": "Body_login_api_auth_login_post",
-        "type": "object"
+        "title": "Body_login_api_auth_login_post"
       },
       "Body_upload_banner_api_events__code__banner_post": {
         "properties": {
           "file": {
+            "type": "string",
             "format": "binary",
-            "title": "File",
-            "type": "string"
+            "title": "File"
           }
         },
+        "type": "object",
         "required": [
           "file"
         ],
-        "title": "Body_upload_banner_api_events__code__banner_post",
-        "type": "object"
+        "title": "Body_upload_banner_api_events__code__banner_post"
       },
       "BridgeApiKeyResponse": {
         "properties": {
           "bridge_api_key": {
-            "title": "Bridge Api Key",
-            "type": "string"
+            "type": "string",
+            "title": "Bridge Api Key"
           }
         },
+        "type": "object",
         "required": [
           "bridge_api_key"
         ],
-        "title": "BridgeApiKeyResponse",
-        "type": "object"
+        "title": "BridgeApiKeyResponse"
       },
       "BridgeCommandRequest": {
-        "description": "Request body for queuing a bridge command.",
         "properties": {
           "command_type": {
-            "description": "The type of command to send to the bridge",
+            "type": "string",
             "enum": [
               "ping",
               "reset_decks",
@@ -684,102 +5895,69 @@
               "restart"
             ],
             "title": "Command Type",
-            "type": "string"
+            "description": "The type of command to send to the bridge"
           }
         },
+        "type": "object",
         "required": [
           "command_type"
         ],
         "title": "BridgeCommandRequest",
-        "type": "object"
+        "description": "Request body for queuing a bridge command."
       },
       "BridgeCommandResponse": {
-        "description": "Response after queuing a bridge command.",
         "properties": {
           "command_id": {
-            "description": "UUID of the queued command",
+            "type": "string",
             "title": "Command Id",
-            "type": "string"
+            "description": "UUID of the queued command"
           },
           "command_type": {
-            "description": "The command type that was queued",
+            "type": "string",
             "title": "Command Type",
-            "type": "string"
+            "description": "The command type that was queued"
           }
         },
+        "type": "object",
         "required": [
           "command_id",
           "command_type"
         ],
         "title": "BridgeCommandResponse",
-        "type": "object"
+        "description": "Response after queuing a bridge command."
       },
       "BridgeCommandsPollResponse": {
-        "description": "Response for bridge polling pending commands.",
         "properties": {
           "commands": {
-            "description": "List of pending commands",
             "items": {
               "$ref": "#/components/schemas/BridgeCommandResponse"
             },
+            "type": "array",
             "title": "Commands",
-            "type": "array"
+            "description": "List of pending commands"
           }
         },
-        "required": [
-          "commands"
-        ],
+        "type": "object",
         "title": "BridgeCommandsPollResponse",
-        "type": "object"
+        "description": "Response for bridge polling pending commands."
       },
       "BridgeStatusPayload": {
-        "description": "Payload from bridge reporting connection status.",
         "properties": {
-          "buffer_size": {
-            "anyOf": [
-              {
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buffer Size"
-          },
-          "circuit_breaker_state": {
-            "anyOf": [
-              {
-                "maxLength": 20,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Circuit Breaker State"
+          "event_code": {
+            "type": "string",
+            "maxLength": 10,
+            "minLength": 1,
+            "title": "Event Code"
           },
           "connected": {
-            "title": "Connected",
-            "type": "boolean"
-          },
-          "deck_count": {
-            "anyOf": [
-              {
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Deck Count"
+            "type": "boolean",
+            "title": "Connected"
           },
           "device_name": {
             "anyOf": [
               {
-                "maxLength": 100,
-                "type": "string"
+                "type": "string",
+                "maxLength": 100
               },
               {
                 "type": "null"
@@ -787,17 +5965,35 @@
             ],
             "title": "Device Name"
           },
-          "event_code": {
-            "maxLength": 10,
-            "minLength": 1,
-            "title": "Event Code",
-            "type": "string"
+          "circuit_breaker_state": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 20
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Circuit Breaker State"
+          },
+          "buffer_size": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Buffer Size"
           },
           "plugin_id": {
             "anyOf": [
               {
-                "maxLength": 50,
-                "type": "string"
+                "type": "string",
+                "maxLength": 50
               },
               {
                 "type": "null"
@@ -805,11 +6001,23 @@
             ],
             "title": "Plugin Id"
           },
+          "deck_count": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deck Count"
+          },
           "uptime_seconds": {
             "anyOf": [
               {
-                "minimum": 0.0,
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -818,53 +6026,20 @@
             "title": "Uptime Seconds"
           }
         },
+        "type": "object",
         "required": [
           "event_code",
           "connected"
         ],
         "title": "BridgeStatusPayload",
-        "type": "object"
+        "description": "Payload from bridge reporting connection status."
       },
       "BridgeStatusResponse": {
-        "description": "Public response for bridge connection status (independent of track data).",
         "properties": {
-          "buffer_size": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buffer Size"
-          },
-          "circuit_breaker_state": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Circuit Breaker State"
-          },
           "connected": {
-            "default": false,
+            "type": "boolean",
             "title": "Connected",
-            "type": "boolean"
-          },
-          "deck_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Deck Count"
+            "default": false
           },
           "device_name": {
             "anyOf": [
@@ -888,6 +6063,28 @@
             ],
             "title": "Last Seen"
           },
+          "circuit_breaker_state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Circuit Breaker State"
+          },
+          "buffer_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Buffer Size"
+          },
           "plugin_id": {
             "anyOf": [
               {
@@ -898,6 +6095,17 @@
               }
             ],
             "title": "Plugin Id"
+          },
+          "deck_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deck Count"
           },
           "uptime_seconds": {
             "anyOf": [
@@ -911,36 +6119,27 @@
             "title": "Uptime Seconds"
           }
         },
-        "required": [
-          "buffer_size",
-          "circuit_breaker_state",
-          "connected",
-          "deck_count",
-          "device_name",
-          "last_seen",
-          "plugin_id",
-          "uptime_seconds"
-        ],
+        "type": "object",
         "title": "BridgeStatusResponse",
-        "type": "object"
+        "description": "Public response for bridge connection status (independent of track data)."
       },
       "BulkActionResponse": {
         "properties": {
-          "count": {
-            "title": "Count",
-            "type": "integer"
-          },
           "status": {
-            "title": "Status",
-            "type": "string"
+            "type": "string",
+            "title": "Status"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
           }
         },
+        "type": "object",
         "required": [
-          "count",
-          "status"
+          "status",
+          "count"
         ],
-        "title": "BulkActionResponse",
-        "type": "object"
+        "title": "BulkActionResponse"
       },
       "BulkDeleteEventsRequest": {
         "properties": {
@@ -948,21 +6147,22 @@
             "items": {
               "type": "string"
             },
+            "type": "array",
             "maxItems": 50,
             "minItems": 1,
-            "title": "Codes",
-            "type": "array"
+            "title": "Codes"
           }
         },
+        "type": "object",
         "required": [
           "codes"
         ],
-        "title": "BulkDeleteEventsRequest",
-        "type": "object"
+        "title": "BulkDeleteEventsRequest"
       },
       "BulkReviewRequest": {
         "properties": {
           "action": {
+            "type": "string",
             "enum": [
               "accept_top_n",
               "accept_threshold",
@@ -970,27 +6170,14 @@
               "reject_ids",
               "reject_remaining"
             ],
-            "title": "Action",
-            "type": "string"
-          },
-          "min_votes": {
-            "anyOf": [
-              {
-                "minimum": 0.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Min Votes"
+            "title": "Action"
           },
           "n": {
             "anyOf": [
               {
+                "type": "integer",
                 "maximum": 200.0,
-                "minimum": 1.0,
-                "type": "integer"
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -998,14 +6185,26 @@
             ],
             "title": "N"
           },
+          "min_votes": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Votes"
+          },
           "request_ids": {
             "anyOf": [
               {
                 "items": {
                   "type": "integer"
                 },
-                "maxItems": 200,
-                "type": "array"
+                "type": "array",
+                "maxItems": 200
               },
               {
                 "type": "null"
@@ -1014,50 +6213,50 @@
             "title": "Request Ids"
           }
         },
+        "type": "object",
         "required": [
           "action"
         ],
-        "title": "BulkReviewRequest",
-        "type": "object"
+        "title": "BulkReviewRequest"
       },
       "BulkReviewResponse": {
         "properties": {
           "accepted": {
-            "title": "Accepted",
-            "type": "integer"
+            "type": "integer",
+            "title": "Accepted"
           },
           "rejected": {
-            "title": "Rejected",
-            "type": "integer"
+            "type": "integer",
+            "title": "Rejected"
           },
           "unchanged": {
-            "title": "Unchanged",
-            "type": "integer"
+            "type": "integer",
+            "title": "Unchanged"
           }
         },
+        "type": "object",
         "required": [
           "accepted",
           "rejected",
           "unchanged"
         ],
-        "title": "BulkReviewResponse",
-        "type": "object"
+        "title": "BulkReviewResponse"
       },
       "CacheClearResponse": {
         "properties": {
           "message": {
-            "title": "Message",
-            "type": "string"
+            "type": "string",
+            "title": "Message"
           }
         },
+        "type": "object",
         "required": [
           "message"
         ],
-        "title": "CacheClearResponse",
-        "type": "object"
+        "title": "CacheClearResponse"
       },
       "CapabilityStatus": {
-        "description": "Status of a specific capability for a service.",
+        "type": "string",
         "enum": [
           "yes",
           "no",
@@ -1066,23 +6265,17 @@
           "not_configured"
         ],
         "title": "CapabilityStatus",
-        "type": "string"
+        "description": "Status of a specific capability for a service."
       },
       "CollectEventPreview": {
         "properties": {
-          "banner_colors": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Banner Colors"
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
           },
           "banner_filename": {
             "anyOf": [
@@ -1106,15 +6299,43 @@
             ],
             "title": "Banner Url"
           },
-          "code": {
-            "title": "Code",
-            "type": "string"
+          "banner_colors": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Banner Colors"
+          },
+          "submission_cap_per_guest": {
+            "type": "integer",
+            "title": "Submission Cap Per Guest"
+          },
+          "registration_enabled": {
+            "type": "boolean",
+            "title": "Registration Enabled"
+          },
+          "phase": {
+            "type": "string",
+            "enum": [
+              "pre_announce",
+              "collection",
+              "live",
+              "closed"
+            ],
+            "title": "Phase"
           },
           "collection_opens_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -1122,16 +6343,11 @@
             ],
             "title": "Collection Opens At"
           },
-          "expires_at": {
-            "format": "date-time",
-            "title": "Expires At",
-            "type": "string"
-          },
           "live_starts_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -1139,44 +6355,25 @@
             ],
             "title": "Live Starts At"
           },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "phase": {
-            "enum": [
-              "pre_announce",
-              "collection",
-              "live",
-              "closed"
-            ],
-            "title": "Phase",
-            "type": "string"
-          },
-          "registration_enabled": {
-            "title": "Registration Enabled",
-            "type": "boolean"
-          },
-          "submission_cap_per_guest": {
-            "title": "Submission Cap Per Guest",
-            "type": "integer"
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expires At"
           }
         },
+        "type": "object",
         "required": [
-          "banner_colors",
-          "banner_filename",
-          "banner_url",
           "code",
-          "collection_opens_at",
-          "expires_at",
-          "live_starts_at",
           "name",
-          "phase",
+          "banner_filename",
+          "submission_cap_per_guest",
           "registration_enabled",
-          "submission_cap_per_guest"
+          "phase",
+          "collection_opens_at",
+          "live_starts_at",
+          "expires_at"
         ],
-        "title": "CollectEventPreview",
-        "type": "object"
+        "title": "CollectEventPreview"
       },
       "CollectLeaderboardResponse": {
         "properties": {
@@ -1184,26 +6381,34 @@
             "items": {
               "$ref": "#/components/schemas/CollectLeaderboardRow"
             },
-            "title": "Requests",
-            "type": "array"
+            "type": "array",
+            "title": "Requests"
           },
           "total": {
-            "title": "Total",
-            "type": "integer"
+            "type": "integer",
+            "title": "Total"
           }
         },
+        "type": "object",
         "required": [
           "requests",
           "total"
         ],
-        "title": "CollectLeaderboardResponse",
-        "type": "object"
+        "title": "CollectLeaderboardResponse"
       },
       "CollectLeaderboardRow": {
         "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
           "artist": {
-            "title": "Artist",
-            "type": "string"
+            "type": "string",
+            "title": "Artist"
           },
           "artwork_url": {
             "anyOf": [
@@ -1216,47 +6421,9 @@
             ],
             "title": "Artwork Url"
           },
-          "bpm": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bpm"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "genre": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "musical_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Musical Key"
+          "vote_count": {
+            "type": "integer",
+            "title": "Vote Count"
           },
           "nickname": {
             "anyOf": [
@@ -1270,6 +6437,7 @@
             "title": "Nickname"
           },
           "status": {
+            "type": "string",
             "enum": [
               "new",
               "accepted",
@@ -1277,50 +6445,12 @@
               "played",
               "rejected"
             ],
-            "title": "Status",
-            "type": "string"
+            "title": "Status"
           },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "vote_count": {
-            "title": "Vote Count",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "artist",
-          "artwork_url",
-          "bpm",
-          "created_at",
-          "genre",
-          "id",
-          "musical_key",
-          "nickname",
-          "status",
-          "title",
-          "vote_count"
-        ],
-        "title": "CollectLeaderboardRow",
-        "type": "object"
-      },
-      "CollectMyPicksItem": {
-        "properties": {
-          "artist": {
-            "title": "Artist",
-            "type": "string"
-          },
-          "artwork_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Artwork Url"
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
           },
           "bpm": {
             "anyOf": [
@@ -1333,10 +6463,16 @@
             ],
             "title": "Bpm"
           },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
+          "musical_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Musical Key"
           },
           "genre": {
             "anyOf": [
@@ -1349,131 +6485,196 @@
             ],
             "title": "Genre"
           },
+          "requester_verified": {
+            "type": "boolean",
+            "title": "Requester Verified",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "artist",
+          "artwork_url",
+          "vote_count",
+          "nickname",
+          "status",
+          "created_at"
+        ],
+        "title": "CollectLeaderboardRow"
+      },
+      "CollectMyPicksItem": {
+        "properties": {
           "id": {
-            "title": "Id",
-            "type": "integer"
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "artist": {
+            "type": "string",
+            "title": "Artist"
+          },
+          "artwork_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Artwork Url"
+          },
+          "vote_count": {
+            "type": "integer",
+            "title": "Vote Count"
+          },
+          "nickname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nickname"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "new",
+              "accepted",
+              "playing",
+              "played",
+              "rejected"
+            ],
+            "title": "Status"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "bpm": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "musical_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Musical Key"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "requester_verified": {
+            "type": "boolean",
+            "title": "Requester Verified",
+            "default": false
           },
           "interaction": {
+            "type": "string",
             "enum": [
               "submitted",
               "upvoted"
             ],
-            "title": "Interaction",
-            "type": "string"
-          },
-          "musical_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Musical Key"
-          },
-          "nickname": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Nickname"
-          },
-          "status": {
-            "enum": [
-              "new",
-              "accepted",
-              "playing",
-              "played",
-              "rejected"
-            ],
-            "title": "Status",
-            "type": "string"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "vote_count": {
-            "title": "Vote Count",
-            "type": "integer"
+            "title": "Interaction"
           }
         },
+        "type": "object",
         "required": [
+          "id",
+          "title",
           "artist",
           "artwork_url",
-          "bpm",
-          "created_at",
-          "genre",
-          "id",
-          "interaction",
-          "musical_key",
+          "vote_count",
           "nickname",
           "status",
-          "title",
-          "vote_count"
+          "created_at",
+          "interaction"
         ],
-        "title": "CollectMyPicksItem",
-        "type": "object"
+        "title": "CollectMyPicksItem"
       },
       "CollectMyPicksResponse": {
         "properties": {
-          "first_suggestion_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "title": "First Suggestion Ids",
-            "type": "array"
-          },
-          "is_top_contributor": {
-            "title": "Is Top Contributor",
-            "type": "boolean"
-          },
           "submitted": {
             "items": {
               "$ref": "#/components/schemas/CollectMyPicksItem"
             },
-            "title": "Submitted",
-            "type": "array"
+            "type": "array",
+            "title": "Submitted"
           },
           "upvoted": {
             "items": {
               "$ref": "#/components/schemas/CollectMyPicksItem"
             },
-            "title": "Upvoted",
-            "type": "array"
+            "type": "array",
+            "title": "Upvoted"
+          },
+          "is_top_contributor": {
+            "type": "boolean",
+            "title": "Is Top Contributor"
+          },
+          "first_suggestion_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "First Suggestion Ids"
           },
           "voted_request_ids": {
             "items": {
               "type": "integer"
             },
-            "title": "Voted Request Ids",
-            "type": "array"
+            "type": "array",
+            "title": "Voted Request Ids"
           }
         },
+        "type": "object",
         "required": [
-          "first_suggestion_ids",
-          "is_top_contributor",
           "submitted",
           "upvoted",
+          "is_top_contributor",
+          "first_suggestion_ids",
           "voted_request_ids"
         ],
-        "title": "CollectMyPicksResponse",
-        "type": "object"
+        "title": "CollectMyPicksResponse"
       },
       "CollectProfileRequest": {
         "properties": {
           "nickname": {
             "anyOf": [
               {
+                "type": "string",
                 "maxLength": 30,
                 "minLength": 2,
-                "pattern": "^[a-zA-Z0-9 _.-]+$",
-                "type": "string"
+                "pattern": "^[a-zA-Z0-9 _.-]+$"
               },
               {
                 "type": "null"
@@ -1482,15 +6683,11 @@
             "title": "Nickname"
           }
         },
-        "title": "CollectProfileRequest",
-        "type": "object"
+        "type": "object",
+        "title": "CollectProfileRequest"
       },
       "CollectProfileResponse": {
         "properties": {
-          "email_verified": {
-            "title": "Email Verified",
-            "type": "boolean"
-          },
           "nickname": {
             "anyOf": [
               {
@@ -1502,37 +6699,69 @@
             ],
             "title": "Nickname"
           },
-          "submission_cap": {
-            "title": "Submission Cap",
-            "type": "integer"
+          "email_verified": {
+            "type": "boolean",
+            "title": "Email Verified"
           },
           "submission_count": {
-            "title": "Submission Count",
-            "type": "integer"
+            "type": "integer",
+            "title": "Submission Count"
+          },
+          "submission_cap": {
+            "type": "integer",
+            "title": "Submission Cap"
           }
         },
+        "type": "object",
         "required": [
-          "email_verified",
           "nickname",
-          "submission_cap",
-          "submission_count"
+          "email_verified",
+          "submission_count",
+          "submission_cap"
         ],
-        "title": "CollectProfileResponse",
-        "type": "object"
+        "title": "CollectProfileResponse"
       },
       "CollectSubmitRequest": {
         "properties": {
-          "artist": {
+          "song_title": {
+            "type": "string",
             "maxLength": 255,
             "minLength": 1,
-            "title": "Artist",
-            "type": "string"
+            "title": "Song Title"
+          },
+          "artist": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Artist"
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "spotify",
+              "beatport",
+              "tidal",
+              "manual"
+            ],
+            "title": "Source"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url"
           },
           "artwork_url": {
             "anyOf": [
               {
-                "maxLength": 500,
-                "type": "string"
+                "type": "string",
+                "maxLength": 500
               },
               {
                 "type": "null"
@@ -1540,25 +6769,11 @@
             ],
             "title": "Artwork Url"
           },
-          "nickname": {
-            "anyOf": [
-              {
-                "maxLength": 30,
-                "minLength": 2,
-                "pattern": "^[a-zA-Z0-9 _.-]+$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Nickname"
-          },
           "note": {
             "anyOf": [
               {
-                "maxLength": 500,
-                "type": "string"
+                "type": "string",
+                "maxLength": 500
               },
               {
                 "type": "null"
@@ -1566,121 +6781,78 @@
             ],
             "title": "Note"
           },
-          "song_title": {
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Song Title",
-            "type": "string"
-          },
-          "source": {
-            "enum": [
-              "spotify",
-              "beatport",
-              "tidal",
-              "manual"
-            ],
-            "title": "Source",
-            "type": "string"
-          },
-          "source_url": {
+          "nickname": {
             "anyOf": [
               {
-                "maxLength": 500,
-                "type": "string"
+                "type": "string",
+                "maxLength": 30,
+                "minLength": 2,
+                "pattern": "^[a-zA-Z0-9 _.-]+$"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Source Url"
+            "title": "Nickname"
           }
         },
+        "type": "object",
         "required": [
           "song_title",
           "artist",
           "source"
         ],
-        "title": "CollectSubmitRequest",
-        "type": "object"
+        "title": "CollectSubmitRequest"
       },
       "CollectVoteRequest": {
         "properties": {
           "request_id": {
-            "title": "Request Id",
-            "type": "integer"
+            "type": "integer",
+            "title": "Request Id"
           }
         },
+        "type": "object",
         "required": [
           "request_id"
         ],
-        "title": "CollectVoteRequest",
-        "type": "object"
+        "title": "CollectVoteRequest"
       },
       "DisplaySettingsResponse": {
-        "description": "Response for display settings update.",
         "properties": {
-          "kiosk_display_only": {
-            "default": false,
-            "title": "Kiosk Display Only",
-            "type": "boolean"
-          },
-          "now_playing_auto_hide_minutes": {
-            "default": 10,
-            "title": "Now Playing Auto Hide Minutes",
-            "type": "integer"
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "default": "ok"
           },
           "now_playing_hidden": {
-            "title": "Now Playing Hidden",
-            "type": "boolean"
-          },
-          "requests_open": {
-            "default": true,
-            "title": "Requests Open",
-            "type": "boolean"
-          },
-          "status": {
-            "default": "ok",
-            "title": "Status",
-            "type": "string"
-          }
-        },
-        "required": [
-          "kiosk_display_only",
-          "now_playing_auto_hide_minutes",
-          "now_playing_hidden",
-          "requests_open",
-          "status"
-        ],
-        "title": "DisplaySettingsResponse",
-        "type": "object"
-      },
-      "DisplaySettingsUpdate": {
-        "description": "Request body for updating display settings.",
-        "properties": {
-          "kiosk_display_only": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Kiosk Display Only"
+            "type": "boolean",
+            "title": "Now Playing Hidden"
           },
           "now_playing_auto_hide_minutes": {
-            "anyOf": [
-              {
-                "maximum": 1440.0,
-                "minimum": 1.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Now Playing Auto Hide Minutes"
+            "type": "integer",
+            "title": "Now Playing Auto Hide Minutes",
+            "default": 10
           },
+          "requests_open": {
+            "type": "boolean",
+            "title": "Requests Open",
+            "default": true
+          },
+          "kiosk_display_only": {
+            "type": "boolean",
+            "title": "Kiosk Display Only",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "now_playing_hidden"
+        ],
+        "title": "DisplaySettingsResponse",
+        "description": "Response for display settings update."
+      },
+      "DisplaySettingsUpdate": {
+        "properties": {
           "now_playing_hidden": {
             "anyOf": [
               {
@@ -1692,6 +6864,19 @@
             ],
             "title": "Now Playing Hidden"
           },
+          "now_playing_auto_hide_minutes": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 1440.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Now Playing Auto Hide Minutes"
+          },
           "requests_open": {
             "anyOf": [
               {
@@ -1702,16 +6887,32 @@
               }
             ],
             "title": "Requests Open"
+          },
+          "kiosk_display_only": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kiosk Display Only"
           }
         },
+        "type": "object",
         "title": "DisplaySettingsUpdate",
-        "type": "object"
+        "description": "Request body for updating display settings."
       },
       "EnrichPreviewItem": {
         "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
           "artist": {
-            "title": "Artist",
-            "type": "string"
+            "type": "string",
+            "title": "Artist"
           },
           "source_url": {
             "anyOf": [
@@ -1723,18 +6924,14 @@
               }
             ],
             "title": "Source Url"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
           }
         },
+        "type": "object",
         "required": [
           "title",
           "artist"
         ],
-        "title": "EnrichPreviewItem",
-        "type": "object"
+        "title": "EnrichPreviewItem"
       },
       "EnrichPreviewRequest": {
         "properties": {
@@ -1742,15 +6939,15 @@
             "items": {
               "$ref": "#/components/schemas/EnrichPreviewItem"
             },
-            "title": "Items",
-            "type": "array"
+            "type": "array",
+            "title": "Items"
           }
         },
+        "type": "object",
         "required": [
           "items"
         ],
-        "title": "EnrichPreviewRequest",
-        "type": "object"
+        "title": "EnrichPreviewRequest"
       },
       "EnrichPreviewResponse": {
         "properties": {
@@ -1758,21 +6955,25 @@
             "items": {
               "$ref": "#/components/schemas/EnrichPreviewResult"
             },
-            "title": "Results",
-            "type": "array"
+            "type": "array",
+            "title": "Results"
           }
         },
+        "type": "object",
         "required": [
           "results"
         ],
-        "title": "EnrichPreviewResponse",
-        "type": "object"
+        "title": "EnrichPreviewResponse"
       },
       "EnrichPreviewResult": {
         "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
           "artist": {
-            "title": "Artist",
-            "type": "string"
+            "type": "string",
+            "title": "Artist"
           },
           "bpm": {
             "anyOf": [
@@ -1784,17 +6985,6 @@
               }
             ],
             "title": "Bpm"
-          },
-          "genre": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
           },
           "key": {
             "anyOf": [
@@ -1807,42 +6997,46 @@
             ],
             "title": "Key"
           },
-          "title": {
-            "title": "Title",
-            "type": "string"
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
           }
         },
+        "type": "object",
         "required": [
-          "artist",
-          "bpm",
-          "genre",
-          "key",
-          "title"
+          "title",
+          "artist"
         ],
-        "title": "EnrichPreviewResult",
-        "type": "object"
+        "title": "EnrichPreviewResult"
       },
       "EventCreate": {
         "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Name"
+          },
           "expires_hours": {
-            "default": 6,
+            "type": "integer",
             "maximum": 48.0,
             "minimum": 1.0,
             "title": "Expires Hours",
-            "type": "integer"
-          },
-          "name": {
-            "maxLength": 100,
-            "minLength": 1,
-            "title": "Name",
-            "type": "string"
+            "default": 6
           }
         },
+        "type": "object",
         "required": [
           "name"
         ],
-        "title": "EventCreate",
-        "type": "object"
+        "title": "EventCreate"
       },
       "EventMusicProfile": {
         "properties": {
@@ -1857,17 +7051,6 @@
             ],
             "title": "Avg Bpm"
           },
-          "bpm_range_high": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bpm Range High"
-          },
           "bpm_range_low": {
             "anyOf": [
               {
@@ -1879,47 +7062,73 @@
             ],
             "title": "Bpm Range Low"
           },
-          "dominant_genres": {
-            "default": [],
-            "items": {
-              "type": "string"
-            },
-            "title": "Dominant Genres",
-            "type": "array"
+          "bpm_range_high": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm Range High"
           },
           "dominant_keys": {
-            "default": [],
             "items": {
               "type": "string"
             },
+            "type": "array",
             "title": "Dominant Keys",
-            "type": "array"
+            "default": []
           },
-          "enriched_count": {
-            "default": 0,
-            "title": "Enriched Count",
-            "type": "integer"
+          "dominant_genres": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Dominant Genres",
+            "default": []
           },
           "track_count": {
-            "default": 0,
+            "type": "integer",
             "title": "Track Count",
-            "type": "integer"
+            "default": 0
+          },
+          "enriched_count": {
+            "type": "integer",
+            "title": "Enriched Count",
+            "default": 0
           }
         },
-        "required": [
-          "avg_bpm",
-          "bpm_range_high",
-          "bpm_range_low",
-          "dominant_genres",
-          "dominant_keys",
-          "enriched_count",
-          "track_count"
-        ],
-        "title": "EventMusicProfile",
-        "type": "object"
+        "type": "object",
+        "title": "EventMusicProfile"
       },
       "EventOut": {
         "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "expires_at": {
+            "type": "string",
+            "title": "Expires At"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
           "archived_at": {
             "anyOf": [
               {
@@ -1930,6 +7139,92 @@
               }
             ],
             "title": "Archived At"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EventStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "join_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Join Url"
+          },
+          "request_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Request Count"
+          },
+          "tidal_sync_enabled": {
+            "type": "boolean",
+            "title": "Tidal Sync Enabled",
+            "default": false
+          },
+          "tidal_playlist_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tidal Playlist Id"
+          },
+          "beatport_sync_enabled": {
+            "type": "boolean",
+            "title": "Beatport Sync Enabled",
+            "default": false
+          },
+          "beatport_playlist_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Beatport Playlist Id"
+          },
+          "banner_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Banner Url"
+          },
+          "banner_kiosk_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Banner Kiosk Url"
           },
           "banner_colors": {
             "anyOf": [
@@ -1945,47 +7240,10 @@
             ],
             "title": "Banner Colors"
           },
-          "banner_kiosk_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Banner Kiosk Url"
-          },
-          "banner_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Banner Url"
-          },
-          "beatport_playlist_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Beatport Playlist Id"
-          },
-          "beatport_sync_enabled": {
-            "default": false,
-            "title": "Beatport Sync Enabled",
-            "type": "boolean"
-          },
-          "code": {
-            "title": "Code",
-            "type": "string"
+          "requests_open": {
+            "type": "boolean",
+            "title": "Requests Open",
+            "default": true
           },
           "collection_opens_at": {
             "anyOf": [
@@ -1998,44 +7256,6 @@
             ],
             "title": "Collection Opens At"
           },
-          "collection_phase_override": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Collection Phase Override"
-          },
-          "created_at": {
-            "title": "Created At",
-            "type": "string"
-          },
-          "expires_at": {
-            "title": "Expires At",
-            "type": "string"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "is_active": {
-            "title": "Is Active",
-            "type": "boolean"
-          },
-          "join_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Join Url"
-          },
           "live_starts_at": {
             "anyOf": [
               {
@@ -2047,42 +7267,12 @@
             ],
             "title": "Live Starts At"
           },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "request_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Request Count"
-          },
-          "requests_open": {
-            "default": true,
-            "title": "Requests Open",
-            "type": "boolean"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/EventStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "submission_cap_per_guest": {
-            "default": 15,
+            "type": "integer",
             "title": "Submission Cap Per Guest",
-            "type": "integer"
+            "default": 15
           },
-          "tidal_playlist_id": {
+          "collection_phase_override": {
             "anyOf": [
               {
                 "type": "string"
@@ -2091,58 +7281,37 @@
                 "type": "null"
               }
             ],
-            "title": "Tidal Playlist Id"
-          },
-          "tidal_sync_enabled": {
-            "default": false,
-            "title": "Tidal Sync Enabled",
-            "type": "boolean"
+            "title": "Collection Phase Override"
           }
         },
+        "type": "object",
         "required": [
-          "archived_at",
-          "banner_colors",
-          "banner_kiosk_url",
-          "banner_url",
-          "beatport_playlist_id",
-          "beatport_sync_enabled",
+          "id",
           "code",
-          "collection_opens_at",
-          "collection_phase_override",
+          "name",
           "created_at",
           "expires_at",
-          "id",
-          "is_active",
-          "join_url",
-          "live_starts_at",
-          "name",
-          "request_count",
-          "requests_open",
-          "status",
-          "submission_cap_per_guest",
-          "tidal_playlist_id",
-          "tidal_sync_enabled"
+          "is_active"
         ],
-        "title": "EventOut",
-        "type": "object"
+        "title": "EventOut"
       },
       "EventStatus": {
-        "description": "Status of an event based on expiry and archive state.",
+        "type": "string",
         "enum": [
           "active",
           "expired",
           "archived"
         ],
         "title": "EventStatus",
-        "type": "string"
+        "description": "Status of an event based on expiry and archive state."
       },
       "EventUpdate": {
         "properties": {
           "expires_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -2153,9 +7322,9 @@
           "name": {
             "anyOf": [
               {
+                "type": "string",
                 "maxLength": 100,
-                "minLength": 1,
-                "type": "string"
+                "minLength": 1
               },
               {
                 "type": "null"
@@ -2164,11 +7333,19 @@
             "title": "Name"
           }
         },
-        "title": "EventUpdate",
-        "type": "object"
+        "type": "object",
+        "title": "EventUpdate"
       },
       "GuestNowPlaying": {
         "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "artist": {
+            "type": "string",
+            "title": "Artist"
+          },
           "album_art_url": {
             "anyOf": [
               {
@@ -2180,33 +7357,33 @@
             ],
             "title": "Album Art Url"
           },
-          "artist": {
-            "title": "Artist",
-            "type": "string"
-          },
           "source": {
-            "title": "Source",
-            "type": "string"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
+            "type": "string",
+            "title": "Source"
           }
         },
+        "type": "object",
         "required": [
-          "album_art_url",
+          "title",
           "artist",
-          "source",
-          "title"
+          "album_art_url",
+          "source"
         ],
-        "title": "GuestNowPlaying",
-        "type": "object"
+        "title": "GuestNowPlaying"
       },
       "GuestRequestInfo": {
         "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
           "artist": {
-            "title": "Artist",
-            "type": "string"
+            "type": "string",
+            "title": "Artist"
           },
           "artwork_url": {
             "anyOf": [
@@ -2219,6 +7396,22 @@
             ],
             "title": "Artwork Url"
           },
+          "nickname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nickname"
+          },
+          "vote_count": {
+            "type": "integer",
+            "title": "Vote Count",
+            "default": 0
+          },
           "bpm": {
             "anyOf": [
               {
@@ -2229,21 +7422,6 @@
               }
             ],
             "title": "Bpm"
-          },
-          "genre": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
           },
           "musical_key": {
             "anyOf": [
@@ -2256,7 +7434,7 @@
             ],
             "title": "Musical Key"
           },
-          "nickname": {
+          "genre": {
             "anyOf": [
               {
                 "type": "string"
@@ -2265,45 +7443,43 @@
                 "type": "null"
               }
             ],
-            "title": "Nickname"
+            "title": "Genre"
+          },
+          "requester_verified": {
+            "type": "boolean",
+            "title": "Requester Verified",
+            "default": false
           },
           "status": {
+            "type": "string",
             "enum": [
               "new",
               "accepted"
             ],
-            "title": "Status",
-            "type": "string"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "vote_count": {
-            "default": 0,
-            "title": "Vote Count",
-            "type": "integer"
+            "title": "Status"
           }
         },
+        "type": "object",
         "required": [
+          "id",
+          "title",
           "artist",
           "artwork_url",
-          "bpm",
-          "genre",
-          "id",
-          "musical_key",
-          "nickname",
-          "status",
-          "title",
-          "vote_count"
+          "status"
         ],
-        "title": "GuestRequestInfo",
-        "type": "object"
+        "title": "GuestRequestInfo"
       },
       "GuestRequestListResponse": {
         "properties": {
           "event": {
             "$ref": "#/components/schemas/PublicEventInfo"
+          },
+          "requests": {
+            "items": {
+              "$ref": "#/components/schemas/GuestRequestInfo"
+            },
+            "type": "array",
+            "title": "Requests"
           },
           "now_playing": {
             "anyOf": [
@@ -2314,22 +7490,14 @@
                 "type": "null"
               }
             ]
-          },
-          "requests": {
-            "items": {
-              "$ref": "#/components/schemas/GuestRequestInfo"
-            },
-            "title": "Requests",
-            "type": "array"
           }
         },
+        "type": "object",
         "required": [
           "event",
-          "now_playing",
           "requests"
         ],
-        "title": "GuestRequestListResponse",
-        "type": "object"
+        "title": "GuestRequestListResponse"
       },
       "HTTPValidationError": {
         "properties": {
@@ -2337,47 +7505,50 @@
             "items": {
               "$ref": "#/components/schemas/ValidationError"
             },
-            "title": "Detail",
-            "type": "array"
+            "type": "array",
+            "title": "Detail"
           }
         },
-        "required": [
-          "detail"
-        ],
-        "title": "HTTPValidationError",
-        "type": "object"
+        "type": "object",
+        "title": "HTTPValidationError"
       },
       "HasRequestedResponse": {
         "properties": {
           "has_requested": {
-            "title": "Has Requested",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Has Requested"
           }
         },
+        "type": "object",
         "required": [
           "has_requested"
         ],
-        "title": "HasRequestedResponse",
-        "type": "object"
+        "title": "HasRequestedResponse"
       },
       "HelpPageSeenRequest": {
         "properties": {
           "page": {
+            "type": "string",
             "maxLength": 100,
             "minLength": 1,
             "pattern": "^[a-z0-9-]+$",
-            "title": "Page",
-            "type": "string"
+            "title": "Page"
           }
         },
+        "type": "object",
         "required": [
           "page"
         ],
-        "title": "HelpPageSeenRequest",
-        "type": "object"
+        "title": "HelpPageSeenRequest"
       },
       "IdentifyRequest": {
         "properties": {
+          "fingerprint_hash": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 8,
+            "title": "Fingerprint Hash"
+          },
           "fingerprint_components": {
             "anyOf": [
               {
@@ -2389,52 +7560,52 @@
               }
             ],
             "title": "Fingerprint Components"
-          },
-          "fingerprint_hash": {
-            "maxLength": 64,
-            "minLength": 8,
-            "title": "Fingerprint Hash",
-            "type": "string"
           }
         },
+        "type": "object",
         "required": [
           "fingerprint_hash"
         ],
-        "title": "IdentifyRequest",
-        "type": "object"
+        "title": "IdentifyRequest"
       },
       "IdentifyResponse": {
         "properties": {
+          "guest_id": {
+            "type": "integer",
+            "title": "Guest Id"
+          },
           "action": {
+            "type": "string",
             "enum": [
               "create",
               "cookie_hit",
               "reconcile"
             ],
-            "title": "Action",
-            "type": "string"
-          },
-          "guest_id": {
-            "title": "Guest Id",
-            "type": "integer"
+            "title": "Action"
           },
           "reconcile_hint": {
-            "default": false,
+            "type": "boolean",
             "title": "Reconcile Hint",
-            "type": "boolean"
+            "default": false
           }
         },
+        "type": "object",
         "required": [
-          "action",
           "guest_id",
-          "reconcile_hint"
+          "action"
         ],
-        "title": "IdentifyResponse",
-        "type": "object"
+        "title": "IdentifyResponse"
       },
       "IntegrationCheckResponse": {
-        "description": "Response for POST /api/admin/integrations/{service}/check.",
         "properties": {
+          "service": {
+            "type": "string",
+            "title": "Service"
+          },
+          "healthy": {
+            "type": "boolean",
+            "title": "Healthy"
+          },
           "capabilities": {
             "$ref": "#/components/schemas/ServiceCapabilities"
           },
@@ -2448,59 +7619,54 @@
               }
             ],
             "title": "Error"
-          },
-          "healthy": {
-            "title": "Healthy",
-            "type": "boolean"
-          },
-          "service": {
-            "title": "Service",
-            "type": "string"
           }
         },
+        "type": "object",
         "required": [
-          "capabilities",
-          "error",
+          "service",
           "healthy",
-          "service"
+          "capabilities"
         ],
         "title": "IntegrationCheckResponse",
-        "type": "object"
+        "description": "Response for POST /api/admin/integrations/{service}/check."
       },
       "IntegrationHealthResponse": {
-        "description": "Response for GET /api/admin/integrations.",
         "properties": {
           "services": {
             "items": {
               "$ref": "#/components/schemas/IntegrationServiceStatus"
             },
-            "title": "Services",
-            "type": "array"
+            "type": "array",
+            "title": "Services"
           }
         },
+        "type": "object",
         "required": [
           "services"
         ],
         "title": "IntegrationHealthResponse",
-        "type": "object"
+        "description": "Response for GET /api/admin/integrations."
       },
       "IntegrationServiceStatus": {
-        "description": "Full status for a single integration service.",
         "properties": {
-          "capabilities": {
-            "$ref": "#/components/schemas/ServiceCapabilities"
-          },
-          "configured": {
-            "title": "Configured",
-            "type": "boolean"
+          "service": {
+            "type": "string",
+            "title": "Service"
           },
           "display_name": {
-            "title": "Display Name",
-            "type": "string"
+            "type": "string",
+            "title": "Display Name"
           },
           "enabled": {
-            "title": "Enabled",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Enabled"
+          },
+          "configured": {
+            "type": "boolean",
+            "title": "Configured"
+          },
+          "capabilities": {
+            "$ref": "#/components/schemas/ServiceCapabilities"
           },
           "last_check_error": {
             "anyOf": [
@@ -2512,96 +7678,150 @@
               }
             ],
             "title": "Last Check Error"
-          },
-          "service": {
-            "title": "Service",
-            "type": "string"
           }
         },
+        "type": "object",
         "required": [
-          "capabilities",
-          "configured",
+          "service",
           "display_name",
           "enabled",
-          "last_check_error",
-          "service"
+          "configured",
+          "capabilities"
         ],
         "title": "IntegrationServiceStatus",
-        "type": "object"
+        "description": "Full status for a single integration service."
       },
       "IntegrationToggleRequest": {
-        "description": "Request body for PATCH /api/admin/integrations/{service}.",
         "properties": {
           "enabled": {
-            "title": "Enabled",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Enabled"
           }
         },
+        "type": "object",
         "required": [
           "enabled"
         ],
         "title": "IntegrationToggleRequest",
-        "type": "object"
+        "description": "Request body for PATCH /api/admin/integrations/{service}."
       },
       "IntegrationToggleResponse": {
-        "description": "Response for PATCH /api/admin/integrations/{service}.",
         "properties": {
-          "enabled": {
-            "title": "Enabled",
-            "type": "boolean"
-          },
           "service": {
-            "title": "Service",
-            "type": "string"
+            "type": "string",
+            "title": "Service"
+          },
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled"
           }
         },
+        "type": "object",
         "required": [
-          "enabled",
-          "service"
+          "service",
+          "enabled"
         ],
         "title": "IntegrationToggleResponse",
-        "type": "object"
+        "description": "Response for PATCH /api/admin/integrations/{service}."
       },
       "KioskAssignRequest": {
-        "description": "Body for reassigning a kiosk to a different event.",
         "properties": {
           "event_code": {
+            "type": "string",
             "maxLength": 10,
             "minLength": 1,
-            "title": "Event Code",
-            "type": "string"
+            "title": "Event Code"
           }
         },
+        "type": "object",
         "required": [
           "event_code"
         ],
         "title": "KioskAssignRequest",
-        "type": "object"
+        "description": "Body for reassigning a kiosk to a different event."
       },
       "KioskCompletePairingRequest": {
-        "description": "Body for completing a kiosk pairing.",
         "properties": {
           "event_code": {
+            "type": "string",
             "maxLength": 10,
             "minLength": 1,
-            "title": "Event Code",
-            "type": "string"
+            "title": "Event Code"
           }
         },
+        "type": "object",
         "required": [
           "event_code"
         ],
         "title": "KioskCompletePairingRequest",
-        "type": "object"
+        "description": "Body for completing a kiosk pairing."
       },
       "KioskDisplayResponse": {
         "properties": {
+          "event": {
+            "$ref": "#/components/schemas/PublicEventInfo"
+          },
+          "qr_join_url": {
+            "type": "string",
+            "title": "Qr Join Url"
+          },
           "accepted_queue": {
             "items": {
               "$ref": "#/components/schemas/PublicRequestInfo"
             },
-            "title": "Accepted Queue",
-            "type": "array"
+            "type": "array",
+            "title": "Accepted Queue"
+          },
+          "now_playing": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicRequestInfo"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "now_playing_hidden": {
+            "type": "boolean",
+            "title": "Now Playing Hidden"
+          },
+          "requests_open": {
+            "type": "boolean",
+            "title": "Requests Open",
+            "default": true
+          },
+          "kiosk_display_only": {
+            "type": "boolean",
+            "title": "Kiosk Display Only",
+            "default": false
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "banner_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Banner Url"
+          },
+          "banner_kiosk_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Banner Kiosk Url"
           },
           "banner_colors": {
             "anyOf": [
@@ -2616,85 +7836,36 @@
               }
             ],
             "title": "Banner Colors"
-          },
-          "banner_kiosk_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Banner Kiosk Url"
-          },
-          "banner_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Banner Url"
-          },
-          "event": {
-            "$ref": "#/components/schemas/PublicEventInfo"
-          },
-          "kiosk_display_only": {
-            "default": false,
-            "title": "Kiosk Display Only",
-            "type": "boolean"
-          },
-          "now_playing": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/PublicRequestInfo"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "now_playing_hidden": {
-            "title": "Now Playing Hidden",
-            "type": "boolean"
-          },
-          "qr_join_url": {
-            "title": "Qr Join Url",
-            "type": "string"
-          },
-          "requests_open": {
-            "default": true,
-            "title": "Requests Open",
-            "type": "boolean"
-          },
-          "updated_at": {
-            "format": "date-time",
-            "title": "Updated At",
-            "type": "string"
           }
         },
+        "type": "object",
         "required": [
-          "accepted_queue",
-          "banner_colors",
-          "banner_kiosk_url",
-          "banner_url",
           "event",
-          "kiosk_display_only",
+          "qr_join_url",
+          "accepted_queue",
           "now_playing",
           "now_playing_hidden",
-          "qr_join_url",
-          "requests_open",
           "updated_at"
         ],
-        "title": "KioskDisplayResponse",
-        "type": "object"
+        "title": "KioskDisplayResponse"
       },
       "KioskOut": {
-        "description": "Kiosk info for DJ dashboard (no session_token).",
         "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
           "event_code": {
             "anyOf": [
               {
@@ -2717,38 +7888,15 @@
             ],
             "title": "Event Name"
           },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "last_seen_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Seen At"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
+          "status": {
+            "type": "string",
+            "title": "Status"
           },
           "paired_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -2756,51 +7904,80 @@
             ],
             "title": "Paired At"
           },
-          "status": {
-            "title": "Status",
-            "type": "string"
+          "last_seen_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Seen At"
           }
         },
+        "type": "object",
         "required": [
-          "event_code",
-          "event_name",
           "id",
-          "last_seen_at",
           "name",
+          "event_code",
+          "status",
           "paired_at",
-          "status"
+          "last_seen_at"
         ],
         "title": "KioskOut",
-        "type": "object"
+        "description": "Kiosk info for DJ dashboard (no session_token)."
       },
-      "KioskPairResponse": {
-        "description": "Returned when a new kiosk pairing session is created.",
+      "KioskPairChallengeResponse": {
         "properties": {
-          "expires_at": {
-            "format": "date-time",
-            "title": "Expires At",
-            "type": "string"
+          "nonce": {
+            "type": "string",
+            "title": "Nonce"
           },
-          "pair_code": {
-            "title": "Pair Code",
-            "type": "string"
-          },
-          "session_token": {
-            "title": "Session Token",
-            "type": "string"
+          "expires_in": {
+            "type": "integer",
+            "title": "Expires In"
           }
         },
+        "type": "object",
         "required": [
-          "expires_at",
+          "nonce",
+          "expires_in"
+        ],
+        "title": "KioskPairChallengeResponse"
+      },
+      "KioskPairResponse": {
+        "properties": {
+          "pair_code": {
+            "type": "string",
+            "title": "Pair Code"
+          },
+          "session_token": {
+            "type": "string",
+            "title": "Session Token"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expires At"
+          }
+        },
+        "type": "object",
+        "required": [
           "pair_code",
-          "session_token"
+          "session_token",
+          "expires_at"
         ],
         "title": "KioskPairResponse",
-        "type": "object"
+        "description": "Returned when a new kiosk pairing session is created."
       },
       "KioskPairStatusResponse": {
-        "description": "Returned when polling a pairing code's status.",
         "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
           "event_code": {
             "anyOf": [
               {
@@ -2822,28 +7999,22 @@
               }
             ],
             "title": "Event Name"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string"
           }
         },
+        "type": "object",
         "required": [
-          "event_code",
-          "event_name",
           "status"
         ],
         "title": "KioskPairStatusResponse",
-        "type": "object"
+        "description": "Returned when polling a pairing code's status."
       },
       "KioskRenameRequest": {
-        "description": "Body for renaming a kiosk.",
         "properties": {
           "name": {
             "anyOf": [
               {
-                "maxLength": 100,
-                "type": "string"
+                "type": "string",
+                "maxLength": 100
               },
               {
                 "type": "null"
@@ -2852,12 +8023,16 @@
             "title": "Name"
           }
         },
+        "type": "object",
         "title": "KioskRenameRequest",
-        "type": "object"
+        "description": "Body for renaming a kiosk."
       },
       "KioskSessionResponse": {
-        "description": "Returned when polling a kiosk's current assignment.",
         "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
           "event_code": {
             "anyOf": [
               {
@@ -2879,40 +8054,43 @@
               }
             ],
             "title": "Event Name"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string"
           }
         },
+        "type": "object",
         "required": [
-          "event_code",
-          "event_name",
           "status"
         ],
         "title": "KioskSessionResponse",
-        "type": "object"
+        "description": "Returned when polling a kiosk's current assignment."
       },
       "LLMPromptRequest": {
         "properties": {
           "prompt": {
+            "type": "string",
             "maxLength": 500,
             "minLength": 3,
-            "title": "Prompt",
-            "type": "string"
+            "title": "Prompt"
           }
         },
+        "type": "object",
         "required": [
           "prompt"
         ],
-        "title": "LLMPromptRequest",
-        "type": "object"
+        "title": "LLMPromptRequest"
       },
       "MyRequestInfo": {
         "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
           "artist": {
-            "title": "Artist",
-            "type": "string"
+            "type": "string",
+            "title": "Artist"
           },
           "artwork_url": {
             "anyOf": [
@@ -2925,16 +8103,8 @@
             ],
             "title": "Artwork Url"
           },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
           "status": {
+            "type": "string",
             "enum": [
               "new",
               "accepted",
@@ -2942,30 +8112,29 @@
               "played",
               "rejected"
             ],
-            "title": "Status",
-            "type": "string"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
+            "title": "Status"
           },
           "vote_count": {
-            "default": 0,
+            "type": "integer",
             "title": "Vote Count",
-            "type": "integer"
+            "default": 0
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
           }
         },
+        "type": "object",
         "required": [
+          "id",
+          "title",
           "artist",
           "artwork_url",
-          "created_at",
-          "id",
           "status",
-          "title",
-          "vote_count"
+          "created_at"
         ],
-        "title": "MyRequestInfo",
-        "type": "object"
+        "title": "MyRequestInfo"
       },
       "MyRequestsResponse": {
         "properties": {
@@ -2973,24 +8142,41 @@
             "items": {
               "$ref": "#/components/schemas/MyRequestInfo"
             },
-            "title": "Requests",
-            "type": "array"
+            "type": "array",
+            "title": "Requests"
           }
         },
+        "type": "object",
         "required": [
           "requests"
         ],
-        "title": "MyRequestsResponse",
-        "type": "object"
+        "title": "MyRequestsResponse"
       },
       "NowPlayingBridgePayload": {
-        "description": "Payload from bridge when a new track starts playing.",
         "properties": {
+          "event_code": {
+            "type": "string",
+            "maxLength": 10,
+            "minLength": 1,
+            "title": "Event Code"
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Title"
+          },
+          "artist": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Artist"
+          },
           "album": {
             "anyOf": [
               {
-                "maxLength": 255,
-                "type": "string"
+                "type": "string",
+                "maxLength": 255
               },
               {
                 "type": "null"
@@ -2998,17 +8184,11 @@
             ],
             "title": "Album"
           },
-          "artist": {
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Artist",
-            "type": "string"
-          },
           "deck": {
             "anyOf": [
               {
-                "maxLength": 10,
-                "type": "string"
+                "type": "string",
+                "maxLength": 10
               },
               {
                 "type": "null"
@@ -3016,42 +8196,38 @@
             ],
             "title": "Deck"
           },
-          "event_code": {
-            "maxLength": 10,
-            "minLength": 1,
-            "title": "Event Code",
-            "type": "string"
-          },
           "source": {
             "anyOf": [
               {
-                "maxLength": 20,
-                "type": "string"
+                "type": "string",
+                "maxLength": 20
               },
               {
                 "type": "null"
               }
             ],
             "title": "Source"
-          },
-          "title": {
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Title",
-            "type": "string"
           }
         },
+        "type": "object",
         "required": [
           "event_code",
           "title",
           "artist"
         ],
         "title": "NowPlayingBridgePayload",
-        "type": "object"
+        "description": "Payload from bridge when a new track starts playing."
       },
       "NowPlayingResponse": {
-        "description": "Response for current now-playing track.",
         "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "artist": {
+            "type": "string",
+            "title": "Artist"
+          },
           "album": {
             "anyOf": [
               {
@@ -3074,30 +8250,6 @@
             ],
             "title": "Album Art Url"
           },
-          "artist": {
-            "title": "Artist",
-            "type": "string"
-          },
-          "bridge_connected": {
-            "default": false,
-            "title": "Bridge Connected",
-            "type": "boolean"
-          },
-          "matched_request_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Matched Request Id"
-          },
-          "source": {
-            "title": "Source",
-            "type": "string"
-          },
           "spotify_uri": {
             "anyOf": [
               {
@@ -3110,56 +8262,68 @@
             "title": "Spotify Uri"
           },
           "started_at": {
-            "title": "Started At",
-            "type": "string"
+            "type": "string",
+            "title": "Started At"
           },
-          "title": {
-            "title": "Title",
-            "type": "string"
+          "source": {
+            "type": "string",
+            "title": "Source"
+          },
+          "matched_request_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Matched Request Id"
+          },
+          "bridge_connected": {
+            "type": "boolean",
+            "title": "Bridge Connected",
+            "default": false
           }
         },
+        "type": "object",
         "required": [
-          "album",
-          "album_art_url",
+          "title",
           "artist",
-          "bridge_connected",
-          "matched_request_id",
-          "source",
-          "spotify_uri",
           "started_at",
-          "title"
+          "source"
         ],
         "title": "NowPlayingResponse",
-        "type": "object"
+        "description": "Response for current now-playing track."
       },
       "PaginatedResponse": {
         "properties": {
           "items": {
             "items": {},
-            "title": "Items",
-            "type": "array"
-          },
-          "limit": {
-            "title": "Limit",
-            "type": "integer"
-          },
-          "page": {
-            "title": "Page",
-            "type": "integer"
+            "type": "array",
+            "title": "Items"
           },
           "total": {
-            "title": "Total",
-            "type": "integer"
+            "type": "integer",
+            "title": "Total"
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
           }
         },
+        "type": "object",
         "required": [
           "items",
-          "limit",
+          "total",
           "page",
-          "total"
+          "limit"
         ],
-        "title": "PaginatedResponse",
-        "type": "object"
+        "title": "PaginatedResponse"
       },
       "PendingReviewResponse": {
         "properties": {
@@ -3167,26 +8331,34 @@
             "items": {
               "$ref": "#/components/schemas/PendingReviewRow"
             },
-            "title": "Requests",
-            "type": "array"
+            "type": "array",
+            "title": "Requests"
           },
           "total": {
-            "title": "Total",
-            "type": "integer"
+            "type": "integer",
+            "title": "Total"
           }
         },
+        "type": "object",
         "required": [
           "requests",
           "total"
         ],
-        "title": "PendingReviewResponse",
-        "type": "object"
+        "title": "PendingReviewResponse"
       },
       "PendingReviewRow": {
         "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "song_title": {
+            "type": "string",
+            "title": "Song Title"
+          },
           "artist": {
-            "title": "Artist",
-            "type": "string"
+            "type": "string",
+            "title": "Artist"
           },
           "artwork_url": {
             "anyOf": [
@@ -3199,14 +8371,9 @@
             ],
             "title": "Artwork Url"
           },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
+          "vote_count": {
+            "type": "integer",
+            "title": "Vote Count"
           },
           "nickname": {
             "anyOf": [
@@ -3218,6 +8385,11 @@
               }
             ],
             "title": "Nickname"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
           },
           "note": {
             "anyOf": [
@@ -3230,11 +8402,8 @@
             ],
             "title": "Note"
           },
-          "song_title": {
-            "title": "Song Title",
-            "type": "string"
-          },
           "status": {
+            "type": "string",
             "enum": [
               "new",
               "accepted",
@@ -3242,31 +8411,37 @@
               "played",
               "rejected"
             ],
-            "title": "Status",
-            "type": "string"
-          },
-          "vote_count": {
-            "title": "Vote Count",
-            "type": "integer"
+            "title": "Status"
           }
         },
+        "type": "object",
         "required": [
+          "id",
+          "song_title",
           "artist",
           "artwork_url",
-          "created_at",
-          "id",
+          "vote_count",
           "nickname",
+          "created_at",
           "note",
-          "song_title",
-          "status",
-          "vote_count"
+          "status"
         ],
-        "title": "PendingReviewRow",
-        "type": "object"
+        "title": "PendingReviewRow"
       },
       "PlayHistoryEntry": {
-        "description": "Single entry in play history.",
         "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "artist": {
+            "type": "string",
+            "title": "Artist"
+          },
           "album": {
             "anyOf": [
               {
@@ -3289,11 +8464,7 @@
             ],
             "title": "Album Art Url"
           },
-          "artist": {
-            "title": "Artist",
-            "type": "string"
-          },
-          "ended_at": {
+          "spotify_uri": {
             "anyOf": [
               {
                 "type": "string"
@@ -3302,11 +8473,7 @@
                 "type": "null"
               }
             ],
-            "title": "Ended At"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
+            "title": "Spotify Uri"
           },
           "matched_request_id": {
             "anyOf": [
@@ -3319,15 +8486,15 @@
             ],
             "title": "Matched Request Id"
           },
-          "play_order": {
-            "title": "Play Order",
-            "type": "integer"
-          },
           "source": {
-            "title": "Source",
-            "type": "string"
+            "type": "string",
+            "title": "Source"
           },
-          "spotify_uri": {
+          "started_at": {
+            "type": "string",
+            "title": "Started At"
+          },
+          "ended_at": {
             "anyOf": [
               {
                 "type": "string"
@@ -3336,78 +8503,78 @@
                 "type": "null"
               }
             ],
-            "title": "Spotify Uri"
+            "title": "Ended At"
           },
-          "started_at": {
-            "title": "Started At",
-            "type": "string"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
+          "play_order": {
+            "type": "integer",
+            "title": "Play Order"
           }
         },
+        "type": "object",
         "required": [
-          "album",
-          "album_art_url",
-          "artist",
-          "ended_at",
           "id",
-          "matched_request_id",
-          "play_order",
+          "title",
+          "artist",
           "source",
-          "spotify_uri",
           "started_at",
-          "title"
+          "play_order"
         ],
         "title": "PlayHistoryEntry",
-        "type": "object"
+        "description": "Single entry in play history."
       },
       "PlayHistoryResponse": {
-        "description": "Paginated response for play history.",
         "properties": {
           "items": {
             "items": {
               "$ref": "#/components/schemas/PlayHistoryEntry"
             },
-            "title": "Items",
-            "type": "array"
+            "type": "array",
+            "title": "Items"
           },
           "total": {
-            "title": "Total",
-            "type": "integer"
+            "type": "integer",
+            "title": "Total"
           }
         },
+        "type": "object",
         "required": [
           "items",
           "total"
         ],
         "title": "PlayHistoryResponse",
-        "type": "object"
+        "description": "Paginated response for play history."
       },
       "PublicEventInfo": {
         "properties": {
           "code": {
-            "title": "Code",
-            "type": "string"
+            "type": "string",
+            "title": "Code"
           },
           "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "string",
+            "title": "Name"
           }
         },
+        "type": "object",
         "required": [
           "code",
           "name"
         ],
-        "title": "PublicEventInfo",
-        "type": "object"
+        "title": "PublicEventInfo"
       },
       "PublicRequestInfo": {
         "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
           "artist": {
-            "title": "Artist",
-            "type": "string"
+            "type": "string",
+            "title": "Artist"
           },
           "artwork_url": {
             "anyOf": [
@@ -3420,6 +8587,22 @@
             ],
             "title": "Artwork Url"
           },
+          "nickname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nickname"
+          },
+          "vote_count": {
+            "type": "integer",
+            "title": "Vote Count",
+            "default": 0
+          },
           "bpm": {
             "anyOf": [
               {
@@ -3430,21 +8613,6 @@
               }
             ],
             "title": "Bpm"
-          },
-          "genre": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
           },
           "musical_key": {
             "anyOf": [
@@ -3457,7 +8625,7 @@
             ],
             "title": "Musical Key"
           },
-          "nickname": {
+          "genre": {
             "anyOf": [
               {
                 "type": "string"
@@ -3466,97 +8634,88 @@
                 "type": "null"
               }
             ],
-            "title": "Nickname"
+            "title": "Genre"
           },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "vote_count": {
-            "default": 0,
-            "title": "Vote Count",
-            "type": "integer"
+          "requester_verified": {
+            "type": "boolean",
+            "title": "Requester Verified",
+            "default": false
           }
         },
+        "type": "object",
         "required": [
-          "artist",
-          "artwork_url",
-          "bpm",
-          "genre",
           "id",
-          "musical_key",
-          "nickname",
           "title",
-          "vote_count"
+          "artist",
+          "artwork_url"
         ],
-        "title": "PublicRequestInfo",
-        "type": "object"
+        "title": "PublicRequestInfo"
       },
       "PublicSettings": {
         "properties": {
           "registration_enabled": {
-            "title": "Registration Enabled",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Registration Enabled"
           },
           "turnstile_site_key": {
-            "title": "Turnstile Site Key",
-            "type": "string"
+            "type": "string",
+            "title": "Turnstile Site Key"
           }
         },
+        "type": "object",
         "required": [
           "registration_enabled",
           "turnstile_site_key"
         ],
-        "title": "PublicSettings",
-        "type": "object"
+        "title": "PublicSettings"
       },
       "RecommendationResponse": {
         "properties": {
-          "llm_available": {
-            "default": false,
-            "title": "Llm Available",
-            "type": "boolean"
+          "suggestions": {
+            "items": {
+              "$ref": "#/components/schemas/RecommendedTrack"
+            },
+            "type": "array",
+            "title": "Suggestions",
+            "default": []
           },
           "profile": {
             "$ref": "#/components/schemas/EventMusicProfile"
           },
           "services_used": {
-            "default": [],
             "items": {
               "type": "string"
             },
+            "type": "array",
             "title": "Services Used",
-            "type": "array"
-          },
-          "suggestions": {
-            "default": [],
-            "items": {
-              "$ref": "#/components/schemas/RecommendedTrack"
-            },
-            "title": "Suggestions",
-            "type": "array"
+            "default": []
           },
           "total_candidates_searched": {
-            "default": 0,
+            "type": "integer",
             "title": "Total Candidates Searched",
-            "type": "integer"
+            "default": 0
+          },
+          "llm_available": {
+            "type": "boolean",
+            "title": "Llm Available",
+            "default": false
           }
         },
+        "type": "object",
         "required": [
-          "llm_available",
-          "profile",
-          "services_used",
-          "suggestions",
-          "total_candidates_searched"
+          "profile"
         ],
-        "title": "RecommendationResponse",
-        "type": "object"
+        "title": "RecommendationResponse"
       },
       "RecommendedTrack": {
         "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
           "artist": {
-            "title": "Artist",
-            "type": "string"
+            "type": "string",
+            "title": "Artist"
           },
           "bpm": {
             "anyOf": [
@@ -3569,9 +8728,69 @@
             ],
             "title": "Bpm"
           },
+          "key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "score": {
+            "type": "number",
+            "title": "Score"
+          },
           "bpm_score": {
-            "title": "Bpm Score",
-            "type": "number"
+            "type": "number",
+            "title": "Bpm Score"
+          },
+          "key_score": {
+            "type": "number",
+            "title": "Key Score"
+          },
+          "genre_score": {
+            "type": "number",
+            "title": "Genre Score"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source"
+          },
+          "track_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Track Id"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
           },
           "cover_url": {
             "anyOf": [
@@ -3595,209 +8814,82 @@
             ],
             "title": "Duration Seconds"
           },
-          "genre": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
-          },
-          "genre_score": {
-            "title": "Genre Score",
-            "type": "number"
-          },
-          "key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Key"
-          },
-          "key_score": {
-            "title": "Key Score",
-            "type": "number"
-          },
           "mb_verified": {
-            "default": false,
+            "type": "boolean",
             "title": "Mb Verified",
-            "type": "boolean"
-          },
-          "score": {
-            "title": "Score",
-            "type": "number"
-          },
-          "source": {
-            "title": "Source",
-            "type": "string"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "track_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Track Id"
-          },
-          "url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Url"
+            "default": false
           }
         },
+        "type": "object",
         "required": [
-          "artist",
-          "bpm",
-          "bpm_score",
-          "cover_url",
-          "duration_seconds",
-          "genre",
-          "genre_score",
-          "key",
-          "key_score",
-          "mb_verified",
-          "score",
-          "source",
           "title",
-          "track_id",
-          "url"
+          "artist",
+          "score",
+          "bpm_score",
+          "key_score",
+          "genre_score",
+          "source"
         ],
-        "title": "RecommendedTrack",
-        "type": "object"
+        "title": "RecommendedTrack"
       },
       "RegisterRequest": {
         "properties": {
-          "confirm_password": {
-            "title": "Confirm Password",
-            "type": "string"
-          },
-          "email": {
-            "format": "email",
-            "title": "Email",
-            "type": "string"
-          },
-          "password": {
-            "maxLength": 128,
-            "minLength": 8,
-            "title": "Password",
-            "type": "string"
-          },
-          "turnstile_token": {
-            "default": "",
-            "maxLength": 4096,
-            "title": "Turnstile Token",
-            "type": "string"
-          },
           "username": {
+            "type": "string",
             "maxLength": 50,
             "minLength": 3,
-            "title": "Username",
-            "type": "string"
+            "title": "Username"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 8,
+            "title": "Password"
+          },
+          "confirm_password": {
+            "type": "string",
+            "title": "Confirm Password"
+          },
+          "turnstile_token": {
+            "type": "string",
+            "maxLength": 4096,
+            "title": "Turnstile Token",
+            "default": ""
           }
         },
+        "type": "object",
         "required": [
           "username",
           "email",
           "password",
           "confirm_password"
         ],
-        "title": "RegisterRequest",
-        "type": "object"
+        "title": "RegisterRequest"
       },
       "RequestCreate": {
         "properties": {
           "artist": {
+            "type": "string",
             "maxLength": 255,
             "minLength": 1,
-            "title": "Artist",
-            "type": "string"
+            "title": "Artist"
           },
-          "artwork_url": {
-            "anyOf": [
-              {
-                "maxLength": 500,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Artwork Url"
-          },
-          "bpm": {
-            "anyOf": [
-              {
-                "maximum": 999.0,
-                "minimum": 1.0,
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bpm"
-          },
-          "genre": {
-            "anyOf": [
-              {
-                "maxLength": 100,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
-          },
-          "musical_key": {
-            "anyOf": [
-              {
-                "maxLength": 20,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Musical Key"
-          },
-          "nickname": {
-            "anyOf": [
-              {
-                "maxLength": 30,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Nickname"
+          "title": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Title"
           },
           "note": {
             "anyOf": [
               {
-                "maxLength": 500,
-                "type": "string"
+                "type": "string",
+                "maxLength": 500
               },
               {
                 "type": "null"
@@ -3805,17 +8897,17 @@
             ],
             "title": "Note"
           },
-          "raw_search_query": {
+          "nickname": {
             "anyOf": [
               {
-                "maxLength": 200,
-                "type": "string"
+                "type": "string",
+                "maxLength": 30
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Raw Search Query"
+            "title": "Nickname"
           },
           "source": {
             "$ref": "#/components/schemas/RequestSource",
@@ -3824,8 +8916,8 @@
           "source_url": {
             "anyOf": [
               {
-                "maxLength": 500,
-                "type": "string"
+                "type": "string",
+                "maxLength": 500
               },
               {
                 "type": "null"
@@ -3833,30 +8925,11 @@
             ],
             "title": "Source Url"
           },
-          "title": {
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Title",
-            "type": "string"
-          }
-        },
-        "required": [
-          "artist",
-          "title"
-        ],
-        "title": "RequestCreate",
-        "type": "object"
-      },
-      "RequestOut": {
-        "properties": {
-          "artist": {
-            "title": "Artist",
-            "type": "string"
-          },
           "artwork_url": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 500
               },
               {
                 "type": "null"
@@ -3864,93 +8937,11 @@
             ],
             "title": "Artwork Url"
           },
-          "bpm": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bpm"
-          },
-          "created_at": {
-            "title": "Created At",
-            "type": "string"
-          },
-          "event_id": {
-            "title": "Event Id",
-            "type": "integer"
-          },
-          "genre": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "is_duplicate": {
-            "default": false,
-            "title": "Is Duplicate",
-            "type": "boolean"
-          },
-          "musical_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Musical Key"
-          },
-          "nickname": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Nickname"
-          },
-          "note": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Note"
-          },
-          "priority_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Priority Score"
-          },
           "raw_search_query": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 200
               },
               {
                 "type": "null"
@@ -3958,13 +8949,72 @@
             ],
             "title": "Raw Search Query"
           },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "bpm": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 999.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "musical_key": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 20
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Musical Key"
+          }
+        },
+        "type": "object",
+        "required": [
+          "artist",
+          "title"
+        ],
+        "title": "RequestCreate"
+      },
+      "RequestOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "event_id": {
+            "type": "integer",
+            "title": "Event Id"
+          },
           "song_title": {
-            "title": "Song Title",
-            "type": "string"
+            "type": "string",
+            "title": "Song Title"
+          },
+          "artist": {
+            "type": "string",
+            "title": "Artist"
           },
           "source": {
-            "title": "Source",
-            "type": "string"
+            "type": "string",
+            "title": "Source"
           },
           "source_url": {
             "anyOf": [
@@ -3977,9 +9027,99 @@
             ],
             "title": "Source Url"
           },
+          "artwork_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Artwork Url"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "nickname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nickname"
+          },
           "status": {
-            "title": "Status",
-            "type": "string"
+            "type": "string",
+            "title": "Status"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "title": "Updated At"
+          },
+          "is_duplicate": {
+            "type": "boolean",
+            "title": "Is Duplicate",
+            "default": false
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "bpm": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "musical_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Musical Key"
+          },
+          "raw_search_query": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Raw Search Query"
           },
           "sync_results_json": {
             "anyOf": [
@@ -3992,42 +9132,41 @@
             ],
             "title": "Sync Results Json"
           },
-          "updated_at": {
-            "title": "Updated At",
-            "type": "string"
-          },
           "vote_count": {
-            "default": 0,
+            "type": "integer",
             "title": "Vote Count",
-            "type": "integer"
+            "default": 0
+          },
+          "priority_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Priority Score"
           }
         },
+        "type": "object",
         "required": [
-          "artist",
-          "artwork_url",
-          "bpm",
-          "created_at",
-          "event_id",
-          "genre",
           "id",
-          "is_duplicate",
-          "musical_key",
-          "nickname",
-          "note",
-          "priority_score",
-          "raw_search_query",
+          "event_id",
           "song_title",
+          "artist",
           "source",
           "source_url",
+          "artwork_url",
+          "note",
           "status",
-          "sync_results_json",
-          "updated_at",
-          "vote_count"
+          "created_at",
+          "updated_at"
         ],
-        "title": "RequestOut",
-        "type": "object"
+        "title": "RequestOut"
       },
       "RequestSource": {
+        "type": "string",
         "enum": [
           "manual",
           "musicbrainz",
@@ -4036,10 +9175,10 @@
           "tidal",
           "beatport"
         ],
-        "title": "RequestSource",
-        "type": "string"
+        "title": "RequestSource"
       },
       "RequestStatus": {
+        "type": "string",
         "enum": [
           "new",
           "accepted",
@@ -4047,8 +9186,7 @@
           "played",
           "rejected"
         ],
-        "title": "RequestStatus",
-        "type": "string"
+        "title": "RequestStatus"
       },
       "RequestUpdate": {
         "properties": {
@@ -4056,14 +9194,22 @@
             "$ref": "#/components/schemas/RequestStatus"
           }
         },
+        "type": "object",
         "required": [
           "status"
         ],
-        "title": "RequestUpdate",
-        "type": "object"
+        "title": "RequestUpdate"
       },
       "SearchResult": {
         "properties": {
+          "artist": {
+            "type": "string",
+            "title": "Artist"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
           "album": {
             "anyOf": [
               {
@@ -4075,85 +9221,10 @@
             ],
             "title": "Album"
           },
-          "album_art": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Album Art"
-          },
-          "artist": {
-            "title": "Artist",
-            "type": "string"
-          },
-          "bpm": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bpm"
-          },
-          "genre": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
-          },
-          "isrc": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Isrc"
-          },
-          "key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Key"
-          },
           "popularity": {
-            "default": 0,
+            "type": "integer",
             "title": "Popularity",
-            "type": "integer"
-          },
-          "preview_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Preview Url"
-          },
-          "source": {
-            "default": "spotify",
-            "title": "Source",
-            "type": "string"
+            "default": 0
           },
           "spotify_id": {
             "anyOf": [
@@ -4166,9 +9237,27 @@
             ],
             "title": "Spotify Id"
           },
-          "title": {
-            "title": "Title",
-            "type": "string"
+          "album_art": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Album Art"
+          },
+          "preview_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preview Url"
           },
           "url": {
             "anyOf": [
@@ -4180,28 +9269,65 @@
               }
             ],
             "title": "Url"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "default": "spotify"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "bpm": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "isrc": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Isrc"
           }
         },
+        "type": "object",
         "required": [
-          "album",
-          "album_art",
           "artist",
-          "bpm",
-          "genre",
-          "isrc",
-          "key",
-          "popularity",
-          "preview_url",
-          "source",
-          "spotify_id",
-          "title",
-          "url"
+          "title"
         ],
-        "title": "SearchResult",
-        "type": "object"
+        "title": "SearchResult"
       },
       "ServiceCapabilities": {
-        "description": "Capability matrix for a single integration service.",
         "properties": {
           "auth": {
             "$ref": "#/components/schemas/CapabilityStatus"
@@ -4213,157 +9339,106 @@
             "$ref": "#/components/schemas/CapabilityStatus"
           }
         },
+        "type": "object",
         "required": [
           "auth",
           "catalog_search",
           "playlist_sync"
         ],
         "title": "ServiceCapabilities",
-        "type": "object"
+        "description": "Capability matrix for a single integration service."
       },
       "StatusMessageResponse": {
         "properties": {
-          "message": {
-            "title": "Message",
-            "type": "string"
-          },
           "status": {
-            "title": "Status",
-            "type": "string"
+            "type": "string",
+            "title": "Status"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
           }
         },
+        "type": "object",
         "required": [
-          "message",
-          "status"
+          "status",
+          "message"
         ],
-        "title": "StatusMessageResponse",
-        "type": "object"
+        "title": "StatusMessageResponse"
       },
       "StatusResponse": {
         "properties": {
           "status": {
-            "title": "Status",
-            "type": "string"
+            "type": "string",
+            "title": "Status"
           }
         },
+        "type": "object",
         "required": [
           "status"
         ],
-        "title": "StatusResponse",
-        "type": "object"
+        "title": "StatusResponse"
       },
       "SystemSettingsOut": {
         "properties": {
-          "beatport_enabled": {
-            "title": "Beatport Enabled",
-            "type": "boolean"
-          },
-          "bridge_enabled": {
-            "title": "Bridge Enabled",
-            "type": "boolean"
-          },
-          "llm_enabled": {
-            "title": "Llm Enabled",
-            "type": "boolean"
-          },
-          "llm_model": {
-            "title": "Llm Model",
-            "type": "string"
-          },
-          "llm_rate_limit_per_minute": {
-            "title": "Llm Rate Limit Per Minute",
-            "type": "integer"
-          },
           "registration_enabled": {
-            "title": "Registration Enabled",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Registration Enabled"
           },
           "search_rate_limit_per_minute": {
-            "title": "Search Rate Limit Per Minute",
-            "type": "integer"
+            "type": "integer",
+            "title": "Search Rate Limit Per Minute"
           },
           "spotify_enabled": {
-            "title": "Spotify Enabled",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Spotify Enabled"
           },
           "tidal_enabled": {
-            "title": "Tidal Enabled",
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "beatport_enabled",
-          "bridge_enabled",
-          "llm_enabled",
-          "llm_model",
-          "llm_rate_limit_per_minute",
-          "registration_enabled",
-          "search_rate_limit_per_minute",
-          "spotify_enabled",
-          "tidal_enabled"
-        ],
-        "title": "SystemSettingsOut",
-        "type": "object"
-      },
-      "SystemSettingsUpdate": {
-        "properties": {
+            "type": "boolean",
+            "title": "Tidal Enabled"
+          },
           "beatport_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "boolean",
             "title": "Beatport Enabled"
           },
           "bridge_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "boolean",
             "title": "Bridge Enabled"
           },
+          "human_verification_enforced": {
+            "type": "boolean",
+            "title": "Human Verification Enforced"
+          },
           "llm_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "boolean",
             "title": "Llm Enabled"
           },
           "llm_model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
             "title": "Llm Model"
           },
           "llm_rate_limit_per_minute": {
-            "anyOf": [
-              {
-                "maximum": 30.0,
-                "minimum": 1.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "integer",
             "title": "Llm Rate Limit Per Minute"
-          },
+          }
+        },
+        "type": "object",
+        "required": [
+          "registration_enabled",
+          "search_rate_limit_per_minute",
+          "spotify_enabled",
+          "tidal_enabled",
+          "beatport_enabled",
+          "bridge_enabled",
+          "human_verification_enforced",
+          "llm_enabled",
+          "llm_model",
+          "llm_rate_limit_per_minute"
+        ],
+        "title": "SystemSettingsOut"
+      },
+      "SystemSettingsUpdate": {
+        "properties": {
           "registration_enabled": {
             "anyOf": [
               {
@@ -4378,9 +9453,9 @@
           "search_rate_limit_per_minute": {
             "anyOf": [
               {
+                "type": "integer",
                 "maximum": 100.0,
-                "minimum": 1.0,
-                "type": "integer"
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -4409,77 +9484,52 @@
               }
             ],
             "title": "Tidal Enabled"
-          }
-        },
-        "title": "SystemSettingsUpdate",
-        "type": "object"
-      },
-      "SystemStats": {
-        "properties": {
-          "active_events": {
-            "title": "Active Events",
-            "type": "integer"
           },
-          "active_users": {
-            "title": "Active Users",
-            "type": "integer"
+          "beatport_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Beatport Enabled"
           },
-          "pending_users": {
-            "title": "Pending Users",
-            "type": "integer"
+          "bridge_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bridge Enabled"
           },
-          "total_events": {
-            "title": "Total Events",
-            "type": "integer"
+          "human_verification_enforced": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Human Verification Enforced"
           },
-          "total_requests": {
-            "title": "Total Requests",
-            "type": "integer"
+          "llm_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Enabled"
           },
-          "total_users": {
-            "title": "Total Users",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "active_events",
-          "active_users",
-          "pending_users",
-          "total_events",
-          "total_requests",
-          "total_users"
-        ],
-        "title": "SystemStats",
-        "type": "object"
-      },
-      "TemplatePlaylistRequest": {
-        "properties": {
-          "playlist_id": {
-            "maxLength": 200,
-            "minLength": 1,
-            "title": "Playlist Id",
-            "type": "string"
-          },
-          "source": {
-            "pattern": "^(tidal|beatport)$",
-            "title": "Source",
-            "type": "string"
-          }
-        },
-        "required": [
-          "source",
-          "playlist_id"
-        ],
-        "title": "TemplatePlaylistRequest",
-        "type": "object"
-      },
-      "TidalAuthCheckResponse": {
-        "properties": {
-          "complete": {
-            "title": "Complete",
-            "type": "boolean"
-          },
-          "error": {
+          "llm_model": {
             "anyOf": [
               {
                 "type": "string"
@@ -4488,7 +9538,89 @@
                 "type": "null"
               }
             ],
-            "title": "Error"
+            "title": "Llm Model"
+          },
+          "llm_rate_limit_per_minute": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 30.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Rate Limit Per Minute"
+          }
+        },
+        "type": "object",
+        "title": "SystemSettingsUpdate"
+      },
+      "SystemStats": {
+        "properties": {
+          "total_users": {
+            "type": "integer",
+            "title": "Total Users"
+          },
+          "active_users": {
+            "type": "integer",
+            "title": "Active Users"
+          },
+          "pending_users": {
+            "type": "integer",
+            "title": "Pending Users"
+          },
+          "total_events": {
+            "type": "integer",
+            "title": "Total Events"
+          },
+          "active_events": {
+            "type": "integer",
+            "title": "Active Events"
+          },
+          "total_requests": {
+            "type": "integer",
+            "title": "Total Requests"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total_users",
+          "active_users",
+          "pending_users",
+          "total_events",
+          "active_events",
+          "total_requests"
+        ],
+        "title": "SystemStats"
+      },
+      "TemplatePlaylistRequest": {
+        "properties": {
+          "source": {
+            "type": "string",
+            "pattern": "^(tidal|beatport)$",
+            "title": "Source"
+          },
+          "playlist_id": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Playlist Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "source",
+          "playlist_id"
+        ],
+        "title": "TemplatePlaylistRequest"
+      },
+      "TidalAuthCheckResponse": {
+        "properties": {
+          "complete": {
+            "type": "boolean",
+            "title": "Complete"
           },
           "pending": {
             "anyOf": [
@@ -4500,6 +9632,17 @@
               }
             ],
             "title": "Pending"
+          },
+          "verification_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Verification Url"
           },
           "user_code": {
             "anyOf": [
@@ -4523,7 +9666,7 @@
             ],
             "title": "User Id"
           },
-          "verification_url": {
+          "error": {
             "anyOf": [
               {
                 "type": "string"
@@ -4532,30 +9675,17 @@
                 "type": "null"
               }
             ],
-            "title": "Verification Url"
+            "title": "Error"
           }
         },
+        "type": "object",
         "required": [
-          "complete",
-          "error",
-          "pending",
-          "user_code",
-          "user_id",
-          "verification_url"
+          "complete"
         ],
-        "title": "TidalAuthCheckResponse",
-        "type": "object"
+        "title": "TidalAuthCheckResponse"
       },
       "TidalAuthStartResponse": {
         "properties": {
-          "message": {
-            "title": "Message",
-            "type": "string"
-          },
-          "user_code": {
-            "title": "User Code",
-            "type": "string"
-          },
           "verification_url": {
             "anyOf": [
               {
@@ -4566,19 +9696,30 @@
               }
             ],
             "title": "Verification Url"
+          },
+          "user_code": {
+            "type": "string",
+            "title": "User Code"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
           }
         },
+        "type": "object",
         "required": [
-          "message",
+          "verification_url",
           "user_code",
-          "verification_url"
+          "message"
         ],
-        "title": "TidalAuthStartResponse",
-        "type": "object"
+        "title": "TidalAuthStartResponse"
       },
       "TidalEventSettings": {
-        "description": "Tidal sync settings for an event.",
         "properties": {
+          "tidal_sync_enabled": {
+            "type": "boolean",
+            "title": "Tidal Sync Enabled"
+          },
           "tidal_playlist_id": {
             "anyOf": [
               {
@@ -4589,53 +9730,60 @@
               }
             ],
             "title": "Tidal Playlist Id"
-          },
-          "tidal_sync_enabled": {
-            "title": "Tidal Sync Enabled",
-            "type": "boolean"
           }
         },
+        "type": "object",
         "required": [
-          "tidal_playlist_id",
           "tidal_sync_enabled"
         ],
         "title": "TidalEventSettings",
-        "type": "object"
+        "description": "Tidal sync settings for an event."
       },
       "TidalEventSettingsUpdate": {
-        "description": "Update Tidal sync settings for an event.",
         "properties": {
           "tidal_sync_enabled": {
-            "title": "Tidal Sync Enabled",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Tidal Sync Enabled"
           }
         },
+        "type": "object",
         "required": [
           "tidal_sync_enabled"
         ],
         "title": "TidalEventSettingsUpdate",
-        "type": "object"
+        "description": "Update Tidal sync settings for an event."
       },
       "TidalManualLink": {
-        "description": "Manual track linking request.",
         "properties": {
           "tidal_track_id": {
+            "type": "string",
             "maxLength": 100,
             "minLength": 1,
             "pattern": "^[0-9]+$",
-            "title": "Tidal Track Id",
-            "type": "string"
+            "title": "Tidal Track Id"
           }
         },
+        "type": "object",
         "required": [
           "tidal_track_id"
         ],
         "title": "TidalManualLink",
-        "type": "object"
+        "description": "Manual track linking request."
       },
       "TidalSearchResult": {
-        "description": "Track result from Tidal search.",
         "properties": {
+          "track_id": {
+            "type": "string",
+            "title": "Track Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "artist": {
+            "type": "string",
+            "title": "Artist"
+          },
           "album": {
             "anyOf": [
               {
@@ -4646,10 +9794,6 @@
               }
             ],
             "title": "Album"
-          },
-          "artist": {
-            "title": "Artist",
-            "type": "string"
           },
           "bpm": {
             "anyOf": [
@@ -4662,7 +9806,7 @@
             ],
             "title": "Bpm"
           },
-          "cover_url": {
+          "key": {
             "anyOf": [
               {
                 "type": "string"
@@ -4671,7 +9815,7 @@
                 "type": "null"
               }
             ],
-            "title": "Cover Url"
+            "title": "Key"
           },
           "duration_seconds": {
             "anyOf": [
@@ -4684,12 +9828,7 @@
             ],
             "title": "Duration Seconds"
           },
-          "explicit": {
-            "default": false,
-            "title": "Explicit",
-            "type": "boolean"
-          },
-          "isrc": {
+          "cover_url": {
             "anyOf": [
               {
                 "type": "string"
@@ -4698,23 +9837,7 @@
                 "type": "null"
               }
             ],
-            "title": "Isrc"
-          },
-          "key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Key"
-          },
-          "popularity": {
-            "default": 0,
-            "title": "Popularity",
-            "type": "integer"
+            "title": "Cover Url"
           },
           "tidal_url": {
             "anyOf": [
@@ -4727,13 +9850,21 @@
             ],
             "title": "Tidal Url"
           },
-          "title": {
-            "title": "Title",
-            "type": "string"
+          "popularity": {
+            "type": "integer",
+            "title": "Popularity",
+            "default": 0
           },
-          "track_id": {
-            "title": "Track Id",
-            "type": "string"
+          "isrc": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Isrc"
           },
           "version": {
             "anyOf": [
@@ -4745,29 +9876,39 @@
               }
             ],
             "title": "Version"
+          },
+          "explicit": {
+            "type": "boolean",
+            "title": "Explicit",
+            "default": false
           }
         },
+        "type": "object",
         "required": [
-          "album",
-          "artist",
-          "bpm",
-          "cover_url",
-          "duration_seconds",
-          "explicit",
-          "isrc",
-          "key",
-          "popularity",
-          "tidal_url",
-          "title",
           "track_id",
-          "version"
+          "title",
+          "artist"
         ],
         "title": "TidalSearchResult",
-        "type": "object"
+        "description": "Track result from Tidal search."
       },
       "TidalStatus": {
-        "description": "Current Tidal account linking status.",
         "properties": {
+          "linked": {
+            "type": "boolean",
+            "title": "Linked"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          },
           "expires_at": {
             "anyOf": [
               {
@@ -4780,52 +9921,23 @@
             "title": "Expires At"
           },
           "integration_enabled": {
-            "default": true,
+            "type": "boolean",
             "title": "Integration Enabled",
-            "type": "boolean"
-          },
-          "linked": {
-            "title": "Linked",
-            "type": "boolean"
-          },
-          "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User Id"
+            "default": true
           }
         },
+        "type": "object",
         "required": [
-          "expires_at",
-          "integration_enabled",
-          "linked",
-          "user_id"
+          "linked"
         ],
         "title": "TidalStatus",
-        "type": "object"
+        "description": "Current Tidal account linking status."
       },
       "TidalSyncResult": {
-        "description": "Result of syncing a request to Tidal playlist.",
         "properties": {
-          "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Error"
-          },
           "request_id": {
-            "title": "Request Id",
-            "type": "integer"
+            "type": "integer",
+            "title": "Request Id"
           },
           "status": {
             "$ref": "#/components/schemas/TidalSyncStatus"
@@ -4840,53 +9952,62 @@
               }
             ],
             "title": "Tidal Track Id"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
           }
         },
+        "type": "object",
         "required": [
-          "error",
           "request_id",
-          "status",
-          "tidal_track_id"
+          "status"
         ],
         "title": "TidalSyncResult",
-        "type": "object"
+        "description": "Result of syncing a request to Tidal playlist."
       },
       "TidalSyncStatus": {
+        "type": "string",
         "enum": [
           "pending",
           "synced",
           "not_found",
           "error"
         ],
-        "title": "TidalSyncStatus",
-        "type": "string"
+        "title": "TidalSyncStatus"
       },
       "Token": {
         "properties": {
           "access_token": {
-            "title": "Access Token",
-            "type": "string"
+            "type": "string",
+            "title": "Access Token"
           },
           "token_type": {
-            "default": "bearer",
+            "type": "string",
             "title": "Token Type",
-            "type": "string"
+            "default": "bearer"
           }
         },
+        "type": "object",
         "required": [
-          "access_token",
-          "token_type"
+          "access_token"
         ],
-        "title": "Token",
-        "type": "object"
+        "title": "Token"
       },
       "UpdateCollectionSettings": {
         "properties": {
           "collection_opens_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -4894,26 +10015,11 @@
             ],
             "title": "Collection Opens At"
           },
-          "collection_phase_override": {
-            "anyOf": [
-              {
-                "enum": [
-                  "force_collection",
-                  "force_live"
-                ],
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Collection Phase Override"
-          },
           "live_starts_at": {
             "anyOf": [
               {
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
@@ -4924,72 +10030,79 @@
           "submission_cap_per_guest": {
             "anyOf": [
               {
+                "type": "integer",
                 "maximum": 100.0,
-                "minimum": 0.0,
-                "type": "integer"
+                "minimum": 0.0
               },
               {
                 "type": "null"
               }
             ],
             "title": "Submission Cap Per Guest"
+          },
+          "collection_phase_override": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "force_collection",
+                  "force_live"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Collection Phase Override"
           }
         },
-        "title": "UpdateCollectionSettings",
-        "type": "object"
+        "type": "object",
+        "title": "UpdateCollectionSettings"
       },
       "UserOut": {
         "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "role": {
+            "type": "string",
+            "title": "Role"
+          },
           "created_at": {
+            "type": "string",
             "format": "date-time",
-            "title": "Created At",
-            "type": "string"
+            "title": "Created At"
           },
           "help_pages_seen": {
-            "default": [],
             "items": {
               "type": "string"
             },
+            "type": "array",
             "title": "Help Pages Seen",
-            "type": "array"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "is_active": {
-            "title": "Is Active",
-            "type": "boolean"
-          },
-          "role": {
-            "title": "Role",
-            "type": "string"
-          },
-          "username": {
-            "title": "Username",
-            "type": "string"
+            "default": []
           }
         },
+        "type": "object",
         "required": [
-          "created_at",
-          "help_pages_seen",
           "id",
+          "username",
           "is_active",
           "role",
-          "username"
+          "created_at"
         ],
-        "title": "UserOut",
-        "type": "object"
+        "title": "UserOut"
       },
       "ValidationError": {
         "properties": {
-          "ctx": {
-            "title": "Context",
-            "type": "object"
-          },
-          "input": {
-            "title": "Input"
-          },
           "loc": {
             "items": {
               "anyOf": [
@@ -5001,5249 +10114,175 @@
                 }
               ]
             },
-            "title": "Location",
-            "type": "array"
+            "type": "array",
+            "title": "Location"
           },
           "msg": {
-            "title": "Message",
-            "type": "string"
+            "type": "string",
+            "title": "Message"
           },
           "type": {
-            "title": "Error Type",
-            "type": "string"
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
           }
         },
+        "type": "object",
         "required": [
-          "ctx",
-          "input",
           "loc",
           "msg",
           "type"
         ],
-        "title": "ValidationError",
-        "type": "object"
+        "title": "ValidationError"
       },
       "VerifyConfirmResponse": {
         "properties": {
+          "verified": {
+            "type": "boolean",
+            "title": "Verified"
+          },
           "guest_id": {
-            "title": "Guest Id",
-            "type": "integer"
+            "type": "integer",
+            "title": "Guest Id"
           },
           "merged": {
-            "title": "Merged",
-            "type": "boolean"
-          },
-          "verified": {
-            "title": "Verified",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Merged"
           }
         },
+        "type": "object",
         "required": [
+          "verified",
           "guest_id",
-          "merged",
-          "verified"
+          "merged"
         ],
-        "title": "VerifyConfirmResponse",
-        "type": "object"
+        "title": "VerifyConfirmResponse"
       },
       "VerifyConfirmSchema": {
         "properties": {
-          "code": {
-            "title": "Code",
-            "type": "string"
-          },
           "email": {
+            "type": "string",
             "format": "email",
-            "title": "Email",
-            "type": "string"
+            "title": "Email"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
           }
         },
+        "type": "object",
         "required": [
           "email",
           "code"
         ],
-        "title": "VerifyConfirmSchema",
-        "type": "object"
+        "title": "VerifyConfirmSchema"
+      },
+      "VerifyHumanRequest": {
+        "properties": {
+          "turnstile_token": {
+            "type": "string",
+            "maxLength": 4096,
+            "minLength": 1,
+            "title": "Turnstile Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "turnstile_token"
+        ],
+        "title": "VerifyHumanRequest"
+      },
+      "VerifyHumanResponse": {
+        "properties": {
+          "verified": {
+            "type": "boolean",
+            "title": "Verified"
+          },
+          "expires_in": {
+            "type": "integer",
+            "title": "Expires In"
+          }
+        },
+        "type": "object",
+        "required": [
+          "verified",
+          "expires_in"
+        ],
+        "title": "VerifyHumanResponse"
       },
       "VerifyRequestResponse": {
         "properties": {
           "sent": {
-            "title": "Sent",
-            "type": "boolean"
+            "type": "boolean",
+            "title": "Sent"
           }
         },
+        "type": "object",
         "required": [
           "sent"
         ],
-        "title": "VerifyRequestResponse",
-        "type": "object"
+        "title": "VerifyRequestResponse"
       },
       "VerifyRequestSchema": {
         "properties": {
           "email": {
+            "type": "string",
             "format": "email",
-            "title": "Email",
-            "type": "string"
+            "title": "Email"
+          },
+          "turnstile_token": {
+            "type": "string",
+            "maxLength": 4096,
+            "minLength": 1,
+            "title": "Turnstile Token"
           }
         },
+        "type": "object",
         "required": [
-          "email"
+          "email",
+          "turnstile_token"
         ],
-        "title": "VerifyRequestSchema",
-        "type": "object"
+        "title": "VerifyRequestSchema"
       },
       "VoteResponse": {
         "properties": {
-          "has_voted": {
-            "title": "Has Voted",
-            "type": "boolean"
-          },
           "status": {
-            "title": "Status",
-            "type": "string"
+            "type": "string",
+            "title": "Status"
           },
           "vote_count": {
-            "title": "Vote Count",
-            "type": "integer"
+            "type": "integer",
+            "title": "Vote Count"
+          },
+          "has_voted": {
+            "type": "boolean",
+            "title": "Has Voted"
           }
         },
+        "type": "object",
         "required": [
-          "has_voted",
           "status",
-          "vote_count"
+          "vote_count",
+          "has_voted"
         ],
-        "title": "VoteResponse",
-        "type": "object"
+        "title": "VoteResponse"
       }
     },
     "securitySchemes": {
       "OAuth2PasswordBearer": {
+        "type": "oauth2",
         "flows": {
           "password": {
             "scopes": {},
             "tokenUrl": "/api/auth/login"
           }
-        },
-        "type": "oauth2"
-      }
-    }
-  },
-  "info": {
-    "description": "Song request system for DJs",
-    "title": "WrzDJ API",
-    "version": "0.1.0"
-  },
-  "openapi": "3.1.0",
-  "paths": {
-    "/api/admin/ai/models": {
-      "get": {
-        "description": "List available AI models.",
-        "operationId": "admin_get_ai_models_api_admin_ai_models_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIModelsResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Get Ai Models",
-        "tags": [
-          "admin"
-        ]
-      }
-    },
-    "/api/admin/ai/settings": {
-      "get": {
-        "description": "Get AI/LLM configuration.",
-        "operationId": "admin_get_ai_settings_api_admin_ai_settings_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AISettingsOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Get Ai Settings",
-        "tags": [
-          "admin"
-        ]
-      },
-      "put": {
-        "description": "Update AI/LLM configuration.",
-        "operationId": "admin_update_ai_settings_api_admin_ai_settings_put",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AISettingsUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AISettingsOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Update Ai Settings",
-        "tags": [
-          "admin"
-        ]
-      }
-    },
-    "/api/admin/events": {
-      "get": {
-        "operationId": "admin_list_events_api_admin_events_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "default": 1,
-              "maximum": 1000,
-              "minimum": 1,
-              "title": "Page",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 20,
-              "maximum": 100,
-              "minimum": 1,
-              "title": "Limit",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin List Events",
-        "tags": [
-          "admin"
-        ]
-      }
-    },
-    "/api/admin/events/bulk-delete": {
-      "post": {
-        "description": "Admin can bulk delete events from any owner.",
-        "operationId": "admin_bulk_delete_events_api_admin_events_bulk_delete_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BulkDeleteEventsRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkActionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Bulk Delete Events",
-        "tags": [
-          "admin"
-        ]
-      }
-    },
-    "/api/admin/events/{code}": {
-      "delete": {
-        "description": "Admin can delete any event.",
-        "operationId": "admin_delete_event_api_admin_events__code__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Delete Event",
-        "tags": [
-          "admin"
-        ]
-      },
-      "patch": {
-        "description": "Admin can edit any event (not just their own).",
-        "operationId": "admin_update_event_api_admin_events__code__patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EventUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AdminEventOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Update Event",
-        "tags": [
-          "admin"
-        ]
-      }
-    },
-    "/api/admin/integrations": {
-      "get": {
-        "description": "Get status of all external integrations (no active health checks).",
-        "operationId": "admin_get_integrations_api_admin_integrations_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IntegrationHealthResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Get Integrations",
-        "tags": [
-          "admin"
-        ]
-      }
-    },
-    "/api/admin/integrations/{service}": {
-      "patch": {
-        "description": "Enable or disable a specific integration.",
-        "operationId": "admin_toggle_integration_api_admin_integrations__service__patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "service",
-            "required": true,
-            "schema": {
-              "title": "Service",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/IntegrationToggleRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IntegrationToggleResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Toggle Integration",
-        "tags": [
-          "admin"
-        ]
-      }
-    },
-    "/api/admin/integrations/{service}/check": {
-      "post": {
-        "description": "Run an active health check for a specific service (rate limited).",
-        "operationId": "admin_check_integration_api_admin_integrations__service__check_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "service",
-            "required": true,
-            "schema": {
-              "title": "Service",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IntegrationCheckResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Check Integration",
-        "tags": [
-          "admin"
-        ]
-      }
-    },
-    "/api/admin/settings": {
-      "get": {
-        "operationId": "admin_get_settings_api_admin_settings_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SystemSettingsOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Get Settings",
-        "tags": [
-          "admin"
-        ]
-      },
-      "patch": {
-        "operationId": "admin_update_settings_api_admin_settings_patch",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SystemSettingsUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SystemSettingsOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Update Settings",
-        "tags": [
-          "admin"
-        ]
-      }
-    },
-    "/api/admin/stats": {
-      "get": {
-        "operationId": "admin_stats_api_admin_stats_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SystemStats"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Stats",
-        "tags": [
-          "admin"
-        ]
-      }
-    },
-    "/api/admin/users": {
-      "get": {
-        "operationId": "admin_list_users_api_admin_users_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "default": 1,
-              "maximum": 1000,
-              "minimum": 1,
-              "title": "Page",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 20,
-              "maximum": 100,
-              "minimum": 1,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "role",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Role"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin List Users",
-        "tags": [
-          "admin"
-        ]
-      },
-      "post": {
-        "operationId": "admin_create_user_api_admin_users_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AdminUserCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AdminUserOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Create User",
-        "tags": [
-          "admin"
-        ]
-      }
-    },
-    "/api/admin/users/{user_id}": {
-      "delete": {
-        "operationId": "admin_delete_user_api_admin_users__user_id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "title": "User Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Delete User",
-        "tags": [
-          "admin"
-        ]
-      },
-      "patch": {
-        "operationId": "admin_update_user_api_admin_users__user_id__patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "title": "User Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AdminUserUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AdminUserOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Update User",
-        "tags": [
-          "admin"
-        ]
-      }
-    },
-    "/api/auth/help-seen": {
-      "post": {
-        "description": "Mark a help page as seen for the current user.",
-        "operationId": "mark_help_page_seen_api_auth_help_seen_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/HelpPageSeenRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Mark Help Page Seen",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/auth/login": {
-      "post": {
-        "operationId": "login_api_auth_login_post",
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_login_api_auth_login_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Token"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Login",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/auth/logout": {
-      "post": {
-        "description": "Invalidate all outstanding JWTs for the current user.\n\nSECURITY (CRIT-2): bumps token_version so every previously-issued JWT\nfor this user fails the version check in get_current_user.",
-        "operationId": "logout_api_auth_logout_post",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Logout",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/auth/me": {
-      "get": {
-        "operationId": "get_me_api_auth_me_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Me",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/auth/register": {
-      "post": {
-        "description": "Register a new user (pending approval).",
-        "operationId": "register_api_auth_register_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RegisterRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Register",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/auth/settings": {
-      "get": {
-        "description": "Public endpoint returning registration status and Turnstile site key.",
-        "operationId": "get_public_settings_api_auth_settings_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PublicSettings"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Public Settings",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/api/beatport/auth/login": {
-      "post": {
-        "description": "Authenticate with Beatport using username/password.\n\nThe backend logs in to Beatport server-side, obtains an authorization\ncode, exchanges it for tokens, and stores them on the user.",
-        "operationId": "login_beatport_api_beatport_auth_login_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BeatportLogin"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Login Beatport",
-        "tags": [
-          "beatport"
-        ]
-      }
-    },
-    "/api/beatport/disconnect": {
-      "post": {
-        "description": "Unlink Beatport account from current user.",
-        "operationId": "disconnect_api_beatport_disconnect_post",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Disconnect",
-        "tags": [
-          "beatport"
-        ]
-      }
-    },
-    "/api/beatport/events/{event_id}/settings": {
-      "get": {
-        "description": "Get Beatport sync settings for an event.",
-        "operationId": "get_event_settings_api_beatport_events__event_id__settings_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "event_id",
-            "required": true,
-            "schema": {
-              "title": "Event Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BeatportEventSettings"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Event Settings",
-        "tags": [
-          "beatport"
-        ]
-      },
-      "put": {
-        "description": "Update Beatport sync settings for an event.",
-        "operationId": "update_event_settings_api_beatport_events__event_id__settings_put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "event_id",
-            "required": true,
-            "schema": {
-              "title": "Event Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BeatportEventSettingsUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BeatportEventSettings"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Update Event Settings",
-        "tags": [
-          "beatport"
-        ]
-      }
-    },
-    "/api/beatport/requests/{request_id}/link": {
-      "post": {
-        "description": "Manually link a Beatport track to a request.\n\nVerifies the track exists on Beatport, then stores the\nBeatport URL and metadata in sync_results_json.",
-        "operationId": "link_track_api_beatport_requests__request_id__link_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "request_id",
-            "required": true,
-            "schema": {
-              "title": "Request Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BeatportManualLink"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Link Track",
-        "tags": [
-          "beatport"
-        ]
-      }
-    },
-    "/api/beatport/search": {
-      "get": {
-        "description": "Search Beatport for tracks.",
-        "operationId": "search_api_beatport_search_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "q",
-            "required": true,
-            "schema": {
-              "maxLength": 200,
-              "minLength": 1,
-              "title": "Q",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 10,
-              "maximum": 50,
-              "minimum": 1,
-              "title": "Limit",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/BeatportSearchResult"
-                  },
-                  "title": "Response Search Api Beatport Search Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Search",
-        "tags": [
-          "beatport"
-        ]
-      }
-    },
-    "/api/beatport/status": {
-      "get": {
-        "description": "Check if current user has linked Beatport account.",
-        "operationId": "get_status_api_beatport_status_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BeatportStatus"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Status",
-        "tags": [
-          "beatport"
-        ]
-      }
-    },
-    "/api/bridge/apikey": {
-      "get": {
-        "description": "Return the server's bridge API key to an admin user.\n\nThe GUI uses this so the DJ doesn't have to manually paste the key.\nRestricted to admins to prevent non-owners from impersonating the bridge.",
-        "operationId": "get_bridge_api_key_api_bridge_apikey_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BridgeApiKeyResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Bridge Api Key",
-        "tags": [
-          "bridge"
-        ]
-      }
-    },
-    "/api/bridge/commands/{code}": {
-      "get": {
-        "description": "Poll and clear pending commands for the bridge.\n\nRequires bridge API key auth. Returns all pending commands and clears the queue.\nRate limited to 30 requests per minute.",
-        "operationId": "get_bridge_commands_api_bridge_commands__code__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "maxLength": 10,
-              "minLength": 1,
-              "title": "Code",
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "x-bridge-api-key",
-            "required": true,
-            "schema": {
-              "title": "X-Bridge-Api-Key",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BridgeCommandsPollResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Bridge Commands",
-        "tags": [
-          "bridge"
-        ]
-      },
-      "post": {
-        "description": "Queue a command for the bridge to pick up.\n\nRequires JWT auth. The user must own the event or be an admin.\nRate limited to 10 requests per minute.",
-        "operationId": "post_bridge_command_api_bridge_commands__code__post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "maxLength": 10,
-              "minLength": 1,
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BridgeCommandRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BridgeCommandResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Post Bridge Command",
-        "tags": [
-          "bridge"
-        ]
-      }
-    },
-    "/api/bridge/nowplaying": {
-      "post": {
-        "description": "Bridge reports a new track playing.\n\nCalled when the DJ loads/plays a new track on their equipment.\nArchives the previous track to play history and updates now_playing.\nRate limited to 60 requests per minute.",
-        "operationId": "post_now_playing_api_bridge_nowplaying_post",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "x-bridge-api-key",
-            "required": true,
-            "schema": {
-              "title": "X-Bridge-Api-Key",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NowPlayingBridgePayload"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Post Now Playing",
-        "tags": [
-          "bridge"
-        ]
-      }
-    },
-    "/api/bridge/nowplaying/{code}": {
-      "delete": {
-        "description": "Bridge signals track ended / deck cleared.\n\nArchives current track to history and clears now_playing.\nRate limited to 60 requests per minute.",
-        "operationId": "delete_now_playing_api_bridge_nowplaying__code__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "maxLength": 10,
-              "minLength": 1,
-              "title": "Code",
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "x-bridge-api-key",
-            "required": true,
-            "schema": {
-              "title": "X-Bridge-Api-Key",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Delete Now Playing",
-        "tags": [
-          "bridge"
-        ]
-      }
-    },
-    "/api/bridge/status": {
-      "post": {
-        "description": "Bridge reports connection status.\n\nCalled when bridge connects/disconnects from DJ equipment.\nRate limited to 30 requests per minute.",
-        "operationId": "post_bridge_status_api_bridge_status_post",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "x-bridge-api-key",
-            "required": true,
-            "schema": {
-              "title": "X-Bridge-Api-Key",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BridgeStatusPayload"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Post Bridge Status",
-        "tags": [
-          "bridge"
-        ]
-      }
-    },
-    "/api/events": {
-      "get": {
-        "operationId": "list_events_api_events_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/EventOut"
-                  },
-                  "title": "Response List Events Api Events Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "List Events",
-        "tags": [
-          "events"
-        ]
-      },
-      "post": {
-        "operationId": "create_new_event_api_events_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EventCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Create New Event",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/activity": {
-      "get": {
-        "description": "Get recent activity log entries for the current user's events.",
-        "operationId": "get_activity_log_api_events_activity_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "event_code",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Event Code"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 50,
-              "maximum": 200,
-              "minimum": 1,
-              "title": "Limit",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/ActivityLogEntry"
-                  },
-                  "title": "Response Get Activity Log Api Events Activity Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Activity Log",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/archived": {
-      "get": {
-        "description": "List all archived and expired events for the current user.",
-        "operationId": "list_archived_events_api_events_archived_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/EventOut"
-                  },
-                  "title": "Response List Archived Events Api Events Archived Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "List Archived Events",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/bulk-delete": {
-      "post": {
-        "description": "Bulk delete multiple events owned by the current user.",
-        "operationId": "bulk_delete_events_endpoint_api_events_bulk_delete_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BulkDeleteEventsRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkActionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Bulk Delete Events Endpoint",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}": {
-      "delete": {
-        "description": "Delete an event and all its requests.",
-        "operationId": "delete_event_endpoint_api_events__code__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Delete Event Endpoint",
-        "tags": [
-          "events"
-        ]
-      },
-      "get": {
-        "operationId": "get_event_api_events__code__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Event",
-        "tags": [
-          "events"
-        ]
-      },
-      "patch": {
-        "operationId": "update_event_endpoint_api_events__code__patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EventUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Update Event Endpoint",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/archive": {
-      "post": {
-        "description": "Archive an event.",
-        "operationId": "archive_event_endpoint_api_events__code__archive_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Archive Event Endpoint",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/banner": {
-      "delete": {
-        "description": "Delete the event's custom banner image.",
-        "operationId": "delete_banner_api_events__code__banner_delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Delete Banner",
-        "tags": [
-          "events"
-        ]
-      },
-      "post": {
-        "description": "Upload a custom banner image for the event.",
-        "operationId": "upload_banner_api_events__code__banner_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_upload_banner_api_events__code__banner_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Upload Banner",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/bulk-review": {
-      "post": {
-        "operationId": "bulk_review_api_events__code__bulk_review_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BulkReviewRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkReviewResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Bulk Review",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/collection": {
-      "get": {
-        "description": "Get pre-event collection scheduling settings.",
-        "operationId": "get_collection_settings_api_events__code__collection_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Get Collection Settings Api Events  Code  Collection Get",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Collection Settings",
-        "tags": [
-          "events"
-        ]
-      },
-      "patch": {
-        "description": "Update pre-event collection scheduling settings.",
-        "operationId": "update_collection_settings_endpoint_api_events__code__collection_patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateCollectionSettings"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Update Collection Settings Endpoint Api Events  Code  Collection Patch",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Update Collection Settings Endpoint",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/display-settings": {
-      "get": {
-        "description": "Get current display settings for an event.",
-        "operationId": "get_display_settings_api_events__code__display_settings_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DisplaySettingsResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Display Settings",
-        "tags": [
-          "events"
-        ]
-      },
-      "patch": {
-        "description": "Update display settings for an event (e.g., hide/show now playing on kiosk).",
-        "operationId": "update_display_settings_api_events__code__display_settings_patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DisplaySettingsUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DisplaySettingsResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Update Display Settings",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/export/csv": {
-      "get": {
-        "description": "Export event requests as CSV. Owner can export regardless of event status.",
-        "operationId": "export_event_csv_api_events__code__export_csv_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Export Event Csv",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/export/play-history/csv": {
-      "get": {
-        "description": "Export play history as CSV. Owner can export regardless of event status.",
-        "operationId": "export_play_history_csv_api_events__code__export_play_history_csv_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Export Play History Csv",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/pending-review": {
-      "get": {
-        "description": "Get pending review data source for DJ bulk-review.",
-        "operationId": "pending_review_api_events__code__pending_review_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PendingReviewResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Pending Review",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/playlists": {
-      "get": {
-        "description": "List the DJ's playlists from connected music services.",
-        "operationId": "get_playlists_api_events__code__playlists_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Playlists",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/recommendations": {
-      "post": {
-        "description": "Generate song recommendations based on the event's musical profile.",
-        "operationId": "get_recommendations_api_events__code__recommendations_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RecommendationResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Recommendations",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/recommendations/from-template": {
-      "post": {
-        "description": "Generate recommendations using a template playlist.",
-        "operationId": "get_recommendations_from_template_api_events__code__recommendations_from_template_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TemplatePlaylistRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RecommendationResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Recommendations From Template",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/recommendations/llm": {
-      "post": {
-        "description": "Generate song recommendations from an LLM-interpreted DJ prompt.",
-        "operationId": "get_llm_recommendations_api_events__code__recommendations_llm_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LLMPromptRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Llm Recommendations",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/requests": {
-      "get": {
-        "operationId": "get_event_requests_api_events__code__requests_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/RequestStatus"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Status"
-            }
-          },
-          {
-            "in": "query",
-            "name": "since",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Since"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 100,
-              "maximum": 500,
-              "minimum": 1,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "sort",
-            "required": false,
-            "schema": {
-              "default": "chronological",
-              "enum": [
-                "chronological",
-                "priority"
-              ],
-              "title": "Sort",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/RequestOut"
-                  },
-                  "title": "Response Get Event Requests Api Events  Code  Requests Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Event Requests",
-        "tags": [
-          "events"
-        ]
-      },
-      "post": {
-        "operationId": "submit_request_api_events__code__requests_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RequestCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RequestOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Submit Request",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/requests/accept-all": {
-      "post": {
-        "description": "Accept all NEW requests for an event in one operation.",
-        "operationId": "accept_all_requests_endpoint_api_events__code__requests_accept_all_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AcceptAllResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Accept All Requests Endpoint",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/requests/bulk": {
-      "delete": {
-        "description": "Bulk delete requests for an event, optionally filtered by status.",
-        "operationId": "bulk_delete_requests_endpoint_api_events__code__requests_bulk_delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Status"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkActionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Bulk Delete Requests Endpoint",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/requests/reject-all": {
-      "post": {
-        "description": "Reject all NEW requests for an event in one operation.",
-        "operationId": "reject_all_requests_endpoint_api_events__code__requests_reject_all_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkActionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Reject All Requests Endpoint",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/search": {
-      "get": {
-        "description": "Public search endpoint for event guests.\n\nPriority: Tidal (primary) \u2192 Spotify (fallback) \u2192 Beatport (event toggle).\nResults are filtered for junk, deduplicated by ISRC, and sorted by popularity.",
-        "operationId": "event_search_api_events__code__search_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "q",
-            "required": true,
-            "schema": {
-              "maxLength": 200,
-              "minLength": 2,
-              "title": "Q",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/SearchResult"
-                  },
-                  "title": "Response Event Search Api Events  Code  Search Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Event Search",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/events/{code}/unarchive": {
-      "post": {
-        "description": "Unarchive an event.",
-        "operationId": "unarchive_event_endpoint_api_events__code__unarchive_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Unarchive Event Endpoint",
-        "tags": [
-          "events"
-        ]
-      }
-    },
-    "/api/health": {
-      "get": {
-        "description": "Health check endpoint for monitoring and load balancers.",
-        "operationId": "api_health_check_api_health_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Api Health Check",
-        "tags": [
-          "health"
-        ]
-      }
-    },
-    "/api/kiosk/mine": {
-      "get": {
-        "description": "List all kiosks paired by the current user.",
-        "operationId": "list_my_kiosks_api_kiosk_mine_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/KioskOut"
-                  },
-                  "title": "Response List My Kiosks Api Kiosk Mine Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "List My Kiosks",
-        "tags": [
-          "kiosk"
-        ]
-      }
-    },
-    "/api/kiosk/pair/{pair_code}/complete": {
-      "post": {
-        "description": "Complete a kiosk pairing by assigning an event.",
-        "operationId": "complete_kiosk_pairing_api_kiosk_pair__pair_code__complete_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "pair_code",
-            "required": true,
-            "schema": {
-              "title": "Pair Code",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/KioskCompletePairingRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KioskOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Complete Kiosk Pairing",
-        "tags": [
-          "kiosk"
-        ]
-      }
-    },
-    "/api/kiosk/{kiosk_id}": {
-      "delete": {
-        "description": "Unpair and delete a kiosk.",
-        "operationId": "delete_kiosk_endpoint_api_kiosk__kiosk_id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "kiosk_id",
-            "required": true,
-            "schema": {
-              "title": "Kiosk Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Delete Kiosk Endpoint",
-        "tags": [
-          "kiosk"
-        ]
-      },
-      "patch": {
-        "description": "Rename a kiosk.",
-        "operationId": "rename_kiosk_endpoint_api_kiosk__kiosk_id__patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "kiosk_id",
-            "required": true,
-            "schema": {
-              "title": "Kiosk Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/KioskRenameRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KioskOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Rename Kiosk Endpoint",
-        "tags": [
-          "kiosk"
-        ]
-      }
-    },
-    "/api/kiosk/{kiosk_id}/assign": {
-      "patch": {
-        "description": "Change which event a kiosk displays.",
-        "operationId": "assign_kiosk_api_kiosk__kiosk_id__assign_patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "kiosk_id",
-            "required": true,
-            "schema": {
-              "title": "Kiosk Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/KioskAssignRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KioskOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Assign Kiosk",
-        "tags": [
-          "kiosk"
-        ]
-      }
-    },
-    "/api/public/collect/{code}": {
-      "get": {
-        "operationId": "preview_api_public_collect__code__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectEventPreview"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Preview",
-        "tags": [
-          "collect"
-        ]
-      }
-    },
-    "/api/public/collect/{code}/enrich-preview": {
-      "post": {
-        "description": "Lightweight Beatport BPM/key lookup for search-time vibes \u2014 no DB writes.",
-        "operationId": "enrich_preview_api_public_collect__code__enrich_preview_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EnrichPreviewRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EnrichPreviewResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Enrich Preview",
-        "tags": [
-          "collect"
-        ]
-      }
-    },
-    "/api/public/collect/{code}/leaderboard": {
-      "get": {
-        "operationId": "leaderboard_api_public_collect__code__leaderboard_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "tab",
-            "required": false,
-            "schema": {
-              "default": "trending",
-              "enum": [
-                "trending",
-                "all"
-              ],
-              "title": "Tab",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectLeaderboardResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Leaderboard",
-        "tags": [
-          "collect"
-        ]
-      }
-    },
-    "/api/public/collect/{code}/profile": {
-      "get": {
-        "description": "Read the calling guest's profile for this event. Anonymous callers\n(no cookie) get the default empty profile \u2014 there is no IP fallback.",
-        "operationId": "get_profile_api_public_collect__code__profile_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectProfileResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Profile",
-        "tags": [
-          "collect"
-        ]
-      },
-      "post": {
-        "operationId": "set_profile_api_public_collect__code__profile_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CollectProfileRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectProfileResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Set Profile",
-        "tags": [
-          "collect"
-        ]
-      }
-    },
-    "/api/public/collect/{code}/profile/me": {
-      "get": {
-        "operationId": "my_picks_api_public_collect__code__profile_me_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectMyPicksResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "My Picks",
-        "tags": [
-          "collect"
-        ]
-      }
-    },
-    "/api/public/collect/{code}/requests": {
-      "post": {
-        "operationId": "submit_api_public_collect__code__requests_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CollectSubmitRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Submit",
-        "tags": [
-          "collect"
-        ]
-      }
-    },
-    "/api/public/collect/{code}/vote": {
-      "post": {
-        "operationId": "vote_api_public_collect__code__vote_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CollectVoteRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Vote",
-        "tags": [
-          "collect"
-        ]
-      }
-    },
-    "/api/public/e/{code}/bridge-status": {
-      "get": {
-        "description": "Get bridge connection status for public display.\n\nIndependent of track data \u2014 returns bridge connectivity even when\nno track is currently playing.",
-        "operationId": "get_public_bridge_status_api_public_e__code__bridge_status_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BridgeStatusResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Public Bridge Status",
-        "tags": [
-          "bridge"
-        ]
-      }
-    },
-    "/api/public/e/{code}/history": {
-      "get": {
-        "description": "Get play history for public display.\n\nReturns the list of tracks played during the event, newest first.",
-        "operationId": "get_public_history_api_public_e__code__history_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 20,
-              "maximum": 100,
-              "minimum": 1,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "offset",
-            "required": false,
-            "schema": {
-              "default": 0,
-              "minimum": 0,
-              "title": "Offset",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlayHistoryResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Public History",
-        "tags": [
-          "bridge"
-        ]
-      }
-    },
-    "/api/public/e/{code}/nowplaying": {
-      "get": {
-        "description": "Get current now-playing track for public display.\n\nReturns the track currently playing from StageLinQ, or None if nothing playing.",
-        "operationId": "get_public_now_playing_api_public_e__code__nowplaying_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/NowPlayingResponse"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "title": "Response Get Public Now Playing Api Public E  Code  Nowplaying Get"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Public Now Playing",
-        "tags": [
-          "bridge"
-        ]
-      }
-    },
-    "/api/public/events/{code}/display": {
-      "get": {
-        "description": "Get public kiosk display data for an event.",
-        "operationId": "get_kiosk_display_api_public_events__code__display_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KioskDisplayResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Kiosk Display",
-        "tags": [
-          "public"
-        ]
-      }
-    },
-    "/api/public/events/{code}/has-requested": {
-      "get": {
-        "description": "Check if the current client has submitted any requests for this event.",
-        "operationId": "check_has_requested_api_public_events__code__has_requested_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HasRequestedResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Check Has Requested",
-        "tags": [
-          "public"
-        ]
-      }
-    },
-    "/api/public/events/{code}/my-requests": {
-      "get": {
-        "description": "Get all requests submitted by the current client for this event.",
-        "operationId": "get_my_requests_api_public_events__code__my_requests_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MyRequestsResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get My Requests",
-        "tags": [
-          "public"
-        ]
-      }
-    },
-    "/api/public/events/{code}/requests": {
-      "get": {
-        "description": "Get publicly visible requests for an event (NEW and ACCEPTED only).",
-        "operationId": "get_public_requests_api_public_events__code__requests_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GuestRequestListResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Public Requests",
-        "tags": [
-          "public"
-        ]
-      }
-    },
-    "/api/public/events/{code}/stream": {
-      "get": {
-        "description": "Public SSE endpoint for real-time event updates.\n\nSECURITY (CRIT-5): rate-limited and existence-checked. Before this fix,\nthe endpoint had no rate limit and no existence check, allowing\nunauthenticated DoS (unlimited long-lived connections exhausting FDs)\nand passive eavesdropping via 6-char event-code brute force.\n\nEvent types:\n- request_created: New request submitted\n- request_status_changed: Request status update\n- now_playing_changed: Now-playing track update\n- requests_bulk_update: Batch accept/reject\n- bridge_status_changed: Bridge connect/disconnect",
-        "operationId": "event_stream_api_public_events__code__stream_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "code",
-            "required": true,
-            "schema": {
-              "title": "Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Event Stream",
-        "tags": [
-          "sse"
-        ]
-      }
-    },
-    "/api/public/guest/identify": {
-      "post": {
-        "description": "Resolve guest identity via cookie token and/or browser fingerprint.",
-        "operationId": "identify_api_public_guest_identify_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/IdentifyRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IdentifyResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Identify",
-        "tags": [
-          "guest"
-        ]
-      }
-    },
-    "/api/public/guest/verify/confirm": {
-      "post": {
-        "description": "Confirm a verification code. May trigger guest merge.",
-        "operationId": "confirm_code_api_public_guest_verify_confirm_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/VerifyConfirmSchema"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VerifyConfirmResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Confirm Code",
-        "tags": [
-          "verify"
-        ]
-      }
-    },
-    "/api/public/guest/verify/request": {
-      "post": {
-        "description": "Send a verification code to the provided email.",
-        "operationId": "request_verification_code_api_public_guest_verify_request_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/VerifyRequestSchema"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VerifyRequestResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Request Verification Code",
-        "tags": [
-          "verify"
-        ]
-      }
-    },
-    "/api/public/kiosk/pair": {
-      "post": {
-        "description": "Create a new kiosk pairing session.",
-        "operationId": "create_pairing_api_public_kiosk_pair_post",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KioskPairResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Create Pairing",
-        "tags": [
-          "kiosk"
-        ]
-      }
-    },
-    "/api/public/kiosk/pair/{pair_code}/status": {
-      "get": {
-        "description": "Poll the status of a pairing code.",
-        "operationId": "get_pair_status_api_public_kiosk_pair__pair_code__status_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "pair_code",
-            "required": true,
-            "schema": {
-              "title": "Pair Code",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KioskPairStatusResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Pair Status",
-        "tags": [
-          "kiosk"
-        ]
-      }
-    },
-    "/api/public/kiosk/session/assignment": {
-      "get": {
-        "description": "Poll the kiosk's current event assignment. Updates last_seen_at.\n\nSession token must be sent in the X-Kiosk-Session header (not in the URL path)\nto prevent token leakage in access logs.",
-        "operationId": "get_session_assignment_api_public_kiosk_session_assignment_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KioskSessionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Session Assignment",
-        "tags": [
-          "kiosk"
-        ]
-      }
-    },
-    "/api/requests/{request_id}": {
-      "delete": {
-        "description": "Delete a single request. Ownership verified via event.",
-        "operationId": "delete_request_endpoint_api_requests__request_id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "request_id",
-            "required": true,
-            "schema": {
-              "title": "Request Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Delete Request Endpoint",
-        "tags": [
-          "requests"
-        ]
-      },
-      "patch": {
-        "operationId": "update_request_api_requests__request_id__patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "request_id",
-            "required": true,
-            "schema": {
-              "title": "Request Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RequestUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RequestOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Update Request",
-        "tags": [
-          "requests"
-        ]
-      }
-    },
-    "/api/requests/{request_id}/refresh-metadata": {
-      "post": {
-        "description": "Clear existing metadata and re-enrich from external services.",
-        "operationId": "refresh_request_metadata_api_requests__request_id__refresh_metadata_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "request_id",
-            "required": true,
-            "schema": {
-              "title": "Request Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RequestOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Refresh Request Metadata",
-        "tags": [
-          "requests"
-        ]
-      }
-    },
-    "/api/requests/{request_id}/vote": {
-      "delete": {
-        "description": "Remove vote from a song request. Idempotent.\n\nRequires a guest cookie. Anonymous callers receive 401.",
-        "operationId": "unvote_request_api_requests__request_id__vote_delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "request_id",
-            "required": true,
-            "schema": {
-              "exclusiveMinimum": 0,
-              "title": "Request Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VoteResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Unvote Request",
-        "tags": [
-          "votes"
-        ]
-      },
-      "post": {
-        "description": "Upvote a song request. Idempotent: voting twice has no effect.\n\nRequires a guest cookie. Anonymous callers receive 401.",
-        "operationId": "vote_for_request_api_requests__request_id__vote_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "request_id",
-            "required": true,
-            "schema": {
-              "exclusiveMinimum": 0,
-              "title": "Request Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VoteResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Vote For Request",
-        "tags": [
-          "votes"
-        ]
-      }
-    },
-    "/api/search": {
-      "get": {
-        "description": "DJ search endpoint. Tidal primary, Spotify fallback.",
-        "operationId": "search_api_search_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "q",
-            "required": true,
-            "schema": {
-              "maxLength": 200,
-              "minLength": 2,
-              "title": "Q",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/SearchResult"
-                  },
-                  "title": "Response Search Api Search Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Search",
-        "tags": [
-          "search"
-        ]
-      }
-    },
-    "/api/search/cache": {
-      "delete": {
-        "description": "Clear all cached search results (admin only).",
-        "operationId": "clear_search_cache_api_search_cache_delete",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CacheClearResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Clear Search Cache",
-        "tags": [
-          "search"
-        ]
-      }
-    },
-    "/api/tidal/auth/cancel": {
-      "post": {
-        "description": "Cancel pending device login.",
-        "operationId": "cancel_auth_api_tidal_auth_cancel_post",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Cancel Auth",
-        "tags": [
-          "tidal"
-        ]
-      }
-    },
-    "/api/tidal/auth/check": {
-      "get": {
-        "description": "Check if device login is complete.\n\nReturns:\n- complete: true if login succeeded\n- pending: true if still waiting for user\n- error: error message if login failed",
-        "operationId": "check_auth_api_tidal_auth_check_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TidalAuthCheckResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Check Auth",
-        "tags": [
-          "tidal"
-        ]
-      }
-    },
-    "/api/tidal/auth/start": {
-      "post": {
-        "description": "Start Tidal device login flow.\n\nReturns a URL and code for the user to visit and authorize.\nThe frontend should poll /auth/check to wait for completion.",
-        "operationId": "start_auth_api_tidal_auth_start_post",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TidalAuthStartResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Start Auth",
-        "tags": [
-          "tidal"
-        ]
-      }
-    },
-    "/api/tidal/disconnect": {
-      "post": {
-        "description": "Unlink Tidal account from current user.",
-        "operationId": "disconnect_api_tidal_disconnect_post",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Disconnect",
-        "tags": [
-          "tidal"
-        ]
-      }
-    },
-    "/api/tidal/events/{event_id}/settings": {
-      "get": {
-        "description": "Get Tidal sync settings for an event.",
-        "operationId": "get_event_settings_api_tidal_events__event_id__settings_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "event_id",
-            "required": true,
-            "schema": {
-              "title": "Event Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TidalEventSettings"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Event Settings",
-        "tags": [
-          "tidal"
-        ]
-      },
-      "put": {
-        "description": "Update Tidal sync settings for an event.",
-        "operationId": "update_event_settings_api_tidal_events__event_id__settings_put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "event_id",
-            "required": true,
-            "schema": {
-              "title": "Event Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TidalEventSettingsUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TidalEventSettings"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Update Event Settings",
-        "tags": [
-          "tidal"
-        ]
-      }
-    },
-    "/api/tidal/requests/{request_id}/link": {
-      "post": {
-        "description": "Manually link a Tidal track to a request.",
-        "operationId": "link_track_api_tidal_requests__request_id__link_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "request_id",
-            "required": true,
-            "schema": {
-              "title": "Request Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TidalManualLink"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TidalSyncResult"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Link Track",
-        "tags": [
-          "tidal"
-        ]
-      }
-    },
-    "/api/tidal/requests/{request_id}/sync": {
-      "post": {
-        "description": "Manually trigger Tidal sync for a request.",
-        "operationId": "sync_request_api_tidal_requests__request_id__sync_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "request_id",
-            "required": true,
-            "schema": {
-              "title": "Request Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TidalSyncResult"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Sync Request",
-        "tags": [
-          "tidal"
-        ]
-      }
-    },
-    "/api/tidal/search": {
-      "get": {
-        "description": "Search Tidal for tracks.",
-        "operationId": "search_api_tidal_search_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "q",
-            "required": true,
-            "schema": {
-              "minLength": 1,
-              "title": "Q",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 10,
-              "maximum": 50,
-              "minimum": 1,
-              "title": "Limit",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/TidalSearchResult"
-                  },
-                  "title": "Response Search Api Tidal Search Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Search",
-        "tags": [
-          "tidal"
-        ]
-      }
-    },
-    "/api/tidal/status": {
-      "get": {
-        "description": "Check if current user has linked Tidal account.",
-        "operationId": "get_status_api_tidal_status_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TidalStatus"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Get Status",
-        "tags": [
-          "tidal"
-        ]
-      }
-    },
-    "/health": {
-      "get": {
-        "operationId": "health_check_health_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Health Check"
+        }
       }
     }
   }

--- a/server/tests/test_api_contracts.py
+++ b/server/tests/test_api_contracts.py
@@ -168,6 +168,7 @@ PUBLIC_REQUEST_INFO_KEYS = {
     "bpm",
     "musical_key",
     "genre",
+    "requester_verified",
 }
 
 GUEST_REQUEST_INFO_KEYS = PUBLIC_REQUEST_INFO_KEYS | {"status"}

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -1,6 +1,6 @@
 """Tests for the public collect preview and leaderboard endpoints."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import pytest
 
@@ -889,3 +889,62 @@ def test_enrich_preview_returns_nulls_when_beatport_raises(client, db, test_even
     assert result["bpm"] is None
     assert result["key"] is None
     assert result["genre"] is None
+
+
+def test_leaderboard_row_requester_verified_true(client, db, test_event: Event):
+    """requester_verified is True when guest has email_verified_at set."""
+    from app.models.guest import Guest
+    from app.models.request import Request, RequestStatus
+
+    _enable_collection(db, test_event)
+    guest = Guest(
+        token="verified_leaderboard_test",
+        email_verified_at=datetime(2026, 5, 1),
+    )
+    db.add(guest)
+    db.flush()
+    req = Request(
+        event_id=test_event.id,
+        song_title="Verified Track",
+        artist="Verified Artist",
+        source="spotify",
+        status=RequestStatus.NEW.value,
+        vote_count=2,
+        dedupe_key="verified_lb_test",
+        submitted_during_collection=True,
+        guest_id=guest.id,
+        nickname="VerifiedUser",
+    )
+    db.add(req)
+    db.commit()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all")
+    assert r.status_code == 200
+    rows = r.json()["requests"]
+    assert len(rows) == 1
+    assert rows[0]["requester_verified"] is True
+
+
+def test_leaderboard_row_requester_verified_false_no_guest(client, db, test_event: Event):
+    """requester_verified is False when request has no guest_id."""
+    from app.models.request import Request, RequestStatus
+
+    _enable_collection(db, test_event)
+    req = Request(
+        event_id=test_event.id,
+        song_title="Anon Track",
+        artist="Anon Artist",
+        source="spotify",
+        status=RequestStatus.NEW.value,
+        vote_count=1,
+        dedupe_key="anon_lb_test",
+        submitted_during_collection=True,
+    )
+    db.add(req)
+    db.commit()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all")
+    assert r.status_code == 200
+    rows = r.json()["requests"]
+    assert len(rows) == 1
+    assert rows[0]["requester_verified"] is False

--- a/server/tests/test_public.py
+++ b/server/tests/test_public.py
@@ -1,5 +1,7 @@
 """Tests for public/kiosk endpoints."""
 
+from datetime import datetime
+
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -434,3 +436,71 @@ class TestSubmitRequestNickname:
         assert response.status_code == 200
         data = response.json()
         assert data["nickname"] is None
+
+
+class TestRequesterVerifiedField:
+    """requester_verified field in GET /api/public/events/{code}/requests."""
+
+    def test_verified_guest_shows_badge(self, client: TestClient, test_event: Event, db: Session):
+        from app.models.guest import Guest
+
+        guest = Guest(token="verified_public_test", email_verified_at=datetime(2026, 5, 1))
+        db.add(guest)
+        db.flush()
+        req = Request(
+            event_id=test_event.id,
+            song_title="Badge Song",
+            artist="Badge Artist",
+            source="spotify",
+            status=RequestStatus.NEW.value,
+            dedupe_key="badge_test_001",
+            guest_id=guest.id,
+            nickname="Verified",
+        )
+        db.add(req)
+        db.commit()
+
+        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["requests"][0]["requester_verified"] is True
+
+    def test_no_guest_shows_false(self, client: TestClient, test_event: Event, db: Session):
+        req = Request(
+            event_id=test_event.id,
+            song_title="Orphan Song",
+            artist="Orphan Artist",
+            source="spotify",
+            status=RequestStatus.NEW.value,
+            dedupe_key="orphan_test_001",
+        )
+        db.add(req)
+        db.commit()
+
+        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["requests"][0]["requester_verified"] is False
+
+    def test_unverified_guest_shows_false(self, client: TestClient, test_event: Event, db: Session):
+        from app.models.guest import Guest
+
+        guest = Guest(token="unverified_public_test", email_verified_at=None)
+        db.add(guest)
+        db.flush()
+        req = Request(
+            event_id=test_event.id,
+            song_title="Unverified Song",
+            artist="Unverified Artist",
+            source="spotify",
+            status=RequestStatus.NEW.value,
+            dedupe_key="unverified_test_001",
+            guest_id=guest.id,
+        )
+        db.add(req)
+        db.commit()
+
+        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["requests"][0]["requester_verified"] is False


### PR DESCRIPTION
## Summary

- Add `requester_verified` field to `PublicRequestInfo` and `CollectLeaderboardRow` schemas
- Outer-join `guests` table in leaderboard and public requests endpoints to derive verification status from `email_verified_at`
- Render green ✓ (`#22c55e`) next to verified users' nicknames on both the join page and collect page

No migration needed — field is computed at query time from existing `Guest.email_verified_at` column.

## Test plan

- [x] Backend: `test_leaderboard_row_requester_verified_true` — verified guest → `true`
- [x] Backend: `test_leaderboard_row_requester_verified_false_no_guest` — no guest → `false`
- [x] Backend: `TestRequesterVerifiedField` — 3 cases (verified, orphan, unverified)
- [x] Backend: API contract test updated with new field
- [x] Frontend: LeaderboardTabs test renders ✓ for verified requester
- [ ] Manual: verify badge appears on `/join/{code}` and `/collect/{code}` pages with a verified guest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a verified badge indicator (green checkmark) displayed next to verified users' names in song request lists and collection leaderboards

* **Tests**
  * Expanded test coverage for verified badge display across different scenarios

* **Documentation**
  * Added implementation plan and design specification for the verified badge feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->