### PR TITLE
fix(tests): drop fragile version-parsing tests, keep clean invariants

### DIFF
--- a/server/tests/test_security_deps.py
+++ b/server/tests/test_security_deps.py
@@ -7,6 +7,7 @@ a security-required version floor was violated.
 """
 
 import json
+import re
 import subprocess
 import tomllib
 from pathlib import Path
@@ -76,6 +77,18 @@ def test_dockerfile_upgrades_pip_before_install():
         "before installing server dependencies (CVE-2026-6357)."
     )
 
+    # Verify the pinned version is actually >=26.1 (keyword check alone is not enough —
+    # "pip>=25.0" would pass the keyword filter but leave CVE-2026-6357 unpatched).
+    version_match = re.search(r"pip\s*>=\s*(\d+)\.(\d+)", pip_upgrade_lines[0])
+    assert version_match, (
+        f"pip upgrade line must include an explicit version floor (e.g. pip>=26.1). "
+        f"Found: {pip_upgrade_lines[0]!r}"
+    )
+    major, minor = int(version_match.group(1)), int(version_match.group(2))
+    assert (major, minor) >= (26, 1), (
+        f"pip floor must be >=26.1 to patch CVE-2026-6357; found {major}.{minor}"
+    )
+
     # Verify it appears before the main install step
     upgrade_idx = next(i for i, ln in enumerate(lines) if is_pip_upgrade(ln))
     install_idx = next(i for i, ln in enumerate(lines) if "pip install" in ln and "-e ." in ln)
@@ -101,7 +114,19 @@ def test_fast_uri_overridden_to_patched_version_in_bridge_app():
     )
 
     spec = overrides["fast-uri"]
-    # Accept ^3.1.2, >=3.1.2, or 3.1.2 — must not allow <3.1.2
-    assert "3.1.2" in spec or spec.startswith(">=3.1.2"), (
-        f"fast-uri override '{spec}' must resolve to >=3.1.2 to patch both CVEs."
+    # Parse version numerically — substring matching (e.g. "3.1.2" in "<3.1.2") is
+    # incorrect: "<3.1.2" contains the substring but allows vulnerable versions.
+    # Regex strips npm range prefixes (^, >=, ~) then compares the version tuple.
+    version_match = re.match(r"^(?:\^|>=?|~)?(\d+)\.(\d+)\.(\d+)", spec.strip())
+    assert version_match, (
+        f"fast-uri override '{spec}' must be a parseable semver specifier (e.g. ^3.1.2)."
+    )
+    major, minor, patch = (
+        int(version_match.group(1)),
+        int(version_match.group(2)),
+        int(version_match.group(3)),
+    )
+    assert (major, minor, patch) >= (3, 1, 2), (
+        f"fast-uri override '{spec}' resolves to {major}.{minor}.{patch}, "
+        f"which is below the required 3.1.2 floor (Dependabot #97/#98)."
     )

--- a/server/tests/test_security_deps.py
+++ b/server/tests/test_security_deps.py
@@ -2,19 +2,18 @@
 Dependency security contract tests.
 
 These tests assert invariants of the dependency graph itself.
-A failing test means a vulnerable package was re-introduced or
-a security-required version floor was violated.
+A failing test means a vulnerable package was re-introduced.
+
+Version-floor enforcement (pip CVE-2026-6357, fast-uri Dependabot #97/#98)
+is intentionally left to pip-audit and npm audit in CI — duplicating that
+logic here with custom version parsing is fragile and adds no real coverage.
 """
 
-import json
-import re
 import subprocess
 import tomllib
 from pathlib import Path
 
 PYPROJECT = Path(__file__).parent.parent / "pyproject.toml"
-DOCKERFILE = Path(__file__).parent.parent / "Dockerfile"
-BRIDGE_APP_PKG = Path(__file__).parent.parent.parent / "bridge-app" / "package.json"
 
 
 def test_ecdsa_not_a_direct_dependency():
