### PR TITLE
fix: admin toggle language + persistent API logs

### DIFF
--- a/dashboard/app/admin/settings/page.tsx
+++ b/dashboard/app/admin/settings/page.tsx
@@ -86,7 +86,7 @@ export default function AdminSettingsPage() {
           </div>
         </HelpSpot>
 
-        <HelpSpot spotId="admin-human-verification" page={PAGE_ID} order={2} title="Human Verification" description="Require guests to complete a Turnstile CAPTCHA before interacting.">
+        <HelpSpot spotId="admin-human-verification" page={PAGE_ID} order={2} title="Human Verification" description="Cloudflare Turnstile always runs silently for guests. Toggle ON to block guests who fail; toggle OFF to only log failures.">
           <div className="form-group" style={{ marginTop: '1.5rem' }}>
             <label style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', cursor: 'pointer' }}>
               <input

--- a/dashboard/app/admin/settings/page.tsx
+++ b/dashboard/app/admin/settings/page.tsx
@@ -96,9 +96,9 @@ export default function AdminSettingsPage() {
                 style={{ width: '1.25rem', height: '1.25rem' }}
               />
               <div>
-                <div style={{ fontWeight: 500 }}>Enforce human verification on guest pages</div>
+                <div style={{ fontWeight: 500 }}>Enforce bot protection on guest pages</div>
                 <div style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
-                  When ON, guests must complete a Cloudflare Turnstile check before submitting requests, voting, or searching. Default OFF (soft mode logs warnings only).
+                  Cloudflare Turnstile runs silently for all guests — most see no challenge. When ON, guests who fail the check are blocked from submitting requests, voting, or searching. When OFF, failures are only logged.
                 </div>
               </div>
             </label>

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -64,6 +64,7 @@ fi
 
 echo "==> Ensuring log directories exist..."
 mkdir -p "$SCRIPT_DIR/logs/api"
+chmod 777 "$SCRIPT_DIR/logs/api"
 
 echo "==> Rebuilding and starting stack..."
 docker compose -f "$COMPOSE_FILE" up -d --build

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -64,7 +64,8 @@ fi
 
 echo "==> Ensuring log directories exist..."
 mkdir -p "$SCRIPT_DIR/logs/api"
-chmod 777 "$SCRIPT_DIR/logs/api"
+chown "$(id -u)":1000 "$SCRIPT_DIR/logs/api"
+chmod 775 "$SCRIPT_DIR/logs/api"
 
 echo "==> Rebuilding and starting stack..."
 docker compose -f "$COMPOSE_FILE" up -d --build

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -62,6 +62,9 @@ else
   echo "    Volume ${UPLOADS_VOLUME} will be created by Docker Compose"
 fi
 
+echo "==> Ensuring log directories exist..."
+mkdir -p "$SCRIPT_DIR/logs/api"
+
 echo "==> Rebuilding and starting stack..."
 docker compose -f "$COMPOSE_FILE" up -d --build
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - api_uploads:/app/uploads
+      - ./logs/api:/app/logs
     environment:
       ENV: production
       DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-wrzdj}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-wrzdj}
@@ -60,6 +61,7 @@ services:
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       EMAIL_FROM_ADDRESS: ${EMAIL_FROM_ADDRESS:-}
       UPLOADS_DIR: /app/uploads
+      LOG_DIR: /app/logs
     ports:
       - "127.0.0.1:${PORT_API:-8000}:8000"
     depends_on:

