### PR TITLE
fix(theme): hide ThemeToggle during onboarding tour

### DIFF
--- a/dashboard/components/ThemeToggle.tsx
+++ b/dashboard/components/ThemeToggle.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useTheme, type Theme } from '@/lib/theme';
+import { useHelp } from '@/lib/help/HelpContext';
 
 const THEME_LABELS: Record<Theme, string> = {
   dark: 'Dark',
@@ -10,6 +11,9 @@ const THEME_LABELS: Record<Theme, string> = {
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
+  const { onboardingActive } = useHelp();
+
+  if (onboardingActive) return null;
 
   return (
     <button

--- a/dashboard/components/__tests__/ThemeToggle.test.tsx
+++ b/dashboard/components/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeToggle } from '../ThemeToggle';
+import * as HelpContext from '@/lib/help/HelpContext';
+import type { HelpContextValue } from '@/lib/help/types';
+
+vi.mock('@/lib/theme', () => ({
+  useTheme: () => ({ theme: 'dark', toggleTheme: vi.fn() }),
+}));
+
+function makeHelpContext(overrides: Partial<HelpContextValue> = {}): HelpContextValue {
+  return {
+    helpMode: false,
+    onboardingActive: false,
+    currentStep: 0,
+    activeSpotId: null,
+    toggleHelpMode: vi.fn(),
+    registerSpot: vi.fn(() => vi.fn()),
+    getSpotsForPage: vi.fn(() => []),
+    startOnboarding: vi.fn(),
+    nextStep: vi.fn(),
+    prevStep: vi.fn(),
+    skipOnboarding: vi.fn(),
+    hasSeenPage: vi.fn(() => false),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.spyOn(HelpContext, 'useHelp').mockReturnValue(makeHelpContext());
+});
+
+describe('ThemeToggle', () => {
+  it('renders the toggle button when onboarding is not active', () => {
+    vi.spyOn(HelpContext, 'useHelp').mockReturnValue(
+      makeHelpContext({ onboardingActive: false })
+    );
+    render(<ThemeToggle />);
+    expect(screen.getByRole('button', { name: /current theme/i })).toBeInTheDocument();
+  });
+
+  it('renders nothing when onboarding is active', () => {
+    vi.spyOn(HelpContext, 'useHelp').mockReturnValue(
+      makeHelpContext({ onboardingActive: true })
+    );
+    render(<ThemeToggle />);
+    expect(screen.queryByRole('button', { name: /current theme/i })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- `ThemeToggle` now reads `onboardingActive` from `HelpContext` and returns `null` while a tour is running
- Resolves z-index conflict where backdrop (z-1050) and step card (z-1060) both painted over the toggle
- Chose Option B (hide toggle) over Option A (raise z-index) — avoids z-index arms race, theme isn't useful mid-tour

## Changes

- `dashboard/components/ThemeToggle.tsx` — import `useHelp`, return `null` when `onboardingActive`
- `dashboard/components/__tests__/ThemeToggle.test.tsx` — new test file (two cases, TDD)

## Test Plan

- [ ] `npm test -- --run` in `dashboard/` passes (924 tests)
- [ ] Trigger help tour on DJ event page — ThemeToggle disappears during tour, reappears after Done/Skip
- [ ] Repeat in `/admin` — same behavior
- [ ] ThemeToggle renders normally on pages with no onboarding spots

Closes #314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Theme toggle button is now hidden during onboarding for a cleaner experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->