### PR TITLE
fix(kiosk,dj): route by join_code, fix QR label, CR nitpicks

### DIFF
--- a/dashboard/app/(dj)/dashboard/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/dashboard/__tests__/page.test.tsx
@@ -69,6 +69,8 @@ function mockEvent(overrides = {}) {
   return {
     id: 1,
     code: 'EVT01',
+      join_code: '10TVEJ',
+      collect_url: null,
     name: 'Friday Night',
     created_at: '2026-01-01T00:00:00Z',
     expires_at: '2026-01-02T00:00:00Z',
@@ -221,7 +223,9 @@ describe('DashboardPage', () => {
 
     it('creates event and adds to list', async () => {
       vi.mocked(api.getEvents).mockResolvedValue([]);
-      const newEvent = mockEvent({ id: 2, code: 'NEW01', name: 'New Party' });
+      const newEvent = mockEvent({ id: 2, code: 'NEW01',
+      join_code: '10WENJ',
+      collect_url: null, name: 'New Party' });
       vi.mocked(api.createEvent).mockResolvedValue(newEvent);
       render(<DashboardPage />);
       await waitFor(() => expect(screen.getByText(/No events yet/)).toBeInTheDocument());
@@ -305,8 +309,12 @@ describe('DashboardPage', () => {
 
   describe('Batch delete (selection mode)', () => {
     const twoEvents = [
-      mockEvent({ id: 1, code: 'EVT01', name: 'Friday Night' }),
-      mockEvent({ id: 2, code: 'EVT02', name: 'Saturday Bash' }),
+      mockEvent({ id: 1, code: 'EVT01',
+      join_code: '10TVEJ',
+      collect_url: null, name: 'Friday Night' }),
+      mockEvent({ id: 2, code: 'EVT02',
+      join_code: '20TVEJ',
+      collect_url: null, name: 'Saturday Bash' }),
     ];
 
     it('renders Advanced checkbox', async () => {

--- a/dashboard/app/(dj)/events/[code]/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/__tests__/page.test.tsx
@@ -184,7 +184,9 @@ import EventQueuePage from '../page';
 
 function mockEvent(overrides = {}) {
   return {
-    id: 1, code: 'TEST', name: 'Test Event',
+    id: 1, code: 'TEST',
+      join_code: 'TSETJO',
+      collect_url: null, name: 'Test Event',
     created_at: '2026-01-01T00:00:00Z', expires_at: '2026-12-31T00:00:00Z',
     is_active: true, join_url: null, requests_open: true,
     tidal_sync_enabled: false, tidal_playlist_id: null,
@@ -305,13 +307,16 @@ describe('EventQueuePage', () => {
       expect(screen.getByTestId('qr-code')).toBeInTheDocument();
     });
 
-    it('renders event code', async () => {
+    it('renders event join_code under the QR (not the collection code)', async () => {
       setupDefaultMocks();
 
       render(<EventQueuePage />);
 
+      // The big bold code shown above the "Scan to join" QR is the join_code
+      // — that's what the QR encodes. Collection code is the URL slug DJs
+      // navigate by but is not the human-facing scan target.
       await waitFor(() => {
-        expect(screen.getByText('TEST')).toBeInTheDocument();
+        expect(screen.getByText('TSETJO')).toBeInTheDocument();
       });
     });
   });

--- a/dashboard/app/(dj)/events/[code]/page.tsx
+++ b/dashboard/app/(dj)/events/[code]/page.tsx
@@ -825,8 +825,9 @@ export default function EventQueuePage() {
   if (tidalStatus?.linked && tidalSyncEnabled) connectedServices.push('tidal');
   if (beatportStatus?.linked && beatportSyncEnabled) connectedServices.push('beatport');
 
-  // Use API's join_url if configured, otherwise use current origin
-  const joinUrl = event.join_url || `${window.location.origin}/join/${event.code}`;
+  // Use API's join_url if configured, otherwise use current origin + the join_code
+  // (NOT event.code — that's the collection code and would 404 the join page).
+  const joinUrl = event.join_url || `${window.location.origin}/join/${event.join_code}`;
   const isExpiredOrArchived = eventStatus === 'expired' || eventStatus === 'archived';
 
   return (
@@ -944,7 +945,7 @@ export default function EventQueuePage() {
         )}
         <div style={{ textAlign: 'center' }}>
           <div className="code" style={{ fontSize: '2rem', color: isExpiredOrArchived ? 'var(--text-tertiary)' : 'var(--color-primary)' }}>
-            {event.code}
+            {event.join_code}
           </div>
           {!isExpiredOrArchived && (
             <>

--- a/dashboard/app/admin/events/__tests__/page.test.tsx
+++ b/dashboard/app/admin/events/__tests__/page.test.tsx
@@ -39,6 +39,7 @@ const mockEvents = {
     {
       id: 1,
       code: 'FRI001',
+      join_code: '100IRF',
       name: 'Friday Night',
       owner_username: 'dj1',
       owner_id: 1,
@@ -50,6 +51,7 @@ const mockEvents = {
     {
       id: 2,
       code: 'SAT002',
+      join_code: '200TAS',
       name: 'Saturday Bash',
       owner_username: 'dj2',
       owner_id: 2,
@@ -61,6 +63,7 @@ const mockEvents = {
     {
       id: 3,
       code: 'SUN003',
+      join_code: '300NUS',
       name: 'Sunday Chill',
       owner_username: 'dj1',
       owner_id: 1,

--- a/dashboard/app/e/[code]/display/page.test.tsx
+++ b/dashboard/app/e/[code]/display/page.test.tsx
@@ -41,8 +41,8 @@ const mockKioskDisplay = {
   event: { code: 'TEST123', name: 'Test Event' },
   qr_join_url: 'https://example.com/join/TEST123',
   accepted_queue: [
-    { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
-    { id: 2, title: 'Song 2', artist: 'Artist 2', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
+    { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false },
+    { id: 2, title: 'Song 2', artist: 'Artist 2', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false },
   ],
   now_playing: null,
   now_playing_hidden: false,
@@ -532,7 +532,7 @@ describe('KioskDisplayPage', () => {
       // Initial: 1 item
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
-        accepted_queue: [{ id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null }],
+        accepted_queue: [{ id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false }],
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(null);
       vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
@@ -544,8 +544,8 @@ describe('KioskDisplayPage', () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
         accepted_queue: [
-          { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
-          { id: 3, title: 'Song 3', artist: 'Artist 3', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
+          { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false },
+          { id: 3, title: 'Song 3', artist: 'Artist 3', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false },
         ],
       });
       await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
@@ -558,7 +558,7 @@ describe('KioskDisplayPage', () => {
       vi.useFakeTimers();
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
-        accepted_queue: [{ id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null }],
+        accepted_queue: [{ id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false }],
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(null);
       vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
@@ -570,8 +570,8 @@ describe('KioskDisplayPage', () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
         accepted_queue: [
-          { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
-          { id: 3, title: 'Song 3', artist: 'Artist 3', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
+          { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false },
+          { id: 3, title: 'Song 3', artist: 'Artist 3', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false },
         ],
       });
       await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
@@ -593,7 +593,7 @@ describe('KioskDisplayPage', () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
         accepted_queue: [
-          { id: 1, title: 'Popular Song', artist: 'Artist', artwork_url: null, nickname: null, vote_count: 5, bpm: null, musical_key: null, genre: null },
+          { id: 1, title: 'Popular Song', artist: 'Artist', artwork_url: null, nickname: null, vote_count: 5, bpm: null, musical_key: null, genre: null, requester_verified: false },
         ],
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(null);
@@ -610,7 +610,7 @@ describe('KioskDisplayPage', () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
         accepted_queue: [
-          { id: 1, title: 'Song', artist: 'Artist', artwork_url: null, nickname: null, vote_count: 1, bpm: null, musical_key: null, genre: null },
+          { id: 1, title: 'Song', artist: 'Artist', artwork_url: null, nickname: null, vote_count: 1, bpm: null, musical_key: null, genre: null, requester_verified: false },
         ],
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(null);
@@ -627,7 +627,7 @@ describe('KioskDisplayPage', () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
         accepted_queue: [
-          { id: 1, title: 'Song', artist: 'Artist', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
+          { id: 1, title: 'Song', artist: 'Artist', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false },
         ],
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(null);
@@ -838,7 +838,7 @@ describe('KioskDisplayPage', () => {
     it('shows request-based now_playing when no bridge now-playing', async () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
-        now_playing: { id: 1, title: 'Request Song', artist: 'Request Artist', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
+        now_playing: { id: 1, title: 'Request Song', artist: 'Request Artist', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false },
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(null);
       vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
@@ -854,7 +854,7 @@ describe('KioskDisplayPage', () => {
     it('hides now-playing when now_playing_hidden is true', async () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
-        now_playing: { id: 1, title: 'Hidden Song', artist: 'Hidden Artist', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null },
+        now_playing: { id: 1, title: 'Hidden Song', artist: 'Hidden Artist', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false },
         now_playing_hidden: true,
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(null);
@@ -896,6 +896,7 @@ describe('KioskDisplayPage', () => {
       vi.mocked(api.getKioskAssignment).mockResolvedValue({
         status: 'active',
         event_code: 'TEST123',
+        event_join_code: 'JOIN78',
         event_name: 'Test Event',
       });
 

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -2542,6 +2542,12 @@ h1, .display-heading {
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .hv-overlay-spinner {
+    animation: none;
+  }
+}
+
 .hv-overlay-retry {
   padding: 0.6rem 1.2rem;
   font-size: 0.9rem;

--- a/dashboard/app/kiosk-pair/__tests__/page.test.tsx
+++ b/dashboard/app/kiosk-pair/__tests__/page.test.tsx
@@ -105,12 +105,12 @@ describe('KioskPairPage', () => {
     // First call returns pairing, second returns active
     mockGetKioskPairStatus
       .mockResolvedValueOnce({ status: 'pairing', event_code: null, event_name: null })
-      .mockResolvedValue({ status: 'active', event_code: 'EVT001', event_name: 'Friday Night' });
+      .mockResolvedValue({ status: 'active', event_code: 'EVT001', event_join_code: 'EVT01J', event_name: 'Friday Night' });
 
     render(<KioskPairPage />);
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/e/EVT001/display');
+      expect(mockPush).toHaveBeenCalledWith('/e/EVT01J/display');
     }, { timeout: 5000 });
   });
 
@@ -134,6 +134,7 @@ describe('KioskPairPage', () => {
     mockGetKioskAssignment.mockResolvedValue({
       status: 'active',
       event_code: 'EVT002',
+      event_join_code: 'EVT02J',
       event_name: 'Saturday',
     });
 
@@ -146,7 +147,7 @@ describe('KioskPairPage', () => {
     });
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/e/EVT002/display');
+      expect(mockPush).toHaveBeenCalledWith('/e/EVT02J/display');
     });
   });
 });

--- a/dashboard/app/kiosk-pair/page.tsx
+++ b/dashboard/app/kiosk-pair/page.tsx
@@ -35,9 +35,12 @@ export default function KioskPairPage() {
     pollRef.current = setInterval(async () => {
       try {
         const status = await api.getKioskPairStatus(code);
-        if (status.status === 'active' && status.event_code) {
+        // /e/{code}/display resolves by event.join_code (post PR #324). Use
+        // event_join_code from the pairing response, NOT event_code (which is
+        // the internal collection code and would 404 the display endpoint).
+        if (status.status === 'active' && status.event_join_code) {
           stopPolling();
-          router.push(`/e/${status.event_code}/display`);
+          router.push(`/e/${status.event_join_code}/display`);
         } else if (status.status === 'expired') {
           stopPolling();
           setState('expired');
@@ -52,8 +55,8 @@ export default function KioskPairPage() {
     stopPolling();
     // Check immediately first
     api.getKioskAssignment(token).then((status) => {
-      if (status.status === 'active' && status.event_code) {
-        router.push(`/e/${status.event_code}/display`);
+      if (status.status === 'active' && status.event_join_code) {
+        router.push(`/e/${status.event_join_code}/display`);
         return;
       }
       if (status.status === 'expired') {
@@ -66,9 +69,9 @@ export default function KioskPairPage() {
       pollRef.current = setInterval(async () => {
         try {
           const s = await api.getKioskAssignment(token);
-          if (s.status === 'active' && s.event_code) {
+          if (s.status === 'active' && s.event_join_code) {
             stopPolling();
-            router.push(`/e/${s.event_code}/display`);
+            router.push(`/e/${s.event_join_code}/display`);
           } else if (s.status === 'expired') {
             stopPolling();
             localStorage.removeItem(SESSION_TOKEN_KEY);

--- a/dashboard/components/HumanVerificationOverlay.tsx
+++ b/dashboard/components/HumanVerificationOverlay.tsx
@@ -28,7 +28,7 @@ export default function HumanVerificationOverlay({
 
   return (
     <div className="hv-overlay-backdrop">
-      <div className="hv-overlay-modal" role="dialog" aria-live="polite">
+      <div className="hv-overlay-modal" role="dialog" aria-modal="true" aria-live="polite">
         {(state === 'idle' || state === 'loading') && <LoadingPanel />}
         {state === 'challenge' && <ChallengePanel />}
         {state === 'failed' && <FailedPanel onRetry={onRetry} />}

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -240,6 +240,23 @@ export interface paths {
         patch: operations["admin_update_user_api_admin_users__user_id__patch"];
         trace?: never;
     };
+    "/api/auth/email/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Confirm Email Change */
+        get: operations["confirm_email_change_api_auth_email_confirm_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/auth/help-seen": {
         parameters: {
             query?: never;
@@ -315,6 +332,40 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/api/auth/me/email/request": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Request Email Change */
+        post: operations["request_email_change_api_auth_me_email_request_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/me/password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Change Password */
+        patch: operations["change_password_api_auth_me_password_patch"];
         trace?: never;
     };
     "/api/auth/register": {
@@ -795,6 +846,30 @@ export interface paths {
         patch: operations["update_collection_settings_endpoint_api_events__code__collection_patch"];
         trace?: never;
     };
+    "/api/events/{code}/collection/sync-tidal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Sync Collection To Tidal
+         * @description Sync all non-rejected collection-phase requests to the DJ's Tidal playlist.
+         *
+         *     Includes pending (new) and accepted requests so the DJ can listen to guest
+         *     suggestions on Tidal before the review step.  Already-synced tracks are
+         *     silently skipped inside sync_requests_batch.
+         */
+        post: operations["sync_collection_to_tidal_api_events__code__collection_sync_tidal_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/events/{code}/display-settings": {
         parameters: {
             query?: never;
@@ -817,6 +892,29 @@ export interface paths {
          * @description Update display settings for an event (e.g., hide/show now playing on kiosk).
          */
         patch: operations["update_display_settings_api_events__code__display_settings_patch"];
+        trace?: never;
+    };
+    "/api/events/{code}/enrich-all": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enrich All Requests
+         * @description Queue enrichment for up to ENRICH_ALL_BATCH_LIMIT requests missing BPM, key, or genre.
+         *
+         *     Batched to avoid exhausting the connection pool when many tracks need enrichment.
+         *     Returns `remaining` so the caller can re-invoke until 0.
+         */
+        post: operations["enrich_all_requests_api_events__code__enrich_all_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/api/events/{code}/export/csv": {
@@ -1238,7 +1336,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/public/collect/{code}/profile": {
+    "/api/public/collect/{code}/live-join-code": {
         parameters: {
             query?: never;
             header?: never;
@@ -1246,10 +1344,31 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Profile
-         * @description Read the calling guest's profile for this event. Anonymous callers
-         *     (no cookie) get the default empty profile — there is no IP fallback.
+         * Get Live Join Code
+         * @description Return the live join_code for an event that has entered the live phase.
+         *
+         *     Requires a verified human cookie (not email verification) so the join_code
+         *     is never leaked to unverified bots scraping /collect during the
+         *     collection-to-live transition. The join_code is otherwise revealed only
+         *     via the QR code at the event venue.
          */
+        get: operations["get_live_join_code_api_public_collect__code__live_join_code_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/public/collect/{code}/profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Profile */
         get: operations["get_profile_api_public_collect__code__profile_get"];
         put?: never;
         /** Set Profile */
@@ -1288,6 +1407,23 @@ export interface paths {
         put?: never;
         /** Submit */
         post: operations["submit_api_public_collect__code__requests_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/public/collect/{code}/requests/{request_id}/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Request Preview */
+        get: operations["request_preview_api_public_collect__code__requests__request_id__preview_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -1510,6 +1646,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/public/guest/verify-human": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Verify Human
+         * @description Validate a Turnstile token and issue a wrzdj_human session cookie.
+         */
+        post: operations["verify_human_api_public_guest_verify_human_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/public/guest/verify-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Verify Status
+         * @description Report whether the caller already has a valid wrzdj_human cookie.
+         *
+         *     Returns verified=false on missing, expired, version-mismatched, or
+         *     tampered cookies. No side effects (no cookie refresh, no DB writes).
+         *     Safe to call on every page mount.
+         */
+        get: operations["verify_status_api_public_guest_verify_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/public/guest/verify/confirm": {
         parameters: {
             query?: never;
@@ -1542,6 +1722,9 @@ export interface paths {
         /**
          * Request Verification Code
          * @description Send a verification code to the provided email.
+         *
+         *     Requires a fresh Turnstile token (separate from the session cookie) to
+         *     protect against email-cost / sender-reputation abuse.
          */
         post: operations["request_verification_code_api_public_guest_verify_request_post"];
         delete?: never;
@@ -1562,8 +1745,31 @@ export interface paths {
         /**
          * Create Pairing
          * @description Create a new kiosk pairing session.
+         *
+         *     Requires a valid X-Pair-Nonce header obtained from /pair-challenge,
+         *     bound to the same client IP. Nonce is consumed on use.
          */
         post: operations["create_pairing_api_public_kiosk_pair_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/public/kiosk/pair-challenge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Pair Challenge
+         * @description Issue a one-time IP-bound nonce required for kiosk pairing.
+         */
+        get: operations["get_pair_challenge_api_public_kiosk_pair_challenge_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -2009,6 +2215,8 @@ export interface components {
             id: number;
             /** Is Active */
             is_active: boolean;
+            /** Join Code */
+            join_code: string;
             /** Name */
             name: string;
             /** Owner Id */
@@ -2318,6 +2526,15 @@ export interface components {
          * @enum {string}
          */
         CapabilityStatus: "yes" | "no" | "not_implemented" | "configured" | "not_configured";
+        /** ChangePasswordRequest */
+        ChangePasswordRequest: {
+            /** Confirm New Password */
+            confirm_new_password: string;
+            /** Current Password */
+            current_password: string;
+            /** New Password */
+            new_password: string;
+        };
         /** CollectEventPreview */
         CollectEventPreview: {
             /** Banner Colors */
@@ -2378,6 +2595,11 @@ export interface components {
             /** Nickname */
             nickname: string | null;
             /**
+             * Requester Verified
+             * @default false
+             */
+            requester_verified: boolean;
+            /**
              * Status
              * @enum {string}
              */
@@ -2414,6 +2636,11 @@ export interface components {
             /** Nickname */
             nickname: string | null;
             /**
+             * Requester Verified
+             * @default false
+             */
+            requester_verified: boolean;
+            /**
              * Status
              * @enum {string}
              */
@@ -2435,6 +2662,16 @@ export interface components {
             upvoted: components["schemas"]["CollectMyPicksItem"][];
             /** Voted Request Ids */
             voted_request_ids: number[];
+        };
+        /** CollectPreviewResponse */
+        CollectPreviewResponse: {
+            /**
+             * Source
+             * @enum {string}
+             */
+            source: "spotify" | "tidal" | "beatport" | "manual";
+            /** Source Url */
+            source_url: string | null;
         };
         /** CollectProfileRequest */
         CollectProfileRequest: {
@@ -2609,6 +2846,8 @@ export interface components {
             beatport_sync_enabled: boolean;
             /** Code */
             code: string;
+            /** Collect Url */
+            collect_url: string | null;
             /** Collection Opens At */
             collection_opens_at: string | null;
             /** Collection Phase Override */
@@ -2621,6 +2860,8 @@ export interface components {
             id: number;
             /** Is Active */
             is_active: boolean;
+            /** Join Code */
+            join_code: string;
             /** Join Url */
             join_url: string | null;
             /** Live Starts At */
@@ -2688,6 +2929,11 @@ export interface components {
             musical_key: string | null;
             /** Nickname */
             nickname: string | null;
+            /**
+             * Requester Verified
+             * @default false
+             */
+            requester_verified: boolean;
             /**
              * Status
              * @enum {string}
@@ -2858,6 +3104,8 @@ export interface components {
         KioskOut: {
             /** Event Code */
             event_code: string | null;
+            /** Event Join Code */
+            event_join_code: string | null;
             /** Event Name */
             event_name: string | null;
             /** Id */
@@ -2870,6 +3118,13 @@ export interface components {
             paired_at: string | null;
             /** Status */
             status: string;
+        };
+        /** KioskPairChallengeResponse */
+        KioskPairChallengeResponse: {
+            /** Expires In */
+            expires_in: number;
+            /** Nonce */
+            nonce: string;
         };
         /**
          * KioskPairResponse
@@ -2893,6 +3148,8 @@ export interface components {
         KioskPairStatusResponse: {
             /** Event Code */
             event_code: string | null;
+            /** Event Join Code */
+            event_join_code: string | null;
             /** Event Name */
             event_name: string | null;
             /** Status */
@@ -2913,6 +3170,8 @@ export interface components {
         KioskSessionResponse: {
             /** Event Code */
             event_code: string | null;
+            /** Event Join Code */
+            event_join_code: string | null;
             /** Event Name */
             event_name: string | null;
             /** Status */
@@ -2922,6 +3181,17 @@ export interface components {
         LLMPromptRequest: {
             /** Prompt */
             prompt: string;
+        };
+        /**
+         * LiveJoinCodeResponse
+         * @description Returns the live join_code for an event that has entered the live phase.
+         *
+         *     Gated by require_verified_human so the join_code never leaks to unverified
+         *     bots scraping the collect URL during the collection-to-live transition.
+         */
+        LiveJoinCodeResponse: {
+            /** Join Code */
+            join_code: string;
         };
         /** MyRequestInfo */
         MyRequestInfo: {
@@ -3105,6 +3375,11 @@ export interface components {
             musical_key: string | null;
             /** Nickname */
             nickname: string | null;
+            /**
+             * Requester Verified
+             * @default false
+             */
+            requester_verified: boolean;
             /** Title */
             title: string;
             /**
@@ -3223,6 +3498,16 @@ export interface components {
             source_url?: string | null;
             /** Title */
             title: string;
+        };
+        /** RequestEmailChangeRequest */
+        RequestEmailChangeRequest: {
+            /** Current Password */
+            current_password: string;
+            /**
+             * New Email
+             * Format: email
+             */
+            new_email: string;
         };
         /** RequestOut */
         RequestOut: {
@@ -3554,6 +3839,10 @@ export interface components {
             live_starts_at?: string | null;
             /** Submission Cap Per Guest */
             submission_cap_per_guest?: number | null;
+            /** Tidal Collection Bidirectional */
+            tidal_collection_bidirectional?: boolean | null;
+            /** Tidal Sync Enabled */
+            tidal_sync_enabled?: boolean | null;
         };
         /** UserOut */
         UserOut: {
@@ -3562,6 +3851,8 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
+            /** Email */
+            email: string | null;
             /**
              * Help Pages Seen
              * @default []
@@ -3571,6 +3862,8 @@ export interface components {
             id: number;
             /** Is Active */
             is_active: boolean;
+            /** Pending Email */
+            pending_email: string | null;
             /** Role */
             role: string;
             /** Username */
@@ -3608,6 +3901,18 @@ export interface components {
              */
             email: string;
         };
+        /** VerifyHumanRequest */
+        VerifyHumanRequest: {
+            /** Turnstile Token */
+            turnstile_token: string;
+        };
+        /** VerifyHumanResponse */
+        VerifyHumanResponse: {
+            /** Expires In */
+            expires_in: number;
+            /** Verified */
+            verified: boolean;
+        };
         /** VerifyRequestResponse */
         VerifyRequestResponse: {
             /** Sent */
@@ -3620,6 +3925,21 @@ export interface components {
              * Format: email
              */
             email: string;
+            /** Turnstile Token */
+            turnstile_token: string;
+        };
+        /**
+         * VerifyStatusResponse
+         * @description Reports whether the caller has a valid wrzdj_human cookie.
+         */
+        VerifyStatusResponse: {
+            /**
+             * Expires In
+             * @default 0
+             */
+            expires_in: number;
+            /** Verified */
+            verified: boolean;
         };
         /** VoteResponse */
         VoteResponse: {
@@ -4130,6 +4450,37 @@ export interface operations {
             };
         };
     };
+    confirm_email_change_api_auth_email_confirm_get: {
+        parameters: {
+            query: {
+                token: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StatusMessageResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     mark_help_page_seen_api_auth_help_seen_post: {
         parameters: {
             query?: never;
@@ -4232,6 +4583,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UserOut"];
+                };
+            };
+        };
+    };
+    request_email_change_api_auth_me_email_request_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RequestEmailChangeRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StatusMessageResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    change_password_api_auth_me_password_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChangePasswordRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StatusMessageResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -5121,6 +5538,37 @@ export interface operations {
             };
         };
     };
+    sync_collection_to_tidal_api_events__code__collection_sync_tidal_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                code: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_display_settings_api_events__code__display_settings_get: {
         parameters: {
             query?: never;
@@ -5174,6 +5622,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DisplaySettingsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    enrich_all_requests_api_events__code__enrich_all_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                code: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */
@@ -5915,6 +6394,37 @@ export interface operations {
             };
         };
     };
+    get_live_join_code_api_public_collect__code__live_join_code_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                code: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiveJoinCodeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_profile_api_public_collect__code__profile_get: {
         parameters: {
             query?: never;
@@ -6034,6 +6544,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    request_preview_api_public_collect__code__requests__request_id__preview_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                code: string;
+                request_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CollectPreviewResponse"];
                 };
             };
             /** @description Validation Error */
@@ -6366,6 +6908,59 @@ export interface operations {
             };
         };
     };
+    verify_human_api_public_guest_verify_human_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["VerifyHumanRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VerifyHumanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    verify_status_api_public_guest_verify_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VerifyStatusResponse"];
+                };
+            };
+        };
+    };
     confirm_code_api_public_guest_verify_confirm_post: {
         parameters: {
             query?: never;
@@ -6448,6 +7043,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["KioskPairResponse"];
+                };
+            };
+        };
+    };
+    get_pair_challenge_api_public_kiosk_pair_challenge_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["KioskPairChallengeResponse"];
                 };
             };
         };

--- a/server/app/api/guest.py
+++ b/server/app/api/guest.py
@@ -96,7 +96,6 @@ async def verify_human(
 def verify_status(
     request: Request,
     response: Response,
-    db: Session = Depends(get_db),
 ) -> VerifyStatusResponse:
     """Report whether the caller already has a valid wrzdj_human cookie.
 

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1,5251 +1,23 @@
 {
-  "openapi": "3.1.0",
-  "info": {
-    "title": "WrzDJ API",
-    "version": "0.1.0"
-  },
-  "paths": {
-    "/api/health": {
-      "get": {
-        "tags": [
-          "health"
-        ],
-        "summary": "Api Health Check",
-        "description": "Health check endpoint for monitoring and load balancers.",
-        "operationId": "api_health_check_api_health_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/auth/login": {
-      "post": {
-        "tags": [
-          "auth"
-        ],
-        "summary": "Login",
-        "operationId": "login_api_auth_login_post",
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_login_api_auth_login_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Token"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/auth/logout": {
-      "post": {
-        "tags": [
-          "auth"
-        ],
-        "summary": "Logout",
-        "description": "Invalidate all outstanding JWTs for the current user.\n\nSECURITY (CRIT-2): bumps token_version so every previously-issued JWT\nfor this user fails the version check in get_current_user.",
-        "operationId": "logout_api_auth_logout_post",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/auth/me": {
-      "get": {
-        "tags": [
-          "auth"
-        ],
-        "summary": "Get Me",
-        "operationId": "get_me_api_auth_me_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/auth/help-seen": {
-      "post": {
-        "tags": [
-          "auth"
-        ],
-        "summary": "Mark Help Page Seen",
-        "description": "Mark a help page as seen for the current user.",
-        "operationId": "mark_help_page_seen_api_auth_help_seen_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/HelpPageSeenRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/auth/settings": {
-      "get": {
-        "tags": [
-          "auth"
-        ],
-        "summary": "Get Public Settings",
-        "description": "Public endpoint returning registration status and Turnstile site key.",
-        "operationId": "get_public_settings_api_auth_settings_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PublicSettings"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/auth/register": {
-      "post": {
-        "tags": [
-          "auth"
-        ],
-        "summary": "Register",
-        "description": "Register a new user (pending approval).",
-        "operationId": "register_api_auth_register_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RegisterRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events": {
-      "get": {
-        "tags": [
-          "events"
-        ],
-        "summary": "List Events",
-        "operationId": "list_events_api_events_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/EventOut"
-                  },
-                  "type": "array",
-                  "title": "Response List Events Api Events Get"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      },
-      "post": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Create New Event",
-        "operationId": "create_new_event_api_events_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EventCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/events/archived": {
-      "get": {
-        "tags": [
-          "events"
-        ],
-        "summary": "List Archived Events",
-        "description": "List all archived and expired events for the current user.",
-        "operationId": "list_archived_events_api_events_archived_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/EventOut"
-                  },
-                  "type": "array",
-                  "title": "Response List Archived Events Api Events Archived Get"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/events/activity": {
-      "get": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Get Activity Log",
-        "description": "Get recent activity log entries for the current user's events.",
-        "operationId": "get_activity_log_api_events_activity_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "event_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Event Code"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 200,
-              "minimum": 1,
-              "default": 50,
-              "title": "Limit"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ActivityLogEntry"
-                  },
-                  "title": "Response Get Activity Log Api Events Activity Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}": {
-      "get": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Get Event",
-        "operationId": "get_event_api_events__code__get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Update Event Endpoint",
-        "operationId": "update_event_endpoint_api_events__code__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EventUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Delete Event Endpoint",
-        "description": "Delete an event and all its requests.",
-        "operationId": "delete_event_endpoint_api_events__code__delete",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/search": {
-      "get": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Event Search",
-        "description": "Public search endpoint for event guests.\n\nPriority: Tidal (primary) \u2192 Spotify (fallback) \u2192 Beatport (event toggle).\nResults are filtered for junk, deduplicated by ISRC, and sorted by popularity.",
-        "operationId": "event_search_api_events__code__search_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          },
-          {
-            "name": "q",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 2,
-              "maxLength": 200,
-              "title": "Q"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SearchResult"
-                  },
-                  "title": "Response Event Search Api Events  Code  Search Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/bulk-delete": {
-      "post": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Bulk Delete Events Endpoint",
-        "description": "Bulk delete multiple events owned by the current user.",
-        "operationId": "bulk_delete_events_endpoint_api_events_bulk_delete_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BulkDeleteEventsRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkActionResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/events/{code}/archive": {
-      "post": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Archive Event Endpoint",
-        "description": "Archive an event.",
-        "operationId": "archive_event_endpoint_api_events__code__archive_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/unarchive": {
-      "post": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Unarchive Event Endpoint",
-        "description": "Unarchive an event.",
-        "operationId": "unarchive_event_endpoint_api_events__code__unarchive_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/display-settings": {
-      "patch": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Update Display Settings",
-        "description": "Update display settings for an event (e.g., hide/show now playing on kiosk).",
-        "operationId": "update_display_settings_api_events__code__display_settings_patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DisplaySettingsUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DisplaySettingsResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Get Display Settings",
-        "description": "Get current display settings for an event.",
-        "operationId": "get_display_settings_api_events__code__display_settings_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DisplaySettingsResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/export/csv": {
-      "get": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Export Event Csv",
-        "description": "Export event requests as CSV. Owner can export regardless of event status.",
-        "operationId": "export_event_csv_api_events__code__export_csv_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/export/play-history/csv": {
-      "get": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Export Play History Csv",
-        "description": "Export play history as CSV. Owner can export regardless of event status.",
-        "operationId": "export_play_history_csv_api_events__code__export_play_history_csv_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/requests": {
-      "post": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Submit Request",
-        "operationId": "submit_request_api_events__code__requests_post",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RequestCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RequestOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Get Event Requests",
-        "operationId": "get_event_requests_api_events__code__requests_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/RequestStatus"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Status"
-            }
-          },
-          {
-            "name": "since",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Since"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 500,
-              "minimum": 1,
-              "default": 100,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "sort",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "enum": [
-                "chronological",
-                "priority"
-              ],
-              "type": "string",
-              "default": "chronological",
-              "title": "Sort"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/RequestOut"
-                  },
-                  "title": "Response Get Event Requests Api Events  Code  Requests Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/requests/accept-all": {
-      "post": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Accept All Requests Endpoint",
-        "description": "Accept all NEW requests for an event in one operation.",
-        "operationId": "accept_all_requests_endpoint_api_events__code__requests_accept_all_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AcceptAllResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/requests/reject-all": {
-      "post": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Reject All Requests Endpoint",
-        "description": "Reject all NEW requests for an event in one operation.",
-        "operationId": "reject_all_requests_endpoint_api_events__code__requests_reject_all_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkActionResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/requests/bulk": {
-      "delete": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Bulk Delete Requests Endpoint",
-        "description": "Bulk delete requests for an event, optionally filtered by status.",
-        "operationId": "bulk_delete_requests_endpoint_api_events__code__requests_bulk_delete",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Status"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkActionResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/recommendations": {
-      "post": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Get Recommendations",
-        "description": "Generate song recommendations based on the event's musical profile.",
-        "operationId": "get_recommendations_api_events__code__recommendations_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RecommendationResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/playlists": {
-      "get": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Get Playlists",
-        "description": "List the DJ's playlists from connected music services.",
-        "operationId": "get_playlists_api_events__code__playlists_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/recommendations/from-template": {
-      "post": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Get Recommendations From Template",
-        "description": "Generate recommendations using a template playlist.",
-        "operationId": "get_recommendations_from_template_api_events__code__recommendations_from_template_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TemplatePlaylistRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RecommendationResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/recommendations/llm": {
-      "post": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Get Llm Recommendations",
-        "description": "Generate song recommendations from an LLM-interpreted DJ prompt.",
-        "operationId": "get_llm_recommendations_api_events__code__recommendations_llm_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LLMPromptRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/banner": {
-      "post": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Upload Banner",
-        "description": "Upload a custom banner image for the event.",
-        "operationId": "upload_banner_api_events__code__banner_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_upload_banner_api_events__code__banner_post"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Delete Banner",
-        "description": "Delete the event's custom banner image.",
-        "operationId": "delete_banner_api_events__code__banner_delete",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/collection": {
-      "get": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Get Collection Settings",
-        "description": "Get pre-event collection scheduling settings.",
-        "operationId": "get_collection_settings_api_events__code__collection_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Get Collection Settings Api Events  Code  Collection Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Update Collection Settings Endpoint",
-        "description": "Update pre-event collection scheduling settings.",
-        "operationId": "update_collection_settings_endpoint_api_events__code__collection_patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateCollectionSettings"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Update Collection Settings Endpoint Api Events  Code  Collection Patch"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/pending-review": {
-      "get": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Pending Review",
-        "description": "Get pending review data source for DJ bulk-review.",
-        "operationId": "pending_review_api_events__code__pending_review_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PendingReviewResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/bulk-review": {
-      "post": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Bulk Review",
-        "operationId": "bulk_review_api_events__code__bulk_review_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BulkReviewRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkReviewResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/events/{code}/enrich-all": {
-      "post": {
-        "tags": [
-          "events"
-        ],
-        "summary": "Enrich All Requests",
-        "description": "Queue enrichment for up to ENRICH_ALL_BATCH_LIMIT requests missing BPM, key, or genre.\n\nBatched to avoid exhausting the connection pool when many tracks need enrichment.\nReturns `remaining` so the caller can re-invoke until 0.",
-        "operationId": "enrich_all_requests_api_events__code__enrich_all_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/requests/{request_id}": {
-      "patch": {
-        "tags": [
-          "requests"
-        ],
-        "summary": "Update Request",
-        "operationId": "update_request_api_requests__request_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "request_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Request Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RequestUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RequestOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "requests"
-        ],
-        "summary": "Delete Request Endpoint",
-        "description": "Delete a single request. Ownership verified via event.",
-        "operationId": "delete_request_endpoint_api_requests__request_id__delete",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "request_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Request Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/requests/{request_id}/refresh-metadata": {
-      "post": {
-        "tags": [
-          "requests"
-        ],
-        "summary": "Refresh Request Metadata",
-        "description": "Clear existing metadata and re-enrich from external services.",
-        "operationId": "refresh_request_metadata_api_requests__request_id__refresh_metadata_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "request_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Request Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RequestOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/requests/{request_id}/vote": {
-      "post": {
-        "tags": [
-          "votes"
-        ],
-        "summary": "Vote For Request",
-        "description": "Upvote a song request. Idempotent: voting twice has no effect.\n\nRequires a guest cookie. Anonymous callers receive 401.",
-        "operationId": "vote_for_request_api_requests__request_id__vote_post",
-        "parameters": [
-          {
-            "name": "request_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "exclusiveMinimum": 0,
-              "title": "Request Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VoteResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "votes"
-        ],
-        "summary": "Unvote Request",
-        "description": "Remove vote from a song request. Idempotent.\n\nRequires a guest cookie. Anonymous callers receive 401.",
-        "operationId": "unvote_request_api_requests__request_id__vote_delete",
-        "parameters": [
-          {
-            "name": "request_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "exclusiveMinimum": 0,
-              "title": "Request Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VoteResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/search": {
-      "get": {
-        "tags": [
-          "search"
-        ],
-        "summary": "Search",
-        "description": "DJ search endpoint. Tidal primary, Spotify fallback.",
-        "operationId": "search_api_search_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "q",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 2,
-              "maxLength": 200,
-              "title": "Q"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SearchResult"
-                  },
-                  "title": "Response Search Api Search Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/search/cache": {
-      "delete": {
-        "tags": [
-          "search"
-        ],
-        "summary": "Clear Search Cache",
-        "description": "Clear all cached search results (admin only).",
-        "operationId": "clear_search_cache_api_search_cache_delete",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CacheClearResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/public/events/{code}/display": {
-      "get": {
-        "tags": [
-          "public"
-        ],
-        "summary": "Get Kiosk Display",
-        "description": "Get public kiosk display data for an event.",
-        "operationId": "get_kiosk_display_api_public_events__code__display_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KioskDisplayResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/events/{code}/requests": {
-      "get": {
-        "tags": [
-          "public"
-        ],
-        "summary": "Get Public Requests",
-        "description": "Get publicly visible requests for an event (NEW and ACCEPTED only).",
-        "operationId": "get_public_requests_api_public_events__code__requests_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GuestRequestListResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/events/{code}/has-requested": {
-      "get": {
-        "tags": [
-          "public"
-        ],
-        "summary": "Check Has Requested",
-        "description": "Check if the current client has submitted any requests for this event.",
-        "operationId": "check_has_requested_api_public_events__code__has_requested_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HasRequestedResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/events/{code}/my-requests": {
-      "get": {
-        "tags": [
-          "public"
-        ],
-        "summary": "Get My Requests",
-        "description": "Get all requests submitted by the current client for this event.",
-        "operationId": "get_my_requests_api_public_events__code__my_requests_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MyRequestsResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/guest/identify": {
-      "post": {
-        "tags": [
-          "guest"
-        ],
-        "summary": "Identify",
-        "description": "Resolve guest identity via cookie token and/or browser fingerprint.",
-        "operationId": "identify_api_public_guest_identify_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/IdentifyRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IdentifyResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/guest/verify-human": {
-      "post": {
-        "tags": [
-          "guest"
-        ],
-        "summary": "Verify Human",
-        "description": "Validate a Turnstile token and issue a wrzdj_human session cookie.",
-        "operationId": "verify_human_api_public_guest_verify_human_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/VerifyHumanRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VerifyHumanResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/guest/verify/request": {
-      "post": {
-        "tags": [
-          "verify"
-        ],
-        "summary": "Request Verification Code",
-        "description": "Send a verification code to the provided email.\n\nRequires a fresh Turnstile token (separate from the session cookie) to\nprotect against email-cost / sender-reputation abuse.",
-        "operationId": "request_verification_code_api_public_guest_verify_request_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/VerifyRequestSchema"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VerifyRequestResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/guest/verify/confirm": {
-      "post": {
-        "tags": [
-          "verify"
-        ],
-        "summary": "Confirm Code",
-        "description": "Confirm a verification code. May trigger guest merge.",
-        "operationId": "confirm_code_api_public_guest_verify_confirm_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/VerifyConfirmSchema"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VerifyConfirmResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/collect/{code}": {
-      "get": {
-        "tags": [
-          "collect"
-        ],
-        "summary": "Preview",
-        "operationId": "preview_api_public_collect__code__get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectEventPreview"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/collect/{code}/leaderboard": {
-      "get": {
-        "tags": [
-          "collect"
-        ],
-        "summary": "Leaderboard",
-        "operationId": "leaderboard_api_public_collect__code__leaderboard_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          },
-          {
-            "name": "tab",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "enum": [
-                "trending",
-                "all"
-              ],
-              "type": "string",
-              "default": "trending",
-              "title": "Tab"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectLeaderboardResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/collect/{code}/profile": {
-      "get": {
-        "tags": [
-          "collect"
-        ],
-        "summary": "Get Profile",
-        "description": "Read the calling guest's profile for this event. Anonymous callers\n(no cookie) get the default empty profile \u2014 there is no IP fallback.",
-        "operationId": "get_profile_api_public_collect__code__profile_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectProfileResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "collect"
-        ],
-        "summary": "Set Profile",
-        "operationId": "set_profile_api_public_collect__code__profile_post",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CollectProfileRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectProfileResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/collect/{code}/profile/me": {
-      "get": {
-        "tags": [
-          "collect"
-        ],
-        "summary": "My Picks",
-        "operationId": "my_picks_api_public_collect__code__profile_me_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectMyPicksResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/collect/{code}/requests": {
-      "post": {
-        "tags": [
-          "collect"
-        ],
-        "summary": "Submit",
-        "operationId": "submit_api_public_collect__code__requests_post",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CollectSubmitRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/collect/{code}/vote": {
-      "post": {
-        "tags": [
-          "collect"
-        ],
-        "summary": "Vote",
-        "operationId": "vote_api_public_collect__code__vote_post",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CollectVoteRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/collect/{code}/enrich-preview": {
-      "post": {
-        "tags": [
-          "collect"
-        ],
-        "summary": "Enrich Preview",
-        "description": "Lightweight Beatport BPM/key lookup for search-time vibes \u2014 no DB writes.",
-        "operationId": "enrich_preview_api_public_collect__code__enrich_preview_post",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EnrichPreviewRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EnrichPreviewResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/events/{code}/stream": {
-      "get": {
-        "tags": [
-          "sse"
-        ],
-        "summary": "Event Stream",
-        "description": "Public SSE endpoint for real-time event updates.\n\nSECURITY (CRIT-5): rate-limited and existence-checked. Before this fix,\nthe endpoint had no rate limit and no existence check, allowing\nunauthenticated DoS (unlimited long-lived connections exhausting FDs)\nand passive eavesdropping via 6-char event-code brute force.\n\nEvent types:\n- request_created: New request submitted\n- request_status_changed: Request status update\n- now_playing_changed: Now-playing track update\n- requests_bulk_update: Batch accept/reject\n- bridge_status_changed: Bridge connect/disconnect",
-        "operationId": "event_stream_api_public_events__code__stream_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/bridge/apikey": {
-      "get": {
-        "tags": [
-          "bridge"
-        ],
-        "summary": "Get Bridge Api Key",
-        "description": "Return the server's bridge API key to an admin user.\n\nThe GUI uses this so the DJ doesn't have to manually paste the key.\nRestricted to admins to prevent non-owners from impersonating the bridge.",
-        "operationId": "get_bridge_api_key_api_bridge_apikey_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BridgeApiKeyResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/bridge/nowplaying": {
-      "post": {
-        "tags": [
-          "bridge"
-        ],
-        "summary": "Post Now Playing",
-        "description": "Bridge reports a new track playing.\n\nCalled when the DJ loads/plays a new track on their equipment.\nArchives the previous track to play history and updates now_playing.\nRate limited to 60 requests per minute.",
-        "operationId": "post_now_playing_api_bridge_nowplaying_post",
-        "parameters": [
-          {
-            "name": "x-bridge-api-key",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Bridge-Api-Key"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NowPlayingBridgePayload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/bridge/status": {
-      "post": {
-        "tags": [
-          "bridge"
-        ],
-        "summary": "Post Bridge Status",
-        "description": "Bridge reports connection status.\n\nCalled when bridge connects/disconnects from DJ equipment.\nRate limited to 30 requests per minute.",
-        "operationId": "post_bridge_status_api_bridge_status_post",
-        "parameters": [
-          {
-            "name": "x-bridge-api-key",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Bridge-Api-Key"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BridgeStatusPayload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/bridge/nowplaying/{code}": {
-      "delete": {
-        "tags": [
-          "bridge"
-        ],
-        "summary": "Delete Now Playing",
-        "description": "Bridge signals track ended / deck cleared.\n\nArchives current track to history and clears now_playing.\nRate limited to 60 requests per minute.",
-        "operationId": "delete_now_playing_api_bridge_nowplaying__code__delete",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 10,
-              "title": "Code"
-            }
-          },
-          {
-            "name": "x-bridge-api-key",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Bridge-Api-Key"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/e/{code}/nowplaying": {
-      "get": {
-        "tags": [
-          "bridge"
-        ],
-        "summary": "Get Public Now Playing",
-        "description": "Get current now-playing track for public display.\n\nReturns the track currently playing from StageLinQ, or None if nothing playing.",
-        "operationId": "get_public_now_playing_api_public_e__code__nowplaying_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/NowPlayingResponse"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "title": "Response Get Public Now Playing Api Public E  Code  Nowplaying Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/e/{code}/bridge-status": {
-      "get": {
-        "tags": [
-          "bridge"
-        ],
-        "summary": "Get Public Bridge Status",
-        "description": "Get bridge connection status for public display.\n\nIndependent of track data \u2014 returns bridge connectivity even when\nno track is currently playing.",
-        "operationId": "get_public_bridge_status_api_public_e__code__bridge_status_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BridgeStatusResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/e/{code}/history": {
-      "get": {
-        "tags": [
-          "bridge"
-        ],
-        "summary": "Get Public History",
-        "description": "Get play history for public display.\n\nReturns the list of tracks played during the event, newest first.",
-        "operationId": "get_public_history_api_public_e__code__history_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 20,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlayHistoryResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/bridge/commands/{code}": {
-      "post": {
-        "tags": [
-          "bridge"
-        ],
-        "summary": "Post Bridge Command",
-        "description": "Queue a command for the bridge to pick up.\n\nRequires JWT auth. The user must own the event or be an admin.\nRate limited to 10 requests per minute.",
-        "operationId": "post_bridge_command_api_bridge_commands__code__post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 10,
-              "title": "Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BridgeCommandRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BridgeCommandResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "bridge"
-        ],
-        "summary": "Get Bridge Commands",
-        "description": "Poll and clear pending commands for the bridge.\n\nRequires bridge API key auth. Returns all pending commands and clears the queue.\nRate limited to 30 requests per minute.",
-        "operationId": "get_bridge_commands_api_bridge_commands__code__get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 10,
-              "title": "Code"
-            }
-          },
-          {
-            "name": "x-bridge-api-key",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Bridge-Api-Key"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BridgeCommandsPollResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/tidal/auth/start": {
-      "post": {
-        "tags": [
-          "tidal"
-        ],
-        "summary": "Start Auth",
-        "description": "Start Tidal device login flow.\n\nReturns a URL and code for the user to visit and authorize.\nThe frontend should poll /auth/check to wait for completion.",
-        "operationId": "start_auth_api_tidal_auth_start_post",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TidalAuthStartResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/tidal/auth/check": {
-      "get": {
-        "tags": [
-          "tidal"
-        ],
-        "summary": "Check Auth",
-        "description": "Check if device login is complete.\n\nReturns:\n- complete: true if login succeeded\n- pending: true if still waiting for user\n- error: error message if login failed",
-        "operationId": "check_auth_api_tidal_auth_check_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TidalAuthCheckResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/tidal/auth/cancel": {
-      "post": {
-        "tags": [
-          "tidal"
-        ],
-        "summary": "Cancel Auth",
-        "description": "Cancel pending device login.",
-        "operationId": "cancel_auth_api_tidal_auth_cancel_post",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/tidal/status": {
-      "get": {
-        "tags": [
-          "tidal"
-        ],
-        "summary": "Get Status",
-        "description": "Check if current user has linked Tidal account.",
-        "operationId": "get_status_api_tidal_status_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TidalStatus"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/tidal/disconnect": {
-      "post": {
-        "tags": [
-          "tidal"
-        ],
-        "summary": "Disconnect",
-        "description": "Unlink Tidal account from current user.",
-        "operationId": "disconnect_api_tidal_disconnect_post",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/tidal/search": {
-      "get": {
-        "tags": [
-          "tidal"
-        ],
-        "summary": "Search",
-        "description": "Search Tidal for tracks.",
-        "operationId": "search_api_tidal_search_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "q",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "title": "Q"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 50,
-              "minimum": 1,
-              "default": 10,
-              "title": "Limit"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TidalSearchResult"
-                  },
-                  "title": "Response Search Api Tidal Search Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/tidal/events/{event_id}/settings": {
-      "get": {
-        "tags": [
-          "tidal"
-        ],
-        "summary": "Get Event Settings",
-        "description": "Get Tidal sync settings for an event.",
-        "operationId": "get_event_settings_api_tidal_events__event_id__settings_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "event_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Event Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TidalEventSettings"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "tidal"
-        ],
-        "summary": "Update Event Settings",
-        "description": "Update Tidal sync settings for an event.",
-        "operationId": "update_event_settings_api_tidal_events__event_id__settings_put",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "event_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Event Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TidalEventSettingsUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TidalEventSettings"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/tidal/requests/{request_id}/sync": {
-      "post": {
-        "tags": [
-          "tidal"
-        ],
-        "summary": "Sync Request",
-        "description": "Manually trigger Tidal sync for a request.",
-        "operationId": "sync_request_api_tidal_requests__request_id__sync_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "request_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Request Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TidalSyncResult"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/tidal/requests/{request_id}/link": {
-      "post": {
-        "tags": [
-          "tidal"
-        ],
-        "summary": "Link Track",
-        "description": "Manually link a Tidal track to a request.",
-        "operationId": "link_track_api_tidal_requests__request_id__link_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "request_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Request Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TidalManualLink"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TidalSyncResult"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/beatport/auth/login": {
-      "post": {
-        "tags": [
-          "beatport"
-        ],
-        "summary": "Login Beatport",
-        "description": "Authenticate with Beatport using username/password.\n\nThe backend logs in to Beatport server-side, obtains an authorization\ncode, exchanges it for tokens, and stores them on the user.",
-        "operationId": "login_beatport_api_beatport_auth_login_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BeatportLogin"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/beatport/status": {
-      "get": {
-        "tags": [
-          "beatport"
-        ],
-        "summary": "Get Status",
-        "description": "Check if current user has linked Beatport account.",
-        "operationId": "get_status_api_beatport_status_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BeatportStatus"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/beatport/disconnect": {
-      "post": {
-        "tags": [
-          "beatport"
-        ],
-        "summary": "Disconnect",
-        "description": "Unlink Beatport account from current user.",
-        "operationId": "disconnect_api_beatport_disconnect_post",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/beatport/search": {
-      "get": {
-        "tags": [
-          "beatport"
-        ],
-        "summary": "Search",
-        "description": "Search Beatport for tracks.",
-        "operationId": "search_api_beatport_search_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "q",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 200,
-              "title": "Q"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 50,
-              "minimum": 1,
-              "default": 10,
-              "title": "Limit"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/BeatportSearchResult"
-                  },
-                  "title": "Response Search Api Beatport Search Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/beatport/events/{event_id}/settings": {
-      "get": {
-        "tags": [
-          "beatport"
-        ],
-        "summary": "Get Event Settings",
-        "description": "Get Beatport sync settings for an event.",
-        "operationId": "get_event_settings_api_beatport_events__event_id__settings_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "event_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Event Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BeatportEventSettings"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "beatport"
-        ],
-        "summary": "Update Event Settings",
-        "description": "Update Beatport sync settings for an event.",
-        "operationId": "update_event_settings_api_beatport_events__event_id__settings_put",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "event_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Event Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BeatportEventSettingsUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BeatportEventSettings"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/beatport/requests/{request_id}/link": {
-      "post": {
-        "tags": [
-          "beatport"
-        ],
-        "summary": "Link Track",
-        "description": "Manually link a Beatport track to a request.\n\nVerifies the track exists on Beatport, then stores the\nBeatport URL and metadata in sync_results_json.",
-        "operationId": "link_track_api_beatport_requests__request_id__link_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "request_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Request Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BeatportManualLink"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatusMessageResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/kiosk/pair-challenge": {
-      "get": {
-        "tags": [
-          "kiosk"
-        ],
-        "summary": "Get Pair Challenge",
-        "description": "Issue a one-time IP-bound nonce required for kiosk pairing.",
-        "operationId": "get_pair_challenge_api_public_kiosk_pair_challenge_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KioskPairChallengeResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/kiosk/pair": {
-      "post": {
-        "tags": [
-          "kiosk"
-        ],
-        "summary": "Create Pairing",
-        "description": "Create a new kiosk pairing session.\n\nRequires a valid X-Pair-Nonce header obtained from /pair-challenge,\nbound to the same client IP. Nonce is consumed on use.",
-        "operationId": "create_pairing_api_public_kiosk_pair_post",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KioskPairResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/kiosk/pair/{pair_code}/status": {
-      "get": {
-        "tags": [
-          "kiosk"
-        ],
-        "summary": "Get Pair Status",
-        "description": "Poll the status of a pairing code.",
-        "operationId": "get_pair_status_api_public_kiosk_pair__pair_code__status_get",
-        "parameters": [
-          {
-            "name": "pair_code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Pair Code"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KioskPairStatusResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/public/kiosk/session/assignment": {
-      "get": {
-        "tags": [
-          "kiosk"
-        ],
-        "summary": "Get Session Assignment",
-        "description": "Poll the kiosk's current event assignment. Updates last_seen_at.\n\nSession token must be sent in the X-Kiosk-Session header (not in the URL path)\nto prevent token leakage in access logs.",
-        "operationId": "get_session_assignment_api_public_kiosk_session_assignment_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KioskSessionResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/kiosk/pair/{pair_code}/complete": {
-      "post": {
-        "tags": [
-          "kiosk"
-        ],
-        "summary": "Complete Kiosk Pairing",
-        "description": "Complete a kiosk pairing by assigning an event.",
-        "operationId": "complete_kiosk_pairing_api_kiosk_pair__pair_code__complete_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "pair_code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Pair Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/KioskCompletePairingRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KioskOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/kiosk/mine": {
-      "get": {
-        "tags": [
-          "kiosk"
-        ],
-        "summary": "List My Kiosks",
-        "description": "List all kiosks paired by the current user.",
-        "operationId": "list_my_kiosks_api_kiosk_mine_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/KioskOut"
-                  },
-                  "type": "array",
-                  "title": "Response List My Kiosks Api Kiosk Mine Get"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/kiosk/{kiosk_id}/assign": {
-      "patch": {
-        "tags": [
-          "kiosk"
-        ],
-        "summary": "Assign Kiosk",
-        "description": "Change which event a kiosk displays.",
-        "operationId": "assign_kiosk_api_kiosk__kiosk_id__assign_patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "kiosk_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Kiosk Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/KioskAssignRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KioskOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/kiosk/{kiosk_id}": {
-      "patch": {
-        "tags": [
-          "kiosk"
-        ],
-        "summary": "Rename Kiosk Endpoint",
-        "description": "Rename a kiosk.",
-        "operationId": "rename_kiosk_endpoint_api_kiosk__kiosk_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "kiosk_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Kiosk Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/KioskRenameRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KioskOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "kiosk"
-        ],
-        "summary": "Delete Kiosk Endpoint",
-        "description": "Unpair and delete a kiosk.",
-        "operationId": "delete_kiosk_endpoint_api_kiosk__kiosk_id__delete",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "kiosk_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Kiosk Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/stats": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Stats",
-        "operationId": "admin_stats_api_admin_stats_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SystemStats"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/users": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin List Users",
-        "operationId": "admin_list_users_api_admin_users_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 1,
-              "title": "Page"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 20,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "role",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Role"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Create User",
-        "operationId": "admin_create_user_api_admin_users_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AdminUserCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AdminUserOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/users/{user_id}": {
-      "patch": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Update User",
-        "operationId": "admin_update_user_api_admin_users__user_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "User Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AdminUserUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AdminUserOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Delete User",
-        "operationId": "admin_delete_user_api_admin_users__user_id__delete",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "User Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/events": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin List Events",
-        "operationId": "admin_list_events_api_admin_events_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 1,
-              "title": "Page"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 20,
-              "title": "Limit"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/events/{code}": {
-      "patch": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Update Event",
-        "description": "Admin can edit any event (not just their own).",
-        "operationId": "admin_update_event_api_admin_events__code__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EventUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AdminEventOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Delete Event",
-        "description": "Admin can delete any event.",
-        "operationId": "admin_delete_event_api_admin_events__code__delete",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/events/bulk-delete": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Bulk Delete Events",
-        "description": "Admin can bulk delete events from any owner.",
-        "operationId": "admin_bulk_delete_events_api_admin_events_bulk_delete_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BulkDeleteEventsRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkActionResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/settings": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Get Settings",
-        "operationId": "admin_get_settings_api_admin_settings_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SystemSettingsOut"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      },
-      "patch": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Update Settings",
-        "operationId": "admin_update_settings_api_admin_settings_patch",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SystemSettingsUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SystemSettingsOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/integrations": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Get Integrations",
-        "description": "Get status of all external integrations (no active health checks).",
-        "operationId": "admin_get_integrations_api_admin_integrations_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IntegrationHealthResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/integrations/{service}": {
-      "patch": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Toggle Integration",
-        "description": "Enable or disable a specific integration.",
-        "operationId": "admin_toggle_integration_api_admin_integrations__service__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "service",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Service"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/IntegrationToggleRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IntegrationToggleResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/integrations/{service}/check": {
-      "post": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Check Integration",
-        "description": "Run an active health check for a specific service (rate limited).",
-        "operationId": "admin_check_integration_api_admin_integrations__service__check_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "service",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Service"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IntegrationCheckResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/ai/models": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Get Ai Models",
-        "description": "List available AI models.",
-        "operationId": "admin_get_ai_models_api_admin_ai_models_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIModelsResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/ai/settings": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Get Ai Settings",
-        "description": "Get AI/LLM configuration.",
-        "operationId": "admin_get_ai_settings_api_admin_ai_settings_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AISettingsOut"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Admin Update Ai Settings",
-        "description": "Update AI/LLM configuration.",
-        "operationId": "admin_update_ai_settings_api_admin_ai_settings_put",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AISettingsUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AISettingsOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/health": {
-      "get": {
-        "summary": "Health Check",
-        "operationId": "health_check_health_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        }
-      }
-    }
-  },
   "components": {
     "schemas": {
       "AIModelInfo": {
         "properties": {
           "id": {
-            "type": "string",
-            "title": "Id"
+            "title": "Id",
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "title": "Name"
+            "title": "Name",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "id",
           "name"
         ],
-        "title": "AIModelInfo"
+        "title": "AIModelInfo",
+        "type": "object"
       },
       "AIModelsResponse": {
         "properties": {
@@ -5253,48 +25,48 @@
             "items": {
               "$ref": "#/components/schemas/AIModelInfo"
             },
-            "type": "array",
-            "title": "Models"
+            "title": "Models",
+            "type": "array"
           }
         },
-        "type": "object",
         "required": [
           "models"
         ],
-        "title": "AIModelsResponse"
+        "title": "AIModelsResponse",
+        "type": "object"
       },
       "AISettingsOut": {
         "properties": {
-          "llm_enabled": {
-            "type": "boolean",
-            "title": "Llm Enabled"
-          },
-          "llm_model": {
-            "type": "string",
-            "title": "Llm Model"
-          },
-          "llm_rate_limit_per_minute": {
-            "type": "integer",
-            "title": "Llm Rate Limit Per Minute"
-          },
           "api_key_configured": {
-            "type": "boolean",
-            "title": "Api Key Configured"
+            "title": "Api Key Configured",
+            "type": "boolean"
           },
           "api_key_masked": {
-            "type": "string",
-            "title": "Api Key Masked"
+            "title": "Api Key Masked",
+            "type": "string"
+          },
+          "llm_enabled": {
+            "title": "Llm Enabled",
+            "type": "boolean"
+          },
+          "llm_model": {
+            "title": "Llm Model",
+            "type": "string"
+          },
+          "llm_rate_limit_per_minute": {
+            "title": "Llm Rate Limit Per Minute",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
+          "api_key_configured",
+          "api_key_masked",
           "llm_enabled",
           "llm_model",
-          "llm_rate_limit_per_minute",
-          "api_key_configured",
-          "api_key_masked"
+          "llm_rate_limit_per_minute"
         ],
-        "title": "AISettingsOut"
+        "title": "AISettingsOut",
+        "type": "object"
       },
       "AISettingsUpdate": {
         "properties": {
@@ -5323,9 +95,9 @@
           "llm_rate_limit_per_minute": {
             "anyOf": [
               {
-                "type": "integer",
                 "maximum": 30.0,
-                "minimum": 1.0
+                "minimum": 1.0,
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -5334,48 +106,32 @@
             "title": "Llm Rate Limit Per Minute"
           }
         },
-        "type": "object",
-        "title": "AISettingsUpdate"
+        "title": "AISettingsUpdate",
+        "type": "object"
       },
       "AcceptAllResponse": {
         "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
           "accepted_count": {
-            "type": "integer",
-            "title": "Accepted Count"
+            "title": "Accepted Count",
+            "type": "integer"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "status",
-          "accepted_count"
+          "accepted_count",
+          "status"
         ],
-        "title": "AcceptAllResponse"
+        "title": "AcceptAllResponse",
+        "type": "object"
       },
       "ActivityLogEntry": {
         "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
           "created_at": {
-            "type": "string",
-            "title": "Created At"
-          },
-          "level": {
-            "type": "string",
-            "title": "Level"
-          },
-          "source": {
-            "type": "string",
-            "title": "Source"
-          },
-          "message": {
-            "type": "string",
-            "title": "Message"
+            "title": "Created At",
+            "type": "string"
           },
           "event_code": {
             "anyOf": [
@@ -5387,152 +143,165 @@
               }
             ],
             "title": "Event Code"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "level": {
+            "title": "Level",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "id",
           "created_at",
+          "event_code",
+          "id",
           "level",
-          "source",
-          "message"
+          "message",
+          "source"
         ],
-        "title": "ActivityLogEntry"
+        "title": "ActivityLogEntry",
+        "type": "object"
       },
       "AdminEventOut": {
         "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
           "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "owner_username": {
-            "type": "string",
-            "title": "Owner Username"
-          },
-          "owner_id": {
-            "type": "integer",
-            "title": "Owner Id"
+            "title": "Code",
+            "type": "string"
           },
           "created_at": {
-            "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "type": "string"
           },
           "expires_at": {
-            "type": "string",
             "format": "date-time",
-            "title": "Expires At"
+            "title": "Expires At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
           },
           "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "join_code": {
+            "title": "Join Code",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "owner_id": {
+            "title": "Owner Id",
+            "type": "integer"
+          },
+          "owner_username": {
+            "title": "Owner Username",
+            "type": "string"
           },
           "request_count": {
-            "type": "integer",
+            "default": 0,
             "title": "Request Count",
-            "default": 0
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
-          "id",
           "code",
-          "name",
-          "owner_username",
-          "owner_id",
           "created_at",
           "expires_at",
-          "is_active"
+          "id",
+          "is_active",
+          "join_code",
+          "name",
+          "owner_id",
+          "owner_username",
+          "request_count"
         ],
-        "title": "AdminEventOut"
+        "title": "AdminEventOut",
+        "type": "object"
       },
       "AdminUserCreate": {
         "properties": {
-          "username": {
-            "type": "string",
-            "maxLength": 50,
-            "minLength": 3,
-            "title": "Username"
-          },
           "password": {
-            "type": "string",
             "maxLength": 128,
             "minLength": 8,
-            "title": "Password"
+            "title": "Password",
+            "type": "string"
           },
           "role": {
-            "type": "string",
+            "default": "dj",
             "title": "Role",
-            "default": "dj"
+            "type": "string"
+          },
+          "username": {
+            "maxLength": 50,
+            "minLength": 3,
+            "title": "Username",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "username",
           "password"
         ],
-        "title": "AdminUserCreate"
+        "title": "AdminUserCreate",
+        "type": "object"
       },
       "AdminUserOut": {
         "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "username": {
-            "type": "string",
-            "title": "Username"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "role": {
-            "type": "string",
-            "title": "Role"
-          },
           "created_at": {
-            "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "type": "string"
           },
           "event_count": {
-            "type": "integer",
+            "default": 0,
             "title": "Event Count",
-            "default": 0
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
+          "created_at",
+          "event_count",
           "id",
-          "username",
           "is_active",
           "role",
-          "created_at"
+          "username"
         ],
-        "title": "AdminUserOut"
+        "title": "AdminUserOut",
+        "type": "object"
       },
       "AdminUserUpdate": {
         "properties": {
-          "role": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Role"
-          },
           "is_active": {
             "anyOf": [
               {
@@ -5547,178 +316,105 @@
           "password": {
             "anyOf": [
               {
-                "type": "string",
                 "maxLength": 128,
-                "minLength": 8
+                "minLength": 8,
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
             "title": "Password"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
           }
         },
-        "type": "object",
-        "title": "AdminUserUpdate"
+        "title": "AdminUserUpdate",
+        "type": "object"
       },
       "BeatportEventSettings": {
+        "description": "Beatport sync settings for an event.",
         "properties": {
           "beatport_sync_enabled": {
-            "type": "boolean",
-            "title": "Beatport Sync Enabled"
+            "title": "Beatport Sync Enabled",
+            "type": "boolean"
           }
         },
-        "type": "object",
         "required": [
           "beatport_sync_enabled"
         ],
         "title": "BeatportEventSettings",
-        "description": "Beatport sync settings for an event."
+        "type": "object"
       },
       "BeatportEventSettingsUpdate": {
+        "description": "Update Beatport sync settings for an event.",
         "properties": {
           "beatport_sync_enabled": {
-            "type": "boolean",
-            "title": "Beatport Sync Enabled"
+            "title": "Beatport Sync Enabled",
+            "type": "boolean"
           }
         },
-        "type": "object",
         "required": [
           "beatport_sync_enabled"
         ],
         "title": "BeatportEventSettingsUpdate",
-        "description": "Update Beatport sync settings for an event."
+        "type": "object"
       },
       "BeatportLogin": {
+        "description": "Login request with Beatport credentials.",
         "properties": {
-          "username": {
-            "type": "string",
-            "maxLength": 200,
-            "minLength": 1,
-            "title": "Username"
-          },
           "password": {
-            "type": "string",
             "maxLength": 200,
             "minLength": 1,
-            "title": "Password"
+            "title": "Password",
+            "type": "string"
+          },
+          "username": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Username",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "username",
           "password"
         ],
         "title": "BeatportLogin",
-        "description": "Login request with Beatport credentials."
+        "type": "object"
       },
       "BeatportManualLink": {
+        "description": "Manual Beatport track linking request.",
         "properties": {
           "beatport_track_id": {
-            "type": "string",
             "maxLength": 100,
             "minLength": 1,
             "pattern": "^[0-9]+$",
-            "title": "Beatport Track Id"
+            "title": "Beatport Track Id",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "beatport_track_id"
         ],
         "title": "BeatportManualLink",
-        "description": "Manual Beatport track linking request."
+        "type": "object"
       },
       "BeatportSearchResult": {
+        "description": "Track result from Beatport search.",
         "properties": {
-          "track_id": {
-            "type": "string",
-            "title": "Track Id"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
           "artist": {
-            "type": "string",
-            "title": "Artist"
-          },
-          "mix_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Mix Name"
-          },
-          "label": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Label"
-          },
-          "genre": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
-          },
-          "bpm": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bpm"
-          },
-          "key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Key"
-          },
-          "duration_seconds": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Duration Seconds"
-          },
-          "cover_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cover Url"
+            "title": "Artist",
+            "type": "string"
           },
           "beatport_url": {
             "anyOf": [
@@ -5731,6 +427,83 @@
             ],
             "title": "Beatport Url"
           },
+          "bpm": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "cover_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Url"
+          },
+          "duration_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Seconds"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "mix_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mix Name"
+          },
           "release_date": {
             "anyOf": [
               {
@@ -5741,22 +514,40 @@
               }
             ],
             "title": "Release Date"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "track_id": {
+            "title": "Track Id",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "track_id",
+          "artist",
+          "beatport_url",
+          "bpm",
+          "cover_url",
+          "duration_seconds",
+          "genre",
+          "key",
+          "label",
+          "mix_name",
+          "release_date",
           "title",
-          "artist"
+          "track_id"
         ],
         "title": "BeatportSearchResult",
-        "description": "Track result from Beatport search."
+        "type": "object"
       },
       "BeatportStatus": {
+        "description": "Current Beatport account linking status.",
         "properties": {
-          "linked": {
-            "type": "boolean",
-            "title": "Linked"
+          "configured": {
+            "default": true,
+            "title": "Configured",
+            "type": "boolean"
           },
           "expires_at": {
             "anyOf": [
@@ -5769,10 +560,14 @@
             ],
             "title": "Expires At"
           },
-          "configured": {
-            "type": "boolean",
-            "title": "Configured",
-            "default": true
+          "integration_enabled": {
+            "default": true,
+            "title": "Integration Enabled",
+            "type": "boolean"
+          },
+          "linked": {
+            "title": "Linked",
+            "type": "boolean"
           },
           "subscription": {
             "anyOf": [
@@ -5784,48 +579,20 @@
               }
             ],
             "title": "Subscription"
-          },
-          "integration_enabled": {
-            "type": "boolean",
-            "title": "Integration Enabled",
-            "default": true
           }
         },
-        "type": "object",
         "required": [
-          "linked"
+          "configured",
+          "expires_at",
+          "integration_enabled",
+          "linked",
+          "subscription"
         ],
         "title": "BeatportStatus",
-        "description": "Current Beatport account linking status."
+        "type": "object"
       },
       "Body_login_api_auth_login_post": {
         "properties": {
-          "grant_type": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^password$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Grant Type"
-          },
-          "username": {
-            "type": "string",
-            "title": "Username"
-          },
-          "password": {
-            "type": "string",
-            "format": "password",
-            "title": "Password"
-          },
-          "scope": {
-            "type": "string",
-            "title": "Scope",
-            "default": ""
-          },
           "client_id": {
             "anyOf": [
               {
@@ -5848,46 +615,73 @@
             ],
             "format": "password",
             "title": "Client Secret"
+          },
+          "grant_type": {
+            "anyOf": [
+              {
+                "pattern": "^password$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grant Type"
+          },
+          "password": {
+            "format": "password",
+            "title": "Password",
+            "type": "string"
+          },
+          "scope": {
+            "default": "",
+            "title": "Scope",
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "username",
           "password"
         ],
-        "title": "Body_login_api_auth_login_post"
+        "title": "Body_login_api_auth_login_post",
+        "type": "object"
       },
       "Body_upload_banner_api_events__code__banner_post": {
         "properties": {
           "file": {
-            "type": "string",
             "format": "binary",
-            "title": "File"
+            "title": "File",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "file"
         ],
-        "title": "Body_upload_banner_api_events__code__banner_post"
+        "title": "Body_upload_banner_api_events__code__banner_post",
+        "type": "object"
       },
       "BridgeApiKeyResponse": {
         "properties": {
           "bridge_api_key": {
-            "type": "string",
-            "title": "Bridge Api Key"
+            "title": "Bridge Api Key",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "bridge_api_key"
         ],
-        "title": "BridgeApiKeyResponse"
+        "title": "BridgeApiKeyResponse",
+        "type": "object"
       },
       "BridgeCommandRequest": {
+        "description": "Request body for queuing a bridge command.",
         "properties": {
           "command_type": {
-            "type": "string",
+            "description": "The type of command to send to the bridge",
             "enum": [
               "ping",
               "reset_decks",
@@ -5895,93 +689,62 @@
               "restart"
             ],
             "title": "Command Type",
-            "description": "The type of command to send to the bridge"
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "command_type"
         ],
         "title": "BridgeCommandRequest",
-        "description": "Request body for queuing a bridge command."
+        "type": "object"
       },
       "BridgeCommandResponse": {
+        "description": "Response after queuing a bridge command.",
         "properties": {
           "command_id": {
-            "type": "string",
+            "description": "UUID of the queued command",
             "title": "Command Id",
-            "description": "UUID of the queued command"
+            "type": "string"
           },
           "command_type": {
-            "type": "string",
+            "description": "The command type that was queued",
             "title": "Command Type",
-            "description": "The command type that was queued"
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "command_id",
           "command_type"
         ],
         "title": "BridgeCommandResponse",
-        "description": "Response after queuing a bridge command."
+        "type": "object"
       },
       "BridgeCommandsPollResponse": {
+        "description": "Response for bridge polling pending commands.",
         "properties": {
           "commands": {
+            "description": "List of pending commands",
             "items": {
               "$ref": "#/components/schemas/BridgeCommandResponse"
             },
-            "type": "array",
             "title": "Commands",
-            "description": "List of pending commands"
+            "type": "array"
           }
         },
-        "type": "object",
+        "required": [
+          "commands"
+        ],
         "title": "BridgeCommandsPollResponse",
-        "description": "Response for bridge polling pending commands."
+        "type": "object"
       },
       "BridgeStatusPayload": {
+        "description": "Payload from bridge reporting connection status.",
         "properties": {
-          "event_code": {
-            "type": "string",
-            "maxLength": 10,
-            "minLength": 1,
-            "title": "Event Code"
-          },
-          "connected": {
-            "type": "boolean",
-            "title": "Connected"
-          },
-          "device_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 100
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Device Name"
-          },
-          "circuit_breaker_state": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 20
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Circuit Breaker State"
-          },
           "buffer_size": {
             "anyOf": [
               {
-                "type": "integer",
-                "minimum": 0.0
+                "minimum": 0.0,
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -5989,23 +752,27 @@
             ],
             "title": "Buffer Size"
           },
-          "plugin_id": {
+          "circuit_breaker_state": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 50
+                "maxLength": 20,
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Plugin Id"
+            "title": "Circuit Breaker State"
+          },
+          "connected": {
+            "title": "Connected",
+            "type": "boolean"
           },
           "deck_count": {
             "anyOf": [
               {
-                "type": "integer",
-                "minimum": 0.0
+                "minimum": 0.0,
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -6013,11 +780,41 @@
             ],
             "title": "Deck Count"
           },
+          "device_name": {
+            "anyOf": [
+              {
+                "maxLength": 100,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Name"
+          },
+          "event_code": {
+            "maxLength": 10,
+            "minLength": 1,
+            "title": "Event Code",
+            "type": "string"
+          },
+          "plugin_id": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Plugin Id"
+          },
           "uptime_seconds": {
             "anyOf": [
               {
-                "type": "integer",
-                "minimum": 0.0
+                "minimum": 0.0,
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -6026,20 +823,53 @@
             "title": "Uptime Seconds"
           }
         },
-        "type": "object",
         "required": [
           "event_code",
           "connected"
         ],
         "title": "BridgeStatusPayload",
-        "description": "Payload from bridge reporting connection status."
+        "type": "object"
       },
       "BridgeStatusResponse": {
+        "description": "Public response for bridge connection status (independent of track data).",
         "properties": {
+          "buffer_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Buffer Size"
+          },
+          "circuit_breaker_state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Circuit Breaker State"
+          },
           "connected": {
-            "type": "boolean",
+            "default": false,
             "title": "Connected",
-            "default": false
+            "type": "boolean"
+          },
+          "deck_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deck Count"
           },
           "device_name": {
             "anyOf": [
@@ -6063,28 +893,6 @@
             ],
             "title": "Last Seen"
           },
-          "circuit_breaker_state": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Circuit Breaker State"
-          },
-          "buffer_size": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buffer Size"
-          },
           "plugin_id": {
             "anyOf": [
               {
@@ -6095,17 +903,6 @@
               }
             ],
             "title": "Plugin Id"
-          },
-          "deck_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Deck Count"
           },
           "uptime_seconds": {
             "anyOf": [
@@ -6119,27 +916,36 @@
             "title": "Uptime Seconds"
           }
         },
-        "type": "object",
+        "required": [
+          "buffer_size",
+          "circuit_breaker_state",
+          "connected",
+          "deck_count",
+          "device_name",
+          "last_seen",
+          "plugin_id",
+          "uptime_seconds"
+        ],
         "title": "BridgeStatusResponse",
-        "description": "Public response for bridge connection status (independent of track data)."
+        "type": "object"
       },
       "BulkActionResponse": {
         "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
           "count": {
-            "type": "integer",
-            "title": "Count"
+            "title": "Count",
+            "type": "integer"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "status",
-          "count"
+          "count",
+          "status"
         ],
-        "title": "BulkActionResponse"
+        "title": "BulkActionResponse",
+        "type": "object"
       },
       "BulkDeleteEventsRequest": {
         "properties": {
@@ -6147,22 +953,21 @@
             "items": {
               "type": "string"
             },
-            "type": "array",
             "maxItems": 50,
             "minItems": 1,
-            "title": "Codes"
+            "title": "Codes",
+            "type": "array"
           }
         },
-        "type": "object",
         "required": [
           "codes"
         ],
-        "title": "BulkDeleteEventsRequest"
+        "title": "BulkDeleteEventsRequest",
+        "type": "object"
       },
       "BulkReviewRequest": {
         "properties": {
           "action": {
-            "type": "string",
             "enum": [
               "accept_top_n",
               "accept_threshold",
@@ -6170,26 +975,14 @@
               "reject_ids",
               "reject_remaining"
             ],
-            "title": "Action"
-          },
-          "n": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "maximum": 200.0,
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "N"
+            "title": "Action",
+            "type": "string"
           },
           "min_votes": {
             "anyOf": [
               {
-                "type": "integer",
-                "minimum": 0.0
+                "minimum": 0.0,
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -6197,14 +990,27 @@
             ],
             "title": "Min Votes"
           },
+          "n": {
+            "anyOf": [
+              {
+                "maximum": 200.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "N"
+          },
           "request_ids": {
             "anyOf": [
               {
                 "items": {
                   "type": "integer"
                 },
-                "type": "array",
-                "maxItems": 200
+                "maxItems": 200,
+                "type": "array"
               },
               {
                 "type": "null"
@@ -6213,50 +1019,50 @@
             "title": "Request Ids"
           }
         },
-        "type": "object",
         "required": [
           "action"
         ],
-        "title": "BulkReviewRequest"
+        "title": "BulkReviewRequest",
+        "type": "object"
       },
       "BulkReviewResponse": {
         "properties": {
           "accepted": {
-            "type": "integer",
-            "title": "Accepted"
+            "title": "Accepted",
+            "type": "integer"
           },
           "rejected": {
-            "type": "integer",
-            "title": "Rejected"
+            "title": "Rejected",
+            "type": "integer"
           },
           "unchanged": {
-            "type": "integer",
-            "title": "Unchanged"
+            "title": "Unchanged",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
           "accepted",
           "rejected",
           "unchanged"
         ],
-        "title": "BulkReviewResponse"
+        "title": "BulkReviewResponse",
+        "type": "object"
       },
       "CacheClearResponse": {
         "properties": {
           "message": {
-            "type": "string",
-            "title": "Message"
+            "title": "Message",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "message"
         ],
-        "title": "CacheClearResponse"
+        "title": "CacheClearResponse",
+        "type": "object"
       },
       "CapabilityStatus": {
-        "type": "string",
+        "description": "Status of a specific capability for a service.",
         "enum": [
           "yes",
           "no",
@@ -6265,17 +1071,50 @@
           "not_configured"
         ],
         "title": "CapabilityStatus",
-        "description": "Status of a specific capability for a service."
+        "type": "string"
+      },
+      "ChangePasswordRequest": {
+        "properties": {
+          "confirm_new_password": {
+            "title": "Confirm New Password",
+            "type": "string"
+          },
+          "current_password": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Current Password",
+            "type": "string"
+          },
+          "new_password": {
+            "maxLength": 128,
+            "minLength": 8,
+            "title": "New Password",
+            "type": "string"
+          }
+        },
+        "required": [
+          "current_password",
+          "new_password",
+          "confirm_new_password"
+        ],
+        "title": "ChangePasswordRequest",
+        "type": "object"
       },
       "CollectEventPreview": {
         "properties": {
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
+          "banner_colors": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Banner Colors"
           },
           "banner_filename": {
             "anyOf": [
@@ -6299,43 +1138,15 @@
             ],
             "title": "Banner Url"
           },
-          "banner_colors": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Banner Colors"
-          },
-          "submission_cap_per_guest": {
-            "type": "integer",
-            "title": "Submission Cap Per Guest"
-          },
-          "registration_enabled": {
-            "type": "boolean",
-            "title": "Registration Enabled"
-          },
-          "phase": {
-            "type": "string",
-            "enum": [
-              "pre_announce",
-              "collection",
-              "live",
-              "closed"
-            ],
-            "title": "Phase"
+          "code": {
+            "title": "Code",
+            "type": "string"
           },
           "collection_opens_at": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
@@ -6343,11 +1154,16 @@
             ],
             "title": "Collection Opens At"
           },
+          "expires_at": {
+            "format": "date-time",
+            "title": "Expires At",
+            "type": "string"
+          },
           "live_starts_at": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
@@ -6355,25 +1171,44 @@
             ],
             "title": "Live Starts At"
           },
-          "expires_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Expires At"
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "phase": {
+            "enum": [
+              "pre_announce",
+              "collection",
+              "live",
+              "closed"
+            ],
+            "title": "Phase",
+            "type": "string"
+          },
+          "registration_enabled": {
+            "title": "Registration Enabled",
+            "type": "boolean"
+          },
+          "submission_cap_per_guest": {
+            "title": "Submission Cap Per Guest",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
-          "code",
-          "name",
+          "banner_colors",
           "banner_filename",
-          "submission_cap_per_guest",
-          "registration_enabled",
-          "phase",
+          "banner_url",
+          "code",
           "collection_opens_at",
+          "expires_at",
           "live_starts_at",
-          "expires_at"
+          "name",
+          "phase",
+          "registration_enabled",
+          "submission_cap_per_guest"
         ],
-        "title": "CollectEventPreview"
+        "title": "CollectEventPreview",
+        "type": "object"
       },
       "CollectLeaderboardResponse": {
         "properties": {
@@ -6381,34 +1216,26 @@
             "items": {
               "$ref": "#/components/schemas/CollectLeaderboardRow"
             },
-            "type": "array",
-            "title": "Requests"
+            "title": "Requests",
+            "type": "array"
           },
           "total": {
-            "type": "integer",
-            "title": "Total"
+            "title": "Total",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
           "requests",
           "total"
         ],
-        "title": "CollectLeaderboardResponse"
+        "title": "CollectLeaderboardResponse",
+        "type": "object"
       },
       "CollectLeaderboardRow": {
         "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
           "artist": {
-            "type": "string",
-            "title": "Artist"
+            "title": "Artist",
+            "type": "string"
           },
           "artwork_url": {
             "anyOf": [
@@ -6421,37 +1248,6 @@
             ],
             "title": "Artwork Url"
           },
-          "vote_count": {
-            "type": "integer",
-            "title": "Vote Count"
-          },
-          "nickname": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Nickname"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "new",
-              "accepted",
-              "playing",
-              "played",
-              "rejected"
-            ],
-            "title": "Status"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          },
           "bpm": {
             "anyOf": [
               {
@@ -6463,16 +1259,10 @@
             ],
             "title": "Bpm"
           },
-          "musical_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Musical Key"
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
           },
           "genre": {
             "anyOf": [
@@ -6485,38 +1275,79 @@
             ],
             "title": "Genre"
           },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "musical_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Musical Key"
+          },
+          "nickname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nickname"
+          },
           "requester_verified": {
-            "type": "boolean",
+            "default": false,
             "title": "Requester Verified",
-            "default": false
+            "type": "boolean"
+          },
+          "status": {
+            "enum": [
+              "new",
+              "accepted",
+              "playing",
+              "played",
+              "rejected"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "vote_count": {
+            "title": "Vote Count",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
-          "id",
-          "title",
           "artist",
           "artwork_url",
-          "vote_count",
+          "bpm",
+          "created_at",
+          "genre",
+          "id",
+          "musical_key",
           "nickname",
+          "requester_verified",
           "status",
-          "created_at"
+          "title",
+          "vote_count"
         ],
-        "title": "CollectLeaderboardRow"
+        "title": "CollectLeaderboardRow",
+        "type": "object"
       },
       "CollectMyPicksItem": {
         "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
           "artist": {
-            "type": "string",
-            "title": "Artist"
+            "title": "Artist",
+            "type": "string"
           },
           "artwork_url": {
             "anyOf": [
@@ -6529,37 +1360,6 @@
             ],
             "title": "Artwork Url"
           },
-          "vote_count": {
-            "type": "integer",
-            "title": "Vote Count"
-          },
-          "nickname": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Nickname"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "new",
-              "accepted",
-              "playing",
-              "played",
-              "rejected"
-            ],
-            "title": "Status"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          },
           "bpm": {
             "anyOf": [
               {
@@ -6571,16 +1371,10 @@
             ],
             "title": "Bpm"
           },
-          "musical_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Musical Key"
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
           },
           "genre": {
             "anyOf": [
@@ -6593,175 +1387,227 @@
             ],
             "title": "Genre"
           },
-          "requester_verified": {
-            "type": "boolean",
-            "title": "Requester Verified",
-            "default": false
+          "id": {
+            "title": "Id",
+            "type": "integer"
           },
           "interaction": {
-            "type": "string",
             "enum": [
               "submitted",
               "upvoted"
             ],
-            "title": "Interaction"
+            "title": "Interaction",
+            "type": "string"
+          },
+          "musical_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Musical Key"
+          },
+          "nickname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nickname"
+          },
+          "requester_verified": {
+            "default": false,
+            "title": "Requester Verified",
+            "type": "boolean"
+          },
+          "status": {
+            "enum": [
+              "new",
+              "accepted",
+              "playing",
+              "played",
+              "rejected"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "vote_count": {
+            "title": "Vote Count",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
-          "id",
-          "title",
           "artist",
           "artwork_url",
-          "vote_count",
-          "nickname",
-          "status",
+          "bpm",
           "created_at",
-          "interaction"
+          "genre",
+          "id",
+          "interaction",
+          "musical_key",
+          "nickname",
+          "requester_verified",
+          "status",
+          "title",
+          "vote_count"
         ],
-        "title": "CollectMyPicksItem"
+        "title": "CollectMyPicksItem",
+        "type": "object"
       },
       "CollectMyPicksResponse": {
         "properties": {
+          "first_suggestion_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "First Suggestion Ids",
+            "type": "array"
+          },
+          "is_top_contributor": {
+            "title": "Is Top Contributor",
+            "type": "boolean"
+          },
           "submitted": {
             "items": {
               "$ref": "#/components/schemas/CollectMyPicksItem"
             },
-            "type": "array",
-            "title": "Submitted"
+            "title": "Submitted",
+            "type": "array"
           },
           "upvoted": {
             "items": {
               "$ref": "#/components/schemas/CollectMyPicksItem"
             },
-            "type": "array",
-            "title": "Upvoted"
-          },
-          "is_top_contributor": {
-            "type": "boolean",
-            "title": "Is Top Contributor"
-          },
-          "first_suggestion_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "First Suggestion Ids"
+            "title": "Upvoted",
+            "type": "array"
           },
           "voted_request_ids": {
             "items": {
               "type": "integer"
             },
-            "type": "array",
-            "title": "Voted Request Ids"
+            "title": "Voted Request Ids",
+            "type": "array"
           }
         },
-        "type": "object",
         "required": [
+          "first_suggestion_ids",
+          "is_top_contributor",
           "submitted",
           "upvoted",
-          "is_top_contributor",
-          "first_suggestion_ids",
           "voted_request_ids"
         ],
-        "title": "CollectMyPicksResponse"
+        "title": "CollectMyPicksResponse",
+        "type": "object"
       },
-      "CollectProfileRequest": {
+      "CollectPreviewResponse": {
         "properties": {
-          "nickname": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 30,
-                "minLength": 2,
-                "pattern": "^[a-zA-Z0-9 _.-]+$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Nickname"
-          }
-        },
-        "type": "object",
-        "title": "CollectProfileRequest"
-      },
-      "CollectProfileResponse": {
-        "properties": {
-          "nickname": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Nickname"
-          },
-          "email_verified": {
-            "type": "boolean",
-            "title": "Email Verified"
-          },
-          "submission_count": {
-            "type": "integer",
-            "title": "Submission Count"
-          },
-          "submission_cap": {
-            "type": "integer",
-            "title": "Submission Cap"
-          }
-        },
-        "type": "object",
-        "required": [
-          "nickname",
-          "email_verified",
-          "submission_count",
-          "submission_cap"
-        ],
-        "title": "CollectProfileResponse"
-      },
-      "CollectSubmitRequest": {
-        "properties": {
-          "song_title": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Song Title"
-          },
-          "artist": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Artist"
-          },
           "source": {
-            "type": "string",
             "enum": [
               "spotify",
-              "beatport",
               "tidal",
+              "beatport",
               "manual"
             ],
-            "title": "Source"
+            "title": "Source",
+            "type": "string"
           },
           "source_url": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 500
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
             "title": "Source Url"
+          }
+        },
+        "required": [
+          "source",
+          "source_url"
+        ],
+        "title": "CollectPreviewResponse",
+        "type": "object"
+      },
+      "CollectProfileRequest": {
+        "properties": {
+          "nickname": {
+            "anyOf": [
+              {
+                "maxLength": 30,
+                "minLength": 2,
+                "pattern": "^[a-zA-Z0-9 _.-]+$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nickname"
+          }
+        },
+        "title": "CollectProfileRequest",
+        "type": "object"
+      },
+      "CollectProfileResponse": {
+        "properties": {
+          "email_verified": {
+            "title": "Email Verified",
+            "type": "boolean"
+          },
+          "nickname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nickname"
+          },
+          "submission_cap": {
+            "title": "Submission Cap",
+            "type": "integer"
+          },
+          "submission_count": {
+            "title": "Submission Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "email_verified",
+          "nickname",
+          "submission_cap",
+          "submission_count"
+        ],
+        "title": "CollectProfileResponse",
+        "type": "object"
+      },
+      "CollectSubmitRequest": {
+        "properties": {
+          "artist": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Artist",
+            "type": "string"
           },
           "artwork_url": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 500
+                "maxLength": 500,
+                "type": "string"
               },
               {
                 "type": "null"
@@ -6769,11 +1615,25 @@
             ],
             "title": "Artwork Url"
           },
+          "nickname": {
+            "anyOf": [
+              {
+                "maxLength": 30,
+                "minLength": 2,
+                "pattern": "^[a-zA-Z0-9 _.-]+$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nickname"
+          },
           "note": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 500
+                "maxLength": 500,
+                "type": "string"
               },
               {
                 "type": "null"
@@ -6781,78 +1641,121 @@
             ],
             "title": "Note"
           },
-          "nickname": {
+          "song_title": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Song Title",
+            "type": "string"
+          },
+          "source": {
+            "enum": [
+              "spotify",
+              "beatport",
+              "tidal",
+              "manual"
+            ],
+            "title": "Source",
+            "type": "string"
+          },
+          "source_url": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 30,
-                "minLength": 2,
-                "pattern": "^[a-zA-Z0-9 _.-]+$"
+                "maxLength": 500,
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Nickname"
+            "title": "Source Url"
           }
         },
-        "type": "object",
         "required": [
           "song_title",
           "artist",
           "source"
         ],
-        "title": "CollectSubmitRequest"
+        "title": "CollectSubmitRequest",
+        "type": "object"
       },
       "CollectVoteRequest": {
         "properties": {
           "request_id": {
-            "type": "integer",
-            "title": "Request Id"
+            "title": "Request Id",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
           "request_id"
         ],
-        "title": "CollectVoteRequest"
+        "title": "CollectVoteRequest",
+        "type": "object"
       },
       "DisplaySettingsResponse": {
+        "description": "Response for display settings update.",
         "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status",
-            "default": "ok"
-          },
-          "now_playing_hidden": {
-            "type": "boolean",
-            "title": "Now Playing Hidden"
+          "kiosk_display_only": {
+            "default": false,
+            "title": "Kiosk Display Only",
+            "type": "boolean"
           },
           "now_playing_auto_hide_minutes": {
-            "type": "integer",
+            "default": 10,
             "title": "Now Playing Auto Hide Minutes",
-            "default": 10
+            "type": "integer"
+          },
+          "now_playing_hidden": {
+            "title": "Now Playing Hidden",
+            "type": "boolean"
           },
           "requests_open": {
-            "type": "boolean",
+            "default": true,
             "title": "Requests Open",
-            "default": true
+            "type": "boolean"
           },
-          "kiosk_display_only": {
-            "type": "boolean",
-            "title": "Kiosk Display Only",
-            "default": false
+          "status": {
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "now_playing_hidden"
+          "kiosk_display_only",
+          "now_playing_auto_hide_minutes",
+          "now_playing_hidden",
+          "requests_open",
+          "status"
         ],
         "title": "DisplaySettingsResponse",
-        "description": "Response for display settings update."
+        "type": "object"
       },
       "DisplaySettingsUpdate": {
+        "description": "Request body for updating display settings.",
         "properties": {
+          "kiosk_display_only": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kiosk Display Only"
+          },
+          "now_playing_auto_hide_minutes": {
+            "anyOf": [
+              {
+                "maximum": 1440.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Now Playing Auto Hide Minutes"
+          },
           "now_playing_hidden": {
             "anyOf": [
               {
@@ -6863,19 +1766,6 @@
               }
             ],
             "title": "Now Playing Hidden"
-          },
-          "now_playing_auto_hide_minutes": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "maximum": 1440.0,
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Now Playing Auto Hide Minutes"
           },
           "requests_open": {
             "anyOf": [
@@ -6887,32 +1777,16 @@
               }
             ],
             "title": "Requests Open"
-          },
-          "kiosk_display_only": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Kiosk Display Only"
           }
         },
-        "type": "object",
         "title": "DisplaySettingsUpdate",
-        "description": "Request body for updating display settings."
+        "type": "object"
       },
       "EnrichPreviewItem": {
         "properties": {
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
           "artist": {
-            "type": "string",
-            "title": "Artist"
+            "title": "Artist",
+            "type": "string"
           },
           "source_url": {
             "anyOf": [
@@ -6924,14 +1798,18 @@
               }
             ],
             "title": "Source Url"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "title",
           "artist"
         ],
-        "title": "EnrichPreviewItem"
+        "title": "EnrichPreviewItem",
+        "type": "object"
       },
       "EnrichPreviewRequest": {
         "properties": {
@@ -6939,15 +1817,15 @@
             "items": {
               "$ref": "#/components/schemas/EnrichPreviewItem"
             },
-            "type": "array",
-            "title": "Items"
+            "title": "Items",
+            "type": "array"
           }
         },
-        "type": "object",
         "required": [
           "items"
         ],
-        "title": "EnrichPreviewRequest"
+        "title": "EnrichPreviewRequest",
+        "type": "object"
       },
       "EnrichPreviewResponse": {
         "properties": {
@@ -6955,25 +1833,21 @@
             "items": {
               "$ref": "#/components/schemas/EnrichPreviewResult"
             },
-            "type": "array",
-            "title": "Results"
+            "title": "Results",
+            "type": "array"
           }
         },
-        "type": "object",
         "required": [
           "results"
         ],
-        "title": "EnrichPreviewResponse"
+        "title": "EnrichPreviewResponse",
+        "type": "object"
       },
       "EnrichPreviewResult": {
         "properties": {
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
           "artist": {
-            "type": "string",
-            "title": "Artist"
+            "title": "Artist",
+            "type": "string"
           },
           "bpm": {
             "anyOf": [
@@ -6985,6 +1859,17 @@
               }
             ],
             "title": "Bpm"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
           },
           "key": {
             "anyOf": [
@@ -6997,46 +1882,42 @@
             ],
             "title": "Key"
           },
-          "genre": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
+          "title": {
+            "title": "Title",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "title",
-          "artist"
+          "artist",
+          "bpm",
+          "genre",
+          "key",
+          "title"
         ],
-        "title": "EnrichPreviewResult"
+        "title": "EnrichPreviewResult",
+        "type": "object"
       },
       "EventCreate": {
         "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 100,
-            "minLength": 1,
-            "title": "Name"
-          },
           "expires_hours": {
-            "type": "integer",
+            "default": 6,
             "maximum": 48.0,
             "minimum": 1.0,
             "title": "Expires Hours",
-            "default": 6
+            "type": "integer"
+          },
+          "name": {
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "name"
         ],
-        "title": "EventCreate"
+        "title": "EventCreate",
+        "type": "object"
       },
       "EventMusicProfile": {
         "properties": {
@@ -7051,17 +1932,6 @@
             ],
             "title": "Avg Bpm"
           },
-          "bpm_range_low": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bpm Range Low"
-          },
           "bpm_range_high": {
             "anyOf": [
               {
@@ -7073,62 +1943,58 @@
             ],
             "title": "Bpm Range High"
           },
-          "dominant_keys": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Dominant Keys",
-            "default": []
+          "bpm_range_low": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm Range Low"
           },
           "dominant_genres": {
+            "default": [],
             "items": {
               "type": "string"
             },
-            "type": "array",
             "title": "Dominant Genres",
-            "default": []
+            "type": "array"
           },
-          "track_count": {
-            "type": "integer",
-            "title": "Track Count",
-            "default": 0
+          "dominant_keys": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Dominant Keys",
+            "type": "array"
           },
           "enriched_count": {
-            "type": "integer",
+            "default": 0,
             "title": "Enriched Count",
-            "default": 0
+            "type": "integer"
+          },
+          "track_count": {
+            "default": 0,
+            "title": "Track Count",
+            "type": "integer"
           }
         },
-        "type": "object",
-        "title": "EventMusicProfile"
+        "required": [
+          "avg_bpm",
+          "bpm_range_high",
+          "bpm_range_low",
+          "dominant_genres",
+          "dominant_keys",
+          "enriched_count",
+          "track_count"
+        ],
+        "title": "EventMusicProfile",
+        "type": "object"
       },
       "EventOut": {
         "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "created_at": {
-            "type": "string",
-            "title": "Created At"
-          },
-          "expires_at": {
-            "type": "string",
-            "title": "Expires At"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
           "archived_at": {
             "anyOf": [
               {
@@ -7140,17 +2006,21 @@
             ],
             "title": "Archived At"
           },
-          "status": {
+          "banner_colors": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/EventStatus"
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
               },
               {
                 "type": "null"
               }
-            ]
+            ],
+            "title": "Banner Colors"
           },
-          "join_url": {
+          "banner_kiosk_url": {
             "anyOf": [
               {
                 "type": "string"
@@ -7159,25 +2029,9 @@
                 "type": "null"
               }
             ],
-            "title": "Join Url"
+            "title": "Banner Kiosk Url"
           },
-          "request_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Request Count"
-          },
-          "tidal_sync_enabled": {
-            "type": "boolean",
-            "title": "Tidal Sync Enabled",
-            "default": false
-          },
-          "tidal_playlist_id": {
+          "banner_url": {
             "anyOf": [
               {
                 "type": "string"
@@ -7186,12 +2040,7 @@
                 "type": "null"
               }
             ],
-            "title": "Tidal Playlist Id"
-          },
-          "beatport_sync_enabled": {
-            "type": "boolean",
-            "title": "Beatport Sync Enabled",
-            "default": false
+            "title": "Banner Url"
           },
           "beatport_playlist_id": {
             "anyOf": [
@@ -7204,7 +2053,16 @@
             ],
             "title": "Beatport Playlist Id"
           },
-          "banner_url": {
+          "beatport_sync_enabled": {
+            "default": false,
+            "title": "Beatport Sync Enabled",
+            "type": "boolean"
+          },
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "collect_url": {
             "anyOf": [
               {
                 "type": "string"
@@ -7213,37 +2071,7 @@
                 "type": "null"
               }
             ],
-            "title": "Banner Url"
-          },
-          "banner_kiosk_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Banner Kiosk Url"
-          },
-          "banner_colors": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Banner Colors"
-          },
-          "requests_open": {
-            "type": "boolean",
-            "title": "Requests Open",
-            "default": true
+            "title": "Collect Url"
           },
           "collection_opens_at": {
             "anyOf": [
@@ -7256,6 +2084,48 @@
             ],
             "title": "Collection Opens At"
           },
+          "collection_phase_override": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Collection Phase Override"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "expires_at": {
+            "title": "Expires At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "join_code": {
+            "title": "Join Code",
+            "type": "string"
+          },
+          "join_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Join Url"
+          },
           "live_starts_at": {
             "anyOf": [
               {
@@ -7267,12 +2137,42 @@
             ],
             "title": "Live Starts At"
           },
-          "submission_cap_per_guest": {
-            "type": "integer",
-            "title": "Submission Cap Per Guest",
-            "default": 15
+          "name": {
+            "title": "Name",
+            "type": "string"
           },
-          "collection_phase_override": {
+          "request_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Request Count"
+          },
+          "requests_open": {
+            "default": true,
+            "title": "Requests Open",
+            "type": "boolean"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EventStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "submission_cap_per_guest": {
+            "default": 15,
+            "title": "Submission Cap Per Guest",
+            "type": "integer"
+          },
+          "tidal_playlist_id": {
             "anyOf": [
               {
                 "type": "string"
@@ -7281,37 +2181,60 @@
                 "type": "null"
               }
             ],
-            "title": "Collection Phase Override"
+            "title": "Tidal Playlist Id"
+          },
+          "tidal_sync_enabled": {
+            "default": false,
+            "title": "Tidal Sync Enabled",
+            "type": "boolean"
           }
         },
-        "type": "object",
         "required": [
-          "id",
+          "archived_at",
+          "banner_colors",
+          "banner_kiosk_url",
+          "banner_url",
+          "beatport_playlist_id",
+          "beatport_sync_enabled",
           "code",
-          "name",
+          "collect_url",
+          "collection_opens_at",
+          "collection_phase_override",
           "created_at",
           "expires_at",
-          "is_active"
+          "id",
+          "is_active",
+          "join_code",
+          "join_url",
+          "live_starts_at",
+          "name",
+          "request_count",
+          "requests_open",
+          "status",
+          "submission_cap_per_guest",
+          "tidal_playlist_id",
+          "tidal_sync_enabled"
         ],
-        "title": "EventOut"
+        "title": "EventOut",
+        "type": "object"
       },
       "EventStatus": {
-        "type": "string",
+        "description": "Status of an event based on expiry and archive state.",
         "enum": [
           "active",
           "expired",
           "archived"
         ],
         "title": "EventStatus",
-        "description": "Status of an event based on expiry and archive state."
+        "type": "string"
       },
       "EventUpdate": {
         "properties": {
           "expires_at": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
@@ -7322,9 +2245,9 @@
           "name": {
             "anyOf": [
               {
-                "type": "string",
                 "maxLength": 100,
-                "minLength": 1
+                "minLength": 1,
+                "type": "string"
               },
               {
                 "type": "null"
@@ -7333,19 +2256,11 @@
             "title": "Name"
           }
         },
-        "type": "object",
-        "title": "EventUpdate"
+        "title": "EventUpdate",
+        "type": "object"
       },
       "GuestNowPlaying": {
         "properties": {
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "artist": {
-            "type": "string",
-            "title": "Artist"
-          },
           "album_art_url": {
             "anyOf": [
               {
@@ -7357,33 +2272,33 @@
             ],
             "title": "Album Art Url"
           },
+          "artist": {
+            "title": "Artist",
+            "type": "string"
+          },
           "source": {
-            "type": "string",
-            "title": "Source"
+            "title": "Source",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "title",
-          "artist",
           "album_art_url",
-          "source"
+          "artist",
+          "source",
+          "title"
         ],
-        "title": "GuestNowPlaying"
+        "title": "GuestNowPlaying",
+        "type": "object"
       },
       "GuestRequestInfo": {
         "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
           "artist": {
-            "type": "string",
-            "title": "Artist"
+            "title": "Artist",
+            "type": "string"
           },
           "artwork_url": {
             "anyOf": [
@@ -7396,22 +2311,6 @@
             ],
             "title": "Artwork Url"
           },
-          "nickname": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Nickname"
-          },
-          "vote_count": {
-            "type": "integer",
-            "title": "Vote Count",
-            "default": 0
-          },
           "bpm": {
             "anyOf": [
               {
@@ -7422,17 +2321,6 @@
               }
             ],
             "title": "Bpm"
-          },
-          "musical_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Musical Key"
           },
           "genre": {
             "anyOf": [
@@ -7445,41 +2333,75 @@
             ],
             "title": "Genre"
           },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "musical_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Musical Key"
+          },
+          "nickname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nickname"
+          },
           "requester_verified": {
-            "type": "boolean",
+            "default": false,
             "title": "Requester Verified",
-            "default": false
+            "type": "boolean"
           },
           "status": {
-            "type": "string",
             "enum": [
               "new",
               "accepted"
             ],
-            "title": "Status"
+            "title": "Status",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "vote_count": {
+            "default": 0,
+            "title": "Vote Count",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
-          "id",
-          "title",
           "artist",
           "artwork_url",
-          "status"
+          "bpm",
+          "genre",
+          "id",
+          "musical_key",
+          "nickname",
+          "requester_verified",
+          "status",
+          "title",
+          "vote_count"
         ],
-        "title": "GuestRequestInfo"
+        "title": "GuestRequestInfo",
+        "type": "object"
       },
       "GuestRequestListResponse": {
         "properties": {
           "event": {
             "$ref": "#/components/schemas/PublicEventInfo"
-          },
-          "requests": {
-            "items": {
-              "$ref": "#/components/schemas/GuestRequestInfo"
-            },
-            "type": "array",
-            "title": "Requests"
           },
           "now_playing": {
             "anyOf": [
@@ -7490,14 +2412,22 @@
                 "type": "null"
               }
             ]
+          },
+          "requests": {
+            "items": {
+              "$ref": "#/components/schemas/GuestRequestInfo"
+            },
+            "title": "Requests",
+            "type": "array"
           }
         },
-        "type": "object",
         "required": [
           "event",
+          "now_playing",
           "requests"
         ],
-        "title": "GuestRequestListResponse"
+        "title": "GuestRequestListResponse",
+        "type": "object"
       },
       "HTTPValidationError": {
         "properties": {
@@ -7505,50 +2435,47 @@
             "items": {
               "$ref": "#/components/schemas/ValidationError"
             },
-            "type": "array",
-            "title": "Detail"
+            "title": "Detail",
+            "type": "array"
           }
         },
-        "type": "object",
-        "title": "HTTPValidationError"
+        "required": [
+          "detail"
+        ],
+        "title": "HTTPValidationError",
+        "type": "object"
       },
       "HasRequestedResponse": {
         "properties": {
           "has_requested": {
-            "type": "boolean",
-            "title": "Has Requested"
+            "title": "Has Requested",
+            "type": "boolean"
           }
         },
-        "type": "object",
         "required": [
           "has_requested"
         ],
-        "title": "HasRequestedResponse"
+        "title": "HasRequestedResponse",
+        "type": "object"
       },
       "HelpPageSeenRequest": {
         "properties": {
           "page": {
-            "type": "string",
             "maxLength": 100,
             "minLength": 1,
             "pattern": "^[a-z0-9-]+$",
-            "title": "Page"
+            "title": "Page",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "page"
         ],
-        "title": "HelpPageSeenRequest"
+        "title": "HelpPageSeenRequest",
+        "type": "object"
       },
       "IdentifyRequest": {
         "properties": {
-          "fingerprint_hash": {
-            "type": "string",
-            "maxLength": 64,
-            "minLength": 8,
-            "title": "Fingerprint Hash"
-          },
           "fingerprint_components": {
             "anyOf": [
               {
@@ -7560,52 +2487,52 @@
               }
             ],
             "title": "Fingerprint Components"
+          },
+          "fingerprint_hash": {
+            "maxLength": 64,
+            "minLength": 8,
+            "title": "Fingerprint Hash",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "fingerprint_hash"
         ],
-        "title": "IdentifyRequest"
+        "title": "IdentifyRequest",
+        "type": "object"
       },
       "IdentifyResponse": {
         "properties": {
-          "guest_id": {
-            "type": "integer",
-            "title": "Guest Id"
-          },
           "action": {
-            "type": "string",
             "enum": [
               "create",
               "cookie_hit",
               "reconcile"
             ],
-            "title": "Action"
+            "title": "Action",
+            "type": "string"
+          },
+          "guest_id": {
+            "title": "Guest Id",
+            "type": "integer"
           },
           "reconcile_hint": {
-            "type": "boolean",
+            "default": false,
             "title": "Reconcile Hint",
-            "default": false
+            "type": "boolean"
           }
         },
-        "type": "object",
         "required": [
+          "action",
           "guest_id",
-          "action"
+          "reconcile_hint"
         ],
-        "title": "IdentifyResponse"
+        "title": "IdentifyResponse",
+        "type": "object"
       },
       "IntegrationCheckResponse": {
+        "description": "Response for POST /api/admin/integrations/{service}/check.",
         "properties": {
-          "service": {
-            "type": "string",
-            "title": "Service"
-          },
-          "healthy": {
-            "type": "boolean",
-            "title": "Healthy"
-          },
           "capabilities": {
             "$ref": "#/components/schemas/ServiceCapabilities"
           },
@@ -7619,54 +2546,59 @@
               }
             ],
             "title": "Error"
+          },
+          "healthy": {
+            "title": "Healthy",
+            "type": "boolean"
+          },
+          "service": {
+            "title": "Service",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "service",
+          "capabilities",
+          "error",
           "healthy",
-          "capabilities"
+          "service"
         ],
         "title": "IntegrationCheckResponse",
-        "description": "Response for POST /api/admin/integrations/{service}/check."
+        "type": "object"
       },
       "IntegrationHealthResponse": {
+        "description": "Response for GET /api/admin/integrations.",
         "properties": {
           "services": {
             "items": {
               "$ref": "#/components/schemas/IntegrationServiceStatus"
             },
-            "type": "array",
-            "title": "Services"
+            "title": "Services",
+            "type": "array"
           }
         },
-        "type": "object",
         "required": [
           "services"
         ],
         "title": "IntegrationHealthResponse",
-        "description": "Response for GET /api/admin/integrations."
+        "type": "object"
       },
       "IntegrationServiceStatus": {
+        "description": "Full status for a single integration service.",
         "properties": {
-          "service": {
-            "type": "string",
-            "title": "Service"
-          },
-          "display_name": {
-            "type": "string",
-            "title": "Display Name"
-          },
-          "enabled": {
-            "type": "boolean",
-            "title": "Enabled"
-          },
-          "configured": {
-            "type": "boolean",
-            "title": "Configured"
-          },
           "capabilities": {
             "$ref": "#/components/schemas/ServiceCapabilities"
+          },
+          "configured": {
+            "title": "Configured",
+            "type": "boolean"
+          },
+          "display_name": {
+            "title": "Display Name",
+            "type": "string"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
           },
           "last_check_error": {
             "anyOf": [
@@ -7678,150 +2610,96 @@
               }
             ],
             "title": "Last Check Error"
+          },
+          "service": {
+            "title": "Service",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "service",
+          "capabilities",
+          "configured",
           "display_name",
           "enabled",
-          "configured",
-          "capabilities"
+          "last_check_error",
+          "service"
         ],
         "title": "IntegrationServiceStatus",
-        "description": "Full status for a single integration service."
+        "type": "object"
       },
       "IntegrationToggleRequest": {
+        "description": "Request body for PATCH /api/admin/integrations/{service}.",
         "properties": {
           "enabled": {
-            "type": "boolean",
-            "title": "Enabled"
+            "title": "Enabled",
+            "type": "boolean"
           }
         },
-        "type": "object",
         "required": [
           "enabled"
         ],
         "title": "IntegrationToggleRequest",
-        "description": "Request body for PATCH /api/admin/integrations/{service}."
+        "type": "object"
       },
       "IntegrationToggleResponse": {
+        "description": "Response for PATCH /api/admin/integrations/{service}.",
         "properties": {
-          "service": {
-            "type": "string",
-            "title": "Service"
-          },
           "enabled": {
-            "type": "boolean",
-            "title": "Enabled"
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "service": {
+            "title": "Service",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "service",
-          "enabled"
+          "enabled",
+          "service"
         ],
         "title": "IntegrationToggleResponse",
-        "description": "Response for PATCH /api/admin/integrations/{service}."
+        "type": "object"
       },
       "KioskAssignRequest": {
+        "description": "Body for reassigning a kiosk to a different event.",
         "properties": {
           "event_code": {
-            "type": "string",
             "maxLength": 10,
             "minLength": 1,
-            "title": "Event Code"
+            "title": "Event Code",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "event_code"
         ],
         "title": "KioskAssignRequest",
-        "description": "Body for reassigning a kiosk to a different event."
+        "type": "object"
       },
       "KioskCompletePairingRequest": {
+        "description": "Body for completing a kiosk pairing.",
         "properties": {
           "event_code": {
-            "type": "string",
             "maxLength": 10,
             "minLength": 1,
-            "title": "Event Code"
+            "title": "Event Code",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "event_code"
         ],
         "title": "KioskCompletePairingRequest",
-        "description": "Body for completing a kiosk pairing."
+        "type": "object"
       },
       "KioskDisplayResponse": {
         "properties": {
-          "event": {
-            "$ref": "#/components/schemas/PublicEventInfo"
-          },
-          "qr_join_url": {
-            "type": "string",
-            "title": "Qr Join Url"
-          },
           "accepted_queue": {
             "items": {
               "$ref": "#/components/schemas/PublicRequestInfo"
             },
-            "type": "array",
-            "title": "Accepted Queue"
-          },
-          "now_playing": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/PublicRequestInfo"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "now_playing_hidden": {
-            "type": "boolean",
-            "title": "Now Playing Hidden"
-          },
-          "requests_open": {
-            "type": "boolean",
-            "title": "Requests Open",
-            "default": true
-          },
-          "kiosk_display_only": {
-            "type": "boolean",
-            "title": "Kiosk Display Only",
-            "default": false
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At"
-          },
-          "banner_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Banner Url"
-          },
-          "banner_kiosk_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Banner Kiosk Url"
+            "title": "Accepted Queue",
+            "type": "array"
           },
           "banner_colors": {
             "anyOf": [
@@ -7836,26 +2714,8 @@
               }
             ],
             "title": "Banner Colors"
-          }
-        },
-        "type": "object",
-        "required": [
-          "event",
-          "qr_join_url",
-          "accepted_queue",
-          "now_playing",
-          "now_playing_hidden",
-          "updated_at"
-        ],
-        "title": "KioskDisplayResponse"
-      },
-      "KioskOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
           },
-          "name": {
+          "banner_kiosk_url": {
             "anyOf": [
               {
                 "type": "string"
@@ -7864,8 +2724,75 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Banner Kiosk Url"
           },
+          "banner_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Banner Url"
+          },
+          "event": {
+            "$ref": "#/components/schemas/PublicEventInfo"
+          },
+          "kiosk_display_only": {
+            "default": false,
+            "title": "Kiosk Display Only",
+            "type": "boolean"
+          },
+          "now_playing": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicRequestInfo"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "now_playing_hidden": {
+            "title": "Now Playing Hidden",
+            "type": "boolean"
+          },
+          "qr_join_url": {
+            "title": "Qr Join Url",
+            "type": "string"
+          },
+          "requests_open": {
+            "default": true,
+            "title": "Requests Open",
+            "type": "boolean"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "accepted_queue",
+          "banner_colors",
+          "banner_kiosk_url",
+          "banner_url",
+          "event",
+          "kiosk_display_only",
+          "now_playing",
+          "now_playing_hidden",
+          "qr_join_url",
+          "requests_open",
+          "updated_at"
+        ],
+        "title": "KioskDisplayResponse",
+        "type": "object"
+      },
+      "KioskOut": {
+        "description": "Kiosk info for DJ dashboard (no session_token).",
+        "properties": {
           "event_code": {
             "anyOf": [
               {
@@ -7876,6 +2803,17 @@
               }
             ],
             "title": "Event Code"
+          },
+          "event_join_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Join Code"
           },
           "event_name": {
             "anyOf": [
@@ -7888,15 +2826,38 @@
             ],
             "title": "Event Name"
           },
-          "status": {
-            "type": "string",
-            "title": "Status"
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "last_seen_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Seen At"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
           },
           "paired_at": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
@@ -7904,80 +2865,70 @@
             ],
             "title": "Paired At"
           },
-          "last_seen_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Seen At"
+          "status": {
+            "title": "Status",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "id",
-          "name",
           "event_code",
-          "status",
+          "event_join_code",
+          "event_name",
+          "id",
+          "last_seen_at",
+          "name",
           "paired_at",
-          "last_seen_at"
+          "status"
         ],
         "title": "KioskOut",
-        "description": "Kiosk info for DJ dashboard (no session_token)."
+        "type": "object"
       },
       "KioskPairChallengeResponse": {
         "properties": {
-          "nonce": {
-            "type": "string",
-            "title": "Nonce"
-          },
           "expires_in": {
-            "type": "integer",
-            "title": "Expires In"
+            "title": "Expires In",
+            "type": "integer"
+          },
+          "nonce": {
+            "title": "Nonce",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "nonce",
-          "expires_in"
+          "expires_in",
+          "nonce"
         ],
-        "title": "KioskPairChallengeResponse"
+        "title": "KioskPairChallengeResponse",
+        "type": "object"
       },
       "KioskPairResponse": {
+        "description": "Returned when a new kiosk pairing session is created.",
         "properties": {
+          "expires_at": {
+            "format": "date-time",
+            "title": "Expires At",
+            "type": "string"
+          },
           "pair_code": {
-            "type": "string",
-            "title": "Pair Code"
+            "title": "Pair Code",
+            "type": "string"
           },
           "session_token": {
-            "type": "string",
-            "title": "Session Token"
-          },
-          "expires_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Expires At"
+            "title": "Session Token",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
+          "expires_at",
           "pair_code",
-          "session_token",
-          "expires_at"
+          "session_token"
         ],
         "title": "KioskPairResponse",
-        "description": "Returned when a new kiosk pairing session is created."
+        "type": "object"
       },
       "KioskPairStatusResponse": {
+        "description": "Returned when polling a pairing code's status.",
         "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
           "event_code": {
             "anyOf": [
               {
@@ -7989,6 +2940,17 @@
             ],
             "title": "Event Code"
           },
+          "event_join_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Join Code"
+          },
           "event_name": {
             "anyOf": [
               {
@@ -7999,22 +2961,29 @@
               }
             ],
             "title": "Event Name"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
+          "event_code",
+          "event_join_code",
+          "event_name",
           "status"
         ],
         "title": "KioskPairStatusResponse",
-        "description": "Returned when polling a pairing code's status."
+        "type": "object"
       },
       "KioskRenameRequest": {
+        "description": "Body for renaming a kiosk.",
         "properties": {
           "name": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 100
+                "maxLength": 100,
+                "type": "string"
               },
               {
                 "type": "null"
@@ -8023,16 +2992,12 @@
             "title": "Name"
           }
         },
-        "type": "object",
         "title": "KioskRenameRequest",
-        "description": "Body for renaming a kiosk."
+        "type": "object"
       },
       "KioskSessionResponse": {
+        "description": "Returned when polling a kiosk's current assignment.",
         "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
           "event_code": {
             "anyOf": [
               {
@@ -8044,6 +3009,17 @@
             ],
             "title": "Event Code"
           },
+          "event_join_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Join Code"
+          },
           "event_name": {
             "anyOf": [
               {
@@ -8054,43 +3030,55 @@
               }
             ],
             "title": "Event Name"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
+          "event_code",
+          "event_join_code",
+          "event_name",
           "status"
         ],
         "title": "KioskSessionResponse",
-        "description": "Returned when polling a kiosk's current assignment."
+        "type": "object"
       },
       "LLMPromptRequest": {
         "properties": {
           "prompt": {
-            "type": "string",
             "maxLength": 500,
             "minLength": 3,
-            "title": "Prompt"
+            "title": "Prompt",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "prompt"
         ],
-        "title": "LLMPromptRequest"
+        "title": "LLMPromptRequest",
+        "type": "object"
+      },
+      "LiveJoinCodeResponse": {
+        "description": "Returns the live join_code for an event that has entered the live phase.\n\nGated by require_verified_human so the join_code never leaks to unverified\nbots scraping the collect URL during the collection-to-live transition.",
+        "properties": {
+          "join_code": {
+            "title": "Join Code",
+            "type": "string"
+          }
+        },
+        "required": [
+          "join_code"
+        ],
+        "title": "LiveJoinCodeResponse",
+        "type": "object"
       },
       "MyRequestInfo": {
         "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
           "artist": {
-            "type": "string",
-            "title": "Artist"
+            "title": "Artist",
+            "type": "string"
           },
           "artwork_url": {
             "anyOf": [
@@ -8103,8 +3091,16 @@
             ],
             "title": "Artwork Url"
           },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
           "status": {
-            "type": "string",
             "enum": [
               "new",
               "accepted",
@@ -8112,29 +3108,30 @@
               "played",
               "rejected"
             ],
-            "title": "Status"
+            "title": "Status",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
           },
           "vote_count": {
-            "type": "integer",
+            "default": 0,
             "title": "Vote Count",
-            "default": 0
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
-          "id",
-          "title",
           "artist",
           "artwork_url",
+          "created_at",
+          "id",
           "status",
-          "created_at"
+          "title",
+          "vote_count"
         ],
-        "title": "MyRequestInfo"
+        "title": "MyRequestInfo",
+        "type": "object"
       },
       "MyRequestsResponse": {
         "properties": {
@@ -8142,41 +3139,24 @@
             "items": {
               "$ref": "#/components/schemas/MyRequestInfo"
             },
-            "type": "array",
-            "title": "Requests"
+            "title": "Requests",
+            "type": "array"
           }
         },
-        "type": "object",
         "required": [
           "requests"
         ],
-        "title": "MyRequestsResponse"
+        "title": "MyRequestsResponse",
+        "type": "object"
       },
       "NowPlayingBridgePayload": {
+        "description": "Payload from bridge when a new track starts playing.",
         "properties": {
-          "event_code": {
-            "type": "string",
-            "maxLength": 10,
-            "minLength": 1,
-            "title": "Event Code"
-          },
-          "title": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Title"
-          },
-          "artist": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Artist"
-          },
           "album": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 255
+                "maxLength": 255,
+                "type": "string"
               },
               {
                 "type": "null"
@@ -8184,11 +3164,17 @@
             ],
             "title": "Album"
           },
+          "artist": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Artist",
+            "type": "string"
+          },
           "deck": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 10
+                "maxLength": 10,
+                "type": "string"
               },
               {
                 "type": "null"
@@ -8196,38 +3182,42 @@
             ],
             "title": "Deck"
           },
+          "event_code": {
+            "maxLength": 10,
+            "minLength": 1,
+            "title": "Event Code",
+            "type": "string"
+          },
           "source": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 20
+                "maxLength": 20,
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
             "title": "Source"
+          },
+          "title": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "event_code",
           "title",
           "artist"
         ],
         "title": "NowPlayingBridgePayload",
-        "description": "Payload from bridge when a new track starts playing."
+        "type": "object"
       },
       "NowPlayingResponse": {
+        "description": "Response for current now-playing track.",
         "properties": {
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "artist": {
-            "type": "string",
-            "title": "Artist"
-          },
           "album": {
             "anyOf": [
               {
@@ -8250,24 +3240,14 @@
             ],
             "title": "Album Art Url"
           },
-          "spotify_uri": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spotify Uri"
+          "artist": {
+            "title": "Artist",
+            "type": "string"
           },
-          "started_at": {
-            "type": "string",
-            "title": "Started At"
-          },
-          "source": {
-            "type": "string",
-            "title": "Source"
+          "bridge_connected": {
+            "default": false,
+            "title": "Bridge Connected",
+            "type": "boolean"
           },
           "matched_request_id": {
             "anyOf": [
@@ -8280,50 +3260,72 @@
             ],
             "title": "Matched Request Id"
           },
-          "bridge_connected": {
-            "type": "boolean",
-            "title": "Bridge Connected",
-            "default": false
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "spotify_uri": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spotify Uri"
+          },
+          "started_at": {
+            "title": "Started At",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "title",
+          "album",
+          "album_art_url",
           "artist",
+          "bridge_connected",
+          "matched_request_id",
+          "source",
+          "spotify_uri",
           "started_at",
-          "source"
+          "title"
         ],
         "title": "NowPlayingResponse",
-        "description": "Response for current now-playing track."
+        "type": "object"
       },
       "PaginatedResponse": {
         "properties": {
           "items": {
             "items": {},
-            "type": "array",
-            "title": "Items"
-          },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          },
-          "page": {
-            "type": "integer",
-            "title": "Page"
+            "title": "Items",
+            "type": "array"
           },
           "limit": {
-            "type": "integer",
-            "title": "Limit"
+            "title": "Limit",
+            "type": "integer"
+          },
+          "page": {
+            "title": "Page",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
           "items",
-          "total",
+          "limit",
           "page",
-          "limit"
+          "total"
         ],
-        "title": "PaginatedResponse"
+        "title": "PaginatedResponse",
+        "type": "object"
       },
       "PendingReviewResponse": {
         "properties": {
@@ -8331,34 +3333,26 @@
             "items": {
               "$ref": "#/components/schemas/PendingReviewRow"
             },
-            "type": "array",
-            "title": "Requests"
+            "title": "Requests",
+            "type": "array"
           },
           "total": {
-            "type": "integer",
-            "title": "Total"
+            "title": "Total",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
           "requests",
           "total"
         ],
-        "title": "PendingReviewResponse"
+        "title": "PendingReviewResponse",
+        "type": "object"
       },
       "PendingReviewRow": {
         "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "song_title": {
-            "type": "string",
-            "title": "Song Title"
-          },
           "artist": {
-            "type": "string",
-            "title": "Artist"
+            "title": "Artist",
+            "type": "string"
           },
           "artwork_url": {
             "anyOf": [
@@ -8371,9 +3365,14 @@
             ],
             "title": "Artwork Url"
           },
-          "vote_count": {
-            "type": "integer",
-            "title": "Vote Count"
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
           },
           "nickname": {
             "anyOf": [
@@ -8386,11 +3385,6 @@
             ],
             "title": "Nickname"
           },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          },
           "note": {
             "anyOf": [
               {
@@ -8402,8 +3396,11 @@
             ],
             "title": "Note"
           },
+          "song_title": {
+            "title": "Song Title",
+            "type": "string"
+          },
           "status": {
-            "type": "string",
             "enum": [
               "new",
               "accepted",
@@ -8411,37 +3408,31 @@
               "played",
               "rejected"
             ],
-            "title": "Status"
+            "title": "Status",
+            "type": "string"
+          },
+          "vote_count": {
+            "title": "Vote Count",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
-          "id",
-          "song_title",
           "artist",
           "artwork_url",
-          "vote_count",
-          "nickname",
           "created_at",
+          "id",
+          "nickname",
           "note",
-          "status"
+          "song_title",
+          "status",
+          "vote_count"
         ],
-        "title": "PendingReviewRow"
+        "title": "PendingReviewRow",
+        "type": "object"
       },
       "PlayHistoryEntry": {
+        "description": "Single entry in play history.",
         "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "artist": {
-            "type": "string",
-            "title": "Artist"
-          },
           "album": {
             "anyOf": [
               {
@@ -8464,35 +3455,9 @@
             ],
             "title": "Album Art Url"
           },
-          "spotify_uri": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spotify Uri"
-          },
-          "matched_request_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Matched Request Id"
-          },
-          "source": {
-            "type": "string",
-            "title": "Source"
-          },
-          "started_at": {
-            "type": "string",
-            "title": "Started At"
+          "artist": {
+            "title": "Artist",
+            "type": "string"
           },
           "ended_at": {
             "anyOf": [
@@ -8505,76 +3470,110 @@
             ],
             "title": "Ended At"
           },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "matched_request_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Matched Request Id"
+          },
           "play_order": {
-            "type": "integer",
-            "title": "Play Order"
+            "title": "Play Order",
+            "type": "integer"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "spotify_uri": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spotify Uri"
+          },
+          "started_at": {
+            "title": "Started At",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "id",
-          "title",
+          "album",
+          "album_art_url",
           "artist",
+          "ended_at",
+          "id",
+          "matched_request_id",
+          "play_order",
           "source",
+          "spotify_uri",
           "started_at",
-          "play_order"
+          "title"
         ],
         "title": "PlayHistoryEntry",
-        "description": "Single entry in play history."
+        "type": "object"
       },
       "PlayHistoryResponse": {
+        "description": "Paginated response for play history.",
         "properties": {
           "items": {
             "items": {
               "$ref": "#/components/schemas/PlayHistoryEntry"
             },
-            "type": "array",
-            "title": "Items"
+            "title": "Items",
+            "type": "array"
           },
           "total": {
-            "type": "integer",
-            "title": "Total"
+            "title": "Total",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
           "items",
           "total"
         ],
         "title": "PlayHistoryResponse",
-        "description": "Paginated response for play history."
+        "type": "object"
       },
       "PublicEventInfo": {
         "properties": {
           "code": {
-            "type": "string",
-            "title": "Code"
+            "title": "Code",
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "title": "Name"
+            "title": "Name",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "code",
           "name"
         ],
-        "title": "PublicEventInfo"
+        "title": "PublicEventInfo",
+        "type": "object"
       },
       "PublicRequestInfo": {
         "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
           "artist": {
-            "type": "string",
-            "title": "Artist"
+            "title": "Artist",
+            "type": "string"
           },
           "artwork_url": {
             "anyOf": [
@@ -8587,22 +3586,6 @@
             ],
             "title": "Artwork Url"
           },
-          "nickname": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Nickname"
-          },
-          "vote_count": {
-            "type": "integer",
-            "title": "Vote Count",
-            "default": 0
-          },
           "bpm": {
             "anyOf": [
               {
@@ -8613,6 +3596,21 @@
               }
             ],
             "title": "Bpm"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
           },
           "musical_key": {
             "anyOf": [
@@ -8625,7 +3623,7 @@
             ],
             "title": "Musical Key"
           },
-          "genre": {
+          "nickname": {
             "anyOf": [
               {
                 "type": "string"
@@ -8634,88 +3632,103 @@
                 "type": "null"
               }
             ],
-            "title": "Genre"
+            "title": "Nickname"
           },
           "requester_verified": {
-            "type": "boolean",
+            "default": false,
             "title": "Requester Verified",
-            "default": false
+            "type": "boolean"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "vote_count": {
+            "default": 0,
+            "title": "Vote Count",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
-          "id",
-          "title",
           "artist",
-          "artwork_url"
+          "artwork_url",
+          "bpm",
+          "genre",
+          "id",
+          "musical_key",
+          "nickname",
+          "requester_verified",
+          "title",
+          "vote_count"
         ],
-        "title": "PublicRequestInfo"
+        "title": "PublicRequestInfo",
+        "type": "object"
       },
       "PublicSettings": {
         "properties": {
           "registration_enabled": {
-            "type": "boolean",
-            "title": "Registration Enabled"
+            "title": "Registration Enabled",
+            "type": "boolean"
           },
           "turnstile_site_key": {
-            "type": "string",
-            "title": "Turnstile Site Key"
+            "title": "Turnstile Site Key",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "registration_enabled",
           "turnstile_site_key"
         ],
-        "title": "PublicSettings"
+        "title": "PublicSettings",
+        "type": "object"
       },
       "RecommendationResponse": {
         "properties": {
-          "suggestions": {
-            "items": {
-              "$ref": "#/components/schemas/RecommendedTrack"
-            },
-            "type": "array",
-            "title": "Suggestions",
-            "default": []
+          "llm_available": {
+            "default": false,
+            "title": "Llm Available",
+            "type": "boolean"
           },
           "profile": {
             "$ref": "#/components/schemas/EventMusicProfile"
           },
           "services_used": {
+            "default": [],
             "items": {
               "type": "string"
             },
-            "type": "array",
             "title": "Services Used",
-            "default": []
+            "type": "array"
+          },
+          "suggestions": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/RecommendedTrack"
+            },
+            "title": "Suggestions",
+            "type": "array"
           },
           "total_candidates_searched": {
-            "type": "integer",
+            "default": 0,
             "title": "Total Candidates Searched",
-            "default": 0
-          },
-          "llm_available": {
-            "type": "boolean",
-            "title": "Llm Available",
-            "default": false
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
-          "profile"
+          "llm_available",
+          "profile",
+          "services_used",
+          "suggestions",
+          "total_candidates_searched"
         ],
-        "title": "RecommendationResponse"
+        "title": "RecommendationResponse",
+        "type": "object"
       },
       "RecommendedTrack": {
         "properties": {
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
           "artist": {
-            "type": "string",
-            "title": "Artist"
+            "title": "Artist",
+            "type": "string"
           },
           "bpm": {
             "anyOf": [
@@ -8728,69 +3741,9 @@
             ],
             "title": "Bpm"
           },
-          "key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Key"
-          },
-          "genre": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
-          },
-          "score": {
-            "type": "number",
-            "title": "Score"
-          },
           "bpm_score": {
-            "type": "number",
-            "title": "Bpm Score"
-          },
-          "key_score": {
-            "type": "number",
-            "title": "Key Score"
-          },
-          "genre_score": {
-            "type": "number",
-            "title": "Genre Score"
-          },
-          "source": {
-            "type": "string",
-            "title": "Source"
-          },
-          "track_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Track Id"
-          },
-          "url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Url"
+            "title": "Bpm Score",
+            "type": "number"
           },
           "cover_url": {
             "anyOf": [
@@ -8814,82 +3767,209 @@
             ],
             "title": "Duration Seconds"
           },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "genre_score": {
+            "title": "Genre Score",
+            "type": "number"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "key_score": {
+            "title": "Key Score",
+            "type": "number"
+          },
           "mb_verified": {
-            "type": "boolean",
+            "default": false,
             "title": "Mb Verified",
-            "default": false
+            "type": "boolean"
+          },
+          "score": {
+            "title": "Score",
+            "type": "number"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "track_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Track Id"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
           }
         },
-        "type": "object",
         "required": [
-          "title",
           "artist",
-          "score",
+          "bpm",
           "bpm_score",
-          "key_score",
+          "cover_url",
+          "duration_seconds",
+          "genre",
           "genre_score",
-          "source"
+          "key",
+          "key_score",
+          "mb_verified",
+          "score",
+          "source",
+          "title",
+          "track_id",
+          "url"
         ],
-        "title": "RecommendedTrack"
+        "title": "RecommendedTrack",
+        "type": "object"
       },
       "RegisterRequest": {
         "properties": {
-          "username": {
-            "type": "string",
-            "maxLength": 50,
-            "minLength": 3,
-            "title": "Username"
+          "confirm_password": {
+            "title": "Confirm Password",
+            "type": "string"
           },
           "email": {
-            "type": "string",
             "format": "email",
-            "title": "Email"
+            "title": "Email",
+            "type": "string"
           },
           "password": {
-            "type": "string",
             "maxLength": 128,
             "minLength": 8,
-            "title": "Password"
-          },
-          "confirm_password": {
-            "type": "string",
-            "title": "Confirm Password"
+            "title": "Password",
+            "type": "string"
           },
           "turnstile_token": {
-            "type": "string",
+            "default": "",
             "maxLength": 4096,
             "title": "Turnstile Token",
-            "default": ""
+            "type": "string"
+          },
+          "username": {
+            "maxLength": 50,
+            "minLength": 3,
+            "title": "Username",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "username",
           "email",
           "password",
           "confirm_password"
         ],
-        "title": "RegisterRequest"
+        "title": "RegisterRequest",
+        "type": "object"
       },
       "RequestCreate": {
         "properties": {
           "artist": {
-            "type": "string",
             "maxLength": 255,
             "minLength": 1,
-            "title": "Artist"
+            "title": "Artist",
+            "type": "string"
           },
-          "title": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Title"
+          "artwork_url": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Artwork Url"
+          },
+          "bpm": {
+            "anyOf": [
+              {
+                "maximum": 999.0,
+                "minimum": 1.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "maxLength": 100,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "musical_key": {
+            "anyOf": [
+              {
+                "maxLength": 20,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Musical Key"
+          },
+          "nickname": {
+            "anyOf": [
+              {
+                "maxLength": 30,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nickname"
           },
           "note": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 500
+                "maxLength": 500,
+                "type": "string"
               },
               {
                 "type": "null"
@@ -8897,17 +3977,17 @@
             ],
             "title": "Note"
           },
-          "nickname": {
+          "raw_search_query": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 30
+                "maxLength": 200,
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Nickname"
+            "title": "Raw Search Query"
           },
           "source": {
             "$ref": "#/components/schemas/RequestSource",
@@ -8916,8 +3996,8 @@
           "source_url": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 500
+                "maxLength": 500,
+                "type": "string"
               },
               {
                 "type": "null"
@@ -8925,107 +4005,46 @@
             ],
             "title": "Source Url"
           },
-          "artwork_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 500
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Artwork Url"
-          },
-          "raw_search_query": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 200
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Raw Search Query"
-          },
-          "genre": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 100
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
-          },
-          "bpm": {
-            "anyOf": [
-              {
-                "type": "number",
-                "maximum": 999.0,
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bpm"
-          },
-          "musical_key": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 20
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Musical Key"
+          "title": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "artist",
           "title"
         ],
-        "title": "RequestCreate"
+        "title": "RequestCreate",
+        "type": "object"
+      },
+      "RequestEmailChangeRequest": {
+        "properties": {
+          "current_password": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Current Password",
+            "type": "string"
+          },
+          "new_email": {
+            "format": "email",
+            "title": "New Email",
+            "type": "string"
+          }
+        },
+        "required": [
+          "current_password",
+          "new_email"
+        ],
+        "title": "RequestEmailChangeRequest",
+        "type": "object"
       },
       "RequestOut": {
         "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "event_id": {
-            "type": "integer",
-            "title": "Event Id"
-          },
-          "song_title": {
-            "type": "string",
-            "title": "Song Title"
-          },
           "artist": {
-            "type": "string",
-            "title": "Artist"
-          },
-          "source": {
-            "type": "string",
-            "title": "Source"
-          },
-          "source_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Url"
+            "title": "Artist",
+            "type": "string"
           },
           "artwork_url": {
             "anyOf": [
@@ -9037,56 +4056,6 @@
               }
             ],
             "title": "Artwork Url"
-          },
-          "note": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Note"
-          },
-          "nickname": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Nickname"
-          },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "created_at": {
-            "type": "string",
-            "title": "Created At"
-          },
-          "updated_at": {
-            "type": "string",
-            "title": "Updated At"
-          },
-          "is_duplicate": {
-            "type": "boolean",
-            "title": "Is Duplicate",
-            "default": false
-          },
-          "genre": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Genre"
           },
           "bpm": {
             "anyOf": [
@@ -9099,6 +4068,34 @@
             ],
             "title": "Bpm"
           },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "event_id": {
+            "title": "Event Id",
+            "type": "integer"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_duplicate": {
+            "default": false,
+            "title": "Is Duplicate",
+            "type": "boolean"
+          },
           "musical_key": {
             "anyOf": [
               {
@@ -9110,6 +4107,39 @@
             ],
             "title": "Musical Key"
           },
+          "nickname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nickname"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "priority_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Priority Score"
+          },
           "raw_search_query": {
             "anyOf": [
               {
@@ -9120,6 +4150,29 @@
               }
             ],
             "title": "Raw Search Query"
+          },
+          "song_title": {
+            "title": "Song Title",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
           },
           "sync_results_json": {
             "anyOf": [
@@ -9132,41 +4185,42 @@
             ],
             "title": "Sync Results Json"
           },
-          "vote_count": {
-            "type": "integer",
-            "title": "Vote Count",
-            "default": 0
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
           },
-          "priority_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Priority Score"
+          "vote_count": {
+            "default": 0,
+            "title": "Vote Count",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
-          "id",
-          "event_id",
-          "song_title",
           "artist",
+          "artwork_url",
+          "bpm",
+          "created_at",
+          "event_id",
+          "genre",
+          "id",
+          "is_duplicate",
+          "musical_key",
+          "nickname",
+          "note",
+          "priority_score",
+          "raw_search_query",
+          "song_title",
           "source",
           "source_url",
-          "artwork_url",
-          "note",
           "status",
-          "created_at",
-          "updated_at"
+          "sync_results_json",
+          "updated_at",
+          "vote_count"
         ],
-        "title": "RequestOut"
+        "title": "RequestOut",
+        "type": "object"
       },
       "RequestSource": {
-        "type": "string",
         "enum": [
           "manual",
           "musicbrainz",
@@ -9175,10 +4229,10 @@
           "tidal",
           "beatport"
         ],
-        "title": "RequestSource"
+        "title": "RequestSource",
+        "type": "string"
       },
       "RequestStatus": {
-        "type": "string",
         "enum": [
           "new",
           "accepted",
@@ -9186,7 +4240,8 @@
           "played",
           "rejected"
         ],
-        "title": "RequestStatus"
+        "title": "RequestStatus",
+        "type": "string"
       },
       "RequestUpdate": {
         "properties": {
@@ -9194,22 +4249,14 @@
             "$ref": "#/components/schemas/RequestStatus"
           }
         },
-        "type": "object",
         "required": [
           "status"
         ],
-        "title": "RequestUpdate"
+        "title": "RequestUpdate",
+        "type": "object"
       },
       "SearchResult": {
         "properties": {
-          "artist": {
-            "type": "string",
-            "title": "Artist"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
           "album": {
             "anyOf": [
               {
@@ -9220,22 +4267,6 @@
               }
             ],
             "title": "Album"
-          },
-          "popularity": {
-            "type": "integer",
-            "title": "Popularity",
-            "default": 0
-          },
-          "spotify_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spotify Id"
           },
           "album_art": {
             "anyOf": [
@@ -9248,32 +4279,20 @@
             ],
             "title": "Album Art"
           },
-          "preview_url": {
+          "artist": {
+            "title": "Artist",
+            "type": "string"
+          },
+          "bpm": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Preview Url"
-          },
-          "url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Url"
-          },
-          "source": {
-            "type": "string",
-            "title": "Source",
-            "default": "spotify"
+            "title": "Bpm"
           },
           "genre": {
             "anyOf": [
@@ -9286,16 +4305,16 @@
             ],
             "title": "Genre"
           },
-          "bpm": {
+          "isrc": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Bpm"
+            "title": "Isrc"
           },
           "key": {
             "anyOf": [
@@ -9308,7 +4327,12 @@
             ],
             "title": "Key"
           },
-          "isrc": {
+          "popularity": {
+            "default": 0,
+            "title": "Popularity",
+            "type": "integer"
+          },
+          "preview_url": {
             "anyOf": [
               {
                 "type": "string"
@@ -9317,17 +4341,60 @@
                 "type": "null"
               }
             ],
-            "title": "Isrc"
+            "title": "Preview Url"
+          },
+          "source": {
+            "default": "spotify",
+            "title": "Source",
+            "type": "string"
+          },
+          "spotify_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spotify Id"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
           }
         },
-        "type": "object",
         "required": [
+          "album",
+          "album_art",
           "artist",
-          "title"
+          "bpm",
+          "genre",
+          "isrc",
+          "key",
+          "popularity",
+          "preview_url",
+          "source",
+          "spotify_id",
+          "title",
+          "url"
         ],
-        "title": "SearchResult"
+        "title": "SearchResult",
+        "type": "object"
       },
       "ServiceCapabilities": {
+        "description": "Capability matrix for a single integration service.",
         "properties": {
           "auth": {
             "$ref": "#/components/schemas/CapabilityStatus"
@@ -9339,152 +4406,105 @@
             "$ref": "#/components/schemas/CapabilityStatus"
           }
         },
-        "type": "object",
         "required": [
           "auth",
           "catalog_search",
           "playlist_sync"
         ],
         "title": "ServiceCapabilities",
-        "description": "Capability matrix for a single integration service."
+        "type": "object"
       },
       "StatusMessageResponse": {
         "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
           "message": {
-            "type": "string",
-            "title": "Message"
+            "title": "Message",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "status",
-          "message"
+          "message",
+          "status"
         ],
-        "title": "StatusMessageResponse"
+        "title": "StatusMessageResponse",
+        "type": "object"
       },
       "StatusResponse": {
         "properties": {
           "status": {
-            "type": "string",
-            "title": "Status"
+            "title": "Status",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "status"
         ],
-        "title": "StatusResponse"
+        "title": "StatusResponse",
+        "type": "object"
       },
       "SystemSettingsOut": {
         "properties": {
-          "registration_enabled": {
-            "type": "boolean",
-            "title": "Registration Enabled"
-          },
-          "search_rate_limit_per_minute": {
-            "type": "integer",
-            "title": "Search Rate Limit Per Minute"
-          },
-          "spotify_enabled": {
-            "type": "boolean",
-            "title": "Spotify Enabled"
-          },
-          "tidal_enabled": {
-            "type": "boolean",
-            "title": "Tidal Enabled"
-          },
           "beatport_enabled": {
-            "type": "boolean",
-            "title": "Beatport Enabled"
+            "title": "Beatport Enabled",
+            "type": "boolean"
           },
           "bridge_enabled": {
-            "type": "boolean",
-            "title": "Bridge Enabled"
+            "title": "Bridge Enabled",
+            "type": "boolean"
           },
           "human_verification_enforced": {
-            "type": "boolean",
-            "title": "Human Verification Enforced"
+            "title": "Human Verification Enforced",
+            "type": "boolean"
           },
           "llm_enabled": {
-            "type": "boolean",
-            "title": "Llm Enabled"
+            "title": "Llm Enabled",
+            "type": "boolean"
           },
           "llm_model": {
-            "type": "string",
-            "title": "Llm Model"
+            "title": "Llm Model",
+            "type": "string"
           },
           "llm_rate_limit_per_minute": {
-            "type": "integer",
-            "title": "Llm Rate Limit Per Minute"
+            "title": "Llm Rate Limit Per Minute",
+            "type": "integer"
+          },
+          "registration_enabled": {
+            "title": "Registration Enabled",
+            "type": "boolean"
+          },
+          "search_rate_limit_per_minute": {
+            "title": "Search Rate Limit Per Minute",
+            "type": "integer"
+          },
+          "spotify_enabled": {
+            "title": "Spotify Enabled",
+            "type": "boolean"
+          },
+          "tidal_enabled": {
+            "title": "Tidal Enabled",
+            "type": "boolean"
           }
         },
-        "type": "object",
         "required": [
-          "registration_enabled",
-          "search_rate_limit_per_minute",
-          "spotify_enabled",
-          "tidal_enabled",
           "beatport_enabled",
           "bridge_enabled",
           "human_verification_enforced",
           "llm_enabled",
           "llm_model",
-          "llm_rate_limit_per_minute"
+          "llm_rate_limit_per_minute",
+          "registration_enabled",
+          "search_rate_limit_per_minute",
+          "spotify_enabled",
+          "tidal_enabled"
         ],
-        "title": "SystemSettingsOut"
+        "title": "SystemSettingsOut",
+        "type": "object"
       },
       "SystemSettingsUpdate": {
         "properties": {
-          "registration_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Registration Enabled"
-          },
-          "search_rate_limit_per_minute": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "maximum": 100.0,
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Search Rate Limit Per Minute"
-          },
-          "spotify_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spotify Enabled"
-          },
-          "tidal_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tidal Enabled"
-          },
           "beatport_enabled": {
             "anyOf": [
               {
@@ -9543,84 +4563,141 @@
           "llm_rate_limit_per_minute": {
             "anyOf": [
               {
-                "type": "integer",
                 "maximum": 30.0,
-                "minimum": 1.0
+                "minimum": 1.0,
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
             "title": "Llm Rate Limit Per Minute"
+          },
+          "registration_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Registration Enabled"
+          },
+          "search_rate_limit_per_minute": {
+            "anyOf": [
+              {
+                "maximum": 100.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Rate Limit Per Minute"
+          },
+          "spotify_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spotify Enabled"
+          },
+          "tidal_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tidal Enabled"
           }
         },
-        "type": "object",
-        "title": "SystemSettingsUpdate"
+        "title": "SystemSettingsUpdate",
+        "type": "object"
       },
       "SystemStats": {
         "properties": {
-          "total_users": {
-            "type": "integer",
-            "title": "Total Users"
+          "active_events": {
+            "title": "Active Events",
+            "type": "integer"
           },
           "active_users": {
-            "type": "integer",
-            "title": "Active Users"
+            "title": "Active Users",
+            "type": "integer"
           },
           "pending_users": {
-            "type": "integer",
-            "title": "Pending Users"
+            "title": "Pending Users",
+            "type": "integer"
           },
           "total_events": {
-            "type": "integer",
-            "title": "Total Events"
-          },
-          "active_events": {
-            "type": "integer",
-            "title": "Active Events"
+            "title": "Total Events",
+            "type": "integer"
           },
           "total_requests": {
-            "type": "integer",
-            "title": "Total Requests"
+            "title": "Total Requests",
+            "type": "integer"
+          },
+          "total_users": {
+            "title": "Total Users",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
-          "total_users",
+          "active_events",
           "active_users",
           "pending_users",
           "total_events",
-          "active_events",
-          "total_requests"
+          "total_requests",
+          "total_users"
         ],
-        "title": "SystemStats"
+        "title": "SystemStats",
+        "type": "object"
       },
       "TemplatePlaylistRequest": {
         "properties": {
-          "source": {
-            "type": "string",
-            "pattern": "^(tidal|beatport)$",
-            "title": "Source"
-          },
           "playlist_id": {
-            "type": "string",
             "maxLength": 200,
             "minLength": 1,
-            "title": "Playlist Id"
+            "title": "Playlist Id",
+            "type": "string"
+          },
+          "source": {
+            "pattern": "^(tidal|beatport)$",
+            "title": "Source",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "source",
           "playlist_id"
         ],
-        "title": "TemplatePlaylistRequest"
+        "title": "TemplatePlaylistRequest",
+        "type": "object"
       },
       "TidalAuthCheckResponse": {
         "properties": {
           "complete": {
-            "type": "boolean",
-            "title": "Complete"
+            "title": "Complete",
+            "type": "boolean"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
           },
           "pending": {
             "anyOf": [
@@ -9633,17 +4710,6 @@
             ],
             "title": "Pending"
           },
-          "verification_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Verification Url"
-          },
           "user_code": {
             "anyOf": [
               {
@@ -9666,26 +4732,6 @@
             ],
             "title": "User Id"
           },
-          "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Error"
-          }
-        },
-        "type": "object",
-        "required": [
-          "complete"
-        ],
-        "title": "TidalAuthCheckResponse"
-      },
-      "TidalAuthStartResponse": {
-        "properties": {
           "verification_url": {
             "anyOf": [
               {
@@ -9696,30 +4742,52 @@
               }
             ],
             "title": "Verification Url"
-          },
-          "user_code": {
-            "type": "string",
-            "title": "User Code"
-          },
-          "message": {
-            "type": "string",
-            "title": "Message"
           }
         },
-        "type": "object",
         "required": [
-          "verification_url",
+          "complete",
+          "error",
+          "pending",
           "user_code",
-          "message"
+          "user_id",
+          "verification_url"
         ],
-        "title": "TidalAuthStartResponse"
+        "title": "TidalAuthCheckResponse",
+        "type": "object"
+      },
+      "TidalAuthStartResponse": {
+        "properties": {
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "user_code": {
+            "title": "User Code",
+            "type": "string"
+          },
+          "verification_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Verification Url"
+          }
+        },
+        "required": [
+          "message",
+          "user_code",
+          "verification_url"
+        ],
+        "title": "TidalAuthStartResponse",
+        "type": "object"
       },
       "TidalEventSettings": {
+        "description": "Tidal sync settings for an event.",
         "properties": {
-          "tidal_sync_enabled": {
-            "type": "boolean",
-            "title": "Tidal Sync Enabled"
-          },
           "tidal_playlist_id": {
             "anyOf": [
               {
@@ -9730,60 +4798,53 @@
               }
             ],
             "title": "Tidal Playlist Id"
+          },
+          "tidal_sync_enabled": {
+            "title": "Tidal Sync Enabled",
+            "type": "boolean"
           }
         },
-        "type": "object",
         "required": [
+          "tidal_playlist_id",
           "tidal_sync_enabled"
         ],
         "title": "TidalEventSettings",
-        "description": "Tidal sync settings for an event."
+        "type": "object"
       },
       "TidalEventSettingsUpdate": {
+        "description": "Update Tidal sync settings for an event.",
         "properties": {
           "tidal_sync_enabled": {
-            "type": "boolean",
-            "title": "Tidal Sync Enabled"
+            "title": "Tidal Sync Enabled",
+            "type": "boolean"
           }
         },
-        "type": "object",
         "required": [
           "tidal_sync_enabled"
         ],
         "title": "TidalEventSettingsUpdate",
-        "description": "Update Tidal sync settings for an event."
+        "type": "object"
       },
       "TidalManualLink": {
+        "description": "Manual track linking request.",
         "properties": {
           "tidal_track_id": {
-            "type": "string",
             "maxLength": 100,
             "minLength": 1,
             "pattern": "^[0-9]+$",
-            "title": "Tidal Track Id"
+            "title": "Tidal Track Id",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "tidal_track_id"
         ],
         "title": "TidalManualLink",
-        "description": "Manual track linking request."
+        "type": "object"
       },
       "TidalSearchResult": {
+        "description": "Track result from Tidal search.",
         "properties": {
-          "track_id": {
-            "type": "string",
-            "title": "Track Id"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "artist": {
-            "type": "string",
-            "title": "Artist"
-          },
           "album": {
             "anyOf": [
               {
@@ -9794,6 +4855,10 @@
               }
             ],
             "title": "Album"
+          },
+          "artist": {
+            "title": "Artist",
+            "type": "string"
           },
           "bpm": {
             "anyOf": [
@@ -9806,7 +4871,7 @@
             ],
             "title": "Bpm"
           },
-          "key": {
+          "cover_url": {
             "anyOf": [
               {
                 "type": "string"
@@ -9815,7 +4880,7 @@
                 "type": "null"
               }
             ],
-            "title": "Key"
+            "title": "Cover Url"
           },
           "duration_seconds": {
             "anyOf": [
@@ -9828,32 +4893,10 @@
             ],
             "title": "Duration Seconds"
           },
-          "cover_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cover Url"
-          },
-          "tidal_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tidal Url"
-          },
-          "popularity": {
-            "type": "integer",
-            "title": "Popularity",
-            "default": 0
+          "explicit": {
+            "default": false,
+            "title": "Explicit",
+            "type": "boolean"
           },
           "isrc": {
             "anyOf": [
@@ -9866,6 +4909,41 @@
             ],
             "title": "Isrc"
           },
+          "key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "popularity": {
+            "default": 0,
+            "title": "Popularity",
+            "type": "integer"
+          },
+          "tidal_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tidal Url"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "track_id": {
+            "title": "Track Id",
+            "type": "string"
+          },
           "version": {
             "anyOf": [
               {
@@ -9876,39 +4954,29 @@
               }
             ],
             "title": "Version"
-          },
-          "explicit": {
-            "type": "boolean",
-            "title": "Explicit",
-            "default": false
           }
         },
-        "type": "object",
         "required": [
-          "track_id",
+          "album",
+          "artist",
+          "bpm",
+          "cover_url",
+          "duration_seconds",
+          "explicit",
+          "isrc",
+          "key",
+          "popularity",
+          "tidal_url",
           "title",
-          "artist"
+          "track_id",
+          "version"
         ],
         "title": "TidalSearchResult",
-        "description": "Track result from Tidal search."
+        "type": "object"
       },
       "TidalStatus": {
+        "description": "Current Tidal account linking status.",
         "properties": {
-          "linked": {
-            "type": "boolean",
-            "title": "Linked"
-          },
-          "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User Id"
-          },
           "expires_at": {
             "anyOf": [
               {
@@ -9921,23 +4989,52 @@
             "title": "Expires At"
           },
           "integration_enabled": {
-            "type": "boolean",
+            "default": true,
             "title": "Integration Enabled",
-            "default": true
+            "type": "boolean"
+          },
+          "linked": {
+            "title": "Linked",
+            "type": "boolean"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
           }
         },
-        "type": "object",
         "required": [
-          "linked"
+          "expires_at",
+          "integration_enabled",
+          "linked",
+          "user_id"
         ],
         "title": "TidalStatus",
-        "description": "Current Tidal account linking status."
+        "type": "object"
       },
       "TidalSyncResult": {
+        "description": "Result of syncing a request to Tidal playlist.",
         "properties": {
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
           "request_id": {
-            "type": "integer",
-            "title": "Request Id"
+            "title": "Request Id",
+            "type": "integer"
           },
           "status": {
             "$ref": "#/components/schemas/TidalSyncStatus"
@@ -9952,62 +5049,53 @@
               }
             ],
             "title": "Tidal Track Id"
-          },
-          "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Error"
           }
         },
-        "type": "object",
         "required": [
+          "error",
           "request_id",
-          "status"
+          "status",
+          "tidal_track_id"
         ],
         "title": "TidalSyncResult",
-        "description": "Result of syncing a request to Tidal playlist."
+        "type": "object"
       },
       "TidalSyncStatus": {
-        "type": "string",
         "enum": [
           "pending",
           "synced",
           "not_found",
           "error"
         ],
-        "title": "TidalSyncStatus"
+        "title": "TidalSyncStatus",
+        "type": "string"
       },
       "Token": {
         "properties": {
           "access_token": {
-            "type": "string",
-            "title": "Access Token"
+            "title": "Access Token",
+            "type": "string"
           },
           "token_type": {
-            "type": "string",
+            "default": "bearer",
             "title": "Token Type",
-            "default": "bearer"
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
-          "access_token"
+          "access_token",
+          "token_type"
         ],
-        "title": "Token"
+        "title": "Token",
+        "type": "object"
       },
       "UpdateCollectionSettings": {
         "properties": {
           "collection_opens_at": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
@@ -10015,11 +5103,26 @@
             ],
             "title": "Collection Opens At"
           },
+          "collection_phase_override": {
+            "anyOf": [
+              {
+                "enum": [
+                  "force_collection",
+                  "force_live"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Collection Phase Override"
+          },
           "live_starts_at": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
@@ -10030,9 +5133,9 @@
           "submission_cap_per_guest": {
             "anyOf": [
               {
-                "type": "integer",
                 "maximum": 100.0,
-                "minimum": 0.0
+                "minimum": 0.0,
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -10040,69 +5143,108 @@
             ],
             "title": "Submission Cap Per Guest"
           },
-          "collection_phase_override": {
+          "tidal_collection_bidirectional": {
             "anyOf": [
               {
-                "type": "string",
-                "enum": [
-                  "force_collection",
-                  "force_live"
-                ]
+                "type": "boolean"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Collection Phase Override"
+            "title": "Tidal Collection Bidirectional"
+          },
+          "tidal_sync_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tidal Sync Enabled"
           }
         },
-        "type": "object",
-        "title": "UpdateCollectionSettings"
+        "title": "UpdateCollectionSettings",
+        "type": "object"
       },
       "UserOut": {
         "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "username": {
-            "type": "string",
-            "title": "Username"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "role": {
-            "type": "string",
-            "title": "Role"
-          },
           "created_at": {
-            "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "type": "string"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
           },
           "help_pages_seen": {
+            "default": [],
             "items": {
               "type": "string"
             },
-            "type": "array",
             "title": "Help Pages Seen",
-            "default": []
+            "type": "array"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "pending_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pending Email"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
+          "created_at",
+          "email",
+          "help_pages_seen",
           "id",
-          "username",
           "is_active",
+          "pending_email",
           "role",
-          "created_at"
+          "username"
         ],
-        "title": "UserOut"
+        "title": "UserOut",
+        "type": "object"
       },
       "ValidationError": {
         "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
           "loc": {
             "items": {
               "anyOf": [
@@ -10114,175 +5256,5714 @@
                 }
               ]
             },
-            "type": "array",
-            "title": "Location"
+            "title": "Location",
+            "type": "array"
           },
           "msg": {
-            "type": "string",
-            "title": "Message"
+            "title": "Message",
+            "type": "string"
           },
           "type": {
-            "type": "string",
-            "title": "Error Type"
-          },
-          "input": {
-            "title": "Input"
-          },
-          "ctx": {
-            "type": "object",
-            "title": "Context"
+            "title": "Error Type",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
+          "ctx",
+          "input",
           "loc",
           "msg",
           "type"
         ],
-        "title": "ValidationError"
+        "title": "ValidationError",
+        "type": "object"
       },
       "VerifyConfirmResponse": {
         "properties": {
-          "verified": {
-            "type": "boolean",
-            "title": "Verified"
-          },
           "guest_id": {
-            "type": "integer",
-            "title": "Guest Id"
+            "title": "Guest Id",
+            "type": "integer"
           },
           "merged": {
-            "type": "boolean",
-            "title": "Merged"
+            "title": "Merged",
+            "type": "boolean"
+          },
+          "verified": {
+            "title": "Verified",
+            "type": "boolean"
           }
         },
-        "type": "object",
         "required": [
-          "verified",
           "guest_id",
-          "merged"
+          "merged",
+          "verified"
         ],
-        "title": "VerifyConfirmResponse"
+        "title": "VerifyConfirmResponse",
+        "type": "object"
       },
       "VerifyConfirmSchema": {
         "properties": {
-          "email": {
-            "type": "string",
-            "format": "email",
-            "title": "Email"
-          },
           "code": {
-            "type": "string",
-            "title": "Code"
+            "title": "Code",
+            "type": "string"
+          },
+          "email": {
+            "format": "email",
+            "title": "Email",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "email",
           "code"
         ],
-        "title": "VerifyConfirmSchema"
+        "title": "VerifyConfirmSchema",
+        "type": "object"
       },
       "VerifyHumanRequest": {
         "properties": {
           "turnstile_token": {
-            "type": "string",
             "maxLength": 4096,
             "minLength": 1,
-            "title": "Turnstile Token"
+            "title": "Turnstile Token",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "turnstile_token"
         ],
-        "title": "VerifyHumanRequest"
+        "title": "VerifyHumanRequest",
+        "type": "object"
       },
       "VerifyHumanResponse": {
         "properties": {
-          "verified": {
-            "type": "boolean",
-            "title": "Verified"
-          },
           "expires_in": {
-            "type": "integer",
-            "title": "Expires In"
+            "title": "Expires In",
+            "type": "integer"
+          },
+          "verified": {
+            "title": "Verified",
+            "type": "boolean"
           }
         },
-        "type": "object",
         "required": [
-          "verified",
-          "expires_in"
+          "expires_in",
+          "verified"
         ],
-        "title": "VerifyHumanResponse"
+        "title": "VerifyHumanResponse",
+        "type": "object"
       },
       "VerifyRequestResponse": {
         "properties": {
           "sent": {
-            "type": "boolean",
-            "title": "Sent"
+            "title": "Sent",
+            "type": "boolean"
           }
         },
-        "type": "object",
         "required": [
           "sent"
         ],
-        "title": "VerifyRequestResponse"
+        "title": "VerifyRequestResponse",
+        "type": "object"
       },
       "VerifyRequestSchema": {
         "properties": {
           "email": {
-            "type": "string",
             "format": "email",
-            "title": "Email"
+            "title": "Email",
+            "type": "string"
           },
           "turnstile_token": {
-            "type": "string",
             "maxLength": 4096,
             "minLength": 1,
-            "title": "Turnstile Token"
+            "title": "Turnstile Token",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "email",
           "turnstile_token"
         ],
-        "title": "VerifyRequestSchema"
+        "title": "VerifyRequestSchema",
+        "type": "object"
+      },
+      "VerifyStatusResponse": {
+        "description": "Reports whether the caller has a valid wrzdj_human cookie.",
+        "properties": {
+          "expires_in": {
+            "default": 0,
+            "title": "Expires In",
+            "type": "integer"
+          },
+          "verified": {
+            "title": "Verified",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "expires_in",
+          "verified"
+        ],
+        "title": "VerifyStatusResponse",
+        "type": "object"
       },
       "VoteResponse": {
         "properties": {
+          "has_voted": {
+            "title": "Has Voted",
+            "type": "boolean"
+          },
           "status": {
-            "type": "string",
-            "title": "Status"
+            "title": "Status",
+            "type": "string"
           },
           "vote_count": {
-            "type": "integer",
-            "title": "Vote Count"
-          },
-          "has_voted": {
-            "type": "boolean",
-            "title": "Has Voted"
+            "title": "Vote Count",
+            "type": "integer"
           }
         },
-        "type": "object",
         "required": [
+          "has_voted",
           "status",
-          "vote_count",
-          "has_voted"
+          "vote_count"
         ],
-        "title": "VoteResponse"
+        "title": "VoteResponse",
+        "type": "object"
       }
     },
     "securitySchemes": {
       "OAuth2PasswordBearer": {
-        "type": "oauth2",
         "flows": {
           "password": {
             "scopes": {},
             "tokenUrl": "/api/auth/login"
           }
-        }
+        },
+        "type": "oauth2"
+      }
+    }
+  },
+  "info": {
+    "description": "Song request system for DJs",
+    "title": "WrzDJ API",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/admin/ai/models": {
+      "get": {
+        "description": "List available AI models.",
+        "operationId": "admin_get_ai_models_api_admin_ai_models_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AIModelsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin Get Ai Models",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/ai/settings": {
+      "get": {
+        "description": "Get AI/LLM configuration.",
+        "operationId": "admin_get_ai_settings_api_admin_ai_settings_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AISettingsOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin Get Ai Settings",
+        "tags": [
+          "admin"
+        ]
+      },
+      "put": {
+        "description": "Update AI/LLM configuration.",
+        "operationId": "admin_update_ai_settings_api_admin_ai_settings_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AISettingsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AISettingsOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin Update Ai Settings",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/events": {
+      "get": {
+        "operationId": "admin_list_events_api_admin_events_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin List Events",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/events/bulk-delete": {
+      "post": {
+        "description": "Admin can bulk delete events from any owner.",
+        "operationId": "admin_bulk_delete_events_api_admin_events_bulk_delete_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkDeleteEventsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkActionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin Bulk Delete Events",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/events/{code}": {
+      "delete": {
+        "description": "Admin can delete any event.",
+        "operationId": "admin_delete_event_api_admin_events__code__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin Delete Event",
+        "tags": [
+          "admin"
+        ]
+      },
+      "patch": {
+        "description": "Admin can edit any event (not just their own).",
+        "operationId": "admin_update_event_api_admin_events__code__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminEventOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin Update Event",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/integrations": {
+      "get": {
+        "description": "Get status of all external integrations (no active health checks).",
+        "operationId": "admin_get_integrations_api_admin_integrations_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationHealthResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin Get Integrations",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/integrations/{service}": {
+      "patch": {
+        "description": "Enable or disable a specific integration.",
+        "operationId": "admin_toggle_integration_api_admin_integrations__service__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "service",
+            "required": true,
+            "schema": {
+              "title": "Service",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IntegrationToggleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationToggleResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin Toggle Integration",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/integrations/{service}/check": {
+      "post": {
+        "description": "Run an active health check for a specific service (rate limited).",
+        "operationId": "admin_check_integration_api_admin_integrations__service__check_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "service",
+            "required": true,
+            "schema": {
+              "title": "Service",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationCheckResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin Check Integration",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/settings": {
+      "get": {
+        "operationId": "admin_get_settings_api_admin_settings_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemSettingsOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin Get Settings",
+        "tags": [
+          "admin"
+        ]
+      },
+      "patch": {
+        "operationId": "admin_update_settings_api_admin_settings_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SystemSettingsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemSettingsOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin Update Settings",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/stats": {
+      "get": {
+        "operationId": "admin_stats_api_admin_stats_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemStats"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin Stats",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/users": {
+      "get": {
+        "operationId": "admin_list_users_api_admin_users_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Role"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin List Users",
+        "tags": [
+          "admin"
+        ]
+      },
+      "post": {
+        "operationId": "admin_create_user_api_admin_users_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminUserCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminUserOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin Create User",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/admin/users/{user_id}": {
+      "delete": {
+        "operationId": "admin_delete_user_api_admin_users__user_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin Delete User",
+        "tags": [
+          "admin"
+        ]
+      },
+      "patch": {
+        "operationId": "admin_update_user_api_admin_users__user_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminUserUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminUserOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Admin Update User",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/auth/email/confirm": {
+      "get": {
+        "operationId": "confirm_email_change_api_auth_email_confirm_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "token",
+            "required": true,
+            "schema": {
+              "title": "Token",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Confirm Email Change",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/help-seen": {
+      "post": {
+        "description": "Mark a help page as seen for the current user.",
+        "operationId": "mark_help_page_seen_api_auth_help_seen_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HelpPageSeenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Mark Help Page Seen",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "operationId": "login_api_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_login_api_auth_login_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Token"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Login",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "description": "Invalidate all outstanding JWTs for the current user.\n\nSECURITY (CRIT-2): bumps token_version so every previously-issued JWT\nfor this user fails the version check in get_current_user.",
+        "operationId": "logout_api_auth_logout_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Logout",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/me": {
+      "get": {
+        "operationId": "get_me_api_auth_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Me",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/me/email/request": {
+      "post": {
+        "operationId": "request_email_change_api_auth_me_email_request_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RequestEmailChangeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Request Email Change",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/me/password": {
+      "patch": {
+        "operationId": "change_password_api_auth_me_password_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangePasswordRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Change Password",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/register": {
+      "post": {
+        "description": "Register a new user (pending approval).",
+        "operationId": "register_api_auth_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Register",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/settings": {
+      "get": {
+        "description": "Public endpoint returning registration status and Turnstile site key.",
+        "operationId": "get_public_settings_api_auth_settings_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicSettings"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Public Settings",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/beatport/auth/login": {
+      "post": {
+        "description": "Authenticate with Beatport using username/password.\n\nThe backend logs in to Beatport server-side, obtains an authorization\ncode, exchanges it for tokens, and stores them on the user.",
+        "operationId": "login_beatport_api_beatport_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BeatportLogin"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Login Beatport",
+        "tags": [
+          "beatport"
+        ]
+      }
+    },
+    "/api/beatport/disconnect": {
+      "post": {
+        "description": "Unlink Beatport account from current user.",
+        "operationId": "disconnect_api_beatport_disconnect_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Disconnect",
+        "tags": [
+          "beatport"
+        ]
+      }
+    },
+    "/api/beatport/events/{event_id}/settings": {
+      "get": {
+        "description": "Get Beatport sync settings for an event.",
+        "operationId": "get_event_settings_api_beatport_events__event_id__settings_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "title": "Event Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeatportEventSettings"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Event Settings",
+        "tags": [
+          "beatport"
+        ]
+      },
+      "put": {
+        "description": "Update Beatport sync settings for an event.",
+        "operationId": "update_event_settings_api_beatport_events__event_id__settings_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "title": "Event Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BeatportEventSettingsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeatportEventSettings"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Event Settings",
+        "tags": [
+          "beatport"
+        ]
+      }
+    },
+    "/api/beatport/requests/{request_id}/link": {
+      "post": {
+        "description": "Manually link a Beatport track to a request.\n\nVerifies the track exists on Beatport, then stores the\nBeatport URL and metadata in sync_results_json.",
+        "operationId": "link_track_api_beatport_requests__request_id__link_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "request_id",
+            "required": true,
+            "schema": {
+              "title": "Request Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BeatportManualLink"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Link Track",
+        "tags": [
+          "beatport"
+        ]
+      }
+    },
+    "/api/beatport/search": {
+      "get": {
+        "description": "Search Beatport for tracks.",
+        "operationId": "search_api_beatport_search_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "schema": {
+              "maxLength": 200,
+              "minLength": 1,
+              "title": "Q",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 50,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/BeatportSearchResult"
+                  },
+                  "title": "Response Search Api Beatport Search Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Search",
+        "tags": [
+          "beatport"
+        ]
+      }
+    },
+    "/api/beatport/status": {
+      "get": {
+        "description": "Check if current user has linked Beatport account.",
+        "operationId": "get_status_api_beatport_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeatportStatus"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Status",
+        "tags": [
+          "beatport"
+        ]
+      }
+    },
+    "/api/bridge/apikey": {
+      "get": {
+        "description": "Return the server's bridge API key to an admin user.\n\nThe GUI uses this so the DJ doesn't have to manually paste the key.\nRestricted to admins to prevent non-owners from impersonating the bridge.",
+        "operationId": "get_bridge_api_key_api_bridge_apikey_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BridgeApiKeyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Bridge Api Key",
+        "tags": [
+          "bridge"
+        ]
+      }
+    },
+    "/api/bridge/commands/{code}": {
+      "get": {
+        "description": "Poll and clear pending commands for the bridge.\n\nRequires bridge API key auth. Returns all pending commands and clears the queue.\nRate limited to 30 requests per minute.",
+        "operationId": "get_bridge_commands_api_bridge_commands__code__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "maxLength": 10,
+              "minLength": 1,
+              "title": "Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-bridge-api-key",
+            "required": true,
+            "schema": {
+              "title": "X-Bridge-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BridgeCommandsPollResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Bridge Commands",
+        "tags": [
+          "bridge"
+        ]
+      },
+      "post": {
+        "description": "Queue a command for the bridge to pick up.\n\nRequires JWT auth. The user must own the event or be an admin.\nRate limited to 10 requests per minute.",
+        "operationId": "post_bridge_command_api_bridge_commands__code__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "maxLength": 10,
+              "minLength": 1,
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BridgeCommandRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BridgeCommandResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Post Bridge Command",
+        "tags": [
+          "bridge"
+        ]
+      }
+    },
+    "/api/bridge/nowplaying": {
+      "post": {
+        "description": "Bridge reports a new track playing.\n\nCalled when the DJ loads/plays a new track on their equipment.\nArchives the previous track to play history and updates now_playing.\nRate limited to 60 requests per minute.",
+        "operationId": "post_now_playing_api_bridge_nowplaying_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-bridge-api-key",
+            "required": true,
+            "schema": {
+              "title": "X-Bridge-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NowPlayingBridgePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Post Now Playing",
+        "tags": [
+          "bridge"
+        ]
+      }
+    },
+    "/api/bridge/nowplaying/{code}": {
+      "delete": {
+        "description": "Bridge signals track ended / deck cleared.\n\nArchives current track to history and clears now_playing.\nRate limited to 60 requests per minute.",
+        "operationId": "delete_now_playing_api_bridge_nowplaying__code__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "maxLength": 10,
+              "minLength": 1,
+              "title": "Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-bridge-api-key",
+            "required": true,
+            "schema": {
+              "title": "X-Bridge-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Now Playing",
+        "tags": [
+          "bridge"
+        ]
+      }
+    },
+    "/api/bridge/status": {
+      "post": {
+        "description": "Bridge reports connection status.\n\nCalled when bridge connects/disconnects from DJ equipment.\nRate limited to 30 requests per minute.",
+        "operationId": "post_bridge_status_api_bridge_status_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-bridge-api-key",
+            "required": true,
+            "schema": {
+              "title": "X-Bridge-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BridgeStatusPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Post Bridge Status",
+        "tags": [
+          "bridge"
+        ]
+      }
+    },
+    "/api/events": {
+      "get": {
+        "operationId": "list_events_api_events_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/EventOut"
+                  },
+                  "title": "Response List Events Api Events Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Events",
+        "tags": [
+          "events"
+        ]
+      },
+      "post": {
+        "operationId": "create_new_event_api_events_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Create New Event",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/activity": {
+      "get": {
+        "description": "Get recent activity log entries for the current user's events.",
+        "operationId": "get_activity_log_api_events_activity_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "event_code",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Event Code"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ActivityLogEntry"
+                  },
+                  "title": "Response Get Activity Log Api Events Activity Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Activity Log",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/archived": {
+      "get": {
+        "description": "List all archived and expired events for the current user.",
+        "operationId": "list_archived_events_api_events_archived_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/EventOut"
+                  },
+                  "title": "Response List Archived Events Api Events Archived Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Archived Events",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/bulk-delete": {
+      "post": {
+        "description": "Bulk delete multiple events owned by the current user.",
+        "operationId": "bulk_delete_events_endpoint_api_events_bulk_delete_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkDeleteEventsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkActionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Bulk Delete Events Endpoint",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}": {
+      "delete": {
+        "description": "Delete an event and all its requests.",
+        "operationId": "delete_event_endpoint_api_events__code__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Event Endpoint",
+        "tags": [
+          "events"
+        ]
+      },
+      "get": {
+        "operationId": "get_event_api_events__code__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Event",
+        "tags": [
+          "events"
+        ]
+      },
+      "patch": {
+        "operationId": "update_event_endpoint_api_events__code__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Event Endpoint",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/archive": {
+      "post": {
+        "description": "Archive an event.",
+        "operationId": "archive_event_endpoint_api_events__code__archive_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Archive Event Endpoint",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/banner": {
+      "delete": {
+        "description": "Delete the event's custom banner image.",
+        "operationId": "delete_banner_api_events__code__banner_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Banner",
+        "tags": [
+          "events"
+        ]
+      },
+      "post": {
+        "description": "Upload a custom banner image for the event.",
+        "operationId": "upload_banner_api_events__code__banner_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_banner_api_events__code__banner_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Upload Banner",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/bulk-review": {
+      "post": {
+        "operationId": "bulk_review_api_events__code__bulk_review_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkReviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkReviewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Bulk Review",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/collection": {
+      "get": {
+        "description": "Get pre-event collection scheduling settings.",
+        "operationId": "get_collection_settings_api_events__code__collection_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Collection Settings Api Events  Code  Collection Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Collection Settings",
+        "tags": [
+          "events"
+        ]
+      },
+      "patch": {
+        "description": "Update pre-event collection scheduling settings.",
+        "operationId": "update_collection_settings_endpoint_api_events__code__collection_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCollectionSettings"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Update Collection Settings Endpoint Api Events  Code  Collection Patch",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Collection Settings Endpoint",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/collection/sync-tidal": {
+      "post": {
+        "description": "Sync all non-rejected collection-phase requests to the DJ's Tidal playlist.\n\nIncludes pending (new) and accepted requests so the DJ can listen to guest\nsuggestions on Tidal before the review step.  Already-synced tracks are\nsilently skipped inside sync_requests_batch.",
+        "operationId": "sync_collection_to_tidal_api_events__code__collection_sync_tidal_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Sync Collection To Tidal",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/display-settings": {
+      "get": {
+        "description": "Get current display settings for an event.",
+        "operationId": "get_display_settings_api_events__code__display_settings_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DisplaySettingsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Display Settings",
+        "tags": [
+          "events"
+        ]
+      },
+      "patch": {
+        "description": "Update display settings for an event (e.g., hide/show now playing on kiosk).",
+        "operationId": "update_display_settings_api_events__code__display_settings_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisplaySettingsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DisplaySettingsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Display Settings",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/enrich-all": {
+      "post": {
+        "description": "Queue enrichment for up to ENRICH_ALL_BATCH_LIMIT requests missing BPM, key, or genre.\n\nBatched to avoid exhausting the connection pool when many tracks need enrichment.\nReturns `remaining` so the caller can re-invoke until 0.",
+        "operationId": "enrich_all_requests_api_events__code__enrich_all_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Enrich All Requests",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/export/csv": {
+      "get": {
+        "description": "Export event requests as CSV. Owner can export regardless of event status.",
+        "operationId": "export_event_csv_api_events__code__export_csv_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Export Event Csv",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/export/play-history/csv": {
+      "get": {
+        "description": "Export play history as CSV. Owner can export regardless of event status.",
+        "operationId": "export_play_history_csv_api_events__code__export_play_history_csv_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Export Play History Csv",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/pending-review": {
+      "get": {
+        "description": "Get pending review data source for DJ bulk-review.",
+        "operationId": "pending_review_api_events__code__pending_review_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PendingReviewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Pending Review",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/playlists": {
+      "get": {
+        "description": "List the DJ's playlists from connected music services.",
+        "operationId": "get_playlists_api_events__code__playlists_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Playlists",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/recommendations": {
+      "post": {
+        "description": "Generate song recommendations based on the event's musical profile.",
+        "operationId": "get_recommendations_api_events__code__recommendations_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecommendationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Recommendations",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/recommendations/from-template": {
+      "post": {
+        "description": "Generate recommendations using a template playlist.",
+        "operationId": "get_recommendations_from_template_api_events__code__recommendations_from_template_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TemplatePlaylistRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecommendationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Recommendations From Template",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/recommendations/llm": {
+      "post": {
+        "description": "Generate song recommendations from an LLM-interpreted DJ prompt.",
+        "operationId": "get_llm_recommendations_api_events__code__recommendations_llm_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LLMPromptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Llm Recommendations",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/requests": {
+      "get": {
+        "operationId": "get_event_requests_api_events__code__requests_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/RequestStatus"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Since"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "chronological",
+              "enum": [
+                "chronological",
+                "priority"
+              ],
+              "title": "Sort",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/RequestOut"
+                  },
+                  "title": "Response Get Event Requests Api Events  Code  Requests Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Event Requests",
+        "tags": [
+          "events"
+        ]
+      },
+      "post": {
+        "operationId": "submit_request_api_events__code__requests_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RequestCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Submit Request",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/requests/accept-all": {
+      "post": {
+        "description": "Accept all NEW requests for an event in one operation.",
+        "operationId": "accept_all_requests_endpoint_api_events__code__requests_accept_all_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptAllResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Accept All Requests Endpoint",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/requests/bulk": {
+      "delete": {
+        "description": "Bulk delete requests for an event, optionally filtered by status.",
+        "operationId": "bulk_delete_requests_endpoint_api_events__code__requests_bulk_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkActionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Bulk Delete Requests Endpoint",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/requests/reject-all": {
+      "post": {
+        "description": "Reject all NEW requests for an event in one operation.",
+        "operationId": "reject_all_requests_endpoint_api_events__code__requests_reject_all_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkActionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Reject All Requests Endpoint",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/search": {
+      "get": {
+        "description": "Public search endpoint for event guests.\n\nPriority: Tidal (primary) \u2192 Spotify (fallback) \u2192 Beatport (event toggle).\nResults are filtered for junk, deduplicated by ISRC, and sorted by popularity.",
+        "operationId": "event_search_api_events__code__search_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "schema": {
+              "maxLength": 200,
+              "minLength": 2,
+              "title": "Q",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/SearchResult"
+                  },
+                  "title": "Response Event Search Api Events  Code  Search Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Event Search",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/events/{code}/unarchive": {
+      "post": {
+        "description": "Unarchive an event.",
+        "operationId": "unarchive_event_endpoint_api_events__code__unarchive_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Unarchive Event Endpoint",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/api/health": {
+      "get": {
+        "description": "Health check endpoint for monitoring and load balancers.",
+        "operationId": "api_health_check_api_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api Health Check",
+        "tags": [
+          "health"
+        ]
+      }
+    },
+    "/api/kiosk/mine": {
+      "get": {
+        "description": "List all kiosks paired by the current user.",
+        "operationId": "list_my_kiosks_api_kiosk_mine_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/KioskOut"
+                  },
+                  "title": "Response List My Kiosks Api Kiosk Mine Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List My Kiosks",
+        "tags": [
+          "kiosk"
+        ]
+      }
+    },
+    "/api/kiosk/pair/{pair_code}/complete": {
+      "post": {
+        "description": "Complete a kiosk pairing by assigning an event.",
+        "operationId": "complete_kiosk_pairing_api_kiosk_pair__pair_code__complete_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pair_code",
+            "required": true,
+            "schema": {
+              "title": "Pair Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KioskCompletePairingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Complete Kiosk Pairing",
+        "tags": [
+          "kiosk"
+        ]
+      }
+    },
+    "/api/kiosk/{kiosk_id}": {
+      "delete": {
+        "description": "Unpair and delete a kiosk.",
+        "operationId": "delete_kiosk_endpoint_api_kiosk__kiosk_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "kiosk_id",
+            "required": true,
+            "schema": {
+              "title": "Kiosk Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Kiosk Endpoint",
+        "tags": [
+          "kiosk"
+        ]
+      },
+      "patch": {
+        "description": "Rename a kiosk.",
+        "operationId": "rename_kiosk_endpoint_api_kiosk__kiosk_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "kiosk_id",
+            "required": true,
+            "schema": {
+              "title": "Kiosk Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KioskRenameRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Rename Kiosk Endpoint",
+        "tags": [
+          "kiosk"
+        ]
+      }
+    },
+    "/api/kiosk/{kiosk_id}/assign": {
+      "patch": {
+        "description": "Change which event a kiosk displays.",
+        "operationId": "assign_kiosk_api_kiosk__kiosk_id__assign_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "kiosk_id",
+            "required": true,
+            "schema": {
+              "title": "Kiosk Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KioskAssignRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Assign Kiosk",
+        "tags": [
+          "kiosk"
+        ]
+      }
+    },
+    "/api/public/collect/{code}": {
+      "get": {
+        "operationId": "preview_api_public_collect__code__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectEventPreview"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Preview",
+        "tags": [
+          "collect"
+        ]
+      }
+    },
+    "/api/public/collect/{code}/enrich-preview": {
+      "post": {
+        "description": "Lightweight Beatport BPM/key lookup for search-time vibes \u2014 no DB writes.",
+        "operationId": "enrich_preview_api_public_collect__code__enrich_preview_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnrichPreviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnrichPreviewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Enrich Preview",
+        "tags": [
+          "collect"
+        ]
+      }
+    },
+    "/api/public/collect/{code}/leaderboard": {
+      "get": {
+        "operationId": "leaderboard_api_public_collect__code__leaderboard_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "tab",
+            "required": false,
+            "schema": {
+              "default": "trending",
+              "enum": [
+                "trending",
+                "all"
+              ],
+              "title": "Tab",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectLeaderboardResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Leaderboard",
+        "tags": [
+          "collect"
+        ]
+      }
+    },
+    "/api/public/collect/{code}/live-join-code": {
+      "get": {
+        "description": "Return the live join_code for an event that has entered the live phase.\n\nRequires a verified human cookie (not email verification) so the join_code\nis never leaked to unverified bots scraping /collect during the\ncollection-to-live transition. The join_code is otherwise revealed only\nvia the QR code at the event venue.",
+        "operationId": "get_live_join_code_api_public_collect__code__live_join_code_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LiveJoinCodeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Live Join Code",
+        "tags": [
+          "collect"
+        ]
+      }
+    },
+    "/api/public/collect/{code}/profile": {
+      "get": {
+        "operationId": "get_profile_api_public_collect__code__profile_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectProfileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Profile",
+        "tags": [
+          "collect"
+        ]
+      },
+      "post": {
+        "operationId": "set_profile_api_public_collect__code__profile_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollectProfileRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectProfileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Set Profile",
+        "tags": [
+          "collect"
+        ]
+      }
+    },
+    "/api/public/collect/{code}/profile/me": {
+      "get": {
+        "operationId": "my_picks_api_public_collect__code__profile_me_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectMyPicksResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "My Picks",
+        "tags": [
+          "collect"
+        ]
+      }
+    },
+    "/api/public/collect/{code}/requests": {
+      "post": {
+        "operationId": "submit_api_public_collect__code__requests_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollectSubmitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Submit",
+        "tags": [
+          "collect"
+        ]
+      }
+    },
+    "/api/public/collect/{code}/requests/{request_id}/preview": {
+      "get": {
+        "operationId": "request_preview_api_public_collect__code__requests__request_id__preview_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "request_id",
+            "required": true,
+            "schema": {
+              "title": "Request Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectPreviewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Request Preview",
+        "tags": [
+          "collect"
+        ]
+      }
+    },
+    "/api/public/collect/{code}/vote": {
+      "post": {
+        "operationId": "vote_api_public_collect__code__vote_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollectVoteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Vote",
+        "tags": [
+          "collect"
+        ]
+      }
+    },
+    "/api/public/e/{code}/bridge-status": {
+      "get": {
+        "description": "Get bridge connection status for public display.\n\nIndependent of track data \u2014 returns bridge connectivity even when\nno track is currently playing.",
+        "operationId": "get_public_bridge_status_api_public_e__code__bridge_status_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BridgeStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Public Bridge Status",
+        "tags": [
+          "bridge"
+        ]
+      }
+    },
+    "/api/public/e/{code}/history": {
+      "get": {
+        "description": "Get play history for public display.\n\nReturns the list of tracks played during the event, newest first.",
+        "operationId": "get_public_history_api_public_e__code__history_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlayHistoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Public History",
+        "tags": [
+          "bridge"
+        ]
+      }
+    },
+    "/api/public/e/{code}/nowplaying": {
+      "get": {
+        "description": "Get current now-playing track for public display.\n\nReturns the track currently playing from StageLinQ, or None if nothing playing.",
+        "operationId": "get_public_now_playing_api_public_e__code__nowplaying_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/NowPlayingResponse"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "title": "Response Get Public Now Playing Api Public E  Code  Nowplaying Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Public Now Playing",
+        "tags": [
+          "bridge"
+        ]
+      }
+    },
+    "/api/public/events/{code}/display": {
+      "get": {
+        "description": "Get public kiosk display data for an event.",
+        "operationId": "get_kiosk_display_api_public_events__code__display_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskDisplayResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Kiosk Display",
+        "tags": [
+          "public"
+        ]
+      }
+    },
+    "/api/public/events/{code}/has-requested": {
+      "get": {
+        "description": "Check if the current client has submitted any requests for this event.",
+        "operationId": "check_has_requested_api_public_events__code__has_requested_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HasRequestedResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Check Has Requested",
+        "tags": [
+          "public"
+        ]
+      }
+    },
+    "/api/public/events/{code}/my-requests": {
+      "get": {
+        "description": "Get all requests submitted by the current client for this event.",
+        "operationId": "get_my_requests_api_public_events__code__my_requests_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MyRequestsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get My Requests",
+        "tags": [
+          "public"
+        ]
+      }
+    },
+    "/api/public/events/{code}/requests": {
+      "get": {
+        "description": "Get publicly visible requests for an event (NEW and ACCEPTED only).",
+        "operationId": "get_public_requests_api_public_events__code__requests_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GuestRequestListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Public Requests",
+        "tags": [
+          "public"
+        ]
+      }
+    },
+    "/api/public/events/{code}/stream": {
+      "get": {
+        "description": "Public SSE endpoint for real-time event updates.\n\nSECURITY (CRIT-5): rate-limited and existence-checked. Before this fix,\nthe endpoint had no rate limit and no existence check, allowing\nunauthenticated DoS (unlimited long-lived connections exhausting FDs)\nand passive eavesdropping via 6-char event-code brute force.\n\nEvent types:\n- request_created: New request submitted\n- request_status_changed: Request status update\n- now_playing_changed: Now-playing track update\n- requests_bulk_update: Batch accept/reject\n- bridge_status_changed: Bridge connect/disconnect",
+        "operationId": "event_stream_api_public_events__code__stream_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Event Stream",
+        "tags": [
+          "sse"
+        ]
+      }
+    },
+    "/api/public/guest/identify": {
+      "post": {
+        "description": "Resolve guest identity via cookie token and/or browser fingerprint.",
+        "operationId": "identify_api_public_guest_identify_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IdentifyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IdentifyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Identify",
+        "tags": [
+          "guest"
+        ]
+      }
+    },
+    "/api/public/guest/verify-human": {
+      "post": {
+        "description": "Validate a Turnstile token and issue a wrzdj_human session cookie.",
+        "operationId": "verify_human_api_public_guest_verify_human_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyHumanRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyHumanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Verify Human",
+        "tags": [
+          "guest"
+        ]
+      }
+    },
+    "/api/public/guest/verify-status": {
+      "get": {
+        "description": "Report whether the caller already has a valid wrzdj_human cookie.\n\nReturns verified=false on missing, expired, version-mismatched, or\ntampered cookies. No side effects (no cookie refresh, no DB writes).\nSafe to call on every page mount.",
+        "operationId": "verify_status_api_public_guest_verify_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Verify Status",
+        "tags": [
+          "guest"
+        ]
+      }
+    },
+    "/api/public/guest/verify/confirm": {
+      "post": {
+        "description": "Confirm a verification code. May trigger guest merge.",
+        "operationId": "confirm_code_api_public_guest_verify_confirm_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyConfirmSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyConfirmResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Confirm Code",
+        "tags": [
+          "verify"
+        ]
+      }
+    },
+    "/api/public/guest/verify/request": {
+      "post": {
+        "description": "Send a verification code to the provided email.\n\nRequires a fresh Turnstile token (separate from the session cookie) to\nprotect against email-cost / sender-reputation abuse.",
+        "operationId": "request_verification_code_api_public_guest_verify_request_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyRequestSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyRequestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Request Verification Code",
+        "tags": [
+          "verify"
+        ]
+      }
+    },
+    "/api/public/kiosk/pair": {
+      "post": {
+        "description": "Create a new kiosk pairing session.\n\nRequires a valid X-Pair-Nonce header obtained from /pair-challenge,\nbound to the same client IP. Nonce is consumed on use.",
+        "operationId": "create_pairing_api_public_kiosk_pair_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskPairResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Create Pairing",
+        "tags": [
+          "kiosk"
+        ]
+      }
+    },
+    "/api/public/kiosk/pair-challenge": {
+      "get": {
+        "description": "Issue a one-time IP-bound nonce required for kiosk pairing.",
+        "operationId": "get_pair_challenge_api_public_kiosk_pair_challenge_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskPairChallengeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Pair Challenge",
+        "tags": [
+          "kiosk"
+        ]
+      }
+    },
+    "/api/public/kiosk/pair/{pair_code}/status": {
+      "get": {
+        "description": "Poll the status of a pairing code.",
+        "operationId": "get_pair_status_api_public_kiosk_pair__pair_code__status_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pair_code",
+            "required": true,
+            "schema": {
+              "title": "Pair Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskPairStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Pair Status",
+        "tags": [
+          "kiosk"
+        ]
+      }
+    },
+    "/api/public/kiosk/session/assignment": {
+      "get": {
+        "description": "Poll the kiosk's current event assignment. Updates last_seen_at.\n\nSession token must be sent in the X-Kiosk-Session header (not in the URL path)\nto prevent token leakage in access logs.",
+        "operationId": "get_session_assignment_api_public_kiosk_session_assignment_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KioskSessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Session Assignment",
+        "tags": [
+          "kiosk"
+        ]
+      }
+    },
+    "/api/requests/{request_id}": {
+      "delete": {
+        "description": "Delete a single request. Ownership verified via event.",
+        "operationId": "delete_request_endpoint_api_requests__request_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "request_id",
+            "required": true,
+            "schema": {
+              "title": "Request Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Request Endpoint",
+        "tags": [
+          "requests"
+        ]
+      },
+      "patch": {
+        "operationId": "update_request_api_requests__request_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "request_id",
+            "required": true,
+            "schema": {
+              "title": "Request Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RequestUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Request",
+        "tags": [
+          "requests"
+        ]
+      }
+    },
+    "/api/requests/{request_id}/refresh-metadata": {
+      "post": {
+        "description": "Clear existing metadata and re-enrich from external services.",
+        "operationId": "refresh_request_metadata_api_requests__request_id__refresh_metadata_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "request_id",
+            "required": true,
+            "schema": {
+              "title": "Request Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Refresh Request Metadata",
+        "tags": [
+          "requests"
+        ]
+      }
+    },
+    "/api/requests/{request_id}/vote": {
+      "delete": {
+        "description": "Remove vote from a song request. Idempotent.\n\nRequires a guest cookie. Anonymous callers receive 401.",
+        "operationId": "unvote_request_api_requests__request_id__vote_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "request_id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": 0,
+              "title": "Request Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VoteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Unvote Request",
+        "tags": [
+          "votes"
+        ]
+      },
+      "post": {
+        "description": "Upvote a song request. Idempotent: voting twice has no effect.\n\nRequires a guest cookie. Anonymous callers receive 401.",
+        "operationId": "vote_for_request_api_requests__request_id__vote_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "request_id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": 0,
+              "title": "Request Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VoteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Vote For Request",
+        "tags": [
+          "votes"
+        ]
+      }
+    },
+    "/api/search": {
+      "get": {
+        "description": "DJ search endpoint. Tidal primary, Spotify fallback.",
+        "operationId": "search_api_search_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "schema": {
+              "maxLength": 200,
+              "minLength": 2,
+              "title": "Q",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/SearchResult"
+                  },
+                  "title": "Response Search Api Search Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Search",
+        "tags": [
+          "search"
+        ]
+      }
+    },
+    "/api/search/cache": {
+      "delete": {
+        "description": "Clear all cached search results (admin only).",
+        "operationId": "clear_search_cache_api_search_cache_delete",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CacheClearResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Clear Search Cache",
+        "tags": [
+          "search"
+        ]
+      }
+    },
+    "/api/tidal/auth/cancel": {
+      "post": {
+        "description": "Cancel pending device login.",
+        "operationId": "cancel_auth_api_tidal_auth_cancel_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Cancel Auth",
+        "tags": [
+          "tidal"
+        ]
+      }
+    },
+    "/api/tidal/auth/check": {
+      "get": {
+        "description": "Check if device login is complete.\n\nReturns:\n- complete: true if login succeeded\n- pending: true if still waiting for user\n- error: error message if login failed",
+        "operationId": "check_auth_api_tidal_auth_check_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TidalAuthCheckResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Check Auth",
+        "tags": [
+          "tidal"
+        ]
+      }
+    },
+    "/api/tidal/auth/start": {
+      "post": {
+        "description": "Start Tidal device login flow.\n\nReturns a URL and code for the user to visit and authorize.\nThe frontend should poll /auth/check to wait for completion.",
+        "operationId": "start_auth_api_tidal_auth_start_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TidalAuthStartResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Start Auth",
+        "tags": [
+          "tidal"
+        ]
+      }
+    },
+    "/api/tidal/disconnect": {
+      "post": {
+        "description": "Unlink Tidal account from current user.",
+        "operationId": "disconnect_api_tidal_disconnect_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusMessageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Disconnect",
+        "tags": [
+          "tidal"
+        ]
+      }
+    },
+    "/api/tidal/events/{event_id}/settings": {
+      "get": {
+        "description": "Get Tidal sync settings for an event.",
+        "operationId": "get_event_settings_api_tidal_events__event_id__settings_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "title": "Event Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TidalEventSettings"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Event Settings",
+        "tags": [
+          "tidal"
+        ]
+      },
+      "put": {
+        "description": "Update Tidal sync settings for an event.",
+        "operationId": "update_event_settings_api_tidal_events__event_id__settings_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "title": "Event Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TidalEventSettingsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TidalEventSettings"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Event Settings",
+        "tags": [
+          "tidal"
+        ]
+      }
+    },
+    "/api/tidal/requests/{request_id}/link": {
+      "post": {
+        "description": "Manually link a Tidal track to a request.",
+        "operationId": "link_track_api_tidal_requests__request_id__link_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "request_id",
+            "required": true,
+            "schema": {
+              "title": "Request Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TidalManualLink"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TidalSyncResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Link Track",
+        "tags": [
+          "tidal"
+        ]
+      }
+    },
+    "/api/tidal/requests/{request_id}/sync": {
+      "post": {
+        "description": "Manually trigger Tidal sync for a request.",
+        "operationId": "sync_request_api_tidal_requests__request_id__sync_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "request_id",
+            "required": true,
+            "schema": {
+              "title": "Request Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TidalSyncResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Sync Request",
+        "tags": [
+          "tidal"
+        ]
+      }
+    },
+    "/api/tidal/search": {
+      "get": {
+        "description": "Search Tidal for tracks.",
+        "operationId": "search_api_tidal_search_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Q",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 50,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/TidalSearchResult"
+                  },
+                  "title": "Response Search Api Tidal Search Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Search",
+        "tags": [
+          "tidal"
+        ]
+      }
+    },
+    "/api/tidal/status": {
+      "get": {
+        "description": "Check if current user has linked Tidal account.",
+        "operationId": "get_status_api_tidal_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TidalStatus"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Status",
+        "tags": [
+          "tidal"
+        ]
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "health_check_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Health Check"
       }
     }
   }


### PR DESCRIPTION
## Summary

Three classes of fixes:

### Kiosk display 404 (production bug)
\`dashboard/app/kiosk-pair/page.tsx\` navigated to \`/e/{status.event_code}/display\` after pairing. Since PR #324 \`/e/{code}/display\` resolves by \`join_code\`, so every kiosk paired post-PR-#324 hit 404. Fix: use \`status.event_join_code\` (field added to KioskSessionResponse in PR #324). Regenerated \`api-types.generated.ts\` so the field is visible to the TS client.

### Event detail page label mismatch
The big bold code shown above the "Scan to join" QR was \`event.code\` (collection code); the QR encodes \`event.join_code\`. Updated the label + the joinUrl fallback. Backend's \`event.join_url\` already had the right value when set; this fixes the visible display + the fallback path.

### CodeRabbit nitpicks from PR #326
- \`verify_status\`: removed unused \`db: Session = Depends(get_db)\`
- Spinner: added \`prefers-reduced-motion: reduce\` override
- Overlay dialog: added \`aria-modal="true"\`

## Test plan
- [x] Frontend: 934/934 vitest
- [x] Backend: ruff/format/bandit clean, verify-status tests pass
- [x] Typecheck clean after schema regen
- [ ] Manual smoke (post-deploy):
  - [ ] Pair a kiosk → display loads (not 404)
  - [ ] DJ event page → QR code label shows the join_code, not collection code
  - [ ] Scan QR with phone → lands on /join/{join_code} → live UX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added join code functionality for event access and display.
  * Introduced human verification system with status tracking.
  * Added password and email change endpoints for authenticated users.
  * New collection sync and preview capabilities.

* **Improvements**
  * Enhanced accessibility with modal dialog attributes.
  * Added support for reduced motion preferences in animations.
  * Expanded requester verification tracking across collection features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->