--- a/docs/superpowers/plans/2026-05-12-admin-ui-fixes-and-persistent-logs.md
+++ b/docs/superpowers/plans/2026-05-12-admin-ui-fixes-and-persistent-logs.md
@@ -1,0 +1,454 @@
+# Admin UI Fixes & Persistent API Logs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix misleading admin toggle label for bot protection, and make API logs persist to a host-mounted directory across container restarts.
+
+**Architecture:** Part A is a two-string frontend change. Part B extracts a `configure_logging()` function to `app/core/logging_config.py`, wires it into `main.py`, and adds a bind-mount volume in the deploy compose file — no new services.
+
+**Tech Stack:** Next.js (Part A); Python `logging` stdlib + `python-json-logger`, FastAPI lifespan, Docker Compose bind-mount (Part B).
+
+---
+
+## Branch
+
+- [ ] **Create feature branch**
+
+```bash
+git checkout -b fix/admin-toggle-text-and-persistent-logs
+```
+
+---
+
+## Task 1: Fix Admin Toggle Label and Description
+
+**Files:**
+- Modify: `dashboard/app/admin/settings/page.tsx:99-101`
+
+- [ ] **Step 1: Apply the two string changes**
+
+In `dashboard/app/admin/settings/page.tsx`, change lines 99–101:
+
+```tsx
+// Before:
+<div style={{ fontWeight: 500 }}>Enforce human verification on guest pages</div>
+<div style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
+  When ON, guests must complete a Cloudflare Turnstile check before submitting requests, voting, or searching. Default OFF (soft mode logs warnings only).
+</div>
+
+// After:
+<div style={{ fontWeight: 500 }}>Enforce bot protection on guest pages</div>
+<div style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
+  Cloudflare Turnstile runs silently for all guests — most see no challenge. When ON, guests who fail the check are blocked from submitting requests, voting, or searching. When OFF, failures are only logged.
+</div>
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd dashboard && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/app/admin/settings/page.tsx
+git commit -m "fix(admin): correct bot protection toggle label and description"
+```
+
+---
+
+## Task 2: Add python-json-logger Dependency
+
+**Files:**
+- Modify: `server/pyproject.toml`
+
+- [ ] **Step 1: Add to dependencies**
+
+In `server/pyproject.toml`, add `"python-json-logger>=3.0"` to the `[project.dependencies]` list (after the `sse-starlette` line):
+
+```toml
+dependencies = [
+    "fastapi>=0.109.0",
+    "uvicorn[standard]>=0.27.0",
+    "sqlalchemy>=2.0.0",
+    "alembic>=1.13.0",
+    "psycopg[binary]>=3.1.0",
+    "pydantic[email]>=2.0.0",
+    "pydantic-settings>=2.0.0",
+    "bcrypt>=4.0.0",
+    "httpx>=0.26.0",
+    "python-multipart>=0.0.27",
+    "spotipy>=2.23.0",
+    "slowapi>=0.1.9",
+    "tidalapi>=0.7.0",
+    "Pillow>=12.1.1",
+    "cryptography>=46.0.7",
+    "PyJWT>=2.12.0",
+    "aiohttp>=3.13.4",
+    "requests>=2.33.0",
+    "python-dotenv>=1.2.2",
+    "mako>=1.3.12",
+    "pyasn1>=0.6.3",
+    "anthropic>=0.40.0",
+    "resend>=2.0.0",
+    "better-profanity>=0.7.0",
+    "sse-starlette>=2.0.0",
+    "python-json-logger>=3.0",
+]
+```
+
+- [ ] **Step 2: Install into venv**
+
+```bash
+cd server && .venv/bin/pip install -e ".[dev]"
+```
+
+Expected: `Successfully installed python-json-logger-3.x.x` (or `Requirement already satisfied` if cached).
+
+- [ ] **Step 3: Verify import works**
+
+```bash
+cd server && .venv/bin/python -c "from pythonjsonlogger.jsonlogger import JsonFormatter; print('ok')"
+```
+
+Expected: `ok`
+
+---
+
+## Task 3: Implement configure_logging() — TDD
+
+**Files:**
+- Create: `server/tests/test_logging_config.py`
+- Create: `server/app/core/logging_config.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `server/tests/test_logging_config.py`:
+
+```python
+import logging
+import logging.handlers
+
+import pytest
+
+
+def _reset_root_logger(original_handlers, original_level):
+    root = logging.getLogger()
+    for h in root.handlers:
+        h.close()
+    root.handlers = original_handlers
+    root.level = original_level
+
+
+@pytest.fixture()
+def clean_root_logger():
+    root = logging.getLogger()
+    original_handlers = list(root.handlers)
+    original_level = root.level
+    root.handlers.clear()
+    yield
+    _reset_root_logger(original_handlers, original_level)
+
+
+def test_no_file_handler_without_log_dir(clean_root_logger, monkeypatch):
+    monkeypatch.delenv("LOG_DIR", raising=False)
+    from app.core.logging_config import configure_logging
+
+    configure_logging()
+
+    root = logging.getLogger()
+    handler_types = [type(h) for h in root.handlers]
+    assert logging.StreamHandler in handler_types
+    assert logging.handlers.RotatingFileHandler not in handler_types
+
+
+def test_file_handler_created_with_log_dir(clean_root_logger, tmp_path, monkeypatch):
+    monkeypatch.setenv("LOG_DIR", str(tmp_path))
+    from app.core.logging_config import configure_logging
+
+    configure_logging()
+
+    root = logging.getLogger()
+    file_handlers = [
+        h for h in root.handlers
+        if isinstance(h, logging.handlers.RotatingFileHandler)
+    ]
+    assert len(file_handlers) == 1
+    assert file_handlers[0].baseFilename == str(tmp_path / "app.log")
+    assert file_handlers[0].maxBytes == 10 * 1024 * 1024
+    assert file_handlers[0].backupCount == 5
+
+
+def test_log_message_written_to_file(clean_root_logger, tmp_path, monkeypatch):
+    monkeypatch.setenv("LOG_DIR", str(tmp_path))
+    from app.core.logging_config import configure_logging
+
+    configure_logging()
+    logging.getLogger("app.logging_config_test").info("hello persistent logs")
+
+    log_file = tmp_path / "app.log"
+    assert log_file.exists()
+    assert "hello persistent logs" in log_file.read_text()
+
+
+def test_root_logger_level_set_to_info(clean_root_logger, monkeypatch):
+    monkeypatch.delenv("LOG_DIR", raising=False)
+    from app.core.logging_config import configure_logging
+
+    configure_logging()
+
+    assert logging.getLogger().level == logging.INFO
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+cd server && .venv/bin/pytest tests/test_logging_config.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'app.core.logging_config'`
+
+- [ ] **Step 3: Implement configure_logging()**
+
+Create `server/app/core/logging_config.py`:
+
+```python
+import logging
+import logging.handlers
+import os
+
+
+def configure_logging() -> None:
+    """Install dual-handler logging on the root logger.
+
+    File handler (plain text, rotating) is added only when LOG_DIR env var is set.
+    Stream handler (JSON) is always active.
+
+    Call once at application startup before any loggers emit messages.
+    """
+    from pythonjsonlogger.jsonlogger import JsonFormatter
+
+    log_dir = os.environ.get("LOG_DIR", "")
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(
+        JsonFormatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+    )
+    root.addHandler(stream_handler)
+
+    if log_dir:
+        os.makedirs(log_dir, exist_ok=True)
+        file_handler = logging.handlers.RotatingFileHandler(
+            os.path.join(log_dir, "app.log"),
+            maxBytes=10 * 1024 * 1024,
+            backupCount=5,
+            encoding="utf-8",
+        )
+        file_handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+        )
+        root.addHandler(file_handler)
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+cd server && .venv/bin/pytest tests/test_logging_config.py -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/tests/test_logging_config.py server/app/core/logging_config.py server/pyproject.toml
+git commit -m "feat(logging): add configure_logging() with dual-handler output"
+```
+
+---
+
+## Task 4: Wire configure_logging() into main.py
+
+**Files:**
+- Modify: `server/app/main.py:25-28` (replace one-liner)
+- Modify: `server/app/main.py:72-80` (update lifespan)
+
+- [ ] **Step 1: Replace the one-liner logging setup**
+
+In `server/app/main.py`, replace lines 25–28:
+
+```python
+# Before:
+# Configure app-level logging so module loggers (enrichment, sync, etc.)
+# emit INFO-level diagnostics instead of being silenced by Python's default WARNING level.
+logging.getLogger("app").setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
+
+# After:
+from app.core.logging_config import configure_logging
+
+configure_logging()
+logger = logging.getLogger(__name__)
+```
+
+- [ ] **Step 2: Add uvicorn logger reconfiguration to lifespan**
+
+In `server/app/main.py`, update the `lifespan` context manager to reconfigure uvicorn loggers at startup (uvicorn installs its own handlers after the module is imported, so this must run inside lifespan):
+
+```python
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
+        lg = logging.getLogger(name)
+        lg.handlers.clear()
+        lg.propagate = True
+    task = asyncio.create_task(_tidal_collection_poll_loop())
+    try:
+        yield
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+```
+
+- [ ] **Step 3: Run full backend test suite**
+
+```bash
+cd server && .venv/bin/pytest --tb=short -q
+```
+
+Expected: all tests pass, no import errors.
+
+- [ ] **Step 4: Run lint and format check**
+
+```bash
+cd server && .venv/bin/ruff check . && .venv/bin/ruff format --check .
+```
+
+Expected: no errors. If format errors: `cd server && .venv/bin/ruff format .` then re-check.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/main.py
+git commit -m "feat(logging): wire configure_logging into main.py and lifespan"
+```
+
+---
+
+## Task 5: Deploy Config — Volume Mount and Log Directory
+
+**Files:**
+- Modify: `deploy/docker-compose.yml` (api service: volumes + environment)
+- Modify: `deploy/deploy.sh` (add mkdir -p before compose up)
+
+- [ ] **Step 1: Add LOG_DIR env var and volume mount to docker-compose.yml**
+
+In `deploy/docker-compose.yml`, in the `api` service:
+
+Add `LOG_DIR: /app/logs` to the `environment` block (after `UPLOADS_DIR`):
+
+```yaml
+      UPLOADS_DIR: /app/uploads
+      LOG_DIR: /app/logs
+```
+
+Add `./logs/api:/app/logs` to the `volumes` block (after `api_uploads`):
+
+```yaml
+    volumes:
+      - api_uploads:/app/uploads
+      - ./logs/api:/app/logs
+```
+
+The `read_only: true` hardening on the container is NOT affected — Docker applies read-only to the overlay filesystem; explicitly mounted volumes remain writable.
+
+- [ ] **Step 2: Add mkdir -p to deploy.sh before compose up**
+
+In `deploy/deploy.sh`, add these lines immediately before the `docker compose up -d --build` line (currently line 66):
+
+```bash
+echo "==> Ensuring log directories exist..."
+mkdir -p "$SCRIPT_DIR/logs/api"
+```
+
+The full section around the change:
+
+```bash
+echo "==> Ensuring log directories exist..."
+mkdir -p "$SCRIPT_DIR/logs/api"
+
+echo "==> Rebuilding and starting stack..."
+docker compose -f "$COMPOSE_FILE" up -d --build
+```
+
+- [ ] **Step 3: Verify docker-compose syntax**
+
+```bash
+docker compose -f deploy/docker-compose.yml config --quiet
+```
+
+Expected: no output (valid YAML).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deploy/docker-compose.yml deploy/deploy.sh
+git commit -m "feat(deploy): bind-mount host log directory for persistent API logs"
+```
+
+---
+
+## Task 6: Full CI Pass and PR
+
+- [ ] **Step 1: Run all backend CI checks**
+
+```bash
+cd server
+.venv/bin/ruff check .
+.venv/bin/ruff format --check .
+.venv/bin/bandit -r app -c pyproject.toml -q
+.venv/bin/pytest --tb=short -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run all frontend CI checks**
+
+```bash
+cd dashboard
+npm run lint
+npx tsc --noEmit
+npm test -- --run
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Push and open PR**
+
+```bash
+git push -u origin fix/admin-toggle-text-and-persistent-logs
+gh pr create \
+  --title "fix: admin toggle language + persistent API logs" \
+  --body "$(cat <<'EOF'
+## Summary
+- Fixes misleading bot protection toggle description in admin settings — Turnstile always runs silently; toggle controls enforcement only
+- Extracts `configure_logging()` to `app/core/logging_config.py` with dual-handler output: rotating plain-text file + JSON stdout
+- Bind-mounts `deploy/logs/api/` on the VPS host so API logs survive `docker compose down` and deploys
+- Deploy script creates the log directory idempotently before `docker compose up`
+
+## Test plan
+- [ ] Visual: load `/admin/settings`, confirm updated label and description
+- [ ] `tail -f ~/WrzDJ/deploy/logs/api/app.log` on VPS after deploy — confirm HTTP access lines appear
+- [ ] `docker compose logs api` still works (JSON stdout unaffected)
+- [ ] `docker compose down && docker compose up -d --build` — confirm log file persists
+- [ ] pytest: 4 new tests in `tests/test_logging_config.py` all pass
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-05-12-admin-ui-fixes-and-persistent-logs-design.md
+++ b/docs/superpowers/specs/2026-05-12-admin-ui-fixes-and-persistent-logs-design.md
@@ -1,0 +1,187 @@
+# Design: Admin UI Fixes & Persistent API Logs
+
+**Date:** 2026-05-12
+**Status:** Approved
+
+## Overview
+
+Two independent improvements:
+
+**A — Bot protection toggle language rewrite:** The existing admin settings checkbox for human verification contains inaccurate and jargon-heavy text. Cloudflare Turnstile always runs silently for all guests; the toggle only controls API enforcement. The current description implies the opposite.
+
+**B — Persistent API logs:** Container restarts and deployments (`docker compose down` + `up`) destroy the Docker log buffer. Meaningful application events — human verification failures, enrichment errors, rate limit hits — are lost on every deploy. Bind-mounting a host directory gives logs a stable path that survives the container lifecycle.
+
+---
+
+## Part A: Bot Protection Toggle Language
+
+### Scope
+
+Single file: `dashboard/app/admin/settings/page.tsx`
+
+### Changes
+
+**Label** (line 99):
+- Before: `"Enforce human verification on guest pages"`
+- After: `"Enforce bot protection on guest pages"`
+
+**Description** (line 101):
+- Before: `"When ON, guests must complete a Cloudflare Turnstile check before submitting requests, voting, or searching. Default OFF (soft mode logs warnings only)."`
+- After: `"Cloudflare Turnstile runs silently for all guests — most see no challenge. When ON, guests who fail the check are blocked from submitting requests, voting, or searching. When OFF, failures are only logged."`
+
+### Why the current text is wrong
+
+`useHumanVerification` renders a Turnstile widget with `appearance: 'interaction-only'` on mount for `/join` and `/collect`. Cloudflare's risk scoring runs automatically — no user action required for low-risk visitors. The toggle (`human_verification_enforced` in `system_settings`) only controls whether `require_verified_human_soft` in `deps.py` raises a 403 on missing/invalid `wrzdj_human` cookie. The challenge fires regardless of toggle state.
+
+### Future: Error Dashboard
+
+Bot protection failures (403s with `code: "human_verification_required"`) and soft-mode warning log events are candidates for surfacing in a future admin error dashboard. The DJ dashboard's existing infrastructure (activity feed, polling patterns) provides the model. **This is out of scope for this spec** — note it as a follow-up feature when the error dashboard is designed.
+
+---
+
+## Part B: Persistent API Logs
+
+### Architecture
+
+Dual-handler Python logging: one handler writes plain text to a rotating file on a host-mounted volume, the other writes JSON to stdout. No new services, no sidecar containers, no external log aggregation.
+
+```
+uvicorn process
+  ├── root logger
+  │     ├── RotatingFileHandler → /app/logs/app.log  (plain text, 10MB × 5)
+  │     └── StreamHandler       → stdout              (JSON via python-json-logger)
+  ├── uvicorn.access  (propagate=True, handlers cleared)
+  └── uvicorn.error   (propagate=True, handlers cleared)
+```
+
+Both uvicorn access logs (HTTP request lines) and application logs (`logging.getLogger("app.*")`) flow through both handlers.
+
+### Files Changed
+
+#### `server/pyproject.toml`
+Add `python-json-logger>=3.0` to `[project.dependencies]`.
+
+#### `server/app/main.py`
+Replace the current one-liner logging setup with a `configure_logging()` function called at module level:
+
+```python
+import logging
+import logging.handlers
+import os
+
+def configure_logging() -> None:
+    log_dir = os.environ.get("LOG_DIR", "/app/logs")
+    os.makedirs(log_dir, exist_ok=True)
+
+    file_handler = logging.handlers.RotatingFileHandler(
+        os.path.join(log_dir, "app.log"),
+        maxBytes=10 * 1024 * 1024,  # 10 MB
+        backupCount=5,
+        encoding="utf-8",
+    )
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+    )
+
+    from pythonjsonlogger.jsonlogger import JsonFormatter
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(
+        JsonFormatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+    )
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(file_handler)
+    root.addHandler(stream_handler)
+
+configure_logging()
+```
+
+The existing `lifespan` context manager in `main.py` reconfigures uvicorn loggers at startup (after uvicorn installs its own handlers):
+
+```python
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # existing startup code ...
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
+        lg = logging.getLogger(name)
+        lg.handlers.clear()
+        lg.propagate = True
+    yield
+    # existing shutdown code ...
+```
+
+`LOG_DIR` defaults to `/app/logs` (production) and can be overridden for local dev (e.g., `LOG_DIR=/tmp/wrzdj-logs`).
+
+#### `deploy/docker-compose.yml`
+Add bind-mount to the `api` service `volumes` list:
+
+```yaml
+volumes:
+  - api_uploads:/app/uploads
+  - ./logs/api:/app/logs        # persistent log directory
+```
+
+The `read_only: true` container hardening is unaffected — Docker applies read-only to the overlay filesystem; explicitly mounted volumes remain writable.
+
+#### `deploy/deploy.sh`
+Add directory creation before `docker compose up`:
+
+```bash
+mkdir -p "$(dirname "$0")/logs/api"
+```
+
+Idempotent. Creates `deploy/logs/api/` on the host if absent. No permissions adjustment needed — Docker bind-mounts inherit host directory ownership.
+
+### Log Location on VPS
+
+```
+~/WrzDJ/deploy/logs/api/
+  app.log        ← current log (tail -f this)
+  app.log.1      ← most recent rotation
+  app.log.2
+  ...
+  app.log.5      ← oldest kept (50 MB total cap)
+```
+
+### Rotation Policy
+
+| Setting | Value | Rationale |
+|---------|-------|-----------|
+| `maxBytes` | 10 MB | Small enough to open in any editor |
+| `backupCount` | 5 | 50 MB total cap; ~weeks of typical traffic |
+| Encoding | UTF-8 | Safe for international song titles in log messages |
+
+### `docker logs` Compatibility
+
+Stdout JSON output is unchanged — `docker compose logs api` continues to work normally. The file handler is additive.
+
+### Local Dev
+
+`LOG_DIR` not set in `.env` by default — `os.makedirs(..., exist_ok=True)` creates `/app/logs` inside the dev container if running locally, or the developer can `export LOG_DIR=/tmp/wrzdj-logs` to redirect to a local path.
+
+No volume mount change needed for local dev — `docker-compose.yml` only applies in production deploys.
+
+---
+
+## Testing
+
+### Part A
+- Visual inspection: load `/admin/settings`, confirm new label and description text
+- No logic changes — no unit tests required
+
+### Part B
+- Start API locally, confirm `app.log` is created in `LOG_DIR`
+- Make one authenticated request, confirm access log line appears in file (plain text) and stdout (JSON)
+- Trigger a soft-mode human verification miss, confirm warning appears in both outputs
+- Verify rotation: set `maxBytes=1` in a test run, confirm `.log.1` is created after first write
+- CI: existing test suite unchanged — logging config is additive
+
+---
+
+## Out of Scope
+
+- Web container logs (Next.js stdout only; low signal; covered by `docker logs web` if needed)
+- External log aggregation (Loki, CloudWatch) — overkill for single-VPS deployment
+- Admin error dashboard for bot protection events — future feature, model after DJ dashboard activity infrastructure
+- Log retention policy beyond rotation (no archival, no S3 offload)

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,8 +23,11 @@ RUN chmod +x scripts/start.sh
 # Create uploads directory
 RUN mkdir -p /app/uploads/banners
 
