### PR TITLE
feat(security): split collection vs live event codes + harden collect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,10 @@ jobs:
         #                  in pip PR #13870; revisit when GitHub Actions ships a patched pip.
         #   CVE-2026-6357  (pip 26.x: PATH handling) - same class as above; affects pip the
         #                  build tool only, not runtime deps. Revisit when GHA upgrades pip.
-        run: pip-audit --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-6357
+        #   PYSEC-2025-183 (pyjwt 2.10.1+ weak encryption, DISPUTED) - no fix released, the
+        #                  pyjwt maintainers contest the advisory. We already pin pyjwt to the
+        #                  latest available (2.12.1). Revisit when an upstream fix lands.
+        run: pip-audit --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-6357 --ignore-vuln PYSEC-2025-183
 
       - name: Run tests with coverage
         env:

--- a/dashboard/app/collect/[code]/page.test.tsx
+++ b/dashboard/app/collect/[code]/page.test.tsx
@@ -1,10 +1,19 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { useEffect } from "react";
+import type React from "react";
 import CollectPage from "./page";
 
 vi.mock("./components/EmailVerification", () => ({
   default: () => <div data-testid="email-verification-stub" />,
+}));
+
+// EmailGate wraps the page; stub as passthrough so tests don't render the
+// Turnstile-driven EmailVerification subtree (which spins up effects against
+// a non-existent window.turnstile in jsdom). The real gate is exercised in
+// dedicated EmailGate tests.
+vi.mock("../../../components/EmailGate", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
 vi.mock("@/lib/useHumanVerification", () => ({

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -15,6 +15,7 @@ import { useGuestIdentity } from '../../../lib/use-guest-identity';
 import { useHumanVerification } from '@/lib/useHumanVerification';
 import { IdentityBar } from '../../../components/IdentityBar';
 import { NicknameGate, GateResult } from '../../../components/NicknameGate';
+import EmailGate from '../../../components/EmailGate';
 import EmailRecoveryButton from '../../../components/EmailRecoveryButton';
 import EmailRecoveryModal from '../../../components/EmailRecoveryModal';
 import CollectDetailSheet from './components/CollectDetailSheet';
@@ -320,6 +321,7 @@ export default function CollectPage() {
   const subFg = 'rgba(255,255,255,0.5)';
 
   return (
+    <EmailGate verified={emailVerified} onVerified={() => setEmailVerified(true)}>
     <main className="collect-page tower">
       {/* Ambient glows */}
       <div style={{ position: 'fixed', top: 40, left: -80, width: 280, height: 280, borderRadius: '50%', background: `radial-gradient(circle, ${accent2}28, transparent 70%)`, filter: 'blur(40px)', pointerEvents: 'none', zIndex: 0 }} />
@@ -639,6 +641,7 @@ export default function CollectPage() {
         </div>
       )}
     </main>
+    </EmailGate>
   );
 }
 

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -210,13 +210,13 @@ export default function CollectPage() {
           return;
         }
         if (ev.phase === 'collection') {
-          const [lb, picks] = await Promise.all([
-            apiClient.getCollectLeaderboard(code, tab),
-            apiClient.getCollectMyPicks(code),
-          ]);
-          if (!cancelled) {
-            setLeaderboard(lb);
-            setMyPicks(picks);
+          // Leaderboard is ungated; my-picks requires email verification, so skip
+          // it until the guest verifies to avoid surfacing a sticky 403 error.
+          const lb = await apiClient.getCollectLeaderboard(code, tab);
+          if (!cancelled) setLeaderboard(lb);
+          if (emailVerified) {
+            const picks = await apiClient.getCollectMyPicks(code);
+            if (!cancelled) setMyPicks(picks);
           }
         }
       } catch (e) {
@@ -238,7 +238,7 @@ export default function CollectPage() {
       if (timer) clearTimeout(timer);
       document.removeEventListener('visibilitychange', onVisibility);
     };
-  }, [code, tab, gateComplete]);
+  }, [code, tab, gateComplete, emailVerified]);
 
   const leaderboardAvgBpm = useMemo(() => {
     const withBpm = (leaderboard?.requests ?? []).filter((r) => r.bpm != null);

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -2439,3 +2439,45 @@ h1, .display-heading {
   from { transform: rotate(-10deg) scale(0.9); }
   to { transform: rotate(10deg) scale(1.1); }
 }
+
+/* EmailGate — full-screen blocker for unverified guests on /collect/[code] */
+.email-gate-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.78);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  padding: 1rem;
+}
+
+.email-gate-modal {
+  background: #1a1a1a;
+  border-radius: 14px;
+  padding: 1.75rem;
+  width: 100%;
+  max-width: 420px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.email-gate-title {
+  font-size: 1.25rem;
+  margin: 0 0 0.5rem 0;
+  color: #ededed;
+}
+
+.email-gate-subtitle {
+  font-size: 0.875rem;
+  color: #a0a0a0;
+  margin: 0 0 1.25rem 0;
+  line-height: 1.45;
+}
+
+.email-gate-hidden {
+  visibility: hidden;
+  pointer-events: none;
+}

--- a/dashboard/components/EmailGate.tsx
+++ b/dashboard/components/EmailGate.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { ReactNode } from 'react';
+import EmailVerification from './EmailVerification';
+
+interface Props {
+  /** True when the calling page has determined the guest is email-verified. */
+  verified: boolean;
+  /** Called after the guest completes OTP — page should refetch profile/me. */
+  onVerified: () => void;
+  /** Wrapped UI; shown only when verified === true. */
+  children: ReactNode;
+}
+
+/**
+ * Full-screen blocker that requires email + Turnstile verification before
+ * exposing collection-page features. Reuses EmailVerification (Turnstile +
+ * OTP) and renders a modal overlay until the guest verifies.
+ */
+export default function EmailGate({ verified, onVerified, children }: Props) {
+  if (verified) {
+    return <>{children}</>;
+  }
+
+  return (
+    <>
+      <div className="email-gate-backdrop" aria-hidden={false}>
+        <div className="email-gate-modal" role="dialog" aria-modal="true">
+          <h2 className="email-gate-title">Verify your email to continue</h2>
+          <p className="email-gate-subtitle">
+            Pre-event submissions and votes require a verified email address. Your email is
+            only used to prevent spam and is never shared.
+          </p>
+          <EmailVerification isVerified={false} onVerified={onVerified} />
+        </div>
+      </div>
+      {/* Render children behind the gate so they're ready when verification completes */}
+      <div className="email-gate-hidden" aria-hidden="true">
+        {children}
+      </div>
+    </>
+  );
+}

--- a/dashboard/components/EmailVerification.tsx
+++ b/dashboard/components/EmailVerification.tsx
@@ -79,7 +79,7 @@ export default function EmailVerification({ isVerified, onVerified, onSkip }: Pr
     try {
       await apiClient.requestVerificationCode(email.trim(), otpTurnstileToken);
       setState('code_sent');
-      setExpiresAt(Date.now() + 15 * 60 * 1000);
+      setExpiresAt(Date.now() + 5 * 60 * 1000);
       setDigits(['', '', '', '', '', '']);
       // Reset widget for next attempt (fresh token per send)
       if (otpWidgetIdRef.current && window.turnstile) {

--- a/dashboard/components/EmailVerification.tsx
+++ b/dashboard/components/EmailVerification.tsx
@@ -220,7 +220,7 @@ export default function EmailVerification({ isVerified, onVerified, onSkip }: Pr
           type="button"
           className="btn-link"
           onClick={sendCode}
-          disabled={sending || secondsLeft > 14 * 60}
+          disabled={sending || secondsLeft > 0}
           style={{ fontSize: '0.8rem', marginTop: '0.25rem' }}
         >
           {sending ? 'Sending...' : "Didn't get it? Resend"}

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -227,6 +227,13 @@ export class HumanVerificationRequiredError extends ApiError {
  * `detail.code === 'human_verification_required'`, the wrapper calls
  * `reverify()` and retries the fetch once.
  */
+export class EmailVerificationRequiredError extends Error {
+  constructor() {
+    super('email_verification_required');
+    this.name = 'EmailVerificationRequiredError';
+  }
+}
+
 export async function withHumanRetry<T>(
   doFetch: () => Promise<Response>,
   reverify: () => Promise<void>,
@@ -237,6 +244,8 @@ export async function withHumanRetry<T>(
     if (body?.detail?.code === 'human_verification_required') {
       await reverify();
       res = await doFetch();
+    } else if (body?.detail?.code === 'email_verification_required') {
+      throw new EmailVerificationRequiredError();
     }
   }
   if (!res.ok) {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1283,6 +1283,10 @@ class ApiClient {
 
   // Note: returns `key` (not `musical_key`) to match EnrichPreviewResult schema —
   // callers merging results into SearchResult use `.key`; leaderboard fields use `.musical_key`.
+  //
+  // Sends credentials because the endpoint is now gated by require_email_verified
+  // (post-2026-05-20 collection hardening). On any failure (403, network, etc.),
+  // we fall back to the unenriched items so search UX degrades gracefully.
   async enrichPreview(
     code: string,
     items: Array<{ title: string; artist: string; source_url?: string }>,
@@ -1293,7 +1297,7 @@ class ApiClient {
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          // No credentials: endpoint is stateless (best-effort BPM lookup, no guest cookie needed)
+          credentials: 'include',
           body: JSON.stringify({ items }),
         },
       );

--- a/deploy/scripts/recovery-elz2g2-2026-05-20.sql
+++ b/deploy/scripts/recovery-elz2g2-2026-05-20.sql
@@ -1,0 +1,57 @@
+-- ELZ2G2 ("Home School Prom 2026") data recovery — 2026-05-20
+--
+-- The Tidal bidirectional poller (poll_tidal_collection_removals) auto-rejected
+-- 142 requests across three sweeps because get_playlist_tracks silently
+-- returned [] on Tidal API failures. The fix lands in the same PR as the
+-- collection/live event code split; THIS SCRIPT restores the affected rows.
+--
+-- USAGE (run from VPS as root or db owner, AFTER deploy.sh succeeds):
+--   ssh wrz-droplet
+--   cd ~/WrzDJ
+--   docker compose -f deploy/docker-compose.yml exec -T db \
+--     pg_dump -U wrzdj -d wrzdj -Fc -f /tmp/pre-recovery-elz2g2.dump
+--   docker compose -f deploy/docker-compose.yml cp deploy/scripts/recovery-elz2g2-2026-05-20.sql db:/tmp/recovery.sql
+--   docker compose -f deploy/docker-compose.yml exec -T db psql -U wrzdj -d wrzdj -f /tmp/recovery.sql
+--
+-- The script is wrapped in a transaction and prints sanity counts. If the
+-- numbers look wrong, run ROLLBACK; instead of COMMIT;.
+
+BEGIN;
+
+-- Snapshot the rows we're about to touch
+CREATE TEMP TABLE elz2g2_recovery AS
+SELECT id, song_title, artist, status, updated_at, tidal_collection_track_id
+FROM requests
+WHERE event_id = 15
+  AND status = 'rejected'
+  AND (
+    updated_at BETWEEN '2026-05-19 13:09:00' AND '2026-05-19 13:10:00'
+    OR updated_at BETWEEN '2026-05-20 05:02:00' AND '2026-05-20 05:04:00'
+    OR updated_at BETWEEN '2026-05-20 22:02:00' AND '2026-05-20 22:08:00'
+  );
+
+-- Expected: ~142 rows across three sweep windows
+\echo 'Recovery candidates:'
+SELECT COUNT(*) AS recovery_count,
+       MIN(updated_at) AS earliest,
+       MAX(updated_at) AS latest
+FROM elz2g2_recovery;
+
+-- Restore status='new'; bump updated_at so the polling fix has a fresh
+-- baseline (now safe because the poller's three guards are deployed).
+UPDATE requests
+SET status = 'new', updated_at = NOW()
+WHERE id IN (SELECT id FROM elz2g2_recovery);
+
+-- Drop the lone surviving pumped vote on request #169 "Uptown Funk"
+-- (vote_id 362 was cast by guest 128, the cookie-cycling iPhone; see
+-- 2026-05-20 production audit notes).
+DELETE FROM request_votes WHERE id = 362;
+UPDATE requests SET vote_count = GREATEST(vote_count - 1, 0) WHERE id = 169;
+
+-- Sanity check before commit
+\echo 'Post-recovery status distribution:'
+SELECT status, COUNT(*) FROM requests WHERE event_id = 15 GROUP BY status ORDER BY 2 DESC;
+
+\echo 'If counts look right (rejected should be ~0-2, new ~140+), type COMMIT; otherwise ROLLBACK;'
+COMMIT;

--- a/deploy/scripts/recovery-elz2g2-2026-05-20.sql
+++ b/deploy/scripts/recovery-elz2g2-2026-05-20.sql
@@ -43,15 +43,44 @@ UPDATE requests
 SET status = 'new', updated_at = NOW()
 WHERE id IN (SELECT id FROM elz2g2_recovery);
 
--- Drop the lone surviving pumped vote on request #169 "Uptown Funk"
--- (vote_id 362 was cast by guest 128, the cookie-cycling iPhone; see
--- 2026-05-20 production audit notes).
-DELETE FROM request_votes WHERE id = 362;
-UPDATE requests SET vote_count = GREATEST(vote_count - 1, 0) WHERE id = 169;
+-- Drop the lone surviving pumped vote on request #169 "Uptown Funk".
+-- vote_id 362 was cast by guest 128, the cookie-cycling iPhone; see
+-- 2026-05-20 production audit notes.
+--
+-- Decrement vote_count only when the DELETE actually removed the row, so
+-- re-running this script (e.g. after a partial recovery) doesn't undercount.
+WITH deleted_vote AS (
+  DELETE FROM request_votes
+  WHERE id = 362
+  RETURNING request_id
+)
+UPDATE requests r
+SET vote_count = GREATEST(r.vote_count - 1, 0)
+FROM deleted_vote dv
+WHERE r.id = dv.request_id;
 
--- Sanity check before commit
+-- Sanity check the resulting state.
 \echo 'Post-recovery status distribution:'
 SELECT status, COUNT(*) FROM requests WHERE event_id = 15 GROUP BY status ORDER BY 2 DESC;
 
-\echo 'If counts look right (rejected should be ~0-2, new ~140+), type COMMIT; otherwise ROLLBACK;'
+-- Hard-guard the commit: abort if counts drift from the expected recovery shape.
+DO $$
+DECLARE
+  recovery_count integer;
+  rejected_count integer;
+BEGIN
+  SELECT COUNT(*) INTO recovery_count FROM elz2g2_recovery;
+  SELECT COUNT(*) INTO rejected_count
+  FROM requests WHERE event_id = 15 AND status = 'rejected';
+
+  IF recovery_count BETWEEN 130 AND 150 AND rejected_count <= 5 THEN
+    RAISE NOTICE 'Recovery looks correct (% rows restored, % still rejected). Committing.',
+      recovery_count, rejected_count;
+  ELSE
+    RAISE EXCEPTION 'Recovery counts out of expected range (restored=%, still-rejected=%). Aborting.',
+      recovery_count, rejected_count;
+  END IF;
+END
+$$;
+
 COMMIT;

--- a/docs/superpowers/specs/2026-05-20-collection-vs-live-event-codes-design.md
+++ b/docs/superpowers/specs/2026-05-20-collection-vs-live-event-codes-design.md
@@ -1,0 +1,497 @@
+# Collection vs Live Event Codes — Design
+
+**Status:** Draft for approval
+**Author:** thewrz
+**Date:** 2026-05-20
+**Related incident:** Production audit of event ELZ2G2 ("Home School Prom 2026") on 2026-05-20.
+
+## Background
+
+The production audit of ELZ2G2 surfaced two problems that share a common solution surface:
+
+1. **Vote pumping via cookie cycling.** One iPhone (UA: iOS 18.6, fingerprint `1bc97a8e418edc278d110b044baa42f4`) created 23 ephemeral `guest_id` rows over 7 days and cast 241 votes (66% of all event votes) without verifying an email. The DB unique constraint `uq_request_vote_guest (request_id, guest_id)` is trivially bypassed by regenerating the guest cookie. The mitigating gate (Turnstile-issued `wrzdj_human` cookie) was not enforced because `system_settings.human_verification_enforced = false` (soft mode). The vote endpoint also has no email-verification dependency.
+
+2. **Mass auto-rejection bug.** 142 of 154 ELZ2G2 requests were silently auto-rejected by `poll_tidal_collection_removals` across three poll cycles (May 19 13:09, May 20 05:02–05:03, May 20 22:02–22:07). Root cause: `get_playlist_tracks` returns `[]` on any exception, making "Tidal API failed" indistinguishable from "playlist is genuinely empty". The poller then iterates synced requests, finds none of their track IDs in the empty set, and rejects all of them.
+
+The user has also confirmed a design direction that has been latent in the codebase: **collection-phase URLs need to be friction-heavy (email + Turnstile), live-event URLs need to be friction-free.** Currently both phases share a single `event.code`, so any QR code or shared URL points at both phases simultaneously.
+
+## Goals
+
+- **Split event identity into two codes per event.** `event.code` (existing) is the collection code; a new `event.join_code` is the live-event/QR code. Same event row, two distinct codes.
+- **Harden the collection page** so vote pumping by cookie cycling becomes structurally impossible: hard human verification (Turnstile) AND email verification on every mutating endpoint.
+- **Keep the live event frictionless.** The join code path is unchanged in behavior — no Turnstile, no email, just a guest cookie + nickname.
+- **Fix the Tidal poller bug** so an API failure or partial response never triggers a mass rejection again.
+- **Recover ELZ2G2 data** by restoring the 142 bug-rejected requests and removing the lone surviving pumped vote.
+
+## Non-goals
+
+- Changing the live-event join experience (cookie, nickname, voting model) in any way other than the URL `{code}` parameter source.
+- Adding proof-of-personhood (biometrics, social vouching) — accepted as overkill for a music-request app.
+- TOTP / authenticator-app verification — would kill the venue use case.
+- Per-event override of `human_verification_enforced` — deferred.
+- HMAC secret rotation tooling — deferred (document procedure only).
+- Bridge resolving events by `join_code` — bridge stays on `event.code`.
+- Migrating non-ELZ2G2 events' data (no other events have inflated `vote_count` rows from the same bug pattern).
+
+## Schema
+
+### Migration
+
+Add `events.join_code` as a NOT NULL, UNIQUE 6-character string column. Backfill existing events by generating a fresh code per event using the existing `_generate_code()` helper, with a uniqueness check that scans both `code` and `join_code` columns to prevent any value being reused as the other type.
+
+```python
+# server/alembic/versions/XXX_add_event_join_code.py
+def upgrade() -> None:
+    op.add_column('events', sa.Column('join_code', sa.String(10), nullable=True))
+    conn = op.get_bind()
+    events = conn.execute(sa.text("SELECT id FROM events WHERE join_code IS NULL")).fetchall()
+    for (event_id,) in events:
+        while True:
+            candidate = _generate_code()
+            exists = conn.execute(
+                sa.text("SELECT 1 FROM events WHERE code = :c OR join_code = :c"),
+                {"c": candidate},
+            ).first()
+            if not exists:
+                conn.execute(
+                    sa.text("UPDATE events SET join_code = :c WHERE id = :id"),
+                    {"c": candidate, "id": event_id},
+                )
+                break
+    op.alter_column('events', 'join_code', nullable=False)
+    op.create_index('ix_events_join_code', 'events', ['join_code'], unique=True)
+
+def downgrade() -> None:
+    op.drop_index('ix_events_join_code', 'events')
+    op.drop_column('events', 'join_code')
+```
+
+### Column semantics after migration
+
+| Column | Role | Used by |
+|---|---|---|
+| `events.code` | Collection code (gated) | `/collect/{code}`, `/api/public/collect/{code}/*`, DJ-facing `(dj)/events/{code}` page, bridge integration |
+| `events.join_code` | Live join / QR code (frictionless) | `/join/{join_code}`, `/api/public/events/{join_code}/*`, `/e/{join_code}/display`, `/kiosk-link/{join_code}` |
+
+### Code generation helper
+
+```python
+# server/app/services/event.py (additions)
+
+def _generate_unique_event_code(db: Session) -> str:
+    """Generate a code unique across both `code` and `join_code` columns."""
+    while True:
+        candidate = _generate_code()
+        exists = (
+            db.query(Event)
+            .filter(or_(Event.code == candidate, Event.join_code == candidate))
+            .first()
+        )
+        if not exists:
+            return candidate
+```
+
+Existing code-generation paths route through this helper for both columns.
+
+## Route resolution
+
+### Lookup helpers (single source of truth)
+
+```python
+# server/app/services/event.py
+
+def get_event_by_collection_code(db: Session, code: str) -> Event | None:
+    return db.query(Event).filter(Event.code == code).first()
+
+def get_event_by_join_code(db: Session, join_code: str) -> Event | None:
+    return db.query(Event).filter(Event.join_code == join_code).first()
+```
+
+Audit every `Event.code ==` filter in `server/app/api/` and route each through the appropriate helper.
+
+### Routing matrix
+
+| Path | Resolves by | Gated? | Guest-visible (QR)? |
+|---|---|---|---|
+| `/collect/{code}` (frontend) | `events.code` | Hard human + email | No |
+| `/api/public/collect/{code}/*` (mutating) | `events.code` | Hard human + email | No |
+| `/api/public/collect/{code}` (preview) | `events.code` | None | No |
+| `/api/public/collect/{code}/leaderboard` | `events.code` | None | No |
+| `/join/{join_code}` (frontend) | `events.join_code` | Unchanged | Yes |
+| `/api/public/events/{join_code}/*` | `events.join_code` | Unchanged | Yes |
+| `/e/{join_code}/display` | `events.join_code` | Unchanged | Yes |
+| `/kiosk-link/{join_code}` | `events.join_code` | Unchanged | Yes |
+| `/(dj)/events/{code}` | `events.code` | DJ auth | DJ-only |
+| Bridge ingestion | `events.code` | Bridge key | DJ-only |
+
+### QR generation
+
+The QR target URL switches from `event.code` to `event.join_code`:
+
+```python
+qr_target = f"{PUBLIC_URL}/join/{event.join_code}"
+```
+
+The DJ dashboard exposes both codes as separate copy buttons with distinct labels (Collection vs Live Join).
+
+### DJ-side bridge
+
+Bridge uses `events.code` (the collection code) unchanged. No bridge code change required.
+
+## Collection-page gating
+
+### New dependency: `require_email_verified`
+
+Chains the existing `require_verified_human` (hard mode) and adds an email-verification check.
+
+```python
+# server/app/api/deps.py
+
+def require_email_verified(
+    db: Session = Depends(get_db),
+    guest_id: int = Depends(require_verified_human),
+) -> int:
+    guest = db.get(Guest, guest_id)
+    if guest is None or guest.verified_email is None:
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "email_verification_required"},
+        )
+    return guest_id
+```
+
+### Switching collect endpoints to hard mode
+
+Replace `require_verified_human_soft` with `require_email_verified` on every mutating collect endpoint AND on personal-profile read endpoints. Collect endpoints are hard-gated regardless of the global `human_verification_enforced` flag — there is no soft-mode fallback for collect.
+
+| Method | Endpoint | Email | Turnstile (hard) |
+|---|---|---|---|
+| GET | `/api/public/collect/{code}` (event preview) | — | — |
+| GET | `/api/public/collect/{code}/leaderboard` | — | — |
+| GET | `/api/public/collect/{code}/profile` | — | required |
+| GET | `/api/public/collect/{code}/profile/me` | required | required |
+| POST | `/api/public/collect/{code}/profile` | required | required |
+| POST | `/api/public/collect/{code}/requests` | required | required |
+| POST | `/api/public/collect/{code}/vote` | required | required |
+| POST | `/api/public/collect/{code}/enrich-preview` | required | required |
+| GET | `/api/public/collect/{code}/...search` | required | required |
+
+### OTP hardening
+
+Audit-driven changes to `services/email_verification.py` (or wherever OTP verify lives):
+
+1. **Expiry: 5 minutes.** Reduce existing expiry (currently unknown — confirm during implementation) to 5 min.
+2. **Attempts: hard cap at 5.** Production audit found `attempts = 0` across all 18 codes — the counter is not being incremented on bad submissions. Fix: increment `attempts` on every failed `verify_email_code` call; reject when `attempts >= 5` with `{"code": "otp_locked"}`.
+3. **User-enumeration safe.** `POST /api/public/guest/verify/request` returns identical `{"sent": true}` response shape whether the email already exists on another `guest_id` or is brand new. The backend silently reconciles (see next item).
+4. **Email-uniqueness reconciliation.** On `verify/confirm`, if `Guest.email_hash` already exists on a different `guest_id`:
+   - Reissue the canonical `guest_id`'s `wrzdj_guest` cookie on the response.
+   - Reissue the `wrzdj_human` cookie bound to the canonical `guest_id`.
+   - Delete the orphan ephemeral guest row.
+   - Return success without disclosing the merge.
+
+   This is the structural defeat of cookie cycling: a verified email maps to exactly one immutable `guest_id` across all future cookie clears.
+
+### Turnstile per-action labels
+
+Use distinct `action` strings (≤32 chars) on each Turnstile widget instance:
+- `collect_otp_send` — fresh per OTP-request call
+- `collect_submit` — collect page session bootstrap before submit
+- `collect_vote` — collect page session bootstrap before vote
+
+Cloudflare uses these for analytics, and they let us tune challenge thresholds per action later.
+
+### Siteverify enforcement
+
+Confirm `services/turnstile.py` treats `timeout-or-duplicate` from Cloudflare siteverify as a hard failure (rejects the token). If it currently passes through, fix it.
+
+### Cookie flags
+
+Confirm `wrzdj_human` is issued with `Secure; HttpOnly; SameSite=Lax`. Lax (not Strict) because the cookie must survive top-level navigation from QR scans and external links.
+
+### Frontend changes
+
+| File | Change |
+|---|---|
+| `dashboard/app/collect/[code]/page.tsx` | Wrap mutating UI in `<EmailGate>` block; reuse existing `useHumanVerification` hook for the Turnstile half |
+| `dashboard/components/EmailGate.tsx` | NEW — full-screen blocker, two stages (email entry + OTP entry), reuses `EmailVerification.tsx` internals |
+| `dashboard/lib/api.ts` | Extend `withHumanRetry` → `withVerificationRetry` (handles both 403 codes: `human_verification_required` and `email_verification_required`) |
+| `dashboard/lib/useEmailVerified.ts` | NEW — hook that fetches `/collect/{code}/profile/me`, returns `{verified, refresh}` |
+
+### Page-load state machine
+
+```
+[Page mount]
+    │
+    ▼
+[1. Fetch GET /collect/{code} (event preview, no gate)]
+    │
+    ▼
+[2. useHumanVerification: Turnstile bootstrap → wrzdj_human cookie]
+    │ on fail/escalate: visible Turnstile widget
+    ▼
+[3. Fetch GET /collect/{code}/profile/me (require_email_verified)]
+    │ 403 email_verification_required → render EmailGate
+    │ 200 → guest is verified
+    ▼
+[4. Render full collect UI: leaderboard, submit, vote, profile]
+```
+
+### Failure UX
+
+| Failure | User-facing message |
+|---|---|
+| Turnstile network/blocked | "Verification challenge failed. Refresh and try again." |
+| OTP send rate-limited | "Too many attempts. Wait 60s." |
+| OTP code expired | "Code expired. Request a new one." |
+| OTP code wrong | "Code didn't match. Try again. ({attempts}/5)" |
+| OTP locked (5 attempts) | "Too many wrong codes. Request a new code." |
+| Email collision (different cookie) | Silently rebound. No user-visible error. |
+
+## Live-page gating
+
+**No change.** The live join experience (`/join/{join_code}`, `/api/public/events/{join_code}/*`) keeps exactly its current behavior: guest cookie + optional nickname, no Turnstile, no email, no human cookie required. The only change is the URL parameter resolves from `events.join_code` instead of `events.code`.
+
+## Tidal poller hardening
+
+### Failure-mode distinction in `get_playlist_tracks`
+
+```python
+class TidalFetchError(Exception):
+    """Raised when Tidal playlist tracks can't be fetched (vs. genuinely empty)."""
+
+
+def get_playlist_tracks(db: Session, user: User, playlist_id: str) -> list:
+    session = get_tidal_session(db, user)
+    if not session:
+        raise TidalFetchError("No active Tidal session for user")
+
+    try:
+        playlist = session.playlist(playlist_id)
+        all_tracks = []
+        offset = 0
+        page_size = 100
+        while True:
+            page = playlist.tracks(limit=page_size, offset=offset)
+            if not page:
+                break
+            all_tracks.extend(page)
+            if len(page) < page_size:
+                break
+            offset += page_size
+        return all_tracks
+    except Exception as e:
+        logger.error("Tidal playlist fetch failed: %s: %s", type(e).__name__, e)
+        raise TidalFetchError(str(e)) from e
+```
+
+Two structural changes:
+- Throws `TidalFetchError` on any failure (no silent `[]`).
+- Paginates through all tracks (handles playlists >100; today's truncation at 100 is a latent bug).
+
+### Safe abort in `poll_tidal_collection_removals`
+
+```python
+def poll_tidal_collection_removals(db: Session, event: Event) -> int:
+    if not event.tidal_collection_playlist_id:
+        return 0
+
+    user = event.created_by
+    try:
+        playlist_tracks = get_playlist_tracks(db, user, event.tidal_collection_playlist_id)
+    except TidalFetchError as e:
+        logger.warning(
+            "Tidal collection poll aborted for event %s: %s. NOT marking any requests rejected.",
+            event.code, e,
+        )
+        log_activity(db, level="warn", source="tidal_poll",
+                     message=f"Poll aborted: {e}", event_code=event.code)
+        return 0
+
+    current_ids = {str(t.id) for t in playlist_tracks}
+
+    synced = (
+        db.query(Request)
+        .filter(
+            Request.event_id == event.id,
+            Request.submitted_during_collection == True,  # noqa: E712
+            Request.tidal_collection_track_id.isnot(None),
+            Request.status != RequestStatus.REJECTED.value,
+        )
+        .all()
+    )
+
+    # Suspicious-empty guard
+    if not current_ids and synced:
+        logger.error(
+            "Tidal collection poll: playlist returned 0 tracks but %d synced requests exist for event %s. "
+            "Suspecting API issue, NOT rejecting.",
+            len(synced), event.code,
+        )
+        log_activity(db, level="warn", source="tidal_poll",
+                     message=f"Empty playlist with {len(synced)} synced rows; rejection sweep skipped",
+                     event_code=event.code)
+        return 0
+
+    candidate_rejections = [
+        req for req in synced if req.tidal_collection_track_id not in current_ids
+    ]
+
+    # Mass-rejection cap (defense in depth)
+    if len(candidate_rejections) > len(synced) * 0.50 and len(candidate_rejections) > 5:
+        logger.error(
+            "Tidal collection poll: refused to reject %d/%d for event %s (>50%% threshold)",
+            len(candidate_rejections), len(synced), event.code,
+        )
+        log_activity(db, level="error", source="tidal_poll",
+                     message=f"Aborted mass rejection: would reject {len(candidate_rejections)}/{len(synced)}",
+                     event_code=event.code)
+        return 0
+
+    for req in candidate_rejections:
+        req.status = RequestStatus.REJECTED.value
+
+    count = len(candidate_rejections)
+    if count > 0:
+        db.commit()
+        rejected_ids = [r.id for r in candidate_rejections]
+        logger.info("Tidal poll: rejected %d removed track(s) for event %s", count, event.code)
+        log_activity(db, level="info", source="tidal_poll",
+                     message=f"Auto-rejected {count} requests (IDs: {rejected_ids[:20]})",
+                     event_code=event.code)
+
+    return count
+```
+
+Three new safety properties:
+1. `TidalFetchError` → abort, no mass-reject.
+2. Suspicious-empty guard: playlist returned 0 tracks while ≥1 synced request exists → abort.
+3. Mass-rejection cap: >50% of synced rows in one cycle → abort.
+
+All three paths write to `activity_log` so the DJ can see what the poller did and didn't do.
+
+## ELZ2G2 data recovery
+
+Run as a one-shot SQL script after the deploy completes and the Tidal poller fix is live. Archived in `deploy/scripts/recovery-elz2g2-2026-05-20.sql`.
+
+```sql
+BEGIN;
+
+CREATE TEMP TABLE elz2g2_recovery AS
+SELECT id, song_title, artist, status, updated_at, tidal_collection_track_id
+FROM requests
+WHERE event_id = 15
+  AND status = 'rejected'
+  AND (
+    updated_at BETWEEN '2026-05-19 13:09:00' AND '2026-05-19 13:10:00'
+    OR updated_at BETWEEN '2026-05-20 05:02:00' AND '2026-05-20 05:04:00'
+    OR updated_at BETWEEN '2026-05-20 22:02:00' AND '2026-05-20 22:08:00'
+  );
+
+-- Expect ~142 rows
+SELECT COUNT(*), MIN(updated_at), MAX(updated_at) FROM elz2g2_recovery;
+
+UPDATE requests
+SET status = 'new', updated_at = NOW()
+WHERE id IN (SELECT id FROM elz2g2_recovery);
+
+-- Drop the lone surviving pumped vote on request #169 (Uptown Funk)
+DELETE FROM request_votes WHERE id = 362;
+UPDATE requests SET vote_count = vote_count - 1 WHERE id = 169;
+
+-- Sanity check before commit
+SELECT status, COUNT(*) FROM requests WHERE event_id = 15 GROUP BY status;
+
+COMMIT;
+```
+
+## Rollout
+
+### Sequence
+
+1. Local CI: ruff check, ruff format --check, bandit, pip-audit, pytest with coverage ≥85; frontend lint, tsc --noEmit, vitest; bridge tsc + vitest; bridge-app tsc + vitest; `alembic upgrade head && alembic check`.
+2. Push branch, PR, watch remote CI green.
+3. Merge to main.
+4. `ssh wrz-droplet` → `git fetch && git checkout main && git pull`.
+5. `pg_dump` to `/backups/pre-collection-split-2026-05-XX.sql.gz`.
+6. `./deploy/deploy.sh` runs the Alembic migration, which adds `join_code` and backfills.
+7. Verify container health, smoke `/healthz`.
+8. Run `deploy/scripts/recovery-elz2g2-2026-05-20.sql`.
+9. Flip `UPDATE system_settings SET human_verification_enforced = true`.
+10. Smoke test (next subsection).
+
+### Smoke tests (post-deploy, pre-announcement)
+
+1. Open `/collect/ELZ2G2` in incognito — EmailGate renders.
+2. Submit a test email, get OTP, submit wrong code 5 times — locked.
+3. Request new code, submit correct — full collect UI appears, submit a song.
+4. Note `guest_id` in DevTools, clear cookies, return — re-verify email → confirm same `guest_id` reissued.
+5. Open `/join/{new_join_code}` in incognito on a phone — no Turnstile, no email; vote works.
+6. As DJ, remove a track from the Tidal collection playlist → wait 5 min → confirm only that track rejected, not all.
+7. As DJ, force Tidal token expiry → wait 5 min → confirm `activity_log` has "Tidal collection poll aborted" with no mass rejection.
+
+### Rollback
+
+```bash
+ssh wrz-droplet
+cd ~/WrzDJ
+git revert HEAD
+./deploy/deploy.sh
+.venv/bin/alembic downgrade -1
+# Recovery SQL changes stay (harmless: requests at 'new' instead of 'rejected')
+# Optional: UPDATE system_settings SET human_verification_enforced = false
+```
+
+## Testing
+
+### Backend (pytest)
+
+| Test | Asserts |
+|---|---|
+| `test_event_has_distinct_join_code` | New event has `code != join_code`, both unique, both 6 chars |
+| `test_join_code_collision_resolved_in_backfill` | Migration backfills unique join_code despite random gen collisions |
+| `test_collect_endpoint_403_without_human_cookie` | Mutating collect endpoint without cookie returns 403 `human_verification_required` even when global `enforced=false` |
+| `test_collect_endpoint_403_without_email_verified` | Guest with valid human cookie but no `verified_email` → 403 `email_verification_required` |
+| `test_join_endpoint_no_gate` | `POST /api/public/events/{join_code}/vote` works with no email and no human cookie |
+| `test_otp_attempts_increment_and_block` | 5 wrong submissions → 6th rejected with `otp_locked`; `attempts` column reflects this |
+| `test_otp_expiry_5_minutes` | Code created with `expires_at = now + 5min` |
+| `test_otp_send_no_enumeration` | Sending OTP to existing email vs new email returns identical response shape |
+| `test_email_reconciliation_rebinds_guest` | New guest cookie verifying existing email → rebound to canonical guest_id, orphan removed |
+| `test_tidal_fetch_error_aborts_rejection` | Mocked Tidal API failure → poller returns 0 rejections, no status changes |
+| `test_tidal_empty_playlist_with_synced_rows_aborts` | Playlist returns 0 tracks, synced_rows>0 → no rejections, activity_log entry |
+| `test_tidal_mass_rejection_cap` | Mock 60% of tracks "removed" → no status changes, activity_log entry |
+| `test_tidal_pagination_handles_150_tracks` | Playlist with 150 tracks → `get_playlist_tracks` returns all 150 |
+| `test_qr_url_uses_join_code` | QR URL generation uses `event.join_code`, never `event.code` |
+
+### Frontend (vitest)
+
+| Test | Asserts |
+|---|---|
+| `EmailGate.test.tsx` | Renders when 403 `email_verification_required` returned from profile/me |
+| `collect-page-blocks-without-email.test.tsx` | Submit/vote actions disabled until both gates pass |
+| `join-page-still-frictionless.test.tsx` | `/join/{code}` page renders without Turnstile widget |
+| `qr-uses-join-code.test.tsx` | DJ-side QR copy button shows join_code URL, not code URL |
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Alembic migration partial-applies on prod | Wrap backfill in single transaction; `pg_dump` immediately before deploy |
+| `human_verification_enforced=true` blocks legit early ELZ2G2 users | Smoke-test the collect flow with two different test emails before flipping |
+| `/join/{join_code}` URL leaks become spammable | Accept (same risk as today's `event.code` URL) |
+| Bridge breaks after migration | No bridge change; bridge keeps resolving by `event.code` |
+| Tidal hardening false-positive aborts | Acceptable: 0 auto-rejections beats 142 wrong auto-rejections; DJ can reject manually |
+| Recovery SQL un-rejects something the DJ explicitly rejected | Audit confirms DJ has not manually rejected anything; the timestamps queried are exclusively from poll cycles |
+
+## Sources informing best-practice decisions
+
+- [Cloudflare Turnstile · widget configurations](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/widget-configurations/)
+- [Cloudflare Turnstile · concepts](https://developers.cloudflare.com/turnstile/concepts/widget/)
+- [OWASP Email Validation and Verification Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Email_Validation_and_Verification_Cheat_Sheet.html)
+- [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
+- [OWASP — Testing for Account Enumeration](https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account)
+- [MDN — One-time passwords](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/OTP)
+- [Authentica — Email OTP best practices](http://authentica.sa/en/email-otp-practices-for-secure-authentication/)
+- [AWS — Secure One-Time Password Architecture](https://aws.amazon.com/blogs/messaging-and-targeting/build-a-secure-one-time-password-architecture-with-aws/)
+- [Teleport — HTTP session management](https://goteleport.com/blog/http-session-best-practices/)
+- [GitGuardian — HMAC secrets explained](https://blog.gitguardian.com/hmac-secrets-explained-authentication/)
+- [arxiv — Sybil-resistant voting mechanism](https://arxiv.org/pdf/2407.01844)

--- a/server/alembic/versions/045_add_event_join_code.py
+++ b/server/alembic/versions/045_add_event_join_code.py
@@ -1,0 +1,71 @@
+"""Add join_code to events for the collection/live event code split.
+
+Revision ID: 045
+Revises: 044
+Create Date: 2026-05-20
+
+Splits event identity into two codes per event:
+- events.code keeps its existing values (becomes the COLLECTION code by intent)
+- events.join_code is a NEW unique 6-char code used by /join/, /e/.../display,
+  /kiosk-link/, and QR generation (the frictionless live-event code)
+
+Backfills every existing event with a freshly-generated join_code that does
+not collide with any existing code OR join_code value.
+"""
+
+import secrets
+import string
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "045"
+down_revision: str | None = "044"
+branch_labels = None
+depends_on = None
+
+
+# Mirrors generate_event_code() in services/event.py — kept local to the
+# migration to avoid coupling to application code that may evolve.
+_SAFE_ALPHABET = (
+    (string.ascii_uppercase + string.digits)
+    .replace("0", "")
+    .replace("O", "")
+    .replace("I", "")
+    .replace("1", "")
+)
+
+
+def _generate_code(length: int = 6) -> str:
+    return "".join(secrets.choice(_SAFE_ALPHABET) for _ in range(length))
+
+
+def upgrade() -> None:
+    # Add nullable first so existing rows don't violate the constraint
+    op.add_column("events", sa.Column("join_code", sa.String(10), nullable=True))
+
+    conn = op.get_bind()
+    rows = conn.execute(sa.text("SELECT id FROM events WHERE join_code IS NULL")).fetchall()
+
+    for (event_id,) in rows:
+        while True:
+            candidate = _generate_code()
+            exists = conn.execute(
+                sa.text("SELECT 1 FROM events WHERE code = :c OR join_code = :c LIMIT 1"),
+                {"c": candidate},
+            ).first()
+            if not exists:
+                conn.execute(
+                    sa.text("UPDATE events SET join_code = :c WHERE id = :id"),
+                    {"c": candidate, "id": event_id},
+                )
+                break
+
+    op.alter_column("events", "join_code", nullable=False)
+    op.create_index("ix_events_join_code", "events", ["join_code"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_events_join_code", table_name="events", if_exists=True)
+    op.drop_column("events", "join_code")

--- a/server/app/api/admin.py
+++ b/server/app/api/admin.py
@@ -211,6 +211,7 @@ def admin_update_event(
     return AdminEventOut(
         id=updated.id,
         code=updated.code,
+        join_code=updated.join_code,
         name=updated.name,
         owner_username=owner.username if owner else "unknown",
         owner_id=updated.created_by_user_id,

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -13,8 +13,8 @@ from sqlalchemy import desc, func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_db, require_verified_human_soft
-from app.core.rate_limit import get_guest_id, limiter
+from app.api.deps import get_db, require_email_verified, require_verified_human
+from app.core.rate_limit import limiter
 from app.models.event import Event
 from app.models.guest import Guest
 from app.models.request import Request as SongRequest
@@ -154,26 +154,25 @@ def leaderboard(
 
 @router.get("/{code}/profile", response_model=CollectProfileResponse)
 @limiter.limit("60/minute")
-def get_profile(code: str, request: Request, db: Session = Depends(get_db)):
-    """Read the calling guest's profile for this event. Anonymous callers
-    (no cookie) get the default empty profile — there is no IP fallback.
-    """
+def get_profile(
+    code: str,
+    request: Request,
+    db: Session = Depends(get_db),
+    guest_id: int = Depends(require_verified_human),
+):
     event = _get_event_or_404(db, code)
-    guest_id = get_guest_id(request, db)
     profile = collect_service.get_profile(db, event_id=event.id, guest_id=guest_id)
+    from app.models.guest import Guest
+
+    guest_row = db.query(Guest).filter(Guest.id == guest_id).first()
+    is_verified = guest_row is not None and guest_row.email_verified_at is not None
     if profile is None:
         return CollectProfileResponse(
             nickname=None,
-            email_verified=False,
+            email_verified=is_verified,
             submission_count=0,
             submission_cap=event.submission_cap_per_guest,
         )
-    is_verified = False
-    if guest_id:
-        from app.models.guest import Guest
-
-        guest_row = db.query(Guest).filter(Guest.id == guest_id).first()
-        is_verified = guest_row is not None and guest_row.email_verified_at is not None
     return CollectProfileResponse(
         nickname=profile.nickname,
         email_verified=is_verified,
@@ -189,12 +188,9 @@ def set_profile(
     payload: CollectProfileRequest,
     request: Request,
     db: Session = Depends(get_db),
-    _human: int | None = Depends(require_verified_human_soft),
+    guest_id: int = Depends(require_email_verified),
 ):
     event = _get_event_or_404(db, code)
-    guest_id = get_guest_id(request, db)
-    if guest_id is None:
-        raise HTTPException(status_code=401, detail="Guest identity required")
     try:
         profile = upsert_profile(
             db,
@@ -236,18 +232,13 @@ def set_profile(
 
 @router.get("/{code}/profile/me", response_model=CollectMyPicksResponse)
 @limiter.limit("60/minute")
-def my_picks(code: str, request: Request, db: Session = Depends(get_db)):
+def my_picks(
+    code: str,
+    request: Request,
+    db: Session = Depends(get_db),
+    guest_id: int = Depends(require_email_verified),
+):
     event = _get_event_or_404(db, code)
-    guest_id = get_guest_id(request, db)
-
-    if guest_id is None:
-        return CollectMyPicksResponse(
-            submitted=[],
-            upvoted=[],
-            is_top_contributor=False,
-            first_suggestion_ids=[],
-            voted_request_ids=[],
-        )
 
     submitted = (
         db.query(SongRequest)
@@ -338,15 +329,11 @@ def submit(
     request: Request,
     background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
-    _human: int | None = Depends(require_verified_human_soft),
+    guest_id: int = Depends(require_email_verified),
 ):
     event = _get_event_or_404(db, code)
     if event.phase != "collection":
         raise HTTPException(status_code=409, detail="Collection has ended")
-
-    guest_id = get_guest_id(request, db)
-    if guest_id is None:
-        raise HTTPException(status_code=401, detail="Guest identity required")
 
     existing = find_duplicate(db, event.id, payload.artist, payload.song_title)
     if existing:
@@ -420,14 +407,11 @@ def vote(
     payload: CollectVoteRequest,
     request: Request,
     db: Session = Depends(get_db),
-    _human: int | None = Depends(require_verified_human_soft),
+    guest_id: int = Depends(require_email_verified),
 ):
     event = _get_event_or_404(db, code)
     if event.phase not in ("collection", "live"):
         raise HTTPException(status_code=409, detail="Voting is closed")
-    guest_id = get_guest_id(request, db)
-    if guest_id is None:
-        raise HTTPException(status_code=401, detail="Guest identity required")
     row = (
         db.query(SongRequest)
         .filter(SongRequest.id == payload.request_id)
@@ -457,7 +441,7 @@ def enrich_preview(
     payload: EnrichPreviewRequest,
     request: Request,
     db: Session = Depends(get_db),
-    _human: int | None = Depends(require_verified_human_soft),
+    _verified: int = Depends(require_email_verified),
 ) -> EnrichPreviewResponse:
     """Lightweight Beatport BPM/key lookup for search-time vibes — no DB writes."""
     event = _get_event_or_404(db, code)
@@ -509,7 +493,7 @@ def request_preview(
     code: str,
     request_id: int,
     request: Request,
-    _human: int | None = Depends(require_verified_human_soft),
+    _verified: int = Depends(require_email_verified),
     db: Session = Depends(get_db),
 ):
     event = _get_event_or_404(db, code)

--- a/server/app/api/deps.py
+++ b/server/app/api/deps.py
@@ -197,3 +197,24 @@ def require_verified_human_soft(
         guest_id_db,
     )
     return guest_id_db
+
+
+def require_email_verified(
+    db: Session = Depends(get_db),
+    guest_id: int = Depends(require_verified_human),
+) -> int:
+    """Require an email-verified guest. Chains require_verified_human (hard mode).
+
+    Apply to every mutating collection-phase endpoint AND personal-data GETs.
+    Returns 403 with structured detail {"code": "email_verification_required"}
+    so the frontend can render the EmailGate component.
+    """
+    from app.models.guest import Guest
+
+    guest = db.get(Guest, guest_id)
+    if guest is None or guest.verified_email is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": "email_verification_required"},
+        )
+    return guest_id

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -243,9 +243,10 @@ def _event_to_out(
     request_count: int | None = None,
     include_status: bool = False,
 ) -> EventOut:
-    """Convert Event model to EventOut schema with join_url."""
+    """Convert Event model to EventOut schema with join_url and collect_url."""
     base_url = _get_base_url(request)
-    join_url = f"{base_url}/join/{event.code}" if base_url else None
+    join_url = f"{base_url}/join/{event.join_code}" if base_url else None
+    collect_url = f"{base_url}/collect/{event.code}" if base_url else None
 
     event_status = compute_event_status(event) if include_status else None
 
@@ -258,6 +259,7 @@ def _event_to_out(
     return EventOut(
         id=event.id,
         code=event.code,
+        join_code=event.join_code,
         name=event.name,
         created_at=event.created_at,
         expires_at=event.expires_at,
@@ -265,6 +267,7 @@ def _event_to_out(
         archived_at=event.archived_at,
         status=event_status,
         join_url=join_url,
+        collect_url=collect_url,
         request_count=request_count,
         tidal_sync_enabled=event.tidal_sync_enabled,
         tidal_playlist_id=event.tidal_playlist_id,

--- a/server/app/api/kiosk.py
+++ b/server/app/api/kiosk.py
@@ -55,11 +55,19 @@ auth_router = APIRouter()
 
 
 def _resolve_event_name(db: Session, event_code: str | None) -> str | None:
-    """Look up the event name for a given code, or return None."""
+    """Look up the event name for a given collection code, or return None."""
     if not event_code:
         return None
     event = db.query(Event).filter(Event.code == event_code).first()
     return event.name if event else None
+
+
+def _resolve_event_join_code(db: Session, event_code: str | None) -> str | None:
+    """Look up the join_code for an event identified by its collection code."""
+    if not event_code:
+        return None
+    event = db.query(Event).filter(Event.code == event_code).first()
+    return event.join_code if event else None
 
 
 def _assert_caller_owns_event(event: Event, user: User) -> None:
@@ -136,9 +144,11 @@ def get_pair_status(pair_code: str, request: Request, db: Session = Depends(get_
         return KioskPairStatusResponse(status="expired")
 
     event_name = _resolve_event_name(db, kiosk.event_code)
+    event_join_code = _resolve_event_join_code(db, kiosk.event_code)
     return KioskPairStatusResponse(
         status=kiosk.status,
         event_code=kiosk.event_code,
+        event_join_code=event_join_code,
         event_name=event_name,
     )
 
@@ -168,9 +178,11 @@ def get_session_assignment(request: Request, db: Session = Depends(get_db)):
         update_kiosk_last_seen(db, kiosk)
 
     event_name = _resolve_event_name(db, kiosk.event_code)
+    event_join_code = _resolve_event_join_code(db, kiosk.event_code)
     return KioskSessionResponse(
         status=kiosk.status,
         event_code=kiosk.event_code,
+        event_join_code=event_join_code,
         event_name=event_name,
     )
 
@@ -214,6 +226,7 @@ def complete_kiosk_pairing(
         id=kiosk.id,
         name=kiosk.name,
         event_code=kiosk.event_code,
+        event_join_code=event.join_code,
         event_name=event.name,
         status=kiosk.status,
         paired_at=kiosk.paired_at,
@@ -235,6 +248,7 @@ def list_my_kiosks(
             id=k.id,
             name=k.name,
             event_code=k.event_code,
+            event_join_code=_resolve_event_join_code(db, k.event_code),
             event_name=_resolve_event_name(db, k.event_code),
             status=k.status,
             paired_at=k.paired_at,
@@ -278,6 +292,7 @@ def assign_kiosk(
         id=kiosk.id,
         name=kiosk.name,
         event_code=kiosk.event_code,
+        event_join_code=event.join_code,
         event_name=event.name,
         status=kiosk.status,
         paired_at=kiosk.paired_at,
@@ -301,6 +316,7 @@ def rename_kiosk_endpoint(
         id=kiosk.id,
         name=kiosk.name,
         event_code=kiosk.event_code,
+        event_join_code=_resolve_event_join_code(db, kiosk.event_code),
         event_name=_resolve_event_name(db, kiosk.event_code),
         status=kiosk.status,
         paired_at=kiosk.paired_at,

--- a/server/app/api/public.py
+++ b/server/app/api/public.py
@@ -15,7 +15,7 @@ from app.core.time import utcnow
 from app.models.guest import Guest
 from app.models.request import Request as SongRequest
 from app.models.request import RequestStatus
-from app.services.event import EventLookupResult, get_event_by_code_with_status
+from app.services.event import EventLookupResult, get_event_by_join_code_with_status
 from app.services.now_playing import get_now_playing, is_now_playing_hidden
 from app.services.request import get_requests_by_guest
 
@@ -98,7 +98,7 @@ def get_kiosk_display(
     db: Session = Depends(get_db),
 ) -> KioskDisplayResponse:
     """Get public kiosk display data for an event."""
-    event, lookup_result = get_event_by_code_with_status(db, code)
+    event, lookup_result = get_event_by_join_code_with_status(db, code)
 
     if lookup_result == EventLookupResult.NOT_FOUND:
         raise HTTPException(status_code=404, detail="Event not found")
@@ -114,7 +114,7 @@ def get_kiosk_display(
         base_url = settings.public_url.rstrip("/")
     else:
         base_url = str(request.base_url).rstrip("/")
-    qr_join_url = f"{base_url}/join/{event.code}"
+    qr_join_url = f"{base_url}/join/{event.join_code}"
 
     # Get accepted requests (status = 'accepted') sorted by vote_count desc, then updated_at asc
     accepted_requests = [r for r in event.requests if r.status == RequestStatus.ACCEPTED.value]
@@ -166,7 +166,7 @@ def get_kiosk_display(
             banner_colors = json.loads(event.banner_colors)
 
     return KioskDisplayResponse(
-        event=PublicEventInfo(code=event.code, name=event.name),
+        event=PublicEventInfo(code=event.join_code, name=event.name),
         qr_join_url=qr_join_url,
         accepted_queue=accepted_queue,
         now_playing=now_playing,
@@ -188,7 +188,7 @@ def get_public_requests(
     db: Session = Depends(get_db),
 ) -> GuestRequestListResponse:
     """Get publicly visible requests for an event (NEW and ACCEPTED only)."""
-    event, lookup_result = get_event_by_code_with_status(db, code)
+    event, lookup_result = get_event_by_join_code_with_status(db, code)
 
     if lookup_result == EventLookupResult.NOT_FOUND:
         raise HTTPException(status_code=404, detail="Event not found")
@@ -226,7 +226,7 @@ def get_public_requests(
             )
 
     return GuestRequestListResponse(
-        event=PublicEventInfo(code=event.code, name=event.name),
+        event=PublicEventInfo(code=event.join_code, name=event.name),
         requests=[
             GuestRequestInfo(
                 id=r.id,
@@ -255,7 +255,7 @@ def check_has_requested(
     db: Session = Depends(get_db),
 ) -> HasRequestedResponse:
     """Check if the current client has submitted any requests for this event."""
-    event, lookup_result = get_event_by_code_with_status(db, code)
+    event, lookup_result = get_event_by_join_code_with_status(db, code)
 
     if lookup_result == EventLookupResult.NOT_FOUND:
         raise HTTPException(status_code=404, detail="Event not found")
@@ -288,7 +288,7 @@ def get_my_requests(
     db: Session = Depends(get_db),
 ) -> MyRequestsResponse:
     """Get all requests submitted by the current client for this event."""
-    event, lookup_result = get_event_by_code_with_status(db, code)
+    event, lookup_result = get_event_by_join_code_with_status(db, code)
 
     if lookup_result == EventLookupResult.NOT_FOUND:
         raise HTTPException(status_code=404, detail="Event not found")

--- a/server/app/api/sse.py
+++ b/server/app/api/sse.py
@@ -11,7 +11,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from app.api.deps import get_db
 from app.core.rate_limit import limiter
-from app.services.event import EventLookupResult, get_event_by_code_with_status
+from app.services.event import EventLookupResult, get_event_by_join_code_with_status
 from app.services.event_bus import get_event_bus
 
 logger = logging.getLogger(__name__)
@@ -70,7 +70,7 @@ async def event_stream(
     - requests_bulk_update: Batch accept/reject
     - bridge_status_changed: Bridge connect/disconnect
     """
-    event, result = get_event_by_code_with_status(db, code)
+    event, result = get_event_by_join_code_with_status(db, code)
     if result == EventLookupResult.NOT_FOUND:
         raise HTTPException(status_code=404, detail="Event not found")
     if result == EventLookupResult.ARCHIVED:

--- a/server/app/models/event.py
+++ b/server/app/models/event.py
@@ -25,6 +25,9 @@ class Event(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     code: Mapped[str] = mapped_column(String(10), unique=True, index=True)
+    # Frictionless live-event code (QR target). Distinct from `code` (collection code).
+    # See docs/superpowers/specs/2026-05-20-collection-vs-live-event-codes-design.md.
+    join_code: Mapped[str] = mapped_column(String(10), unique=True, index=True)
     name: Mapped[str] = mapped_column(String(100))
     created_by_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow)

--- a/server/app/schemas/event.py
+++ b/server/app/schemas/event.py
@@ -55,6 +55,7 @@ class DisplaySettingsResponse(BaseModel):
 class EventOut(BaseSchema):
     id: int
     code: str
+    join_code: str
     name: str
     created_at: IsoDatetime
     expires_at: IsoDatetime
@@ -62,6 +63,7 @@ class EventOut(BaseSchema):
     archived_at: OptionalIsoDatetime = None
     status: EventStatus | None = None
     join_url: str | None = None
+    collect_url: str | None = None
     request_count: int | None = None
     # Tidal sync settings
     tidal_sync_enabled: bool = False

--- a/server/app/schemas/kiosk.py
+++ b/server/app/schemas/kiosk.py
@@ -18,6 +18,7 @@ class KioskPairStatusResponse(BaseModel):
 
     status: str
     event_code: str | None = None
+    event_join_code: str | None = None
     event_name: str | None = None
 
 
@@ -26,6 +27,7 @@ class KioskSessionResponse(BaseModel):
 
     status: str
     event_code: str | None = None
+    event_join_code: str | None = None
     event_name: str | None = None
 
 
@@ -53,6 +55,7 @@ class KioskOut(BaseModel):
     id: int
     name: str | None
     event_code: str | None
+    event_join_code: str | None = None
     event_name: str | None = None
     status: str
     paired_at: datetime | None

--- a/server/app/schemas/user.py
+++ b/server/app/schemas/user.py
@@ -52,6 +52,7 @@ class AdminUserOut(BaseSchema):
 class AdminEventOut(BaseSchema):
     id: int
     code: str
+    join_code: str
     name: str
     owner_username: str
     owner_id: int

--- a/server/app/services/admin.py
+++ b/server/app/services/admin.py
@@ -116,6 +116,7 @@ def get_all_events_admin(db: Session, page: int = 1, limit: int = 20) -> tuple[l
             {
                 "id": event.id,
                 "code": event.code,
+                "join_code": event.join_code,
                 "name": event.name,
                 "owner_username": owner_username,
                 "owner_id": event.created_by_user_id,

--- a/server/app/services/email_verification.py
+++ b/server/app/services/email_verification.py
@@ -20,8 +20,8 @@ from app.services.email_sender import send_verification_email
 _logger = logging.getLogger("app.guest.verify")
 
 MAX_CODES_PER_EMAIL_PER_HOUR = 5
-CODE_VALIDITY_MINUTES = 15
-MAX_ATTEMPTS = 3
+CODE_VALIDITY_MINUTES = 5
+MAX_ATTEMPTS = 5
 
 
 class RateLimitExceededError(Exception):

--- a/server/app/services/event.py
+++ b/server/app/services/event.py
@@ -67,9 +67,19 @@ def compute_event_status(event: Event) -> EventStatus:
 
 
 def create_event(db: Session, name: str, user: User, expires_hours: int = 6) -> Event:
-    """Create a new event with distinct, globally-unique collection and join codes."""
+    """Create a new event with distinct, globally-unique collection and join codes.
+
+    The second code is checked against the first in-memory candidate so both
+    columns receive distinct values even before the first row is committed.
+    """
     code = generate_unique_event_code(db)
-    join_code = generate_unique_event_code(db)
+    # Generate join_code separately, retrying if it collides with `code` (the
+    # in-memory candidate not yet committed) — generate_unique_event_code only
+    # consults persisted rows.
+    while True:
+        join_code = generate_unique_event_code(db)
+        if join_code != code:
+            break
 
     expires_at = utcnow() + timedelta(hours=expires_hours)
     event = Event(

--- a/server/app/services/event.py
+++ b/server/app/services/event.py
@@ -69,30 +69,43 @@ def compute_event_status(event: Event) -> EventStatus:
 def create_event(db: Session, name: str, user: User, expires_hours: int = 6) -> Event:
     """Create a new event with distinct, globally-unique collection and join codes.
 
-    The second code is checked against the first in-memory candidate so both
-    columns receive distinct values even before the first row is committed.
+    Concurrency safety: in-memory generation is best-effort; the database
+    UNIQUE constraints on `code` and `join_code` are the actual guarantee.
+    If two concurrent transactions race and pick overlapping values, the
+    INSERT raises IntegrityError and we retry with fresh codes.
     """
-    code = generate_unique_event_code(db)
-    # Generate join_code separately, retrying if it collides with `code` (the
-    # in-memory candidate not yet committed) — generate_unique_event_code only
-    # consults persisted rows.
-    while True:
-        join_code = generate_unique_event_code(db)
-        if join_code != code:
-            break
+    from sqlalchemy.exc import IntegrityError
 
     expires_at = utcnow() + timedelta(hours=expires_hours)
-    event = Event(
-        code=code,
-        join_code=join_code,
-        name=name,
-        created_by_user_id=user.id,
-        expires_at=expires_at,
-    )
-    db.add(event)
-    db.commit()
-    db.refresh(event)
-    return event
+    max_attempts = 8
+    for attempt in range(max_attempts):
+        code = generate_unique_event_code(db)
+        # Ensure the second code is distinct from the first in-memory candidate;
+        # generate_unique_event_code only consults persisted rows.
+        while True:
+            join_code = generate_unique_event_code(db)
+            if join_code != code:
+                break
+
+        event = Event(
+            code=code,
+            join_code=join_code,
+            name=name,
+            created_by_user_id=user.id,
+            expires_at=expires_at,
+        )
+        db.add(event)
+        try:
+            db.commit()
+        except IntegrityError:
+            db.rollback()
+            if attempt == max_attempts - 1:
+                raise
+            continue
+        db.refresh(event)
+        return event
+    # Unreachable: loop either returns or raises on the final iteration.
+    raise RuntimeError("create_event: exhausted retries without resolution")
 
 
 def get_event_by_code_with_status(db: Session, code: str) -> tuple[Event | None, EventLookupResult]:

--- a/server/app/services/event.py
+++ b/server/app/services/event.py
@@ -3,7 +3,7 @@ import string
 from datetime import datetime, timedelta
 from enum import Enum
 
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
 from app.core.time import utcnow
@@ -30,6 +30,33 @@ def generate_event_code(length: int = 6) -> str:
     return "".join(secrets.choice(alphabet) for _ in range(length))
 
 
+def generate_unique_event_code(db: Session, length: int = 6) -> str:
+    """Generate a code that is unique across BOTH `code` and `join_code` columns.
+
+    Prevents a value from being reused as the other type, which would collapse
+    the collection/live split.
+    """
+    while True:
+        candidate = generate_event_code(length)
+        exists = (
+            db.query(Event.id)
+            .filter(or_(Event.code == candidate, Event.join_code == candidate))
+            .first()
+        )
+        if not exists:
+            return candidate
+
+
+def get_event_by_collection_code(db: Session, code: str) -> Event | None:
+    """Resolve an event by its collection code (gated routes: /collect/*)."""
+    return db.query(Event).filter(Event.code == code.upper()).first()
+
+
+def get_event_by_join_code(db: Session, join_code: str) -> Event | None:
+    """Resolve an event by its live/join code (frictionless routes: /join, /e/.../display)."""
+    return db.query(Event).filter(Event.join_code == join_code.upper()).first()
+
+
 def compute_event_status(event: Event) -> EventStatus:
     """Compute the status of an event based on its state."""
     if event.archived_at is not None:
@@ -40,16 +67,18 @@ def compute_event_status(event: Event) -> EventStatus:
 
 
 def create_event(db: Session, name: str, user: User, expires_hours: int = 6) -> Event:
-    """Create a new event with a unique code."""
-    # Generate a unique code
-    while True:
-        code = generate_event_code()
-        existing = db.query(Event).filter(Event.code == code).first()
-        if not existing:
-            break
+    """Create a new event with distinct, globally-unique collection and join codes."""
+    code = generate_unique_event_code(db)
+    join_code = generate_unique_event_code(db)
 
     expires_at = utcnow() + timedelta(hours=expires_hours)
-    event = Event(code=code, name=name, created_by_user_id=user.id, expires_at=expires_at)
+    event = Event(
+        code=code,
+        join_code=join_code,
+        name=name,
+        created_by_user_id=user.id,
+        expires_at=expires_at,
+    )
     db.add(event)
     db.commit()
     db.refresh(event)
@@ -58,23 +87,31 @@ def create_event(db: Session, name: str, user: User, expires_hours: int = 6) -> 
 
 def get_event_by_code_with_status(db: Session, code: str) -> tuple[Event | None, EventLookupResult]:
     """
-    Get an event by code and return lookup result status.
+    Get an event by COLLECTION code and return lookup result status.
 
-    Returns:
-        Tuple of (event, lookup_result) where lookup_result indicates
-        if the event was found, not found, expired, or archived.
+    Used by DJ-facing routes, bridge integration, and any internal lookup that
+    starts from the canonical event identifier. For guest-facing live routes
+    (/join, /e/.../display, /kiosk-link), use get_event_by_join_code_with_status.
     """
     event = db.query(Event).filter(Event.code == code.upper()).first()
+    return _event_with_status(event)
 
+
+def get_event_by_join_code_with_status(
+    db: Session, join_code: str
+) -> tuple[Event | None, EventLookupResult]:
+    """Get an event by LIVE join code (the QR target) and return lookup status."""
+    event = db.query(Event).filter(Event.join_code == join_code.upper()).first()
+    return _event_with_status(event)
+
+
+def _event_with_status(event: Event | None) -> tuple[Event | None, EventLookupResult]:
     if not event:
         return None, EventLookupResult.NOT_FOUND
-
     if event.archived_at is not None:
         return event, EventLookupResult.ARCHIVED
-
     if event.expires_at <= utcnow() or not event.is_active:
         return event, EventLookupResult.EXPIRED
-
     return event, EventLookupResult.FOUND
 
 

--- a/server/app/services/tidal.py
+++ b/server/app/services/tidal.py
@@ -481,13 +481,36 @@ def poll_tidal_collection_removals(db: Session, event: Event) -> int:
     tidal_collection_track_id is no longer present, and marks them rejected.
     Only runs when the event has a collection playlist configured.
 
-    Returns the count of newly rejected requests.
+    Three safety guards prevent the mass-rejection bug from recurring:
+    1. Abort on TidalFetchError (API failure is NOT 'playlist is empty').
+    2. Abort if the playlist returns 0 tracks while synced rows exist.
+    3. Abort if a single sweep would reject >50% of synced rows.
+
+    Returns the count of newly rejected requests (0 on any safety abort).
     """
+    from app.services.activity_log import log_activity
+
     if not event.tidal_collection_playlist_id:
         return 0
 
     user = event.created_by
-    playlist_tracks = get_playlist_tracks(db, user, event.tidal_collection_playlist_id)
+    try:
+        playlist_tracks = get_playlist_tracks(db, user, event.tidal_collection_playlist_id)
+    except TidalFetchError as e:
+        logger.warning(
+            "Tidal collection poll aborted for event %s: %s. NOT marking any requests rejected.",
+            event.code,
+            e,
+        )
+        log_activity(
+            db,
+            level="warn",
+            source="tidal_poll",
+            message=f"Poll aborted: {e}",
+            event_code=event.code,
+        )
+        return 0
+
     current_ids = {str(t.id) for t in playlist_tracks}
 
     synced = (
@@ -501,15 +524,61 @@ def poll_tidal_collection_removals(db: Session, event: Event) -> int:
         .all()
     )
 
-    count = 0
-    for req in synced:
-        if req.tidal_collection_track_id not in current_ids:
-            req.status = RequestStatus.REJECTED.value
-            count += 1
+    # Guard 2: suspicious-empty playlist
+    if not current_ids and synced:
+        logger.error(
+            "Tidal collection poll: playlist returned 0 tracks but %d synced requests exist "
+            "for event %s. Suspecting API issue, NOT rejecting.",
+            len(synced),
+            event.code,
+        )
+        log_activity(
+            db,
+            level="warn",
+            source="tidal_poll",
+            message=(f"Empty playlist with {len(synced)} synced rows; rejection sweep skipped"),
+            event_code=event.code,
+        )
+        return 0
 
+    candidate_rejections = [
+        req for req in synced if req.tidal_collection_track_id not in current_ids
+    ]
+
+    # Guard 3: mass-rejection cap (>50% of synced rows in one sweep)
+    if len(candidate_rejections) > len(synced) * 0.50 and len(candidate_rejections) > 5:
+        logger.error(
+            "Tidal collection poll: refused to reject %d/%d for event %s (>50%% threshold)",
+            len(candidate_rejections),
+            len(synced),
+            event.code,
+        )
+        log_activity(
+            db,
+            level="error",
+            source="tidal_poll",
+            message=(
+                f"Aborted mass rejection: would reject {len(candidate_rejections)}/{len(synced)}"
+            ),
+            event_code=event.code,
+        )
+        return 0
+
+    for req in candidate_rejections:
+        req.status = RequestStatus.REJECTED.value
+
+    count = len(candidate_rejections)
     if count > 0:
         db.commit()
+        rejected_ids = [r.id for r in candidate_rejections]
         logger.info("Tidal poll: rejected %d removed track(s) for event %s", count, event.code)
+        log_activity(
+            db,
+            level="info",
+            source="tidal_poll",
+            message=f"Auto-rejected {count} requests (IDs: {rejected_ids[:20]})",
+            event_code=event.code,
+        )
 
     return count
 
@@ -650,18 +719,43 @@ def list_user_playlists(db: Session, user: User) -> list[TidalPlaylistInfo]:
         return []
 
 
+class TidalFetchError(Exception):
+    """Raised when Tidal playlist tracks can't be fetched (vs. genuinely empty).
+
+    Callers that auto-reject based on track membership MUST distinguish "API
+    failed" from "playlist is empty" — silently returning [] on failure leads
+    to mass false-positive rejections (see ELZ2G2 incident 2026-05-19/20).
+    """
+
+
 def get_playlist_tracks(db: Session, user: User, playlist_id: str) -> list:
-    """Get tracks from a Tidal playlist. Returns raw tidalapi.Track objects."""
+    """Get tracks from a Tidal playlist. Returns raw tidalapi.Track objects.
+
+    Paginates through all results — tidalapi's playlist.tracks() truncates
+    at 100 by default which would partially-reject longer playlists.
+    Raises TidalFetchError on any failure (no silent []).
+    """
     session = get_tidal_session(db, user)
     if not session:
-        return []
+        raise TidalFetchError("No active Tidal session for user")
 
     try:
         playlist = session.playlist(playlist_id)
-        return playlist.tracks() or []
+        all_tracks = []
+        offset = 0
+        page_size = 100
+        while True:
+            page = playlist.tracks(limit=page_size, offset=offset)
+            if not page:
+                break
+            all_tracks.extend(page)
+            if len(page) < page_size:
+                break
+            offset += page_size
+        return all_tracks
     except Exception as e:
-        logger.error(f"Failed to get Tidal playlist tracks: {e}")
-        return []
+        logger.error("Tidal playlist fetch failed: %s: %s", type(e).__name__, e)
+        raise TidalFetchError(str(e)) from e
 
 
 def search_tidal_by_isrc(

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -138,9 +138,10 @@ def auth_headers(client: TestClient, test_user: User) -> dict[str, str]:
 
 @pytest.fixture
 def test_event(db: Session, test_user: User) -> Event:
-    """Create a test event."""
+    """Create a test event with distinct collection and join codes."""
     event = Event(
         code="TEST01",
+        join_code="JOIN01",
         name="Test Event",
         created_by_user_id=test_user.id,
         expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -141,7 +141,7 @@ def test_event(db: Session, test_user: User) -> Event:
     """Create a test event with distinct collection and join codes."""
     event = Event(
         code="TEST01",
-        join_code="JOIN01",
+        join_code="UG4BHD",
         name="Test Event",
         created_by_user_id=test_user.id,
         expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_admin.py
+++ b/server/tests/test_admin.py
@@ -187,6 +187,7 @@ class TestAdminUserManagement:
 
         event = Event(
             code="DOOM01",
+            join_code="DOOM01J",
             name="Doomed Event",
             created_by_user_id=user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_admin.py
+++ b/server/tests/test_admin.py
@@ -187,7 +187,7 @@ class TestAdminUserManagement:
 
         event = Event(
             code="DOOM01",
-            join_code="EOOM01",
+            join_code="LJA3W9",
             name="Doomed Event",
             created_by_user_id=user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_admin.py
+++ b/server/tests/test_admin.py
@@ -187,7 +187,7 @@ class TestAdminUserManagement:
 
         event = Event(
             code="DOOM01",
-            join_code="DOOM01J",
+            join_code="EOOM01",
             name="Doomed Event",
             created_by_user_id=user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_api_contracts.py
+++ b/server/tests/test_api_contracts.py
@@ -68,6 +68,7 @@ USER_OUT_KEYS = {
 EVENT_OUT_KEYS = {
     "id",
     "code",
+    "join_code",
     "name",
     "created_at",
     "expires_at",
@@ -75,6 +76,7 @@ EVENT_OUT_KEYS = {
     "archived_at",
     "status",
     "join_url",
+    "collect_url",
     "request_count",
     "tidal_sync_enabled",
     "tidal_playlist_id",
@@ -118,6 +120,7 @@ ADMIN_USER_OUT_KEYS = {"id", "username", "is_active", "role", "created_at", "eve
 ADMIN_EVENT_OUT_KEYS = {
     "id",
     "code",
+    "join_code",
     "name",
     "owner_username",
     "owner_id",
@@ -336,14 +339,14 @@ class TestVoteContracts:
 
 class TestPublicContracts:
     def test_kiosk_display_shape(self, client: TestClient, test_event: Event):
-        resp = client.get(f"/api/public/events/{test_event.code}/display")
+        resp = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert resp.status_code == 200
         data = resp.json()
         _assert_keys(data, KIOSK_DISPLAY_KEYS, "GET /api/public/events/{code}/display")
         _assert_keys(data["event"], PUBLIC_EVENT_INFO_KEYS, "kiosk.event")
 
     def test_guest_requests_shape(self, client: TestClient, test_event: Event, test_request):
-        resp = client.get(f"/api/public/events/{test_event.code}/requests")
+        resp = client.get(f"/api/public/events/{test_event.join_code}/requests")
         assert resp.status_code == 200
         data = resp.json()
         assert "event" in data
@@ -353,7 +356,7 @@ class TestPublicContracts:
             _assert_keys(data["requests"][0], GUEST_REQUEST_INFO_KEYS, "guest.requests[0]")
 
     def test_has_requested_shape(self, client: TestClient, test_event: Event):
-        resp = client.get(f"/api/public/events/{test_event.code}/has-requested")
+        resp = client.get(f"/api/public/events/{test_event.join_code}/has-requested")
         assert resp.status_code == 200
         _assert_keys(resp.json(), {"has_requested"}, "GET /api/public/events/{code}/has-requested")
 

--- a/server/tests/test_banner.py
+++ b/server/tests/test_banner.py
@@ -194,6 +194,7 @@ class TestSaveBannerToEvent:
 
         event = Event(
             code="BNR01",
+            join_code="BNR01J",
             name="Banner Test",
             created_by_user_id=user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_banner.py
+++ b/server/tests/test_banner.py
@@ -194,7 +194,7 @@ class TestSaveBannerToEvent:
 
         event = Event(
             code="BNR01",
-            join_code="BNR01J",
+            join_code="SJZEX2",
             name="Banner Test",
             created_by_user_id=user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_batch_operations.py
+++ b/server/tests/test_batch_operations.py
@@ -228,7 +228,7 @@ def _create_event(db: Session, user: User, code: str, name: str = "Test Event") 
     """Helper to create an event for bulk delete tests."""
     event = Event(
         code=code,
-        join_code=f"{code}J"[:10],
+        join_code=f"{code}J"[:6],
         name=name,
         created_by_user_id=user.id,
         expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_batch_operations.py
+++ b/server/tests/test_batch_operations.py
@@ -224,11 +224,22 @@ class TestBulkDeleteEndpoint:
         assert response.json()["count"] == 0
 
 
+def _derive_join_code(code: str) -> str:
+    """Build a deterministic 6-char join_code that's guaranteed != code.
+
+    Replaces the first character with a different letter so the result always
+    differs from `code` while staying within the safe-alphabet length contract.
+    """
+    head = code[0].upper()
+    swap = "Z" if head != "Z" else "Y"
+    return (swap + code[1:])[:6].ljust(6, "X")[:6]
+
+
 def _create_event(db: Session, user: User, code: str, name: str = "Test Event") -> Event:
     """Helper to create an event for bulk delete tests."""
     event = Event(
         code=code,
-        join_code=f"{code}J"[:6],
+        join_code=_derive_join_code(code),
         name=name,
         created_by_user_id=user.id,
         expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_batch_operations.py
+++ b/server/tests/test_batch_operations.py
@@ -228,6 +228,7 @@ def _create_event(db: Session, user: User, code: str, name: str = "Test Event") 
     """Helper to create an event for bulk delete tests."""
     event = Event(
         code=code,
+        join_code=f"{code}J"[:10],
         name=name,
         created_by_user_id=user.id,
         expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_beatport.py
+++ b/server/tests/test_beatport.py
@@ -604,7 +604,7 @@ def beatport_event(db: Session, beatport_user: User) -> Event:
 
     event = Event(
         code="BPTEST",
-        join_code="BPTESTJ",
+        join_code="CPTEST",
         name="BP Playlist Test",
         created_by_user_id=beatport_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_beatport.py
+++ b/server/tests/test_beatport.py
@@ -604,7 +604,7 @@ def beatport_event(db: Session, beatport_user: User) -> Event:
 
     event = Event(
         code="BPTEST",
-        join_code="CPTEST",
+        join_code="K6L6GZ",
         name="BP Playlist Test",
         created_by_user_id=beatport_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_beatport.py
+++ b/server/tests/test_beatport.py
@@ -604,6 +604,7 @@ def beatport_event(db: Session, beatport_user: User) -> Event:
 
     event = Event(
         code="BPTEST",
+        join_code="BPTESTJ",
         name="BP Playlist Test",
         created_by_user_id=beatport_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_beatport_adapter.py
+++ b/server/tests/test_beatport_adapter.py
@@ -40,7 +40,7 @@ def bp_user(db: Session) -> User:
 def bp_event(db: Session, bp_user: User) -> Event:
     event = Event(
         code="BPADPT",
-        join_code="CPADPT",
+        join_code="QV79EC",
         name="BP Adapter Test",
         created_by_user_id=bp_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_beatport_adapter.py
+++ b/server/tests/test_beatport_adapter.py
@@ -40,7 +40,7 @@ def bp_user(db: Session) -> User:
 def bp_event(db: Session, bp_user: User) -> Event:
     event = Event(
         code="BPADPT",
-        join_code="BPADPTJ",
+        join_code="CPADPT",
         name="BP Adapter Test",
         created_by_user_id=bp_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_beatport_adapter.py
+++ b/server/tests/test_beatport_adapter.py
@@ -40,6 +40,7 @@ def bp_user(db: Session) -> User:
 def bp_event(db: Session, bp_user: User) -> Event:
     event = Event(
         code="BPADPT",
+        join_code="BPADPTJ",
         name="BP Adapter Test",
         created_by_user_id=bp_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_beatport_api.py
+++ b/server/tests/test_beatport_api.py
@@ -43,7 +43,7 @@ def bp_api_headers(client: TestClient, bp_api_user: User) -> dict[str, str]:
 def bp_api_event(db: Session, bp_api_user: User) -> Event:
     event = Event(
         code="BPAPI1",
-        join_code="CPAPI1",
+        join_code="GRWQLD",
         name="BP API Test Event",
         created_by_user_id=bp_api_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_beatport_api.py
+++ b/server/tests/test_beatport_api.py
@@ -43,6 +43,7 @@ def bp_api_headers(client: TestClient, bp_api_user: User) -> dict[str, str]:
 def bp_api_event(db: Session, bp_api_user: User) -> Event:
     event = Event(
         code="BPAPI1",
+        join_code="BPAPI1J",
         name="BP API Test Event",
         created_by_user_id=bp_api_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_beatport_api.py
+++ b/server/tests/test_beatport_api.py
@@ -43,7 +43,7 @@ def bp_api_headers(client: TestClient, bp_api_user: User) -> dict[str, str]:
 def bp_api_event(db: Session, bp_api_user: User) -> Event:
     event = Event(
         code="BPAPI1",
-        join_code="BPAPI1J",
+        join_code="CPAPI1",
         name="BP API Test Event",
         created_by_user_id=bp_api_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_bridge_api.py
+++ b/server/tests/test_bridge_api.py
@@ -75,7 +75,7 @@ def test_event(db: Session, test_user: User) -> Event:
     """Create a test event."""
     event = Event(
         code="TEST01",
-        join_code="TEST01J",
+        join_code="UEST01",
         name="Test Event",
         created_by_user_id=test_user.id,
         expires_at=utcnow() + timedelta(hours=6),
@@ -91,7 +91,7 @@ def expired_event(db: Session, test_user: User) -> Event:
     """Create an expired event."""
     event = Event(
         code="EXPIRE",
-        join_code="EXPIREJ",
+        join_code="FXPIRE",
         name="Expired Event",
         created_by_user_id=test_user.id,
         expires_at=utcnow() - timedelta(hours=1),

--- a/server/tests/test_bridge_api.py
+++ b/server/tests/test_bridge_api.py
@@ -75,7 +75,7 @@ def test_event(db: Session, test_user: User) -> Event:
     """Create a test event."""
     event = Event(
         code="TEST01",
-        join_code="UEST01",
+        join_code="UG4BHD",
         name="Test Event",
         created_by_user_id=test_user.id,
         expires_at=utcnow() + timedelta(hours=6),
@@ -91,7 +91,7 @@ def expired_event(db: Session, test_user: User) -> Event:
     """Create an expired event."""
     event = Event(
         code="EXPIRE",
-        join_code="FXPIRE",
+        join_code="2ZZN6B",
         name="Expired Event",
         created_by_user_id=test_user.id,
         expires_at=utcnow() - timedelta(hours=1),

--- a/server/tests/test_bridge_api.py
+++ b/server/tests/test_bridge_api.py
@@ -75,6 +75,7 @@ def test_event(db: Session, test_user: User) -> Event:
     """Create a test event."""
     event = Event(
         code="TEST01",
+        join_code="TEST01J",
         name="Test Event",
         created_by_user_id=test_user.id,
         expires_at=utcnow() + timedelta(hours=6),
@@ -90,6 +91,7 @@ def expired_event(db: Session, test_user: User) -> Event:
     """Create an expired event."""
     event = Event(
         code="EXPIRE",
+        join_code="EXPIREJ",
         name="Expired Event",
         created_by_user_id=test_user.id,
         expires_at=utcnow() - timedelta(hours=1),

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -21,19 +21,45 @@ def _enable_collection(db, event: Event):
 def _default_guest_cookie(client, db):
     """Most collect endpoints require a wrzdj_guest cookie (identity is guest_id only).
 
-    See docs/RECOVERY-IP-IDENTITY.md.
+    After the 2026-05-20 collection-hardening change, the collect mutating
+    endpoints also require a verified email and a valid wrzdj_human cookie.
+    The default test guest is therefore pre-verified, and we issue a
+    matching wrzdj_human cookie so the gate passes without an OTP roundtrip.
+
+    See docs/RECOVERY-IP-IDENTITY.md and
+    docs/superpowers/specs/2026-05-20-collection-vs-live-event-codes-design.md.
     """
+    import hashlib
+
+    from fastapi import Response
+
+    from app.services.human_verification import COOKIE_NAME as HUMAN_COOKIE_NAME
+    from app.services.human_verification import issue_human_cookie
+
+    email = "default-test@example.com"
     guest = Guest(
         token="defaultguest" + "0" * 52,
         fingerprint_hash="fp_default",
+        verified_email=email,
+        email_hash=hashlib.sha256(email.encode()).hexdigest(),
+        email_verified_at=utcnow(),
         created_at=utcnow(),
         last_seen_at=utcnow(),
     )
     db.add(guest)
     db.commit()
     db.refresh(guest)
+
+    # Mint a valid wrzdj_human cookie tied to this guest_id.
+    helper_resp = Response()
+    issue_human_cookie(helper_resp, guest.id)
+    raw = helper_resp.headers.get("set-cookie", "")
+    human_value = raw.split("=", 1)[1].split(";", 1)[0] if "=" in raw else ""
+
     client.cookies.clear()
     client.cookies.set("wrzdj_guest", guest.token)
+    if human_value:
+        client.cookies.set(HUMAN_COOKIE_NAME, human_value)
     return guest
 
 
@@ -91,7 +117,7 @@ def test_collect_profile_set_nickname(client, db, test_event):
     assert r.status_code == 200
     body = r.json()
     assert body["nickname"] == "DancingQueen"
-    assert body["email_verified"] is False
+    assert body["email_verified"] is True
     assert body["submission_count"] == 0
     assert body["submission_cap"] == 15
 
@@ -113,7 +139,7 @@ def test_collect_profile_email_field_ignored(client, db, test_event):
         json={"nickname": "AJ"},
     )
     assert r.status_code == 200
-    assert r.json()["email_verified"] is False
+    assert r.json()["email_verified"] is True
 
 
 def test_collect_profile_me_empty_when_no_interactions(client, db, test_event):
@@ -359,7 +385,7 @@ def test_collect_get_profile_does_not_create_row(client, db, test_event):
     body = r.json()
     assert body == {
         "nickname": None,
-        "email_verified": False,
+        "email_verified": True,
         "submission_count": 0,
         "submission_cap": test_event.submission_cap_per_guest,
     }
@@ -386,7 +412,7 @@ def test_collect_get_profile_returns_existing_state(client, db, test_event):
     assert r.status_code == 200
     body = r.json()
     assert body["nickname"] == "Reader"
-    assert body["email_verified"] is False
+    assert body["email_verified"] is True
     assert body["submission_cap"] == test_event.submission_cap_per_guest
 
 
@@ -563,20 +589,40 @@ class TestNicknameUniqueness:
     """Tests for per-event nickname collision detection."""
 
     def _make_guest(self, db, token_suffix: str, verified: bool = False):
+        """Build a guest. Always email-verified so the require_email_verified
+        gate on collect endpoints lets them through — nickname uniqueness is
+        an independent concern from email verification. The `verified` arg
+        controls whether email_verified_at is set so 'claimed' detection works.
+        """
+        import hashlib
+
         from app.core.time import utcnow
 
+        email = f"{token_suffix}@example.com"
         g = Guest(
             token="guest" + token_suffix.ljust(59, "0"),
             fingerprint_hash=f"fp_{token_suffix}",
+            verified_email=email,
+            email_hash=hashlib.sha256(email.encode()).hexdigest(),
+            email_verified_at=utcnow() if verified else None,
             created_at=utcnow(),
             last_seen_at=utcnow(),
         )
-        if verified:
-            g.email_verified_at = utcnow()
         db.add(g)
         db.commit()
         db.refresh(g)
         return g
+
+    def _human_cookie_for(self, guest_id: int) -> str:
+        """Mint a wrzdj_human cookie value for the given guest_id."""
+        from fastapi import Response
+
+        from app.services.human_verification import issue_human_cookie
+
+        resp = Response()
+        issue_human_cookie(resp, guest_id)
+        raw = resp.headers.get("set-cookie", "")
+        return raw.split("=", 1)[1].split(";", 1)[0] if "=" in raw else ""
 
     def test_available_nickname_succeeds(self, client, db, test_event):
         r = client.post(
@@ -586,18 +632,28 @@ class TestNicknameUniqueness:
         assert r.status_code == 200
         assert r.json()["nickname"] == "UniqueNick"
 
-    def test_collision_unclaimed_returns_409_claimed_false(self, client, db, test_event):
+    def test_collision_unclaimed_returns_409_claimed_false(
+        self, client, db, test_event, _default_guest_cookie
+    ):
         # default guest (autouse) claims "Alex"
         client.post(
             f"/api/public/collect/{test_event.code}/profile",
             json={"nickname": "Alex"},
         )
+        # Mark default guest unverified-after-claim so "claimed" returns False.
+        # The autouse fixture pre-verifies for gate-pass; this test specifically
+        # exercises the post-claim unverified state.
+        _default_guest_cookie.email_verified_at = None
+        db.commit()
         # second guest tries "Alex"
         guest2 = self._make_guest(db, "two")
         r = client.post(
             f"/api/public/collect/{test_event.code}/profile",
             json={"nickname": "Alex"},
-            cookies={"wrzdj_guest": guest2.token},
+            cookies={
+                "wrzdj_guest": guest2.token,
+                "wrzdj_human": self._human_cookie_for(guest2.id),
+            },
         )
         assert r.status_code == 409
         body = r.json()["detail"]
@@ -610,14 +666,20 @@ class TestNicknameUniqueness:
         client.post(
             f"/api/public/collect/{test_event.code}/profile",
             json={"nickname": "Alex"},
-            cookies={"wrzdj_guest": verified_guest.token},
+            cookies={
+                "wrzdj_guest": verified_guest.token,
+                "wrzdj_human": self._human_cookie_for(verified_guest.id),
+            },
         )
         # second guest tries same name
         guest2 = self._make_guest(db, "two")
         r = client.post(
             f"/api/public/collect/{test_event.code}/profile",
             json={"nickname": "Alex"},
-            cookies={"wrzdj_guest": guest2.token},
+            cookies={
+                "wrzdj_guest": guest2.token,
+                "wrzdj_human": self._human_cookie_for(guest2.id),
+            },
         )
         assert r.status_code == 409
         body = r.json()["detail"]
@@ -645,7 +707,10 @@ class TestNicknameUniqueness:
             r = client.post(
                 f"/api/public/collect/{test_event.code}/profile",
                 json={"nickname": variant},
-                cookies={"wrzdj_guest": g.token},
+                cookies={
+                    "wrzdj_guest": g.token,
+                    "wrzdj_human": self._human_cookie_for(g.id),
+                },
             )
             assert r.status_code == 409, f"Expected 409 for variant '{variant}'"
 

--- a/server/tests/test_dedup.py
+++ b/server/tests/test_dedup.py
@@ -113,7 +113,7 @@ class TestFindDuplicate:
     def test_no_match_different_event(self, db, test_event, test_user):
         other_event = Event(
             code="OTHER1",
-            join_code="PTHER1",
+            join_code="WX8XQG",
             name="Other Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_dedup.py
+++ b/server/tests/test_dedup.py
@@ -113,6 +113,7 @@ class TestFindDuplicate:
     def test_no_match_different_event(self, db, test_event, test_user):
         other_event = Event(
             code="OTHER1",
+            join_code="OTHER1J",
             name="Other Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_dedup.py
+++ b/server/tests/test_dedup.py
@@ -113,7 +113,7 @@ class TestFindDuplicate:
     def test_no_match_different_event(self, db, test_event, test_user):
         other_event = Event(
             code="OTHER1",
-            join_code="OTHER1J",
+            join_code="PTHER1",
             name="Other Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_email_verification.py
+++ b/server/tests/test_email_verification.py
@@ -65,12 +65,14 @@ def test_verify_wrong_code_increments_attempts(db: Session, test_guest: Guest):
 
 
 def test_verify_three_strikes_invalidates(db: Session, test_guest: Guest):
-    """3 wrong attempts -> code no longer accepted."""
+    """MAX_ATTEMPTS wrong attempts -> code no longer accepted (now 5 per OTP best practice)."""
+    from app.services.email_verification import MAX_ATTEMPTS
+
     with patch("app.services.email_verification.send_verification_email"):
         code_row = create_verification_code(db, guest_id=test_guest.id, email="fan@test.com")
     real_code = code_row.code
 
-    for _ in range(3):
+    for _ in range(MAX_ATTEMPTS):
         with pytest.raises(CodeInvalidError):
             confirm_verification_code(
                 db, guest_id=test_guest.id, email="fan@test.com", code="000000"

--- a/server/tests/test_events.py
+++ b/server/tests/test_events.py
@@ -157,6 +157,7 @@ class TestDeleteEvent:
         # Create event
         event = Event(
             code="DELME1",
+            join_code="DELME1J",
             name="Event With Data",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -256,6 +257,7 @@ class TestExpiredEvents:
         # Create an expired event
         expired_event = Event(
             code="EXPIR1",
+            join_code="EXPIR1J",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -273,6 +275,7 @@ class TestExpiredEvents:
         """Test that submitting a request to expired event returns 410."""
         expired_event = Event(
             code="EXPIR2",
+            join_code="EXPIR2J",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -293,6 +296,7 @@ class TestExpiredEvents:
         """Test that owner can still view requests for expired events."""
         expired_event = Event(
             code="EXPIR3",
+            join_code="EXPIR3J",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -312,6 +316,7 @@ class TestExpiredEvents:
         """Test that kiosk display for expired event returns 410."""
         expired_event = Event(
             code="EXPIR4",
+            join_code="EXPIR4J",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -319,7 +324,7 @@ class TestExpiredEvents:
         db.add(expired_event)
         db.commit()
 
-        response = client.get(f"/api/public/events/{expired_event.code}/display")
+        response = client.get(f"/api/public/events/{expired_event.join_code}/display")
         assert response.status_code == 410
         assert response.json()["detail"]
 
@@ -333,6 +338,7 @@ class TestExpiredEvents:
         # Expired event should be 410
         expired_event = Event(
             code="EXPIR5",
+            join_code="EXPIR5J",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -437,6 +443,7 @@ class TestArchiveEvents:
         # Create an archived event
         archived_event = Event(
             code="ARCHV1",
+            join_code="ARCHV1J",
             name="Archived Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -447,6 +454,7 @@ class TestArchiveEvents:
         # Create an expired event
         expired_event = Event(
             code="EXPRD1",
+            join_code="EXPRD1J",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -476,6 +484,7 @@ class TestArchiveEvents:
         # Create an archived event with requests
         archived_event = Event(
             code="ARCHV2",
+            join_code="ARCHV2J",
             name="Archived With Requests",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -562,6 +571,7 @@ class TestCsvExport:
 
         other_event = Event(
             code="OTHER1",
+            join_code="OTHER1J",
             name="Other User Event",
             created_by_user_id=other_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -581,6 +591,7 @@ class TestCsvExport:
         """Test that owner can export CSV for expired events."""
         expired_event = Event(
             code="EXPCSV",
+            join_code="EXPCSVJ",
             name="Expired CSV Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -600,6 +611,7 @@ class TestCsvExport:
         """Test that owner can export CSV for archived events."""
         archived_event = Event(
             code="ARCSV1",
+            join_code="ARCSV1J",
             name="Archived CSV Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -984,6 +996,7 @@ class TestDisplaySettings:
 
         other_event = Event(
             code="OTHER3",
+            join_code="OTHER3J",
             name="Other User Event",
             created_by_user_id=other_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -1077,7 +1090,7 @@ class TestRequestsOpen:
         )
 
         # Kiosk should still work (not 410)
-        response = client.get(f"/api/public/events/{test_event.code}/display")
+        response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         data = response.json()
         assert data["requests_open"] is False
@@ -1104,7 +1117,7 @@ class TestKioskDisplayNowPlayingHidden:
 
     def test_kiosk_display_includes_now_playing_hidden(self, client: TestClient, test_event: Event):
         """Test that kiosk display includes now_playing_hidden field."""
-        response = client.get(f"/api/public/events/{test_event.code}/display")
+        response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         data = response.json()
         assert "now_playing_hidden" in data
@@ -1124,7 +1137,7 @@ class TestKioskDisplayNowPlayingHidden:
         db.add(now_playing)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/display")
+        response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         data = response.json()
         assert data["now_playing_hidden"] is True
@@ -1145,7 +1158,7 @@ class TestKioskDisplayNowPlayingHidden:
         db.add(now_playing)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/display")
+        response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         data = response.json()
         assert data["now_playing_hidden"] is False
@@ -1156,7 +1169,7 @@ class TestKioskDisplayOnly:
 
     def test_kiosk_display_includes_display_only_field(self, client: TestClient, test_event: Event):
         """Test that kiosk display response includes kiosk_display_only."""
-        response = client.get(f"/api/public/events/{test_event.code}/display")
+        response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         data = response.json()
         assert "kiosk_display_only" in data
@@ -1174,7 +1187,7 @@ class TestKioskDisplayOnly:
         )
 
         # Check public kiosk endpoint
-        response = client.get(f"/api/public/events/{test_event.code}/display")
+        response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         assert response.json()["kiosk_display_only"] is True
 
@@ -1253,6 +1266,7 @@ class TestPlayHistoryCsvExport:
 
         other_event = Event(
             code="OTHER2",
+            join_code="OTHER2J",
             name="Other User Event",
             created_by_user_id=other_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -1379,6 +1393,7 @@ class TestPlayHistoryCsvExport:
         """Test that owner can export play history CSV for expired events."""
         expired_event = Event(
             code="EXPHIS",
+            join_code="EXPHISJ",
             name="Expired Play History Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -1398,6 +1413,7 @@ class TestPlayHistoryCsvExport:
         """Test that owner can export play history CSV for archived events."""
         archived_event = Event(
             code="ARCHIS",
+            join_code="ARCHISJ",
             name="Archived Play History Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -1453,6 +1469,7 @@ class TestEventSearch:
 
         event = Event(
             code="BPSRCH",
+            join_code="BPSRCHJ",
             name="BP Search Test",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -1514,6 +1531,7 @@ class TestEventSearch:
         """Expired event returns 410 for search."""
         expired_event = Event(
             code="EXPSRC",
+            join_code="EXPSRCJ",
             name="Expired Search Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -1552,6 +1570,7 @@ class TestEventSearch:
 
         event = Event(
             code="TDSRCH",
+            join_code="TDSRCHJ",
             name="Tidal Search Test",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -1589,6 +1608,7 @@ class TestEventSearch:
 
         event = Event(
             code="FBSRCH",
+            join_code="FBSRCHJ",
             name="Fallback Search Test",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_events.py
+++ b/server/tests/test_events.py
@@ -157,7 +157,7 @@ class TestDeleteEvent:
         # Create event
         event = Event(
             code="DELME1",
-            join_code="DELME1J",
+            join_code="EELME1",
             name="Event With Data",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -257,7 +257,7 @@ class TestExpiredEvents:
         # Create an expired event
         expired_event = Event(
             code="EXPIR1",
-            join_code="EXPIR1J",
+            join_code="FXPIR1",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -275,7 +275,7 @@ class TestExpiredEvents:
         """Test that submitting a request to expired event returns 410."""
         expired_event = Event(
             code="EXPIR2",
-            join_code="EXPIR2J",
+            join_code="FXPIR2",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -296,7 +296,7 @@ class TestExpiredEvents:
         """Test that owner can still view requests for expired events."""
         expired_event = Event(
             code="EXPIR3",
-            join_code="EXPIR3J",
+            join_code="FXPIR3",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -316,7 +316,7 @@ class TestExpiredEvents:
         """Test that kiosk display for expired event returns 410."""
         expired_event = Event(
             code="EXPIR4",
-            join_code="EXPIR4J",
+            join_code="FXPIR4",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -338,7 +338,7 @@ class TestExpiredEvents:
         # Expired event should be 410
         expired_event = Event(
             code="EXPIR5",
-            join_code="EXPIR5J",
+            join_code="FXPIR5",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -443,7 +443,7 @@ class TestArchiveEvents:
         # Create an archived event
         archived_event = Event(
             code="ARCHV1",
-            join_code="ARCHV1J",
+            join_code="BRCHV1",
             name="Archived Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -454,7 +454,7 @@ class TestArchiveEvents:
         # Create an expired event
         expired_event = Event(
             code="EXPRD1",
-            join_code="EXPRD1J",
+            join_code="FXPRD1",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -484,7 +484,7 @@ class TestArchiveEvents:
         # Create an archived event with requests
         archived_event = Event(
             code="ARCHV2",
-            join_code="ARCHV2J",
+            join_code="BRCHV2",
             name="Archived With Requests",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -571,7 +571,7 @@ class TestCsvExport:
 
         other_event = Event(
             code="OTHER1",
-            join_code="OTHER1J",
+            join_code="PTHER1",
             name="Other User Event",
             created_by_user_id=other_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -591,7 +591,7 @@ class TestCsvExport:
         """Test that owner can export CSV for expired events."""
         expired_event = Event(
             code="EXPCSV",
-            join_code="EXPCSVJ",
+            join_code="FXPCSV",
             name="Expired CSV Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -611,7 +611,7 @@ class TestCsvExport:
         """Test that owner can export CSV for archived events."""
         archived_event = Event(
             code="ARCSV1",
-            join_code="ARCSV1J",
+            join_code="BRCSV1",
             name="Archived CSV Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -996,7 +996,7 @@ class TestDisplaySettings:
 
         other_event = Event(
             code="OTHER3",
-            join_code="OTHER3J",
+            join_code="PTHER3",
             name="Other User Event",
             created_by_user_id=other_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -1266,7 +1266,7 @@ class TestPlayHistoryCsvExport:
 
         other_event = Event(
             code="OTHER2",
-            join_code="OTHER2J",
+            join_code="PTHER2",
             name="Other User Event",
             created_by_user_id=other_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -1393,7 +1393,7 @@ class TestPlayHistoryCsvExport:
         """Test that owner can export play history CSV for expired events."""
         expired_event = Event(
             code="EXPHIS",
-            join_code="EXPHISJ",
+            join_code="FXPHIS",
             name="Expired Play History Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -1413,7 +1413,7 @@ class TestPlayHistoryCsvExport:
         """Test that owner can export play history CSV for archived events."""
         archived_event = Event(
             code="ARCHIS",
-            join_code="ARCHISJ",
+            join_code="BRCHIS",
             name="Archived Play History Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -1469,7 +1469,7 @@ class TestEventSearch:
 
         event = Event(
             code="BPSRCH",
-            join_code="BPSRCHJ",
+            join_code="CPSRCH",
             name="BP Search Test",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -1531,7 +1531,7 @@ class TestEventSearch:
         """Expired event returns 410 for search."""
         expired_event = Event(
             code="EXPSRC",
-            join_code="EXPSRCJ",
+            join_code="FXPSRC",
             name="Expired Search Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -1570,7 +1570,7 @@ class TestEventSearch:
 
         event = Event(
             code="TDSRCH",
-            join_code="TDSRCHJ",
+            join_code="UDSRCH",
             name="Tidal Search Test",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -1608,7 +1608,7 @@ class TestEventSearch:
 
         event = Event(
             code="FBSRCH",
-            join_code="FBSRCHJ",
+            join_code="GBSRCH",
             name="Fallback Search Test",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_events.py
+++ b/server/tests/test_events.py
@@ -157,7 +157,7 @@ class TestDeleteEvent:
         # Create event
         event = Event(
             code="DELME1",
-            join_code="EELME1",
+            join_code="Y9B853",
             name="Event With Data",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -257,7 +257,7 @@ class TestExpiredEvents:
         # Create an expired event
         expired_event = Event(
             code="EXPIR1",
-            join_code="FXPIR1",
+            join_code="DL347H",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -275,7 +275,7 @@ class TestExpiredEvents:
         """Test that submitting a request to expired event returns 410."""
         expired_event = Event(
             code="EXPIR2",
-            join_code="FXPIR2",
+            join_code="SMFZUG",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -296,7 +296,7 @@ class TestExpiredEvents:
         """Test that owner can still view requests for expired events."""
         expired_event = Event(
             code="EXPIR3",
-            join_code="FXPIR3",
+            join_code="TKFJBW",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -316,7 +316,7 @@ class TestExpiredEvents:
         """Test that kiosk display for expired event returns 410."""
         expired_event = Event(
             code="EXPIR4",
-            join_code="FXPIR4",
+            join_code="WTBZJZ",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -338,7 +338,7 @@ class TestExpiredEvents:
         # Expired event should be 410
         expired_event = Event(
             code="EXPIR5",
-            join_code="FXPIR5",
+            join_code="WV769S",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -443,7 +443,7 @@ class TestArchiveEvents:
         # Create an archived event
         archived_event = Event(
             code="ARCHV1",
-            join_code="BRCHV1",
+            join_code="JJ7MLN",
             name="Archived Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -454,7 +454,7 @@ class TestArchiveEvents:
         # Create an expired event
         expired_event = Event(
             code="EXPRD1",
-            join_code="FXPRD1",
+            join_code="KGQ35Q",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -484,7 +484,7 @@ class TestArchiveEvents:
         # Create an archived event with requests
         archived_event = Event(
             code="ARCHV2",
-            join_code="BRCHV2",
+            join_code="D44QZS",
             name="Archived With Requests",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -571,7 +571,7 @@ class TestCsvExport:
 
         other_event = Event(
             code="OTHER1",
-            join_code="PTHER1",
+            join_code="WX8XQG",
             name="Other User Event",
             created_by_user_id=other_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -591,7 +591,7 @@ class TestCsvExport:
         """Test that owner can export CSV for expired events."""
         expired_event = Event(
             code="EXPCSV",
-            join_code="FXPCSV",
+            join_code="8AQM9R",
             name="Expired CSV Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -611,7 +611,7 @@ class TestCsvExport:
         """Test that owner can export CSV for archived events."""
         archived_event = Event(
             code="ARCSV1",
-            join_code="BRCSV1",
+            join_code="ZT548E",
             name="Archived CSV Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -996,7 +996,7 @@ class TestDisplaySettings:
 
         other_event = Event(
             code="OTHER3",
-            join_code="PTHER3",
+            join_code="22LAZP",
             name="Other User Event",
             created_by_user_id=other_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -1266,7 +1266,7 @@ class TestPlayHistoryCsvExport:
 
         other_event = Event(
             code="OTHER2",
-            join_code="PTHER2",
+            join_code="7PJBSF",
             name="Other User Event",
             created_by_user_id=other_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -1393,7 +1393,7 @@ class TestPlayHistoryCsvExport:
         """Test that owner can export play history CSV for expired events."""
         expired_event = Event(
             code="EXPHIS",
-            join_code="FXPHIS",
+            join_code="UDD294",
             name="Expired Play History Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -1413,7 +1413,7 @@ class TestPlayHistoryCsvExport:
         """Test that owner can export play history CSV for archived events."""
         archived_event = Event(
             code="ARCHIS",
-            join_code="BRCHIS",
+            join_code="X9K3WM",
             name="Archived Play History Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -1469,7 +1469,7 @@ class TestEventSearch:
 
         event = Event(
             code="BPSRCH",
-            join_code="CPSRCH",
+            join_code="L8QGF8",
             name="BP Search Test",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -1531,7 +1531,7 @@ class TestEventSearch:
         """Expired event returns 410 for search."""
         expired_event = Event(
             code="EXPSRC",
-            join_code="FXPSRC",
+            join_code="TM2WQM",
             name="Expired Search Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -1570,7 +1570,7 @@ class TestEventSearch:
 
         event = Event(
             code="TDSRCH",
-            join_code="UDSRCH",
+            join_code="53VUXU",
             name="Tidal Search Test",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -1608,7 +1608,7 @@ class TestEventSearch:
 
         event = Event(
             code="FBSRCH",
-            join_code="GBSRCH",
+            join_code="6DX252",
             name="Fallback Search Test",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_guest_merge.py
+++ b/server/tests/test_guest_merge.py
@@ -128,7 +128,7 @@ def test_merge_moves_profile_different_event(db: Session, test_event: Event, tes
     target = _make_guest(db, "tgt_pe")
     other_event = Event(
         code="OTHER1",
-        join_code="PTHER1",
+        join_code="WX8XQG",
         name="Other Event",
         created_by_user_id=test_user.id,
         expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_guest_merge.py
+++ b/server/tests/test_guest_merge.py
@@ -128,6 +128,7 @@ def test_merge_moves_profile_different_event(db: Session, test_event: Event, tes
     target = _make_guest(db, "tgt_pe")
     other_event = Event(
         code="OTHER1",
+        join_code="OTHER1J",
         name="Other Event",
         created_by_user_id=test_user.id,
         expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_guest_merge.py
+++ b/server/tests/test_guest_merge.py
@@ -128,7 +128,7 @@ def test_merge_moves_profile_different_event(db: Session, test_event: Event, tes
     target = _make_guest(db, "tgt_pe")
     other_event = Event(
         code="OTHER1",
-        join_code="OTHER1J",
+        join_code="PTHER1",
         name="Other Event",
         created_by_user_id=test_user.id,
         expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_guest_now_playing.py
+++ b/server/tests/test_guest_now_playing.py
@@ -105,7 +105,7 @@ class TestGuestNowPlaying:
 
         expired = Event(
             code="EXPRD1",
-            join_code="FXPRD1",
+            join_code="KGQ35Q",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -113,7 +113,7 @@ class TestGuestNowPlaying:
         db.add(expired)
         db.commit()
 
-        response = client.get("/api/public/events/FXPRD1/requests")
+        response = client.get("/api/public/events/KGQ35Q/requests")
         assert response.status_code == 410
 
     def test_nonexistent_event_returns_404(self, client: TestClient):

--- a/server/tests/test_guest_now_playing.py
+++ b/server/tests/test_guest_now_playing.py
@@ -105,7 +105,7 @@ class TestGuestNowPlaying:
 
         expired = Event(
             code="EXPRD1",
-            join_code="EXPRD1J",
+            join_code="FXPRD1",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -113,7 +113,7 @@ class TestGuestNowPlaying:
         db.add(expired)
         db.commit()
 
-        response = client.get("/api/public/events/EXPRD1J/requests")
+        response = client.get("/api/public/events/FXPRD1/requests")
         assert response.status_code == 410
 
     def test_nonexistent_event_returns_404(self, client: TestClient):

--- a/server/tests/test_guest_now_playing.py
+++ b/server/tests/test_guest_now_playing.py
@@ -24,7 +24,7 @@ class TestGuestNowPlaying:
         db.add(np)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/requests")
         assert response.status_code == 200
         data = response.json()
         assert data["now_playing"] is not None
@@ -34,7 +34,7 @@ class TestGuestNowPlaying:
         assert data["now_playing"]["source"] == "stagelinq"
 
     def test_returns_null_when_nothing_playing(self, client: TestClient, test_event: Event):
-        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/requests")
         assert response.status_code == 200
         data = response.json()
         assert data["now_playing"] is None
@@ -55,7 +55,7 @@ class TestGuestNowPlaying:
         db.add(np)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/requests")
         assert response.status_code == 200
         # Endpoint should still return valid response regardless of hide state
         assert "now_playing" in response.json()
@@ -83,7 +83,7 @@ class TestGuestNowPlaying:
         db.add(np)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/requests")
         assert response.status_code == 200
         data = response.json()
         assert len(data["requests"]) == 1
@@ -92,10 +92,10 @@ class TestGuestNowPlaying:
         assert data["now_playing"]["source"] == "pioneer"
 
     def test_event_info_present(self, client: TestClient, test_event: Event):
-        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/requests")
         assert response.status_code == 200
         data = response.json()
-        assert data["event"]["code"] == test_event.code
+        assert data["event"]["code"] == test_event.join_code
         assert data["event"]["name"] == test_event.name
 
     def test_expired_event_returns_410(self, client: TestClient, db: Session, test_user):
@@ -105,6 +105,7 @@ class TestGuestNowPlaying:
 
         expired = Event(
             code="EXPRD1",
+            join_code="EXPRD1J",
             name="Expired Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -112,7 +113,7 @@ class TestGuestNowPlaying:
         db.add(expired)
         db.commit()
 
-        response = client.get("/api/public/events/EXPRD1/requests")
+        response = client.get("/api/public/events/EXPRD1J/requests")
         assert response.status_code == 410
 
     def test_nonexistent_event_returns_404(self, client: TestClient):

--- a/server/tests/test_kiosk.py
+++ b/server/tests/test_kiosk.py
@@ -184,6 +184,7 @@ class TestAssignKioskEvent:
         # Create second event
         event2 = Event(
             code="EVT002",
+            join_code="EVT002J",
             name="Second Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_kiosk.py
+++ b/server/tests/test_kiosk.py
@@ -184,7 +184,7 @@ class TestAssignKioskEvent:
         # Create second event
         event2 = Event(
             code="EVT002",
-            join_code="FVT002",
+            join_code="WHHQ8B",
             name="Second Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_kiosk.py
+++ b/server/tests/test_kiosk.py
@@ -184,7 +184,7 @@ class TestAssignKioskEvent:
         # Create second event
         event2 = Event(
             code="EVT002",
-            join_code="EVT002J",
+            join_code="FVT002",
             name="Second Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_kiosk_api.py
+++ b/server/tests/test_kiosk_api.py
@@ -291,7 +291,7 @@ class TestAssignKiosk:
         complete_pairing(db, kiosk, test_event.code, test_user.id)
         event2 = Event(
             code="EVT002",
-            join_code="FVT002",
+            join_code="WHHQ8B",
             name="Second Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -444,9 +444,14 @@ class TestKioskIdor:
 
     @staticmethod
     def _make_victim_event(db: Session, owner: User, code: str = "VICTIM") -> Event:
+        # Deterministic 6-char join_code that's always distinct from `code`:
+        # swap first character (avoids the f"{code}J"[:6] collision when code is 6 chars).
+        head = code[0].upper()
+        swap = "Z" if head != "Z" else "Y"
+        join_code = (swap + code[1:])[:6].ljust(6, "X")[:6]
         evt = Event(
             code=code,
-            join_code=f"{code}J"[:6],
+            join_code=join_code,
             name="Victim Event",
             created_by_user_id=owner.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_kiosk_api.py
+++ b/server/tests/test_kiosk_api.py
@@ -291,6 +291,7 @@ class TestAssignKiosk:
         complete_pairing(db, kiosk, test_event.code, test_user.id)
         event2 = Event(
             code="EVT002",
+            join_code="EVT002J",
             name="Second Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -445,6 +446,7 @@ class TestKioskIdor:
     def _make_victim_event(db: Session, owner: User, code: str = "VICTIM") -> Event:
         evt = Event(
             code=code,
+            join_code=f"{code}J"[:10],
             name="Victim Event",
             created_by_user_id=owner.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_kiosk_api.py
+++ b/server/tests/test_kiosk_api.py
@@ -291,7 +291,7 @@ class TestAssignKiosk:
         complete_pairing(db, kiosk, test_event.code, test_user.id)
         event2 = Event(
             code="EVT002",
-            join_code="EVT002J",
+            join_code="FVT002",
             name="Second Event",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -446,7 +446,7 @@ class TestKioskIdor:
     def _make_victim_event(db: Session, owner: User, code: str = "VICTIM") -> Event:
         evt = Event(
             code=code,
-            join_code=f"{code}J"[:10],
+            join_code=f"{code}J"[:6],
             name="Victim Event",
             created_by_user_id=owner.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_no_ip_identity.py
+++ b/server/tests/test_no_ip_identity.py
@@ -31,9 +31,16 @@ def _enable_collection(db: Session, event: Event) -> None:
 
 
 def _make_guest(db: Session, suffix: str) -> Guest:
+    """Build a fully gate-clearing guest (verified email + human cookie issued by _set_cookie)."""
+    import hashlib
+
+    email = f"{suffix}@example.com"
     g = Guest(
         token=suffix.ljust(64, "0"),
         fingerprint_hash=f"fp_{suffix}",
+        verified_email=email,
+        email_hash=hashlib.sha256(email.encode()).hexdigest(),
+        email_verified_at=utcnow(),
         created_at=utcnow(),
         last_seen_at=utcnow(),
     )
@@ -44,8 +51,20 @@ def _make_guest(db: Session, suffix: str) -> Guest:
 
 
 def _set_cookie(client: TestClient, guest: Guest) -> None:
+    from fastapi import Response
+
+    from app.services.human_verification import COOKIE_NAME as HUMAN_COOKIE_NAME
+    from app.services.human_verification import issue_human_cookie
+
+    resp = Response()
+    issue_human_cookie(resp, guest.id)
+    raw = resp.headers.get("set-cookie", "")
+    human_value = raw.split("=", 1)[1].split(";", 1)[0] if "=" in raw else ""
+
     client.cookies.clear()
     client.cookies.set("wrzdj_guest", guest.token)
+    if human_value:
+        client.cookies.set(HUMAN_COOKIE_NAME, human_value)
 
 
 def test_get_profile_returns_none_without_guest_id(db: Session, test_event: Event):
@@ -98,10 +117,11 @@ def test_my_picks_empty_without_guest_id(client: TestClient, db: Session, test_e
 
     client.cookies.clear()
     r = client.get(f"/api/public/collect/{test_event.code}/profile/me")
-    assert r.status_code == 200
-    body = r.json()
-    assert body["submitted"] == []
-    assert body["upvoted"] == []
+    # /profile/me is now hard-gated (require_email_verified). Anonymous calls
+    # 403 instead of returning empty — stricter than the prior empty fallback,
+    # which is the desired behavior post-2026-05-20 collection hardening.
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "human_verification_required"
 
 
 def test_has_requested_false_without_guest_id(client: TestClient, db: Session, test_event: Event):
@@ -123,7 +143,7 @@ def test_has_requested_false_without_guest_id(client: TestClient, db: Session, t
     db.commit()
 
     client.cookies.clear()
-    r = client.get(f"/api/public/events/{test_event.code}/has-requested")
+    r = client.get(f"/api/public/events/{test_event.join_code}/has-requested")
     assert r.status_code == 200
     assert r.json()["has_requested"] is False
 

--- a/server/tests/test_no_ip_logging.py
+++ b/server/tests/test_no_ip_logging.py
@@ -56,7 +56,7 @@ def test_app_fingerprint_logger_does_not_emit(
         f"/api/public/collect/{test_event.code}/profile",
         json={"nickname": "Tester"},
     )
-    client.get(f"/api/public/events/{test_event.code}/has-requested")
+    client.get(f"/api/public/events/{test_event.join_code}/has-requested")
 
     fp_records = [r for r in caplog.records if r.name == "app.fingerprint"]
     assert fp_records == [], (

--- a/server/tests/test_now_playing.py
+++ b/server/tests/test_now_playing.py
@@ -60,7 +60,7 @@ def test_event(db: Session, test_user: User) -> Event:
     """Create a test event."""
     event = Event(
         code="TEST01",
-        join_code="TEST01J",
+        join_code="UEST01",
         name="Test Event",
         created_by_user_id=test_user.id,
         expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_now_playing.py
+++ b/server/tests/test_now_playing.py
@@ -60,7 +60,7 @@ def test_event(db: Session, test_user: User) -> Event:
     """Create a test event."""
     event = Event(
         code="TEST01",
-        join_code="UEST01",
+        join_code="UG4BHD",
         name="Test Event",
         created_by_user_id=test_user.id,
         expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_now_playing.py
+++ b/server/tests/test_now_playing.py
@@ -60,6 +60,7 @@ def test_event(db: Session, test_user: User) -> Event:
     """Create a test event."""
     event = Event(
         code="TEST01",
+        join_code="TEST01J",
         name="Test Event",
         created_by_user_id=test_user.id,
         expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_public.py
+++ b/server/tests/test_public.py
@@ -55,7 +55,7 @@ class TestMyRequests:
         db.add_all([req1, req2])
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/my-requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/my-requests")
         assert response.status_code == 200
         data = response.json()
         assert len(data["requests"]) == 1
@@ -86,7 +86,7 @@ class TestMyRequests:
             db.add(req)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/my-requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/my-requests")
         assert response.status_code == 200
         data = response.json()
         assert len(data["requests"]) == 5
@@ -95,7 +95,7 @@ class TestMyRequests:
 
     def test_my_requests_empty(self, client: TestClient, test_event: Event):
         """my-requests returns empty list when no requests match."""
-        response = client.get(f"/api/public/events/{test_event.code}/my-requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/my-requests")
         assert response.status_code == 200
         data = response.json()
         assert data["requests"] == []
@@ -124,7 +124,7 @@ class TestMyRequests:
         db.add(req)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/my-requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/my-requests")
         assert response.status_code == 200
         data = response.json()
         r = data["requests"][0]
@@ -141,10 +141,10 @@ class TestKioskDisplay:
 
     def test_kiosk_display_success(self, client: TestClient, test_event: Event):
         """Test getting kiosk display data."""
-        response = client.get(f"/api/public/events/{test_event.code}/display")
+        response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         data = response.json()
-        assert data["event"]["code"] == test_event.code
+        assert data["event"]["code"] == test_event.join_code
         assert data["event"]["name"] == test_event.name
         assert "qr_join_url" in data
         assert "accepted_queue" in data
@@ -169,7 +169,7 @@ class TestKioskDisplay:
         db.add(request)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/display")
+        response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         data = response.json()
         assert len(data["accepted_queue"]) == 1
@@ -200,7 +200,7 @@ class TestKioskDisplay:
         db.add(np)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/display")
+        response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         data = response.json()
         assert data["now_playing"] is not None
@@ -209,18 +209,20 @@ class TestKioskDisplay:
 
     def test_kiosk_display_no_now_playing(self, client: TestClient, test_event: Event):
         """Test kiosk display when nothing is playing."""
-        response = client.get(f"/api/public/events/{test_event.code}/display")
+        response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         data = response.json()
         assert data["now_playing"] is None
 
     def test_kiosk_display_qr_url_format(self, client: TestClient, test_event: Event):
-        """Test QR join URL is properly formatted."""
-        response = client.get(f"/api/public/events/{test_event.code}/display")
+        """Test QR join URL is properly formatted and uses the join_code (not collection code)."""
+        response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         data = response.json()
-        assert test_event.code in data["qr_join_url"]
+        # QR target is the frictionless live URL — must use join_code.
+        assert test_event.join_code in data["qr_join_url"]
         assert "/join/" in data["qr_join_url"]
+        assert test_event.code not in data["qr_join_url"]
 
     def test_kiosk_display_nickname_in_queue(
         self, client: TestClient, test_event: Event, db: Session
@@ -238,7 +240,7 @@ class TestKioskDisplay:
         db.add(request)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/display")
+        response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         data = response.json()
         assert len(data["accepted_queue"]) == 1
@@ -257,7 +259,7 @@ class TestKioskDisplay:
         db.add(request)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/display")
+        response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         data = response.json()
         assert data["accepted_queue"][0]["nickname"] is None
@@ -280,7 +282,7 @@ class TestGuestRequestList:
         db.add(request)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/requests")
         assert response.status_code == 200
         data = response.json()
         assert len(data["requests"]) == 1
@@ -299,7 +301,7 @@ class TestGuestRequestList:
         db.add(request)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/requests")
         assert response.status_code == 200
         data = response.json()
         assert data["requests"][0]["nickname"] is None
@@ -327,7 +329,7 @@ class TestPublicRequestsEnrichmentFields:
         db.add(req)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/requests")
         assert response.status_code == 200
         requests = response.json()["requests"]
         assert len(requests) == 1
@@ -351,7 +353,7 @@ class TestPublicRequestsEnrichmentFields:
         db.add(req)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/requests")
         assert response.status_code == 200
         requests = response.json()["requests"]
         assert len(requests) == 1
@@ -460,7 +462,7 @@ class TestRequesterVerifiedField:
         db.add(req)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/requests")
         assert response.status_code == 200
         data = response.json()
         assert data["requests"][0]["requester_verified"] is True
@@ -477,7 +479,7 @@ class TestRequesterVerifiedField:
         db.add(req)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/requests")
         assert response.status_code == 200
         data = response.json()
         assert data["requests"][0]["requester_verified"] is False
@@ -500,7 +502,7 @@ class TestRequesterVerifiedField:
         db.add(req)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/requests")
+        response = client.get(f"/api/public/events/{test_event.join_code}/requests")
         assert response.status_code == 200
         data = response.json()
         assert data["requests"][0]["requester_verified"] is False

--- a/server/tests/test_public.py
+++ b/server/tests/test_public.py
@@ -216,13 +216,16 @@ class TestKioskDisplay:
 
     def test_kiosk_display_qr_url_format(self, client: TestClient, test_event: Event):
         """Test QR join URL is properly formatted and uses the join_code (not collection code)."""
+        from urllib.parse import urlparse
+
         response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         data = response.json()
-        # QR target is the frictionless live URL — must use join_code.
-        assert test_event.join_code in data["qr_join_url"]
-        assert "/join/" in data["qr_join_url"]
-        assert test_event.code not in data["qr_join_url"]
+        # QR target is the frictionless live URL — must use join_code on the
+        # /join/ path segment exactly (avoid loose substring checks that can
+        # pass when code is a substring of join_code or vice versa).
+        path = urlparse(data["qr_join_url"]).path
+        assert path == f"/join/{test_event.join_code}"
 
     def test_kiosk_display_nickname_in_queue(
         self, client: TestClient, test_event: Event, db: Session

--- a/server/tests/test_sse_security.py
+++ b/server/tests/test_sse_security.py
@@ -41,7 +41,7 @@ class TestSseExistenceCheck:
         """Archived events must not be streamable."""
         evt = Event(
             code="ARCHIV",
-            join_code="BRCHIV",
+            join_code="8MWM4Y",
             name="Archived",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -65,7 +65,7 @@ class TestSseExistenceCheck:
         """Expired events must not be streamable."""
         evt = Event(
             code="EXPIRD",
-            join_code="FXPIRD",
+            join_code="UNZC4W",
             name="Expired",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),

--- a/server/tests/test_sse_security.py
+++ b/server/tests/test_sse_security.py
@@ -41,6 +41,7 @@ class TestSseExistenceCheck:
         """Archived events must not be streamable."""
         evt = Event(
             code="ARCHIV",
+            join_code="ARCHIVJ",
             name="Archived",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -50,7 +51,7 @@ class TestSseExistenceCheck:
         db.commit()
 
         resp = client.get(
-            f"/api/public/events/{evt.code}/stream",
+            f"/api/public/events/{evt.join_code}/stream",
             headers={"Accept": "text/event-stream"},
         )
         assert resp.status_code in (404, 410)
@@ -64,6 +65,7 @@ class TestSseExistenceCheck:
         """Expired events must not be streamable."""
         evt = Event(
             code="EXPIRD",
+            join_code="EXPIRDJ",
             name="Expired",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),
@@ -72,7 +74,7 @@ class TestSseExistenceCheck:
         db.commit()
 
         resp = client.get(
-            f"/api/public/events/{evt.code}/stream",
+            f"/api/public/events/{evt.join_code}/stream",
             headers={"Accept": "text/event-stream"},
         )
         assert resp.status_code in (404, 410)

--- a/server/tests/test_sse_security.py
+++ b/server/tests/test_sse_security.py
@@ -41,7 +41,7 @@ class TestSseExistenceCheck:
         """Archived events must not be streamable."""
         evt = Event(
             code="ARCHIV",
-            join_code="ARCHIVJ",
+            join_code="BRCHIV",
             name="Archived",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -65,7 +65,7 @@ class TestSseExistenceCheck:
         """Expired events must not be streamable."""
         evt = Event(
             code="EXPIRD",
-            join_code="EXPIRDJ",
+            join_code="FXPIRD",
             name="Expired",
             created_by_user_id=test_user.id,
             expires_at=utcnow() - timedelta(hours=1),

--- a/server/tests/test_sync_orchestrator.py
+++ b/server/tests/test_sync_orchestrator.py
@@ -47,7 +47,7 @@ def tidal_user(db: Session) -> User:
 def tidal_event(db: Session, tidal_user: User) -> Event:
     event = Event(
         code="ORCH01",
-        join_code="ORCH01J",
+        join_code="PRCH01",
         name="Orchestrator Test Event",
         created_by_user_id=tidal_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_sync_orchestrator.py
+++ b/server/tests/test_sync_orchestrator.py
@@ -47,6 +47,7 @@ def tidal_user(db: Session) -> User:
 def tidal_event(db: Session, tidal_user: User) -> Event:
     event = Event(
         code="ORCH01",
+        join_code="ORCH01J",
         name="Orchestrator Test Event",
         created_by_user_id=tidal_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_sync_orchestrator.py
+++ b/server/tests/test_sync_orchestrator.py
@@ -47,7 +47,7 @@ def tidal_user(db: Session) -> User:
 def tidal_event(db: Session, tidal_user: User) -> Event:
     event = Event(
         code="ORCH01",
-        join_code="PRCH01",
+        join_code="8BBQQG",
         name="Orchestrator Test Event",
         created_by_user_id=tidal_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_sync_results_exposure.py
+++ b/server/tests/test_sync_results_exposure.py
@@ -136,7 +136,7 @@ class TestPersistSyncResultIncludesUrlAndDuration:
 
         event = Event(
             code="ENRICH",
-            join_code="FNRICH",
+            join_code="UY238A",
             name="Enrich Test",
             created_by_user_id=1,
             expires_at=datetime.now(UTC) + timedelta(hours=6),
@@ -183,7 +183,7 @@ class TestPersistSyncResultIncludesUrlAndDuration:
 
         event = Event(
             code="ENRICH2",
-            join_code="ENRICH",
+            join_code="FZ8V79",
             name="Enrich Test 2",
             created_by_user_id=1,
             expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_sync_results_exposure.py
+++ b/server/tests/test_sync_results_exposure.py
@@ -136,6 +136,7 @@ class TestPersistSyncResultIncludesUrlAndDuration:
 
         event = Event(
             code="ENRICH",
+            join_code="ENRICHJ",
             name="Enrich Test",
             created_by_user_id=1,
             expires_at=datetime.now(UTC) + timedelta(hours=6),
@@ -182,6 +183,7 @@ class TestPersistSyncResultIncludesUrlAndDuration:
 
         event = Event(
             code="ENRICH2",
+            join_code="ENRICH2J",
             name="Enrich Test 2",
             created_by_user_id=1,
             expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_sync_results_exposure.py
+++ b/server/tests/test_sync_results_exposure.py
@@ -136,7 +136,7 @@ class TestPersistSyncResultIncludesUrlAndDuration:
 
         event = Event(
             code="ENRICH",
-            join_code="ENRICHJ",
+            join_code="FNRICH",
             name="Enrich Test",
             created_by_user_id=1,
             expires_at=datetime.now(UTC) + timedelta(hours=6),
@@ -183,7 +183,7 @@ class TestPersistSyncResultIncludesUrlAndDuration:
 
         event = Event(
             code="ENRICH2",
-            join_code="ENRICH2J",
+            join_code="ENRICH",
             name="Enrich Test 2",
             created_by_user_id=1,
             expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_template_playlists.py
+++ b/server/tests/test_template_playlists.py
@@ -350,7 +350,7 @@ class TestGenerateRecommendationsFromTemplate:
 
         event = Event(
             code="TMPL01",
-            join_code="TMPL01J",
+            join_code="UMPL01",
             name="Template Test",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -409,7 +409,7 @@ class TestGenerateRecommendationsFromTemplate:
 
         event = Event(
             code="TMPL02",
-            join_code="TMPL02J",
+            join_code="UMPL02",
             name="Dedup Test",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -469,7 +469,7 @@ class TestGenerateRecommendationsFromTemplate:
 
         event = Event(
             code="TMPL03",
-            join_code="TMPL03J",
+            join_code="UMPL03",
             name="Empty Template",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -494,7 +494,7 @@ class TestGenerateRecommendationsFromTemplate:
 
         event = Event(
             code="TMPL04",
-            join_code="TMPL04J",
+            join_code="UMPL04",
             name="Invalid Source",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_template_playlists.py
+++ b/server/tests/test_template_playlists.py
@@ -350,6 +350,7 @@ class TestGenerateRecommendationsFromTemplate:
 
         event = Event(
             code="TMPL01",
+            join_code="TMPL01J",
             name="Template Test",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -408,6 +409,7 @@ class TestGenerateRecommendationsFromTemplate:
 
         event = Event(
             code="TMPL02",
+            join_code="TMPL02J",
             name="Dedup Test",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -467,6 +469,7 @@ class TestGenerateRecommendationsFromTemplate:
 
         event = Event(
             code="TMPL03",
+            join_code="TMPL03J",
             name="Empty Template",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -491,6 +494,7 @@ class TestGenerateRecommendationsFromTemplate:
 
         event = Event(
             code="TMPL04",
+            join_code="TMPL04J",
             name="Invalid Source",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_template_playlists.py
+++ b/server/tests/test_template_playlists.py
@@ -350,7 +350,7 @@ class TestGenerateRecommendationsFromTemplate:
 
         event = Event(
             code="TMPL01",
-            join_code="UMPL01",
+            join_code="HGY9C7",
             name="Template Test",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -409,7 +409,7 @@ class TestGenerateRecommendationsFromTemplate:
 
         event = Event(
             code="TMPL02",
-            join_code="UMPL02",
+            join_code="BFFZXF",
             name="Dedup Test",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -469,7 +469,7 @@ class TestGenerateRecommendationsFromTemplate:
 
         event = Event(
             code="TMPL03",
-            join_code="UMPL03",
+            join_code="SCJRSB",
             name="Empty Template",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),
@@ -494,7 +494,7 @@ class TestGenerateRecommendationsFromTemplate:
 
         event = Event(
             code="TMPL04",
-            join_code="UMPL04",
+            join_code="ACR5FZ",
             name="Invalid Source",
             created_by_user_id=test_user.id,
             expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_tidal.py
+++ b/server/tests/test_tidal.py
@@ -92,7 +92,7 @@ def tidal_event(db: Session, tidal_user: User) -> Event:
     """Create an event with Tidal sync enabled."""
     event = Event(
         code="TIDAL1",
-        join_code="UIDAL1",
+        join_code="4MF78Z",
         name="Tidal Test Event",
         created_by_user_id=tidal_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_tidal.py
+++ b/server/tests/test_tidal.py
@@ -92,6 +92,7 @@ def tidal_event(db: Session, tidal_user: User) -> Event:
     """Create an event with Tidal sync enabled."""
     event = Event(
         code="TIDAL1",
+        join_code="TIDAL1J",
         name="Tidal Test Event",
         created_by_user_id=tidal_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_tidal.py
+++ b/server/tests/test_tidal.py
@@ -92,7 +92,7 @@ def tidal_event(db: Session, tidal_user: User) -> Event:
     """Create an event with Tidal sync enabled."""
     event = Event(
         code="TIDAL1",
-        join_code="TIDAL1J",
+        join_code="UIDAL1",
         name="Tidal Test Event",
         created_by_user_id=tidal_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_tidal_adapter.py
+++ b/server/tests/test_tidal_adapter.py
@@ -42,7 +42,7 @@ def tidal_user(db: Session) -> User:
 def tidal_event(db: Session, tidal_user: User) -> Event:
     event = Event(
         code="ADAPT1",
-        join_code="BDAPT1",
+        join_code="RZL4R2",
         name="Adapter Test Event",
         created_by_user_id=tidal_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_tidal_adapter.py
+++ b/server/tests/test_tidal_adapter.py
@@ -42,7 +42,7 @@ def tidal_user(db: Session) -> User:
 def tidal_event(db: Session, tidal_user: User) -> Event:
     event = Event(
         code="ADAPT1",
-        join_code="ADAPT1J",
+        join_code="BDAPT1",
         name="Adapter Test Event",
         created_by_user_id=tidal_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_tidal_adapter.py
+++ b/server/tests/test_tidal_adapter.py
@@ -42,6 +42,7 @@ def tidal_user(db: Session) -> User:
 def tidal_event(db: Session, tidal_user: User) -> Event:
     event = Event(
         code="ADAPT1",
+        join_code="ADAPT1J",
         name="Adapter Test Event",
         created_by_user_id=tidal_user.id,
         expires_at=datetime.now(UTC) + timedelta(hours=6),

--- a/server/tests/test_votes.py
+++ b/server/tests/test_votes.py
@@ -27,6 +27,7 @@ def votable_event_and_request(db: Session) -> tuple[Event, SongRequest]:
 
     event = Event(
         code="F3VOTE",
+        join_code="F3VOTEJ",
         name="NAT Vote Test",
         created_by_user_id=user.id,
         expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_votes.py
+++ b/server/tests/test_votes.py
@@ -27,7 +27,7 @@ def votable_event_and_request(db: Session) -> tuple[Event, SongRequest]:
 
     event = Event(
         code="F3VOTE",
-        join_code="F3VOTEJ",
+        join_code="G3VOTE",
         name="NAT Vote Test",
         created_by_user_id=user.id,
         expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_votes.py
+++ b/server/tests/test_votes.py
@@ -27,7 +27,7 @@ def votable_event_and_request(db: Session) -> tuple[Event, SongRequest]:
 
     event = Event(
         code="F3VOTE",
-        join_code="G3VOTE",
+        join_code="QYWKSC",
         name="NAT Vote Test",
         created_by_user_id=user.id,
         expires_at=utcnow() + timedelta(hours=6),

--- a/server/tests/test_voting.py
+++ b/server/tests/test_voting.py
@@ -303,7 +303,7 @@ class TestVoteCountInResponses:
         db.add(request)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/display")
+        response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         data = response.json()
         assert len(data["accepted_queue"]) == 1
@@ -326,7 +326,7 @@ class TestVoteCountInResponses:
             db.add(request)
         db.commit()
 
-        response = client.get(f"/api/public/events/{test_event.code}/display")
+        response = client.get(f"/api/public/events/{test_event.join_code}/display")
         assert response.status_code == 200
         queue = response.json()["accepted_queue"]
         assert len(queue) == 3


### PR DESCRIPTION
## Summary

Splits each event into two codes so the collection phase can be friction-heavy (email + Turnstile required) while the live event stays frictionless (just a guest cookie + nickname). QR codes only ever expose the live join code.

This also fixes the Tidal bidirectional poller bug that silently auto-rejected 142 of 154 ELZ2G2 requests across three poll cycles on May 19-20, and ships a one-shot SQL script to restore the affected rows + drop the lone surviving cookie-pumper vote.

## Audit context

A production audit of event ELZ2G2 ("Home School Prom 2026") on 2026-05-20 surfaced two problems:

1. **Vote pumping via cookie cycling** — one unverified iPhone (UA: iOS 18.6, fingerprint `1bc97a8e…`) generated 23 ephemeral `guest_id` rows over 7 days and cast 241 votes (66% of all event votes). Bypass worked because the global `human_verification_enforced=false` left the wrzdj_human gate in soft mode AND the vote endpoint had no email verification.
2. **Mass auto-rejection** — `poll_tidal_collection_removals` rejected 125 requests in a single transaction on May 19 13:09, plus smaller sweeps on May 20. Root cause: `get_playlist_tracks` silently returned `[]` on any Tidal API failure (auth error, network hiccup, transient outage), indistinguishable from "playlist is genuinely empty". The poller then rejected every synced request because none matched an empty set.

## What changed

### Schema
- `events.join_code` (new, NOT NULL UNIQUE, 6 chars) backfilled per existing event by Alembic 045
- `events.code` keeps its existing values and becomes the **collection** code by intent

### Collection hardening
- New `require_email_verified` dependency in `app/api/deps.py` — chains hard-mode `require_verified_human` and adds an email-verified check; returns 403 with structured `{code: "email_verification_required"}`
- Every mutating collect endpoint + personal-data GETs (`/profile`, `/profile/me`, `/profile` POST, `/requests`, `/vote`, `/enrich-preview`, `/requests/{id}/preview`) now requires the new dep — hard 403, no soft-mode bypass for collect regardless of `system_settings.human_verification_enforced`
- OTP: validity 15→5 min, max attempts 3→5 (per OWASP/MDN guidance; existing attempts counter and Turnstile siteverify kept)

### Live-side URL resolution
- `/api/public/events/{code}/*`, `/e/{code}/display`, `/kiosk-link/{code}`, and the SSE stream now resolve by `events.join_code`
- QR target switched from `event.code` to `event.join_code`
- Kiosk responses include both `event_code` (collection) and `event_join_code` (for kiosk frontend to navigate to `/e/{join_code}/display`)
- Live join behavior is **otherwise unchanged** per design direction — no new gates added to `/join/`

### Tidal poller hardening
- `get_playlist_tracks` raises new `TidalFetchError` on session/API failure (no silent `[]`)
- `get_playlist_tracks` paginates through all results (was truncating at 100)
- `poll_tidal_collection_removals` has three new safety guards:
  1. Abort on `TidalFetchError`
  2. Abort if playlist returns 0 tracks while synced rows exist
  3. Abort if a single sweep would reject >50% of synced rows
- All three aborts log to `activity_log` for DJ observability

### Frontend
- New `EmailGate` component renders a full-screen blocking modal until the guest verifies email + passes Turnstile; reuses existing `EmailVerification` (Turnstile + OTP) flow
- `withHumanRetry` now distinguishes `EmailVerificationRequiredError` so the UI can render `EmailGate` instead of retrying blindly
- DJ event responses (`EventOut`) now surface both `code/collect_url` and `join_code/join_url`

### Bridge
**No change** — bridge keeps resolving events by `event.code` (collection code, the internal canonical identifier)

### Data recovery (post-deploy, manual step)
`deploy/scripts/recovery-elz2g2-2026-05-20.sql` restores the 142 bug-rejected ELZ2G2 rows to `status='new'` and drops the lone surviving cookie-pumper vote on request #169. Run AFTER the deploy succeeds; takes a backup snapshot via `pg_dump` first.

## Test plan

- [x] Backend: `pytest` — 2011 passed
- [x] Backend: `ruff check`, `ruff format --check`, `bandit`, `alembic upgrade head && alembic check` — all clean
- [x] Frontend: `vitest` — 929 passed
- [x] Frontend: `eslint`, `tsc --noEmit` — clean
- [ ] Manual smoke on production (post-deploy):
  - [ ] Open `/collect/ELZ2G2` in incognito → EmailGate renders, Turnstile + OTP flow works
  - [ ] Vote pumping via cookie clear → blocked at the email-uniqueness rebind step
  - [ ] Open `/join/{new-join-code}` in incognito on phone → no Turnstile, no email, vote works
  - [ ] Remove a track from Tidal collection playlist → wait 5 min → confirm only that track rejected, not all
  - [ ] Force Tidal token expiry → wait 5 min → confirm activity_log shows "Tidal collection poll aborted" with no mass rejection
- [ ] Run `deploy/scripts/recovery-elz2g2-2026-05-20.sql` on production after deploy
- [ ] Flip `UPDATE system_settings SET human_verification_enforced = true` after recovery completes

## Spec

[docs/superpowers/specs/2026-05-20-collection-vs-live-event-codes-design.md](https://github.com/wrzonance/WrzDJ/blob/feat/collection-vs-live-event-codes/docs/superpowers/specs/2026-05-20-collection-vs-live-event-codes-design.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full-screen email verification gate on collection pages (preloads UI).
  * Events now expose a separate live/join code distinct from collection codes; join-code used in public/join flows and kiosks.

* **Bug Fixes**
  * Safer playlist polling to avoid mass false rejections.
  * Recovery script to restore misclassified requests and remove a stray vote.

* **Updates**
  * OTP validity shortened to 5 minutes; max attempts raised to 5.
  * Collection APIs require email verification and return a specific verification-required error.

* **Documentation**
  * Added detailed design spec for codes, gating, OTP hardening, rollout and recovery.

* **Tests**
  * Widespread test updates and mocks to reflect join codes and gating behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->