### PR TITLE
fix: remove 6-hour time window from request deduplication

### DIFF
--- a/dashboard/app/collect/[code]/components/CollectDetailSheet.test.tsx
+++ b/dashboard/app/collect/[code]/components/CollectDetailSheet.test.tsx
@@ -3,6 +3,17 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import CollectDetailSheet from './CollectDetailSheet';
 import type { CollectLeaderboardRow } from '@/lib/api';
 
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>();
+  return {
+    ...actual,
+    apiClient: {
+      ...actual.apiClient,
+      getCollectPreview: vi.fn().mockResolvedValue({ source: 'manual', source_url: null }),
+    },
+  };
+});
+
 const mockRow: CollectLeaderboardRow = {
   id: 1,
   title: 'Levels',
@@ -30,6 +41,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={mockRow}
+        code="TEST"
         rank={3}
         totalCount={10}
         voted={false}
@@ -51,6 +63,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={mockRow}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={false}
@@ -68,6 +81,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={mockRow}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={false}
@@ -83,6 +97,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={mockRow}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={false}
@@ -99,6 +114,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={rowNoPills}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={false}
@@ -116,6 +132,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={rowBpmOnly}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={false}
@@ -133,6 +150,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={rowKeyOnly}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={false}
@@ -150,6 +168,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={rowWithNickname}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={false}
@@ -166,6 +185,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={mockRow}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={false}
@@ -181,6 +201,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={mockRow}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={false}
@@ -196,6 +217,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={mockRow}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={true}
@@ -212,6 +234,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={mockRow}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={false}
@@ -229,6 +252,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={mockRow}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={false}
@@ -249,6 +273,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={rowWithArt}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={false}
@@ -266,6 +291,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={mockRow}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={false}
@@ -289,6 +315,7 @@ describe('CollectDetailSheet', () => {
     const { container } = render(
       <CollectDetailSheet
         row={mockRow}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={false}
@@ -313,6 +340,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={mockRow}
+        code="TEST"
         rank={1}
         totalCount={5}
         voted={false}
@@ -330,6 +358,7 @@ describe('CollectDetailSheet', () => {
     render(
       <CollectDetailSheet
         row={mockRow}
+        code="TEST"
         rank={2}
         totalCount={20}
         voted={false}

--- a/dashboard/app/collect/[code]/components/CollectDetailSheet.test.tsx
+++ b/dashboard/app/collect/[code]/components/CollectDetailSheet.test.tsx
@@ -354,6 +354,100 @@ describe('CollectDetailSheet', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it('renders Spotify embed iframe when preview has spotify source_url', async () => {
+    const { apiClient } = await import('@/lib/api');
+    vi.mocked(apiClient.getCollectPreview).mockResolvedValueOnce({
+      source: 'spotify',
+      source_url: 'https://open.spotify.com/track/abc123',
+    });
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        code="TEST"
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    const iframe = document.querySelector('iframe');
+    expect(iframe).toBeTruthy();
+    expect(iframe!.src).toContain('open.spotify.com/embed/track/abc123');
+    expect(iframe!.title).toBe('Levels by Avicii');
+  });
+
+  it('renders Tidal embed iframe with tidal params', async () => {
+    const { apiClient } = await import('@/lib/api');
+    vi.mocked(apiClient.getCollectPreview).mockResolvedValueOnce({
+      source: 'tidal',
+      source_url: 'https://tidal.com/browse/track/12345',
+    });
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        code="TEST"
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    const iframe = document.querySelector('iframe');
+    expect(iframe).toBeTruthy();
+    expect(iframe!.src).toContain('embed.tidal.com/tracks/12345');
+    expect(iframe!.src).toContain('coverImageStyle=round');
+  });
+
+  it('renders Beatport external link when preview source is beatport', async () => {
+    const { apiClient } = await import('@/lib/api');
+    vi.mocked(apiClient.getCollectPreview).mockResolvedValueOnce({
+      source: 'beatport',
+      source_url: 'https://www.beatport.com/track/test/99999',
+    });
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        code="TEST"
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    expect(screen.getByText('OPEN IN BEATPORT')).toBeTruthy();
+    const link = screen.getByText('OPEN IN BEATPORT').closest('a');
+    expect(link!.href).toBe('https://www.beatport.com/track/test/99999');
+    expect(link!.target).toBe('_blank');
+  });
+
+  it('renders no preview when source_url is null', async () => {
+    const { apiClient } = await import('@/lib/api');
+    vi.mocked(apiClient.getCollectPreview).mockResolvedValueOnce({
+      source: 'manual',
+      source_url: null,
+    });
+    render(
+      <CollectDetailSheet
+        row={mockRow}
+        code="TEST"
+        rank={1}
+        totalCount={5}
+        voted={false}
+        onVote={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {});
+    expect(document.querySelector('iframe')).toBeNull();
+    expect(screen.queryByText('OPEN IN BEATPORT')).toBeNull();
+  });
+
   it('displays vote count and rank in stats row', async () => {
     render(
       <CollectDetailSheet

--- a/dashboard/app/collect/[code]/components/CollectDetailSheet.tsx
+++ b/dashboard/app/collect/[code]/components/CollectDetailSheet.tsx
@@ -176,6 +176,7 @@ export default function CollectDetailSheet({
         <div style={{ marginTop: 12 }}>
           <iframe
             src={embedUrl + (source === 'tidal' ? '?coverImageStyle=round&tracklist=false' : '')}
+            title={`${row.title} by ${row.artist}`}
             width="100%"
             height={152}
             style={{ borderRadius: 14, border: 'none' }}

--- a/dashboard/app/collect/[code]/components/CollectDetailSheet.tsx
+++ b/dashboard/app/collect/[code]/components/CollectDetailSheet.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import type { CollectLeaderboardRow } from '@/lib/api';
+import type { CollectLeaderboardRow, CollectPreviewResponse } from '@/lib/api';
+import { apiClient } from '@/lib/api';
+import { getEmbedUrl, getPreviewSource } from '@/lib/preview-embed';
 
 interface Props {
   row: CollectLeaderboardRow;
+  code: string;
   rank: number;
   totalCount: number;
   voted: boolean;
@@ -32,7 +35,7 @@ function artGradient(seed: string) {
 }
 
 export default function CollectDetailSheet({
-  row, rank, totalCount, voted, onVote, onClose,
+  row, code, rank, totalCount, voted, onVote, onClose,
 }: Props) {
   const [isWide, setIsWide] = useState<boolean | null>(null);
 
@@ -42,6 +45,16 @@ export default function CollectDetailSheet({
     window.addEventListener('resize', check);
     return () => window.removeEventListener('resize', check);
   }, []);
+
+  const [preview, setPreview] = useState<CollectPreviewResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiClient.getCollectPreview(code, row.id).then((data) => {
+      if (!cancelled) setPreview(data);
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [code, row.id]);
 
   const surface = 'rgba(255,255,255,0.05)';
   const border = 'rgba(255,255,255,0.1)';
@@ -151,6 +164,55 @@ export default function CollectDetailSheet({
     </div>
   );
 
+  const previewSection = (() => {
+    if (!preview || !preview.source_url) return null;
+
+    const previewData = { source: preview.source, sourceUrl: preview.source_url };
+    const embedUrl = getEmbedUrl(previewData);
+    const source = getPreviewSource(previewData);
+
+    if (embedUrl) {
+      return (
+        <div style={{ marginTop: 12 }}>
+          <iframe
+            src={embedUrl + (source === 'tidal' ? '?coverImageStyle=round&tracklist=false' : '')}
+            width="100%"
+            height={152}
+            style={{ borderRadius: 14, border: 'none' }}
+            allow="encrypted-media"
+            loading="lazy"
+          />
+        </div>
+      );
+    }
+
+    if (source === 'beatport') {
+      return (
+        <div style={{ marginTop: 12 }}>
+          <a
+            href={preview.source_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+              width: '100%', height: 44, borderRadius: 12,
+              background: surface, border: `1px solid ${border}`,
+              fontFamily: 'var(--font-mono, monospace)', fontSize: 11, fontWeight: 700,
+              color: 'rgba(255,255,255,0.7)', textDecoration: 'none', letterSpacing: 1,
+            }}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3"/>
+            </svg>
+            OPEN IN BEATPORT
+          </a>
+        </div>
+      );
+    }
+
+    return null;
+  })();
+
   if (isWide === null) return null;
 
   /* ── Desktop: centered dialog ─────────────────────────────── */
@@ -200,6 +262,7 @@ export default function CollectDetailSheet({
           <div style={{ padding: '0 16px 16px' }}>
             {statsRow}
             {suggestedBy}
+            {previewSection}
             {voteBtn}
           </div>
         </div>
@@ -244,6 +307,7 @@ export default function CollectDetailSheet({
 
         {statsRow}
         {suggestedBy}
+        {previewSection}
       </div>
 
       {/* Bottom vote CTA */}

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -434,6 +434,7 @@ export default function CollectPage() {
       {detailRow && (
         <CollectDetailSheet
           row={detailRow}
+          code={code}
           rank={(leaderboard?.requests ?? []).findIndex((r) => r.id === detailRow.id) + 1 || 1}
           totalCount={leaderboard?.requests.length ?? 0}
           voted={detailVoted || votedIds.has(detailRow.id)}

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -152,6 +152,11 @@ export interface CollectMyPicksResponse {
   voted_request_ids: number[];
 }
 
+export interface CollectPreviewResponse {
+  source: 'spotify' | 'tidal' | 'beatport' | 'manual';
+  source_url: string | null;
+}
+
 export interface CollectionSettingsResponse {
   collection_opens_at: string | null;
   live_starts_at: string | null;
@@ -1248,6 +1253,15 @@ class ApiClient {
     } catch {
       return items.map((i) => ({ title: i.title, artist: i.artist }));
     }
+  }
+
+  async getCollectPreview(code: string, requestId: number): Promise<CollectPreviewResponse> {
+    const res = await fetch(
+      `${getApiUrl()}/api/public/collect/${code}/requests/${requestId}/preview`,
+      { method: 'GET', headers: { 'Content-Type': 'application/json' }, credentials: 'include' },
+    );
+    if (!res.ok) throw new ApiError(`getCollectPreview failed: ${res.status}`, res.status);
+    return res.json();
   }
 
   // ========== Pre-Event Collection (DJ-authenticated) ==========

--- a/docs/superpowers/plans/2026-05-05-collect-song-preview.md
+++ b/docs/superpowers/plans/2026-05-05-collect-song-preview.md
@@ -1,0 +1,434 @@
+# Collect Song Preview Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add inline Spotify/Tidal iframe preview to `CollectDetailSheet` via a lazy-fetch endpoint that protects source URLs from bulk scraping.
+
+**Architecture:** New `GET /api/public/collect/{code}/requests/{id}/preview` endpoint returns `source` + `source_url` for a single request, gated by human verification and rate limiting. Frontend fetches on detail sheet open, renders embed iframe (Spotify/Tidal) or external link (Beatport) using existing `preview-embed.ts` utilities.
+
+**Tech Stack:** Python/FastAPI (backend endpoint), React/TypeScript (frontend embed), existing `preview-embed.ts` utilities.
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Modify | `server/app/schemas/collect.py` | Add `CollectPreviewResponse` schema |
+| Modify | `server/app/api/collect.py` | Add preview endpoint |
+| Modify | `server/tests/test_collect_public.py` | Tests for preview endpoint |
+| Modify | `dashboard/lib/api.ts` | Add `getCollectPreview()` method + `CollectPreviewResponse` interface |
+| Modify | `dashboard/app/collect/[code]/components/CollectDetailSheet.tsx` | Fetch + render embed |
+
+---
+
+### Task 1: Backend Schema
+
+**Files:**
+- Modify: `server/app/schemas/collect.py:73` (after `CollectLeaderboardRow`)
+
+- [ ] **Step 1: Add `CollectPreviewResponse` schema**
+
+Add after line 73 in `server/app/schemas/collect.py` (after `CollectLeaderboardRow` class):
+
+```python
+class CollectPreviewResponse(BaseModel):
+    source: Literal["spotify", "tidal", "beatport", "manual"]
+    source_url: str | None
+```
+
+- [ ] **Step 2: Export from the schema import in collect API**
+
+In `server/app/api/collect.py`, add `CollectPreviewResponse` to the import block from `app.schemas.collect` (line 23-37):
+
+```python
+from app.schemas.collect import (
+    CollectEventPreview,
+    CollectLeaderboardResponse,
+    CollectLeaderboardRow,
+    CollectMyPicksItem,
+    CollectMyPicksResponse,
+    CollectPreviewResponse,  # NEW
+    CollectProfileRequest,
+    CollectProfileResponse,
+    CollectSubmitRequest,
+    CollectVoteRequest,
+    EnrichPreviewItem,  # noqa: F401
+    EnrichPreviewRequest,
+    EnrichPreviewResponse,
+    EnrichPreviewResult,
+)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/app/schemas/collect.py server/app/api/collect.py
+git commit -m "feat(collect): add CollectPreviewResponse schema"
+```
+
+---
+
+### Task 2: Backend Endpoint
+
+**Files:**
+- Modify: `server/app/api/collect.py` (add endpoint after existing endpoints)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/tests/test_collect_public.py`:
+
+```python
+def test_collect_preview_returns_source_url(client, db, test_event, collection_requests):
+    """Preview endpoint returns source + source_url for a valid request."""
+    _enable_collection(db, test_event)
+    req = collection_requests[0]
+    req.source_url = "https://open.spotify.com/track/abc123"
+    db.commit()
+
+    r = client.get(
+        f"/api/public/collect/{test_event.code}/requests/{req.id}/preview"
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["source"] == "spotify"
+    assert body["source_url"] == "https://open.spotify.com/track/abc123"
+
+
+def test_collect_preview_null_source_url_for_manual(client, db, test_event, collection_requests):
+    """Preview endpoint returns source_url=null for manual entries."""
+    _enable_collection(db, test_event)
+    req = collection_requests[0]
+    req.source = "manual"
+    req.source_url = None
+    db.commit()
+
+    r = client.get(
+        f"/api/public/collect/{test_event.code}/requests/{req.id}/preview"
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["source"] == "manual"
+    assert body["source_url"] is None
+
+
+def test_collect_preview_404_wrong_event(client, db, test_event, collection_requests):
+    """Preview endpoint returns 404 when request belongs to a different event."""
+    _enable_collection(db, test_event)
+    req = collection_requests[0]
+
+    r = client.get(f"/api/public/collect/ZZZZZZ/requests/{req.id}/preview")
+    assert r.status_code == 404
+
+
+def test_collect_preview_404_nonexistent_request(client, db, test_event):
+    """Preview endpoint returns 404 for nonexistent request ID."""
+    _enable_collection(db, test_event)
+
+    r = client.get(f"/api/public/collect/{test_event.code}/requests/99999/preview")
+    assert r.status_code == 404
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && .venv/bin/pytest tests/test_collect_public.py::test_collect_preview_returns_source_url tests/test_collect_public.py::test_collect_preview_null_source_url_for_manual tests/test_collect_public.py::test_collect_preview_404_wrong_event tests/test_collect_public.py::test_collect_preview_404_nonexistent_request -v`
+
+Expected: FAIL with 404 (no matching route)
+
+- [ ] **Step 3: Implement the endpoint**
+
+Add at the end of `server/app/api/collect.py` (after the `enrich_preview` endpoint):
+
+```python
+@router.get(
+    "/{code}/requests/{request_id}/preview",
+    response_model=CollectPreviewResponse,
+)
+@limiter.limit("10/minute")
+def request_preview(
+    code: str,
+    request_id: int,
+    request: Request,
+    _human: int | None = Depends(require_verified_human_soft),
+    db: Session = Depends(get_db),
+):
+    event = _get_event_or_404(db, code)
+    song_request = (
+        db.query(SongRequest)
+        .filter(SongRequest.id == request_id, SongRequest.event_id == event.id)
+        .one_or_none()
+    )
+    if song_request is None:
+        raise HTTPException(status_code=404, detail="Request not found")
+    return CollectPreviewResponse(
+        source=song_request.source,
+        source_url=song_request.source_url,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd server && .venv/bin/pytest tests/test_collect_public.py::test_collect_preview_returns_source_url tests/test_collect_public.py::test_collect_preview_null_source_url_for_manual tests/test_collect_public.py::test_collect_preview_404_wrong_event tests/test_collect_public.py::test_collect_preview_404_nonexistent_request -v`
+
+Expected: All 4 PASS
+
+- [ ] **Step 5: Run full backend CI checks**
+
+```bash
+cd server && .venv/bin/ruff check . && .venv/bin/ruff format --check . && .venv/bin/pytest --tb=short -q
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/app/api/collect.py server/tests/test_collect_public.py
+git commit -m "feat(collect): add preview endpoint for lazy source_url fetch"
+```
+
+---
+
+### Task 3: Frontend API Client
+
+**Files:**
+- Modify: `dashboard/lib/api.ts` (add interface + method)
+
+- [ ] **Step 1: Add `CollectPreviewResponse` interface**
+
+Add after the `CollectMyPicksResponse` interface (around line 150) in `dashboard/lib/api.ts`:
+
+```typescript
+export interface CollectPreviewResponse {
+  source: 'spotify' | 'tidal' | 'beatport' | 'manual';
+  source_url: string | null;
+}
+```
+
+- [ ] **Step 2: Add `getCollectPreview()` method**
+
+Add in the `ApiClient` class, after the `enrichCollectPreview` method (in the Pre-Event Collection section):
+
+```typescript
+  async getCollectPreview(code: string, requestId: number): Promise<CollectPreviewResponse> {
+    const res = await fetch(
+      `${getApiUrl()}/api/public/collect/${code}/requests/${requestId}/preview`,
+      { method: 'GET', headers: { 'Content-Type': 'application/json' }, credentials: 'include' },
+    );
+    if (!res.ok) throw new ApiError(`getCollectPreview failed: ${res.status}`, res.status);
+    return res.json();
+  }
+```
+
+- [ ] **Step 3: Run frontend type check**
+
+```bash
+cd dashboard && npx tsc --noEmit
+```
+
+Expected: PASS (no type errors)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dashboard/lib/api.ts
+git commit -m "feat(collect): add getCollectPreview API client method"
+```
+
+---
+
+### Task 4: Frontend Embed in Detail Sheet
+
+**Files:**
+- Modify: `dashboard/app/collect/[code]/components/CollectDetailSheet.tsx`
+
+- [ ] **Step 1: Add `code` prop to component interface**
+
+The detail sheet needs the event code to call the preview endpoint. Update the `Props` interface:
+
+```typescript
+interface Props {
+  row: CollectLeaderboardRow;
+  code: string;  // NEW — event code for preview fetch
+  rank: number;
+  totalCount: number;
+  voted: boolean;
+  onVote: () => void;
+  onClose: () => void;
+}
+```
+
+Update the destructuring:
+
+```typescript
+export default function CollectDetailSheet({
+  row, code, rank, totalCount, voted, onVote, onClose,
+}: Props) {
+```
+
+- [ ] **Step 2: Add preview fetch + embed state**
+
+Add imports at the top:
+
+```typescript
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { CollectLeaderboardRow, CollectPreviewResponse } from '@/lib/api';
+import { apiClient } from '@/lib/api';
+import { getEmbedUrl, getPreviewSource } from '@/lib/preview-embed';
+```
+
+Add state and fetch effect after the `isWide` effect (around line 44):
+
+```typescript
+  const [preview, setPreview] = useState<CollectPreviewResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiClient.getCollectPreview(code, row.id).then((data) => {
+      if (!cancelled) setPreview(data);
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [code, row.id]);
+```
+
+- [ ] **Step 3: Create the embed section JSX**
+
+Add a variable before the `if (isWide === null)` guard (around line 154):
+
+```typescript
+  const previewSection = (() => {
+    if (!preview || !preview.source_url) return null;
+
+    const previewData = { source: preview.source, sourceUrl: preview.source_url };
+    const embedUrl = getEmbedUrl(previewData);
+    const source = getPreviewSource(previewData);
+
+    if (embedUrl) {
+      return (
+        <div style={{ marginTop: 12 }}>
+          <iframe
+            src={embedUrl + (source === 'tidal' ? '?coverImageStyle=round&tracklist=false' : '')}
+            width="100%"
+            height={152}
+            style={{ borderRadius: 14, border: 'none' }}
+            allow="encrypted-media"
+            loading="lazy"
+          />
+        </div>
+      );
+    }
+
+    if (source === 'beatport') {
+      return (
+        <div style={{ marginTop: 12 }}>
+          <a
+            href={preview.source_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+              width: '100%', height: 44, borderRadius: 12,
+              background: surface, border: `1px solid ${border}`,
+              fontFamily: 'var(--font-mono, monospace)', fontSize: 11, fontWeight: 700,
+              color: 'rgba(255,255,255,0.7)', textDecoration: 'none', letterSpacing: 1,
+            }}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3"/>
+            </svg>
+            OPEN IN BEATPORT
+          </a>
+        </div>
+      );
+    }
+
+    return null;
+  })();
+```
+
+- [ ] **Step 4: Insert `previewSection` in the desktop layout**
+
+In the desktop (wide) branch, add `{previewSection}` after `{suggestedBy}` and before `{voteBtn}` in the bottom `<div>` (around line 200-205):
+
+```typescript
+          <div style={{ padding: '0 16px 16px' }}>
+            {statsRow}
+            {suggestedBy}
+            {previewSection}
+            {voteBtn}
+          </div>
+```
+
+- [ ] **Step 5: Insert `previewSection` in the mobile layout**
+
+In the mobile branch, add `{previewSection}` after `{suggestedBy}` inside the scrollable area (around line 247):
+
+```typescript
+        {statsRow}
+        {suggestedBy}
+        {previewSection}
+      </div>
+```
+
+- [ ] **Step 6: Pass `code` prop from the parent page**
+
+In `dashboard/app/collect/[code]/page.tsx`, update the `CollectDetailSheet` usage (line 435):
+
+```typescript
+      {detailRow && (
+        <CollectDetailSheet
+          row={detailRow}
+          code={code}
+          rank={(leaderboard?.requests ?? []).findIndex((r) => r.id === detailRow.id) + 1 || 1}
+          totalCount={leaderboard?.requests.length ?? 0}
+          voted={detailVoted || votedIds.has(detailRow.id)}
+          onVote={async () => {
+```
+
+- [ ] **Step 7: Run frontend type check and lint**
+
+```bash
+cd dashboard && npx tsc --noEmit && npm run lint
+```
+
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add dashboard/app/collect/\[code\]/components/CollectDetailSheet.tsx dashboard/app/collect/\[code\]/page.tsx
+git commit -m "feat(collect): render song preview embed in detail sheet"
+```
+
+---
+
+### Task 5: Final Verification
+
+- [ ] **Step 1: Run full backend CI**
+
+```bash
+cd server && .venv/bin/ruff check . && .venv/bin/ruff format --check . && .venv/bin/bandit -r app -c pyproject.toml -q && .venv/bin/pytest --tb=short -q
+```
+
+- [ ] **Step 2: Run full frontend CI**
+
+```bash
+cd dashboard && npm run lint && npx tsc --noEmit && npm test -- --run
+```
+
+- [ ] **Step 3: Manual smoke test**
+
+Start the dev server and verify:
+1. Open `/collect/{code}` page
+2. Tap a song with a Spotify `source_url` — iframe embed appears in detail sheet
+3. Tap a song with a Tidal `source_url` — iframe embed appears
+4. Tap a song with a Beatport `source_url` — "OPEN IN BEATPORT" link appears
+5. Tap a manual entry — no preview section visible
+6. Verify embed doesn't cause layout shift on mobile
+
+- [ ] **Step 4: Final commit (if any lint/format fixes needed)**
+
+```bash
+cd server && .venv/bin/ruff format .
+git add -u && git commit -m "style: format fixes"
+```

--- a/docs/superpowers/specs/2026-05-05-collect-song-preview-design.md
+++ b/docs/superpowers/specs/2026-05-05-collect-song-preview-design.md
@@ -1,0 +1,120 @@
+# Collect Page Song Preview
+
+**Date:** 2026-05-05
+**Status:** Approved
+
+## Problem
+
+Guests on the `/collect` page can vote on songs but cannot preview them before voting. Adding inline playback lets guests make more informed decisions and increases engagement.
+
+## Solution
+
+Add an iframe embed player (Spotify/Tidal) to the `CollectDetailSheet` component, fetched lazily via a new rate-limited endpoint to prevent bulk URL harvesting.
+
+## Backend
+
+### New Endpoint
+
+```
+GET /api/public/collect/{code}/requests/{request_id}/preview
+```
+
+**Response (200):**
+```json
+{
+  "source": "spotify",
+  "source_url": "https://open.spotify.com/track/abc123"
+}
+```
+
+**Response (200 with null):** Request exists but has no `source_url` (manual entry) — returns `{ "source": "manual", "source_url": null }`.
+
+**Response (404):** Request not found or doesn't belong to the given event.
+
+**Guards:**
+- `require_verified_human_soft` dependency (Turnstile-verified `wrzdj_human` cookie)
+- Rate limit: `10/minute` per guest (via `get_guest_id`)
+- Validates that `request_id` belongs to the event identified by `code`
+
+**Schema:**
+```python
+class CollectPreviewResponse(BaseModel):
+    source: Literal["spotify", "tidal", "beatport", "manual"]
+    source_url: str | None
+```
+
+### No Changes To
+
+- `CollectLeaderboardRow` schema (source_url stays excluded from bulk responses)
+- Database models (no new columns)
+- Existing enrichment pipeline
+
+## Frontend
+
+### CollectDetailSheet Changes
+
+On mount (when sheet opens):
+1. Fetch `GET /api/public/collect/{code}/requests/{row.id}/preview`
+2. While loading: render nothing in preview area (avoid layout shift for fast responses)
+3. On success, determine embed type via `getEmbedUrl()` from `preview-embed.ts`:
+   - **Spotify/Tidal** (embeddable): Render `<iframe>` with embed URL
+   - **Beatport** (not embeddable): Render "Open in Beatport" external link button
+   - **No source_url / manual**: Render nothing (section absent)
+
+### Iframe Specs
+
+- Height: 152px (matches Spotify/Tidal compact player)
+- Width: 100%
+- Border radius: 14px (matches sheet card style)
+- `allow="encrypted-media"` attribute
+- `loading="lazy"` attribute
+- Dark theme parameter where supported (`?theme=0` for Tidal)
+
+### Position in Sheet
+
+- **Mobile:** Below `suggestedBy` card, above the fixed-position vote button. Inside the scrollable area so it doesn't eat viewport on small screens.
+- **Desktop:** Below `suggestedBy` card, above vote button (both in-flow).
+
+### External Link Fallback (Beatport)
+
+Styled as a subtle outlined button matching the sheet's design language:
+- Monospace label: "OPEN IN BEATPORT"
+- External link icon
+- Opens in new tab (`target="_blank" rel="noopener noreferrer"`)
+
+### No New Dependencies
+
+Uses existing `preview-embed.ts` utilities: `getEmbedUrl()`, `getPreviewSource()`, `canEmbed()`.
+
+## Abuse Mitigation
+
+| Vector | Protection |
+|--------|-----------|
+| Bulk URL harvesting from leaderboard | `source_url` not in `CollectLeaderboardRow` — only via per-request endpoint |
+| Automated embed loading | `wrzdj_human` cookie required (Cloudflare Turnstile-verified) |
+| Rate abuse on preview endpoint | `10/minute` per `guest_id` — human-friendly, bot-hostile |
+| Cross-event request enumeration | Endpoint validates `request.event_id` matches event with given `code` |
+| Iframe embed play-count inflation | Spotify/Tidal enforce their own anti-fraud; we limit how many embed URLs a single guest can obtain per minute |
+
+### API Call Impact Analysis
+
+- **Zero additional calls to Spotify/Tidal from our backend.** The endpoint only reads `source_url` from our DB.
+- Embed iframes load directly from Spotify/Tidal CDNs (client-side). Their infrastructure handles scale.
+- Our backend cost: one DB query per detail sheet open (select `source`, `source_url` from `requests` where `id` and `event.code` match). Negligible.
+
+## Testing
+
+### Backend
+- Endpoint returns correct `source` and `source_url` for Spotify/Tidal/Beatport requests
+- Returns 200 with `source_url: null` for manual entries (no source_url)
+- Returns 404 for request IDs not belonging to the given event code
+- Rate limit triggers at 11th request within 1 minute
+- Human verification cookie enforced (when `human_verification_enforced=True`)
+
+### Frontend
+- Iframe renders with correct embed URL for Spotify track
+- Iframe renders with correct embed URL for Tidal track
+- External link renders for Beatport track
+- Nothing renders for manual entry (no source_url)
+- Loading state doesn't cause layout shift
+- Preview section scrollable on small mobile screens

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -26,6 +26,7 @@ from app.schemas.collect import (
     CollectLeaderboardRow,
     CollectMyPicksItem,
     CollectMyPicksResponse,
+    CollectPreviewResponse,
     CollectProfileRequest,
     CollectProfileResponse,
     CollectSubmitRequest,
@@ -492,3 +493,29 @@ def enrich_preview(
         )
 
     return EnrichPreviewResponse(results=results)
+
+
+@router.get(
+    "/{code}/requests/{request_id}/preview",
+    response_model=CollectPreviewResponse,
+)
+@limiter.limit("10/minute")
+def request_preview(
+    code: str,
+    request_id: int,
+    request: Request,
+    _human: int | None = Depends(require_verified_human_soft),
+    db: Session = Depends(get_db),
+):
+    event = _get_event_or_404(db, code)
+    song_request = (
+        db.query(SongRequest)
+        .filter(SongRequest.id == request_id, SongRequest.event_id == event.id)
+        .one_or_none()
+    )
+    if song_request is None:
+        raise HTTPException(status_code=404, detail="Request not found")
+    return CollectPreviewResponse(
+        source=song_request.source,
+        source_url=song_request.source_url,
+    )

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -73,6 +73,11 @@ class CollectLeaderboardRow(BaseModel):
     requester_verified: bool = False
 
 
+class CollectPreviewResponse(BaseModel):
+    source: Literal["spotify", "tidal", "beatport", "manual"]
+    source_url: str | None
+
+
 class CollectLeaderboardResponse(BaseModel):
     requests: list[CollectLeaderboardRow]
     total: int

--- a/server/app/services/dedup.py
+++ b/server/app/services/dedup.py
@@ -5,11 +5,9 @@ Both the join-page (request.py) and collect (collect.py) flows import from here.
 """
 
 import hashlib
-from datetime import timedelta
 
 from sqlalchemy.orm import Session
 
-from app.core.time import utcnow
 from app.models.request import Request
 
 
@@ -24,17 +22,14 @@ def find_duplicate(
     event_id: int,
     artist: str,
     title: str,
-    window_hours: int = 6,
 ) -> Request | None:
-    """Find an existing request with the same artist+title within the time window."""
+    """Find an existing request with the same artist+title in the event."""
     dedupe_key = compute_dedupe_key(artist, title)
-    cutoff = utcnow() - timedelta(hours=window_hours)
     return (
         db.query(Request)
         .filter(
             Request.event_id == event_id,
             Request.dedupe_key == dedupe_key,
-            Request.created_at > cutoff,
         )
         .first()
     )

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -948,3 +948,52 @@ def test_leaderboard_row_requester_verified_false_no_guest(client, db, test_even
     rows = r.json()["requests"]
     assert len(rows) == 1
     assert rows[0]["requester_verified"] is False
+
+
+# ── Request preview tests ────────────────────────────────────────────────────
+
+
+def test_collect_preview_returns_source_url(client, db, test_event, collection_requests):
+    """Preview endpoint returns source + source_url for a valid request."""
+    _enable_collection(db, test_event)
+    req = collection_requests[0]
+    req.source_url = "https://open.spotify.com/track/abc123"
+    db.commit()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/requests/{req.id}/preview")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["source"] == "spotify"
+    assert body["source_url"] == "https://open.spotify.com/track/abc123"
+
+
+def test_collect_preview_null_source_url_for_manual(client, db, test_event, collection_requests):
+    """Preview endpoint returns source_url=null for manual entries."""
+    _enable_collection(db, test_event)
+    req = collection_requests[0]
+    req.source = "manual"
+    req.source_url = None
+    db.commit()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/requests/{req.id}/preview")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["source"] == "manual"
+    assert body["source_url"] is None
+
+
+def test_collect_preview_404_wrong_event(client, db, test_event, collection_requests):
+    """Preview endpoint returns 404 when request belongs to a different event."""
+    _enable_collection(db, test_event)
+    req = collection_requests[0]
+
+    r = client.get(f"/api/public/collect/ZZZZZZ/requests/{req.id}/preview")
+    assert r.status_code == 404
+
+
+def test_collect_preview_404_nonexistent_request(client, db, test_event):
+    """Preview endpoint returns 404 for nonexistent request ID."""
+    _enable_collection(db, test_event)
+
+    r = client.get(f"/api/public/collect/{test_event.code}/requests/99999/preview")
+    assert r.status_code == 404

--- a/server/tests/test_dedup.py
+++ b/server/tests/test_dedup.py
@@ -9,6 +9,8 @@ from app.models.request import Request as SongRequest
 from app.models.request import RequestStatus
 from app.services.dedup import compute_dedupe_key, find_duplicate
 
+# find_duplicate has no time window — dedup is per-event, period.
+
 
 class TestComputeDedupeKey:
     def test_consistent_hash(self):
@@ -92,7 +94,7 @@ class TestFindDuplicate:
         result = find_duplicate(db, test_event.id, "The Killers", "Somebody Told Me")
         assert result is None
 
-    def test_no_match_outside_window(self, db, test_event):
+    def test_finds_match_regardless_of_age(self, db, test_event):
         key = compute_dedupe_key("The Killers", "Mr. Brightside")
         old_request = SongRequest(
             event_id=test_event.id,
@@ -101,12 +103,12 @@ class TestFindDuplicate:
             source="spotify",
             status=RequestStatus.NEW.value,
             dedupe_key=key,
-            created_at=utcnow() - timedelta(hours=7),
+            created_at=utcnow() - timedelta(days=30),
         )
         db.add(old_request)
         db.commit()
         result = find_duplicate(db, test_event.id, "The Killers", "Mr. Brightside")
-        assert result is None
+        assert result is not None
 
     def test_no_match_different_event(self, db, test_event, test_user):
         other_event = Event(


### PR DESCRIPTION
## Summary

- Removed the 6-hour `window_hours` time window from `find_duplicate()` in `server/app/services/dedup.py`
- Deduplication is now purely event-scoped: same artist+title in the same event = duplicate, regardless of when submitted
- Root cause: collection-phase events span weeks, so the 6h window allowed the same song to be submitted as a new request after the window expired

## Production fix applied

Merged 2 duplicate pairs in ELZ2G2 event before this deploy:
- "Dancing Queen" (ABBA): kept #70, merged votes from #73, deleted #73
- "Shape of You" (Ed Sheeran): kept #47, deleted #102 (votes already on #47)

## Test plan

- [x] `test_finds_match_regardless_of_age` — verifies 30-day-old requests still deduplicate
- [x] All 1955 backend tests pass (88% coverage)
- [x] Frontend, bridge, bridge-app CI all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added song preview capability to Collect detail pages with embedded playback for Spotify and Tidal, plus external links for Beatport songs
  * Dynamic preview display based on available source information

* **Improvements**
  * Enhanced duplicate song request detection to work consistently regardless of request timing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->