-# Create non-root user
-RUN useradd -m appuser && chown -R appuser:appuser /app
+# Create non-root user with fixed UID/GID 1000 so bind-mounted host directories
+# (e.g. deploy/logs/api) can be chown'd to :1000 with chmod 775 instead of 777.
+RUN groupadd -g 1000 appuser \
+    && useradd -u 1000 -g 1000 -m appuser \
+    && chown -R appuser:appuser /app
 USER appuser
 
 # Default port (can be overridden by PaaS via PORT env var)

--- a/server/app/core/logging_config.py
+++ b/server/app/core/logging_config.py
@@ -2,6 +2,8 @@ import logging
 import logging.handlers
 import os
 
+_CONFIGURED = False
+
 
 def configure_logging() -> None:
     """Install dual-handler logging on the root logger.
@@ -11,6 +13,11 @@ def configure_logging() -> None:
 
     Call once at application startup before any loggers emit messages.
     """
+    global _CONFIGURED
+    if _CONFIGURED:
+        return
+    _CONFIGURED = True
+
     from pythonjsonlogger.json import JsonFormatter
 
     log_dir = os.environ.get("LOG_DIR", "")

--- a/server/app/core/logging_config.py
+++ b/server/app/core/logging_config.py
@@ -30,14 +30,19 @@ def configure_logging() -> None:
     root.addHandler(stream_handler)
 
     if log_dir:
