### PR TITLE
feat: sync collection suggestions to Tidal playlist

### DIFF
--- a/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
+++ b/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
@@ -13,7 +13,7 @@ interface EventShape {
   collection_phase_override: 'force_collection' | 'force_live' | null;
   phase: 'pre_announce' | 'collection' | 'live' | 'closed';
   tidal_sync_enabled: boolean;
-  tidal_playlist_id: string | null;
+  tidal_collection_playlist_id: string | null;
 }
 
 interface Props {
@@ -336,9 +336,9 @@ export default function PreEventVotingTab({
               >
                 {syncing ? 'Syncing…' : 'Sync collection to Tidal'}
               </button>
-              {event.tidal_playlist_id && (
+              {event.tidal_collection_playlist_id && (
                 <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
-                  Playlist linked ✓
+                  Pre-event playlist linked ✓
                 </span>
               )}
               {syncResult !== null && (

--- a/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
+++ b/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
@@ -162,11 +162,14 @@ export default function PreEventVotingTab({
 
   async function handleToggleTidalSync(enabled: boolean) {
     setTogglingTidal(true);
+    setSyncError(null);
     try {
       const resp = await apiClient.patchCollectionSettings(event.code, {
         tidal_sync_enabled: enabled,
       });
       onEventChange(resp);
+    } catch (err) {
+      setSyncError(err instanceof Error ? err.message : 'Failed to update Tidal sync setting');
     } finally {
       setTogglingTidal(false);
     }

--- a/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
+++ b/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
@@ -12,10 +12,14 @@ interface EventShape {
   submission_cap_per_guest: number;
   collection_phase_override: 'force_collection' | 'force_live' | null;
   phase: 'pre_announce' | 'collection' | 'live' | 'closed';
+  tidal_sync_enabled: boolean;
+  tidal_playlist_id: string | null;
 }
 
 interface Props {
   event: EventShape;
+  tidalConnected: boolean;
+  tidalIntegrationEnabled: boolean;
   onEventChange: (next: Partial<EventShape>) => void;
 }
 
@@ -70,7 +74,12 @@ function toIso(local: string): string | null {
   return new Date(local).toISOString();
 }
 
-export default function PreEventVotingTab({ event, onEventChange }: Props) {
+export default function PreEventVotingTab({
+  event,
+  tidalConnected,
+  tidalIntegrationEnabled,
+  onEventChange,
+}: Props) {
   const [pending, setPending] = useState<PendingReviewRow[]>([]);
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [confirming, setConfirming] = useState<ConfirmAction | null>(null);
@@ -86,9 +95,14 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
   const [settingsError, setSettingsError] = useState<string | null>(null);
   const [settingsSaved, setSettingsSaved] = useState(false);
 
+  const [togglingTidal, setTogglingTidal] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [syncResult, setSyncResult] = useState<{ queued: number } | null>(null);
+  const [syncError, setSyncError] = useState<string | null>(null);
+
   useEffect(() => {
     refresh();
-     
+
   }, [event.code]);
 
   async function refresh() {
@@ -146,6 +160,34 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
     }
   }
 
+  async function handleToggleTidalSync(enabled: boolean) {
+    setTogglingTidal(true);
+    try {
+      const resp = await apiClient.patchCollectionSettings(event.code, {
+        tidal_sync_enabled: enabled,
+      });
+      onEventChange(resp);
+    } finally {
+      setTogglingTidal(false);
+    }
+  }
+
+  async function handleSyncToTidal() {
+    setSyncing(true);
+    setSyncResult(null);
+    setSyncError(null);
+    try {
+      const result = await apiClient.syncCollectionToTidal(event.code);
+      setSyncResult(result);
+      setTimeout(() => setSyncResult(null), 5000);
+    } catch (err) {
+      setSyncError(err instanceof Error ? err.message : 'Sync failed');
+      setTimeout(() => setSyncError(null), 5000);
+    } finally {
+      setSyncing(false);
+    }
+  }
+
   const shareUrl =
     typeof window !== 'undefined'
       ? `${window.location.origin}/collect/${event.code}`
@@ -160,6 +202,8 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
     }
     setSelected(next);
   }
+
+  const showTidalSection = tidalConnected && tidalIntegrationEnabled;
 
   return (
     <div style={{ padding: '1rem' }}>
@@ -259,6 +303,55 @@ export default function PreEventVotingTab({ event, onEventChange }: Props) {
           </button>
         </form>
       </div>
+
+      {showTidalSection && (
+        <div className="card" style={{ marginBottom: '1.25rem' }}>
+          <h3 style={{ marginBottom: '0.75rem', fontSize: '1rem' }}>Tidal Collection Sync</h3>
+          <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '0.875rem' }}>
+            Sync guest suggestions to a Tidal playlist so you can listen while you plan your set.
+            Playlist name: <strong>{event.code} – {event.name}</strong>
+          </p>
+
+          <label className="collection-fieldset-toggle" style={{ marginBottom: '0.875rem' }}>
+            <input
+              type="checkbox"
+              checked={event.tidal_sync_enabled}
+              disabled={togglingTidal}
+              onChange={(e) => handleToggleTidalSync(e.target.checked)}
+            />
+            Enable Tidal sync for this collection
+          </label>
+
+          {event.tidal_sync_enabled && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexWrap: 'wrap' }}>
+              <button
+                type="button"
+                className="btn btn-sm"
+                style={{ background: '#1db954', color: '#fff' }}
+                disabled={syncing}
+                onClick={handleSyncToTidal}
+              >
+                {syncing ? 'Syncing…' : 'Sync collection to Tidal'}
+              </button>
+              {event.tidal_playlist_id && (
+                <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
+                  Playlist linked ✓
+                </span>
+              )}
+              {syncResult !== null && (
+                <span style={{ fontSize: '0.875rem', color: '#4ade80' }}>
+                  {syncResult.queued === 0
+                    ? 'All tracks already synced.'
+                    : `Queued ${syncResult.queued} track${syncResult.queued === 1 ? '' : 's'} for sync.`}
+                </span>
+              )}
+              {syncError && (
+                <span style={{ fontSize: '0.875rem', color: '#f87171' }}>{syncError}</span>
+              )}
+            </div>
+          )}
+        </div>
+      )}
 
       <div className="card" style={{ marginBottom: '1.25rem' }}>
         <h3 style={{ marginBottom: '0.75rem', fontSize: '1rem' }}>Phase controls</h3>

--- a/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
+++ b/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
@@ -12,7 +12,7 @@ const baseEvent = {
   collection_phase_override: null,
   phase: "collection" as const,
   tidal_sync_enabled: false,
-  tidal_playlist_id: null,
+  tidal_collection_playlist_id: null,
 };
 
 vi.mock("@/lib/api", () => ({
@@ -26,7 +26,7 @@ vi.mock("@/lib/api", () => ({
       collection_phase_override: "force_live",
       phase: "live",
       tidal_sync_enabled: false,
-      tidal_playlist_id: null,
+      tidal_collection_playlist_id: null,
     }),
     getPendingReview: vi.fn().mockResolvedValue({ requests: [], total: 0 }),
     bulkReview: vi.fn().mockResolvedValue({ accepted: 0, rejected: 0, unchanged: 0 }),

--- a/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
+++ b/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import PreEventVotingTab from "../PreEventVotingTab";
+import { apiClient } from "@/lib/api";
 
 const baseEvent = {
   code: "ABC",
@@ -112,5 +113,20 @@ describe("PreEventVotingTab", () => {
       />
     );
     expect(screen.queryByRole("button", { name: /sync collection to tidal/i })).not.toBeInTheDocument();
+  });
+
+  it("triggers collection sync when sync button is clicked", async () => {
+    render(
+      <PreEventVotingTab
+        event={{ ...baseEvent, tidal_sync_enabled: true }}
+        tidalConnected={true}
+        tidalIntegrationEnabled={true}
+        onEventChange={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /sync collection to tidal/i }));
+    await waitFor(() => {
+      expect(apiClient.syncCollectionToTidal).toHaveBeenCalledWith("ABC");
+    });
   });
 });

--- a/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
+++ b/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
@@ -10,6 +10,8 @@ const baseEvent = {
   submission_cap_per_guest: 15,
   collection_phase_override: null,
   phase: "collection" as const,
+  tidal_sync_enabled: false,
+  tidal_playlist_id: null,
 };
 
 vi.mock("@/lib/api", () => ({
@@ -22,15 +24,25 @@ vi.mock("@/lib/api", () => ({
       submission_cap_per_guest: 15,
       collection_phase_override: "force_live",
       phase: "live",
+      tidal_sync_enabled: false,
+      tidal_playlist_id: null,
     }),
     getPendingReview: vi.fn().mockResolvedValue({ requests: [], total: 0 }),
     bulkReview: vi.fn().mockResolvedValue({ accepted: 0, rejected: 0, unchanged: 0 }),
+    syncCollectionToTidal: vi.fn().mockResolvedValue({ queued: 3 }),
   },
 }));
 
 describe("PreEventVotingTab", () => {
   it("renders phase and share link", () => {
-    render(<PreEventVotingTab event={baseEvent} onEventChange={vi.fn()} />);
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={vi.fn()}
+      />
+    );
     expect(screen.getByText(/current phase/i)).toBeInTheDocument();
     expect(screen.getAllByText(/collection/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/\/collect\/ABC/i)).toBeInTheDocument();
@@ -38,11 +50,67 @@ describe("PreEventVotingTab", () => {
 
   it("applies force_live override via button", async () => {
     const onEventChange = vi.fn();
-    render(<PreEventVotingTab event={baseEvent} onEventChange={onEventChange} />);
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={onEventChange}
+      />
+    );
     fireEvent.click(screen.getByRole("button", { name: /start live now/i }));
     fireEvent.click(screen.getByRole("button", { name: /^confirm$/i }));
     await waitFor(() => {
       expect(onEventChange).toHaveBeenCalled();
     });
+  });
+
+  it("hides Tidal section when Tidal not connected", () => {
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={true}
+        onEventChange={vi.fn()}
+      />
+    );
+    expect(screen.queryByText(/tidal collection sync/i)).not.toBeInTheDocument();
+  });
+
+  it("shows Tidal section when Tidal connected and integration enabled", () => {
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={true}
+        tidalIntegrationEnabled={true}
+        onEventChange={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/tidal collection sync/i)).toBeInTheDocument();
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+  });
+
+  it("sync button only visible when tidal_sync_enabled is true", () => {
+    render(
+      <PreEventVotingTab
+        event={{ ...baseEvent, tidal_sync_enabled: true }}
+        tidalConnected={true}
+        tidalIntegrationEnabled={true}
+        onEventChange={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("button", { name: /sync collection to tidal/i })).toBeInTheDocument();
+  });
+
+  it("sync button hidden when tidal_sync_enabled is false", () => {
+    render(
+      <PreEventVotingTab
+        event={{ ...baseEvent, tidal_sync_enabled: false }}
+        tidalConnected={true}
+        tidalIntegrationEnabled={true}
+        onEventChange={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole("button", { name: /sync collection to tidal/i })).not.toBeInTheDocument();
   });
 });

--- a/dashboard/app/events/[code]/page.tsx
+++ b/dashboard/app/events/[code]/page.tsx
@@ -1122,7 +1122,7 @@ export default function EventQueuePage() {
                 collection_phase_override: collectionSettings.collection_phase_override,
                 phase: collectionSettings.phase,
                 tidal_sync_enabled: collectionSettings.tidal_sync_enabled,
-                tidal_playlist_id: collectionSettings.tidal_playlist_id,
+                tidal_collection_playlist_id: collectionSettings.tidal_collection_playlist_id,
               }}
               tidalConnected={!!tidalStatus?.linked}
               tidalIntegrationEnabled={!!tidalStatus?.integration_enabled}

--- a/dashboard/app/events/[code]/page.tsx
+++ b/dashboard/app/events/[code]/page.tsx
@@ -1121,7 +1121,11 @@ export default function EventQueuePage() {
                 submission_cap_per_guest: collectionSettings.submission_cap_per_guest,
                 collection_phase_override: collectionSettings.collection_phase_override,
                 phase: collectionSettings.phase,
+                tidal_sync_enabled: collectionSettings.tidal_sync_enabled,
+                tidal_playlist_id: collectionSettings.tidal_playlist_id,
               }}
+              tidalConnected={!!tidalStatus?.linked}
+              tidalIntegrationEnabled={!!tidalStatus?.integration_enabled}
               onEventChange={(next) => setCollectionSettings((prev) => prev ? { ...prev, ...next } : prev)}
             />
           )}

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -164,7 +164,7 @@ export interface CollectionSettingsResponse {
   collection_phase_override: 'force_collection' | 'force_live' | null;
   phase: 'pre_announce' | 'collection' | 'live' | 'closed';
   tidal_sync_enabled: boolean;
-  tidal_playlist_id: string | null;
+  tidal_collection_playlist_id: string | null;
 }
 
 export interface CollectionSyncResponse {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -163,6 +163,12 @@ export interface CollectionSettingsResponse {
   submission_cap_per_guest: number;
   collection_phase_override: 'force_collection' | 'force_live' | null;
   phase: 'pre_announce' | 'collection' | 'live' | 'closed';
+  tidal_sync_enabled: boolean;
+  tidal_playlist_id: string | null;
+}
+
+export interface CollectionSyncResponse {
+  queued: number;
 }
 
 export interface PendingReviewRow {
@@ -1321,12 +1327,17 @@ class ApiClient {
       live_starts_at?: string | null;
       submission_cap_per_guest?: number;
       collection_phase_override?: 'force_collection' | 'force_live' | null;
+      tidal_sync_enabled?: boolean;
     },
   ): Promise<CollectionSettingsResponse> {
     return this.fetch(`/api/events/${code}/collection`, {
       method: 'PATCH',
       body: JSON.stringify(data),
     });
+  }
+
+  async syncCollectionToTidal(code: string): Promise<CollectionSyncResponse> {
+    return this.fetch(`/api/events/${code}/collection/sync-tidal`, { method: 'POST' });
   }
 
   async getPendingReview(code: string): Promise<PendingReviewResponse> {

--- a/server/alembic/versions/043_add_tidal_collection_playlist_id.py
+++ b/server/alembic/versions/043_add_tidal_collection_playlist_id.py
@@ -1,0 +1,26 @@
+"""Add tidal_collection_playlist_id to events.
+
+Revision ID: 043
+Revises: 042
+Create Date: 2026-05-11
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "043"
+down_revision: str | None = "042"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "events",
+        sa.Column("tidal_collection_playlist_id", sa.String(100), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("events", "tidal_collection_playlist_id")

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -42,8 +42,9 @@ from app.services.beatport import search_beatport_tracks
 from app.services.collect import NicknameConflictError, upsert_profile
 from app.services.dedup import compute_dedupe_key, find_duplicate
 from app.services.sync.enrichment_pipeline import _find_best_match
-from app.services.sync.orchestrator import enrich_request_metadata, sync_request_to_services
+from app.services.sync.orchestrator import enrich_request_metadata
 from app.services.system_settings import get_system_settings
+from app.services.tidal import sync_collection_requests_batch
 from app.services.vote import add_vote
 
 logger = logging.getLogger(__name__)
@@ -399,7 +400,9 @@ def submit(
     if not (row.genre and row.bpm and row.musical_key):
         background_tasks.add_task(enrich_request_metadata, db, row.id)
     if event.tidal_sync_enabled and get_system_settings(db).tidal_enabled:
-        background_tasks.add_task(sync_request_to_services, db, row)
+        background_tasks.add_task(
+            sync_collection_requests_batch, db, event.created_by, event, [row]
+        )
     log_activity(
         db,
         level="info",

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -42,7 +42,7 @@ from app.services.beatport import search_beatport_tracks
 from app.services.collect import NicknameConflictError, upsert_profile
 from app.services.dedup import compute_dedupe_key, find_duplicate
 from app.services.sync.enrichment_pipeline import _find_best_match
-from app.services.sync.orchestrator import enrich_request_metadata
+from app.services.sync.orchestrator import enrich_request_metadata, sync_request_to_services
 from app.services.system_settings import get_system_settings
 from app.services.vote import add_vote
 
@@ -398,6 +398,8 @@ def submit(
     db.refresh(row)
     if not (row.genre and row.bpm and row.musical_key):
         background_tasks.add_task(enrich_request_metadata, db, row.id)
+    if event.tidal_sync_enabled and get_system_settings(db).tidal_enabled:
+        background_tasks.add_task(sync_request_to_services, db, row)
     log_activity(
         db,
         level="info",

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -96,6 +96,7 @@ from app.services.request import (
 )
 from app.services.sync.orchestrator import enrich_request_metadata, sync_requests_batch
 from app.services.sync.registry import get_connected_adapters
+from app.services.tidal import sync_collection_requests_batch
 
 router = APIRouter()
 
@@ -1068,7 +1069,7 @@ def sync_collection_to_tidal(
     ]
 
     if eligible:
-        background_tasks.add_task(sync_requests_batch, db, eligible)
+        background_tasks.add_task(sync_collection_requests_batch, db, user, event, eligible)
 
     return {"queued": len(eligible)}
 

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -675,7 +675,7 @@ def accept_all_requests_endpoint(
     # Trigger batch sync — one background task for all accepted requests
     # Uses sequential search + batch playlist add to avoid API rate limiting
     if accepted and get_connected_adapters(event.created_by):
-        background_tasks.add_task(_sync_requests_with_fresh_session, [r.id for r in accepted])
+        background_tasks.add_task(sync_requests_batch, db, accepted)
 
     if accepted:
         publish_event(
@@ -1068,7 +1068,7 @@ def sync_collection_to_tidal(
     ]
 
     if eligible:
-        background_tasks.add_task(_sync_requests_with_fresh_session, [r.id for r in eligible])
+        background_tasks.add_task(sync_requests_batch, db, eligible)
 
     return {"queued": len(eligible)}
 
@@ -1115,7 +1115,7 @@ def bulk_review(
     if accepted_rows:
         for row in accepted_rows:
             background_tasks.add_task(enrich_request_metadata, db, row.id)
-        background_tasks.add_task(_sync_requests_with_fresh_session, [r.id for r in accepted_rows])
+        background_tasks.add_task(sync_requests_batch, db, accepted_rows)
     return BulkReviewResponse(accepted=accepted, rejected=rejected, unchanged=0)
 
 

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -675,7 +675,7 @@ def accept_all_requests_endpoint(
     # Trigger batch sync — one background task for all accepted requests
     # Uses sequential search + batch playlist add to avoid API rate limiting
     if accepted and get_connected_adapters(event.created_by):
-        background_tasks.add_task(sync_requests_batch, db, accepted)
+        background_tasks.add_task(_sync_requests_with_fresh_session, [r.id for r in accepted])
 
     if accepted:
         publish_event(
@@ -1068,7 +1068,7 @@ def sync_collection_to_tidal(
     ]
 
     if eligible:
-        background_tasks.add_task(sync_requests_batch, db, eligible)
+        background_tasks.add_task(_sync_requests_with_fresh_session, [r.id for r in eligible])
 
     return {"queued": len(eligible)}
 
@@ -1115,7 +1115,7 @@ def bulk_review(
     if accepted_rows:
         for row in accepted_rows:
             background_tasks.add_task(enrich_request_metadata, db, row.id)
-        background_tasks.add_task(sync_requests_batch, db, accepted_rows)
+        background_tasks.add_task(_sync_requests_with_fresh_session, [r.id for r in accepted_rows])
     return BulkReviewResponse(accepted=accepted, rejected=rejected, unchanged=0)
 
 
@@ -1134,6 +1134,26 @@ def _enrich_with_fresh_session(request_id: int) -> None:
     session = SessionLocal()
     try:
         enrich_request_metadata(session, request_id)
+    finally:
+        session.close()
+
+
+def _sync_requests_with_fresh_session(request_ids: list[int]) -> None:
+    """Run sync_requests_batch in its own DB session.
+
+    Same rationale as _enrich_with_fresh_session: the request-scoped `db` stays
+    open until all background tasks complete; for large collections this exhausts
+    the SQLAlchemy connection pool.  Re-querying by ID inside a fresh session
+    releases the connection as soon as the batch finishes.
+    """
+    from app.db.session import SessionLocal
+    from app.models.request import Request as SongRequest
+
+    session = SessionLocal()
+    try:
+        rows = session.query(SongRequest).filter(SongRequest.id.in_(request_ids)).all()
+        if rows:
+            sync_requests_batch(session, rows)
     finally:
         session.close()
 

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -1027,6 +1027,52 @@ def update_collection_settings_endpoint(
     return collection_settings_payload(event)
 
 
+@router.post("/{code}/collection/sync-tidal")
+@limiter.limit("5/minute")
+def sync_collection_to_tidal(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    event: Event = Depends(get_event_for_dj_or_admin),
+    db: Session = Depends(get_db),
+):
+    """Sync all non-rejected collection-phase requests to the DJ's Tidal playlist.
+
+    Includes pending (new) and accepted requests so the DJ can listen to guest
+    suggestions on Tidal before the review step.  Already-synced tracks are
+    silently skipped inside sync_requests_batch.
+    """
+    from app.services.system_settings import get_system_settings
+
+    sys_settings = get_system_settings(db)
+    if not sys_settings.tidal_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Tidal integration is currently unavailable",
+        )
+
+    user = event.created_by
+    if not user.tidal_access_token:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Tidal account not linked",
+        )
+
+    if not event.tidal_sync_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Tidal sync not enabled for this event",
+        )
+
+    eligible = [
+        r for r in event.requests if r.submitted_during_collection and r.status != "rejected"
+    ]
+
+    if eligible:
+        background_tasks.add_task(sync_requests_batch, db, eligible)
+
+    return {"queued": len(eligible)}
+
+
 @router.get("/{code}/pending-review", response_model=PendingReviewResponse)
 def pending_review(
     event: Event = Depends(get_event_for_dj_or_admin),

--- a/server/app/models/event.py
+++ b/server/app/models/event.py
@@ -34,6 +34,7 @@ class Event(Base):
 
     # Tidal playlist sync
     tidal_playlist_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    tidal_collection_playlist_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
     tidal_sync_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
 
     # Beatport sync

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -135,6 +135,7 @@ class UpdateCollectionSettings(BaseModel):
     live_starts_at: datetime | None = None
     submission_cap_per_guest: int | None = Field(default=None, ge=0, le=100)
     collection_phase_override: Literal["force_collection", "force_live"] | None = None
+    tidal_sync_enabled: bool | None = None
 
 
 class PendingReviewRow(BaseModel):

--- a/server/app/services/collect.py
+++ b/server/app/services/collect.py
@@ -37,7 +37,7 @@ def collection_settings_payload(event: Event) -> dict:
         "collection_phase_override": event.collection_phase_override,
         "phase": event.phase,
         "tidal_sync_enabled": event.tidal_sync_enabled,
-        "tidal_playlist_id": event.tidal_playlist_id,
+        "tidal_collection_playlist_id": event.tidal_collection_playlist_id,
     }
 
 

--- a/server/app/services/collect.py
+++ b/server/app/services/collect.py
@@ -36,6 +36,8 @@ def collection_settings_payload(event: Event) -> dict:
         "submission_cap_per_guest": event.submission_cap_per_guest,
         "collection_phase_override": event.collection_phase_override,
         "phase": event.phase,
+        "tidal_sync_enabled": event.tidal_sync_enabled,
+        "tidal_playlist_id": event.tidal_playlist_id,
     }
 
 
@@ -56,6 +58,8 @@ def update_collection_settings(
         event.submission_cap_per_guest = payload.submission_cap_per_guest
     if "collection_phase_override" in payload.model_fields_set:
         event.collection_phase_override = payload.collection_phase_override
+    if payload.tidal_sync_enabled is not None:
+        event.tidal_sync_enabled = payload.tidal_sync_enabled
 
     opens = event.collection_opens_at
     live = event.live_starts_at

--- a/server/app/services/tidal.py
+++ b/server/app/services/tidal.py
@@ -323,6 +323,75 @@ def create_event_playlist(
         return None
 
 
+def ensure_collection_playlist(
+    db: Session,
+    user: User,
+    event: Event,
+) -> str | None:
+    """Create (or reuse) the pre-event collection Tidal playlist for an event.
+
+    Kept separate from create_event_playlist so collection suggestions and
+    live-event accepted requests land in two distinct Tidal playlists.
+    """
+    if event.tidal_collection_playlist_id:
+        return event.tidal_collection_playlist_id
+
+    session = get_tidal_session(db, user)
+    if not session:
+        return None
+
+    try:
+        playlist_name = f"WrzDJ: {event.code} – {event.name} (pre-event)"
+        description = f"Pre-event song suggestions for {event.name}"
+
+        playlist = session.user.create_playlist(playlist_name, description)
+
+        event.tidal_collection_playlist_id = str(playlist.id)
+        db.commit()
+
+        logger.info(f"Created Tidal collection playlist {playlist.id} for event {event.code}")
+        return event.tidal_collection_playlist_id
+
+    except Exception as e:
+        logger.error(f"Failed to create Tidal collection playlist: {e}")
+        return None
+
+
+def sync_collection_requests_batch(
+    db: Session,
+    user: User,
+    event: Event,
+    requests: list,
+) -> None:
+    """Batch-sync pre-event collection requests to the collection playlist.
+
+    Searches tracks sequentially, then adds all found IDs in one API call.
+    Tidal's allow_duplicates=False deduplicates silently at the API layer.
+    """
+    if not requests:
+        return
+
+    playlist_id = ensure_collection_playlist(db, user, event)
+    if not playlist_id:
+        return
+
+    session = get_tidal_session(db, user)
+    if not session:
+        return
+
+    track_ids: list[str] = []
+    for req in requests:
+        try:
+            result = search_tidal_tracks(session, req.song_title, req.artist)
+            if result:
+                track_ids.append(result.track_id)
+        except Exception as e:
+            logger.error(f"Collection sync search failed for '{req.song_title}': {e}")
+
+    if track_ids:
+        add_tracks_to_playlist(db, user, playlist_id, track_ids)
+
+
 def add_track_to_playlist(
     db: Session,
     user: User,

--- a/server/app/services/tidal.py
+++ b/server/app/services/tidal.py
@@ -307,7 +307,7 @@ def create_event_playlist(
         return None
 
     try:
-        playlist_name = f"WrzDJ: {event.name}"
+        playlist_name = f"WrzDJ: {event.code} – {event.name}"
         description = f"Song requests for {event.name}"
 
         playlist = session.user.create_playlist(playlist_name, description)

--- a/server/app/services/tidal.py
+++ b/server/app/services/tidal.py
@@ -375,16 +375,12 @@ def sync_collection_requests_batch(
     if not playlist_id:
         return
 
-    session = get_tidal_session(db, user)
-    if not session:
-        return
-
     track_ids: list[str] = []
     for req in requests:
         try:
-            result = search_tidal_tracks(session, req.song_title, req.artist)
-            if result:
-                track_ids.append(result.track_id)
+            results = search_tidal_tracks(db, user, f"{req.song_title} {req.artist}")
+            if results:
+                track_ids.append(results[0].track_id)
         except Exception as e:
             logger.error(f"Collection sync search failed for '{req.song_title}': {e}")
 

--- a/server/tests/test_collect_dj.py
+++ b/server/tests/test_collect_dj.py
@@ -272,6 +272,25 @@ def test_collection_settings_includes_tidal_fields(client, db, auth_headers, tes
     assert body["tidal_sync_enabled"] is True
 
 
+def test_sync_collection_to_tidal_integration_disabled(
+    client, db, auth_headers, test_event, collection_requests
+):
+    from app.services.system_settings import get_system_settings
+
+    sys = get_system_settings(db)
+    sys.tidal_enabled = False
+    test_event.created_by.tidal_access_token = "fake_tidal_token"
+    test_event.tidal_sync_enabled = True
+    db.commit()
+
+    r = client.post(
+        f"/api/events/{test_event.code}/collection/sync-tidal",
+        headers=auth_headers,
+    )
+    assert r.status_code == 503
+    assert "unavailable" in r.json()["detail"]
+
+
 def test_sync_collection_to_tidal_no_tidal_linked(
     client, db, auth_headers, test_event, collection_requests
 ):

--- a/server/tests/test_collect_dj.py
+++ b/server/tests/test_collect_dj.py
@@ -268,7 +268,7 @@ def test_collection_settings_includes_tidal_fields(client, db, auth_headers, tes
     assert r.status_code == 200
     body = r.json()
     assert "tidal_sync_enabled" in body
-    assert "tidal_playlist_id" in body
+    assert "tidal_collection_playlist_id" in body
     assert body["tidal_sync_enabled"] is True
 
 

--- a/server/tests/test_collect_dj.py
+++ b/server/tests/test_collect_dj.py
@@ -246,3 +246,90 @@ def test_patch_collection_auto_extends_expires_at(client, db, auth_headers, test
     assert test_event.live_starts_at is not None
     # expires_at should now be > live_starts_at (the auto-extend applied)
     assert test_event.expires_at > test_event.live_starts_at
+
+
+def test_patch_collection_tidal_sync_enabled(client, db, auth_headers, test_event):
+    r = client.patch(
+        f"/api/events/{test_event.code}/collection",
+        json={"tidal_sync_enabled": True},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["tidal_sync_enabled"] is True
+    db.refresh(test_event)
+    assert test_event.tidal_sync_enabled is True
+
+
+def test_collection_settings_includes_tidal_fields(client, db, auth_headers, test_event):
+    test_event.tidal_sync_enabled = True
+    db.commit()
+    r = client.get(f"/api/events/{test_event.code}/collection", headers=auth_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert "tidal_sync_enabled" in body
+    assert "tidal_playlist_id" in body
+    assert body["tidal_sync_enabled"] is True
+
+
+def test_sync_collection_to_tidal_no_tidal_linked(
+    client, db, auth_headers, test_event, collection_requests
+):
+    test_event.tidal_sync_enabled = True
+    db.commit()
+    r = client.post(
+        f"/api/events/{test_event.code}/collection/sync-tidal",
+        headers=auth_headers,
+    )
+    assert r.status_code == 400
+    assert "not linked" in r.json()["detail"]
+
+
+def test_sync_collection_to_tidal_sync_disabled(
+    client, db, auth_headers, test_event, collection_requests
+):
+    test_event.created_by.tidal_access_token = "fake_tidal_token"
+    # tidal_sync_enabled defaults to False — leave it
+    db.commit()
+    r = client.post(
+        f"/api/events/{test_event.code}/collection/sync-tidal",
+        headers=auth_headers,
+    )
+    assert r.status_code == 400
+    assert "not enabled" in r.json()["detail"]
+
+
+def test_sync_collection_to_tidal_queues_eligible(
+    client, db, auth_headers, test_event, collection_requests
+):
+    test_event.created_by.tidal_access_token = "fake_tidal_token"
+    test_event.tidal_sync_enabled = True
+    # Mark one request as rejected — it should be excluded from the queued count
+    collection_requests[2].status = "rejected"
+    db.commit()
+
+    r = client.post(
+        f"/api/events/{test_event.code}/collection/sync-tidal",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    body = r.json()
+    # 3 total collection requests, 1 rejected → 2 eligible
+    assert body["queued"] == 2
+
+
+def test_sync_collection_to_tidal_empty_queued_when_all_rejected(
+    client, db, auth_headers, test_event, collection_requests
+):
+    test_event.created_by.tidal_access_token = "fake_tidal_token"
+    test_event.tidal_sync_enabled = True
+    for req in collection_requests:
+        req.status = "rejected"
+    db.commit()
+
+    r = client.post(
+        f"/api/events/{test_event.code}/collection/sync-tidal",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["queued"] == 0

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -1000,7 +1000,7 @@ def test_collect_preview_404_nonexistent_request(client, db, test_event):
 
 
 def test_collect_submit_triggers_tidal_sync_when_enabled(client, db, test_event: Event):
-    """Submitting when tidal_sync_enabled=True and tidal_enabled queues sync_request_to_services."""
+    """Submitting when tidal_sync_enabled queues sync_collection_requests_batch."""
     from unittest.mock import patch
 
     from app.services.system_settings import get_system_settings
@@ -1012,7 +1012,7 @@ def test_collect_submit_triggers_tidal_sync_when_enabled(client, db, test_event:
     sys.tidal_enabled = True
     db.commit()
 
-    with patch("app.api.collect.sync_request_to_services") as mock_sync:
+    with patch("app.api.collect.sync_collection_requests_batch") as mock_sync:
         r = client.post(
             f"/api/public/collect/{test_event.code}/requests",
             json={"song_title": "Auto Sync Song", "artist": "DJ Test", "source": "spotify"},
@@ -1023,13 +1023,13 @@ def test_collect_submit_triggers_tidal_sync_when_enabled(client, db, test_event:
 
 
 def test_collect_submit_skips_tidal_sync_when_disabled(client, db, test_event: Event):
-    """Submitting when tidal_sync_enabled=False does not queue sync_request_to_services."""
+    """Submitting when tidal_sync_enabled=False does not queue sync_collection_requests_batch."""
     from unittest.mock import patch
 
     _enable_collection(db, test_event)
     # tidal_sync_enabled defaults to False
 
-    with patch("app.api.collect.sync_request_to_services") as mock_sync:
+    with patch("app.api.collect.sync_collection_requests_batch") as mock_sync:
         r = client.post(
             f"/api/public/collect/{test_event.code}/requests",
             json={"song_title": "No Sync Song", "artist": "DJ Test", "source": "spotify"},

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -997,3 +997,43 @@ def test_collect_preview_404_nonexistent_request(client, db, test_event):
 
     r = client.get(f"/api/public/collect/{test_event.code}/requests/99999/preview")
     assert r.status_code == 404
+
+
+def test_collect_submit_triggers_tidal_sync_when_enabled(client, db, test_event: Event):
+    """Submitting when tidal_sync_enabled=True and tidal_enabled queues sync_request_to_services."""
+    from unittest.mock import patch
+
+    from app.services.system_settings import get_system_settings
+
+    _enable_collection(db, test_event)
+    test_event.tidal_sync_enabled = True
+    test_event.created_by.tidal_access_token = "fake_token"
+    sys = get_system_settings(db)
+    sys.tidal_enabled = True
+    db.commit()
+
+    with patch("app.api.collect.sync_request_to_services") as mock_sync:
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/requests",
+            json={"song_title": "Auto Sync Song", "artist": "DJ Test", "source": "spotify"},
+        )
+
+    assert r.status_code == 201
+    mock_sync.assert_called_once()
+
+
+def test_collect_submit_skips_tidal_sync_when_disabled(client, db, test_event: Event):
+    """Submitting when tidal_sync_enabled=False does not queue sync_request_to_services."""
+    from unittest.mock import patch
+
+    _enable_collection(db, test_event)
+    # tidal_sync_enabled defaults to False
+
+    with patch("app.api.collect.sync_request_to_services") as mock_sync:
+        r = client.post(
+            f"/api/public/collect/{test_event.code}/requests",
+            json={"song_title": "No Sync Song", "artist": "DJ Test", "source": "spotify"},
+        )
+
+    assert r.status_code == 201
+    mock_sync.assert_not_called()


### PR DESCRIPTION
## Summary

- New **Tidal Collection Sync** card on the pre-event tab: checkbox (off by default) enables Tidal sync for the collection phase; **Sync collection to Tidal** button pushes all non-rejected guest suggestions — including unreviewed `new` requests — to the DJ's Tidal playlist so they can listen on mobile while planning the set
- Playlist name now includes the event code: `WrzDJ: ABCDEF – My Event Name` (previously only event name)
- Already-synced tracks are silently skipped (Tidal API dedup + `sync_results_json` application-level guard)
- Section only visible when Tidal is linked and the integration is admin-enabled

## Test plan

- [ ] Backend: 7 new tests in `test_collect_dj.py` covering toggle, settings payload, no-Tidal-linked guard, sync-disabled guard, eligible count, empty-when-all-rejected
- [ ] Frontend: 5 new `PreEventVotingTab` tests — Tidal card visibility, checkbox, sync button conditional
- [ ] Manual: link Tidal, open pre-event tab, enable checkbox, click sync, confirm playlist appears in Tidal mobile app with correct name
- [ ] Manual: re-click sync — no duplicate tracks added
- [ ] CI: 1988 backend tests pass, 87.97% coverage; 946 frontend tests pass; TypeScript clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tidal collection syncing: per-event opt-in toggle, manual "Sync to Tidal" action, queued-sync feedback and status indicators.
  * Automatic enqueue of collection syncs when requests are submitted and event sync is enabled.
  * Event collection playlists persisted separately; playlist titles include event code and name.

* **Tests**
  * Added UI and server tests covering visibility, toggle behavior, sync triggering, queued results, and error cases.

* **Chores**
  * Database migration to store collection playlist identifier.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/303)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->