### PR TITLE
feat: Tidal collection playlist bidirectional sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ A real-time song request system for DJs. Guests scan a QR code to submit request
 - Mandatory nickname gate with profanity filter and letter-padding bypass protection
 - Email verification with one-time codes (Resend API) and cross-device guest profile merge
 - Pre-event song collection (`/collect`) — guests vote on suggestions before the night, DJs bulk-review
+- Inline song preview in the collect detail sheet (Spotify/Tidal embed)
+- Verified badge next to email-verified nicknames in request lists and leaderboard
 - Tower v2 UI on `/join` and `/collect` with banner art, song detail panels, and vibes enrichment
 
 **DJ dashboard**
@@ -52,6 +54,8 @@ A real-time song request system for DJs. Guests scan a QR code to submit request
 - Event banners, play history with source badges, CSV export
 - "Enrich All" advanced action to backfill BPM/key/genre on existing requests in batches
 - Pre-event collection toggle per event (enable guest voting before doors open)
+- Collection suggestions sync to a dedicated pre-event Tidal playlist; bidirectional option auto-rejects requests removed from the playlist
+- Self-service account management: DJs can update their own password and email address
 - Bridge connection status, activity log, contextual help system
 - Cloud provider OAuth (Tidal, Beatport) with per-event playlist sync toggles
 