-        os.makedirs(log_dir, exist_ok=True)
-        file_handler = logging.handlers.RotatingFileHandler(
-            os.path.join(log_dir, "app.log"),
-            maxBytes=10 * 1024 * 1024,
-            backupCount=5,
-            encoding="utf-8",
-        )
-        file_handler.setFormatter(
-            logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
-        )
-        root.addHandler(file_handler)
+        try:
+            os.makedirs(log_dir, exist_ok=True)
+            file_handler = logging.handlers.RotatingFileHandler(
+                os.path.join(log_dir, "app.log"),
+                maxBytes=10 * 1024 * 1024,
+                backupCount=5,
+                encoding="utf-8",
+            )
+            file_handler.setFormatter(
+                logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+            )
+            root.addHandler(file_handler)
+        except OSError as exc:
+            logging.getLogger(__name__).warning(
+                "Could not create log file handler in %s: %s", log_dir, exc
+            )

--- a/server/app/core/logging_config.py
+++ b/server/app/core/logging_config.py
@@ -1,0 +1,36 @@
+import logging
+import logging.handlers
+import os
+
+
+def configure_logging() -> None:
+    """Install dual-handler logging on the root logger.
+
+    File handler (plain text, rotating) is added only when LOG_DIR env var is set.
+    Stream handler (JSON) is always active.
+
+    Call once at application startup before any loggers emit messages.
+    """
+    from pythonjsonlogger.json import JsonFormatter
+
+    log_dir = os.environ.get("LOG_DIR", "")
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(JsonFormatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+    root.addHandler(stream_handler)
+
+    if log_dir:
+        os.makedirs(log_dir, exist_ok=True)
+        file_handler = logging.handlers.RotatingFileHandler(
+            os.path.join(log_dir, "app.log"),
+            maxBytes=10 * 1024 * 1024,
+            backupCount=5,
+            encoding="utf-8",
+        )
+        file_handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+        )
+        root.addHandler(file_handler)

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -14,6 +14,7 @@ from slowapi.errors import RateLimitExceeded
 
 from app.api import api_router
 from app.core.config import get_settings
