### PR TITLE
fix(theme): dark text on buttons in day mode (#315)

### DIFF
--- a/dashboard/app/join/[code]/components/MyRequestsTracker.tsx
+++ b/dashboard/app/join/[code]/components/MyRequestsTracker.tsx
@@ -85,13 +85,13 @@ export default function MyRequestsTracker({
                   <div
                     className="guest-request-item-art"
                     style={{
-                      background: '#333',
+                      background: 'var(--card)',
                       display: 'flex',
                       alignItems: 'center',
                       justifyContent: 'center',
                     }}
                   >
-                    <span style={{ fontSize: '1.25rem', color: '#666' }}>&#9835;</span>
+                    <span style={{ fontSize: '1.25rem', color: 'var(--text-secondary)' }}>&#9835;</span>
                   </div>
                 )}
                 <div className="guest-request-item-info">

--- a/dashboard/app/join/[code]/components/__tests__/MyRequestsTracker.test.tsx
+++ b/dashboard/app/join/[code]/components/__tests__/MyRequestsTracker.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import MyRequestsTracker from '../MyRequestsTracker';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getMyRequests: vi.fn().mockResolvedValue({
+      requests: [
+        {
+          id: 1,
+          title: 'Test Song',
+          artist: 'Test Artist',
+          status: 'new',
+          artwork_url: null,
+          created_at: '2026-05-16T00:00:00Z',
+          vote_count: 0,
+        },
+      ],
+    }),
+  },
+}));
+
+describe('MyRequestsTracker', () => {
+  it('art placeholder uses theme-safe background', async () => {
+    render(
+      <MyRequestsTracker
+        eventCode="EVT001"
+        refreshKey={0}
+        onRequestIdsLoaded={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Song')).toBeInTheDocument();
+    });
+
+    const placeholder = document.querySelector('div.guest-request-item-art');
+    expect(placeholder).not.toBeNull();
+    expect(placeholder!).toHaveAttribute('style', expect.stringContaining('var(--card)'));
+  });
+
+  it('art placeholder icon uses theme-safe text color', async () => {
+    render(
+      <MyRequestsTracker
+        eventCode="EVT001"
+        refreshKey={0}
+        onRequestIdsLoaded={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Song')).toBeInTheDocument();
+    });
+
+    const placeholder = document.querySelector('div.guest-request-item-art');
+    const icon = placeholder!.querySelector('span');
+    expect(icon).not.toBeNull();
+    expect(icon!).toHaveAttribute('style', expect.stringContaining('var(--text-secondary)'));
+  });
+});

--- a/dashboard/app/kiosk-link/[code]/__tests__/page.test.tsx
+++ b/dashboard/app/kiosk-link/[code]/__tests__/page.test.tsx
@@ -120,4 +120,28 @@ describe('KioskLinkPage', () => {
       expect(screen.getByText(/expired/i)).toBeInTheDocument();
     });
   });
+
+  it('event selector buttons use theme-safe background and text color', async () => {
+    render(<KioskLinkPage />);
+
+    await waitFor(() => {
+      const btn = screen.getByText('Friday Night').closest('button')!;
+      expect(btn).toHaveAttribute('style', expect.stringContaining('var(--surface-raised)'));
+      expect(btn).toHaveAttribute('style', expect.stringContaining('var(--text)'));
+    });
+  });
+
+  it('try again button uses theme-safe background', async () => {
+    const err = new Error('Test error');
+    mockCompleteKioskPairing.mockRejectedValue(err);
+    render(<KioskLinkPage />);
+
+    await waitFor(() => screen.getByText('Friday Night'));
+    fireEvent.click(screen.getByText('Friday Night').closest('button')!);
+
+    await waitFor(() => {
+      const tryAgainBtn = screen.getByRole('button', { name: /try again/i });
+      expect(tryAgainBtn).toHaveAttribute('style', expect.stringContaining('var(--surface-raised)'));
+    });
+  });
 });

--- a/dashboard/app/kiosk-link/[code]/page.tsx
+++ b/dashboard/app/kiosk-link/[code]/page.tsx
@@ -92,10 +92,10 @@ export default function KioskLinkPage() {
                       width: '100%',
                       textAlign: 'left',
                       padding: '0.75rem 1rem',
-                      background: '#1a1a1a',
+                      background: 'var(--surface-raised)',
                       border: '1px solid #333',
                       borderRadius: '8px',
-                      color: '#ededed',
+                      color: 'var(--text)',
                       cursor: 'pointer',
                     }}
                   >
@@ -143,7 +143,7 @@ export default function KioskLinkPage() {
             <button
               onClick={() => setState('picking')}
               className="btn"
-              style={{ background: '#333' }}
+              style={{ background: 'var(--surface-raised)' }}
             >
               Try Again
             </button>

--- a/dashboard/app/pending/__tests__/page.test.tsx
+++ b/dashboard/app/pending/__tests__/page.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import PendingPage from '../page';
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    isLoading: false,
+    role: 'pending',
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getMe: vi.fn().mockResolvedValue({ role: 'pending' }),
+  },
+}));
+
+describe('PendingPage', () => {
+  it('logout button uses theme-safe background', () => {
+    render(<PendingPage />);
+    const btn = screen.getByRole('button', { name: /logout/i });
+    expect(btn).toHaveAttribute('style', expect.stringContaining('var(--surface-raised)'));
+  });
+});

--- a/dashboard/app/pending/page.tsx
+++ b/dashboard/app/pending/page.tsx
@@ -56,7 +56,7 @@ export default function PendingPage() {
         </p>
         <button
           className="btn"
-          style={{ background: '#333' }}
+          style={{ background: 'var(--surface-raised)' }}
           onClick={logout}
         >
           Logout


### PR DESCRIPTION
## Summary

- `pending/page.tsx`: logout button `background: '#333'` → `var(--surface-raised)`
- `kiosk-link/[code]/page.tsx`: event selector buttons `#1a1a1a`/`#ededed` → `var(--surface-raised)`/`var(--text)`; try-again button `#333` → `var(--surface-raised)`
- `MyRequestsTracker.tsx`: art placeholder `background: '#333'` → `var(--card)`, icon `color: '#666'` → `var(--text-secondary)`

Closes #315.

## Test Plan

- [ ] New: `app/pending/__tests__/page.test.tsx` — logout button uses `var(--surface-raised)`
- [ ] Extended: `app/kiosk-link/[code]/__tests__/page.test.tsx` — event selector + try-again buttons use CSS variables
- [ ] New: `app/join/[code]/components/__tests__/MyRequestsTracker.test.tsx` — art placeholder uses `var(--card)` + `var(--text-secondary)`
- [ ] Toggle day mode in DJ dashboard, verify all four locations render readable text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling across the dashboard to use a consistent theme system instead of fixed colors, improving visual consistency and ensuring colors automatically adapt to your theme preference.
  * Refined styling for event selection buttons, logout button, and placeholder artwork with improved visual cohesion.
  * Enhanced the overall appearance with a unified color theming system across multiple pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->