### PR TITLE
fix(routing): bridge endpoints + DJ kiosk links use join_code

### DIFF
--- a/dashboard/app/(dj)/events/[code]/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/__tests__/page.test.tsx
@@ -307,7 +307,7 @@ describe('EventQueuePage', () => {
       expect(screen.getByTestId('qr-code')).toBeInTheDocument();
     });
 
-    it('renders event join_code under the QR (not the collection code)', async () => {
+    it('renders event join_code under the QR and encodes it in the QR payload', async () => {
       setupDefaultMocks();
 
       render(<EventQueuePage />);
@@ -318,6 +318,11 @@ describe('EventQueuePage', () => {
       await waitFor(() => {
         expect(screen.getByText('TSETJO')).toBeInTheDocument();
       });
+      // Lock in the QR routing contract: scanning the QR must take guests to
+      // /join/{join_code}, not /join/{collection_code}.
+      const qr = screen.getByTestId('qr-code');
+      expect(qr.getAttribute('data-value')).toContain('/join/TSETJO');
+      expect(qr.getAttribute('data-value')).not.toContain('/join/TEST');
     });
   });
 

--- a/dashboard/app/(dj)/events/[code]/components/EventManagementTab.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/EventManagementTab.tsx
@@ -63,6 +63,7 @@ export function EventManagementTab(props: EventManagementTabProps) {
       <HelpSpot spotId="event-kiosk" page="event-manage" order={1} title="Kiosk Controls" description="Toggle requests open/closed, show/hide now-playing, enable display-only mode.">
         <KioskControlsCard
           code={props.code}
+          joinCode={props.event.join_code}
           requestsOpen={props.requestsOpen}
           togglingRequests={props.togglingRequests}
           onToggleRequests={props.onToggleRequests}
@@ -98,7 +99,7 @@ export function EventManagementTab(props: EventManagementTabProps) {
       />
 
       <HelpSpot spotId="event-stream-overlay" page="event-manage" order={3} title="Stream Overlay" description="Copy the OBS browser source URL to show currently playing track on your stream.">
-        <StreamOverlayCard code={props.code} />
+        <StreamOverlayCard joinCode={props.event.join_code} />
       </HelpSpot>
 
       <HelpSpot spotId="event-bridge" page="event-manage" order={4} title="Bridge Status" description="Shows Bridge App connection status with live diagnostics. When connected, use Ping to test responsiveness, Reset Decks to clear stale track state, Reconnect to re-establish equipment detection, or Restart for a full bridge reset.">

--- a/dashboard/app/(dj)/events/[code]/components/KioskControlsCard.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/KioskControlsCard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 interface KioskControlsCardProps {
-  code: string;
+  code: string;        // collection code (DJ-side identifier; kept for legacy uses)
+  joinCode: string;    // join_code — used for the public /e/{join_code}/display URL
   requestsOpen: boolean;
   togglingRequests: boolean;
   onToggleRequests: () => void;
@@ -19,7 +20,8 @@ interface KioskControlsCardProps {
 }
 
 export function KioskControlsCard({
-  code,
+  code: _code,
+  joinCode,
   requestsOpen,
   togglingRequests,
   onToggleRequests,
@@ -45,7 +47,7 @@ export function KioskControlsCard({
           </p>
         </div>
         <a
-          href={`/e/${code}/display`}
+          href={`/e/${joinCode}/display`}
           target="_blank"
           rel="noopener noreferrer"
           className="btn btn-sm"

--- a/dashboard/app/(dj)/events/[code]/components/StreamOverlayCard.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/StreamOverlayCard.tsx
@@ -4,14 +4,14 @@ import { useState } from 'react';
 import { Tooltip } from '@/components/Tooltip';
 
 interface StreamOverlayCardProps {
-  code: string;
+  joinCode: string;  // join_code — overlay URL routes by join_code per public-page contract
 }
 
-export function StreamOverlayCard({ code }: StreamOverlayCardProps) {
+export function StreamOverlayCard({ joinCode }: StreamOverlayCardProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
-    const overlayUrl = `${window.location.origin}/e/${code}/overlay`;
+    const overlayUrl = `${window.location.origin}/e/${joinCode}/overlay`;
     try {
       await navigator.clipboard.writeText(overlayUrl);
       setCopied(true);
@@ -32,7 +32,7 @@ export function StreamOverlayCard({ code }: StreamOverlayCardProps) {
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <a
-            href={`/e/${code}/overlay`}
+            href={`/e/${joinCode}/overlay`}
             target="_blank"
             rel="noopener noreferrer"
             className="btn btn-sm"

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -693,6 +693,9 @@ a {
   .identity-bar-pulse {
     animation: none;
   }
+  .hv-overlay-spinner {
+    animation: none;
+  }
 }
 
 /* Sticky bottom button */
@@ -2542,11 +2545,8 @@ h1, .display-heading {
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .hv-overlay-spinner {
-    animation: none;
-  }
-}
+/* hv-overlay-spinner prefers-reduced-motion override consolidated into the
+   primary block near line 687. */
 
 .hv-overlay-retry {
   padding: 0.6rem 1.2rem;

--- a/server/app/api/bridge.py
+++ b/server/app/api/bridge.py
@@ -27,6 +27,7 @@ from app.services.event import (
     EventLookupResult,
     get_event_by_code_for_owner,
     get_event_by_code_with_status,
+    get_event_by_join_code_with_status,
 )
 from app.services.event_bus import publish_event
 from app.services.now_playing import (
@@ -180,8 +181,11 @@ def get_public_now_playing(
     Get current now-playing track for public display.
 
     Returns the track currently playing from StageLinQ, or None if nothing playing.
+
+    Resolves by join_code: this endpoint serves the kiosk display + OBS overlay
+    pages, which route by join_code per the post-PR-#324 public/guest URL contract.
     """
-    event, lookup_result = get_event_by_code_with_status(db, code)
+    event, lookup_result = get_event_by_join_code_with_status(db, code)
 
     if lookup_result == EventLookupResult.NOT_FOUND:
         raise HTTPException(status_code=404, detail="Event not found")
@@ -206,9 +210,10 @@ def get_public_bridge_status(
     Get bridge connection status for public display.
 
     Independent of track data — returns bridge connectivity even when
-    no track is currently playing.
+    no track is currently playing. Resolves by join_code: serves guest-facing
+    kiosk display + overlay pages.
     """
-    event, lookup_result = get_event_by_code_with_status(db, code)
+    event, lookup_result = get_event_by_join_code_with_status(db, code)
 
     if lookup_result == EventLookupResult.NOT_FOUND:
         raise HTTPException(status_code=404, detail="Event not found")
@@ -239,8 +244,9 @@ def get_public_history(
     Get play history for public display.
 
     Returns the list of tracks played during the event, newest first.
+    Resolves by join_code: serves guest-facing kiosk display.
     """
-    event, lookup_result = get_event_by_code_with_status(db, code)
+    event, lookup_result = get_event_by_join_code_with_status(db, code)
 
     if lookup_result == EventLookupResult.NOT_FOUND:
         raise HTTPException(status_code=404, detail="Event not found")

--- a/server/tests/test_bridge_api.py
+++ b/server/tests/test_bridge_api.py
@@ -343,7 +343,7 @@ class TestGetPublicNowPlaying:
         )
 
         # Get public now_playing
-        response = client.get("/api/public/e/TEST01/nowplaying")
+        response = client.get("/api/public/e/UG4BHD/nowplaying")
 
         assert response.status_code == 200
         data = response.json()
@@ -354,7 +354,7 @@ class TestGetPublicNowPlaying:
 
     def test_returns_null_when_empty(self, client: TestClient, test_event: Event):
         """Returns null when no track playing."""
-        response = client.get("/api/public/e/TEST01/nowplaying")
+        response = client.get("/api/public/e/UG4BHD/nowplaying")
 
         assert response.status_code == 200
         assert response.json() is None
@@ -366,7 +366,7 @@ class TestGetPublicNowPlaying:
 
     def test_expired_event(self, client: TestClient, expired_event: Event):
         """Returns 410 for expired event."""
-        response = client.get("/api/public/e/EXPIRE/nowplaying")
+        response = client.get("/api/public/e/2ZZN6B/nowplaying")
         assert response.status_code == 410
 
 
@@ -375,7 +375,7 @@ class TestGetPublicHistory:
 
     def test_returns_empty_history(self, client: TestClient, test_event: Event):
         """Returns empty history."""
-        response = client.get("/api/public/e/TEST01/history")
+        response = client.get("/api/public/e/UG4BHD/history")
 
         assert response.status_code == 200
         data = response.json()
@@ -396,7 +396,7 @@ class TestGetPublicHistory:
             db.add(history)
         db.commit()
 
-        response = client.get("/api/public/e/TEST01/history")
+        response = client.get("/api/public/e/UG4BHD/history")
 
         assert response.status_code == 200
         data = response.json()
@@ -418,7 +418,7 @@ class TestGetPublicHistory:
             db.add(history)
         db.commit()
 
-        response = client.get("/api/public/e/TEST01/history?limit=3&offset=3")
+        response = client.get("/api/public/e/UG4BHD/history?limit=3&offset=3")
 
         assert response.status_code == 200
         data = response.json()
@@ -427,11 +427,11 @@ class TestGetPublicHistory:
 
     def test_limit_capped(self, client: TestClient, test_event: Event):
         """Limit is capped at 100 via Query validation."""
-        response = client.get("/api/public/e/TEST01/history?limit=200")
+        response = client.get("/api/public/e/UG4BHD/history?limit=200")
         assert response.status_code == 422  # FastAPI rejects limit > 100
 
         # Valid limit at the boundary works
-        response = client.get("/api/public/e/TEST01/history?limit=100")
+        response = client.get("/api/public/e/UG4BHD/history?limit=100")
         assert response.status_code == 200
 
     def test_event_not_found(self, client: TestClient):
@@ -441,7 +441,7 @@ class TestGetPublicHistory:
 
     def test_expired_event(self, client: TestClient, expired_event: Event):
         """Returns 410 for expired event."""
-        response = client.get("/api/public/e/EXPIRE/history")
+        response = client.get("/api/public/e/2ZZN6B/history")
         assert response.status_code == 410
 
 

--- a/server/tests/test_bridge_api.py
+++ b/server/tests/test_bridge_api.py
@@ -370,6 +370,41 @@ class TestGetPublicNowPlaying:
         assert response.status_code == 410
 
 
+class TestGetPublicBridgeStatus:
+    """Tests for GET /api/public/e/{code}/bridge-status endpoint.
+
+    This endpoint resolves by join_code (post PR #324 / #328 routing migration)
+    because it serves the kiosk display + OBS overlay public pages.
+    """
+
+    def test_returns_default_status_when_no_now_playing(
+        self, client: TestClient, test_event: Event
+    ):
+        """Returns default (disconnected) status when no track has ever played."""
+        response = client.get("/api/public/e/UG4BHD/bridge-status")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["connected"] is False
+        assert data["device_name"] is None
+
+    def test_event_not_found(self, client: TestClient):
+        """Returns 404 for an unknown event code."""
+        response = client.get("/api/public/e/INVALID/bridge-status")
+        assert response.status_code == 404
+
+    def test_collection_code_is_rejected(self, client: TestClient, test_event: Event):
+        """Locks in the join_code routing contract: passing the collection
+        code must 404. Prevents accidental regression to the pre-PR-#328
+        get_event_by_code_with_status resolver."""
+        response = client.get(f"/api/public/e/{test_event.code}/bridge-status")
+        assert response.status_code == 404
+
+    def test_expired_event(self, client: TestClient, expired_event: Event):
+        """Returns 410 for an expired event (resolved via join_code)."""
+        response = client.get("/api/public/e/2ZZN6B/bridge-status")
+        assert response.status_code == 410
+
+
 class TestGetPublicHistory:
     """Tests for GET /api/public/e/{code}/history endpoint."""
 


### PR DESCRIPTION
## Summary

Completes the join_code routing migration started in PR #324. Two more surfaces were left on the collection-code path and broke the kiosk display end-to-end:

1. **Backend bridge public endpoints** (\`/api/public/e/{code}/{nowplaying,bridge-status,history}\`) resolved by collection code. The kiosk display page now visits these with the join_code (per PR #324 Phase 5), so all three were 404'ing.
2. **DJ-dashboard kiosk preview + stream-overlay links** linked to \`/e/{collection_code}/...\` — those URLs route by join_code, so the buttons 404'd as well.

Plus the two unactioned CR nitpicks from PR #327:
- Consolidate duplicate \`prefers-reduced-motion\` blocks in globals.css
- QR payload assertion in event detail test

## Test plan

- [x] Backend: full pytest (2023 pass), ruff/format/bandit clean
- [x] Frontend: 934 vitest pass, tsc + lint clean
- [ ] Manual smoke (post-deploy):
  - [ ] Pair a kiosk → /e/{join_code}/display loads with now-playing data
  - [ ] DJ event page → "Preview Kiosk" button goes to /e/{join_code}/display
  - [ ] DJ event page → "Stream Overlay" copies URL with join_code
  - [ ] /api/public/e/HQELUS/nowplaying → 200 (was 404)
  - [ ] /api/public/e/ELZ2G2/nowplaying → 404 (collection code rejected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * QR codes, kiosk preview links, and stream overlay links now consistently use event join codes for public-facing access.
  * Public endpoints for kiosk/guest pages now resolve events by join code.
  * Consolidated reduced-motion handling to improve accessibility for the human-verification spinner.

* **Tests**
  * Updated integration and UI tests to validate join-code routing and QR payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->