+from app.core.logging_config import configure_logging
 from app.core.rate_limit import limiter, rate_limit_exceeded_handler
 from app.core.security_headers import SecurityHeadersMiddleware
 
@@ -22,9 +23,7 @@ mimetypes.add_type("image/webp", ".webp")
 
 settings = get_settings()
 
-# Configure app-level logging so module loggers (enrichment, sync, etc.)
-# emit INFO-level diagnostics instead of being silenced by Python's default WARNING level.
-logging.getLogger("app").setLevel(logging.INFO)
+configure_logging()
 logger = logging.getLogger(__name__)
 
 # Explicit CORS methods for non-wildcard origins — must include every HTTP method used by the API
@@ -71,6 +70,10 @@ async def _tidal_collection_poll_loop() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
+        lg = logging.getLogger(name)
+        lg.handlers.clear()
+        lg.propagate = True
     task = asyncio.create_task(_tidal_collection_poll_loop())
     try:
         yield

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "resend>=2.0.0",
     "better-profanity>=0.7.0",
     "sse-starlette>=2.0.0",
+    "python-json-logger>=3.0",
 ]
 
 [project.optional-dependencies]

--- a/server/tests/test_logging_config.py
+++ b/server/tests/test_logging_config.py
@@ -1,0 +1,71 @@
+import logging
+import logging.handlers
+
+import pytest
+
+
+def _reset_root_logger(original_handlers, original_level):
+    root = logging.getLogger()
+    for h in root.handlers:
+        h.close()
+    root.handlers = original_handlers
+    root.level = original_level
+
+
+@pytest.fixture()
+def clean_root_logger():
+    root = logging.getLogger()
+    original_handlers = list(root.handlers)
+    original_level = root.level
+    root.handlers.clear()
+    yield
+    _reset_root_logger(original_handlers, original_level)
+
+
+def test_no_file_handler_without_log_dir(clean_root_logger, monkeypatch):
+    monkeypatch.delenv("LOG_DIR", raising=False)
+    from app.core.logging_config import configure_logging
+
+    configure_logging()
+
+    root = logging.getLogger()
+    handler_types = [type(h) for h in root.handlers]
+    assert logging.StreamHandler in handler_types
+    assert logging.handlers.RotatingFileHandler not in handler_types
+
+
+def test_file_handler_created_with_log_dir(clean_root_logger, tmp_path, monkeypatch):
+    monkeypatch.setenv("LOG_DIR", str(tmp_path))
+    from app.core.logging_config import configure_logging
+
+    configure_logging()
+
+    root = logging.getLogger()
+    file_handlers = [
+        h for h in root.handlers if isinstance(h, logging.handlers.RotatingFileHandler)
+    ]
+    assert len(file_handlers) == 1
+    assert file_handlers[0].baseFilename == str(tmp_path / "app.log")
+    assert file_handlers[0].maxBytes == 10 * 1024 * 1024
+    assert file_handlers[0].backupCount == 5
+
+
+def test_log_message_written_to_file(clean_root_logger, tmp_path, monkeypatch):
+    monkeypatch.setenv("LOG_DIR", str(tmp_path))
+    from app.core.logging_config import configure_logging
+
+    configure_logging()
+    logging.getLogger("app.logging_config_test").info("hello persistent logs")
+
+    log_file = tmp_path / "app.log"
+    assert log_file.exists()
+    assert "hello persistent logs" in log_file.read_text()
+
+
+def test_root_logger_level_set_to_info(clean_root_logger, monkeypatch):
+    monkeypatch.delenv("LOG_DIR", raising=False)
+    from app.core.logging_config import configure_logging
+
+    configure_logging()
+
+    assert logging.getLogger().level == logging.INFO

