### PR TITLE
feat(ci): publish Docker images to GHCR for self-hosters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,14 +203,3 @@ jobs:
       - name: Run tests
         run: python -m pytest test_portal.py -q
 
-  docker-build:
-    name: Docker Build Smoke Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Build backend image
-        run: docker build -t wrzdj-api-test server/
-
-      - name: Build frontend image
-        run: docker build --build-arg NEXT_PUBLIC_API_URL=http://localhost:8000 -t wrzdj-web-test dashboard/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,104 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  API_IMAGE: ghcr.io/wrzonance/wrzdj-api
+  WEB_IMAGE: ghcr.io/wrzonance/wrzdj-web
+
+jobs:
+  publish-api:
+    name: Publish API image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
+        with:
+          images: ${{ env.API_IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: ./server
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  publish-web:
+    name: Publish Web image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
+        with:
+          images: ${{ env.WEB_IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: ./dashboard
+          build-args: |
+            NEXT_PUBLIC_API_URL=__WRZDJ_API_URL__
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,6 +41,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=sha-,format=short
@@ -85,6 +86,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=sha-,format=short

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,9 @@ jobs:
         run: |
           tar -czf wrzdj-deploy-scripts.tar.gz \
             deploy/docker-compose.yml \
+            deploy/docker-compose.ghcr.yml \
             deploy/deploy.sh \
+            deploy/deploy-ghcr.sh \
             deploy/DEPLOYMENT.md \
             deploy/.env.example \
             deploy/nginx/ \

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -43,7 +43,8 @@ RUN chown nextjs:nodejs .next
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-COPY --chmod=755 docker-entrypoint.sh /docker-entrypoint.sh
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
 USER nextjs
 

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:26-alpine@sha256:e71ac5e964b9201072425d59d2e876359efa25dc96bb1768cb73295728d6e4ea AS base
+FROM node:26-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps
@@ -43,6 +43,8 @@ RUN chown nextjs:nodejs .next
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
+COPY --chmod=755 docker-entrypoint.sh /docker-entrypoint.sh
+
 USER nextjs
 
 # Port configuration - PaaS platforms set PORT env var
@@ -57,4 +59,5 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:${PORT:-3000}/ || exit 1
 
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/dashboard/docker-entrypoint.sh
+++ b/dashboard/docker-entrypoint.sh
@@ -2,8 +2,12 @@
 set -e
 
 if [ -n "${NEXT_PUBLIC_API_URL:-}" ]; then
-  find /app/.next -type f -name "*.js" \
-    -exec sed -i "s|__WRZDJ_API_URL__|${NEXT_PUBLIC_API_URL}|g" {} +
+  # Patch both .js chunks (client bundle references) and .json manifests
+  # (routes-manifest.json holds the CSP connect-src value baked at build time).
+  # Delimiter @ avoids collision with | in URLs and is illegal in the authority
+  # component of standard URLs.
+  find /app/.next -type f \( -name "*.js" -o -name "*.json" \) \
+    -exec sed -i "s@__WRZDJ_API_URL__@${NEXT_PUBLIC_API_URL}@g" {} +
 else
   echo "WARNING: NEXT_PUBLIC_API_URL not set. Browser requests will fall back to window.location.hostname:8000. CSP will block cross-origin API calls." >&2
 fi

--- a/dashboard/docker-entrypoint.sh
+++ b/dashboard/docker-entrypoint.sh
@@ -10,7 +10,7 @@ if [ -n "${NEXT_PUBLIC_API_URL:-}" ]; then
   # Escape sed replacement metacharacters in the URL: backslash and ampersand
   # (& = "matched text" in sed replacement). The delimiter @ does not need
   # escaping because it's illegal in URL authority components.
-  ESCAPED_URL=$(printf '%s' "${NEXT_PUBLIC_API_URL}" | sed -e 's/[\&]/\\&/g')
+  ESCAPED_URL=$(printf '%s' "${NEXT_PUBLIC_API_URL}" | sed -e 's/[&\\]/\\&/g')
   find /app/.next -type f \( -name "*.js" -o -name "*.json" \) \
     -exec sed -i "s@__WRZDJ_API_URL__@${ESCAPED_URL}@g" {} +
 else

--- a/dashboard/docker-entrypoint.sh
+++ b/dashboard/docker-entrypoint.sh
@@ -6,8 +6,13 @@ if [ -n "${NEXT_PUBLIC_API_URL:-}" ]; then
   # (routes-manifest.json holds the CSP connect-src value baked at build time).
   # Delimiter @ avoids collision with | in URLs and is illegal in the authority
   # component of standard URLs.
+  #
+  # Escape sed replacement metacharacters in the URL: backslash and ampersand
+  # (& = "matched text" in sed replacement). The delimiter @ does not need
+  # escaping because it's illegal in URL authority components.
+  ESCAPED_URL=$(printf '%s' "${NEXT_PUBLIC_API_URL}" | sed -e 's/[\&]/\\&/g')
   find /app/.next -type f \( -name "*.js" -o -name "*.json" \) \
-    -exec sed -i "s@__WRZDJ_API_URL__@${NEXT_PUBLIC_API_URL}@g" {} +
+    -exec sed -i "s@__WRZDJ_API_URL__@${ESCAPED_URL}@g" {} +
 else
   echo "WARNING: NEXT_PUBLIC_API_URL not set. Browser requests will fall back to window.location.hostname:8000. CSP will block cross-origin API calls." >&2
 fi

--- a/dashboard/docker-entrypoint.sh
+++ b/dashboard/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+if [ -n "${NEXT_PUBLIC_API_URL:-}" ]; then
+  find /app/.next -type f -name "*.js" \
+    -exec sed -i "s|__WRZDJ_API_URL__|${NEXT_PUBLIC_API_URL}|g" {} +
+else
+  echo "WARNING: NEXT_PUBLIC_API_URL not set. Browser requests will fall back to window.location.hostname:8000. CSP will block cross-origin API calls." >&2
+fi
+
+exec "$@"

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -7,6 +7,12 @@
 ENV=production
 
 # =============================================================================
+# GHCR Image Version (for deploy-ghcr.sh / docker-compose.ghcr.yml)
+# =============================================================================
+# Pin to a specific release (e.g. v2026.05.16) or use latest / a sha-* tag
+WRZDJ_VERSION=latest
+
+# =============================================================================
 # Database (Docker Compose internal)
 # =============================================================================
 POSTGRES_USER=wrzdj

--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -2,23 +2,52 @@
 
 ## Quick Start (Pre-built Images)
 
-Pull and run without building from source — no compiler, no git, no Node.js needed on the server:
+Pull and run without building from source — no compiler, no git, no Node.js needed on the server.
+
+### Prerequisites
+
+- **Docker Engine 24+** and **`docker compose` v2** (`docker compose version` should print `v2.x`)
+- **~2 GB RAM**, ~5 GB disk for images + Postgres data volume
+- Outbound HTTPS access to `ghcr.io` for image pulls
+- Ports `8000` (API) and `3000` (web) free, or override via `PORT_API` / `PORT_FRONTEND` in `.env`
+
+### Steps
 
 ```bash
-# 1. Get the deploy files (from a release tarball or by cloning)
-cp deploy/.env.example deploy/.env
+# 1a. Option A — Clone the repo (always latest)
+git clone https://github.com/wrzonance/WrzDJ.git
+cd WrzDJ
 
-# 2. Fill in required vars: POSTGRES_PASSWORD, JWT_SECRET, TOKEN_ENCRYPTION_KEY,
-#    HUMAN_COOKIE_SECRET, CORS_ORIGINS, PUBLIC_URL, NEXT_PUBLIC_API_URL
+# 1b. Option B — Or grab the deploy bundle from a release (no source code)
+#     curl -L -o wrzdj-deploy.tar.gz \
+#       https://github.com/wrzonance/WrzDJ/releases/latest/download/wrzdj-deploy-scripts.tar.gz
+#     mkdir wrzdj && tar -xzf wrzdj-deploy.tar.gz -C wrzdj && cd wrzdj
+
+# 2. Copy the env template and fill in REQUIRED values
+cp deploy/.env.example deploy/.env
+# Edit deploy/.env — required:
+#   POSTGRES_PASSWORD, JWT_SECRET, TOKEN_ENCRYPTION_KEY, HUMAN_COOKIE_SECRET,
+#   CORS_ORIGINS, PUBLIC_URL, NEXT_PUBLIC_API_URL
+# Optional integrations (leave blank if unused):
+#   SPOTIFY_*, TIDAL_*, BEATPORT_*, TURNSTILE_*, ANTHROPIC_API_KEY, RESEND_*, BRIDGE_API_KEY
 
 # 3. Deploy
-./deploy/deploy-ghcr.sh              # pulls latest
-./deploy/deploy-ghcr.sh v2026.05.16 # or pin a specific release
+./deploy/deploy-ghcr.sh              # pulls latest, restarts stack, waits for /health
+./deploy/deploy-ghcr.sh v2026.05.16  # or pin a specific release
+```
+
+### Verify the deploy
+
+```bash
+curl -sf http://127.0.0.1:8000/health   # expect: {"status":"ok"}
+docker compose -f deploy/docker-compose.ghcr.yml ps  # all "Up (healthy)"
 ```
 
 Images are published automatically on every push to `main` and on every `v*` tag:
 - [ghcr.io/wrzonance/wrzdj-api](https://github.com/wrzonance/WrzDJ/pkgs/container/wrzdj-api)
 - [ghcr.io/wrzonance/wrzdj-web](https://github.com/wrzonance/WrzDJ/pkgs/container/wrzdj-web)
+
+> **Authentication errors on first pull?** New GHCR packages default to **private**, even on a public repo. If `docker pull` returns `401 Unauthorized`, the package owner needs to toggle visibility to public (one-time, in the package settings on the link above). If the package is public and you still see 401, open an issue.
 
 ---
 

--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -1,5 +1,29 @@
 # WrzDJ VPS Deployment Guide
 
+## Quick Start (Pre-built Images)
+
+Pull and run without building from source — no compiler, no git, no Node.js needed on the server:
+
+```bash
+# 1. Get the deploy files (from a release tarball or by cloning)
+cp deploy/.env.example deploy/.env
+
+# 2. Fill in required vars: POSTGRES_PASSWORD, JWT_SECRET, TOKEN_ENCRYPTION_KEY,
+#    HUMAN_COOKIE_SECRET, CORS_ORIGINS, PUBLIC_URL, NEXT_PUBLIC_API_URL
+
+# 3. Deploy
+./deploy/deploy-ghcr.sh              # pulls latest
+./deploy/deploy-ghcr.sh v2026.05.16 # or pin a specific release
+```
+
+Images are published automatically on every push to `main` and on every `v*` tag:
+- [ghcr.io/wrzonance/wrzdj-api](https://github.com/wrzonance/WrzDJ/pkgs/container/wrzdj-api)
+- [ghcr.io/wrzonance/wrzdj-web](https://github.com/wrzonance/WrzDJ/pkgs/container/wrzdj-web)
+
+---
+
+## Build-from-Source Deployment
+
 This guide covers deploying WrzDJ on a VPS using Docker Compose with the subdomain model:
 - **Frontend**: `https://app.yourdomain.com`
 - **Backend**: `https://api.yourdomain.com`

--- a/deploy/deploy-ghcr.sh
+++ b/deploy/deploy-ghcr.sh
@@ -28,6 +28,31 @@ WRZDJ_VERSION="$VERSION" docker compose -f "$COMPOSE_FILE" pull api web
 echo "==> Stopping existing containers..."
 docker compose -f "$COMPOSE_FILE" down --remove-orphans 2>/dev/null || true
 
+# Mirror deploy.sh: kill any non-Docker process (or Docker proxy) holding the
+# service ports between `down` and `up`. docker compose down alone does not
+# always release these — see MEMORY.md "Production Deploy (VPS)" notes.
+PORT_FRONTEND="${PORT_FRONTEND:-3000}"
+echo "==> Checking for processes holding ports $PORT_API and $PORT_FRONTEND..."
+for PORT in $PORT_API $PORT_FRONTEND; do
+  PIDS=$(ss -tlnp 2>/dev/null | grep ":${PORT}" | grep -oP 'pid=\K[0-9]+' | sort -u || true)
+  if [ -n "${PIDS:-}" ]; then
+    for PID in $PIDS; do
+      PROC=$(ps -p "$PID" -o comm= 2>/dev/null || echo "unknown")
+      echo "    Port $PORT held by PID $PID ($PROC) — killing"
+      kill "$PID" 2>/dev/null || true
+    done
+    sleep 1
+    for PID in $PIDS; do
+      if kill -0 "$PID" 2>/dev/null; then
+        echo "    PID $PID still alive — sending SIGKILL"
+        kill -9 "$PID" 2>/dev/null || true
+      fi
+    done
+  else
+    echo "    Port $PORT is free"
+  fi
+done
+
 echo "==> Ensuring log directories exist..."
 mkdir -p "$SCRIPT_DIR/logs/api"
 

--- a/deploy/deploy-ghcr.sh
+++ b/deploy/deploy-ghcr.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WrzDJ GHCR Deploy Script
+# Usage: ./deploy/deploy-ghcr.sh [VERSION]
+#
+# VERSION can be: latest, v2026.05.16, sha-a3f8c2b (default: latest)
+# Pulls pre-built images from GHCR and starts the stack.
+# For build-from-source deploys, use deploy/deploy.sh instead.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.ghcr.yml"
+VERSION="${1:-latest}"
+
+# Load env file if present
+if [ -f "$SCRIPT_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/.env"
+  set +a
+fi
+
+PORT_API="${PORT_API:-8000}"
+
+echo "==> Pulling WrzDJ $VERSION images..."
+WRZDJ_VERSION="$VERSION" docker compose -f "$COMPOSE_FILE" pull api web
+
+echo "==> Stopping existing containers..."
+docker compose -f "$COMPOSE_FILE" down --remove-orphans 2>/dev/null || true
+
+echo "==> Ensuring log directories exist..."
+mkdir -p "$SCRIPT_DIR/logs/api"
+
+echo "==> Starting stack..."
+WRZDJ_VERSION="$VERSION" docker compose -f "$COMPOSE_FILE" up -d
+
+echo "==> Waiting for API to become healthy..."
+ELAPSED=0
+while [ $ELAPSED -lt 60 ]; do
+  if curl -sf "http://127.0.0.1:${PORT_API}/health" > /dev/null 2>&1; then
+    echo "    API healthy after ${ELAPSED}s"
+    break
+  fi
+  if [ $ELAPSED -eq 0 ]; then
+    printf "    Waiting"
+  fi
+  printf "."
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+done
+
+if [ $ELAPSED -ge 60 ]; then
+  echo ""
+  echo "WARNING: API did not become healthy within 60s"
+  echo "==> API logs:"
+  docker compose -f "$COMPOSE_FILE" logs --tail=20 api
+fi
+
+echo ""
+echo "==> Service status:"
+docker compose -f "$COMPOSE_FILE" ps
+
+echo "==> Deploy complete"

--- a/deploy/deploy-ghcr.sh
+++ b/deploy/deploy-ghcr.sh
@@ -76,9 +76,10 @@ done
 
 if [ $ELAPSED -ge 60 ]; then
   echo ""
-  echo "WARNING: API did not become healthy within 60s"
+  echo "ERROR: API did not become healthy within 60s"
   echo "==> API logs:"
   docker compose -f "$COMPOSE_FILE" logs --tail=20 api
+  exit 1
 fi
 
 echo ""

--- a/deploy/docker-compose.ghcr.yml
+++ b/deploy/docker-compose.ghcr.yml
@@ -1,0 +1,114 @@
+# WrzDJ Production Docker Compose — Pre-built GHCR Images
+#
+# Pull pre-built images from GHCR instead of building from source.
+# For build-from-source, use deploy/docker-compose.yml.
+#
+# Usage:
+#   1. Copy deploy/.env.example to deploy/.env and fill in values
+#   2. Run: ./deploy/deploy-ghcr.sh [VERSION]
+#      Or:  WRZDJ_VERSION=v2026.05.16 docker compose -f deploy/docker-compose.ghcr.yml up -d
+#
+# Domain model (subdomain):
+#   - Frontend: https://app.yourdomain.com -> web:3000
+#   - Backend:  https://api.yourdomain.com -> api:8000
+
+services:
+  db:
+    image: postgres:16-alpine@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-wrzdj}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: ${POSTGRES_DB:-wrzdj}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-wrzdj}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    # Not exposed externally - only accessible from other containers
+
+  api:
+    image: ghcr.io/wrzonance/wrzdj-api:${WRZDJ_VERSION:-latest}
+    volumes:
+      - api_uploads:/app/uploads
+      - ./logs/api:/app/logs
+    environment:
+      ENV: production
+      DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-wrzdj}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-wrzdj}
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
+      SPOTIFY_CLIENT_ID: ${SPOTIFY_CLIENT_ID:-}
+      SPOTIFY_CLIENT_SECRET: ${SPOTIFY_CLIENT_SECRET:-}
+      TIDAL_CLIENT_ID: ${TIDAL_CLIENT_ID:-}
+      TIDAL_CLIENT_SECRET: ${TIDAL_CLIENT_SECRET:-}
+      TIDAL_REDIRECT_URI: ${TIDAL_REDIRECT_URI:-}
+      BEATPORT_CLIENT_ID: ${BEATPORT_CLIENT_ID:-}
+      BEATPORT_CLIENT_SECRET: ${BEATPORT_CLIENT_SECRET:-}
+      BEATPORT_REDIRECT_URI: ${BEATPORT_REDIRECT_URI:-}
+      BEATPORT_AUTH_BASE_URL: ${BEATPORT_AUTH_BASE_URL:-}
+      TOKEN_ENCRYPTION_KEY: ${TOKEN_ENCRYPTION_KEY:?TOKEN_ENCRYPTION_KEY is required}
+      HUMAN_COOKIE_SECRET: ${HUMAN_COOKIE_SECRET:?HUMAN_COOKIE_SECRET is required (32-byte base64 HMAC key)}
+      CORS_ORIGINS: ${CORS_ORIGINS:?CORS_ORIGINS is required (e.g. https://app.yourdomain.com)}
+      PUBLIC_URL: ${PUBLIC_URL:?PUBLIC_URL is required (e.g. https://app.yourdomain.com)}
+      BOOTSTRAP_ADMIN_USERNAME: ${BOOTSTRAP_ADMIN_USERNAME:-}
+      BOOTSTRAP_ADMIN_PASSWORD: ${BOOTSTRAP_ADMIN_PASSWORD:-}
+      BRIDGE_API_KEY: ${BRIDGE_API_KEY:-}
+      TURNSTILE_SECRET_KEY: ${TURNSTILE_SECRET_KEY:-}
+      TURNSTILE_SITE_KEY: ${TURNSTILE_SITE_KEY:-}
+      TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.1,::1,172.16.0.0/12}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      EMAIL_FROM_ADDRESS: ${EMAIL_FROM_ADDRESS:-}
+      UPLOADS_DIR: /app/uploads
+      LOG_DIR: /app/logs
+    ports:
+      - "127.0.0.1:${PORT_API:-8000}:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+    # SECURITY (H-I4): container hardening
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    pids_limit: 200
+    mem_limit: 1g
+    read_only: true
+    tmpfs:
+      - /tmp
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
+      interval: 10s
+      timeout: 5s
+      start_period: 30s
+      retries: 3
+
+  web:
+    image: ghcr.io/wrzonance/wrzdj-web:${WRZDJ_VERSION:-latest}
+    environment:
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:?NEXT_PUBLIC_API_URL is required (e.g. https://api.yourdomain.com)}
+    ports:
+      - "127.0.0.1:${PORT_FRONTEND:-3000}:3000"
+    depends_on:
+      api:
+        condition: service_healthy
+    restart: unless-stopped
+    # SECURITY (H-I4): container hardening
+    # NOTE: read_only intentionally omitted — docker-entrypoint.sh sed-patches
+    # .next/**/*.js at startup (replaces __WRZDJ_API_URL__ placeholder with the
+    # runtime NEXT_PUBLIC_API_URL value). The web container holds no DB access or
+    # encryption keys, making a writable filesystem an acceptable trade-off.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    pids_limit: 100
+    mem_limit: 512m
+    tmpfs:
+      - /tmp
+
+volumes:
+  postgres_data:
+  api_uploads:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+FROM python:3.11-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Closes #312.

Adds a CI/CD workflow that builds and publishes the API and frontend Docker images to GitHub Container Registry on every push to `main` and on every `v*` tag. Community users can now run WrzDJ without building the images manually.

Images published:
- `ghcr.io/wrzonance/wrzdj-api` — FastAPI backend
- `ghcr.io/wrzonance/wrzdj-web` — Next.js frontend

Tags produced: `latest` (main only), `v2026.MM.DD` (on tags), `sha-<short>` (every push), `pr-N` (PR builds, no push).

## What's New

- `.github/workflows/docker-publish.yml` — multi-arch publish workflow (linux/amd64 + linux/arm64)
- `deploy/docker-compose.ghcr.yml` — pull-from-GHCR compose file for end users
- `deploy/deploy-ghcr.sh` — helper script (pull + restart + healthcheck)
- `dashboard/docker-entrypoint.sh` — runtime substitution of the build-time `NEXT_PUBLIC_API_URL` placeholder
- `deploy/DEPLOYMENT.md` — Quick Start section for pre-built images

## Why the Entrypoint Sed Pass

`NEXT_PUBLIC_API_URL` is baked into the Next.js bundle at build time — in JS chunks AND in `routes-manifest.json` (where the CSP `connect-src` header lives). A distributable image can't know the operator's API URL at build time. The workflow builds with placeholder `__WRZDJ_API_URL__`; the entrypoint substitutes the runtime `NEXT_PUBLIC_API_URL` env var across both `.js` and `.json` files in `/app/.next/` before starting the server.

Operators set `NEXT_PUBLIC_API_URL` in their `.env`; the existing `deploy/docker-compose.yml` build-from-source path is unchanged.

## Test Plan

Verified locally end-to-end:

- [x] Backend image builds clean
- [x] Frontend image builds clean with `--build-arg NEXT_PUBLIC_API_URL=__WRZDJ_API_URL__`
- [x] Pre-substitution: 14 files contain the placeholder, including `routes-manifest.json` (the CSP gatekeeper)
- [x] Post-substitution: 0 placeholder occurrences remain
- [x] Full stack via `deploy/docker-compose.ghcr.yml`: db + api + web all healthy
- [x] CSP header in actual HTTP response reflects the runtime `NEXT_PUBLIC_API_URL` (not the placeholder)
- [x] `docker compose -f deploy/docker-compose.ghcr.yml config` validates cleanly
- [x] No PII / hardcoded personal infrastructure references
- [x] CI smoke test (`docker-build` job) removed from `ci.yml` — superseded by `pull_request` builds in this workflow

CI will validate multi-arch (amd64 + arm64) on push.

## One-Time Post-Merge Manual Step

GHCR packages default to **private** on first publish, even on a public repo:

1. After first push to `main` lands, check `https://github.com/wrzonance?tab=packages`
2. For each package (`wrzdj-api`, `wrzdj-web`) → **Package settings → Change visibility → Public**
3. Optionally: **Connect Repository → WrzDJ** to link the package sidebar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publish API and web Docker images to GitHub Container Registry.
  * Add deploy script and compose file to run pre-built images with automated health checks and port handling.
  * Container startup now supports runtime API URL substitution for pre-built web images.

* **Documentation**
  * Quick-start guide for deploying pre-built images added to deployment docs; example env includes version setting.

* **Chores**
  * CI workflow no longer runs the post-test Docker build smoke job.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->