### PR TITLE
chore: add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,80 @@
+name: Dependabot auto-merge
+
+# pull_request_target runs in the base-branch context so GITHUB_TOKEN has
+# write access. Actor check below ensures only Dependabot triggers this.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: dependabot/fetch-metadata@v2
+        id: meta
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # patch + minor: always auto-merge — backward-compatible by semver contract
+      - name: Auto-merge patch and minor updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review --approve "$PR_URL" -b "Automated: patch/minor dependency update"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # major dev deps: auto-merge — no production runtime impact
+      - name: Auto-merge major dev dependency updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-major' &&
+          steps.meta.outputs.dependency-type == 'direct:development'
+        run: |
+          gh pr review --approve "$PR_URL" -b "Automated: major dev dependency update"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Docker image updates: auto-merge — Docker build smoke test gates these
+      - name: Auto-merge Docker image updates
+        if: |
+          steps.meta.outputs.update-type == 'docker-tag-update' ||
+          steps.meta.outputs.update-type == 'docker-digest-update'
+        run: |
+          gh pr review --approve "$PR_URL" -b "Automated: Docker image update"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # GitHub Actions updates: auto-merge — CI workflow changes, no runtime impact
+      - name: Auto-merge GitHub Actions updates
+        if: steps.meta.outputs.package-ecosystem == 'github-actions'
+        run: |
+          gh pr review --approve "$PR_URL" -b "Automated: GitHub Actions update"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # major prod deps: label for awareness, require manual merge
+      # (Docker and Actions are handled above and will not reach this step)
+      - name: Label major production dependency updates for manual review
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-major' &&
+          steps.meta.outputs.dependency-type != 'direct:development'
+        run: gh pr edit "$PR_URL" --add-label "major-update"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,16 +17,20 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: dependabot/fetch-metadata@v2
+      # Pinned to commit SHA — floating tags are unsafe on pull_request_target
+      # with write permissions (supply chain attack surface). v2 = 21025c7
+      - uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a
         id: meta
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # patch + minor: always auto-merge — backward-compatible by semver contract
+      # Excludes github-actions (handled by dedicated step below to avoid duplicate calls)
       - name: Auto-merge patch and minor updates
         if: |
-          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          steps.meta.outputs.update-type == 'version-update:semver-minor'
+          (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+           steps.meta.outputs.update-type == 'version-update:semver-minor') &&
+          steps.meta.outputs.package-ecosystem != 'github-actions'
         run: |
           gh pr review --approve "$PR_URL" -b "Automated: patch/minor dependency update"
           gh pr merge --auto --squash "$PR_URL"
@@ -35,10 +39,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # major dev deps: auto-merge — no production runtime impact
+      # Excludes github-actions (handled by dedicated step below to avoid duplicate calls)
       - name: Auto-merge major dev dependency updates
         if: |
           steps.meta.outputs.update-type == 'version-update:semver-major' &&
-          steps.meta.outputs.dependency-type == 'direct:development'
+          steps.meta.outputs.dependency-type == 'direct:development' &&
+          steps.meta.outputs.package-ecosystem != 'github-actions'
         run: |
           gh pr review --approve "$PR_URL" -b "Automated: major dev dependency update"
           gh pr merge --auto --squash "$PR_URL"
@@ -59,6 +65,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # GitHub Actions updates: auto-merge — CI workflow changes, no runtime impact
+      # Handles all semver tiers for actions (patch/minor/major all safe to auto-merge)
       - name: Auto-merge GitHub Actions updates
         if: steps.meta.outputs.package-ecosystem == 'github-actions'
         run: |
@@ -69,11 +76,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # major prod deps: label for awareness, require manual merge
-      # (Docker and Actions are handled above and will not reach this step)
+      # Excludes github-actions (already handled above, never reaches this step)
       - name: Label major production dependency updates for manual review
         if: |
           steps.meta.outputs.update-type == 'version-update:semver-major' &&
-          steps.meta.outputs.dependency-type != 'direct:development'
+          steps.meta.outputs.dependency-type != 'direct:development' &&
+          steps.meta.outputs.package-ecosystem != 'github-actions'
         run: gh pr edit "$PR_URL" --add-label "major-update"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary

Implements automated Dependabot PR merging using GitHub's native auto-merge feature, gated on required CI status checks.

**Merge tiers:**
| Update type | Action |
|-------------|--------|
| patch / minor | Auto-merge on CI pass |
| major dev deps | Auto-merge on CI pass |
| Docker tag/digest | Auto-merge on CI pass (Docker smoke test gates) |
| GitHub Actions | Auto-merge on CI pass |
| major prod deps | Label `major-update` — manual merge required |

**Infra changes applied across all 4 wrzonance repos (WrzDJ, HonkHonk, DMXr, SpecR):**
- `allow_auto_merge` enabled
- `delete_branch_on_merge` enabled
- `major-update` label created
- Vulnerability alerts enabled
- Automated security fixes (Dependabot security updates) enabled
- Required status checks set on WrzDJ and SpecR (were empty)
- Workflow deployed to HonkHonk, DMXr, SpecR directly
- Dependabot grouping added to HonkHonk, DMXr, SpecR configs

**Why `pull_request_target`:** runs in base-branch context for write-token access. Actor check (`dependabot[bot]`) ensures no other PRs trigger this. No code from the PR branch is checked out.

## Test plan

- [ ] CI passes
- [ ] CodeRabbit review
- [ ] Manually trigger a Dependabot PR after merge to verify auto-merge fires

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated dependency-management workflow to auto-approve and auto-merge safe dependency updates (patch/minor, Docker tags/digests, and select major dev deps), auto-merge all CI/actions ecosystem updates, and label semver-major production dependency updates for manual review to preserve safety guardrails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->