--- a/server/tests/test_logging_config.py
+++ b/server/tests/test_logging_config.py
@@ -14,11 +14,16 @@ def _reset_root_logger(original_handlers, original_level):
 
 @pytest.fixture()
 def clean_root_logger():
+    import app.core.logging_config as logging_config
+
     root = logging.getLogger()
     original_handlers = list(root.handlers)
     original_level = root.level
+    original_configured = logging_config._CONFIGURED
     root.handlers.clear()
+    logging_config._CONFIGURED = False
     yield
+    logging_config._CONFIGURED = original_configured
     _reset_root_logger(original_handlers, original_level)
 
 
@@ -31,7 +36,7 @@ def test_no_file_handler_without_log_dir(clean_root_logger, monkeypatch):
     root = logging.getLogger()
     handler_types = [type(h) for h in root.handlers]
     assert logging.StreamHandler in handler_types
-    assert logging.handlers.RotatingFileHandler not in handler_types
+    assert not any(isinstance(h, logging.handlers.BaseRotatingHandler) for h in root.handlers)
 
 
 def test_file_handler_created_with_log_dir(clean_root_logger, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Fixes misleading bot protection toggle description in admin settings — Turnstile always runs silently; toggle controls enforcement only
- Extracts `configure_logging()` to `app/core/logging_config.py` with dual-handler output: rotating plain-text file + JSON stdout
- Bind-mounts `deploy/logs/api/` on the VPS host so API logs survive `docker compose down` and deploys
- Deploy script creates the log directory idempotently before `docker compose up`

## Test plan
- [ ] Visual: load `/admin/settings`, confirm updated label and description
- [ ] `tail -f ~/WrzDJ/deploy/logs/api/app.log` on VPS after deploy — confirm HTTP access lines appear
- [ ] `docker compose logs api` still works (JSON stdout unaffected)
- [ ] `docker compose down && docker compose up -d --build` — confirm log file persists
- [ ] pytest: 4 new tests in `tests/test_logging_config.py` all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API logs now persist across deployments for improved monitoring and debugging

* **UI/UX Updates**
  * Clarified admin setting label and help text to better explain bot-protection behavior (silent verification vs enforcement)

* **Tests**
  * Added tests to verify logging setup and persisted log output

* **Documentation**
  * Added implementation plan and design spec describing admin UI wording and persistent logging approach

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/311)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->