### PR TITLE
docs(plans): add retroactive plans for v2026.05.16 theme fixes

### DIFF
--- a/docs/superpowers/plans/2026-05-16-fix-daylight-button-contrast.md
+++ b/docs/superpowers/plans/2026-05-16-fix-daylight-button-contrast.md
@@ -1,0 +1,417 @@
+# Fix Daylight Mode Button Contrast (Issue #315) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace four hardcoded dark hex backgrounds/colors on buttons and art placeholders with CSS variables so they render with correct contrast in daylight mode.
+
+**Architecture:** One-line swap per occurrence — hardcoded hex values (`#333`, `#1a1a1a`, `#ededed`, `#666`) → appropriate CSS variables (`var(--surface-raised)`, `var(--card)`, `var(--text)`, `var(--text-secondary)`). No new abstractions; new test files for pages that lack them, additions to the existing kiosk-link test file.
+
+**Tech Stack:** React/Next.js, TypeScript, Vitest, `@testing-library/react`, `@testing-library/jest-dom`
+
+---
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| Modify | `dashboard/app/pending/page.tsx` (line 59) |
+| Create | `dashboard/app/pending/__tests__/page.test.tsx` |
+| Modify | `dashboard/app/kiosk-link/[code]/page.tsx` (lines 95–106, 146) |
+| Modify | `dashboard/app/kiosk-link/[code]/__tests__/page.test.tsx` (add 2 tests) |
+| Modify | `dashboard/app/join/[code]/components/MyRequestsTracker.tsx` (lines 88, 94) |
+| Create | `dashboard/app/join/[code]/components/__tests__/MyRequestsTracker.test.tsx` |
+
+---
+
+## Setup
+
+- [ ] **Create feature branch**
+
+```bash
+git checkout -b fix/daylight-button-contrast
+```
+
+---
+
+## Task 1: Pending Page — Logout Button
+
+**Root cause:** `background: '#333'` is always dark. In daylight mode, `.btn` inherits `color: var(--text)` → near-black text on dark background (~1.3:1 contrast).
+
+**Files:**
+- Modify: `dashboard/app/pending/page.tsx:59`
+- Create: `dashboard/app/pending/__tests__/page.test.tsx`
+
+---
+
+- [ ] **Step 1: Create failing test**
+
+Create `dashboard/app/pending/__tests__/page.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import PendingPage from '../page';
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    isLoading: false,
+    role: 'pending',
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getMe: vi.fn().mockResolvedValue({ role: 'pending' }),
+  },
+}));
+
+describe('PendingPage', () => {
+  it('logout button uses theme-safe background', () => {
+    render(<PendingPage />);
+    const btn = screen.getByRole('button', { name: /logout/i });
+    expect(btn).toHaveAttribute('style', expect.stringContaining('var(--surface-raised)'));
+  });
+});
+```
+
+- [ ] **Step 2: Run test — confirm FAIL**
+
+```bash
+cd dashboard && npm test -- --run "app/pending/__tests__/page.test.tsx"
+```
+
+Expected: FAIL — `style` attribute contains `#333`, not `var(--surface-raised)`.
+
+- [ ] **Step 3: Fix the code**
+
+In `dashboard/app/pending/page.tsx`, change line 59:
+
+```tsx
+// Before
+style={{ background: '#333' }}
+
+// After
+style={{ background: 'var(--surface-raised)' }}
+```
+
+Full button after fix:
+```tsx
+<button
+  className="btn"
+  style={{ background: 'var(--surface-raised)' }}
+  onClick={logout}
+>
+  Logout
+</button>
+```
+
+- [ ] **Step 4: Run test — confirm PASS**
+
+```bash
+cd dashboard && npm test -- --run "app/pending/__tests__/page.test.tsx"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/app/pending/__tests__/page.test.tsx dashboard/app/pending/page.tsx
+git commit -m "fix(theme): pending logout button uses var(--surface-raised) for daylight contrast"
+```
+
+---
+
+## Task 2: Kiosk-Link Page — Event Selector + Try Again Buttons
+
+**Root cause:**
+- Event selector buttons: `background: '#1a1a1a'` + explicit `color: '#ededed'` → white text on dark background in all modes. In daylight mode this is always wrong.
+- Try Again button: `background: '#333'` → same problem as pending logout.
+
+**Files:**
+- Modify: `dashboard/app/kiosk-link/[code]/page.tsx` (event button ~line 95, try-again button ~line 146)
+- Modify: `dashboard/app/kiosk-link/[code]/__tests__/page.test.tsx` (add 2 tests)
+
+---
+
+- [ ] **Step 1: Add failing tests to existing test file**
+
+Open `dashboard/app/kiosk-link/[code]/__tests__/page.test.tsx` and add these two tests inside the existing `describe('KioskLinkPage', ...)` block, after the last existing `it(...)`:
+
+```tsx
+  it('event selector buttons use theme-safe background and text color', async () => {
+    render(<KioskLinkPage />);
+
+    await waitFor(() => {
+      const btn = screen.getByText('Friday Night').closest('button')!;
+      expect(btn).toHaveAttribute('style', expect.stringContaining('var(--surface-raised)'));
+      expect(btn).toHaveAttribute('style', expect.stringContaining('var(--text)'));
+    });
+  });
+
+  it('try again button uses theme-safe background', async () => {
+    const err = new Error('Test error');
+    mockCompleteKioskPairing.mockRejectedValue(err);
+    render(<KioskLinkPage />);
+
+    await waitFor(() => screen.getByText('Friday Night'));
+    fireEvent.click(screen.getByText('Friday Night').closest('button')!);
+
+    await waitFor(() => {
+      const tryAgainBtn = screen.getByRole('button', { name: /try again/i });
+      expect(tryAgainBtn).toHaveAttribute('style', expect.stringContaining('var(--surface-raised)'));
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests — confirm FAIL**
+
+```bash
+cd dashboard && npm test -- --run "app/kiosk-link/\[code\]/__tests__/page.test.tsx"
+```
+
+Expected: the two new tests FAIL; the 5 existing tests still PASS.
+
+- [ ] **Step 3: Fix the event selector button styles**
+
+In `dashboard/app/kiosk-link/[code]/page.tsx`, find the event selector button (around line 92–107) and replace the `style` object:
+
+```tsx
+// Before
+style={{
+  width: '100%',
+  textAlign: 'left',
+  padding: '0.75rem 1rem',
+  background: '#1a1a1a',
+  border: '1px solid #333',
+  borderRadius: '8px',
+  color: '#ededed',
+  cursor: 'pointer',
+}}
+
+// After
+style={{
+  width: '100%',
+  textAlign: 'left',
+  padding: '0.75rem 1rem',
+  background: 'var(--surface-raised)',
+  border: '1px solid #333',
+  borderRadius: '8px',
+  color: 'var(--text)',
+  cursor: 'pointer',
+}}
+```
+
+- [ ] **Step 4: Fix the try-again button style**
+
+In `dashboard/app/kiosk-link/[code]/page.tsx`, find the Try Again button (around line 146):
+
+```tsx
+// Before
+style={{ background: '#333' }}
+
+// After
+style={{ background: 'var(--surface-raised)' }}
+```
+
+- [ ] **Step 5: Run tests — confirm all PASS**
+
+```bash
+cd dashboard && npm test -- --run "app/kiosk-link/\[code\]/__tests__/page.test.tsx"
+```
+
+Expected: all 7 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "dashboard/app/kiosk-link/[code]/page.tsx" "dashboard/app/kiosk-link/[code]/__tests__/page.test.tsx"
+git commit -m "fix(theme): kiosk-link buttons use CSS variables for daylight contrast"
+```
+
+---
+
+## Task 3: MyRequestsTracker — Art Placeholder
+
+**Root cause:** When a request has no artwork, a placeholder div renders with `background: '#333'` and a music-note icon with `color: '#666'`. Both are hardcoded dark values — in daylight mode the background stays dark while everything around it is light.
+
+**Files:**
+- Modify: `dashboard/app/join/[code]/components/MyRequestsTracker.tsx` (lines 88, 94)
+- Create: `dashboard/app/join/[code]/components/__tests__/MyRequestsTracker.test.tsx`
+
+---
+
+- [ ] **Step 1: Create failing test**
+
+Create `dashboard/app/join/[code]/components/__tests__/MyRequestsTracker.test.tsx`:
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import MyRequestsTracker from '../MyRequestsTracker';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getMyRequests: vi.fn().mockResolvedValue({
+      requests: [
+        {
+          id: 1,
+          title: 'Test Song',
+          artist: 'Test Artist',
+          status: 'new',
+          artwork_url: null,
+          created_at: '2026-05-16T00:00:00Z',
+          vote_count: 0,
+        },
+      ],
+    }),
+  },
+}));
+
+describe('MyRequestsTracker', () => {
+  it('art placeholder uses theme-safe background', async () => {
+    render(
+      <MyRequestsTracker
+        eventCode="EVT001"
+        refreshKey={0}
+        onRequestIdsLoaded={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Song')).toBeInTheDocument();
+    });
+
+    // The placeholder is a div with class guest-request-item-art (not an img)
+    const placeholder = document.querySelector('div.guest-request-item-art');
+    expect(placeholder).not.toBeNull();
+    expect(placeholder!).toHaveAttribute('style', expect.stringContaining('var(--card)'));
+  });
+
+  it('art placeholder icon uses theme-safe text color', async () => {
+    render(
+      <MyRequestsTracker
+        eventCode="EVT001"
+        refreshKey={0}
+        onRequestIdsLoaded={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Song')).toBeInTheDocument();
+    });
+
+    const placeholder = document.querySelector('div.guest-request-item-art');
+    const icon = placeholder!.querySelector('span');
+    expect(icon).not.toBeNull();
+    expect(icon!).toHaveAttribute('style', expect.stringContaining('var(--text-secondary)'));
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — confirm FAIL**
+
+```bash
+cd dashboard && npm test -- --run "app/join/\[code\]/components/__tests__/MyRequestsTracker.test.tsx"
+```
+
+Expected: both tests FAIL — `style` attributes contain `#333` and `#666`, not the CSS variables.
+
+- [ ] **Step 3: Fix the placeholder background**
+
+In `dashboard/app/join/[code]/components/MyRequestsTracker.tsx`, find the art placeholder div (~line 85) and change:
+
+```tsx
+// Before
+style={{
+  background: '#333',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}}
+
+// After
+style={{
+  background: 'var(--card)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}}
+```
+
+- [ ] **Step 4: Fix the icon color**
+
+In the same file, change the inner span (~line 94):
+
+```tsx
+// Before
+<span style={{ fontSize: '1.25rem', color: '#666' }}>&#9835;</span>
+
+// After
+<span style={{ fontSize: '1.25rem', color: 'var(--text-secondary)' }}>&#9835;</span>
+```
+
+- [ ] **Step 5: Run tests — confirm all PASS**
+
+```bash
+cd dashboard && npm test -- --run "app/join/\[code\]/components/__tests__/MyRequestsTracker.test.tsx"
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 6: Run full test suite — confirm no regressions**
+
+```bash
+cd dashboard && npm test -- --run
+```
+
+Expected: all tests PASS, coverage thresholds met.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add "dashboard/app/join/[code]/components/MyRequestsTracker.tsx" "dashboard/app/join/[code]/components/__tests__/MyRequestsTracker.test.tsx"
+git commit -m "fix(theme): art placeholder uses CSS variables for daylight contrast"
+```
+
+---
+
+## Wrap-Up
+
+- [ ] **Push branch**
+
+```bash
+git push -u origin fix/daylight-button-contrast
+```
+
+- [ ] **Open PR**
+
+```bash
+gh pr create \
+  --title "fix(theme): dark text on buttons in day mode (#315)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Replaces `background: '#333'` on pending page logout button with `var(--surface-raised)`
+- Replaces `background: '#1a1a1a'` + `color: '#ededed'` on kiosk-link event selector buttons with `var(--surface-raised)` + `var(--text)`
+- Replaces `background: '#333'` on kiosk-link try-again button with `var(--surface-raised)`
+- Replaces `background: '#333'` + `color: '#666'` on MyRequestsTracker art placeholder with `var(--card)` + `var(--text-secondary)`
+
+Fixes #315.
+
+## Test plan
+
+- [ ] New test: `app/pending/__tests__/page.test.tsx` — asserts logout button uses `var(--surface-raised)`
+- [ ] Extended test: `app/kiosk-link/[code]/__tests__/page.test.tsx` — asserts event selector + try-again buttons use CSS variables
+- [ ] New test: `app/join/[code]/components/__tests__/MyRequestsTracker.test.tsx` — asserts placeholder uses `var(--card)` + `var(--text-secondary)`
+- [ ] Toggle day mode via the theme toggle in the DJ dashboard and verify all four locations visually
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-05-16-fix-theme-toggle-onboarding-conflict.md
+++ b/docs/superpowers/plans/2026-05-16-fix-theme-toggle-onboarding-conflict.md
@@ -1,0 +1,255 @@
+# Fix ThemeToggle / OnboardingOverlay Z-Index Conflict Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hide the ThemeToggle during an active onboarding tour so it no longer visually conflicts with the OnboardingOverlay backdrop (z-1050) and step card (z-1060).
+
+**Architecture:** `ThemeToggle` reads `onboardingActive` from `HelpContext` (already wraps both DJ and admin layouts via `app/layout.tsx`) and returns `null` when a tour is running. No z-index changes, no new state, no layout modifications — the fix lives entirely in `ThemeToggle.tsx`.
+
+**Tech Stack:** React 19, Next.js 16+, TypeScript strict, Vitest + Testing Library
+
+---
+
+## Branch
+
+```bash
+git checkout -b fix/theme-toggle-onboarding-conflict
+```
+
+---
+
+## File Map
+
+| Action | File | What changes |
+|---|---|---|
+| Modify | `dashboard/components/ThemeToggle.tsx` | Add `useHelp()` call; return `null` when `onboardingActive` |
+| Create | `dashboard/components/__tests__/ThemeToggle.test.tsx` | New test file — two cases |
+
+No other files need to change. `(dj)/layout.tsx` and `admin/layout.tsx` keep their existing ThemeToggle render — the toggle itself handles its own visibility.
+
+---
+
+## Background: Z-Index Ladder (for reference only — do not change these values)
+
+| z-index | Element | File |
+|---|---|---|
+| 1050 | ThemeToggle wrapper div | `(dj)/layout.tsx:13`, `admin/layout.tsx:45` |
+| 1050 | OnboardingOverlay backdrop | `OnboardingOverlay.tsx:82` |
+| 1060 | OnboardingOverlay step card | `OnboardingOverlay.tsx:105` |
+| 1200 | `.help-btn-container` | `globals.css:1213` |
+
+The conflict: backdrop renders after toggle in DOM → paints over toggle at z-1050 tie. Step card at z-1060 fully covers toggle. Fix: hide toggle during tour instead of raising its z-index.
+
+---
+
+## Task 1: Write Failing Tests for ThemeToggle
+
+**Files:**
+- Create: `dashboard/components/__tests__/ThemeToggle.test.tsx`
+
+- [ ] **Step 1.1: Create the test file with failing tests**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeToggle } from '../ThemeToggle';
+import * as HelpContext from '@/lib/help/HelpContext';
+import type { HelpContextValue } from '@/lib/help/types';
+
+vi.mock('@/lib/theme', () => ({
+  useTheme: () => ({ theme: 'dark', toggleTheme: vi.fn() }),
+}));
+
+function makeHelpContext(overrides: Partial<HelpContextValue> = {}): HelpContextValue {
+  return {
+    helpMode: false,
+    onboardingActive: false,
+    currentStep: 0,
+    activeSpotId: null,
+    toggleHelpMode: vi.fn(),
+    registerSpot: vi.fn(() => vi.fn()),
+    getSpotsForPage: vi.fn(() => []),
+    startOnboarding: vi.fn(),
+    nextStep: vi.fn(),
+    prevStep: vi.fn(),
+    skipOnboarding: vi.fn(),
+    hasSeenPage: vi.fn(() => false),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.spyOn(HelpContext, 'useHelp').mockReturnValue(makeHelpContext());
+});
+
+describe('ThemeToggle', () => {
+  it('renders the toggle button when onboarding is not active', () => {
+    vi.spyOn(HelpContext, 'useHelp').mockReturnValue(
+      makeHelpContext({ onboardingActive: false })
+    );
+    render(<ThemeToggle />);
+    expect(screen.getByRole('button', { name: /current theme/i })).toBeInTheDocument();
+  });
+
+  it('renders nothing when onboarding is active', () => {
+    vi.spyOn(HelpContext, 'useHelp').mockReturnValue(
+      makeHelpContext({ onboardingActive: true })
+    );
+    render(<ThemeToggle />);
+    expect(screen.queryByRole('button', { name: /current theme/i })).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 1.2: Run the tests to confirm they fail**
+
+```bash
+cd /home/adam/github/WrzDJ/dashboard && npm test -- --run components/__tests__/ThemeToggle.test.tsx
+```
+
+Expected output: both tests FAIL. The first test may pass (button exists), but the second test will FAIL because the current `ThemeToggle` doesn't read `onboardingActive` and always renders. You'll also see an error about `useHelp` not being found in `ThemeToggle`.
+
+- [ ] **Step 1.3: Commit the failing tests**
+
+```bash
+cd /home/adam/github/WrzDJ
+git add dashboard/components/__tests__/ThemeToggle.test.tsx
+git commit -m "test(theme): failing tests for ThemeToggle visibility during onboarding"
+```
+
+---
+
+## Task 2: Implement the Fix
+
+**Files:**
+- Modify: `dashboard/components/ThemeToggle.tsx`
+
+- [ ] **Step 2.1: Add `useHelp` to ThemeToggle and gate on `onboardingActive`**
+
+Replace the entire file content with:
+
+```typescript
+'use client';
+
+import { useTheme, type Theme } from '@/lib/theme';
+import { useHelp } from '@/lib/help/HelpContext';
+
+const THEME_LABELS: Record<Theme, string> = {
+  dark: 'Dark',
+  'high-contrast': 'Hi-Con',
+  daylight: 'Day',
+};
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  const { onboardingActive } = useHelp();
+
+  if (onboardingActive) return null;
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="theme-toggle"
+      title={`Theme: ${THEME_LABELS[theme]} (click to change)`}
+      aria-label={`Current theme: ${THEME_LABELS[theme]}. Click to change.`}
+    >
+      <span className={`theme-toggle-icon theme-toggle-icon--${theme}`} />
+      <span className="theme-toggle-label">{THEME_LABELS[theme]}</span>
+    </button>
+  );
+}
+```
+
+- [ ] **Step 2.2: Run the tests to confirm they pass**
+
+```bash
+cd /home/adam/github/WrzDJ/dashboard && npm test -- --run components/__tests__/ThemeToggle.test.tsx
+```
+
+Expected output:
+```
+✓ ThemeToggle > renders the toggle button when onboarding is not active
+✓ ThemeToggle > renders nothing when onboarding is active
+```
+
+- [ ] **Step 2.3: Run the full frontend test suite to check for regressions**
+
+```bash
+cd /home/adam/github/WrzDJ/dashboard && npm test -- --run
+```
+
+Expected: all tests pass. If any test imports `ThemeToggle` without mocking `useHelp`, it will throw "useHelp must be used within a HelpProvider". Fix by adding to that test: `vi.mock('@/lib/help/HelpContext', () => ({ useHelp: () => ({ onboardingActive: false }) }))`.
+
+- [ ] **Step 2.4: Run TypeScript type check**
+
+```bash
+cd /home/adam/github/WrzDJ/dashboard && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 2.5: Commit the implementation**
+
+```bash
+cd /home/adam/github/WrzDJ
+git add dashboard/components/ThemeToggle.tsx
+git commit -m "fix(theme): hide ThemeToggle during onboarding tour to resolve z-index conflict"
+```
+
+---
+
+## Task 3: Push and Open PR
+
+- [ ] **Step 3.1: Push the branch**
+
+```bash
+git push -u origin fix/theme-toggle-onboarding-conflict
+```
+
+- [ ] **Step 3.2: Open a PR**
+
+```bash
+gh pr create \
+  --title "fix(theme): hide ThemeToggle during onboarding tour" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- `ThemeToggle` now reads `onboardingActive` from `HelpContext` and returns `null` while a tour is running
+- Resolves z-index conflict: backdrop at z-1050 and step card at z-1060 both painted over the toggle
+- Chose Option B (hide toggle) over Option A (raise z-index) to avoid z-index arms race — theme isn't useful mid-tour
+
+## Files Changed
+
+- `dashboard/components/ThemeToggle.tsx` — add `useHelp()`, return `null` when `onboardingActive`
+- `dashboard/components/__tests__/ThemeToggle.test.tsx` — new test file (two cases)
+
+## Test Plan
+
+- [ ] Run `npm test -- --run` in `dashboard/` — all tests pass
+- [ ] Start a DJ session, open an event page, trigger the help tour — confirm ThemeToggle disappears during tour and reappears after Done/Skip
+- [ ] Repeat in `/admin` — same behavior
+- [ ] Confirm ThemeToggle renders normally on pages with no onboarding (no HelpSpots registered)
+
+Closes #314
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+- ✅ ThemeToggle hidden during onboarding tour — Task 2 implements this
+- ✅ Backdrop z-1050 / card z-1060 no longer conflicts with toggle — fixed by hiding toggle
+- ✅ Option B chosen (hide) over Option A (raise z-index) — as recommended in issue
+- ✅ Files listed in issue covered: `ThemeToggle.tsx` (chosen over layout approach — cleaner single location)
+
+**Placeholder scan:** No TBDs or vague steps. All steps include exact commands and code.
+
+**Type consistency:** `HelpContextValue` is imported directly from `@/lib/help/types` in tests, matching its definition. `onboardingActive: boolean` is a direct destructure from `useHelp()` — matches `HelpState` interface at `lib/help/types.ts:12`.
+
+**Edge cases handled:**
+- Pages where HelpProvider has no registered spots: `onboardingActive` stays `false` → toggle renders normally
+- The `useHelp` mock in tests uses the exact same `HelpContextValue` shape used across all other test files


### PR DESCRIPTION
## Summary

Adds the two plan files generated and executed via the superpowers writing-plans skill during the work that became:
- #316 — hide ThemeToggle during onboarding tour
- #317 — dark text on buttons in day mode

The plan files were never committed at the time of those PRs. Adding now for historical record and to match the existing `docs/superpowers/plans/` convention (18 prior plans already tracked).

## Test plan

- [ ] Pure docs — no behavior change, no CI implications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added internal planning documentation outlining implementation strategies for upcoming improvements to contrast and UI interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->