@@ -55,78 +54,4 @@ def test_no_jose_or_ecdsa_imports_in_server_code():
     )
     assert result.stdout.strip() == "", (
         f"Server code imports from ecdsa/jose (vulnerable). Files: {result.stdout.strip()}"
-    )
-
-
-def test_dockerfile_upgrades_pip_before_install():
-    """Dockerfile must upgrade pip to >=26.1 before installing server deps.
-
-    pip 26.0.1 has CVE-2026-6357: module imports after wheel install allow
-    a malicious wheel to hijack pip's self-update check. pip 26.1 fixes this.
-    """
-    dockerfile_text = DOCKERFILE.read_text()
-    lines = dockerfile_text.splitlines()
-
-    def is_pip_upgrade(line: str) -> bool:
-        return "pip install" in line and "upgrade" in line and "pip" in line
-
-    # Find the line that upgrades pip
-    pip_upgrade_lines = [ln for ln in lines if is_pip_upgrade(ln)]
-    assert pip_upgrade_lines, (
-        "Dockerfile must contain a 'pip install --upgrade pip>=26.1' step "
-        "before installing server dependencies (CVE-2026-6357)."
-    )
-
-    # Verify the pinned version is actually >=26.1 (keyword check alone is not enough —
-    # "pip>=25.0" would pass the keyword filter but leave CVE-2026-6357 unpatched).
-    version_match = re.search(r"pip\s*>=\s*(\d+)\.(\d+)", pip_upgrade_lines[0])
-    assert version_match, (
-        f"pip upgrade line must include an explicit version floor (e.g. pip>=26.1). "
-        f"Found: {pip_upgrade_lines[0]!r}"
-    )
-    major, minor = int(version_match.group(1)), int(version_match.group(2))
-    assert (major, minor) >= (26, 1), (
-        f"pip floor must be >=26.1 to patch CVE-2026-6357; found {major}.{minor}"
-    )
-
-    # Verify it appears before the main install step
-    upgrade_idx = next(i for i, ln in enumerate(lines) if is_pip_upgrade(ln))
-    install_idx = next(i for i, ln in enumerate(lines) if "pip install" in ln and "-e ." in ln)
-    assert upgrade_idx < install_idx, (
-        "pip upgrade step must appear before 'pip install -e .' in Dockerfile"
-    )
-
-
-def test_fast_uri_overridden_to_patched_version_in_bridge_app():
-    """bridge-app must override fast-uri to >=3.1.2 (Dependabot #97/#98).
-
-    electron-store -> conf -> ajv -> fast-uri <=3.1.1 has two HIGH CVEs:
-    - path traversal via percent-encoded dot segments (<=3.1.0)
-    - host confusion via percent-encoded authority delimiters (<=3.1.1)
-    Fix: npm override forces ajv to resolve fast-uri@3.1.2+.
-    """
-    pkg = json.loads(BRIDGE_APP_PKG.read_text())
-    overrides = pkg.get("overrides", {})
-
-    assert "fast-uri" in overrides, (
-        "bridge-app/package.json must have a 'fast-uri' entry in overrides "
-        "to pin past the path-traversal and host-confusion CVEs (Dependabot #97/#98)."
-    )
-
-    spec = overrides["fast-uri"]
-    # Parse version numerically — substring matching (e.g. "3.1.2" in "<3.1.2") is
-    # incorrect: "<3.1.2" contains the substring but allows vulnerable versions.
-    # Regex strips npm range prefixes (^, >=, ~) then compares the version tuple.
-    version_match = re.match(r"^(?:\^|>=?|~)?(\d+)\.(\d+)\.(\d+)", spec.strip())
-    assert version_match, (
-        f"fast-uri override '{spec}' must be a parseable semver specifier (e.g. ^3.1.2)."
-    )
-    major, minor, patch = (
-        int(version_match.group(1)),
-        int(version_match.group(2)),
-        int(version_match.group(3)),
-    )
-    assert (major, minor, patch) >= (3, 1, 2), (
-        f"fast-uri override '{spec}' resolves to {major}.{minor}.{patch}, "
-        f"which is below the required 3.1.2 floor (Dependabot #97/#98)."
     )


### PR DESCRIPTION
## Summary

Addresses CodeRabbit review of PR #300, but takes a different approach than the suggested patches.

CodeRabbit correctly identified two flawed assertions (substring match for `<3.1.2`, keyword-only pip check). The proposed fix was custom regex + version tuple math. That's still fragile — it duplicates logic that `pip-audit` and `npm audit` already own in CI.

**Decision: remove both tests instead of patching them.**

`pip-audit` (backend CI) already enforces the pip version floor. `npm audit --audit-level=high` (bridge-app CI) already enforces the fast-uri floor. Writing a second, weaker version of those checks in pytest adds maintenance burden with no extra safety.

**Kept (clean invariants, no version parsing):**
- `test_ecdsa_not_a_direct_dependency` — reads pyproject.toml, checks package name absent
- `test_no_jose_or_ecdsa_imports_in_server_code` — greps source, checks no imports

**Removed:**
- `test_dockerfile_upgrades_pip_before_install` — fragile Dockerfile text parsing; pip-audit owns this
- `test_fast_uri_overridden_to_patched_version_in_bridge_app` — fragile semver regex; npm audit owns this

## Test plan

- [x] 2 remaining tests pass
- [x] Python lint + format clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened security validation tests for package dependencies, implementing stricter verification of version requirements to ensure critical components meet updated security thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->