### PR TITLE
fix(collect): visible fallback container for Turnstile escalation

### DIFF
--- a/dashboard/lib/useHumanVerification.ts
+++ b/dashboard/lib/useHumanVerification.ts
@@ -69,20 +69,30 @@ export function useHumanVerification(): UseHumanVerification {
     if (!container) {
       container = document.createElement('div');
       container.setAttribute('data-testid', 'human-verify-fallback');
+      // Zero-size, pointer-events:none container. Cloudflare's injected
+      // iframe sizes itself for invisible vs visible challenge mode and
+      // overflows the container naturally; the wrapper just provides a
+      // stable, centered anchor point in the DOM. Pointer-events:none
+      // ensures the container doesn't intercept clicks on underlying gate
+      // UI when no challenge is being shown.
       Object.assign(container.style, {
         position: 'fixed',
         top: '50%',
         left: '50%',
         transform: 'translate(-50%, -50%)',
         zIndex: '10000',
-        // Cloudflare hides the widget itself during invisible mode and
-        // expands it during escalation; the container only needs to be
-        // mounted and reachable. Use min-width/height so the iframe
-        // injected by Turnstile has room to expand for the visible
-        // challenge.
-        minWidth: '300px',
-        minHeight: '65px',
+        width: '0',
+        height: '0',
+        overflow: 'visible',
+        pointerEvents: 'none',
       });
+      // Re-enable pointer events on the injected iframe so the user can
+      // interact with a visible challenge widget when Cloudflare escalates.
+      const styleEl = document.createElement('style');
+      styleEl.textContent = `
+        [data-testid="human-verify-fallback"] iframe { pointer-events: auto; }
+      `;
+      document.head.appendChild(styleEl);
       document.body.appendChild(container);
       fallbackOwned = true;
     }

--- a/dashboard/lib/useHumanVerification.ts
+++ b/dashboard/lib/useHumanVerification.ts
@@ -22,6 +22,7 @@ export interface UseHumanVerification {
 export function useHumanVerification(): UseHumanVerification {
   const [state, setState] = useState<HumanVerificationState>('idle');
   const widgetContainerRef = useRef<HTMLDivElement | null>(null);
+  const fallbackContainerRef = useRef<HTMLDivElement | null>(null);
   const widgetIdRef = useRef<string | null>(null);
   const verifiedResolversRef = useRef<Array<() => void>>([]);
   const stateRef = useRef(state);
@@ -55,12 +56,39 @@ export function useHumanVerification(): UseHumanVerification {
     await loadTurnstileScript();
     if (!window.turnstile) return;
 
-    // Use ref container if attached; otherwise create a hidden fallback container
+    // Use the page-supplied ref container if it's attached; otherwise create a
+    // visible fallback positioned at center-screen. Cloudflare can escalate
+    // from invisible to visible challenge on suspicious sessions, so the
+    // fallback container MUST be reachable to the user — a display:none
+    // fallback would trap visible-challenge escalations and lock the guest
+    // out of any page that hasn't rendered its widget container yet (e.g.
+    // collect pages where the page-level container sits behind a gate
+    // early-return that hasn't mounted yet).
     let container = widgetContainerRef.current;
+    let fallbackOwned = false;
     if (!container) {
       container = document.createElement('div');
-      container.style.display = 'none';
+      container.setAttribute('data-testid', 'human-verify-fallback');
+      Object.assign(container.style, {
+        position: 'fixed',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        zIndex: '10000',
+        // Cloudflare hides the widget itself during invisible mode and
+        // expands it during escalation; the container only needs to be
+        // mounted and reachable. Use min-width/height so the iframe
+        // injected by Turnstile has room to expand for the visible
+        // challenge.
+        minWidth: '300px',
+        minHeight: '65px',
+      });
       document.body.appendChild(container);
+      fallbackOwned = true;
+    }
+    // Track for cleanup so we can remove the fallback on unmount
+    if (fallbackOwned) {
+      fallbackContainerRef.current = container;
     }
 
     if (widgetIdRef.current) {
@@ -91,6 +119,10 @@ export function useHumanVerification(): UseHumanVerification {
       if (widgetIdRef.current && window.turnstile) {
         window.turnstile.remove(widgetIdRef.current);
         widgetIdRef.current = null;
+      }
+      if (fallbackContainerRef.current) {
+        fallbackContainerRef.current.remove();
+        fallbackContainerRef.current = null;
       }
     };
   }, []);


### PR DESCRIPTION
## Summary

The collect page renders NicknameGate via an early return BEFORE the main return block that hosts the Turnstile widget container. \`useHumanVerification\`'s \`useEffect\` runs once on mount, finds \`widgetContainerRef.current\` is null (because the main return hasn't rendered), and creates a fallback container hidden via \`display: none\`.

When Cloudflare escalates to a visible challenge (suspicious sessions, privacy mode, blocked canvas fingerprinting), the widget lands in that hidden container and the user is locked out — no UI to click, no way to complete verification, infinite 403 loop on \`/profile\`.

## Fix

Position the fallback container at center-screen with z-index above everything else, give it the minimum dimensions Turnstile needs for an expanded challenge widget, and clean it up on unmount.

## How surfaced

A DJ owner was locked out of their own /collect/ELZ2G2 page; backend logs showed 18+ retried /profile 403s with no successful verification. Browser console showed Turnstile widget escalating but the user never saw the challenge UI.

## Test plan

- [x] frontend vitest: 929/929 pass
- [x] tsc --noEmit clean
- [ ] Smoke: in incognito Firefox, open /collect/ELZ2G2 — verify Turnstile widget renders if escalated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved human verification fallback so the verification element reliably appears centered and accessible when the normal container is unavailable.
  * Ensures the injected verification iframe can receive input while keeping the surrounding fallback non-interactive.
  * Cleans up the fallback element on unmount to avoid leftover DOM artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->