--- a/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
+++ b/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
@@ -97,6 +97,7 @@ export default function PreEventVotingTab({
   const [settingsSaved, setSettingsSaved] = useState(false);
 
   const [togglingTidal, setTogglingTidal] = useState(false);
+  const [togglingBidirectional, setTogglingBidirectional] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [syncResult, setSyncResult] = useState<{ queued: number } | null>(null);
   const [syncError, setSyncError] = useState<string | null>(null);
@@ -177,6 +178,7 @@ export default function PreEventVotingTab({
   }
 
   async function handleToggleBidirectional(enabled: boolean) {
+    setTogglingBidirectional(true);
     setSyncError(null);
     try {
       const resp = await apiClient.patchCollectionSettings(event.code, {
@@ -187,6 +189,8 @@ export default function PreEventVotingTab({
       setSyncError(
         err instanceof Error ? err.message : 'Failed to update bidirectional sync setting',
       );
+    } finally {
+      setTogglingBidirectional(false);
     }
   }
 
@@ -372,6 +376,7 @@ export default function PreEventVotingTab({
                 <input
                   type="checkbox"
                   checked={event.tidal_collection_bidirectional}
+                  disabled={togglingBidirectional}
                   onChange={(e) => handleToggleBidirectional(e.target.checked)}
                 />
                 Songs removed from Tidal playlist are auto-rejected

--- a/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
+++ b/dashboard/app/events/[code]/components/PreEventVotingTab.tsx
@@ -14,6 +14,7 @@ interface EventShape {
   phase: 'pre_announce' | 'collection' | 'live' | 'closed';
   tidal_sync_enabled: boolean;
   tidal_collection_playlist_id: string | null;
+  tidal_collection_bidirectional: boolean;
 }
 
 interface Props {
@@ -175,6 +176,20 @@ export default function PreEventVotingTab({
     }
   }
 
+  async function handleToggleBidirectional(enabled: boolean) {
+    setSyncError(null);
+    try {
+      const resp = await apiClient.patchCollectionSettings(event.code, {
+        tidal_collection_bidirectional: enabled,
+      });
+      onEventChange(resp);
+    } catch (err) {
+      setSyncError(
+        err instanceof Error ? err.message : 'Failed to update bidirectional sync setting',
+      );
+    }
+  }
+
   async function handleSyncToTidal() {
     setSyncing(true);
     setSyncResult(null);
@@ -326,31 +341,41 @@ export default function PreEventVotingTab({
           </label>
 
           {event.tidal_sync_enabled && (
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexWrap: 'wrap' }}>
-              <button
-                type="button"
-                className="btn btn-sm"
-                style={{ background: '#1db954', color: '#fff' }}
-                disabled={syncing}
-                onClick={handleSyncToTidal}
-              >
-                {syncing ? 'Syncing…' : 'Sync collection to Tidal'}
-              </button>
-              {event.tidal_collection_playlist_id && (
-                <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
-                  Pre-event playlist linked ✓
-                </span>
-              )}
-              {syncResult !== null && (
-                <span style={{ fontSize: '0.875rem', color: '#4ade80' }}>
-                  {syncResult.queued === 0
-                    ? 'All tracks already synced.'
-                    : `Queued ${syncResult.queued} track${syncResult.queued === 1 ? '' : 's'} for sync.`}
-                </span>
-              )}
-              {syncError && (
-                <span style={{ fontSize: '0.875rem', color: '#f87171' }}>{syncError}</span>
-              )}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexWrap: 'wrap' }}>
+                <button
+                  type="button"
+                  className="btn btn-sm"
+                  style={{ background: '#1db954', color: '#fff' }}
+                  disabled={syncing}
+                  onClick={handleSyncToTidal}
+                >
+                  {syncing ? 'Syncing…' : 'Sync collection to Tidal'}
+                </button>
+                {event.tidal_collection_playlist_id && (
+                  <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
+                    Pre-event playlist linked ✓
+                  </span>
+                )}
+                {syncResult !== null && (
+                  <span style={{ fontSize: '0.875rem', color: '#4ade80' }}>
+                    {syncResult.queued === 0
+                      ? 'All tracks already synced.'
+                      : `Queued ${syncResult.queued} track${syncResult.queued === 1 ? '' : 's'} for sync.`}
+                  </span>
+                )}
+                {syncError && (
+                  <span style={{ fontSize: '0.875rem', color: '#f87171' }}>{syncError}</span>
+                )}
+              </div>
+              <label className="collection-fieldset-toggle">
+                <input
+                  type="checkbox"
+                  checked={event.tidal_collection_bidirectional}
+                  onChange={(e) => handleToggleBidirectional(e.target.checked)}
+                />
+                Songs removed from Tidal playlist are auto-rejected
+              </label>
             </div>
           )}
         </div>

--- a/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
+++ b/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
@@ -131,4 +131,23 @@ describe("PreEventVotingTab", () => {
       expect(apiClient.syncCollectionToTidal).toHaveBeenCalledWith("ABC");
     });
   });
+
+  it("patches tidal_collection_bidirectional when checkbox is toggled", async () => {
+    render(
+      <PreEventVotingTab
+        event={{ ...baseEvent, tidal_sync_enabled: true, tidal_collection_bidirectional: false }}
+        tidalConnected={true}
+        tidalIntegrationEnabled={true}
+        onEventChange={vi.fn()}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /songs removed from tidal playlist are auto-rejected/i })
+    );
+    await waitFor(() => {
+      expect(apiClient.patchCollectionSettings).toHaveBeenCalledWith("ABC", {
+        tidal_collection_bidirectional: true,
+      });
+    });
+  });
 });

--- a/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
+++ b/dashboard/app/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
@@ -13,6 +13,7 @@ const baseEvent = {
   phase: "collection" as const,
   tidal_sync_enabled: false,
   tidal_collection_playlist_id: null,
+  tidal_collection_bidirectional: false,
 };
 
 vi.mock("@/lib/api", () => ({
@@ -27,6 +28,7 @@ vi.mock("@/lib/api", () => ({
       phase: "live",
       tidal_sync_enabled: false,
       tidal_collection_playlist_id: null,
+      tidal_collection_bidirectional: false,
     }),
     getPendingReview: vi.fn().mockResolvedValue({ requests: [], total: 0 }),
     bulkReview: vi.fn().mockResolvedValue({ accepted: 0, rejected: 0, unchanged: 0 }),

--- a/dashboard/app/events/[code]/page.tsx
+++ b/dashboard/app/events/[code]/page.tsx
@@ -1123,6 +1123,7 @@ export default function EventQueuePage() {
                 phase: collectionSettings.phase,
                 tidal_sync_enabled: collectionSettings.tidal_sync_enabled,
                 tidal_collection_playlist_id: collectionSettings.tidal_collection_playlist_id,
+                tidal_collection_bidirectional: collectionSettings.tidal_collection_bidirectional,
               }}
               tidalConnected={!!tidalStatus?.linked}
               tidalIntegrationEnabled={!!tidalStatus?.integration_enabled}

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -165,6 +165,7 @@ export interface CollectionSettingsResponse {
   phase: 'pre_announce' | 'collection' | 'live' | 'closed';
   tidal_sync_enabled: boolean;
   tidal_collection_playlist_id: string | null;
+  tidal_collection_bidirectional: boolean;
 }
 
 export interface CollectionSyncResponse {
@@ -1328,6 +1329,7 @@ class ApiClient {
       submission_cap_per_guest?: number;
       collection_phase_override?: 'force_collection' | 'force_live' | null;
       tidal_sync_enabled?: boolean;
+      tidal_collection_bidirectional?: boolean;
     },
   ): Promise<CollectionSettingsResponse> {
     return this.fetch(`/api/events/${code}/collection`, {

--- a/docs/superpowers/plans/2026-05-10-tidal-collection-bidirectional-sync.md
+++ b/docs/superpowers/plans/2026-05-10-tidal-collection-bidirectional-sync.md
@@ -1,0 +1,1385 @@
+# Tidal Collection Playlist Bidirectional Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add bidirectional sync between WrzDJ's pre-event collection list and its Tidal collection playlist — rejecting in WrzDJ removes the track from Tidal, and (opt-in) removing from Tidal auto-rejects in WrzDJ via a periodic background poll.
+
+**Architecture:** Store the matched Tidal track ID on each synced collection request (`Request.tidal_collection_track_id`). On rejection, fire a background task calling `playlist.remove_by_id()`. An asyncio lifespan task polls every 5 minutes for events with `tidal_collection_bidirectional=True`, comparing current playlist tracks against synced requests and rejecting any that were removed. A new checkbox in the collection settings UI exposes the opt-in flag.
+
+**Tech Stack:** FastAPI BackgroundTasks, asyncio (lifespan), tidalapi `UserPlaylist.remove_by_id()`, SQLAlchemy 2.0, Alembic, Next.js TypeScript
+
+---
+
+## File Map
+
+**Create:**
+- `server/alembic/versions/044_add_tidal_collection_bidir.py`
+
+**Modify (backend):**
+- `server/app/models/event.py` — add `tidal_collection_bidirectional: Mapped[bool]`
+- `server/app/models/request.py` — add `tidal_collection_track_id: Mapped[str | None]`
+- `server/app/services/tidal.py` — update `sync_collection_requests_batch`; add `remove_track_from_collection_playlist`, `remove_collection_tracks_batch`, `poll_tidal_collection_removals`
+- `server/app/services/collect.py` — `execute_bulk_review` returns 4-tuple including rejected rows
+- `server/app/schemas/collect.py` — add `tidal_collection_bidirectional` to `UpdateCollectionSettings`
+- `server/app/api/events.py` — `bulk_review` fires removal background task; `collection_settings_payload` includes new field
+- `server/app/api/requests.py` — PATCH fires removal task for rejected collection requests
+- `server/app/main.py` — add lifespan context manager with asyncio poll loop
+
+**Modify (frontend):**
+- `dashboard/lib/api.ts` — add `tidal_collection_bidirectional` to `CollectionSettingsResponse` and patch payload
+- `dashboard/app/events/[code]/components/PreEventVotingTab.tsx` — add bidirectional checkbox
+
+**Tests:**
+- `server/tests/test_tidal.py`
+- `server/tests/test_collect_dj.py`
+- `server/tests/test_collect_service.py`
+- `server/tests/test_requests.py`
+
+---
+
+### Task 1: Migration and Model Columns
+
+**Files:**
+- Create: `server/alembic/versions/044_add_tidal_collection_bidir.py`
+- Modify: `server/app/models/event.py`
+- Modify: `server/app/models/request.py`
+
+- [ ] **Step 1: Create the Alembic migration**
+
+Create `server/alembic/versions/044_add_tidal_collection_bidir.py`:
+
+```python
+"""Add tidal_collection_track_id to requests and tidal_collection_bidirectional to events.
+
+Revision ID: 044
+Revises: 043
+Create Date: 2026-05-11
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "044"
+down_revision: str | None = "043"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "requests",
+        sa.Column("tidal_collection_track_id", sa.String(50), nullable=True),
+    )
+    op.add_column(
+        "events",
+        sa.Column(
+            "tidal_collection_bidirectional",
+            sa.Boolean,
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("requests", "tidal_collection_track_id")
+    op.drop_column("events", "tidal_collection_bidirectional")
+```
+
+- [ ] **Step 2: Add `tidal_collection_track_id` to `Request` model**
+
+In `server/app/models/request.py`, after the `vote_count` field, add:
+
+```python
+    # Tidal collection playlist tracking — set when a request is successfully synced
+    tidal_collection_track_id: Mapped[str | None] = mapped_column(String(50), nullable=True)
+```
+
+- [ ] **Step 3: Add `tidal_collection_bidirectional` to `Event` model**
+
+In `server/app/models/event.py`, after the `tidal_collection_playlist_id` line, add:
+
+```python
+    tidal_collection_bidirectional: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="0"
+    )
+```
+
+Verify `Boolean` is already imported from `sqlalchemy` at the top of `event.py`. If not, add it to the existing `from sqlalchemy import ...` line.
+
+- [ ] **Step 4: Run the migration and verify no drift**
+
+```bash
+cd server && .venv/bin/alembic upgrade head && .venv/bin/alembic check
+```
+
+Expected: `No new upgrade operations detected.`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/alembic/versions/044_add_tidal_collection_bidir.py \
+        server/app/models/request.py \
+        server/app/models/event.py
+git commit -m "feat: add tidal_collection_track_id and tidal_collection_bidirectional columns"
+```
+
+---
+
+### Task 2: Store Track ID in `sync_collection_requests_batch`
+
+**Files:**
+- Modify: `server/app/services/tidal.py` (function `sync_collection_requests_batch`)
+- Test: `server/tests/test_tidal.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/tests/test_tidal.py`:
+
+```python
+def test_sync_collection_stores_track_id(db, test_event, test_user, mocker):
+    from app.models.request import Request as SongRequest, RequestStatus
+    from app.services.tidal import sync_collection_requests_batch
+
+    row = SongRequest(
+        event_id=test_event.id,
+        song_title="Acid Rain",
+        artist="Objekt",
+        status=RequestStatus.NEW.value,
+        dedupe_key="objekt-acid-rain",
+        submitted_during_collection=True,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+
+    mock_track = mocker.MagicMock()
+    mock_track.id = 99887766
+    mock_track.name = "Acid Rain"
+    mock_track.artist = mocker.MagicMock()
+    mock_track.artist.name = "Objekt"
+    mock_track.artists = []
+    mock_track.album = None
+    mock_track.bpm = None
+    mock_track.key = None
+    mock_track.duration = None
+    mock_track.popularity = 0
+    mock_track.isrc = None
+    mock_track.version = None
+    mock_track.explicit = False
+
+    mock_session = mocker.MagicMock()
+    mock_session.search.return_value = {"tracks": [mock_track]}
+
+    mocker.patch("app.services.tidal.get_tidal_session", return_value=mock_session)
+    mocker.patch("app.services.tidal.ensure_collection_playlist", return_value="playlist-abc")
+    mocker.patch("app.services.tidal.add_tracks_to_playlist", return_value=True)
+
+    sync_collection_requests_batch(db, test_user, test_event, [row])
+    db.refresh(row)
+
+    assert row.tidal_collection_track_id == "99887766"
+```
+
+- [ ] **Step 2: Verify test fails**
+
+```bash
+cd server && .venv/bin/pytest tests/test_tidal.py::test_sync_collection_stores_track_id -v
+```
+
+Expected: FAIL — `tidal_collection_track_id` is `None` (not yet stored).
+
+- [ ] **Step 3: Update `sync_collection_requests_batch` in `tidal.py`**
+
+Replace the existing `sync_collection_requests_batch` function:
+
+```python
+def sync_collection_requests_batch(
+    db: Session,
+    user: User,
+    event: Event,
+    requests: list,
+) -> None:
+    """Batch-sync pre-event collection requests to the collection playlist.
+
+    Searches tracks sequentially, adds all found IDs in one API call, and
+    stores the matched Tidal track ID on each request for bidirectional sync.
+    Tidal's allow_duplicates=False deduplicates silently at the API layer.
+    """
+    if not requests:
+        return
+
+    playlist_id = ensure_collection_playlist(db, user, event)
+    if not playlist_id:
+        return
+
+    track_ids: list[str] = []
+    matched: list[tuple] = []  # (request, track_id)
+    for req in requests:
+        try:
+            results = search_tidal_tracks(db, user, f"{req.song_title} {req.artist}")
+            if results:
+                track_id = results[0].track_id
+                track_ids.append(track_id)
+                matched.append((req, track_id))
+        except Exception as e:
+            logger.error(f"Collection sync search failed for '{req.song_title}': {e}")
+
+    if track_ids:
+        if add_tracks_to_playlist(db, user, playlist_id, track_ids):
+            for req, track_id in matched:
+                req.tidal_collection_track_id = track_id
+            db.commit()
+```
+
+- [ ] **Step 4: Verify test passes**
+
+```bash
+cd server && .venv/bin/pytest tests/test_tidal.py::test_sync_collection_stores_track_id -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/services/tidal.py server/tests/test_tidal.py
+git commit -m "feat: store tidal_collection_track_id after batch sync"
+```
+
+---
+
+### Task 3: Remove Functions in `tidal.py`
+
+**Files:**
+- Modify: `server/app/services/tidal.py`
+- Test: `server/tests/test_tidal.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `server/tests/test_tidal.py`:
+
+```python
+def test_remove_track_from_collection_playlist_success(test_event, test_user, mocker):
+    from app.services.tidal import remove_track_from_collection_playlist
+
+    mock_playlist = mocker.MagicMock()
+    mock_playlist.remove_by_id.return_value = True
+    mock_session = mocker.MagicMock()
+    mock_session.playlist.return_value = mock_playlist
+    mocker.patch("app.services.tidal.get_tidal_session", return_value=mock_session)
+
+    test_event.tidal_collection_playlist_id = "pl-123"
+    db_mock = mocker.MagicMock()
+
+    result = remove_track_from_collection_playlist(db_mock, test_user, test_event, "track-456")
+
+    mock_session.playlist.assert_called_once_with("pl-123")
+    mock_playlist.remove_by_id.assert_called_once_with("track-456")
+    assert result is True
+
+
+def test_remove_track_from_collection_playlist_no_playlist(test_event, test_user, mocker):
+    from app.services.tidal import remove_track_from_collection_playlist
+
+    mock_session = mocker.MagicMock()
+    mocker.patch("app.services.tidal.get_tidal_session", return_value=mock_session)
+    test_event.tidal_collection_playlist_id = None
+    db_mock = mocker.MagicMock()
+
+    result = remove_track_from_collection_playlist(db_mock, test_user, test_event, "track-456")
+
+    mock_session.playlist.assert_not_called()
+    assert result is False
+
+
+def test_remove_collection_tracks_batch_calls_per_track(test_event, test_user, mocker):
+    from app.services.tidal import remove_collection_tracks_batch
+
+    mock_remove = mocker.patch(
+        "app.services.tidal.remove_track_from_collection_playlist", return_value=True
+    )
+    test_event.tidal_collection_playlist_id = "pl-123"
+    db_mock = mocker.MagicMock()
+
+    remove_collection_tracks_batch(db_mock, test_user, test_event, ["t1", "t2", "t3"])
+
+    assert mock_remove.call_count == 3
+```
+
+- [ ] **Step 2: Verify tests fail**
+
+```bash
+cd server && .venv/bin/pytest \
+  tests/test_tidal.py::test_remove_track_from_collection_playlist_success \
+  tests/test_tidal.py::test_remove_track_from_collection_playlist_no_playlist \
+  tests/test_tidal.py::test_remove_collection_tracks_batch_calls_per_track -v
+```
+
+Expected: FAIL — functions not defined.
+
+- [ ] **Step 3: Add the two functions to `tidal.py`**
+
+Add after `add_tracks_to_playlist` and before `sync_request_to_tidal`:
+
+```python
+def remove_track_from_collection_playlist(
+    db: Session,
+    user: User,
+    event: Event,
+    track_id: str,
+) -> bool:
+    """Remove a single track from the event's Tidal collection playlist.
+
+    Returns True on success, False if the playlist doesn't exist or the API call fails.
+    Failures are logged but not raised — removal is best-effort.
+    """
+    playlist_id = event.tidal_collection_playlist_id
+    if not playlist_id:
+        return False
+
+    session = get_tidal_session(db, user)
+    if not session:
+        return False
+
+    try:
+        playlist = session.playlist(playlist_id)
+        return bool(playlist.remove_by_id(track_id))
+    except Exception as e:
+        logger.error(f"Failed to remove track {track_id} from collection playlist: {e}")
+        return False
+
+
+def remove_collection_tracks_batch(
+    db: Session,
+    user: User,
+    event: Event,
+    track_ids: list[str],
+) -> None:
+    """Remove multiple tracks from the collection playlist, one by one.
+
+    Best-effort: logs failures per track but does not abort on error.
+    """
+    for track_id in track_ids:
+        remove_track_from_collection_playlist(db, user, event, track_id)
+```
+
+- [ ] **Step 4: Verify tests pass**
+
+```bash
+cd server && .venv/bin/pytest \
+  tests/test_tidal.py::test_remove_track_from_collection_playlist_success \
+  tests/test_tidal.py::test_remove_track_from_collection_playlist_no_playlist \
+  tests/test_tidal.py::test_remove_collection_tracks_batch_calls_per_track -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/services/tidal.py server/tests/test_tidal.py
+git commit -m "feat: add remove_track_from_collection_playlist and batch variant"
+```
+
+---
+
+### Task 4: `poll_tidal_collection_removals`
+
+**Files:**
+- Modify: `server/app/services/tidal.py`
+- Test: `server/tests/test_tidal.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `server/tests/test_tidal.py`:
+
+```python
+def test_poll_tidal_collection_removals_rejects_missing_track(db, test_event, test_user, mocker):
+    from app.models.request import Request as SongRequest, RequestStatus
+    from app.services.tidal import poll_tidal_collection_removals
+
+    test_event.tidal_collection_playlist_id = "pl-xyz"
+    test_event.created_by = test_user
+
+    kept = SongRequest(
+        event_id=test_event.id,
+        song_title="Track A",
+        artist="Artist A",
+        status=RequestStatus.NEW.value,
+        dedupe_key="track-a",
+        submitted_during_collection=True,
+        tidal_collection_track_id="111",
+    )
+    removed = SongRequest(
+        event_id=test_event.id,
+        song_title="Track B",
+        artist="Artist B",
+        status=RequestStatus.NEW.value,
+        dedupe_key="track-b",
+        submitted_during_collection=True,
+        tidal_collection_track_id="222",
+    )
+    db.add_all([kept, removed])
+    db.commit()
+
+    mock_track = mocker.MagicMock()
+    mock_track.id = 111  # only "111" still in playlist; "222" was removed
+
+    mocker.patch("app.services.tidal.get_playlist_tracks", return_value=[mock_track])
+
+    count = poll_tidal_collection_removals(db, test_event)
+
+    db.refresh(kept)
+    db.refresh(removed)
+
+    assert count == 1
+    assert kept.status == RequestStatus.NEW.value
+    assert removed.status == RequestStatus.REJECTED.value
+
+
+def test_poll_tidal_collection_removals_no_playlist_returns_zero(db, test_event, test_user, mocker):
+    from app.services.tidal import poll_tidal_collection_removals
+
+    test_event.tidal_collection_playlist_id = None
+    test_event.created_by = test_user
+
+    mock_get = mocker.patch("app.services.tidal.get_playlist_tracks")
+
+    count = poll_tidal_collection_removals(db, test_event)
+
+    mock_get.assert_not_called()
+    assert count == 0
+
+
+def test_poll_tidal_collection_removals_skips_already_rejected(db, test_event, test_user, mocker):
+    from app.models.request import Request as SongRequest, RequestStatus
+    from app.services.tidal import poll_tidal_collection_removals
+
+    test_event.tidal_collection_playlist_id = "pl-xyz"
+    test_event.created_by = test_user
+
+    already_rejected = SongRequest(
+        event_id=test_event.id,
+        song_title="Old Track",
+        artist="Artist",
+        status=RequestStatus.REJECTED.value,
+        dedupe_key="old-track",
+        submitted_during_collection=True,
+        tidal_collection_track_id="333",
+    )
+    db.add(already_rejected)
+    db.commit()
+
+    mocker.patch("app.services.tidal.get_playlist_tracks", return_value=[])
+
+    count = poll_tidal_collection_removals(db, test_event)
+
+    assert count == 0  # already rejected — not double-counted
+```
+
+- [ ] **Step 2: Verify tests fail**
+
+```bash
+cd server && .venv/bin/pytest \
+  tests/test_tidal.py::test_poll_tidal_collection_removals_rejects_missing_track \
+  tests/test_tidal.py::test_poll_tidal_collection_removals_no_playlist_returns_zero \
+  tests/test_tidal.py::test_poll_tidal_collection_removals_skips_already_rejected -v
+```
+
+Expected: FAIL — function not defined.
+
+- [ ] **Step 3: Add `poll_tidal_collection_removals` to `tidal.py`**
+
+The existing import at the top of `tidal.py` reads:
+```python
+from app.models.request import Request, TidalSyncStatus
+```
+
+Update it to:
+```python
+from app.models.request import Request, RequestStatus, TidalSyncStatus
+```
+
+Append after `remove_collection_tracks_batch`:
+
+```python
+def poll_tidal_collection_removals(db: Session, event: Event) -> int:
+    """Detect tracks removed from the Tidal collection playlist and reject them in WrzDJ.
+
+    Fetches current playlist contents, finds collection requests whose
+    tidal_collection_track_id is no longer present, and marks them rejected.
+    Only runs when the event has a collection playlist configured.
+
+    Returns the count of newly rejected requests.
+    """
+    if not event.tidal_collection_playlist_id:
+        return 0
+
+    user = event.created_by
+    playlist_tracks = get_playlist_tracks(db, user, event.tidal_collection_playlist_id)
+    current_ids = {str(t.id) for t in playlist_tracks}
+
+    synced = (
+        db.query(Request)
+        .filter(
+            Request.event_id == event.id,
+            Request.submitted_during_collection == True,  # noqa: E712
+            Request.tidal_collection_track_id.isnot(None),
+            Request.status != RequestStatus.REJECTED.value,
+        )
+        .all()
+    )
+
+    count = 0
+    for req in synced:
+        if req.tidal_collection_track_id not in current_ids:
+            req.status = RequestStatus.REJECTED.value
+            count += 1
+
+    if count > 0:
+        db.commit()
+        logger.info("Tidal poll: rejected %d removed track(s) for event %s", count, event.code)
+
+    return count
+```
+
+- [ ] **Step 4: Verify tests pass**
+
+```bash
+cd server && .venv/bin/pytest \
+  tests/test_tidal.py::test_poll_tidal_collection_removals_rejects_missing_track \
+  tests/test_tidal.py::test_poll_tidal_collection_removals_no_playlist_returns_zero \
+  tests/test_tidal.py::test_poll_tidal_collection_removals_skips_already_rejected -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/services/tidal.py server/tests/test_tidal.py
+git commit -m "feat: add poll_tidal_collection_removals"
+```
+
+---
+
+### Task 5: Direction 1 — Bulk Review Rejection Fires Removal Task
+
+**Files:**
+- Modify: `server/app/services/collect.py` (`execute_bulk_review`)
+- Modify: `server/app/api/events.py` (`bulk_review` endpoint)
+- Test: `server/tests/test_collect_service.py`
+- Test: `server/tests/test_collect_dj.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `server/tests/test_collect_service.py`:
+
+```python
+def test_execute_bulk_review_returns_rejected_rows(db, test_event):
+    from app.models.request import Request as SongRequest, RequestStatus
+    from app.schemas.collect import BulkReviewRequest
+    from app.services.collect import execute_bulk_review
+
+    req = SongRequest(
+        event_id=test_event.id,
+        song_title="Track",
+        artist="Artist",
+        status=RequestStatus.NEW.value,
+        dedupe_key="track-artist",
+        submitted_during_collection=True,
+        tidal_collection_track_id="tid-1",
+    )
+    db.add(req)
+    db.commit()
+
+    payload = BulkReviewRequest(action="reject_ids", request_ids=[req.id])
+    accepted, rejected, accepted_rows, rejected_rows = execute_bulk_review(
+        db, test_event.id, payload
+    )
+
+    assert accepted == 0
+    assert rejected == 1
+    assert len(rejected_rows) == 1
+    assert rejected_rows[0].id == req.id
+```
+
+Add to `server/tests/test_collect_dj.py`:
+
+```python
+def test_bulk_reject_queues_tidal_removal_for_synced_requests(
+    client, db, auth_headers, test_event, mocker
+):
+    from app.models.request import Request as SongRequest, RequestStatus
+
+    req = SongRequest(
+        event_id=test_event.id,
+        song_title="Gone Track",
+        artist="DJ X",
+        status=RequestStatus.NEW.value,
+        dedupe_key="gone-track",
+        submitted_during_collection=True,
+        tidal_collection_track_id="tid-999",
+    )
+    db.add(req)
+    db.commit()
+    db.refresh(req)
+
+    test_event.tidal_sync_enabled = True
+    db.commit()
+
+    mock_remove = mocker.patch("app.api.events.remove_collection_tracks_batch")
+
+    resp = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "reject_ids", "request_ids": [req.id]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    mock_remove.assert_called_once()
+    _, _, _, track_ids = mock_remove.call_args[0]
+    assert "tid-999" in track_ids
+
+
+def test_bulk_reject_skips_tidal_removal_when_no_track_id(
+    client, db, auth_headers, test_event, mocker
+):
+    from app.models.request import Request as SongRequest, RequestStatus
+
+    req = SongRequest(
+        event_id=test_event.id,
+        song_title="Unsynced",
+        artist="DJ X",
+        status=RequestStatus.NEW.value,
+        dedupe_key="unsynced",
+        submitted_during_collection=True,
+        tidal_collection_track_id=None,
+    )
+    db.add(req)
+    db.commit()
+
+    test_event.tidal_sync_enabled = True
+    db.commit()
+
+    mock_remove = mocker.patch("app.api.events.remove_collection_tracks_batch")
+
+    resp = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "reject_ids", "request_ids": [req.id]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    mock_remove.assert_not_called()
+```
+
+- [ ] **Step 2: Verify tests fail**
+
+```bash
+cd server && .venv/bin/pytest \
+  tests/test_collect_service.py::test_execute_bulk_review_returns_rejected_rows \
+  tests/test_collect_dj.py::test_bulk_reject_queues_tidal_removal_for_synced_requests \
+  tests/test_collect_dj.py::test_bulk_reject_skips_tidal_removal_when_no_track_id -v
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Update `execute_bulk_review` in `collect.py`**
+
+Replace the entire function with the updated version that adds a `rejected_rows` accumulator and returns it:
+
+```python
+def execute_bulk_review(
+    db: Session, event_id: int, payload: BulkReviewRequest
+) -> tuple[int, int, list[SongRequest], list[SongRequest]]:
+    """Apply a bulk-review action to collection-phase pending requests.
+
+    Returns (accepted_count, rejected_count, accepted_rows, rejected_rows). Caller is expected
+    to pass accepted_rows to sync_requests_batch() and rejected_rows to
+    remove_collection_tracks_batch() as FastAPI background tasks.
+    """
+    pending_q = (
+        db.query(SongRequest)
+        .filter(SongRequest.event_id == event_id)
+        .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
+        .filter(SongRequest.status == "new")
+    )
+
+    accepted = 0
+    rejected = 0
+    accepted_rows: list[SongRequest] = []
+    rejected_rows: list[SongRequest] = []
+
+    if payload.action == "accept_top_n":
+        if payload.n is None:
+            raise HTTPException(status_code=400, detail="n is required")
+        rows = (
+            pending_q.order_by(SongRequest.vote_count.desc(), SongRequest.created_at.asc())
+            .limit(payload.n)
+            .all()
+        )
+        for r in rows:
+            r.status = "accepted"
+            accepted += 1
+            accepted_rows.append(r)
+    elif payload.action == "accept_threshold":
+        if payload.min_votes is None:
+            raise HTTPException(status_code=400, detail="min_votes is required")
+        rows = pending_q.filter(SongRequest.vote_count >= payload.min_votes).all()
+        for r in rows:
+            r.status = "accepted"
+            accepted += 1
+            accepted_rows.append(r)
+    elif payload.action == "accept_ids":
+        if not payload.request_ids:
+            raise HTTPException(status_code=400, detail="request_ids is required")
+        rows = pending_q.filter(SongRequest.id.in_(payload.request_ids)).all()
+        for r in rows:
+            r.status = "accepted"
+            accepted += 1
+            accepted_rows.append(r)
+    elif payload.action == "reject_ids":
+        if not payload.request_ids:
+            raise HTTPException(status_code=400, detail="request_ids is required")
+        rows = pending_q.filter(SongRequest.id.in_(payload.request_ids)).all()
+        for r in rows:
+            r.status = "rejected"
+            rejected += 1
+            rejected_rows.append(r)
+    elif payload.action == "reject_remaining":
+        rows = pending_q.all()
+        for r in rows:
+            r.status = "rejected"
+            rejected += 1
+            rejected_rows.append(r)
+
+    db.commit()
+    return accepted, rejected, accepted_rows, rejected_rows
+```
+
+- [ ] **Step 4: Update the `bulk_review` endpoint in `events.py`**
+
+Update the import line (find the existing `from app.services.tidal import sync_collection_requests_batch` near line 99):
+
+```python
+from app.services.tidal import (
+    remove_collection_tracks_batch,
+    sync_collection_requests_batch,
+)
+```
+
+Replace the `bulk_review` function body:
+
+```python
+@router.post("/{code}/bulk-review", response_model=BulkReviewResponse)
+def bulk_review(
+    payload: BulkReviewRequest,
+    background_tasks: BackgroundTasks,
+    event: Event = Depends(get_event_for_dj_or_admin),
+    db: Session = Depends(get_db),
+):
+    accepted, rejected, accepted_rows, rejected_rows = execute_bulk_review(db, event.id, payload)
+    if accepted_rows:
+        for row in accepted_rows:
+            background_tasks.add_task(enrich_request_metadata, db, row.id)
+        background_tasks.add_task(sync_requests_batch, db, accepted_rows)
+
+    # Direction 1: remove rejected+synced tracks from the Tidal collection playlist
+    if event.tidal_sync_enabled:
+        track_ids_to_remove = [
+            r.tidal_collection_track_id
+            for r in rejected_rows
+            if r.tidal_collection_track_id
+        ]
+        if track_ids_to_remove:
+            background_tasks.add_task(
+                remove_collection_tracks_batch,
+                db,
+                event.created_by,
+                event,
+                track_ids_to_remove,
+            )
+
+    return BulkReviewResponse(accepted=accepted, rejected=rejected, unchanged=0)
+```
+
+- [ ] **Step 5: Verify tests pass**
+
+```bash
+cd server && .venv/bin/pytest \
+  tests/test_collect_service.py::test_execute_bulk_review_returns_rejected_rows \
+  tests/test_collect_dj.py::test_bulk_reject_queues_tidal_removal_for_synced_requests \
+  tests/test_collect_dj.py::test_bulk_reject_skips_tidal_removal_when_no_track_id -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full backend suite to catch any callers of `execute_bulk_review` that need the updated destructuring**
+
+```bash
+cd server && .venv/bin/pytest --tb=short -q
+```
+
+Fix any failures from the changed 3-tuple → 4-tuple return before continuing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/app/services/collect.py server/app/api/events.py \
+        server/tests/test_collect_service.py server/tests/test_collect_dj.py
+git commit -m "feat: bulk review rejection removes tracks from Tidal collection playlist"
+```
+
+---
+
+### Task 6: Direction 1 — Individual PATCH Rejection Fires Removal Task
+
+**Files:**
+- Modify: `server/app/api/requests.py`
+- Test: `server/tests/test_requests.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `server/tests/test_requests.py`:
+
+```python
+def test_rejecting_synced_collection_request_queues_tidal_removal(
+    client, db, auth_headers, test_event, mocker
+):
+    from app.models.request import Request as SongRequest, RequestStatus
+
+    test_event.tidal_sync_enabled = True
+    db.commit()
+
+    req = SongRequest(
+        event_id=test_event.id,
+        song_title="Synced Track",
+        artist="DJ Y",
+        status=RequestStatus.NEW.value,
+        dedupe_key="synced-track-dj-y",
+        submitted_during_collection=True,
+        tidal_collection_track_id="tid-555",
+    )
+    db.add(req)
+    db.commit()
+    db.refresh(req)
+
+    mock_remove = mocker.patch("app.api.requests.remove_track_from_collection_playlist")
+
+    resp = client.patch(
+        f"/api/events/{test_event.code}/requests/{req.id}",
+        json={"status": "rejected"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    mock_remove.assert_called_once()
+
+
+def test_rejecting_unsynced_collection_request_skips_tidal(
+    client, db, auth_headers, test_event, mocker
+):
+    from app.models.request import Request as SongRequest, RequestStatus
+
+    req = SongRequest(
+        event_id=test_event.id,
+        song_title="Unsynced Track",
+        artist="DJ Z",
+        status=RequestStatus.NEW.value,
+        dedupe_key="unsynced-track-dj-z",
+        submitted_during_collection=True,
+        tidal_collection_track_id=None,
+    )
+    db.add(req)
+    db.commit()
+    db.refresh(req)
+
+    mock_remove = mocker.patch("app.api.requests.remove_track_from_collection_playlist")
+
+    resp = client.patch(
+        f"/api/events/{test_event.code}/requests/{req.id}",
+        json={"status": "rejected"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    mock_remove.assert_not_called()
+```
+
+- [ ] **Step 2: Verify tests fail**
+
+```bash
+cd server && .venv/bin/pytest \
+  tests/test_requests.py::test_rejecting_synced_collection_request_queues_tidal_removal \
+  tests/test_requests.py::test_rejecting_unsynced_collection_request_skips_tidal -v
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Update `requests.py`**
+
+Add the import near the top of `server/app/api/requests.py`:
+
+```python
+from app.services.tidal import remove_track_from_collection_playlist
+```
+
+In the `PATCH /{request_id}` handler, find the existing block that checks `update_data.status == RequestStatus.ACCEPTED`. After it, add:
+
+```python
+    if (
+        update_data.status == RequestStatus.REJECTED
+        and request.submitted_during_collection
+        and request.tidal_collection_track_id
+        and request.event.tidal_sync_enabled
+    ):
+        background_tasks.add_task(
+            remove_track_from_collection_playlist,
+            db,
+            request.event.created_by,
+            request.event,
+            request.tidal_collection_track_id,
+        )
+```
+
+Note: `request` in `requests.py` refers to the `SongRequest` ORM object (not the FastAPI `Request`). The FastAPI request is named differently in that handler — check the existing variable names before editing to avoid shadowing. If the handler uses `req` for the ORM object, use `req.event` and `req.submitted_during_collection` etc.
+
+- [ ] **Step 4: Verify tests pass**
+
+```bash
+cd server && .venv/bin/pytest \
+  tests/test_requests.py::test_rejecting_synced_collection_request_queues_tidal_removal \
+  tests/test_requests.py::test_rejecting_unsynced_collection_request_skips_tidal -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/api/requests.py server/tests/test_requests.py
+git commit -m "feat: individual request rejection removes track from Tidal collection playlist"
+```
+
+---
+
+### Task 7: Asyncio Lifespan Poller
+
+**Files:**
+- Modify: `server/app/main.py`
+
+- [ ] **Step 1: Add the lifespan and poll loop to `main.py`**
+
+The current `main.py` creates `app = FastAPI(...)` without a `lifespan` argument. Update the file to add the following **before** the `app = FastAPI(...)` line:
+
+```python
+import asyncio
+import contextlib
+from contextlib import asynccontextmanager
+```
+
+Add these at module level (after imports, before `app = FastAPI(...)`):
+
+```python
+TIDAL_COLLECTION_POLL_INTERVAL_SECONDS = 300  # 5 minutes
+
+
+def _run_tidal_collection_poll() -> None:
+    """Synchronous poll, executed in a thread to avoid blocking the event loop."""
+    from app.db.session import SessionLocal
+    from app.models.event import Event
+    from app.services.tidal import poll_tidal_collection_removals
+
+    db = SessionLocal()
+    try:
+        events = (
+            db.query(Event)
+            .filter(
+                Event.tidal_sync_enabled == True,  # noqa: E712
+                Event.tidal_collection_bidirectional == True,  # noqa: E712
+                Event.tidal_collection_playlist_id.isnot(None),
+            )
+            .all()
+        )
+        for event in events:
+            if event.phase == "collection":
+                try:
+                    poll_tidal_collection_removals(db, event)
+                except Exception:
+                    logger.exception(
+                        "Tidal collection poll failed for event %s", event.code
+                    )
+    finally:
+        db.close()
+
+
+async def _tidal_collection_poll_loop() -> None:
+    while True:
+        await asyncio.sleep(TIDAL_COLLECTION_POLL_INTERVAL_SECONDS)
+        try:
+            await asyncio.to_thread(_run_tidal_collection_poll)
+        except Exception:
+            logger.exception("Tidal collection poll loop error")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    task = asyncio.create_task(_tidal_collection_poll_loop())
+    try:
+        yield
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+```
+
+Then update the `app = FastAPI(...)` call to pass `lifespan=lifespan`:
+
+```python
+app = FastAPI(
+    title="WrzDJ API",
+    description="Song request system for DJs",
+    version="0.1.0",
+    lifespan=lifespan,
+    docs_url=None if settings.is_production else "/docs",
+    redoc_url=None if settings.is_production else "/redoc",
+    openapi_url=None if settings.is_production else "/openapi.json",
+)
+```
+
+- [ ] **Step 2: Verify the app starts cleanly**
+
+```bash
+cd server && source .venv/bin/activate && uvicorn app.main:app --host 0.0.0.0 --port 8001 &
+sleep 3 && curl -s http://localhost:8001/api/health && kill %1
+```
+
+Expected: health endpoint responds (JSON with `"status":"ok"` or equivalent). No import errors or startup exceptions in uvicorn output.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+cd server && .venv/bin/pytest --tb=short -q
+```
+
+Expected: all passing. The lifespan task does not fire during pytest (no ASGI lifespan is triggered by the default TestClient unless explicitly configured).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/app/main.py
+git commit -m "feat: asyncio lifespan task polls Tidal collection playlists every 5 minutes"
+```
+
+---
+
+### Task 8: Schema + API for `tidal_collection_bidirectional`
+
+**Files:**
+- Modify: `server/app/schemas/collect.py`
+- Modify: `server/app/services/collect.py` (`collection_settings_payload`, `update_collection_settings`)
+- Test: `server/tests/test_collect_dj.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `server/tests/test_collect_dj.py`:
+
+```python
+def test_collection_settings_response_includes_bidirectional(client, auth_headers, test_event):
+    resp = client.get(
+        f"/api/events/{test_event.code}/collection",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert "tidal_collection_bidirectional" in resp.json()
+    assert resp.json()["tidal_collection_bidirectional"] is False  # default
+
+
+def test_patch_collection_settings_sets_bidirectional(client, db, auth_headers, test_event):
+    resp = client.patch(
+        f"/api/events/{test_event.code}/collection",
+        json={"tidal_collection_bidirectional": True},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["tidal_collection_bidirectional"] is True
+
+    db.refresh(test_event)
+    assert test_event.tidal_collection_bidirectional is True
+```
+
+- [ ] **Step 2: Verify tests fail**
+
+```bash
+cd server && .venv/bin/pytest \
+  tests/test_collect_dj.py::test_collection_settings_response_includes_bidirectional \
+  tests/test_collect_dj.py::test_patch_collection_settings_sets_bidirectional -v
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Update `UpdateCollectionSettings` schema in `collect.py`**
+
+In `server/app/schemas/collect.py`, find `UpdateCollectionSettings` and add the new field:
+
+```python
+class UpdateCollectionSettings(BaseModel):
+    collection_opens_at: datetime | None = None
+    live_starts_at: datetime | None = None
+    submission_cap_per_guest: int | None = None
+    collection_phase_override: str | None = None
+    tidal_sync_enabled: bool | None = None
+    tidal_collection_bidirectional: bool | None = None
+```
+
+- [ ] **Step 4: Update `collection_settings_payload` in `collect.py` service**
+
+In `server/app/services/collect.py`, update `collection_settings_payload`:
+
+```python
+def collection_settings_payload(event: Event) -> dict:
+    return {
+        "collection_opens_at": event.collection_opens_at,
+        "live_starts_at": event.live_starts_at,
+        "submission_cap_per_guest": event.submission_cap_per_guest,
+        "collection_phase_override": event.collection_phase_override,
+        "phase": event.phase,
+        "tidal_sync_enabled": event.tidal_sync_enabled,
+        "tidal_collection_playlist_id": event.tidal_collection_playlist_id,
+        "tidal_collection_bidirectional": event.tidal_collection_bidirectional,
+    }
+```
+
+In `update_collection_settings`, after the `tidal_sync_enabled` block, add:
+
+```python
+    if payload.tidal_collection_bidirectional is not None:
+        event.tidal_collection_bidirectional = payload.tidal_collection_bidirectional
+```
+
+- [ ] **Step 5: Verify tests pass**
+
+```bash
+cd server && .venv/bin/pytest \
+  tests/test_collect_dj.py::test_collection_settings_response_includes_bidirectional \
+  tests/test_collect_dj.py::test_patch_collection_settings_sets_bidirectional -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run full backend CI checks**
+
+```bash
+cd server
+.venv/bin/ruff check .
+.venv/bin/ruff format --check .
+.venv/bin/bandit -r app -c pyproject.toml -q
+.venv/bin/pytest --tb=short -q
+```
+
+Fix any lint issues before committing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/app/schemas/collect.py server/app/services/collect.py \
+        server/tests/test_collect_dj.py
+git commit -m "feat: expose tidal_collection_bidirectional in collection settings API"
+```
+
+---
+
+### Task 9: Frontend Checkbox
+
+**Files:**
+- Modify: `dashboard/lib/api.ts`
+- Modify: `dashboard/app/events/[code]/components/PreEventVotingTab.tsx`
+
+- [ ] **Step 1: Update `CollectionSettingsResponse` and patch payload in `api.ts`**
+
+In `dashboard/lib/api.ts`, find `CollectionSettingsResponse` and add the new field:
+
+```typescript
+export interface CollectionSettingsResponse {
+  collection_opens_at: string | null;
+  live_starts_at: string | null;
+  submission_cap_per_guest: number;
+  collection_phase_override: 'force_collection' | 'force_live' | null;
+  phase: 'pre_announce' | 'collection' | 'live' | 'closed';
+  tidal_sync_enabled: boolean;
+  tidal_collection_playlist_id: string | null;
+  tidal_collection_bidirectional: boolean;
+}
+```
+
+Find `patchCollectionSettings` and add the new field to the settings parameter type:
+
+```typescript
+async patchCollectionSettings(
+  code: string,
+  settings: {
+    collection_opens_at?: string | null;
+    live_starts_at?: string | null;
+    submission_cap_per_guest?: number;
+    collection_phase_override?: string | null;
+    tidal_sync_enabled?: boolean;
+    tidal_collection_bidirectional?: boolean;
+  },
+): Promise<CollectionSettingsResponse>
+```
+
+- [ ] **Step 2: Add `tidal_collection_bidirectional` to `EventShape` in `PreEventVotingTab.tsx`**
+
+Update the `EventShape` interface (lines 7–17):
+
+```typescript
+interface EventShape {
+  code: string;
+  name: string;
+  collection_opens_at: string | null;
+  live_starts_at: string | null;
+  submission_cap_per_guest: number;
+  collection_phase_override: 'force_collection' | 'force_live' | null;
+  phase: 'pre_announce' | 'collection' | 'live' | 'closed';
+  tidal_sync_enabled: boolean;
+  tidal_collection_playlist_id: string | null;
+  tidal_collection_bidirectional: boolean;
+}
+```
+
+- [ ] **Step 3: Add the handler function**
+
+After `handleToggleTidalSync` (around line 176), add:
+
+```typescript
+  async function handleToggleBidirectional(enabled: boolean) {
+    setSyncError(null);
+    try {
+      const resp = await apiClient.patchCollectionSettings(event.code, {
+        tidal_collection_bidirectional: enabled,
+      });
+      onEventChange(resp);
+    } catch (err) {
+      setSyncError(
+        err instanceof Error ? err.message : 'Failed to update bidirectional sync setting',
+      );
+    }
+  }
+```
+
+- [ ] **Step 4: Add the checkbox to the JSX**
+
+Replace the existing `{event.tidal_sync_enabled && (...)}` block (lines 328–355) with the updated version that adds the checkbox as a second row:
+
+```tsx
+          {event.tidal_sync_enabled && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexWrap: 'wrap' }}>
+                <button
+                  type="button"
+                  className="btn btn-sm"
+                  style={{ background: '#1db954', color: '#fff' }}
+                  disabled={syncing}
+                  onClick={handleSyncToTidal}
+                >
+                  {syncing ? 'Syncing…' : 'Sync collection to Tidal'}
+                </button>
+                {event.tidal_collection_playlist_id && (
+                  <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
+                    Pre-event playlist linked ✓
+                  </span>
+                )}
+                {syncResult !== null && (
+                  <span style={{ fontSize: '0.875rem', color: '#4ade80' }}>
+                    {syncResult.queued === 0
+                      ? 'All tracks already synced.'
+                      : `Queued ${syncResult.queued} track${syncResult.queued === 1 ? '' : 's'} for sync.`}
+                  </span>
+                )}
+                {syncError && (
+                  <span style={{ fontSize: '0.875rem', color: '#f87171' }}>{syncError}</span>
+                )}
+              </div>
+              <label className="collection-fieldset-toggle">
+                <input
+                  type="checkbox"
+                  checked={event.tidal_collection_bidirectional}
+                  onChange={(e) => handleToggleBidirectional(e.target.checked)}
+                />
+                Songs removed from Tidal playlist are auto-rejected
+              </label>
+            </div>
+          )}
+```
+
+- [ ] **Step 5: Fix any TypeScript errors from callers that construct `EventShape`**
+
+Run:
+
+```bash
+cd dashboard && npx tsc --noEmit 2>&1 | head -40
+```
+
+For any error that says an object literal is missing `tidal_collection_bidirectional`, add `tidal_collection_bidirectional: false` (or the real value from the API response) to that object. Common locations: `page.tsx` in `app/events/[code]/`, test fixtures in `__tests__/`.
+
+- [ ] **Step 6: Run frontend CI checks**
+
+```bash
+cd dashboard
+npm run lint
+npx tsc --noEmit
+npm test -- --run
+```
+
+Expected: all passing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/lib/api.ts \
+        "dashboard/app/events/[code]/components/PreEventVotingTab.tsx"
+git commit -m "feat: bidirectional Tidal sync checkbox in collection settings"
+```
+
+---
+
+### Task 10: Final CI Pass and PR
+
+- [ ] **Step 1: Full backend CI**
+
+```bash
+cd server
+.venv/bin/ruff check .
+.venv/bin/ruff format --check .
+.venv/bin/bandit -r app -c pyproject.toml -q
+.venv/bin/pytest --tb=short -q
+.venv/bin/alembic upgrade head && .venv/bin/alembic check
+```
+
+- [ ] **Step 2: Full frontend CI**
+
+```bash
+cd dashboard && npm run lint && npx tsc --noEmit && npm test -- --run
+```
+
+- [ ] **Step 3: Push and open PR**
+
+```bash
+git push -u origin <your-branch>
+gh pr create \
+  --title "feat: Tidal collection playlist bidirectional sync" \
+  --body "$(cat <<'EOF'
+## Summary
+- Rejecting a collection song in WrzDJ dashboard removes it from the Tidal collection playlist (direction 1, always on when Tidal sync enabled)
+- New opt-in: removing a track from the Tidal playlist auto-rejects it in WrzDJ via a 5-minute asyncio background poller (direction 2)
+- New checkbox in collection settings: "Songs removed from Tidal playlist are auto-rejected"
+- `Request.tidal_collection_track_id` persists the Tidal match for reliable bidirectional mapping without re-searching
+
+## Test plan
+- [ ] Enable Tidal sync on a collection event; submit songs via guest page; verify `tidal_collection_track_id` is populated on each synced request
+- [ ] Reject via bulk-review; verify track disappears from Tidal collection playlist
+- [ ] Reject via individual song PATCH; verify same Tidal removal
+- [ ] Enable bidirectional checkbox; remove a track directly in Tidal; wait up to 5 min; verify song appears as rejected in WrzDJ dashboard
+- [ ] Verify public guest leaderboard still shows all songs regardless of reject status
+- [ ] Verify requests with no `tidal_collection_track_id` do not trigger any Tidal API call on rejection
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-05-10-tidal-collection-bidirectional-sync-design.md
+++ b/docs/superpowers/specs/2026-05-10-tidal-collection-bidirectional-sync-design.md
@@ -1,0 +1,188 @@
+# Tidal Collection Playlist Bidirectional Sync
+
+**Date:** 2026-05-10  
+**Status:** Approved
+
+## Summary
+
+Adds bidirectional sync between WrzDJ's pre-event collection list and its Tidal collection playlist.
+
+- **Direction 1 (always on):** Rejecting a collection song in the WrzDJ dashboard removes it from the Tidal collection playlist.
+- **Direction 2 (opt-in):** Removing a track from the Tidal collection playlist auto-rejects it in WrzDJ, via a periodic background poll.
+
+The public guest leaderboard is unaffected — it always shows all collection submissions regardless of accept/reject status. Accept/reject is a DJ-only concern.
+
+## Data Model
+
+### New column: `Request.tidal_collection_track_id`
+
+```python
+tidal_collection_track_id: Mapped[str | None] = mapped_column(String(50), nullable=True)
+```
+
+- Set when `sync_collection_requests_batch` successfully matches and adds a track to the Tidal collection playlist.
+- Used by direction 1 (know what to remove) and direction 2 (know which requests are synced).
+- `None` means the request was never successfully synced to Tidal — no removal attempted.
+
+### New column: `Event.tidal_collection_bidirectional`
+
+```python
+tidal_collection_bidirectional: Mapped[bool] = mapped_column(Boolean, default=False, server_default="0")
+```
+
+- Guards direction 2 polling. Default `False` — opt-in, not automatic.
+- Only meaningful when `tidal_sync_enabled=True` and a collection playlist exists.
+
+### Migration
+
+`server/alembic/versions/044_add_tidal_collection_bidir.py`
+
+Adds both columns. `tidal_collection_track_id` on `requests`, `tidal_collection_bidirectional` on `events`.
+
+## Direction 1: Reject in WrzDJ → Remove from Tidal
+
+Triggered from two entry points. Both fire a background task.
+
+### Entry point 1: Bulk review (`POST /events/{code}/bulk-review`)
+
+After `execute_bulk_review` returns rejected rows, any row with `tidal_collection_track_id` set is queued for removal.
+
+```python
+if rejected_rows_with_track_id:
+    background_tasks.add_task(
+        remove_collection_tracks_batch, db, user, event, track_ids
+    )
+```
+
+### Entry point 2: Individual status change (`PATCH /requests/{request_id}`)
+
+When status transitions to `rejected` and the request has `submitted_during_collection=True` and `tidal_collection_track_id` set:
+
+```python
+if update_data.status == RequestStatus.REJECTED and req.tidal_collection_track_id:
+    background_tasks.add_task(
+        remove_track_from_collection_playlist, db, user, event, req.tidal_collection_track_id
+    )
+```
+
+### New Tidal service functions
+
+```python
+def remove_track_from_collection_playlist(
+    db: Session, user: User, event: Event, track_id: str
+) -> bool:
+    """Remove a single track from the event's Tidal collection playlist."""
+
+def remove_collection_tracks_batch(
+    db: Session, user: User, event: Event, track_ids: list[str]
+) -> None:
+    """Remove multiple tracks from the collection playlist. Best-effort per track."""
+```
+
+Both call `playlist.remove_by_id()` from tidalapi. Failures are logged, not raised — removal is best-effort.
+
+### `sync_collection_requests_batch` update
+
+After successfully adding a track, store the Tidal track ID on the request:
+
+```python
+req.tidal_collection_track_id = results[0].track_id
+db.commit()
+```
+
+## Direction 2: Remove from Tidal → Auto-reject in WrzDJ
+
+### New Tidal service function
+
+```python
+def poll_tidal_collection_removals(db: Session, event: Event) -> int:
+    """
+    Compares current Tidal collection playlist tracks against synced WrzDJ requests.
+    Rejects any request whose tidal_collection_track_id is no longer in the playlist.
+    Returns count of newly rejected requests.
+    """
+```
+
+Logic:
+1. Fetch current track IDs from `event.tidal_collection_playlist_id` via `get_playlist_tracks()`
+2. Query all non-rejected collection requests for the event where `tidal_collection_track_id IS NOT NULL`
+3. Any request whose `tidal_collection_track_id` is not in the current playlist → set `status = "rejected"`
+4. Commit and return count
+
+### Asyncio lifespan poller
+
+Added to `main.py` via FastAPI's lifespan context manager:
+
+```python
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    task = asyncio.create_task(_tidal_collection_poll_loop())
+    try:
+        yield
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+```
+
+Poll loop:
+- Runs every 5 minutes
+- Opens its own `SessionLocal()` per cycle (does not reuse request-scoped session)
+- Queries events where: `tidal_sync_enabled=True`, `tidal_collection_bidirectional=True`, `tidal_collection_playlist_id IS NOT NULL`, and `phase='collection'`
+- Calls `poll_tidal_collection_removals(db, event)` for each
+- Logs count of rejections per event; errors per event are caught and logged, do not abort the loop
+
+## API Changes
+
+### Collection settings schema
+
+`UpdateCollectionSettings` and `collection_settings_payload()` gain:
+
+```python
+tidal_collection_bidirectional: bool | None = None  # in UpdateCollectionSettings
+tidal_collection_bidirectional: bool              # in payload response
+```
+
+### `update_collection_settings` service
+
+Handles the new field alongside existing ones:
+
+```python
+if payload.tidal_collection_bidirectional is not None:
+    event.tidal_collection_bidirectional = payload.tidal_collection_bidirectional
+```
+
+## Frontend
+
+### Collection settings panel
+
+New checkbox below the existing Tidal sync toggle:
+
+> ☑ Songs removed from Tidal playlist are auto-rejected
+
+- Maps to `tidal_collection_bidirectional`
+- Disabled (greyed out) when `tidal_sync_enabled` is false
+- `PATCH /{code}/collection` saves it
+
+## What Does Not Change
+
+- **Public leaderboard** (`GET /collect/{code}/leaderboard`): returns all `submitted_during_collection` requests with no status filter. Guests always see the full static list.
+- **Guest "My Picks"**: shows submitted and upvoted songs regardless of DJ accept/reject status.
+- **Collection submission**: guests can still submit during collection regardless of other songs' statuses.
+- **Main event playlist** (`tidal_playlist_id`): unaffected. This feature only touches the collection playlist.
+
+## Error Handling
+
+- Tidal API failures in direction 1 are logged and do not roll back the WrzDJ status change. The reject is permanent; the Tidal removal is best-effort.
+- Tidal API failures in direction 2 polling are logged per-event and do not abort other events' polls.
+- If `tidal_collection_track_id` is `None` on a rejected request (track was never synced), no Tidal call is made.
+
+## Testing
+
+- Unit: `remove_track_from_collection_playlist` with mock tidalapi session
+- Unit: `poll_tidal_collection_removals` — request present in playlist (no change), request absent (rejected)
+- Unit: `sync_collection_requests_batch` stores `tidal_collection_track_id` after successful add
+- Integration: `POST /events/{code}/bulk-review` with `reject_ids` — verifies background task queued
+- Integration: `PATCH /requests/{request_id}` to rejected — verifies background task queued for collection requests
+- Integration: `PATCH /{code}/collection` saves `tidal_collection_bidirectional`
+- Poll loop: verify it skips events with `tidal_collection_bidirectional=False`

--- a/server/alembic/versions/044_add_tidal_collection_bidir.py
+++ b/server/alembic/versions/044_add_tidal_collection_bidir.py
@@ -20,6 +20,12 @@ def upgrade() -> None:
         "requests",
         sa.Column("tidal_collection_track_id", sa.String(50), nullable=True),
     )
+    op.create_index(
+        "ix_requests_tidal_collection_track_id",
+        "requests",
+        ["tidal_collection_track_id"],
+        unique=False,
+    )
     op.add_column(
         "events",
         sa.Column(
@@ -32,5 +38,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    op.drop_index("ix_requests_tidal_collection_track_id", table_name="requests", if_exists=True)
     op.drop_column("requests", "tidal_collection_track_id")
     op.drop_column("events", "tidal_collection_bidirectional")

--- a/server/alembic/versions/044_add_tidal_collection_bidir.py
+++ b/server/alembic/versions/044_add_tidal_collection_bidir.py
@@ -1,0 +1,36 @@
+"""Add tidal_collection_track_id to requests and tidal_collection_bidirectional to events.
+
+Revision ID: 044
+Revises: 043
+Create Date: 2026-05-11
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "044"
+down_revision: str | None = "043"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "requests",
+        sa.Column("tidal_collection_track_id", sa.String(50), nullable=True),
+    )
+    op.add_column(
+        "events",
+        sa.Column(
+            "tidal_collection_bidirectional",
+            sa.Boolean,
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("requests", "tidal_collection_track_id")
+    op.drop_column("events", "tidal_collection_bidirectional")

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -96,7 +96,10 @@ from app.services.request import (
 )
 from app.services.sync.orchestrator import enrich_request_metadata, sync_requests_batch
 from app.services.sync.registry import get_connected_adapters
-from app.services.tidal import sync_collection_requests_batch
+from app.services.tidal import (
+    remove_collection_tracks_batch,
+    sync_collection_requests_batch,
+)
 
 router = APIRouter()
 
@@ -1107,7 +1110,7 @@ def bulk_review(
     event: Event = Depends(get_event_for_dj_or_admin),
     db: Session = Depends(get_db),
 ):
-    accepted, rejected, accepted_rows = execute_bulk_review(db, event.id, payload)
+    accepted, rejected, accepted_rows, rejected_rows = execute_bulk_review(db, event.id, payload)
     # Enrich + sync accepted requests. Guest-collect submissions arrive without
     # BPM/key/genre. enrich_request_metadata fills those in directly (Tidal/
     # Beatport/MusicBrainz cascade) — this works regardless of whether the DJ
@@ -1117,6 +1120,21 @@ def bulk_review(
         for row in accepted_rows:
             background_tasks.add_task(enrich_request_metadata, db, row.id)
         background_tasks.add_task(sync_requests_batch, db, accepted_rows)
+
+    # Direction 1: remove rejected+synced tracks from the Tidal collection playlist
+    if event.tidal_sync_enabled:
+        track_ids_to_remove = [
+            r.tidal_collection_track_id for r in rejected_rows if r.tidal_collection_track_id
+        ]
+        if track_ids_to_remove:
+            background_tasks.add_task(
+                remove_collection_tracks_batch,
+                db,
+                event.created_by,
+                event,
+                track_ids_to_remove,
+            )
+
     return BulkReviewResponse(accepted=accepted, rejected=rejected, unchanged=0)
 
 

--- a/server/app/api/requests.py
+++ b/server/app/api/requests.py
@@ -22,6 +22,7 @@ from app.services.request import (
 )
 from app.services.sync.orchestrator import enrich_request_metadata, sync_request_to_services
 from app.services.sync.registry import get_connected_adapters
+from app.services.tidal import remove_track_from_collection_playlist
 
 router = APIRouter()
 
@@ -76,6 +77,21 @@ def update_request(
     if update_data.status == RequestStatus.ACCEPTED:
         if get_connected_adapters(request.event.created_by):
             background_tasks.add_task(sync_request_to_services, db, request)
+
+    # Remove from Tidal collection playlist when a synced collection request is rejected
+    if (
+        update_data.status == RequestStatus.REJECTED
+        and request.submitted_during_collection
+        and request.tidal_collection_track_id
+        and request.event.tidal_sync_enabled
+    ):
+        background_tasks.add_task(
+            remove_track_from_collection_playlist,
+            db,
+            request.event.created_by,
+            request.event,
+            request.tidal_collection_track_id,
+        )
 
     # Auto-set now_playing when a request is set to "playing"
     if update_data.status == RequestStatus.PLAYING:

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -25,6 +25,7 @@ settings = get_settings()
 # Configure app-level logging so module loggers (enrichment, sync, etc.)
 # emit INFO-level diagnostics instead of being silenced by Python's default WARNING level.
 logging.getLogger("app").setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
 
 # Explicit CORS methods for non-wildcard origins — must include every HTTP method used by the API
 CORS_ALLOW_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
@@ -93,8 +94,6 @@ app = FastAPI(
 # Rate limiting
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
-
-logger = logging.getLogger(__name__)
 
 
 @app.exception_handler(Exception)

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,5 +1,8 @@
+import asyncio
+import contextlib
 import logging
 import mimetypes
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -26,10 +29,61 @@ logging.getLogger("app").setLevel(logging.INFO)
 # Explicit CORS methods for non-wildcard origins — must include every HTTP method used by the API
 CORS_ALLOW_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
 
+TIDAL_COLLECTION_POLL_INTERVAL_SECONDS = 300  # 5 minutes
+
+
+def _run_tidal_collection_poll() -> None:
+    """Synchronous poll, executed in a thread to avoid blocking the event loop."""
+    from app.db.session import SessionLocal
+    from app.models.event import Event
+    from app.services.tidal import poll_tidal_collection_removals
+
+    db = SessionLocal()
+    try:
+        events = (
+            db.query(Event)
+            .filter(
+                Event.tidal_sync_enabled == True,  # noqa: E712
+                Event.tidal_collection_bidirectional == True,  # noqa: E712
+                Event.tidal_collection_playlist_id.isnot(None),
+            )
+            .all()
+        )
+        for event in events:
+            if event.phase == "collection":
+                try:
+                    poll_tidal_collection_removals(db, event)
+                except Exception:
+                    logger.exception("Tidal collection poll failed for event %s", event.code)
+    finally:
+        db.close()
+
+
+async def _tidal_collection_poll_loop() -> None:
+    while True:
+        await asyncio.sleep(TIDAL_COLLECTION_POLL_INTERVAL_SECONDS)
+        try:
+            await asyncio.to_thread(_run_tidal_collection_poll)
+        except Exception:
+            logger.exception("Tidal collection poll loop error")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    task = asyncio.create_task(_tidal_collection_poll_loop())
+    try:
+        yield
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
 app = FastAPI(
     title="WrzDJ API",
     description="Song request system for DJs",
     version="0.1.0",
+    lifespan=lifespan,
     # Disable API docs in production
     docs_url=None if settings.is_production else "/docs",
     redoc_url=None if settings.is_production else "/redoc",

--- a/server/app/models/event.py
+++ b/server/app/models/event.py
@@ -36,6 +36,9 @@ class Event(Base):
     tidal_playlist_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
     tidal_collection_playlist_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
     tidal_sync_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+    tidal_collection_bidirectional: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="0"
+    )
 
     # Beatport sync
     beatport_sync_enabled: Mapped[bool] = mapped_column(Boolean, default=False)

--- a/server/app/models/request.py
+++ b/server/app/models/request.py
@@ -65,7 +65,9 @@ class Request(Base):
     vote_count: Mapped[int] = mapped_column(Integer, default=0)
 
     # Tidal collection playlist tracking — set when a request is successfully synced
-    tidal_collection_track_id: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    tidal_collection_track_id: Mapped[str | None] = mapped_column(
+        String(50), nullable=True, index=True
+    )
 
     # Pre-event collection flag — set on insert when event.phase == "collection"
     submitted_during_collection: Mapped[bool] = mapped_column(

--- a/server/app/models/request.py
+++ b/server/app/models/request.py
@@ -64,6 +64,9 @@ class Request(Base):
     # Voting
     vote_count: Mapped[int] = mapped_column(Integer, default=0)
 
+    # Tidal collection playlist tracking — set when a request is successfully synced
+    tidal_collection_track_id: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
     # Pre-event collection flag — set on insert when event.phase == "collection"
     submitted_during_collection: Mapped[bool] = mapped_column(
         Boolean, default=False, nullable=False, server_default="0", index=True

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -136,6 +136,7 @@ class UpdateCollectionSettings(BaseModel):
     submission_cap_per_guest: int | None = Field(default=None, ge=0, le=100)
     collection_phase_override: Literal["force_collection", "force_live"] | None = None
     tidal_sync_enabled: bool | None = None
+    tidal_collection_bidirectional: bool | None = None
 
 
 class PendingReviewRow(BaseModel):

--- a/server/app/services/collect.py
+++ b/server/app/services/collect.py
@@ -91,14 +91,12 @@ def get_pending_review_rows(db: Session, event_id: int, limit: int = 200) -> lis
 
 def execute_bulk_review(
     db: Session, event_id: int, payload: BulkReviewRequest
-) -> tuple[int, int, list[SongRequest]]:
+) -> tuple[int, int, list[SongRequest], list[SongRequest]]:
     """Apply a bulk-review action to collection-phase pending requests.
 
-    Returns (accepted_count, rejected_count, accepted_rows). Caller is expected
-    to pass accepted_rows to sync_requests_batch() as a FastAPI background task
-    so the metadata-enrichment + playlist-sync pipeline runs before the tracks
-    show up in the DJ queue. Guest-collect submissions don't have BPM/key/genre;
-    this is the first chance to fill them in.
+    Returns (accepted_count, rejected_count, accepted_rows, rejected_rows). Caller is expected
+    to pass accepted_rows to sync_requests_batch() and rejected_rows to
+    remove_collection_tracks_batch() as FastAPI background tasks.
 
     Raises HTTPException(400) when the payload parameters are inconsistent with
     the selected action.
@@ -113,6 +111,7 @@ def execute_bulk_review(
     accepted = 0
     rejected = 0
     accepted_rows: list[SongRequest] = []
+    rejected_rows: list[SongRequest] = []
 
     if payload.action == "accept_top_n":
         if payload.n is None:
@@ -149,14 +148,16 @@ def execute_bulk_review(
         for r in rows:
             r.status = "rejected"
             rejected += 1
+            rejected_rows.append(r)
     elif payload.action == "reject_remaining":
         rows = pending_q.all()
         for r in rows:
             r.status = "rejected"
             rejected += 1
+            rejected_rows.append(r)
 
     db.commit()
-    return accepted, rejected, accepted_rows
+    return accepted, rejected, accepted_rows, rejected_rows
 
 
 class SubmissionCapExceeded(Exception):

--- a/server/app/services/collect.py
+++ b/server/app/services/collect.py
@@ -38,6 +38,7 @@ def collection_settings_payload(event: Event) -> dict:
         "phase": event.phase,
         "tidal_sync_enabled": event.tidal_sync_enabled,
         "tidal_collection_playlist_id": event.tidal_collection_playlist_id,
+        "tidal_collection_bidirectional": event.tidal_collection_bidirectional,
     }
 
 
@@ -60,6 +61,8 @@ def update_collection_settings(
         event.collection_phase_override = payload.collection_phase_override
     if payload.tidal_sync_enabled is not None:
         event.tidal_sync_enabled = payload.tidal_sync_enabled
+    if payload.tidal_collection_bidirectional is not None:
+        event.tidal_collection_bidirectional = payload.tidal_collection_bidirectional
 
     opens = event.collection_opens_at
     live = event.live_starts_at

--- a/server/app/services/tidal.py
+++ b/server/app/services/tidal.py
@@ -433,6 +433,47 @@ def add_tracks_to_playlist(
         return False
 
 
+def remove_track_from_collection_playlist(
+    db: Session,
+    user: User,
+    event: Event,
+    track_id: str,
+) -> bool:
+    """Remove a single track from the event's Tidal collection playlist.
+
+    Returns True on success, False if the playlist doesn't exist or the API call fails.
+    Failures are logged but not raised — removal is best-effort.
+    """
+    playlist_id = event.tidal_collection_playlist_id
+    if not playlist_id:
+        return False
+
+    session = get_tidal_session(db, user)
+    if not session:
+        return False
+
+    try:
+        playlist = session.playlist(playlist_id)
+        return bool(playlist.remove_by_id(track_id))
+    except Exception as e:
+        logger.error(f"Failed to remove track {track_id} from collection playlist: {e}")
+        return False
+
+
+def remove_collection_tracks_batch(
+    db: Session,
+    user: User,
+    event: Event,
+    track_ids: list[str],
+) -> None:
+    """Remove multiple tracks from the collection playlist, one by one.
+
+    Best-effort: logs failures per track but does not abort on error.
+    """
+    for track_id in track_ids:
+        remove_track_from_collection_playlist(db, user, event, track_id)
+
+
 def sync_request_to_tidal(
     db: Session,
     request: Request,

--- a/server/app/services/tidal.py
+++ b/server/app/services/tidal.py
@@ -15,7 +15,7 @@ import tidalapi
 from sqlalchemy.orm import Session
 
 from app.models.event import Event
-from app.models.request import Request, TidalSyncStatus  # TidalSyncStatus used in TidalSyncResult
+from app.models.request import Request, RequestStatus, TidalSyncStatus
 from app.models.user import User
 from app.schemas.tidal import TidalSearchResult, TidalSyncResult
 from app.services.track_normalizer import artist_match_score, primary_artist
@@ -472,6 +472,46 @@ def remove_collection_tracks_batch(
     """
     for track_id in track_ids:
         remove_track_from_collection_playlist(db, user, event, track_id)
+
+
+def poll_tidal_collection_removals(db: Session, event: Event) -> int:
+    """Detect tracks removed from the Tidal collection playlist and reject them in WrzDJ.
+
+    Fetches current playlist contents, finds collection requests whose
+    tidal_collection_track_id is no longer present, and marks them rejected.
+    Only runs when the event has a collection playlist configured.
+
+    Returns the count of newly rejected requests.
+    """
+    if not event.tidal_collection_playlist_id:
+        return 0
+
+    user = event.created_by
+    playlist_tracks = get_playlist_tracks(db, user, event.tidal_collection_playlist_id)
+    current_ids = {str(t.id) for t in playlist_tracks}
+
+    synced = (
+        db.query(Request)
+        .filter(
+            Request.event_id == event.id,
+            Request.submitted_during_collection == True,  # noqa: E712
+            Request.tidal_collection_track_id.isnot(None),
+            Request.status != RequestStatus.REJECTED.value,
+        )
+        .all()
+    )
+
+    count = 0
+    for req in synced:
+        if req.tidal_collection_track_id not in current_ids:
+            req.status = RequestStatus.REJECTED.value
+            count += 1
+
+    if count > 0:
+        db.commit()
+        logger.info("Tidal poll: rejected %d removed track(s) for event %s", count, event.code)
+
+    return count
 
 
 def sync_request_to_tidal(

--- a/server/app/services/tidal.py
+++ b/server/app/services/tidal.py
@@ -365,7 +365,8 @@ def sync_collection_requests_batch(
 ) -> None:
     """Batch-sync pre-event collection requests to the collection playlist.
 
-    Searches tracks sequentially, then adds all found IDs in one API call.
+    Searches tracks sequentially, adds all found IDs in one API call, and
+    stores the matched Tidal track ID on each request for bidirectional sync.
     Tidal's allow_duplicates=False deduplicates silently at the API layer.
     """
     if not requests:
@@ -376,16 +377,22 @@ def sync_collection_requests_batch(
         return
 
     track_ids: list[str] = []
+    matched: list[tuple] = []  # (request, track_id)
     for req in requests:
         try:
             results = search_tidal_tracks(db, user, f"{req.song_title} {req.artist}")
             if results:
-                track_ids.append(results[0].track_id)
+                track_id = results[0].track_id
+                track_ids.append(track_id)
+                matched.append((req, track_id))
         except Exception as e:
             logger.error(f"Collection sync search failed for '{req.song_title}': {e}")
 
     if track_ids:
-        add_tracks_to_playlist(db, user, playlist_id, track_ids)
+        if add_tracks_to_playlist(db, user, playlist_id, track_ids):
+            for req, track_id in matched:
+                req.tidal_collection_track_id = track_id
+            db.commit()
 
 
 def add_track_to_playlist(

--- a/server/tests/test_collect_dj.py
+++ b/server/tests/test_collect_dj.py
@@ -337,6 +337,87 @@ def test_sync_collection_to_tidal_queues_eligible(
     assert body["queued"] == 2
 
 
+def test_bulk_reject_queues_tidal_removal_for_synced_requests(
+    client, db, auth_headers, test_event, monkeypatch
+):
+    from app.models.request import Request as SongRequest
+    from app.models.request import RequestStatus
+
+    req = SongRequest(
+        event_id=test_event.id,
+        song_title="Gone Track",
+        artist="DJ X",
+        status=RequestStatus.NEW.value,
+        dedupe_key="gone-track",
+        submitted_during_collection=True,
+        tidal_collection_track_id="tid-999",
+    )
+    db.add(req)
+    db.commit()
+    db.refresh(req)
+
+    test_event.tidal_sync_enabled = True
+    db.commit()
+
+    calls = []
+
+    def fake_remove(db, user, event, track_ids):
+        calls.append((db, user, event, track_ids))
+
+    import app.api.events as events_module
+
+    monkeypatch.setattr(events_module, "remove_collection_tracks_batch", fake_remove)
+
+    resp = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "reject_ids", "request_ids": [req.id]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert len(calls) == 1
+    _, _, _, track_ids = calls[0]
+    assert "tid-999" in track_ids
+
+
+def test_bulk_reject_skips_tidal_removal_when_no_track_id(
+    client, db, auth_headers, test_event, monkeypatch
+):
+    from app.models.request import Request as SongRequest
+    from app.models.request import RequestStatus
+
+    req = SongRequest(
+        event_id=test_event.id,
+        song_title="Unsynced",
+        artist="DJ X",
+        status=RequestStatus.NEW.value,
+        dedupe_key="unsynced",
+        submitted_during_collection=True,
+        tidal_collection_track_id=None,
+    )
+    db.add(req)
+    db.commit()
+
+    test_event.tidal_sync_enabled = True
+    db.commit()
+
+    calls = []
+
+    def fake_remove(db, user, event, track_ids):
+        calls.append((db, user, event, track_ids))
+
+    import app.api.events as events_module
+
+    monkeypatch.setattr(events_module, "remove_collection_tracks_batch", fake_remove)
+
+    resp = client.post(
+        f"/api/events/{test_event.code}/bulk-review",
+        json={"action": "reject_ids", "request_ids": [req.id]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert len(calls) == 0
+
+
 def test_sync_collection_to_tidal_empty_queued_when_all_rejected(
     client, db, auth_headers, test_event, collection_requests
 ):

--- a/server/tests/test_collect_dj.py
+++ b/server/tests/test_collect_dj.py
@@ -433,3 +433,26 @@ def test_sync_collection_to_tidal_empty_queued_when_all_rejected(
     )
     assert r.status_code == 200
     assert r.json()["queued"] == 0
+
+
+def test_collection_settings_response_includes_bidirectional(client, auth_headers, test_event):
+    resp = client.get(
+        f"/api/events/{test_event.code}/collection",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert "tidal_collection_bidirectional" in resp.json()
+    assert resp.json()["tidal_collection_bidirectional"] is False  # default
+
+
+def test_patch_collection_settings_sets_bidirectional(client, db, auth_headers, test_event):
+    resp = client.patch(
+        f"/api/events/{test_event.code}/collection",
+        json={"tidal_collection_bidirectional": True},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["tidal_collection_bidirectional"] is True
+
+    db.refresh(test_event)
+    assert test_event.tidal_collection_bidirectional is True

--- a/server/tests/test_collect_service.py
+++ b/server/tests/test_collect_service.py
@@ -80,3 +80,32 @@ def test_check_and_increment_allows_unlimited_when_cap_zero(db, test_event: Even
         .one()
     )
     assert profile.submission_count == 20
+
+
+def test_execute_bulk_review_returns_rejected_rows(db, test_event):
+    from app.models.request import Request as SongRequest
+    from app.models.request import RequestStatus
+    from app.schemas.collect import BulkReviewRequest
+    from app.services.collect import execute_bulk_review
+
+    req = SongRequest(
+        event_id=test_event.id,
+        song_title="Track",
+        artist="Artist",
+        status=RequestStatus.NEW.value,
+        dedupe_key="track-artist",
+        submitted_during_collection=True,
+        tidal_collection_track_id="tid-1",
+    )
+    db.add(req)
+    db.commit()
+
+    payload = BulkReviewRequest(action="reject_ids", request_ids=[req.id])
+    accepted, rejected, accepted_rows, rejected_rows = execute_bulk_review(
+        db, test_event.id, payload
+    )
+
+    assert accepted == 0
+    assert rejected == 1
+    assert len(rejected_rows) == 1
+    assert rejected_rows[0].id == req.id

--- a/server/tests/test_requests.py
+++ b/server/tests/test_requests.py
@@ -758,6 +758,9 @@ class TestPatchRejectionTidalRemoval:
         from app.models.request import Request as SongRequest
         from app.models.request import RequestStatus
 
+        test_event.tidal_sync_enabled = True
+        db.commit()
+
         req = SongRequest(
             event_id=test_event.id,
             song_title="Unsynced Track",

--- a/server/tests/test_requests.py
+++ b/server/tests/test_requests.py
@@ -706,3 +706,84 @@ class TestSubmitRequestCollectionFlag:
         assert resp.status_code == 200
         row = db.query(Request).filter(Request.id == resp.json()["id"]).one()
         assert row.submitted_during_collection is False
+
+
+class TestPatchRejectionTidalRemoval:
+    """Tests for individual PATCH rejection firing Tidal collection removal."""
+
+    def test_rejecting_synced_collection_request_queues_tidal_removal(
+        self, client: TestClient, db: Session, auth_headers: dict, test_event: Event, monkeypatch
+    ):
+        """Rejecting a synced collection request queues removal from Tidal playlist."""
+        from app.models.request import Request as SongRequest
+        from app.models.request import RequestStatus
+
+        test_event.tidal_sync_enabled = True
+        db.commit()
+
+        req = SongRequest(
+            event_id=test_event.id,
+            song_title="Synced Track",
+            artist="DJ Y",
+            status=RequestStatus.NEW.value,
+            dedupe_key="synced-track-dj-y",
+            submitted_during_collection=True,
+            tidal_collection_track_id="tid-555",
+        )
+        db.add(req)
+        db.commit()
+        db.refresh(req)
+
+        calls = []
+
+        def mock_remove(*args, **kwargs):
+            calls.append(args)
+
+        import app.api.requests as requests_module
+
+        monkeypatch.setattr(requests_module, "remove_track_from_collection_playlist", mock_remove)
+
+        resp = client.patch(
+            f"/api/requests/{req.id}",
+            json={"status": "rejected"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert len(calls) == 1
+
+    def test_rejecting_unsynced_collection_request_skips_tidal(
+        self, client: TestClient, db: Session, auth_headers: dict, test_event: Event, monkeypatch
+    ):
+        """Rejecting a collection request with no tidal_collection_track_id skips removal."""
+        from app.models.request import Request as SongRequest
+        from app.models.request import RequestStatus
+
+        req = SongRequest(
+            event_id=test_event.id,
+            song_title="Unsynced Track",
+            artist="DJ Z",
+            status=RequestStatus.NEW.value,
+            dedupe_key="unsynced-track-dj-z",
+            submitted_during_collection=True,
+            tidal_collection_track_id=None,
+        )
+        db.add(req)
+        db.commit()
+        db.refresh(req)
+
+        calls = []
+
+        def mock_remove(*args, **kwargs):
+            calls.append(args)
+
+        import app.api.requests as requests_module
+
+        monkeypatch.setattr(requests_module, "remove_track_from_collection_playlist", mock_remove)
+
+        resp = client.patch(
+            f"/api/requests/{req.id}",
+            json={"status": "rejected"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert len(calls) == 0

--- a/server/tests/test_tidal.py
+++ b/server/tests/test_tidal.py
@@ -779,3 +779,61 @@ class TestCollectionSync:
         # Refresh and verify
         db.refresh(row)
         assert row.tidal_collection_track_id == "99887766"
+
+
+class TestCollectionRemove:
+    """Tests for removing tracks from collection playlists."""
+
+    @patch("app.services.tidal.get_tidal_session")
+    def test_remove_track_from_collection_playlist_success(
+        self, mock_session_fn: MagicMock, test_event, test_user
+    ):
+        """Test successful removal of track from collection playlist."""
+        from app.services.tidal import remove_track_from_collection_playlist
+
+        mock_playlist = MagicMock()
+        mock_playlist.remove_by_id.return_value = True
+        mock_session = MagicMock()
+        mock_session.playlist.return_value = mock_playlist
+        mock_session_fn.return_value = mock_session
+
+        test_event.tidal_collection_playlist_id = "pl-123"
+        db_mock = MagicMock()
+
+        result = remove_track_from_collection_playlist(db_mock, test_user, test_event, "track-456")
+
+        mock_session.playlist.assert_called_once_with("pl-123")
+        mock_playlist.remove_by_id.assert_called_once_with("track-456")
+        assert result is True
+
+    @patch("app.services.tidal.get_tidal_session")
+    def test_remove_track_from_collection_playlist_no_playlist(
+        self, mock_session_fn: MagicMock, test_event, test_user
+    ):
+        """Test removal fails gracefully when no collection playlist exists."""
+        from app.services.tidal import remove_track_from_collection_playlist
+
+        mock_session = MagicMock()
+        mock_session_fn.return_value = mock_session
+        test_event.tidal_collection_playlist_id = None
+        db_mock = MagicMock()
+
+        result = remove_track_from_collection_playlist(db_mock, test_user, test_event, "track-456")
+
+        mock_session.playlist.assert_not_called()
+        assert result is False
+
+    @patch("app.services.tidal.remove_track_from_collection_playlist")
+    def test_remove_collection_tracks_batch_calls_per_track(
+        self, mock_remove: MagicMock, test_event, test_user
+    ):
+        """Test batch removal calls remove function for each track."""
+        from app.services.tidal import remove_collection_tracks_batch
+
+        mock_remove.return_value = True
+        test_event.tidal_collection_playlist_id = "pl-123"
+        db_mock = MagicMock()
+
+        remove_collection_tracks_batch(db_mock, test_user, test_event, ["t1", "t2", "t3"])
+
+        assert mock_remove.call_count == 3

--- a/server/tests/test_tidal.py
+++ b/server/tests/test_tidal.py
@@ -726,3 +726,56 @@ class TestCascadeTidalFlow:
         mock_session_fn.return_value = None
         result = search_track(db, tidal_user, "deadmau5", "Strobe")
         assert result is None
+
+
+class TestCollectionSync:
+    """Tests for pre-event collection playlist sync."""
+
+    @patch("app.services.tidal.add_tracks_to_playlist")
+    @patch("app.services.tidal.ensure_collection_playlist")
+    @patch("app.services.tidal.search_tidal_tracks")
+    def test_sync_collection_stores_track_id(
+        self,
+        mock_search: MagicMock,
+        mock_ensure_playlist: MagicMock,
+        mock_add: MagicMock,
+        db: Session,
+        test_event,
+        test_user,
+    ):
+        """Test that sync_collection_requests_batch stores tidal_collection_track_id."""
+        from app.models.request import Request as SongRequest
+        from app.services.tidal import sync_collection_requests_batch
+
+        # Create a test request with collection flag
+        row = SongRequest(
+            event_id=test_event.id,
+            song_title="Acid Rain",
+            artist="Objekt",
+            status=RequestStatus.NEW.value,
+            dedupe_key="objekt-acid-rain",
+            submitted_during_collection=True,
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+
+        # Mock search result
+        mock_result = TidalSearchResult(
+            track_id="99887766",
+            title="Acid Rain",
+            artist="Objekt",
+            tidal_url="https://tidal.com/browse/track/99887766",
+        )
+
+        # Setup mock returns
+        mock_search.return_value = [mock_result]
+        mock_ensure_playlist.return_value = "playlist-abc"
+        mock_add.return_value = True
+
+        # Call the function
+        sync_collection_requests_batch(db, test_user, test_event, [row])
+
+        # Refresh and verify
+        db.refresh(row)
+        assert row.tidal_collection_track_id == "99887766"

--- a/server/tests/test_tidal.py
+++ b/server/tests/test_tidal.py
@@ -837,3 +837,91 @@ class TestCollectionRemove:
         remove_collection_tracks_batch(db_mock, test_user, test_event, ["t1", "t2", "t3"])
 
         assert mock_remove.call_count == 3
+
+    @patch("app.services.tidal.get_playlist_tracks")
+    def test_poll_tidal_collection_removals_rejects_missing_track(
+        self, mock_get_tracks: MagicMock, db: Session, test_event: Event, test_user: User
+    ):
+        """Test poll detects tracks removed from Tidal playlist and rejects them."""
+        from app.services.tidal import poll_tidal_collection_removals
+
+        test_event.tidal_collection_playlist_id = "pl-xyz"
+        test_event.created_by = test_user
+
+        kept = Request(
+            event_id=test_event.id,
+            song_title="Track A",
+            artist="Artist A",
+            status=RequestStatus.NEW.value,
+            dedupe_key="track-a",
+            submitted_during_collection=True,
+            tidal_collection_track_id="111",
+        )
+        removed = Request(
+            event_id=test_event.id,
+            song_title="Track B",
+            artist="Artist B",
+            status=RequestStatus.NEW.value,
+            dedupe_key="track-b",
+            submitted_during_collection=True,
+            tidal_collection_track_id="222",
+        )
+        db.add_all([kept, removed])
+        db.commit()
+
+        mock_track = MagicMock()
+        mock_track.id = 111  # only "111" still in playlist; "222" was removed
+
+        mock_get_tracks.return_value = [mock_track]
+
+        count = poll_tidal_collection_removals(db, test_event)
+
+        db.refresh(kept)
+        db.refresh(removed)
+
+        assert count == 1
+        assert kept.status == RequestStatus.NEW.value
+        assert removed.status == RequestStatus.REJECTED.value
+
+    @patch("app.services.tidal.get_playlist_tracks")
+    def test_poll_tidal_collection_removals_no_playlist_returns_zero(
+        self, mock_get_tracks: MagicMock, db: Session, test_event: Event, test_user: User
+    ):
+        """Test poll returns 0 when event has no collection playlist."""
+        from app.services.tidal import poll_tidal_collection_removals
+
+        test_event.tidal_collection_playlist_id = None
+        test_event.created_by = test_user
+
+        count = poll_tidal_collection_removals(db, test_event)
+
+        mock_get_tracks.assert_not_called()
+        assert count == 0
+
+    @patch("app.services.tidal.get_playlist_tracks")
+    def test_poll_tidal_collection_removals_skips_already_rejected(
+        self, mock_get_tracks: MagicMock, db: Session, test_event: Event, test_user: User
+    ):
+        """Test poll does not double-count already rejected requests."""
+        from app.services.tidal import poll_tidal_collection_removals
+
+        test_event.tidal_collection_playlist_id = "pl-xyz"
+        test_event.created_by = test_user
+
+        already_rejected = Request(
+            event_id=test_event.id,
+            song_title="Old Track",
+            artist="Artist",
+            status=RequestStatus.REJECTED.value,
+            dedupe_key="old-track",
+            submitted_during_collection=True,
+            tidal_collection_track_id="333",
+        )
+        db.add(already_rejected)
+        db.commit()
+
+        mock_get_tracks.return_value = []
+
+        count = poll_tidal_collection_removals(db, test_event)
+
+        assert count == 0  # already rejected — not double-counted


### PR DESCRIPTION
## Summary
- Rejecting a collection song in WrzDJ dashboard removes it from the Tidal collection playlist (direction 1, always on when Tidal sync enabled)
- New opt-in: removing a track from the Tidal playlist auto-rejects it in WrzDJ via a 5-minute asyncio background poller (direction 2)
- New checkbox in collection settings: "Songs removed from Tidal playlist are auto-rejected"
- `Request.tidal_collection_track_id` persists the Tidal match for reliable bidirectional mapping without re-searching

## Test plan
- [ ] Enable Tidal sync on a collection event; submit songs via guest page; verify `tidal_collection_track_id` is populated on each synced request
- [ ] Reject via bulk-review; verify track disappears from Tidal collection playlist
- [ ] Reject via individual song PATCH; verify same Tidal removal
- [ ] Enable bidirectional checkbox; remove a track directly in Tidal; wait up to 5 min; verify song appears as rejected in WrzDJ dashboard
- [ ] Verify public guest leaderboard still shows all songs regardless of reject status
- [ ] Verify requests with no `tidal_collection_track_id` do not trigger any Tidal API call on rejection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bidirectional Tidal collection sync: songs removed from your Tidal playlist can be auto-rejected in the event collection.
  * Dashboard toggle/checkbox in pre-event voting to opt into/out of bidirectional sync.
  * Server-side background poll runs periodically to detect playlist removals and auto-reject matching requests; removals are also enqueued when requests are rejected.

* **Documentation**
  * Added design and implementation plan for bidirectional Tidal collection sync.

* **Tests**
  * Expanded test coverage for Tidal sync, removals, polling, API settings, and related request flows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/304)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->