### PR TITLE
feat(ai): provider-agnostic LLM gateway + 3 connectors + recommendation migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,22 @@ BOOTSTRAP_ADMIN_PASSWORD=your-secure-password
 # TURNSTILE_SECRET_KEY=your-secret-key
 
 # =============================================================================
+# LLM / AI providers
+# =============================================================================
+# As of v2026.05.24, LLM credentials are managed per-DJ via the gateway
+# (admin: /admin/ai, DJ: /settings/ai). On first deploy, ANTHROPIC_API_KEY
+# is migrated into an "anthropic_apikey" connector owned by the first admin
+# user and set as the org-default connector. After the migration runs you
+# can remove ANTHROPIC_API_KEY from this file — a follow-up release will
+# delete the env-var fallback path entirely (tracked under the "AI Engine
+# Back-end Redesign" milestone).
+#
+# ANTHROPIC_API_KEY=your-anthropic-key       # DEPRECATED — migrated to connector
+# ANTHROPIC_MODEL=claude-haiku-4-5-20251001
+# ANTHROPIC_MAX_TOKENS=1024
+# ANTHROPIC_TIMEOUT_SECONDS=15
+
+# =============================================================================
 # Frontend (Next.js)
 # =============================================================================
 # API URL for the dashboard to connect to

--- a/.env.example
+++ b/.env.example
@@ -123,11 +123,11 @@ BOOTSTRAP_ADMIN_PASSWORD=your-secure-password
 # =============================================================================
 # As of v2026.05.24, LLM credentials are managed per-DJ via the gateway
 # (admin: /admin/ai, DJ: /settings/ai). On first deploy, ANTHROPIC_API_KEY
-# is migrated into an "anthropic_apikey" connector owned by the first admin
-# user and set as the org-default connector. After the migration runs you
-# can remove ANTHROPIC_API_KEY from this file — a follow-up release will
-# delete the env-var fallback path entirely (tracked under the "AI Engine
-# Back-end Redesign" milestone).
+# is migrated into a system-default "anthropic_apikey" connector (assigned
+# to the first admin user for management, set as the org-wide default).
+# After the migration runs you can remove ANTHROPIC_API_KEY from this file
+# — a follow-up release will delete the env-var fallback path entirely
+# (tracked under the "AI Engine Back-end Redesign" milestone).
 #
 # ANTHROPIC_API_KEY=your-anthropic-key       # DEPRECATED — migrated to connector
 # ANTHROPIC_MODEL=claude-haiku-4-5-20251001

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,13 +312,32 @@ REJECTED → NEW (re-open)
 - `server/app/services/track_normalizer.py` — track normalization & remix detection
 - `server/app/services/version_filter.py` — filters unwanted versions (karaoke, demo) with fuzzy matching
 
+### LLM Gateway (provider-agnostic dispatch)
+- `server/app/services/llm/` — connector-based dispatch usable by any agentic feature:
+  - `gateway.py` — `Gateway.dispatch(db, actor, request, *, purpose)` resolves a connector (per-DJ MRU → org default → raise `NoLlmConfigured`) and routes through the matching adapter. Logs every call to `llm_call_log` (counts only — never prompt/completion content) and writes a `llm_audit_event` row for credential lifecycle events.
+  - `base.py` — canonical `ChatRequest` / `ChatResponse` / `ToolSpec` / `LlmAdapter` ABC
+  - `registry.py` — connector_type → adapter class lookup; auto-registers all adapters on import
+  - `tool_translation.py` — JSON-Schema ToolSpec ↔ per-provider tool/function shape + response parsers
+  - `url_validator.py` — validates custom OpenAI-compatible base URLs (HTTPS any host; HTTP loopback + RFC1918 only)
+  - `connector_storage.py` — CRUD + validation + audit/call logging helpers
+  - `exceptions.py` — `AuthInvalid` / `RateLimited` / `QuotaExceeded` / `ProviderUnavailable` / `ToolTranslationError` / `NoLlmConfigured`
+  - `adapters/openai_apikey.py` — OpenAI Platform API-key adapter (httpx-based)
+  - `adapters/openai_compatible.py` — Custom OpenAI-compatible endpoint (Hermes Agent, Ollama, vLLM, LMStudio)
+  - `adapters/anthropic_apikey.py` — Anthropic API-key adapter (uses the `anthropic` SDK)
+- Models: `LlmConnector` (encrypted credentials via `EncryptedText`), `LlmCallLog`, `LlmAuditEvent`
+- Admin endpoints (`/api/admin/llm/*`): connector policy, force-revoke, usage rollup
+- DJ endpoints (`/api/llm/connectors`): list/create/rotate/test/delete (rate-limited, scoped to current user)
+- Admin UI: `/admin/ai` (policy + per-DJ table + usage)
+- DJ UI: `/settings/ai` (connect/test/delete; includes Hermes onboarding for ChatGPT subscription path)
+- The recommendation engine routes through the gateway (`actor = event.created_by`, `purpose = "recommendation"`); the legacy env-var path in `services/recommendation/llm_client.py` remains only as a fallback for callers that don't pass `db`/`actor` (kept until the env-var cleanup follow-up issue ships).
+
 ### Recommendation Engine
 - `server/app/services/recommendation/` — multi-stage pipeline:
   - `service.py` — orchestrator: profile analysis → search → scoring → deduplication
   - `enrichment.py` — fills missing BPM/key/genre from Beatport/MusicBrainz/Tidal (for recommendations; request-level enrichment is in `sync/orchestrator.py`)
   - `scorer.py` — multi-dimensional scoring: BPM compatibility, harmonic mixing, genre affinity, artist diversity penalties
   - `camelot.py` — harmonic mixing wheel (Camelot key compatibility, half-time/double-time BPM)
-  - `llm_client.py` — Claude Haiku integration (6/min rate limit, forced tool_use schema for structured JSON)
+  - `llm_client.py` — gateway-backed query generation (forced `tool_use` schema for structured JSON; legacy direct-Anthropic path retained as fallback for callers without `db`/`actor`)
   - `llm_hooks.py` — structured response models for LLM queries
   - `template.py` — playlist-based template recommendations (DJ picks a Tidal/Beatport playlist as "vibe" source)
   - `mb_verify.py` — MusicBrainz artist verification to detect AI-generated filler tracks (cached in DB)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ NEXT_PUBLIC_API_URL="http://LAN_IP:8000" npm run dev
 - Encryption: `TOKEN_ENCRYPTION_KEY` (Fernet, 44 chars base64) — required in production for OAuth token encryption
 - Beatport: `BEATPORT_CLIENT_ID`, `BEATPORT_CLIENT_SECRET`, `BEATPORT_REDIRECT_URI`, `BEATPORT_AUTH_BASE_URL`
 - Soundcharts: `SOUNDCHARTS_APP_ID`, `SOUNDCHARTS_API_KEY` (song discovery for recommendations)
-- Anthropic (LLM recommendations): `ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL` (default: `claude-haiku-4-5-20251001`), `ANTHROPIC_MAX_TOKENS`, `ANTHROPIC_TIMEOUT_SECONDS`
+- Anthropic (LLM recommendations, legacy): `ANTHROPIC_API_KEY` (**DEPRECATED** — migrated to the LLM Gateway connector system; see `.env.example` LLM section), `ANTHROPIC_MODEL` (default: `claude-haiku-4-5-20251001`), `ANTHROPIC_MAX_TOKENS`, `ANTHROPIC_TIMEOUT_SECONDS`
 
 ## Running CI Checks Locally
 

--- a/dashboard/app/(dj)/settings/ai/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/settings/ai/__tests__/page.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+import SettingsAIPage from '../page';
+import { api } from '@/lib/api';
+import type { LlmConnector } from '@/lib/api-types';
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    isLoading: false,
+    role: 'dj',
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => '/settings/ai',
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const NOW = new Date().toISOString();
+
+function makeConnector(overrides: Partial<LlmConnector> = {}): LlmConnector {
+  return {
+    id: 1,
+    user_id: 42,
+    connector_type: 'openai_apikey',
+    display_name: 'My OpenAI',
+    status: 'active',
+    base_url_plain: null,
+    model_hint: 'gpt-5-mini',
+    created_at: NOW,
+    updated_at: NOW,
+    last_used_at: null,
+    last_error: null,
+    ...overrides,
+  };
+}
+
+describe('SettingsAIPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lists existing connectors', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([
+      makeConnector({ display_name: 'My OpenAI' }),
+      makeConnector({
+        id: 2,
+        connector_type: 'anthropic_apikey',
+        display_name: 'My Claude',
+        model_hint: 'claude-haiku',
+      }),
+    ]);
+    vi.spyOn(api, 'getAdminLlmPolicy').mockRejectedValue(new Error('forbidden'));
+
+    render(<SettingsAIPage />);
+
+    await waitFor(() => expect(screen.getByText('My OpenAI')).toBeInTheDocument());
+    expect(screen.getByText('My Claude')).toBeInTheDocument();
+  });
+
+  it('respects admin policy when filtering allowed connector types', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
+    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: false,
+      llm_compatible_connector_enabled: true,
+      llm_default_connector_id: null,
+    });
+
+    render(<SettingsAIPage />);
+
+    await waitFor(() => expect(screen.getByText('+ Add provider')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('+ Add provider'));
+
+    // Provider dropdown should only contain the openai_compatible option
+    const select = screen.getByLabelText('Provider') as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).toEqual(['openai_compatible']);
+  });
+
+  it('runs Test and surfaces the result', async () => {
+    const row = makeConnector();
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([row]);
+    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: true,
+      llm_compatible_connector_enabled: true,
+      llm_default_connector_id: null,
+    });
+    const testSpy = vi.spyOn(api, 'testLlmConnector').mockResolvedValue({
+      ok: true,
+      error_code: null,
+      message: null,
+    });
+    // The refresh after Test re-lists connectors
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([row]);
+
+    render(<SettingsAIPage />);
+
+    await waitFor(() => expect(screen.getByText('My OpenAI')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'Test' }));
+    await waitFor(() => {
+      expect(testSpy).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it('deletes after confirmation', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([makeConnector()]);
+    vi.spyOn(api, 'getAdminLlmPolicy').mockRejectedValue(new Error('nope'));
+    const delSpy = vi.spyOn(api, 'deleteLlmConnector').mockResolvedValue();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<SettingsAIPage />);
+
+    await waitFor(() => expect(screen.getByText('My OpenAI')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => expect(delSpy).toHaveBeenCalledWith(1));
+  });
+});

--- a/dashboard/app/(dj)/settings/ai/page.tsx
+++ b/dashboard/app/(dj)/settings/ai/page.tsx
@@ -56,6 +56,7 @@ export default function SettingsAIPage() {
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [submitting, setSubmitting] = useState(false);
   const [submitMessage, setSubmitMessage] = useState('');
+  const [submitError, setSubmitError] = useState('');
   const [testStateById, setTestStateById] = useState<Record<number, string>>({});
 
   useEffect(() => {
@@ -100,16 +101,26 @@ export default function SettingsAIPage() {
   if (isLoading || !isAuthenticated) return null;
 
   const handleOpenForm = () => {
-    setForm({ ...EMPTY_FORM, open: true, connector_type: allowedTypes[0] ?? 'openai_apikey' });
+    if (allowedTypes.length === 0) {
+      setSubmitError('Connector creation is currently disabled by admin policy.');
+      setSubmitMessage('');
+      return;
+    }
+    setForm({ ...EMPTY_FORM, open: true, connector_type: allowedTypes[0] });
     setSubmitMessage('');
+    setSubmitError('');
   };
 
-  const handleCancel = () => setForm(EMPTY_FORM);
+  const handleCancel = () => {
+    setForm(EMPTY_FORM);
+    setSubmitError('');
+  };
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
     setSubmitting(true);
     setSubmitMessage('');
+    setSubmitError('');
     const payload: LlmConnectorCreate = {
       connector_type: form.connector_type,
       display_name: form.display_name,
@@ -127,7 +138,7 @@ export default function SettingsAIPage() {
       setForm(EMPTY_FORM);
       setSubmitMessage(`Created "${created.display_name}". Run "Test" to verify it works.`);
     } catch (err) {
-      setSubmitMessage(
+      setSubmitError(
         err instanceof Error ? err.message : 'Create failed (check your inputs)',
       );
     } finally {
@@ -184,6 +195,9 @@ export default function SettingsAIPage() {
       {submitMessage && (
         <div style={{ color: 'var(--color-success)', marginTop: '1rem' }}>{submitMessage}</div>
       )}
+      {submitError && (
+        <div style={{ color: 'var(--color-danger)', marginTop: '1rem' }}>{submitError}</div>
+      )}
 
       <section style={{ marginTop: '2rem' }}>
         <h2>Connected providers</h2>
@@ -222,7 +236,12 @@ export default function SettingsAIPage() {
       </section>
 
       <section style={{ marginTop: '2rem' }}>
-        {!form.open && (
+        {allowedTypes.length === 0 && !form.open && (
+          <p style={{ color: 'var(--text-secondary)' }}>
+            Connector creation is currently disabled by admin policy.
+          </p>
+        )}
+        {allowedTypes.length > 0 && !form.open && (
           <button className="btn btn-primary" onClick={handleOpenForm}>
             + Add provider
           </button>

--- a/dashboard/app/(dj)/settings/ai/page.tsx
+++ b/dashboard/app/(dj)/settings/ai/page.tsx
@@ -1,0 +1,371 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+
+import { api } from '@/lib/api';
+import type {
+  LlmAdminPolicy,
+  LlmConnector,
+  LlmConnectorCreate,
+  LlmConnectorType,
+} from '@/lib/api-types';
+import { useAuth } from '@/lib/auth';
+
+const CONNECTOR_TYPE_LABELS: Record<LlmConnectorType, string> = {
+  openai_apikey: 'OpenAI API key',
+  anthropic_apikey: 'Anthropic API key',
+  openai_compatible: 'Custom OpenAI-compatible endpoint',
+};
+
+const STATUS_LABELS: Record<string, { text: string; color: string }> = {
+  active: { text: 'Active', color: 'var(--color-success)' },
+  auth_invalid: { text: 'Auth invalid', color: 'var(--color-danger)' },
+  disabled: { text: 'Disabled', color: 'var(--text-secondary)' },
+};
+
+interface FormState {
+  open: boolean;
+  connector_type: LlmConnectorType;
+  display_name: string;
+  api_key: string;
+  base_url: string;
+  bearer: string;
+  model_hint: string;
+}
+
+const EMPTY_FORM: FormState = {
+  open: false,
+  connector_type: 'openai_apikey',
+  display_name: '',
+  api_key: '',
+  base_url: '',
+  bearer: '',
+  model_hint: '',
+};
+
+export default function SettingsAIPage() {
+  const router = useRouter();
+  const { isAuthenticated, isLoading } = useAuth();
+
+  const [policy, setPolicy] = useState<LlmAdminPolicy | null>(null);
+  const [connectors, setConnectors] = useState<LlmConnector[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitMessage, setSubmitMessage] = useState('');
+  const [testStateById, setTestStateById] = useState<Record<number, string>>({});
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.push('/login');
+    }
+  }, [isAuthenticated, isLoading, router]);
+
+  useEffect(() => {
+    let active = true;
+    if (!isAuthenticated) return;
+    setLoading(true);
+    setError('');
+    Promise.all([api.listLlmConnectors(), fetchPolicySoft()])
+      .then(([rows, p]) => {
+        if (!active) return;
+        setConnectors(rows);
+        setPolicy(p);
+      })
+      .catch((err) => {
+        if (!active) return;
+        setError(err instanceof Error ? err.message : 'Failed to load');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [isAuthenticated]);
+
+  const allowedTypes = useMemo(() => {
+    if (!policy) return Object.keys(CONNECTOR_TYPE_LABELS) as LlmConnectorType[];
+    const out: LlmConnectorType[] = [];
+    if (policy.llm_apikey_connectors_enabled) {
+      out.push('openai_apikey', 'anthropic_apikey');
+    }
+    if (policy.llm_compatible_connector_enabled) out.push('openai_compatible');
+    return out;
+  }, [policy]);
+
+  if (isLoading || !isAuthenticated) return null;
+
+  const handleOpenForm = () => {
+    setForm({ ...EMPTY_FORM, open: true, connector_type: allowedTypes[0] ?? 'openai_apikey' });
+    setSubmitMessage('');
+  };
+
+  const handleCancel = () => setForm(EMPTY_FORM);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setSubmitMessage('');
+    const payload: LlmConnectorCreate = {
+      connector_type: form.connector_type,
+      display_name: form.display_name,
+      model_hint: form.model_hint || null,
+      api_key:
+        form.connector_type === 'openai_compatible' ? null : form.api_key,
+      base_url:
+        form.connector_type === 'openai_compatible' ? form.base_url : null,
+      bearer:
+        form.connector_type === 'openai_compatible' ? form.bearer || null : null,
+    };
+    try {
+      const created = await api.createLlmConnector(payload);
+      setConnectors((prev) => [created, ...prev]);
+      setForm(EMPTY_FORM);
+      setSubmitMessage(`Created "${created.display_name}". Run "Test" to verify it works.`);
+    } catch (err) {
+      setSubmitMessage(
+        err instanceof Error ? err.message : 'Create failed (check your inputs)',
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleTest = async (id: number) => {
+    setTestStateById((s) => ({ ...s, [id]: 'Testing…' }));
+    try {
+      const result = await api.testLlmConnector(id);
+      setTestStateById((s) => ({
+        ...s,
+        [id]: result.ok ? 'OK' : `Failed: ${result.error_code ?? 'unknown'}`,
+      }));
+      // Refresh the row so updated status renders
+      const fresh = await api.listLlmConnectors();
+      setConnectors(fresh);
+    } catch (err) {
+      setTestStateById((s) => ({
+        ...s,
+        [id]: err instanceof Error ? err.message : 'Test failed',
+      }));
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!window.confirm('Delete this connector? This cannot be undone.')) return;
+    try {
+      await api.deleteLlmConnector(id);
+      setConnectors((prev) => prev.filter((c) => c.id !== id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed');
+    }
+  };
+
+  return (
+    <main style={{ maxWidth: '720px', margin: '0 auto', padding: '2rem 1rem' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '2rem' }}>
+        <Link href="/dashboard" style={{ color: 'var(--text-secondary)', textDecoration: 'none', fontSize: '0.875rem' }}>
+          ← Dashboard
+        </Link>
+        <h1 style={{ margin: 0 }}>AI providers</h1>
+      </div>
+
+      <p style={{ color: 'var(--text-secondary)' }}>
+        Connect your own LLM provider so AI-assisted features (recommendations, etc.) bill to
+        your account. Credentials are encrypted at rest. Calls consume your account&apos;s API or
+        subscription quota directly.
+      </p>
+
+      {loading && <div className="loading">Loading…</div>}
+      {error && <div style={{ color: 'var(--color-danger)', marginTop: '1rem' }}>{error}</div>}
+      {submitMessage && (
+        <div style={{ color: 'var(--color-success)', marginTop: '1rem' }}>{submitMessage}</div>
+      )}
+
+      <section style={{ marginTop: '2rem' }}>
+        <h2>Connected providers</h2>
+        {connectors.length === 0 && !loading && (
+          <p style={{ color: 'var(--text-secondary)' }}>No connectors yet.</p>
+        )}
+        {connectors.map((c) => {
+          const status = STATUS_LABELS[c.status] ?? { text: c.status, color: 'var(--text-secondary)' };
+          return (
+            <div key={c.id} className="card" style={{ marginTop: '1rem' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
+                <div>
+                  <div style={{ fontWeight: 600 }}>{c.display_name}</div>
+                  <div style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
+                    {CONNECTOR_TYPE_LABELS[c.connector_type as LlmConnectorType] ?? c.connector_type}
+                    {c.model_hint ? ` · ${c.model_hint}` : ''}
+                    {c.base_url_plain ? ` · ${c.base_url_plain}` : ''}
+                  </div>
+                  <div style={{ marginTop: '0.5rem', fontSize: '0.875rem', color: status.color, fontWeight: 600 }}>
+                    {status.text}
+                    {testStateById[c.id] ? ` · ${testStateById[c.id]}` : ''}
+                  </div>
+                </div>
+                <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                  <button className="btn btn-secondary" onClick={() => handleTest(c.id)}>
+                    Test
+                  </button>
+                  <button className="btn btn-danger" onClick={() => handleDelete(c.id)}>
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </section>
+
+      <section style={{ marginTop: '2rem' }}>
+        {!form.open && (
+          <button className="btn btn-primary" onClick={handleOpenForm}>
+            + Add provider
+          </button>
+        )}
+        {form.open && (
+          <form className="card" onSubmit={handleCreate} style={{ marginTop: '1rem' }}>
+            <h2 style={{ marginTop: 0 }}>Add provider</h2>
+
+            <div className="form-group">
+              <label htmlFor="connector_type">Provider</label>
+              <select
+                id="connector_type"
+                className="input"
+                value={form.connector_type}
+                onChange={(e) =>
+                  setForm({ ...form, connector_type: e.target.value as LlmConnectorType })
+                }
+              >
+                {allowedTypes.map((t) => (
+                  <option key={t} value={t}>
+                    {CONNECTOR_TYPE_LABELS[t]}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="display_name">Display name</label>
+              <input
+                id="display_name"
+                className="input"
+                value={form.display_name}
+                onChange={(e) => setForm({ ...form, display_name: e.target.value })}
+                placeholder="e.g. My OpenAI"
+                maxLength={80}
+                required
+              />
+            </div>
+
+            {form.connector_type !== 'openai_compatible' ? (
+              <div className="form-group">
+                <label htmlFor="api_key">API key</label>
+                <input
+                  id="api_key"
+                  className="input"
+                  type="password"
+                  value={form.api_key}
+                  onChange={(e) => setForm({ ...form, api_key: e.target.value })}
+                  placeholder={
+                    form.connector_type === 'anthropic_apikey'
+                      ? 'sk-ant-…'
+                      : 'sk-proj-… / sk-…'
+                  }
+                  required
+                />
+              </div>
+            ) : (
+              <>
+                <div className="form-group">
+                  <label htmlFor="base_url">Base URL</label>
+                  <input
+                    id="base_url"
+                    className="input"
+                    value={form.base_url}
+                    onChange={(e) => setForm({ ...form, base_url: e.target.value })}
+                    placeholder="http://127.0.0.1:11434/v1"
+                    required
+                  />
+                  <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', margin: '0.5rem 0 0' }}>
+                    HTTPS is required for public hosts. HTTP is only allowed for loopback (
+                    <code>127.0.0.1</code>, <code>localhost</code>) and private (RFC1918) IPs.
+                  </p>
+                </div>
+                <div className="form-group">
+                  <label htmlFor="bearer">Bearer token (optional)</label>
+                  <input
+                    id="bearer"
+                    className="input"
+                    type="password"
+                    value={form.bearer}
+                    onChange={(e) => setForm({ ...form, bearer: e.target.value })}
+                  />
+                </div>
+                <details style={{ marginTop: '1rem' }}>
+                  <summary style={{ cursor: 'pointer', fontWeight: 600 }}>
+                    Want to use your ChatGPT Plus / Pro subscription?
+                  </summary>
+                  <p style={{ marginTop: '0.5rem' }}>
+                    Install{' '}
+                    <a
+                      href="https://github.com/NousResearch/hermes-agent"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Hermes Agent
+                    </a>
+                    , run <code>hermes proxy</code>, and paste the URL it prints below. Your
+                    ChatGPT account never leaves your machine — WrzDJ only talks to your local
+                    Hermes proxy.
+                  </p>
+                </details>
+              </>
+            )}
+
+            <div className="form-group">
+              <label htmlFor="model_hint">Model (optional)</label>
+              <input
+                id="model_hint"
+                className="input"
+                value={form.model_hint}
+                onChange={(e) => setForm({ ...form, model_hint: e.target.value })}
+                placeholder={
+                  form.connector_type === 'anthropic_apikey'
+                    ? 'claude-haiku-4-5-20251001'
+                    : form.connector_type === 'openai_apikey'
+                    ? 'gpt-5-mini'
+                    : 'e.g. llama3'
+                }
+              />
+            </div>
+
+            <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
+              <button type="submit" className="btn btn-primary" disabled={submitting}>
+                {submitting ? 'Saving…' : 'Save'}
+              </button>
+              <button type="button" className="btn btn-secondary" onClick={handleCancel}>
+                Cancel
+              </button>
+            </div>
+          </form>
+        )}
+      </section>
+    </main>
+  );
+}
+
+async function fetchPolicySoft(): Promise<LlmAdminPolicy | null> {
+  // DJ users don't have access to the admin policy endpoint — return null so
+  // the UI falls back to "all types allowed" defaults. Admins get the real
+  // payload (the same component is used in the admin /admin/ai page).
+  try {
+    return await api.getAdminLlmPolicy();
+  } catch {
+    return null;
+  }
+}

--- a/dashboard/app/admin/ai/__tests__/page.test.tsx
+++ b/dashboard/app/admin/ai/__tests__/page.test.tsx
@@ -131,4 +131,105 @@ describe('AdminAISettingsPage', () => {
       expect(screen.getByText('Failed to load AI settings')).toBeInTheDocument();
     });
   });
+
+  it('renders connector policy + per-DJ connector cards when gateway data loads', async () => {
+    vi.spyOn(api, 'getAISettings').mockResolvedValue({
+      llm_enabled: true,
+      llm_model: 'claude-haiku-4-5-20251001',
+      llm_rate_limit_per_minute: 3,
+      api_key_configured: true,
+      api_key_masked: '...abcd',
+    });
+    vi.spyOn(api, 'getAIModels').mockResolvedValue({
+      models: [{ id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5' }],
+    });
+    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: true,
+      llm_compatible_connector_enabled: true,
+      llm_default_connector_id: null,
+    });
+    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([
+      {
+        id: 1,
+        user_id: 42,
+        dj_username: 'someDJ',
+        connector_type: 'openai_apikey',
+        display_name: 'My OpenAI',
+        status: 'active',
+        base_url_plain: null,
+        model_hint: 'gpt-5-mini',
+        created_at: '2026-05-01T00:00:00Z',
+        updated_at: '2026-05-01T00:00:00Z',
+        last_used_at: null,
+        last_error: null,
+      },
+    ]);
+    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({
+      days: 30,
+      rows: [],
+    });
+
+    render(<AdminAISettingsPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Connector policy')).toBeInTheDocument(),
+    );
+    expect(screen.getByText('Per-DJ connectors')).toBeInTheDocument();
+    expect(screen.getByText('someDJ')).toBeInTheDocument();
+    expect(screen.getByText(/Usage — last 30 days/)).toBeInTheDocument();
+  });
+
+  it('force-revokes a connector via the admin table', async () => {
+    vi.spyOn(api, 'getAISettings').mockResolvedValue({
+      llm_enabled: true,
+      llm_model: 'claude-haiku-4-5-20251001',
+      llm_rate_limit_per_minute: 3,
+      api_key_configured: true,
+      api_key_masked: '...abcd',
+    });
+    vi.spyOn(api, 'getAIModels').mockResolvedValue({ models: [] });
+    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: true,
+      llm_compatible_connector_enabled: true,
+      llm_default_connector_id: null,
+    });
+    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([
+      {
+        id: 9,
+        user_id: 42,
+        dj_username: 'badDJ',
+        connector_type: 'openai_apikey',
+        display_name: 'Compromised',
+        status: 'active',
+        base_url_plain: null,
+        model_hint: null,
+        created_at: '2026-05-01T00:00:00Z',
+        updated_at: '2026-05-01T00:00:00Z',
+        last_used_at: null,
+        last_error: null,
+      },
+    ]);
+    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
+    const revokeSpy = vi.spyOn(api, 'revokeAdminLlmConnector').mockResolvedValue({
+      id: 9,
+      user_id: 42,
+      dj_username: 'badDJ',
+      connector_type: 'openai_apikey',
+      display_name: 'Compromised',
+      status: 'disabled',
+      base_url_plain: null,
+      model_hint: null,
+      created_at: '2026-05-01T00:00:00Z',
+      updated_at: '2026-05-01T00:00:00Z',
+      last_used_at: null,
+      last_error: null,
+    });
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<AdminAISettingsPage />);
+
+    await waitFor(() => expect(screen.getByText('Compromised')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Force-revoke'));
+    await waitFor(() => expect(revokeSpy).toHaveBeenCalledWith(9));
+  });
 });

--- a/dashboard/app/admin/ai/page.tsx
+++ b/dashboard/app/admin/ai/page.tsx
@@ -1,8 +1,14 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { api } from '@/lib/api';
-import type { AISettings, AIModelInfo } from '@/lib/api-types';
+import type {
+  AISettings,
+  AIModelInfo,
+  LlmAdminConnector,
+  LlmAdminPolicy,
+  LlmAdminUsage,
+} from '@/lib/api-types';
 import { useAdminPage } from '@/lib/useAdminPage';
 import { HelpSpot } from '@/components/help/HelpSpot';
 import { HelpButton } from '@/components/help/HelpButton';
@@ -10,11 +16,23 @@ import { OnboardingOverlay } from '@/components/help/OnboardingOverlay';
 
 const PAGE_ID = 'admin-ai';
 
+const TYPE_LABELS: Record<string, string> = {
+  openai_apikey: 'OpenAI',
+  anthropic_apikey: 'Anthropic',
+  openai_compatible: 'OpenAI-compatible',
+};
+
 export default function AdminAISettingsPage() {
   const [models, setModels] = useState<AIModelInfo[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+
+  // LLM gateway state
+  const [policy, setPolicy] = useState<LlmAdminPolicy | null>(null);
+  const [connectors, setConnectors] = useState<LlmAdminConnector[]>([]);
+  const [usage, setUsage] = useState<LlmAdminUsage | null>(null);
+  const [policyMessage, setPolicyMessage] = useState('');
 
   const { data: settings, loading, error: loadError, setData: setSettings } = useAdminPage<AISettings>({
     pageId: PAGE_ID,
@@ -28,6 +46,27 @@ export default function AdminAISettingsPage() {
     },
     onError: () => 'Failed to load AI settings',
   });
+
+  useEffect(() => {
+    let active = true;
+    Promise.all([
+      api.getAdminLlmPolicy(),
+      api.listAllLlmConnectors(),
+      api.getAdminLlmUsage(30),
+    ])
+      .then(([p, c, u]) => {
+        if (!active) return;
+        setPolicy(p);
+        setConnectors(c);
+        setUsage(u);
+      })
+      .catch(() => {
+        // soft-fail — legacy AI settings card still renders
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const handleSave = async () => {
     if (!settings) return;
@@ -47,6 +86,41 @@ export default function AdminAISettingsPage() {
       setError(err instanceof Error ? err.message : 'Failed to save settings');
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handlePolicyPatch = async (next: Partial<LlmAdminPolicy>) => {
+    if (!policy) return;
+    setPolicyMessage('');
+    const optimistic = { ...policy, ...next };
+    const prev = policy;
+    setPolicy(optimistic);
+    try {
+      const updated = await api.updateAdminLlmPolicy({
+        llm_apikey_connectors_enabled: optimistic.llm_apikey_connectors_enabled,
+        llm_compatible_connector_enabled: optimistic.llm_compatible_connector_enabled,
+        llm_default_connector_id: optimistic.llm_default_connector_id,
+        clear_default: optimistic.llm_default_connector_id === null,
+      });
+      setPolicy(updated);
+      setPolicyMessage('Policy saved');
+      setTimeout(() => setPolicyMessage(''), 2000);
+    } catch (err) {
+      setPolicy(prev);
+      setPolicyMessage(err instanceof Error ? err.message : 'Save failed');
+    }
+  };
+
+  const handleRevoke = async (id: number) => {
+    if (!window.confirm('Force-revoke this connector? The DJ will need to re-add it.')) return;
+    try {
+      const updated = await api.revokeAdminLlmConnector(id);
+      setConnectors((prev) => prev.map((c) => (c.id === id ? updated : c)));
+      // Reload policy in case the default changed
+      const newPolicy = await api.getAdminLlmPolicy();
+      setPolicy(newPolicy);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Revoke failed');
     }
   };
 
@@ -189,6 +263,149 @@ export default function AdminAISettingsPage() {
           {saving ? 'Saving...' : 'Save Settings'}
         </button>
       </div>
+
+      {/* ====== LLM Gateway connector policy ====== */}
+      {policy && (
+        <div className="card" style={{ marginTop: '2rem' }}>
+          <h2 style={{ marginTop: 0 }}>Connector policy</h2>
+          {policyMessage && (
+            <div style={{ marginBottom: '1rem', color: 'var(--text-secondary)' }}>{policyMessage}</div>
+          )}
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              checked={policy.llm_apikey_connectors_enabled}
+              onChange={(e) => handlePolicyPatch({ llm_apikey_connectors_enabled: e.target.checked })}
+            />
+            Allow API-key connectors (OpenAI, Anthropic)
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', cursor: 'pointer', marginTop: '0.75rem' }}>
+            <input
+              type="checkbox"
+              checked={policy.llm_compatible_connector_enabled}
+              onChange={(e) => handlePolicyPatch({ llm_compatible_connector_enabled: e.target.checked })}
+            />
+            Allow custom OpenAI-compatible endpoints
+          </label>
+
+          <div className="form-group" style={{ marginTop: '1.5rem' }}>
+            <label htmlFor="default-connector">Org default connector</label>
+            <div style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '0.5rem' }}>
+              Used when a system call has no DJ actor (background jobs).
+            </div>
+            <select
+              id="default-connector"
+              className="input"
+              value={policy.llm_default_connector_id ?? ''}
+              onChange={(e) => {
+                const v = e.target.value;
+                if (!v) {
+                  handlePolicyPatch({ llm_default_connector_id: null });
+                } else {
+                  handlePolicyPatch({ llm_default_connector_id: parseInt(v) });
+                }
+              }}
+              style={{ maxWidth: '480px' }}
+            >
+              <option value="">— None —</option>
+              {connectors
+                .filter((c) => c.status === 'active')
+                .map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.dj_username} — {c.display_name} ({TYPE_LABELS[c.connector_type] ?? c.connector_type})
+                  </option>
+                ))}
+            </select>
+          </div>
+
+          <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginTop: '1rem' }}>
+            WrzDJ stores provider credentials encrypted at rest. Calls consume the DJ&apos;s
+            quota or billing directly. Credentials are never shared between DJs.
+          </p>
+        </div>
+      )}
+
+      {/* ====== Per-DJ connectors table ====== */}
+      <div className="card" style={{ marginTop: '2rem' }}>
+        <h2 style={{ marginTop: 0 }}>Per-DJ connectors</h2>
+        {connectors.length === 0 ? (
+          <p style={{ color: 'var(--text-secondary)' }}>No DJs have connected an LLM yet.</p>
+        ) : (
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr>
+                  {['DJ', 'Type', 'Name', 'Status', 'Last used', 'Actions'].map((h) => (
+                    <th key={h} style={{ textAlign: 'left', padding: '0.5rem', borderBottom: '1px solid var(--border-color)' }}>
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {connectors.map((c) => (
+                  <tr key={c.id}>
+                    <td style={{ padding: '0.5rem' }}>{c.dj_username}</td>
+                    <td style={{ padding: '0.5rem' }}>
+                      {TYPE_LABELS[c.connector_type] ?? c.connector_type}
+                    </td>
+                    <td style={{ padding: '0.5rem' }}>{c.display_name}</td>
+                    <td style={{ padding: '0.5rem' }}>{c.status}</td>
+                    <td style={{ padding: '0.5rem', color: 'var(--text-secondary)' }}>
+                      {c.last_used_at ? new Date(c.last_used_at).toLocaleString() : '—'}
+                    </td>
+                    <td style={{ padding: '0.5rem' }}>
+                      {c.status !== 'disabled' && (
+                        <button className="btn btn-danger" onClick={() => handleRevoke(c.id)}>
+                          Force-revoke
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* ====== Usage ====== */}
+      {usage && (
+        <div className="card" style={{ marginTop: '2rem' }}>
+          <h2 style={{ marginTop: 0 }}>Usage — last {usage.days} days</h2>
+          {usage.rows.length === 0 ? (
+            <p style={{ color: 'var(--text-secondary)' }}>No calls yet.</p>
+          ) : (
+            <div style={{ overflowX: 'auto' }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <thead>
+                  <tr>
+                    {['DJ', 'Connector', 'Calls', 'Tokens in', 'Tokens out', 'Error rate'].map((h) => (
+                      <th key={h} style={{ textAlign: 'left', padding: '0.5rem', borderBottom: '1px solid var(--border-color)' }}>
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {usage.rows.map((r) => (
+                    <tr key={r.connector_id}>
+                      <td style={{ padding: '0.5rem' }}>{r.dj_username}</td>
+                      <td style={{ padding: '0.5rem' }}>
+                        {r.display_name} <span style={{ color: 'var(--text-secondary)' }}>· {TYPE_LABELS[r.connector_type] ?? r.connector_type}</span>
+                      </td>
+                      <td style={{ padding: '0.5rem' }}>{r.total_calls}</td>
+                      <td style={{ padding: '0.5rem' }}>{r.total_tokens_in}</td>
+                      <td style={{ padding: '0.5rem' }}>{r.total_tokens_out}</td>
+                      <td style={{ padding: '0.5rem' }}>{(r.error_rate * 100).toFixed(1)}%</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/dashboard/app/admin/ai/page.tsx
+++ b/dashboard/app/admin/ai/page.tsx
@@ -49,20 +49,26 @@ export default function AdminAISettingsPage() {
 
   useEffect(() => {
     let active = true;
-    Promise.all([
+    // Load each gateway section independently — a transient failure in one
+    // request shouldn't hide the others (e.g. usage 500 should not blank the
+    // policy + connectors panes).
+    Promise.allSettled([
       api.getAdminLlmPolicy(),
       api.listAllLlmConnectors(),
       api.getAdminLlmUsage(30),
-    ])
-      .then(([p, c, u]) => {
-        if (!active) return;
-        setPolicy(p);
-        setConnectors(c);
-        setUsage(u);
-      })
-      .catch(() => {
-        // soft-fail — legacy AI settings card still renders
-      });
+    ]).then(([p, c, u]) => {
+      if (!active) return;
+      if (p.status === 'fulfilled') setPolicy(p.value);
+      if (c.status === 'fulfilled') setConnectors(c.value);
+      if (u.status === 'fulfilled') setUsage(u.value);
+      if (
+        p.status === 'rejected' ||
+        c.status === 'rejected' ||
+        u.status === 'rejected'
+      ) {
+        setPolicyMessage('Some LLM gateway data failed to load');
+      }
+    });
     return () => {
       active = false;
     };

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -520,6 +520,101 @@ describe('ApiClient', () => {
     });
   });
 
+  describe('LLM Gateway API', () => {
+    beforeEach(() => {
+      api.setToken('test-token');
+    });
+
+    it('lists per-DJ connectors', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            id: 1,
+            user_id: 42,
+            connector_type: 'openai_apikey',
+            display_name: 'My OpenAI',
+            status: 'active',
+            base_url_plain: null,
+            model_hint: 'gpt-5-mini',
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+            last_used_at: null,
+            last_error: null,
+          },
+        ],
+      });
+
+      const result = await api.listLlmConnectors();
+      expect(result).toHaveLength(1);
+      expect(result[0].connector_type).toBe('openai_apikey');
+    });
+
+    it('creates a connector via POST', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 2,
+          user_id: 42,
+          connector_type: 'openai_compatible',
+          display_name: 'Hermes',
+          status: 'active',
+          base_url_plain: 'http://127.0.0.1:11434/v1',
+          model_hint: null,
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+          last_used_at: null,
+          last_error: null,
+        }),
+      });
+
+      const result = await api.createLlmConnector({
+        connector_type: 'openai_compatible',
+        display_name: 'Hermes',
+        base_url: 'http://127.0.0.1:11434/v1',
+        bearer: null,
+        api_key: null,
+        model_hint: null,
+      });
+      expect(result.id).toBe(2);
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.method).toBe('POST');
+    });
+
+    it('updates admin LLM policy via PATCH', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          llm_apikey_connectors_enabled: false,
+          llm_compatible_connector_enabled: true,
+          llm_default_connector_id: null,
+        }),
+      });
+      const result = await api.updateAdminLlmPolicy({
+        llm_apikey_connectors_enabled: false,
+        llm_compatible_connector_enabled: null,
+        llm_default_connector_id: null,
+        clear_default: true,
+      });
+      expect(result.llm_apikey_connectors_enabled).toBe(false);
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.method).toBe('PATCH');
+    });
+
+    it('fetches admin usage with days param', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ days: 30, rows: [] }),
+      });
+
+      await api.getAdminLlmUsage(30);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/admin/llm/usage?days=30');
+    });
+  });
+
   describe('Activity Log API', () => {
     beforeEach(() => {
       api.setToken('test-token');

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -169,6 +169,75 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/llm/connectors": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Connectors Admin */
+        get: operations["list_connectors_admin_api_admin_llm_connectors_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/llm/connectors/{connector_id}/revoke": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Revoke Connector Admin */
+        post: operations["revoke_connector_admin_api_admin_llm_connectors__connector_id__revoke_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/llm/policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Policy */
+        get: operations["get_policy_api_admin_llm_policy_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Patch Policy */
+        patch: operations["patch_policy_api_admin_llm_policy_patch"];
+        trace?: never;
+    };
+    "/api/admin/llm/usage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Usage */
+        get: operations["get_usage_api_admin_llm_usage_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/settings": {
         parameters: {
             query?: never;
@@ -1282,6 +1351,76 @@ export interface paths {
         patch: operations["assign_kiosk_api_kiosk__kiosk_id__assign_patch"];
         trace?: never;
     };
+    "/api/llm/connectors": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Connectors */
+        get: operations["list_connectors_api_llm_connectors_get"];
+        put?: never;
+        /** Create Connector Endpoint */
+        post: operations["create_connector_endpoint_api_llm_connectors_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llm/connectors/{connector_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Connector Endpoint */
+        delete: operations["delete_connector_endpoint_api_llm_connectors__connector_id__delete"];
+        options?: never;
+        head?: never;
+        /** Update Connector Metadata */
+        patch: operations["update_connector_metadata_api_llm_connectors__connector_id__patch"];
+        trace?: never;
+    };
+    "/api/llm/connectors/{connector_id}/credentials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Rotate Connector Credentials */
+        put: operations["rotate_connector_credentials_api_llm_connectors__connector_id__credentials_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llm/connectors/{connector_id}/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Test Connector */
+        post: operations["test_connector_api_llm_connectors__connector_id__test_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/public/collect/{code}": {
         parameters: {
             query?: never;
@@ -1459,7 +1598,8 @@ export interface paths {
          * @description Get bridge connection status for public display.
          *
          *     Independent of track data — returns bridge connectivity even when
-         *     no track is currently playing.
+         *     no track is currently playing. Resolves by join_code: serves guest-facing
+         *     kiosk display + overlay pages.
          */
         get: operations["get_public_bridge_status_api_public_e__code__bridge_status_get"];
         put?: never;
@@ -1482,6 +1622,7 @@ export interface paths {
          * @description Get play history for public display.
          *
          *     Returns the list of tracks played during the event, newest first.
+         *     Resolves by join_code: serves guest-facing kiosk display.
          */
         get: operations["get_public_history_api_public_e__code__history_get"];
         put?: never;
@@ -1504,6 +1645,9 @@ export interface paths {
          * @description Get current now-playing track for public display.
          *
          *     Returns the track currently playing from StageLinQ, or None if nothing playing.
+         *
+         *     Resolves by join_code: this endpoint serves the kiosk display + OBS overlay
+         *     pages, which route by join_code per the post-PR-#324 public/guest URL contract.
          */
         get: operations["get_public_now_playing_api_public_e__code__nowplaying_get"];
         put?: never;
@@ -2197,6 +2341,48 @@ export interface components {
             /** Source */
             source: string;
         };
+        /**
+         * AdminConnectorOut
+         * @description Admin view — adds the DJ's username for display.
+         */
+        AdminConnectorOut: {
+            /** Base Url Plain */
+            base_url_plain: string | null;
+            /**
+             * Connector Type
+             * @enum {string}
+             */
+            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible";
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Display Name */
+            display_name: string;
+            /** Dj Username */
+            dj_username: string;
+            /** Id */
+            id: number;
+            /** Last Error */
+            last_error: string | null;
+            /** Last Used At */
+            last_used_at: string | null;
+            /** Model Hint */
+            model_hint: string | null;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "active" | "auth_invalid" | "disabled";
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** User Id */
+            user_id: number;
+        };
         /** AdminEventOut */
         AdminEventOut: {
             /** Code */
@@ -2228,6 +2414,36 @@ export interface components {
              * @default 0
              */
             request_count: number;
+        };
+        /** AdminPolicyOut */
+        AdminPolicyOut: {
+            /** Llm Apikey Connectors Enabled */
+            llm_apikey_connectors_enabled: boolean;
+            /** Llm Compatible Connector Enabled */
+            llm_compatible_connector_enabled: boolean;
+            /** Llm Default Connector Id */
+            llm_default_connector_id: number | null;
+        };
+        /** AdminPolicyPatch */
+        AdminPolicyPatch: {
+            /**
+             * Clear Default
+             * @default false
+             */
+            clear_default: boolean;
+            /** Llm Apikey Connectors Enabled */
+            llm_apikey_connectors_enabled?: boolean | null;
+            /** Llm Compatible Connector Enabled */
+            llm_compatible_connector_enabled?: boolean | null;
+            /** Llm Default Connector Id */
+            llm_default_connector_id?: number | null;
+        };
+        /** AdminUsageOut */
+        AdminUsageOut: {
+            /** Days */
+            days: number;
+            /** Rows */
+            rows: components["schemas"]["UsageRow"][];
         };
         /** AdminUserCreate */
         AdminUserCreate: {
@@ -2713,6 +2929,92 @@ export interface components {
         CollectVoteRequest: {
             /** Request Id */
             request_id: number;
+        };
+        /** ConnectorCreate */
+        ConnectorCreate: {
+            /** Api Key */
+            api_key?: string | null;
+            /** Base Url */
+            base_url?: string | null;
+            /** Bearer */
+            bearer?: string | null;
+            /**
+             * Connector Type
+             * @enum {string}
+             */
+            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible";
+            /** Display Name */
+            display_name: string;
+            /** Model Hint */
+            model_hint?: string | null;
+        };
+        /** ConnectorCredentialsRotate */
+        ConnectorCredentialsRotate: {
+            /** Api Key */
+            api_key?: string | null;
+            /** Base Url */
+            base_url?: string | null;
+            /** Bearer */
+            bearer?: string | null;
+        };
+        /**
+         * ConnectorOut
+         * @description Public-safe connector view — never includes the credential blob.
+         */
+        ConnectorOut: {
+            /** Base Url Plain */
+            base_url_plain: string | null;
+            /**
+             * Connector Type
+             * @enum {string}
+             */
+            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible";
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Display Name */
+            display_name: string;
+            /** Id */
+            id: number;
+            /** Last Error */
+            last_error: string | null;
+            /** Last Used At */
+            last_used_at: string | null;
+            /** Model Hint */
+            model_hint: string | null;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "active" | "auth_invalid" | "disabled";
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** User Id */
+            user_id: number;
+        };
+        /**
+         * ConnectorPatch
+         * @description Metadata-only patch (no credential rotation here).
+         */
+        ConnectorPatch: {
+            /** Display Name */
+            display_name?: string | null;
+            /** Model Hint */
+            model_hint?: string | null;
+        };
+        /** ConnectorTestResult */
+        ConnectorTestResult: {
+            /** Error Code */
+            error_code: string | null;
+            /** Message */
+            message: string | null;
+            /** Ok */
+            ok: boolean;
         };
         /**
          * DisplaySettingsResponse
@@ -3844,6 +4146,30 @@ export interface components {
             /** Tidal Sync Enabled */
             tidal_sync_enabled?: boolean | null;
         };
+        /** UsageRow */
+        UsageRow: {
+            /** Connector Id */
+            connector_id: number;
+            /**
+             * Connector Type
+             * @enum {string}
+             */
+            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible";
+            /** Display Name */
+            display_name: string;
+            /** Dj Username */
+            dj_username: string;
+            /** Error Count */
+            error_count: number;
+            /** Error Rate */
+            error_rate: number;
+            /** Total Calls */
+            total_calls: number;
+            /** Total Tokens In */
+            total_tokens_in: number;
+            /** Total Tokens Out */
+            total_tokens_out: number;
+        };
         /** UserOut */
         UserOut: {
             /**
@@ -4234,6 +4560,141 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["IntegrationCheckResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_connectors_admin_api_admin_llm_connectors_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminConnectorOut"][];
+                };
+            };
+        };
+    };
+    revoke_connector_admin_api_admin_llm_connectors__connector_id__revoke_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                connector_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminConnectorOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_policy_api_admin_llm_policy_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminPolicyOut"];
+                };
+            };
+        };
+    };
+    patch_policy_api_admin_llm_policy_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AdminPolicyPatch"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminPolicyOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_usage_api_admin_llm_usage_get: {
+        parameters: {
+            query?: {
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminUsageOut"];
                 };
             };
             /** @description Validation Error */
@@ -6282,6 +6743,189 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["KioskOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_connectors_api_llm_connectors_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectorOut"][];
+                };
+            };
+        };
+    };
+    create_connector_endpoint_api_llm_connectors_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConnectorCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectorOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_connector_endpoint_api_llm_connectors__connector_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                connector_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_connector_metadata_api_llm_connectors__connector_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                connector_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConnectorPatch"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectorOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    rotate_connector_credentials_api_llm_connectors__connector_id__credentials_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                connector_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConnectorCredentialsRotate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectorOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    test_connector_api_llm_connectors__connector_id__test_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                connector_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectorTestResult"];
                 };
             };
             /** @description Validation Error */

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -2930,7 +2930,21 @@ export interface components {
             /** Request Id */
             request_id: number;
         };
-        /** ConnectorCreate */
+        /**
+         * ConnectorCreate
+         * @description Provider-agnostic create payload.
+         *
+         *     Field requirements vary by ``connector_type``:
+         *
+         *     - ``openai_apikey`` / ``anthropic_apikey``: ``api_key`` required;
+         *       ``base_url`` and ``bearer`` are ignored.
+         *     - ``openai_compatible``: ``base_url`` required; ``bearer`` optional;
+         *       ``api_key`` is ignored.
+         *
+         *     The combination is enforced by :meth:`_require_credentials_for_type`.
+         *     See ``build_create_payload`` in ``services/llm/connector_storage.py``
+         *     for the full validation flow (including key shape checks).
+         */
         ConnectorCreate: {
             /** Api Key */
             api_key?: string | null;
@@ -2948,7 +2962,13 @@ export interface components {
             /** Model Hint */
             model_hint?: string | null;
         };
-        /** ConnectorCredentialsRotate */
+        /**
+         * ConnectorCredentialsRotate
+         * @description Rotation payload — at least one credential field must be supplied.
+         *
+         *     Field semantics mirror :class:`ConnectorCreate`. The actual field required
+         *     depends on the connector being rotated (validated in ``rotate_credentials``).
+         */
         ConnectorCredentialsRotate: {
             /** Api Key */
             api_key?: string | null;

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -63,8 +63,9 @@ export type LlmAdminPolicy = Schemas['AdminPolicyOut'];
 export type LlmAdminPolicyPatch = Schemas['AdminPolicyPatch'];
 export type LlmAdminUsage = Schemas['AdminUsageOut'];
 export type LlmUsageRow = Schemas['UsageRow'];
-export type LlmConnectorType = 'openai_apikey' | 'anthropic_apikey' | 'openai_compatible';
-export type LlmConnectorStatus = 'active' | 'auth_invalid' | 'disabled';
+// Derive from schema so backend enum changes propagate to TS automatically.
+export type LlmConnectorType = Schemas['ConnectorOut']['connector_type'];
+export type LlmConnectorStatus = Schemas['ConnectorOut']['status'];
 export type ActivityLogEntry = Schemas['ActivityLogEntry'];
 export type CapabilityStatus = Schemas['CapabilityStatus'];
 export type ServiceCapabilities = Schemas['ServiceCapabilities'];

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -51,6 +51,20 @@ export type AIModelInfo = Schemas['AIModelInfo'];
 export type AIModelsResponse = Schemas['AIModelsResponse'];
 export type AISettings = Schemas['AISettingsOut'];
 export type AISettingsUpdate = Schemas['AISettingsUpdate'];
+
+// LLM gateway (issue #329)
+export type LlmConnector = Schemas['ConnectorOut'];
+export type LlmAdminConnector = Schemas['AdminConnectorOut'];
+export type LlmConnectorCreate = Schemas['ConnectorCreate'];
+export type LlmConnectorPatch = Schemas['ConnectorPatch'];
+export type LlmConnectorCredentialsRotate = Schemas['ConnectorCredentialsRotate'];
+export type LlmConnectorTestResult = Schemas['ConnectorTestResult'];
+export type LlmAdminPolicy = Schemas['AdminPolicyOut'];
+export type LlmAdminPolicyPatch = Schemas['AdminPolicyPatch'];
+export type LlmAdminUsage = Schemas['AdminUsageOut'];
+export type LlmUsageRow = Schemas['UsageRow'];
+export type LlmConnectorType = 'openai_apikey' | 'anthropic_apikey' | 'openai_compatible';
+export type LlmConnectorStatus = 'active' | 'auth_invalid' | 'disabled';
 export type ActivityLogEntry = Schemas['ActivityLogEntry'];
 export type CapabilityStatus = Schemas['CapabilityStatus'];
 export type ServiceCapabilities = Schemas['ServiceCapabilities'];

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -5,6 +5,15 @@ import type {
   AISettings,
   AISettingsUpdate,
   ActivityLogEntry,
+  LlmAdminConnector,
+  LlmAdminPolicy,
+  LlmAdminPolicyPatch,
+  LlmAdminUsage,
+  LlmConnector,
+  LlmConnectorCreate,
+  LlmConnectorCredentialsRotate,
+  LlmConnectorPatch,
+  LlmConnectorTestResult,
   ArchivedEvent,
   BeatportEventSettings,
   BeatportSearchResult,
@@ -49,6 +58,18 @@ export type {
   AIModelsResponse,
   AISettings,
   AISettingsUpdate,
+  LlmAdminConnector,
+  LlmAdminPolicy,
+  LlmAdminPolicyPatch,
+  LlmAdminUsage,
+  LlmConnector,
+  LlmConnectorCreate,
+  LlmConnectorCredentialsRotate,
+  LlmConnectorPatch,
+  LlmConnectorStatus,
+  LlmConnectorTestResult,
+  LlmConnectorType,
+  LlmUsageRow,
   ArchivedEvent,
   BeatportEventSettings,
   BeatportSearchResult,
@@ -1121,6 +1142,69 @@ class ApiClient {
       method: 'PUT',
       body: JSON.stringify(data),
     });
+  }
+
+  // ========== LLM connectors (per-DJ) ==========
+
+  async listLlmConnectors(): Promise<LlmConnector[]> {
+    return this.fetch('/api/llm/connectors');
+  }
+
+  async createLlmConnector(data: LlmConnectorCreate): Promise<LlmConnector> {
+    return this.fetch('/api/llm/connectors', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updateLlmConnector(id: number, data: LlmConnectorPatch): Promise<LlmConnector> {
+    return this.fetch(`/api/llm/connectors/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async rotateLlmConnectorCredentials(
+    id: number,
+    data: LlmConnectorCredentialsRotate,
+  ): Promise<LlmConnector> {
+    return this.fetch(`/api/llm/connectors/${id}/credentials`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async testLlmConnector(id: number): Promise<LlmConnectorTestResult> {
+    return this.fetch(`/api/llm/connectors/${id}/test`, { method: 'POST' });
+  }
+
+  async deleteLlmConnector(id: number): Promise<void> {
+    await this.fetch(`/api/llm/connectors/${id}`, { method: 'DELETE' });
+  }
+
+  // ========== Admin LLM policy + oversight ==========
+
+  async getAdminLlmPolicy(): Promise<LlmAdminPolicy> {
+    return this.fetch('/api/admin/llm/policy');
+  }
+
+  async updateAdminLlmPolicy(data: LlmAdminPolicyPatch): Promise<LlmAdminPolicy> {
+    return this.fetch('/api/admin/llm/policy', {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async listAllLlmConnectors(): Promise<LlmAdminConnector[]> {
+    return this.fetch('/api/admin/llm/connectors');
+  }
+
+  async revokeAdminLlmConnector(id: number): Promise<LlmAdminConnector> {
+    return this.fetch(`/api/admin/llm/connectors/${id}/revoke`, { method: 'POST' });
+  }
+
+  async getAdminLlmUsage(days = 30): Promise<LlmAdminUsage> {
+    return this.fetch(`/api/admin/llm/usage?days=${days}`);
   }
 
   // ========== Kiosk Pairing ==========

--- a/server/alembic/versions/046_admin_ai_oauth.py
+++ b/server/alembic/versions/046_admin_ai_oauth.py
@@ -1,0 +1,309 @@
+"""LLM gateway: connectors + call log + audit event + system_settings columns + data migration.
+
+Revision ID: 046
+Revises: 045
+Create Date: 2026-05-24
+
+Creates:
+- llm_connectors: per-DJ encrypted credential storage (Fernet via EncryptedText)
+- llm_call_log: per-call telemetry (counts only, no prompt/completion content)
+- llm_audit_event: connector lifecycle events for security review
+- 3 new columns on system_settings (apikey policy, compatible policy, default connector FK)
+
+Data migration:
+- If ANTHROPIC_API_KEY env var is set, creates an "anthropic_apikey" connector
+  named "Org Default (migrated from env var)" owned by the first admin user,
+  and points system_settings.llm_default_connector_id at it.
+- Idempotent: skips if a connector with that name already exists.
+- Skipped silently if no env var, no admin user, or encryption key unavailable.
+"""
+
+import json
+import logging
+import os
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from alembic import op
+from app.core.encryption import encrypt_value
+
+revision: str = "046"
+down_revision: str | None = "045"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger(__name__)
+
+_MIGRATED_DISPLAY_NAME = "Org Default (migrated from env var)"
+
+
+def upgrade() -> None:
+    # llm_connectors
+    op.create_table(
+        "llm_connectors",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("connector_type", sa.String(40), nullable=False),
+        sa.Column("display_name", sa.String(80), nullable=False),
+        sa.Column("status", sa.String(20), nullable=False, server_default="active"),
+        sa.Column("credentials", sa.Text(), nullable=False),
+        sa.Column("base_url_plain", sa.String(255), nullable=True),
+        sa.Column("model_hint", sa.String(80), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("last_used_at", sa.DateTime(), nullable=True),
+        sa.Column("last_error", sa.String(255), nullable=True),
+        sa.UniqueConstraint(
+            "user_id", "connector_type", "display_name", name="uq_dj_connector_label"
+        ),
+    )
+    op.create_index("ix_llm_connectors_user_id", "llm_connectors", ["user_id"])
+    op.create_index("ix_llm_connectors_connector_type", "llm_connectors", ["connector_type"])
+    op.create_index("ix_user_active", "llm_connectors", ["user_id", "status"])
+
+    # llm_call_log
+    op.create_table(
+        "llm_call_log",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "connector_id",
+            sa.Integer(),
+            sa.ForeignKey("llm_connectors.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("purpose", sa.String(40), nullable=False),
+        sa.Column("status", sa.String(20), nullable=False),
+        sa.Column("latency_ms", sa.Integer(), nullable=False),
+        sa.Column("tokens_in", sa.Integer(), nullable=True),
+        sa.Column("tokens_out", sa.Integer(), nullable=True),
+        sa.Column("error_code", sa.String(60), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_llm_call_log_connector_id", "llm_call_log", ["connector_id"])
+    op.create_index("ix_llm_call_log_purpose", "llm_call_log", ["purpose"])
+    op.create_index("ix_llm_call_log_created_at", "llm_call_log", ["created_at"])
+
+    # llm_audit_event
+    op.create_table(
+        "llm_audit_event",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "actor_user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "target_connector_id",
+            sa.Integer(),
+            sa.ForeignKey("llm_connectors.id"),
+            nullable=True,
+        ),
+        sa.Column("event_type", sa.String(60), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_llm_audit_event_actor_user_id", "llm_audit_event", ["actor_user_id"])
+    op.create_index("ix_llm_audit_event_event_type", "llm_audit_event", ["event_type"])
+
+    # system_settings additions
+    op.add_column(
+        "system_settings",
+        sa.Column(
+            "llm_apikey_connectors_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+    op.add_column(
+        "system_settings",
+        sa.Column(
+            "llm_compatible_connector_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+    op.add_column(
+        "system_settings",
+        sa.Column(
+            "llm_default_connector_id",
+            sa.Integer(),
+            sa.ForeignKey("llm_connectors.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+    # Data migration: convert ANTHROPIC_API_KEY env var into a connector + org default
+    _migrate_env_var_anthropic_key()
+
+
+def downgrade() -> None:
+    op.drop_column("system_settings", "llm_default_connector_id")
+    op.drop_column("system_settings", "llm_compatible_connector_enabled")
+    op.drop_column("system_settings", "llm_apikey_connectors_enabled")
+
+    op.drop_index("ix_llm_audit_event_event_type", table_name="llm_audit_event")
+    op.drop_index("ix_llm_audit_event_actor_user_id", table_name="llm_audit_event")
+    op.drop_table("llm_audit_event")
+
+    op.drop_index("ix_llm_call_log_created_at", table_name="llm_call_log")
+    op.drop_index("ix_llm_call_log_purpose", table_name="llm_call_log")
+    op.drop_index("ix_llm_call_log_connector_id", table_name="llm_call_log")
+    op.drop_table("llm_call_log")
+
+    op.drop_index("ix_user_active", table_name="llm_connectors")
+    op.drop_index("ix_llm_connectors_connector_type", table_name="llm_connectors")
+    op.drop_index("ix_llm_connectors_user_id", table_name="llm_connectors")
+    op.drop_table("llm_connectors")
+
+
+def _migrate_env_var_anthropic_key() -> None:
+    """Best-effort data migration. Never fails the migration."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if not api_key:
+        return
+
+    conn = op.get_bind()
+    session = Session(bind=conn)
+    try:
+        admin_row = session.execute(
+            sa.text("SELECT id FROM users WHERE role = 'admin' ORDER BY id ASC LIMIT 1")
+        ).first()
+        if not admin_row:
+            logger.info("046_admin_ai_oauth: no admin user found, skipping data migration")
+            return
+
+        admin_id = admin_row[0]
+
+        # Idempotency: skip if a connector with this label already exists.
+        existing = session.execute(
+            sa.text("SELECT id FROM llm_connectors WHERE user_id = :uid AND display_name = :name"),
+            {"uid": admin_id, "name": _MIGRATED_DISPLAY_NAME},
+        ).first()
+        if existing:
+            logger.info("046_admin_ai_oauth: connector already exists, skipping data migration")
+            return
+
+        try:
+            encrypted_creds = encrypt_value(json.dumps({"api_key": api_key}))
+        except Exception:
+            logger.warning("046_admin_ai_oauth: encryption unavailable, skipping data migration")
+            return
+
+        # Pull anthropic_model from settings if available; falls back to default.
+        try:
+            from app.core.config import get_settings
+
+            model_hint = get_settings().anthropic_model
+        except Exception:
+            model_hint = "claude-haiku-4-5-20251001"
+
+        now = datetime.now(UTC).replace(tzinfo=None)
+        result = session.execute(
+            sa.text(
+                "INSERT INTO llm_connectors "
+                "(user_id, connector_type, display_name, status, credentials, "
+                "model_hint, created_at, updated_at) "
+                "VALUES (:uid, :ctype, :name, :status, :creds, "
+                ":mhint, :created, :updated) "
+                "RETURNING id"
+            ),
+            {
+                "uid": admin_id,
+                "ctype": "anthropic_apikey",
+                "name": _MIGRATED_DISPLAY_NAME,
+                "status": "active",
+                "creds": encrypted_creds,
+                "mhint": model_hint,
+                "created": now,
+                "updated": now,
+            },
+        )
+        connector_id_row = result.first()
+        if connector_id_row is None:
+            # SQLite doesn't support RETURNING — fetch lastrowid via execute
+            connector_id = session.execute(
+                sa.text(
+                    "SELECT id FROM llm_connectors WHERE user_id = :uid AND display_name = :name"
+                ),
+                {"uid": admin_id, "name": _MIGRATED_DISPLAY_NAME},
+            ).scalar()
+        else:
+            connector_id = connector_id_row[0]
+
+        if connector_id is None:
+            logger.warning("046_admin_ai_oauth: could not resolve new connector id")
+            return
+
+        # Ensure system_settings row exists, then point at the new connector.
+        ss = session.execute(sa.text("SELECT id FROM system_settings LIMIT 1")).first()
+        if ss:
+            session.execute(
+                sa.text(
+                    "UPDATE system_settings SET llm_default_connector_id = :cid WHERE id = :sid"
+                ),
+                {"cid": connector_id, "sid": ss[0]},
+            )
+        else:
+            session.execute(
+                sa.text(
+                    "INSERT INTO system_settings (id, llm_default_connector_id) VALUES (1, :cid)"
+                ),
+                {"cid": connector_id},
+            )
+
+        # Audit event
+        session.execute(
+            sa.text(
+                "INSERT INTO llm_audit_event "
+                "(actor_user_id, target_connector_id, event_type, created_at) "
+                "VALUES (:uid, :cid, :etype, :created)"
+            ),
+            {
+                "uid": admin_id,
+                "cid": connector_id,
+                "etype": "connector_created",
+                "created": now,
+            },
+        )
+
+        session.commit()
+        logger.info(
+            "046_admin_ai_oauth: migrated ANTHROPIC_API_KEY env var to "
+            "connector_id=%s for admin user_id=%s",
+            connector_id,
+            admin_id,
+        )
+    except Exception as exc:
+        logger.warning("046_admin_ai_oauth: data migration failed: %s", exc)
+        session.rollback()
+    finally:
+        session.close()

--- a/server/alembic/versions/046_admin_ai_oauth.py
+++ b/server/alembic/versions/046_admin_ai_oauth.py
@@ -118,7 +118,7 @@ def upgrade() -> None:
         sa.Column(
             "target_connector_id",
             sa.Integer(),
-            sa.ForeignKey("llm_connectors.id"),
+            sa.ForeignKey("llm_connectors.id", ondelete="SET NULL"),
             nullable=True,
         ),
         sa.Column("event_type", sa.String(60), nullable=False),

--- a/server/app/api/__init__.py
+++ b/server/app/api/__init__.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from app.api import (
     admin,
+    admin_llm,
     auth,
     beatport,
     bridge,
@@ -9,6 +10,7 @@ from app.api import (
     events,
     guest,
     kiosk,
+    llm,
     public,
     requests,
     search,
@@ -43,3 +45,5 @@ api_router.include_router(beatport.router, prefix="/beatport", tags=["beatport"]
 api_router.include_router(kiosk.public_router, prefix="/public/kiosk", tags=["kiosk"])
 api_router.include_router(kiosk.auth_router, prefix="/kiosk", tags=["kiosk"])
 api_router.include_router(admin.router, prefix="/admin", tags=["admin"])
+api_router.include_router(llm.router, prefix="/llm", tags=["llm"])
+api_router.include_router(admin_llm.router, prefix="/admin/llm", tags=["admin", "llm"])

--- a/server/app/api/admin_llm.py
+++ b/server/app/api/admin_llm.py
@@ -1,0 +1,204 @@
+"""Admin LLM policy + connector oversight endpoints.
+
+Authentication: ``get_current_admin``.
+Routes are mounted at ``/api/admin/llm``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import Request as FastAPIRequest
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_admin, get_db
+from app.core.rate_limit import limiter
+from app.models.llm_connector import LlmConnector
+from app.models.user import User
+from app.schemas.llm import (
+    AdminConnectorOut,
+    AdminPolicyOut,
+    AdminPolicyPatch,
+    AdminUsageOut,
+    UsageRow,
+)
+from app.services.llm.connector_storage import (
+    AUDIT_POLICY_CHANGED,
+    AUDIT_REVOKED_BY_ADMIN,
+    audit_event,
+    get_connector,
+    get_usage_stats,
+    get_user_label,
+    list_all_connectors,
+    revoke_connector,
+)
+from app.services.system_settings import get_system_settings, update_system_settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/policy", response_model=AdminPolicyOut)
+@limiter.limit("60/minute")
+def get_policy(
+    request: FastAPIRequest,
+    _admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> AdminPolicyOut:
+    settings = get_system_settings(db)
+    return AdminPolicyOut(
+        llm_apikey_connectors_enabled=settings.llm_apikey_connectors_enabled,
+        llm_compatible_connector_enabled=settings.llm_compatible_connector_enabled,
+        llm_default_connector_id=settings.llm_default_connector_id,
+    )
+
+
+@router.patch("/policy", response_model=AdminPolicyOut)
+@limiter.limit("30/minute")
+def patch_policy(
+    request: FastAPIRequest,
+    payload: AdminPolicyPatch,
+    admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> AdminPolicyOut:
+    update_kwargs: dict = {}
+    if payload.llm_apikey_connectors_enabled is not None:
+        update_kwargs["llm_apikey_connectors_enabled"] = payload.llm_apikey_connectors_enabled
+    if payload.llm_compatible_connector_enabled is not None:
+        update_kwargs["llm_compatible_connector_enabled"] = payload.llm_compatible_connector_enabled
+
+    # Default connector handling:
+    # - clear_default=True takes precedence and sets to NULL
+    # - otherwise, llm_default_connector_id (if non-None) is validated and set
+    if payload.clear_default:
+        update_kwargs["llm_default_connector_id"] = None
+    elif payload.llm_default_connector_id is not None:
+        target = get_connector(db, payload.llm_default_connector_id)
+        if target is None:
+            raise HTTPException(status_code=400, detail="default connector not found")
+        if target.status != "active":
+            raise HTTPException(
+                status_code=400,
+                detail="default connector must be active",
+            )
+        update_kwargs["llm_default_connector_id"] = target.id
+
+    settings = update_system_settings(db, **update_kwargs)
+    audit_event(
+        db,
+        actor_user_id=admin.id,
+        target_connector_id=settings.llm_default_connector_id,
+        event_type=AUDIT_POLICY_CHANGED,
+    )
+    db.commit()
+    return AdminPolicyOut(
+        llm_apikey_connectors_enabled=settings.llm_apikey_connectors_enabled,
+        llm_compatible_connector_enabled=settings.llm_compatible_connector_enabled,
+        llm_default_connector_id=settings.llm_default_connector_id,
+    )
+
+
+@router.get("/connectors", response_model=list[AdminConnectorOut])
+@limiter.limit("60/minute")
+def list_connectors_admin(
+    request: FastAPIRequest,
+    _admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> list[AdminConnectorOut]:
+    rows = list_all_connectors(db)
+    user_ids = {r.user_id for r in rows}
+    usernames: dict[int, str] = {}
+    if user_ids:
+        users = db.query(User).filter(User.id.in_(user_ids)).all()
+        usernames = {u.id: u.username for u in users}
+
+    out: list[AdminConnectorOut] = []
+    for r in rows:
+        payload = AdminConnectorOut.model_validate(
+            {
+                **{c.name: getattr(r, c.name) for c in LlmConnector.__table__.columns},
+                "dj_username": usernames.get(r.user_id) or f"user#{r.user_id}",
+            }
+        )
+        out.append(payload)
+    return out
+
+
+@router.post("/connectors/{connector_id}/revoke", response_model=AdminConnectorOut)
+@limiter.limit("30/minute")
+def revoke_connector_admin(
+    request: FastAPIRequest,
+    connector_id: int,
+    admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> AdminConnectorOut:
+    row = get_connector(db, connector_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Connector not found")
+
+    revoke_connector(row)
+    audit_event(
+        db,
+        actor_user_id=admin.id,
+        target_connector_id=row.id,
+        event_type=AUDIT_REVOKED_BY_ADMIN,
+    )
+
+    # If the revoked connector was the system default, clear it.
+    settings = get_system_settings(db)
+    if settings.llm_default_connector_id == row.id:
+        settings.llm_default_connector_id = None
+
+    db.commit()
+    db.refresh(row)
+    return AdminConnectorOut.model_validate(
+        {
+            **{c.name: getattr(row, c.name) for c in LlmConnector.__table__.columns},
+            "dj_username": get_user_label(db, row.user_id),
+        }
+    )
+
+
+@router.get("/usage", response_model=AdminUsageOut)
+@limiter.limit("30/minute")
+def get_usage(
+    request: FastAPIRequest,
+    days: int = Query(default=30, ge=1, le=180),
+    _admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> AdminUsageOut:
+    rows = get_usage_stats(db, days=days)
+    rows_out: list[UsageRow] = []
+    if rows:
+        connector_ids = [r["connector_id"] for r in rows]
+        connectors = db.query(LlmConnector).filter(LlmConnector.id.in_(connector_ids)).all()
+        connector_map = {c.id: c for c in connectors}
+        user_ids = {c.user_id for c in connectors}
+        users = db.query(User).filter(User.id.in_(user_ids)).all() if user_ids else []
+        usernames = {u.id: u.username for u in users}
+
+        for r in rows:
+            cid = r["connector_id"]
+            c = connector_map.get(cid)
+            if c is None:
+                continue
+            total = r["total_calls"]
+            errors = r["error_count"]
+            rows_out.append(
+                UsageRow(
+                    connector_id=cid,
+                    dj_username=usernames.get(c.user_id, f"user#{c.user_id}"),
+                    display_name=c.display_name,
+                    connector_type=c.connector_type,  # type: ignore[arg-type]
+                    total_calls=total,
+                    total_tokens_in=r["total_tokens_in"],
+                    total_tokens_out=r["total_tokens_out"],
+                    error_count=errors,
+                    error_rate=(errors / total) if total else 0.0,
+                )
+            )
+    # Sort: most calls first, then by error rate desc as tiebreaker
+    rows_out.sort(key=lambda r: (-r.total_calls, -r.error_rate))
+    return AdminUsageOut(days=days, rows=rows_out)

--- a/server/app/api/admin_llm.py
+++ b/server/app/api/admin_llm.py
@@ -71,8 +71,13 @@ def patch_policy(
 
     # Default connector handling:
     # - clear_default=True takes precedence and sets to NULL
+    # - explicit `llm_default_connector_id: null` also clears the default
     # - otherwise, llm_default_connector_id (if non-None) is validated and set
-    if payload.clear_default:
+    explicit_null_default = (
+        "llm_default_connector_id" in payload.model_fields_set
+        and payload.llm_default_connector_id is None
+    )
+    if payload.clear_default or explicit_null_default:
         update_kwargs["llm_default_connector_id"] = None
     elif payload.llm_default_connector_id is not None:
         target = get_connector(db, payload.llm_default_connector_id)

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -190,7 +190,7 @@ def _request_to_out(r) -> RequestOut:
     )
 
 
-def _build_recommendation_response(result, db) -> RecommendationResponse:
+def _build_recommendation_response(result, db, actor=None) -> RecommendationResponse:
     """Build a RecommendationResponse from a recommendation engine result."""
     from app.services.recommendation.camelot import parse_key
     from app.services.recommendation.llm_hooks import is_llm_available
@@ -233,7 +233,7 @@ def _build_recommendation_response(result, db) -> RecommendationResponse:
         profile=profile,
         services_used=result.services_used,
         total_candidates_searched=result.total_candidates_searched,
-        llm_available=is_llm_available(db),
+        llm_available=is_llm_available(db, actor=actor),
     )
 
 
@@ -840,7 +840,7 @@ def get_recommendations(
         )
 
     result = generate_recommendations(db, user, event)
-    return _build_recommendation_response(result, db)
+    return _build_recommendation_response(result, db, actor=user)
 
 
 @router.get("/{code}/playlists")
@@ -917,7 +917,7 @@ def get_recommendations_from_template(
         template_source=template_request.source,
         template_id=template_request.playlist_id,
     )
-    return _build_recommendation_response(result, db)
+    return _build_recommendation_response(result, db, actor=user)
 
 
 @router.post("/{code}/recommendations/llm")
@@ -938,13 +938,13 @@ async def get_llm_recommendations(
     sys_settings = get_system_settings(db)
     _llm_rate_limit_cache["value"] = sys_settings.llm_rate_limit_per_minute
 
-    if not is_llm_available(db):
+    user = event.created_by
+
+    if not is_llm_available(db, actor=user):
         raise HTTPException(
             status_code=503,
             detail="LLM recommendations not configured. Set ANTHROPIC_API_KEY to enable.",
         )
-
-    user = event.created_by
 
     has_services = bool(user.tidal_access_token) or bool(user.beatport_access_token)
     if not has_services:

--- a/server/app/api/llm.py
+++ b/server/app/api/llm.py
@@ -172,7 +172,17 @@ def update_connector_metadata(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    db.commit()
+    try:
+        db.commit()
+    except Exception as exc:  # likely a UniqueConstraint collision on rename
+        db.rollback()
+        if "uq_dj_connector_label" in str(exc):
+            raise HTTPException(
+                status_code=409,
+                detail="You already have a connector with that display name and type",
+            ) from exc
+        logger.exception("Failed to update LLM connector metadata")
+        raise HTTPException(status_code=500, detail="Failed to update connector metadata") from exc
     db.refresh(row)
     return ConnectorOut.model_validate(row)
 

--- a/server/app/api/llm.py
+++ b/server/app/api/llm.py
@@ -1,0 +1,281 @@
+"""Per-DJ LLM connector management endpoints.
+
+Authentication: ``get_current_active_user`` (any DJ, not pending).
+Routes are mounted at ``/api/llm/connectors``.
+
+All endpoints scope queries by ``user_id = current_user.id`` server-side.
+404 (not 403) is returned for connector IDs the DJ doesn't own — this avoids
+leaking the existence of another DJ's connectors.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi import Request as FastAPIRequest
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_active_user, get_db
+from app.core.rate_limit import limiter
+from app.models.llm_connector import (
+    CONNECTOR_TYPE_OPENAI_COMPATIBLE,
+    STATUS_DISABLED,
+    VALID_CONNECTOR_TYPES,
+)
+from app.models.user import User
+from app.schemas.llm import (
+    ConnectorCreate,
+    ConnectorCredentialsRotate,
+    ConnectorOut,
+    ConnectorPatch,
+    ConnectorTestResult,
+)
+from app.services.llm.connector_storage import (
+    AUDIT_CREATED,
+    AUDIT_CREDENTIALS_ROTATED,
+    AUDIT_DELETED,
+    AUDIT_HEALTH_CHECK,
+    audit_event,
+    build_create_payload,
+    create_connector,
+    delete_connector,
+    get_connector_for_user,
+    list_connectors_for_user,
+    rotate_credentials,
+    update_metadata,
+)
+from app.services.llm.exceptions import (
+    AuthInvalid,
+    LlmError,
+    ProviderUnavailable,
+    QuotaExceeded,
+    RateLimited,
+    ToolTranslationError,
+)
+from app.services.llm.registry import get_adapter_class
+from app.services.system_settings import get_system_settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _check_connector_type_allowed(db: Session, connector_type: str) -> None:
+    """Enforce the admin policy toggles. Raises 403 when blocked."""
+    settings = get_system_settings(db)
+    if connector_type == CONNECTOR_TYPE_OPENAI_COMPATIBLE:
+        if not settings.llm_compatible_connector_enabled:
+            raise HTTPException(
+                status_code=403,
+                detail="Custom OpenAI-compatible connectors are disabled by admin policy",
+            )
+    elif connector_type in VALID_CONNECTOR_TYPES:
+        if not settings.llm_apikey_connectors_enabled:
+            raise HTTPException(
+                status_code=403,
+                detail="API-key connectors are disabled by admin policy",
+            )
+
+
+def _sanitize_error(exc: Exception) -> tuple[str, str]:
+    """Map an LLM exception to (error_code, user-friendly message).
+
+    Upstream error bodies / stack traces are deliberately NOT included.
+    """
+    if isinstance(exc, AuthInvalid):
+        return "auth_invalid", "Authentication failed against the provider"
+    if isinstance(exc, RateLimited):
+        return "rate_limited", "Provider rate limited the request"
+    if isinstance(exc, QuotaExceeded):
+        return "quota_exceeded", "Provider quota or billing failure"
+    if isinstance(exc, ProviderUnavailable):
+        return "provider_unavailable", "Provider unreachable or timed out"
+    if isinstance(exc, ToolTranslationError):
+        return "tool_translation_error", "Unexpected response shape"
+    if isinstance(exc, LlmError):
+        return "llm_error", "LLM error"
+    return "unknown", "Unknown error"
+
+
+@router.get("/connectors", response_model=list[ConnectorOut])
+@limiter.limit("60/minute")
+def list_connectors(
+    request: FastAPIRequest,
+    user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+) -> list[ConnectorOut]:
+    rows = list_connectors_for_user(db, user.id)
+    return [ConnectorOut.model_validate(r) for r in rows]
+
+
+@router.post("/connectors", response_model=ConnectorOut, status_code=201)
+@limiter.limit("5/minute")
+def create_connector_endpoint(
+    request: FastAPIRequest,
+    payload: ConnectorCreate,
+    user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+) -> ConnectorOut:
+    _check_connector_type_allowed(db, payload.connector_type)
+
+    try:
+        built = build_create_payload(
+            connector_type=payload.connector_type,
+            display_name=payload.display_name,
+            api_key=payload.api_key,
+            base_url=payload.base_url,
+            bearer=payload.bearer,
+            model_hint=payload.model_hint,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        row = create_connector(db, user_id=user.id, payload=built)
+    except Exception as exc:  # likely a UniqueConstraint collision
+        db.rollback()
+        if "uq_dj_connector_label" in str(exc):
+            raise HTTPException(
+                status_code=409,
+                detail="You already have a connector with that display name and type",
+            ) from exc
+        logger.exception("Failed to create LLM connector")
+        raise HTTPException(status_code=500, detail="Failed to create connector") from exc
+
+    audit_event(
+        db,
+        actor_user_id=user.id,
+        target_connector_id=row.id,
+        event_type=AUDIT_CREATED,
+    )
+    db.commit()
+    db.refresh(row)
+    return ConnectorOut.model_validate(row)
+
+
+@router.patch("/connectors/{connector_id}", response_model=ConnectorOut)
+@limiter.limit("30/minute")
+def update_connector_metadata(
+    request: FastAPIRequest,
+    connector_id: int,
+    payload: ConnectorPatch,
+    user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+) -> ConnectorOut:
+    row = get_connector_for_user(db, connector_id, user.id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Connector not found")
+
+    try:
+        update_metadata(row, display_name=payload.display_name, model_hint=payload.model_hint)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    db.commit()
+    db.refresh(row)
+    return ConnectorOut.model_validate(row)
+
+
+@router.put("/connectors/{connector_id}/credentials", response_model=ConnectorOut)
+@limiter.limit("5/minute")
+def rotate_connector_credentials(
+    request: FastAPIRequest,
+    connector_id: int,
+    payload: ConnectorCredentialsRotate,
+    user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+) -> ConnectorOut:
+    row = get_connector_for_user(db, connector_id, user.id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Connector not found")
+
+    try:
+        rotate_credentials(
+            db,
+            connector=row,
+            api_key=payload.api_key,
+            base_url=payload.base_url,
+            bearer=payload.bearer,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    audit_event(
+        db,
+        actor_user_id=user.id,
+        target_connector_id=row.id,
+        event_type=AUDIT_CREDENTIALS_ROTATED,
+    )
+    db.commit()
+    db.refresh(row)
+    return ConnectorOut.model_validate(row)
+
+
+@router.post("/connectors/{connector_id}/test", response_model=ConnectorTestResult)
+@limiter.limit("10/minute")
+async def test_connector(
+    request: FastAPIRequest,
+    connector_id: int,
+    user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+) -> ConnectorTestResult:
+    row = get_connector_for_user(db, connector_id, user.id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Connector not found")
+
+    adapter_cls = get_adapter_class(row.connector_type)
+    adapter = adapter_cls(row)
+
+    audit_event(
+        db,
+        actor_user_id=user.id,
+        target_connector_id=row.id,
+        event_type=AUDIT_HEALTH_CHECK,
+    )
+
+    try:
+        await adapter.health_check()
+    except AuthInvalid as exc:
+        row.status = "auth_invalid"
+        row.last_error = "auth_invalid"
+        db.commit()
+        code, message = _sanitize_error(exc)
+        return ConnectorTestResult(ok=False, error_code=code, message=message)
+    except LlmError as exc:
+        # Don't flip status for transient errors — DJ will see message + retry.
+        code, message = _sanitize_error(exc)
+        db.commit()
+        return ConnectorTestResult(ok=False, error_code=code, message=message)
+    except Exception:  # noqa: BLE001 — sanitised
+        logger.exception("Connector health check failed unexpectedly")
+        db.commit()
+        return ConnectorTestResult(ok=False, error_code="unknown", message="Unknown error")
+
+    row.last_error = None
+    if row.status != STATUS_DISABLED:
+        row.status = "active"
+    db.commit()
+    return ConnectorTestResult(ok=True)
+
+
+@router.delete("/connectors/{connector_id}", status_code=204)
+@limiter.limit("30/minute")
+def delete_connector_endpoint(
+    request: FastAPIRequest,
+    connector_id: int,
+    user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+) -> None:
+    row = get_connector_for_user(db, connector_id, user.id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Connector not found")
+    audit_event(
+        db,
+        actor_user_id=user.id,
+        target_connector_id=row.id,
+        event_type=AUDIT_DELETED,
+    )
+    delete_connector(db, row)
+    db.commit()
+    return None

--- a/server/app/models/__init__.py
+++ b/server/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.event import Event
 from app.models.guest import Guest
 from app.models.guest_profile import GuestProfile  # noqa: F401
 from app.models.kiosk import Kiosk
+from app.models.llm_connector import LlmAuditEvent, LlmCallLog, LlmConnector
 from app.models.mb_artist_cache import MbArtistCache
 from app.models.now_playing import NowPlaying
 from app.models.pending_email_change import PendingEmailChange
@@ -23,6 +24,9 @@ __all__ = [
     "Guest",
     "GuestProfile",
     "Kiosk",
+    "LlmAuditEvent",
+    "LlmCallLog",
+    "LlmConnector",
     "MbArtistCache",
     "NowPlaying",
     "PendingEmailChange",

--- a/server/app/models/llm_connector.py
+++ b/server/app/models/llm_connector.py
@@ -127,7 +127,7 @@ class LlmAuditEvent(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     actor_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True, nullable=False)
     target_connector_id: Mapped[int | None] = mapped_column(
-        ForeignKey("llm_connectors.id"), nullable=True
+        ForeignKey("llm_connectors.id", ondelete="SET NULL"), nullable=True
     )
     event_type: Mapped[str] = mapped_column(String(60), index=True, nullable=False)
     created_at: Mapped[datetime] = mapped_column(

--- a/server/app/models/llm_connector.py
+++ b/server/app/models/llm_connector.py
@@ -1,0 +1,135 @@
+"""LLM connector models — provider-agnostic credential storage and audit trail.
+
+Tables:
+- llm_connectors: per-DJ LLM provider credentials (encrypted at rest)
+- llm_call_log: per-call telemetry (counts only — no prompt/completion content)
+- llm_audit_event: security-relevant credential lifecycle events
+
+See docs/superpowers/specs/2026-05-24-admin-ai-oauth-design.md §4.2.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.encryption import EncryptedText
+from app.models.base import Base
+
+# Valid connector types — keep in sync with services/llm/registry.py
+CONNECTOR_TYPE_OPENAI_APIKEY = "openai_apikey"
+CONNECTOR_TYPE_ANTHROPIC_APIKEY = "anthropic_apikey"
+CONNECTOR_TYPE_OPENAI_COMPATIBLE = "openai_compatible"
+
+VALID_CONNECTOR_TYPES = frozenset(
+    {
+        CONNECTOR_TYPE_OPENAI_APIKEY,
+        CONNECTOR_TYPE_ANTHROPIC_APIKEY,
+        CONNECTOR_TYPE_OPENAI_COMPATIBLE,
+    }
+)
+
+# Connector statuses
+STATUS_ACTIVE = "active"
+STATUS_AUTH_INVALID = "auth_invalid"
+STATUS_DISABLED = "disabled"
+
+# Audit event types
+AUDIT_CREATED = "connector_created"
+AUDIT_CREDENTIALS_ROTATED = "connector_credentials_rotated"
+AUDIT_DELETED = "connector_deleted"
+AUDIT_REVOKED_BY_ADMIN = "connector_revoked_by_admin"
+AUDIT_AUTH_INVALID_OBSERVED = "auth_invalid_observed"
+AUDIT_POLICY_CHANGED = "policy_changed"
+AUDIT_HEALTH_CHECK = "connector_health_check"
+
+
+class LlmConnector(Base):
+    """Per-DJ LLM provider credentials.
+
+    `credentials` is a JSON string encrypted via Fernet. Shape varies by type:
+    - openai_apikey / anthropic_apikey: {"api_key": "..."}
+    - openai_compatible: {"base_url": "...", "bearer": "..." | null}
+
+    `base_url_plain` mirrors the openai_compatible base_url in plaintext so admin
+    listing can render without decrypting. Contains no credentials.
+    """
+
+    __tablename__ = "llm_connectors"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    connector_type: Mapped[str] = mapped_column(String(40), index=True, nullable=False)
+    display_name: Mapped[str] = mapped_column(String(80), nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default=STATUS_ACTIVE)
+    credentials: Mapped[str] = mapped_column(EncryptedText, nullable=False)
+
+    base_url_plain: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    model_hint: Mapped[str | None] = mapped_column(String(80), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    last_error: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "connector_type", "display_name", name="uq_dj_connector_label"),
+        Index("ix_user_active", "user_id", "status"),
+    )
+
+
+class LlmCallLog(Base):
+    """Per-call telemetry — counts only, never prompt/completion content.
+
+    30-day retention is the default; daily cleanup deletes older rows.
+    """
+
+    __tablename__ = "llm_call_log"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    connector_id: Mapped[int] = mapped_column(
+        ForeignKey("llm_connectors.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    purpose: Mapped[str] = mapped_column(String(40), index=True, nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    latency_ms: Mapped[int] = mapped_column(Integer, nullable=False)
+    tokens_in: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    tokens_out: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    error_code: Mapped[str | None] = mapped_column(String(60), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), index=True
+    )
+
+
+class LlmAuditEvent(Base):
+    """Security-relevant connector lifecycle events.
+
+    Indefinite retention (no auto-cleanup). Includes admin-triggered events
+    so org operators have a complete audit trail for security reviews.
+    """
+
+    __tablename__ = "llm_audit_event"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    actor_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True, nullable=False)
+    target_connector_id: Mapped[int | None] = mapped_column(
+        ForeignKey("llm_connectors.id"), nullable=True
+    )
+    event_type: Mapped[str] = mapped_column(String(60), index=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )

--- a/server/app/models/system_settings.py
+++ b/server/app/models/system_settings.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Integer, String
+from sqlalchemy import Boolean, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base
@@ -25,3 +25,13 @@ class SystemSettings(Base):
     llm_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     llm_model: Mapped[str] = mapped_column(String(100), default="claude-haiku-4-5-20251001")
     llm_rate_limit_per_minute: Mapped[int] = mapped_column(Integer, default=3)
+
+    # LLM gateway connector policy (admin-controlled)
+    # See docs/superpowers/specs/2026-05-24-admin-ai-oauth-design.md §4.2
+    llm_apikey_connectors_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    llm_compatible_connector_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    # Org-default connector — used when a system-context (no actor) LLM call is dispatched
+    # FK kept nullable; SET NULL on connector delete to avoid orphan references.
+    llm_default_connector_id: Mapped[int | None] = mapped_column(
+        ForeignKey("llm_connectors.id", ondelete="SET NULL"), nullable=True
+    )

--- a/server/app/schemas/llm.py
+++ b/server/app/schemas/llm.py
@@ -1,0 +1,98 @@
+"""Pydantic schemas for the LLM gateway / connector API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ConnectorType = Literal["openai_apikey", "anthropic_apikey", "openai_compatible"]
+ConnectorStatus = Literal["active", "auth_invalid", "disabled"]
+
+
+class ConnectorOut(BaseModel):
+    """Public-safe connector view — never includes the credential blob."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    user_id: int
+    connector_type: ConnectorType
+    display_name: str
+    status: ConnectorStatus
+    base_url_plain: str | None = None
+    model_hint: str | None = None
+    created_at: datetime
+    updated_at: datetime
+    last_used_at: datetime | None = None
+    last_error: str | None = None
+
+
+class AdminConnectorOut(ConnectorOut):
+    """Admin view — adds the DJ's username for display."""
+
+    dj_username: str
+
+
+class ConnectorCreate(BaseModel):
+    connector_type: ConnectorType
+    display_name: str = Field(..., min_length=1, max_length=80)
+    model_hint: str | None = Field(default=None, max_length=80)
+
+    # Set for apikey types
+    api_key: str | None = Field(default=None, max_length=512)
+
+    # Set for openai_compatible
+    base_url: str | None = Field(default=None, max_length=512)
+    bearer: str | None = Field(default=None, max_length=512)
+
+
+class ConnectorPatch(BaseModel):
+    """Metadata-only patch (no credential rotation here)."""
+
+    display_name: str | None = Field(default=None, min_length=1, max_length=80)
+    model_hint: str | None = Field(default=None, max_length=80)
+
+
+class ConnectorCredentialsRotate(BaseModel):
+    api_key: str | None = Field(default=None, max_length=512)
+    base_url: str | None = Field(default=None, max_length=512)
+    bearer: str | None = Field(default=None, max_length=512)
+
+
+class ConnectorTestResult(BaseModel):
+    ok: bool
+    error_code: str | None = None
+    message: str | None = None
+
+
+class AdminPolicyOut(BaseModel):
+    llm_apikey_connectors_enabled: bool
+    llm_compatible_connector_enabled: bool
+    llm_default_connector_id: int | None
+
+
+class AdminPolicyPatch(BaseModel):
+    llm_apikey_connectors_enabled: bool | None = None
+    llm_compatible_connector_enabled: bool | None = None
+    # Use a sentinel sentinel: clients can send null to clear, or omit to leave unchanged
+    llm_default_connector_id: int | None = None
+    clear_default: bool = False
+
+
+class UsageRow(BaseModel):
+    connector_id: int
+    dj_username: str
+    display_name: str
+    connector_type: ConnectorType
+    total_calls: int
+    total_tokens_in: int
+    total_tokens_out: int
+    error_count: int
+    error_rate: float
+
+
+class AdminUsageOut(BaseModel):
+    days: int
+    rows: list[UsageRow]

--- a/server/app/schemas/llm.py
+++ b/server/app/schemas/llm.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 ConnectorType = Literal["openai_apikey", "anthropic_apikey", "openai_compatible"]
 ConnectorStatus = Literal["active", "auth_invalid", "disabled"]
@@ -36,6 +36,20 @@ class AdminConnectorOut(ConnectorOut):
 
 
 class ConnectorCreate(BaseModel):
+    """Provider-agnostic create payload.
+
+    Field requirements vary by ``connector_type``:
+
+    - ``openai_apikey`` / ``anthropic_apikey``: ``api_key`` required;
+      ``base_url`` and ``bearer`` are ignored.
+    - ``openai_compatible``: ``base_url`` required; ``bearer`` optional;
+      ``api_key`` is ignored.
+
+    The combination is enforced by :meth:`_require_credentials_for_type`.
+    See ``build_create_payload`` in ``services/llm/connector_storage.py``
+    for the full validation flow (including key shape checks).
+    """
+
     connector_type: ConnectorType
     display_name: str = Field(..., min_length=1, max_length=80)
     model_hint: str | None = Field(default=None, max_length=80)
@@ -47,6 +61,16 @@ class ConnectorCreate(BaseModel):
     base_url: str | None = Field(default=None, max_length=512)
     bearer: str | None = Field(default=None, max_length=512)
 
+    @model_validator(mode="after")
+    def _require_credentials_for_type(self) -> ConnectorCreate:
+        if self.connector_type in ("openai_apikey", "anthropic_apikey"):
+            if not self.api_key:
+                raise ValueError("api_key is required for API-key connectors")
+        elif self.connector_type == "openai_compatible":
+            if not self.base_url:
+                raise ValueError("base_url is required for openai_compatible connectors")
+        return self
+
 
 class ConnectorPatch(BaseModel):
     """Metadata-only patch (no credential rotation here)."""
@@ -56,9 +80,21 @@ class ConnectorPatch(BaseModel):
 
 
 class ConnectorCredentialsRotate(BaseModel):
+    """Rotation payload — at least one credential field must be supplied.
+
+    Field semantics mirror :class:`ConnectorCreate`. The actual field required
+    depends on the connector being rotated (validated in ``rotate_credentials``).
+    """
+
     api_key: str | None = Field(default=None, max_length=512)
     base_url: str | None = Field(default=None, max_length=512)
     bearer: str | None = Field(default=None, max_length=512)
+
+    @model_validator(mode="after")
+    def _require_at_least_one(self) -> ConnectorCredentialsRotate:
+        if not (self.api_key or self.base_url or self.bearer):
+            raise ValueError("At least one of api_key, base_url, or bearer must be provided")
+        return self
 
 
 class ConnectorTestResult(BaseModel):

--- a/server/app/services/llm/__init__.py
+++ b/server/app/services/llm/__init__.py
@@ -1,0 +1,47 @@
+"""LLM gateway — provider-agnostic dispatch for agentic features.
+
+See docs/superpowers/specs/2026-05-24-admin-ai-oauth-design.md.
+
+Entrypoint: ``Gateway.dispatch(db, actor, request, *, purpose)`` →
+``ChatResponse``. Adapters live under :mod:`app.services.llm.adapters`.
+"""
+
+from app.services.llm.base import (
+    ChatRequest,
+    ChatResponse,
+    ContentBlock,
+    LlmAdapter,
+    Message,
+    TokenUsage,
+    ToolCall,
+    ToolSpec,
+)
+from app.services.llm.exceptions import (
+    AuthInvalid,
+    LlmError,
+    NoLlmConfigured,
+    ProviderUnavailable,
+    QuotaExceeded,
+    RateLimited,
+    ToolTranslationError,
+)
+from app.services.llm.gateway import Gateway
+
+__all__ = [
+    "AuthInvalid",
+    "ChatRequest",
+    "ChatResponse",
+    "ContentBlock",
+    "Gateway",
+    "LlmAdapter",
+    "LlmError",
+    "Message",
+    "NoLlmConfigured",
+    "ProviderUnavailable",
+    "QuotaExceeded",
+    "RateLimited",
+    "TokenUsage",
+    "ToolCall",
+    "ToolSpec",
+    "ToolTranslationError",
+]

--- a/server/app/services/llm/adapters/__init__.py
+++ b/server/app/services/llm/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Per-provider adapter classes — auto-registered with the gateway registry."""

--- a/server/app/services/llm/adapters/_httpx_openai.py
+++ b/server/app/services/llm/adapters/_httpx_openai.py
@@ -43,8 +43,15 @@ def _messages_to_openai(req: ChatRequest) -> list[dict]:
     for m in req.messages:
         content = m.content
         if isinstance(content, list):
-            # Concatenate text blocks — MVP is text-only.
-            text = "".join(getattr(b, "text", "") or "" for b in content)
+            # Concatenate text blocks — MVP is text-only. Blocks may be dicts
+            # (e.g. {"type": "text", "text": "..."}) or objects with a .text attr.
+            parts: list[str] = []
+            for b in content:
+                if isinstance(b, dict):
+                    parts.append(b.get("text") or "")
+                else:
+                    parts.append(getattr(b, "text", "") or "")
+            text = "".join(parts)
         else:
             text = content or ""
 

--- a/server/app/services/llm/adapters/_httpx_openai.py
+++ b/server/app/services/llm/adapters/_httpx_openai.py
@@ -1,0 +1,185 @@
+"""Shared httpx-backed OpenAI Chat Completions caller.
+
+Both ``openai_apikey`` (Platform) and ``openai_compatible`` (Hermes/Ollama/etc.)
+use the same OpenAI Chat Completions wire format. They differ only in:
+
+- base URL (``https://api.openai.com/v1`` vs the user-supplied URL)
+- header (always ``Authorization: Bearer <token>``; bearer is optional for compatible)
+
+This helper handles the actual HTTP call + error mapping. Adapters wrap it with
+type-specific credential extraction and registration.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import httpx
+
+from app.services.llm.base import ChatRequest, ChatResponse, Message
+from app.services.llm.exceptions import (
+    AuthInvalid,
+    ProviderUnavailable,
+    QuotaExceeded,
+    RateLimited,
+    ToolTranslationError,
+)
+from app.services.llm.tool_translation import parse_openai_response, to_openai_tools
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_SECONDS = 30.0
+MAX_TIMEOUT_SECONDS = 120.0
+
+
+def _messages_to_openai(req: ChatRequest) -> list[dict]:
+    """Translate canonical messages to OpenAI chat-completions format."""
+    out: list[dict] = []
+    if req.system:
+        out.append({"role": "system", "content": req.system})
+
+    for m in req.messages:
+        content = m.content
+        if isinstance(content, list):
+            # Concatenate text blocks — MVP is text-only.
+            text = "".join(getattr(b, "text", "") or "" for b in content)
+        else:
+            text = content or ""
+
+        msg: dict[str, Any] = {"role": _normalise_role(m.role), "content": text}
+        if m.role == "tool":
+            if not m.tool_call_id:
+                raise ToolTranslationError("Tool result message missing tool_call_id")
+            msg["tool_call_id"] = m.tool_call_id
+        out.append(msg)
+    return out
+
+
+def _normalise_role(role: str) -> str:
+    # OpenAI uses identical role names for system/user/assistant/tool.
+    return role
+
+
+def _build_payload(req: ChatRequest, model: str | None) -> dict:
+    tools, choice = to_openai_tools(req.tools, req.force_tool)
+
+    body: dict[str, Any] = {
+        "model": model,
+        "messages": _messages_to_openai(req),
+    }
+    if req.max_tokens is not None:
+        body["max_tokens"] = req.max_tokens
+    if req.temperature is not None:
+        body["temperature"] = req.temperature
+    if tools:
+        body["tools"] = tools
+    if choice is not None:
+        body["tool_choice"] = choice
+
+    return body
+
+
+async def call_openai_chat(
+    *,
+    base_url: str,
+    api_key: str | None,
+    request: ChatRequest,
+    fallback_model: str | None,
+    extra_headers: dict | None = None,
+) -> ChatResponse:
+    """Issue a Chat Completions request and parse the response.
+
+    ``base_url`` must end either at the API root (``/v1``) or at the actual host
+    root — this helper appends ``/chat/completions`` and is tolerant of either
+    form. Adapters are responsible for ensuring URLs are validated upstream.
+    """
+    model = request.model or fallback_model
+    if not model:
+        raise ToolTranslationError(
+            "model is required (set ChatRequest.model or LlmConnector.model_hint)"
+        )
+
+    endpoint = _build_chat_endpoint(base_url)
+
+    headers: dict[str, str] = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"  # nosec B106
+    if extra_headers:
+        headers.update(extra_headers)
+
+    timeout = request.timeout_seconds or DEFAULT_TIMEOUT_SECONDS
+    timeout = min(max(timeout, 1.0), MAX_TIMEOUT_SECONDS)
+
+    payload = _build_payload(request, model)
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(endpoint, json=payload, headers=headers)
+    except httpx.TimeoutException as exc:
+        raise ProviderUnavailable("Upstream timeout") from exc
+    except httpx.HTTPError as exc:
+        raise ProviderUnavailable("Upstream network error") from exc
+
+    _raise_for_status(resp)
+
+    try:
+        body = resp.json()
+    except json.JSONDecodeError as exc:
+        raise ToolTranslationError("Upstream returned non-JSON body") from exc
+    except ValueError as exc:
+        raise ToolTranslationError("Upstream returned non-JSON body") from exc
+
+    return parse_openai_response(body)
+
+
+def _build_chat_endpoint(base_url: str) -> str:
+    base = base_url.rstrip("/")
+    if base.endswith("/chat/completions"):
+        return base
+    return f"{base}/chat/completions"
+
+
+def _raise_for_status(resp: httpx.Response) -> None:
+    if 200 <= resp.status_code < 300:
+        return
+
+    code = resp.status_code
+    if code in (401, 403):
+        raise AuthInvalid(f"Auth failed (HTTP {code})")
+    if code == 402:
+        raise QuotaExceeded("Quota or billing failure (HTTP 402)")
+    if code == 429:
+        retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
+        raise RateLimited("Rate limited (HTTP 429)", retry_after_seconds=retry_after)
+    if 500 <= code < 600:
+        raise ProviderUnavailable(f"Upstream error (HTTP {code})")
+    # 4xx other than the above → treat as a malformed input / translation error
+    # since the gateway only emits known shapes.
+    raise ToolTranslationError(f"Upstream rejected request (HTTP {code})")
+
+
+def _parse_retry_after(value: str | None) -> int | None:
+    if not value:
+        return None
+    try:
+        return int(float(value))
+    except ValueError:
+        return None
+
+
+def build_healthcheck_request() -> ChatRequest:
+    """Return a minimal request used to verify the connector is alive.
+
+    A 1-token call is cheap and exercises the auth path. Adapters override the
+    ``model`` via the connector's ``model_hint`` before sending.
+    """
+    return ChatRequest(
+        messages=[Message(role="user", content="ping")],
+        max_tokens=1,
+        temperature=0.0,
+    )

--- a/server/app/services/llm/adapters/anthropic_apikey.py
+++ b/server/app/services/llm/adapters/anthropic_apikey.py
@@ -1,0 +1,167 @@
+"""Anthropic API-key adapter — uses the official ``anthropic`` SDK."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from anthropic import (
+    APIConnectionError,
+    APIError,
+    APIStatusError,
+    APITimeoutError,
+    AsyncAnthropic,
+)
+
+from app.services.llm.base import ChatRequest, ChatResponse, LlmAdapter, Message
+from app.services.llm.exceptions import (
+    AuthInvalid,
+    ProviderUnavailable,
+    QuotaExceeded,
+    RateLimited,
+    ToolTranslationError,
+)
+from app.services.llm.registry import register_adapter
+from app.services.llm.tool_translation import (
+    parse_anthropic_response,
+    to_anthropic_tools,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "claude-opus-4-7"
+DEFAULT_MAX_TOKENS = 1024
+DEFAULT_TIMEOUT_SECONDS = 30.0
+MAX_TIMEOUT_SECONDS = 120.0
+
+
+class AnthropicApiKeyAdapter(LlmAdapter):
+    connector_type = "anthropic_apikey"
+
+    def _extract_api_key(self) -> str:
+        raw = self.connector.credentials or ""
+        try:
+            blob = json.loads(raw)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise AuthInvalid("Connector credentials are malformed") from exc
+        api_key = blob.get("api_key") if isinstance(blob, dict) else None
+        if not api_key:
+            raise AuthInvalid("Connector is missing an api_key")
+        return str(api_key)
+
+    def _client(self, *, timeout: float) -> AsyncAnthropic:
+        return AsyncAnthropic(api_key=self._extract_api_key(), timeout=timeout)
+
+    async def chat(self, request: ChatRequest) -> ChatResponse:
+        model = request.model or self.connector.model_hint or DEFAULT_MODEL
+        max_tokens = request.max_tokens or DEFAULT_MAX_TOKENS
+        timeout = min(
+            max(request.timeout_seconds or DEFAULT_TIMEOUT_SECONDS, 1.0),
+            MAX_TIMEOUT_SECONDS,
+        )
+
+        anthropic_messages = self._translate_messages(request.messages)
+        tools, choice = to_anthropic_tools(request.tools, request.force_tool)
+
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "messages": anthropic_messages,
+        }
+        if request.system:
+            kwargs["system"] = request.system
+        if request.temperature is not None:
+            kwargs["temperature"] = request.temperature
+        if tools:
+            kwargs["tools"] = tools
+        if choice is not None:
+            kwargs["tool_choice"] = choice
+
+        client = self._client(timeout=timeout)
+
+        try:
+            message = await client.messages.create(**kwargs)
+        except APITimeoutError as exc:
+            raise ProviderUnavailable("Upstream timeout") from exc
+        except APIConnectionError as exc:
+            raise ProviderUnavailable("Upstream network error") from exc
+        except APIStatusError as exc:
+            self._raise_for_status(exc)
+        except APIError as exc:
+            raise ProviderUnavailable(f"Anthropic API error: {type(exc).__name__}") from exc
+
+        return parse_anthropic_response(message)
+
+    async def health_check(self) -> None:
+        # 1-token ping to validate the key + reach the API.
+        ping = ChatRequest(
+            messages=[Message(role="user", content="ping")],
+            max_tokens=1,
+            temperature=0.0,
+        )
+        await self.chat(ping)
+
+    @staticmethod
+    def _translate_messages(messages: list[Message]) -> list[dict]:
+        """Translate canonical messages to Anthropic's user/assistant shape.
+
+        System messages are pulled out by the caller (``request.system``).
+        Tool-result messages map to ``role=user`` with a ``tool_result`` block.
+        """
+        out: list[dict] = []
+        for m in messages:
+            if m.role == "system":
+                # Ignored here — must be passed via request.system. We swallow
+                # it silently to avoid a hard error on legacy callers.
+                continue
+            content = m.content
+            if isinstance(content, list):
+                text = "".join(getattr(b, "text", "") or "" for b in content)
+            else:
+                text = content or ""
+
+            if m.role == "tool":
+                if not m.tool_call_id:
+                    raise ToolTranslationError("Tool message missing tool_call_id")
+                out.append(
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": m.tool_call_id,
+                                "content": text,
+                            }
+                        ],
+                    }
+                )
+                continue
+
+            role = "assistant" if m.role == "assistant" else "user"
+            out.append({"role": role, "content": text})
+        return out
+
+    @staticmethod
+    def _raise_for_status(exc: APIStatusError) -> None:
+        status = getattr(exc, "status_code", None)
+        if status in (401, 403):
+            raise AuthInvalid(f"Auth failed (HTTP {status})") from exc
+        if status == 402:
+            raise QuotaExceeded("Quota or billing failure (HTTP 402)") from exc
+        if status == 429:
+            retry_after = None
+            try:
+                resp_headers = getattr(exc.response, "headers", {}) or {}
+                retry_after_raw = resp_headers.get("retry-after") or resp_headers.get("Retry-After")
+                if retry_after_raw:
+                    retry_after = int(float(retry_after_raw))
+            except (TypeError, ValueError, AttributeError):
+                retry_after = None
+            raise RateLimited("Rate limited (HTTP 429)", retry_after_seconds=retry_after) from exc
+        if status is not None and 500 <= status < 600:
+            raise ProviderUnavailable(f"Upstream error (HTTP {status})") from exc
+        raise ToolTranslationError(f"Upstream rejected request (HTTP {status})") from exc
+
+
+register_adapter("anthropic_apikey", AnthropicApiKeyAdapter)

--- a/server/app/services/llm/adapters/openai_apikey.py
+++ b/server/app/services/llm/adapters/openai_apikey.py
@@ -1,0 +1,57 @@
+"""OpenAI Platform API-key adapter."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from app.services.llm.adapters._httpx_openai import (
+    build_healthcheck_request,
+    call_openai_chat,
+)
+from app.services.llm.base import ChatRequest, ChatResponse, LlmAdapter
+from app.services.llm.exceptions import AuthInvalid
+from app.services.llm.registry import register_adapter
+
+logger = logging.getLogger(__name__)
+
+OPENAI_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_MODEL = "gpt-5-mini"
+
+
+class OpenAIApiKeyAdapter(LlmAdapter):
+    connector_type = "openai_apikey"
+
+    def _extract_api_key(self) -> str:
+        raw = self.connector.credentials or ""
+        try:
+            blob = json.loads(raw)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise AuthInvalid("Connector credentials are malformed") from exc
+        api_key = blob.get("api_key") if isinstance(blob, dict) else None
+        if not api_key:
+            raise AuthInvalid("Connector is missing an api_key")
+        return str(api_key)
+
+    async def chat(self, request: ChatRequest) -> ChatResponse:
+        api_key = self._extract_api_key()
+        return await call_openai_chat(
+            base_url=OPENAI_BASE_URL,
+            api_key=api_key,
+            request=request,
+            fallback_model=self.connector.model_hint or DEFAULT_MODEL,
+        )
+
+    async def health_check(self) -> None:
+        api_key = self._extract_api_key()
+        ping = build_healthcheck_request()
+        # We just need to exercise the auth path — discard the response.
+        await call_openai_chat(
+            base_url=OPENAI_BASE_URL,
+            api_key=api_key,
+            request=ping,
+            fallback_model=self.connector.model_hint or DEFAULT_MODEL,
+        )
+
+
+register_adapter("openai_apikey", OpenAIApiKeyAdapter)

--- a/server/app/services/llm/adapters/openai_compatible.py
+++ b/server/app/services/llm/adapters/openai_compatible.py
@@ -1,0 +1,60 @@
+"""OpenAI-compatible endpoint adapter (Hermes Agent / Ollama / LMStudio / vLLM)."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from app.services.llm.adapters._httpx_openai import (
+    build_healthcheck_request,
+    call_openai_chat,
+)
+from app.services.llm.base import ChatRequest, ChatResponse, LlmAdapter
+from app.services.llm.exceptions import AuthInvalid
+from app.services.llm.registry import register_adapter
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "gpt-5-mini"
+
+
+class OpenAICompatibleAdapter(LlmAdapter):
+    connector_type = "openai_compatible"
+
+    def _extract_credentials(self) -> tuple[str, str | None]:
+        """Return (base_url, bearer-or-None)."""
+        raw = self.connector.credentials or ""
+        try:
+            blob = json.loads(raw)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise AuthInvalid("Connector credentials are malformed") from exc
+        if not isinstance(blob, dict):
+            raise AuthInvalid("Connector credentials shape is invalid")
+        base_url = blob.get("base_url") or self.connector.base_url_plain
+        if not base_url:
+            raise AuthInvalid("Connector is missing a base_url")
+        bearer = blob.get("bearer")
+        # Empty-string bearer is treated as no bearer.
+        return str(base_url), (str(bearer) if bearer else None)
+
+    async def chat(self, request: ChatRequest) -> ChatResponse:
+        base_url, bearer = self._extract_credentials()
+        return await call_openai_chat(
+            base_url=base_url,
+            api_key=bearer,
+            request=request,
+            fallback_model=self.connector.model_hint or DEFAULT_MODEL,
+        )
+
+    async def health_check(self) -> None:
+        base_url, bearer = self._extract_credentials()
+        ping = build_healthcheck_request()
+        await call_openai_chat(
+            base_url=base_url,
+            api_key=bearer,
+            request=ping,
+            fallback_model=self.connector.model_hint or DEFAULT_MODEL,
+        )
+
+
+register_adapter("openai_compatible", OpenAICompatibleAdapter)

--- a/server/app/services/llm/base.py
+++ b/server/app/services/llm/base.py
@@ -1,0 +1,114 @@
+"""Canonical request / response types + LlmAdapter ABC.
+
+Adapters convert between provider-native request/response shapes and these
+canonical models. See spec §4.4.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ContentBlock(BaseModel):
+    """Optional multi-modal content block — text-only in MVP."""
+
+    type: Literal["text"] = "text"
+    text: str
+
+
+class Message(BaseModel):
+    role: Literal["system", "user", "assistant", "tool"]
+    content: str | list[ContentBlock]
+    tool_call_id: str | None = None
+    # When role == "assistant" and the message includes tool_use blocks,
+    # callers may serialise them as text + tool_calls separately. Adapters
+    # handle the per-provider shape; gateway callers just supply text/role.
+
+
+class ToolSpec(BaseModel):
+    """Canonical tool definition — JSON Schema shape carries the input schema."""
+
+    name: str
+    description: str
+    input_schema: dict
+
+
+class ToolCall(BaseModel):
+    """An LLM-issued call to a tool, parsed from the provider response."""
+
+    id: str
+    name: str
+    input: dict
+
+
+class TokenUsage(BaseModel):
+    prompt: int
+    completion: int
+
+
+class ChatRequest(BaseModel):
+    """Provider-agnostic chat request."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    messages: list[Message]
+    tools: list[ToolSpec] | None = None
+    force_tool: str | None = None
+    max_tokens: int | None = None
+    temperature: float | None = None
+    # Overrides the connector's model_hint when present.
+    model: str | None = None
+    # Per-call timeout in seconds; adapters may clamp to a max.
+    timeout_seconds: float | None = None
+    # Optional system prompt — adapters surface this as the provider's native
+    # system role (Anthropic top-level system; OpenAI as the first system msg).
+    system: str | None = None
+
+
+class ChatResponse(BaseModel):
+    """Provider-agnostic chat response."""
+
+    text: str = ""
+    tool_calls: list[ToolCall] = Field(default_factory=list)
+    stop_reason: Literal["end_turn", "tool_use", "max_tokens", "error"]
+    usage: TokenUsage | None = None
+    # The provider model id that actually produced the response (for telemetry).
+    model: str | None = None
+
+
+class LlmAdapter(ABC):
+    """Adapter interface — one per connector_type.
+
+    Adapters are instantiated per call, given the resolved ``LlmConnector`` row.
+    They must read credentials lazily (the row's ``credentials`` column is an
+    ``EncryptedText`` column; accessing the attribute auto-decrypts).
+    """
+
+    #: connector_type identifier — set on the subclass.
+    connector_type: str = ""
+
+    def __init__(self, connector) -> None:  # noqa: ANN001 — LlmConnector type
+        self.connector = connector
+
+    @abstractmethod
+    async def chat(self, request: ChatRequest) -> ChatResponse:
+        """Dispatch a chat request, returning a canonical response.
+
+        Must raise one of:
+        - AuthInvalid (401/403)
+        - RateLimited (429, with retry_after_seconds if provided)
+        - QuotaExceeded (402 / billing failure)
+        - ProviderUnavailable (5xx / network / timeout)
+        - ToolTranslationError (couldn't translate input or parse output)
+        """
+
+    @abstractmethod
+    async def health_check(self) -> None:
+        """Validate the credential against the provider.
+
+        Raises the same typed exceptions as ``chat()``. Returns ``None`` on
+        success.
+        """

--- a/server/app/services/llm/connector_storage.py
+++ b/server/app/services/llm/connector_storage.py
@@ -252,8 +252,11 @@ def update_metadata(
         connector.display_name = display_name
     if model_hint is not None:
         model_hint = model_hint.strip() or None
-        if model_hint is not None and not _is_safe_model_hint(model_hint):
-            raise ValueError("model_hint contains invalid characters")
+        if model_hint is not None:
+            if len(model_hint) > 80:
+                raise ValueError("model_hint must be 80 characters or fewer")
+            if not _is_safe_model_hint(model_hint):
+                raise ValueError("model_hint contains invalid characters")
         connector.model_hint = model_hint
     return connector
 

--- a/server/app/services/llm/connector_storage.py
+++ b/server/app/services/llm/connector_storage.py
@@ -1,0 +1,379 @@
+"""SQLAlchemy CRUD helpers for LlmConnector + audit/call logging."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from sqlalchemy import case, func, select
+from sqlalchemy.orm import Session
+
+from app.models.llm_connector import (
+    AUDIT_AUTH_INVALID_OBSERVED,
+    AUDIT_CREATED,
+    AUDIT_CREDENTIALS_ROTATED,
+    AUDIT_DELETED,
+    AUDIT_HEALTH_CHECK,
+    AUDIT_POLICY_CHANGED,
+    AUDIT_REVOKED_BY_ADMIN,
+    CONNECTOR_TYPE_ANTHROPIC_APIKEY,
+    CONNECTOR_TYPE_OPENAI_APIKEY,
+    CONNECTOR_TYPE_OPENAI_COMPATIBLE,
+    STATUS_ACTIVE,
+    STATUS_AUTH_INVALID,
+    STATUS_DISABLED,
+    VALID_CONNECTOR_TYPES,
+    LlmAuditEvent,
+    LlmCallLog,
+    LlmConnector,
+)
+from app.models.user import User
+from app.services.llm.url_validator import (
+    InvalidBaseUrlError,
+    validate_compatible_base_url,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def list_connectors_for_user(db: Session, user_id: int) -> list[LlmConnector]:
+    return (
+        db.query(LlmConnector)
+        .filter(LlmConnector.user_id == user_id)
+        .order_by(LlmConnector.created_at.desc())
+        .all()
+    )
+
+
+def list_all_connectors(db: Session) -> list[LlmConnector]:
+    return (
+        db.query(LlmConnector)
+        .order_by(LlmConnector.user_id.asc(), LlmConnector.created_at.desc())
+        .all()
+    )
+
+
+def get_connector_for_user(db: Session, connector_id: int, user_id: int) -> LlmConnector | None:
+    return (
+        db.query(LlmConnector)
+        .filter(LlmConnector.id == connector_id, LlmConnector.user_id == user_id)
+        .one_or_none()
+    )
+
+
+def get_connector(db: Session, connector_id: int) -> LlmConnector | None:
+    return db.get(LlmConnector, connector_id)
+
+
+class CreateConnectorPayload:
+    """Validated creation payload — see :func:`create_connector`."""
+
+    __slots__ = ("connector_type", "display_name", "credentials", "base_url_plain", "model_hint")
+
+    def __init__(
+        self,
+        *,
+        connector_type: str,
+        display_name: str,
+        credentials: dict,
+        base_url_plain: str | None = None,
+        model_hint: str | None = None,
+    ) -> None:
+        self.connector_type = connector_type
+        self.display_name = display_name
+        self.credentials = credentials
+        self.base_url_plain = base_url_plain
+        self.model_hint = model_hint
+
+
+def build_create_payload(
+    *,
+    connector_type: str,
+    display_name: str,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    bearer: str | None = None,
+    model_hint: str | None = None,
+) -> CreateConnectorPayload:
+    """Translate request fields into a validated ``CreateConnectorPayload``.
+
+    Raises :class:`ValueError` on validation errors. The caller is responsible
+    for returning a 400 to the client.
+    """
+    if connector_type not in VALID_CONNECTOR_TYPES:
+        raise ValueError(f"Unknown connector_type: {connector_type!r}")
+
+    display_name = (display_name or "").strip()
+    if not display_name:
+        raise ValueError("display_name is required")
+    if len(display_name) > 80:
+        raise ValueError("display_name must be 80 characters or fewer")
+    if any(ord(c) < 0x20 for c in display_name):
+        raise ValueError("display_name must not contain control characters")
+
+    if model_hint is not None:
+        model_hint = model_hint.strip() or None
+        if model_hint is not None:
+            if len(model_hint) > 80:
+                raise ValueError("model_hint must be 80 characters or fewer")
+            if not _is_safe_model_hint(model_hint):
+                raise ValueError(
+                    "model_hint may only contain letters, digits, dot, underscore, or hyphen"
+                )
+
+    creds: dict[str, Any]
+    plain_base_url: str | None = None
+
+    if connector_type in (
+        CONNECTOR_TYPE_OPENAI_APIKEY,
+        CONNECTOR_TYPE_ANTHROPIC_APIKEY,
+    ):
+        if not api_key:
+            raise ValueError("api_key is required")
+        api_key = api_key.strip()
+        if not _looks_like_api_key(connector_type, api_key):
+            raise ValueError("api_key format is invalid")
+        creds = {"api_key": api_key}
+    elif connector_type == CONNECTOR_TYPE_OPENAI_COMPATIBLE:
+        if not base_url:
+            raise ValueError("base_url is required")
+        try:
+            plain_base_url = validate_compatible_base_url(base_url)
+        except InvalidBaseUrlError as exc:
+            raise ValueError(str(exc)) from exc
+        creds = {"base_url": plain_base_url, "bearer": bearer or None}
+    else:  # pragma: no cover — guarded by the membership check above
+        raise ValueError(f"Unsupported connector_type: {connector_type!r}")
+
+    return CreateConnectorPayload(
+        connector_type=connector_type,
+        display_name=display_name,
+        credentials=creds,
+        base_url_plain=plain_base_url,
+        model_hint=model_hint,
+    )
+
+
+_OPENAI_KEY_PREFIXES = ("sk-",)
+_ANTHROPIC_KEY_PREFIX = "sk-ant-"
+_SAFE_CHARS = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.")
+_SAFE_MODEL_CHARS = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.")
+
+
+def _is_safe_model_hint(s: str) -> bool:
+    return all(c in _SAFE_MODEL_CHARS for c in s)
+
+
+def _looks_like_api_key(connector_type: str, key: str) -> bool:
+    """Cheap shape check — full validation is on the upstream API at health-check time."""
+    if not key or " " in key or "\n" in key:
+        return False
+    if not all(c in _SAFE_CHARS for c in key):
+        return False
+    if connector_type == CONNECTOR_TYPE_ANTHROPIC_APIKEY:
+        return key.startswith(_ANTHROPIC_KEY_PREFIX) and len(key) >= len(_ANTHROPIC_KEY_PREFIX) + 30
+    if connector_type == CONNECTOR_TYPE_OPENAI_APIKEY:
+        return any(key.startswith(p) for p in _OPENAI_KEY_PREFIXES) and len(key) >= 20
+    return False
+
+
+def create_connector(db: Session, *, user_id: int, payload: CreateConnectorPayload) -> LlmConnector:
+    """Persist a new connector. Caller is responsible for audit event + commit."""
+    row = LlmConnector(
+        user_id=user_id,
+        connector_type=payload.connector_type,
+        display_name=payload.display_name,
+        status=STATUS_ACTIVE,
+        credentials=json.dumps(payload.credentials),
+        base_url_plain=payload.base_url_plain,
+        model_hint=payload.model_hint,
+    )
+    db.add(row)
+    db.flush()
+    db.refresh(row)
+    return row
+
+
+def rotate_credentials(
+    db: Session,
+    *,
+    connector: LlmConnector,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    bearer: str | None = None,
+) -> LlmConnector:
+    """Rotate the credential blob in-place. Caller commits."""
+    blob: dict[str, Any]
+    if connector.connector_type in (
+        CONNECTOR_TYPE_OPENAI_APIKEY,
+        CONNECTOR_TYPE_ANTHROPIC_APIKEY,
+    ):
+        if not api_key:
+            raise ValueError("api_key is required for rotation")
+        api_key = api_key.strip()
+        if not _looks_like_api_key(connector.connector_type, api_key):
+            raise ValueError("api_key format is invalid")
+        blob = {"api_key": api_key}
+    elif connector.connector_type == CONNECTOR_TYPE_OPENAI_COMPATIBLE:
+        if not base_url:
+            raise ValueError("base_url is required for rotation")
+        try:
+            base_url = validate_compatible_base_url(base_url)
+        except InvalidBaseUrlError as exc:
+            raise ValueError(str(exc)) from exc
+        blob = {"base_url": base_url, "bearer": bearer or None}
+        connector.base_url_plain = base_url
+    else:  # pragma: no cover
+        raise ValueError(f"Unsupported connector_type: {connector.connector_type!r}")
+
+    connector.credentials = json.dumps(blob)
+    # Clear status/last_error on successful rotation — caller may run a fresh health check.
+    if connector.status == STATUS_AUTH_INVALID:
+        connector.status = STATUS_ACTIVE
+        connector.last_error = None
+    return connector
+
+
+def update_metadata(
+    connector: LlmConnector,
+    *,
+    display_name: str | None = None,
+    model_hint: str | None = None,
+) -> LlmConnector:
+    if display_name is not None:
+        display_name = display_name.strip()
+        if not display_name:
+            raise ValueError("display_name is required")
+        if len(display_name) > 80:
+            raise ValueError("display_name must be 80 characters or fewer")
+        if any(ord(c) < 0x20 for c in display_name):
+            raise ValueError("display_name must not contain control characters")
+        connector.display_name = display_name
+    if model_hint is not None:
+        model_hint = model_hint.strip() or None
+        if model_hint is not None and not _is_safe_model_hint(model_hint):
+            raise ValueError("model_hint contains invalid characters")
+        connector.model_hint = model_hint
+    return connector
+
+
+def delete_connector(db: Session, connector: LlmConnector) -> None:
+    db.delete(connector)
+
+
+def revoke_connector(connector: LlmConnector) -> LlmConnector:
+    """Admin-only: mark a connector disabled. Caller commits + audits."""
+    connector.status = STATUS_DISABLED
+    return connector
+
+
+def audit_event(
+    db: Session,
+    *,
+    actor_user_id: int,
+    target_connector_id: int | None,
+    event_type: str,
+) -> LlmAuditEvent:
+    row = LlmAuditEvent(
+        actor_user_id=actor_user_id,
+        target_connector_id=target_connector_id,
+        event_type=event_type,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def log_call(
+    db: Session,
+    *,
+    connector_id: int,
+    purpose: str,
+    status: str,
+    latency_ms: int,
+    tokens_in: int | None = None,
+    tokens_out: int | None = None,
+    error_code: str | None = None,
+) -> LlmCallLog:
+    row = LlmCallLog(
+        connector_id=connector_id,
+        purpose=purpose,
+        status=status,
+        latency_ms=latency_ms,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        error_code=error_code,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def get_user_label(db: Session, user_id: int) -> str:
+    user = db.get(User, user_id)
+    return user.username if user else f"user#{user_id}"
+
+
+def get_usage_stats(db: Session, *, days: int = 30) -> list[dict]:
+    """Aggregate per-connector telemetry for the admin Usage card.
+
+    Returns a list of dicts with: connector_id, total_calls, total_tokens_in,
+    total_tokens_out, error_count. The caller joins back to LlmConnector for
+    display labels.
+    """
+    from datetime import timedelta
+
+    from app.core.time import utcnow
+
+    cutoff = utcnow() - timedelta(days=days)
+
+    stmt = (
+        select(
+            LlmCallLog.connector_id,
+            func.count(LlmCallLog.id).label("total_calls"),
+            func.coalesce(func.sum(LlmCallLog.tokens_in), 0).label("total_tokens_in"),
+            func.coalesce(func.sum(LlmCallLog.tokens_out), 0).label("total_tokens_out"),
+            func.sum(case((LlmCallLog.status != "ok", 1), else_=0)).label("error_count"),
+        )
+        .where(LlmCallLog.created_at >= cutoff)
+        .group_by(LlmCallLog.connector_id)
+    )
+    rows = db.execute(stmt).all()
+    return [
+        {
+            "connector_id": int(r.connector_id),
+            "total_calls": int(r.total_calls or 0),
+            "total_tokens_in": int(r.total_tokens_in or 0),
+            "total_tokens_out": int(r.total_tokens_out or 0),
+            "error_count": int(r.error_count or 0),
+        }
+        for r in rows
+    ]
+
+
+# Re-export audit event constants for callers
+__all__ = [
+    "AUDIT_AUTH_INVALID_OBSERVED",
+    "AUDIT_CREATED",
+    "AUDIT_CREDENTIALS_ROTATED",
+    "AUDIT_DELETED",
+    "AUDIT_HEALTH_CHECK",
+    "AUDIT_POLICY_CHANGED",
+    "AUDIT_REVOKED_BY_ADMIN",
+    "CreateConnectorPayload",
+    "audit_event",
+    "build_create_payload",
+    "create_connector",
+    "delete_connector",
+    "get_connector",
+    "get_connector_for_user",
+    "get_usage_stats",
+    "get_user_label",
+    "list_all_connectors",
+    "list_connectors_for_user",
+    "log_call",
+    "revoke_connector",
+    "rotate_credentials",
+    "update_metadata",
+]

--- a/server/app/services/llm/exceptions.py
+++ b/server/app/services/llm/exceptions.py
@@ -1,0 +1,40 @@
+"""Typed exceptions for the LLM gateway.
+
+Adapters raise these specific types; the gateway never re-raises a provider's
+native exception or HTTP error body to callers — that prevents bearer-token /
+credential leakage in error messages.
+"""
+
+from __future__ import annotations
+
+
+class LlmError(Exception):
+    """Base class for all gateway-raised LLM errors."""
+
+
+class NoLlmConfigured(LlmError):
+    """No active connector for the actor and no system default connector."""
+
+
+class AuthInvalid(LlmError):
+    """The provider returned 401 / 403 — connector marked auth_invalid."""
+
+
+class RateLimited(LlmError):
+    """The provider returned 429 — caller should back off and try later."""
+
+    def __init__(self, message: str = "Rate limited", retry_after_seconds: int | None = None):
+        super().__init__(message)
+        self.retry_after_seconds = retry_after_seconds
+
+
+class QuotaExceeded(LlmError):
+    """Billing / quota failure (402 or provider-specific quota error)."""
+
+
+class ProviderUnavailable(LlmError):
+    """Transient upstream failure — 5xx, network error, or timeout."""
+
+
+class ToolTranslationError(LlmError):
+    """Canonical ToolSpec couldn't be translated or the response couldn't be parsed."""

--- a/server/app/services/llm/gateway.py
+++ b/server/app/services/llm/gateway.py
@@ -1,0 +1,187 @@
+"""Gateway entrypoint — resolves a connector and dispatches to the adapter.
+
+See spec §4.3.
+
+Resolution order:
+1. If ``actor`` is not ``None``: most-recently-used active connector for the DJ.
+2. Else: ``SystemSettings.llm_default_connector_id`` if set and active.
+3. Else: raise :class:`NoLlmConfigured`.
+"""
+
+from __future__ import annotations
+
+import logging
+from time import monotonic
+
+from sqlalchemy import desc
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.models.llm_connector import (
+    AUDIT_AUTH_INVALID_OBSERVED,
+    STATUS_ACTIVE,
+    STATUS_AUTH_INVALID,
+    LlmConnector,
+)
+from app.models.system_settings import SystemSettings
+from app.models.user import User
+from app.services.llm.base import ChatRequest, ChatResponse
+from app.services.llm.connector_storage import audit_event, log_call
+from app.services.llm.exceptions import (
+    AuthInvalid,
+    LlmError,
+    NoLlmConfigured,
+    ProviderUnavailable,
+    QuotaExceeded,
+    RateLimited,
+    ToolTranslationError,
+)
+from app.services.llm.registry import get_adapter_class
+
+logger = logging.getLogger(__name__)
+
+
+class Gateway:
+    """Single dispatch entrypoint."""
+
+    @staticmethod
+    async def dispatch(
+        db: Session,
+        actor: User | None,
+        request: ChatRequest,
+        *,
+        purpose: str,
+    ) -> ChatResponse:
+        connector = _resolve_connector(db, actor)
+        adapter_cls = get_adapter_class(connector.connector_type)
+        adapter = adapter_cls(connector)
+
+        started = monotonic()
+        try:
+            response = await adapter.chat(request)
+        except AuthInvalid:
+            connector.status = STATUS_AUTH_INVALID
+            connector.last_error = "auth_invalid"
+            db.commit()
+            log_call(
+                db,
+                connector_id=connector.id,
+                purpose=purpose,
+                status="auth_invalid",
+                latency_ms=int((monotonic() - started) * 1000),
+                error_code="401",
+            )
+            audit_event(
+                db,
+                actor_user_id=actor.id if actor else _system_actor_id(db, connector),
+                target_connector_id=connector.id,
+                event_type=AUDIT_AUTH_INVALID_OBSERVED,
+            )
+            db.commit()
+            raise
+        except RateLimited as exc:
+            log_call(
+                db,
+                connector_id=connector.id,
+                purpose=purpose,
+                status="rate_limited",
+                latency_ms=int((monotonic() - started) * 1000),
+                error_code=str(exc.retry_after_seconds or ""),
+            )
+            db.commit()
+            raise
+        except QuotaExceeded:
+            log_call(
+                db,
+                connector_id=connector.id,
+                purpose=purpose,
+                status="quota_exceeded",
+                latency_ms=int((monotonic() - started) * 1000),
+                error_code="402",
+            )
+            db.commit()
+            raise
+        except ProviderUnavailable as exc:
+            log_call(
+                db,
+                connector_id=connector.id,
+                purpose=purpose,
+                status="provider_unavailable",
+                latency_ms=int((monotonic() - started) * 1000),
+                error_code=type(exc).__name__,
+            )
+            db.commit()
+            raise
+        except ToolTranslationError:
+            log_call(
+                db,
+                connector_id=connector.id,
+                purpose=purpose,
+                status="tool_translation_error",
+                latency_ms=int((monotonic() - started) * 1000),
+                error_code="translation",
+            )
+            db.commit()
+            raise
+        except LlmError:
+            log_call(
+                db,
+                connector_id=connector.id,
+                purpose=purpose,
+                status="error",
+                latency_ms=int((monotonic() - started) * 1000),
+                error_code="llm_error",
+            )
+            db.commit()
+            raise
+
+        # success path
+        connector.last_used_at = utcnow()
+        connector.last_error = None
+        latency_ms = int((monotonic() - started) * 1000)
+        tokens_in = response.usage.prompt if response.usage else None
+        tokens_out = response.usage.completion if response.usage else None
+        log_call(
+            db,
+            connector_id=connector.id,
+            purpose=purpose,
+            status="ok",
+            latency_ms=latency_ms,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+        )
+        db.commit()
+        return response
+
+
+def _resolve_connector(db: Session, actor: User | None) -> LlmConnector:
+    if actor is not None:
+        row = (
+            db.query(LlmConnector)
+            .filter(
+                LlmConnector.user_id == actor.id,
+                LlmConnector.status == STATUS_ACTIVE,
+            )
+            .order_by(desc(LlmConnector.last_used_at), desc(LlmConnector.id))
+            .first()
+        )
+        if row is not None:
+            return row
+
+    settings = db.query(SystemSettings).first()
+    if settings and settings.llm_default_connector_id:
+        default = db.get(LlmConnector, settings.llm_default_connector_id)
+        if default is not None and default.status == STATUS_ACTIVE:
+            return default
+
+    raise NoLlmConfigured("No active LLM connector for this DJ and no system default configured")
+
+
+def _system_actor_id(db: Session, connector: LlmConnector) -> int:
+    """Best-effort actor id for system-context audit rows.
+
+    When the gateway is called with ``actor=None`` (system context), audit
+    events should still record an actor; fall back to the connector's owner so
+    the trail is traceable.
+    """
+    return connector.user_id

--- a/server/app/services/llm/gateway.py
+++ b/server/app/services/llm/gateway.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 from time import monotonic
 
-from sqlalchemy import desc
+from sqlalchemy import desc, nulls_last
 from sqlalchemy.orm import Session
 
 from app.core.time import utcnow
@@ -162,7 +162,7 @@ def _resolve_connector(db: Session, actor: User | None) -> LlmConnector:
                 LlmConnector.user_id == actor.id,
                 LlmConnector.status == STATUS_ACTIVE,
             )
-            .order_by(desc(LlmConnector.last_used_at), desc(LlmConnector.id))
+            .order_by(nulls_last(desc(LlmConnector.last_used_at)), desc(LlmConnector.id))
             .first()
         )
         if row is not None:

--- a/server/app/services/llm/registry.py
+++ b/server/app/services/llm/registry.py
@@ -1,0 +1,51 @@
+"""Adapter registry — maps connector_type strings to adapter classes.
+
+Importing the adapters package via ``from app.services.llm.adapters import *``
+auto-registers each adapter via ``register_adapter``.
+"""
+
+from __future__ import annotations
+
+from app.services.llm.base import LlmAdapter
+
+_REGISTRY: dict[str, type[LlmAdapter]] = {}
+
+
+def register_adapter(connector_type: str, cls: type[LlmAdapter]) -> None:
+    """Register an adapter class for a connector_type."""
+    if not connector_type:
+        raise ValueError("connector_type must be non-empty")
+    if not issubclass(cls, LlmAdapter):
+        raise TypeError("Adapter must subclass LlmAdapter")
+    _REGISTRY[connector_type] = cls
+
+
+def get_adapter_class(connector_type: str) -> type[LlmAdapter]:
+    """Return the adapter class for a connector_type or raise KeyError."""
+    if connector_type not in _REGISTRY:
+        raise KeyError(f"No adapter registered for connector_type={connector_type!r}")
+    return _REGISTRY[connector_type]
+
+
+def list_connector_types() -> list[str]:
+    """Return all registered connector_type names (sorted, stable order)."""
+    return sorted(_REGISTRY.keys())
+
+
+def is_registered(connector_type: str) -> bool:
+    """Cheap membership check, used by callers that wish to soft-validate."""
+    return connector_type in _REGISTRY
+
+
+# Eagerly import adapters to populate the registry. This avoids callers needing
+# to remember an explicit "register" step.
+def _bootstrap() -> None:
+    # Local imports keep the registry module dependency-free at import time.
+    from app.services.llm.adapters import (  # noqa: F401
+        anthropic_apikey,
+        openai_apikey,
+        openai_compatible,
+    )
+
+
+_bootstrap()

--- a/server/app/services/llm/registry.py
+++ b/server/app/services/llm/registry.py
@@ -12,11 +12,23 @@ _REGISTRY: dict[str, type[LlmAdapter]] = {}
 
 
 def register_adapter(connector_type: str, cls: type[LlmAdapter]) -> None:
-    """Register an adapter class for a connector_type."""
+    """Register an adapter class for a connector_type.
+
+    Re-registering the *same* class is a no-op (safe for re-imports during
+    tests). Registering a *different* class for an already-bound
+    ``connector_type`` raises :class:`ValueError` — silently overwriting
+    adapters would make behavior depend on import order and hide collisions.
+    """
     if not connector_type:
         raise ValueError("connector_type must be non-empty")
     if not issubclass(cls, LlmAdapter):
         raise TypeError("Adapter must subclass LlmAdapter")
+    existing = _REGISTRY.get(connector_type)
+    if existing is not None and existing is not cls:
+        raise ValueError(
+            f"connector_type {connector_type!r} already registered by "
+            f"{existing.__name__}; refusing to overwrite with {cls.__name__}"
+        )
     _REGISTRY[connector_type] = cls
 
 

--- a/server/app/services/llm/tool_translation.py
+++ b/server/app/services/llm/tool_translation.py
@@ -1,0 +1,210 @@
+"""Translate canonical ``ToolSpec`` → per-provider tool/function shape.
+
+Each translation helper returns a tuple ``(tools_list, tool_choice_or_none)``
+ready to drop into the provider's request body.
+
+Also exposes response parsers that convert provider-native message shapes
+back into canonical ``ChatResponse`` (with ``tool_calls``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Literal
+
+from app.services.llm.base import ChatResponse, TokenUsage, ToolCall, ToolSpec
+from app.services.llm.exceptions import ToolTranslationError
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI
+# ---------------------------------------------------------------------------
+def to_openai_tools(
+    tools: list[ToolSpec] | None, force: str | None
+) -> tuple[list[dict] | None, Any]:
+    if not tools:
+        return None, None
+    fns = [
+        {
+            "type": "function",
+            "function": {
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.input_schema,
+            },
+        }
+        for t in tools
+    ]
+    choice: Any = None
+    if force is not None:
+        if not any(t.name == force for t in tools):
+            raise ToolTranslationError(f"force_tool={force!r} not in tools list")
+        choice = {"type": "function", "function": {"name": force}}
+    return fns, choice
+
+
+def parse_openai_response(payload: dict) -> ChatResponse:
+    """Parse an OpenAI chat-completions response body."""
+    try:
+        choice = payload["choices"][0]
+        msg = choice["message"]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise ToolTranslationError("OpenAI response missing choices/message") from exc
+
+    text = msg.get("content") or ""
+
+    tool_calls: list[ToolCall] = []
+    raw_tool_calls = msg.get("tool_calls") or []
+    for tc in raw_tool_calls:
+        fn = tc.get("function") or {}
+        name = fn.get("name") or tc.get("name") or ""
+        raw_args = fn.get("arguments")
+        try:
+            input_obj = json.loads(raw_args) if isinstance(raw_args, str) else (raw_args or {})
+        except json.JSONDecodeError as exc:
+            raise ToolTranslationError("OpenAI tool_call arguments are not valid JSON") from exc
+        tool_calls.append(ToolCall(id=str(tc.get("id") or name), name=name, input=input_obj))
+
+    stop_reason = _normalise_openai_finish_reason(choice.get("finish_reason"))
+    usage_payload = payload.get("usage") or {}
+    usage = None
+    if usage_payload:
+        usage = TokenUsage(
+            prompt=int(usage_payload.get("prompt_tokens", 0)),
+            completion=int(usage_payload.get("completion_tokens", 0)),
+        )
+
+    # If the model used tool_calls, force-set stop_reason to tool_use even if
+    # finish_reason reported "stop" (some compatible servers do).
+    if tool_calls and stop_reason != "tool_use":
+        stop_reason = "tool_use"
+
+    return ChatResponse(
+        text=text,
+        tool_calls=tool_calls,
+        stop_reason=stop_reason,
+        usage=usage,
+        model=payload.get("model"),
+    )
+
+
+def _normalise_openai_finish_reason(
+    reason: str | None,
+) -> Literal["end_turn", "tool_use", "max_tokens", "error"]:
+    if reason in (None, "stop"):
+        return "end_turn"
+    if reason == "tool_calls" or reason == "function_call":
+        return "tool_use"
+    if reason == "length":
+        return "max_tokens"
+    return "error"
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+def to_anthropic_tools(
+    tools: list[ToolSpec] | None, force: str | None
+) -> tuple[list[dict] | None, Any]:
+    if not tools:
+        return None, None
+    anthropic_tools = [
+        {
+            "name": t.name,
+            "description": t.description,
+            "input_schema": t.input_schema,
+        }
+        for t in tools
+    ]
+    choice: Any = None
+    if force is not None:
+        if not any(t.name == force for t in tools):
+            raise ToolTranslationError(f"force_tool={force!r} not in tools list")
+        choice = {"type": "tool", "name": force}
+    return anthropic_tools, choice
+
+
+def parse_anthropic_response(message: Any) -> ChatResponse:
+    """Parse the official ``anthropic`` SDK Message object."""
+    text_parts: list[str] = []
+    tool_calls: list[ToolCall] = []
+
+    if isinstance(message, dict):
+        content_blocks = message.get("content") or []
+    else:
+        content_blocks = getattr(message, "content", None) or []
+    for block in content_blocks:
+        if isinstance(block, dict):
+            btype = block.get("type")
+        else:
+            btype = getattr(block, "type", None)
+        if btype == "text":
+            if isinstance(block, dict):
+                text = block.get("text") or ""
+            else:
+                text = getattr(block, "text", "") or ""
+            text_parts.append(text)
+        elif btype == "tool_use":
+            if isinstance(block, dict):
+                name = block.get("name")
+                tool_id = block.get("id") or name
+                input_obj = block.get("input")
+            else:
+                name = getattr(block, "name", None)
+                tool_id = getattr(block, "id", None) or name
+                input_obj = getattr(block, "input", None)
+            tool_calls.append(
+                ToolCall(id=str(tool_id), name=str(name), input=dict(input_obj or {}))
+            )
+
+    stop_raw = getattr(message, "stop_reason", None) or (
+        message.get("stop_reason") if isinstance(message, dict) else None
+    )
+    stop_reason = _normalise_anthropic_stop_reason(stop_raw)
+    if tool_calls and stop_reason != "tool_use":
+        stop_reason = "tool_use"
+
+    usage_obj = getattr(message, "usage", None) or (
+        message.get("usage") if isinstance(message, dict) else None
+    )
+    usage = None
+    if usage_obj is not None:
+        prompt = (
+            getattr(usage_obj, "input_tokens", None)
+            if not isinstance(usage_obj, dict)
+            else usage_obj.get("input_tokens")
+        )
+        completion = (
+            getattr(usage_obj, "output_tokens", None)
+            if not isinstance(usage_obj, dict)
+            else usage_obj.get("output_tokens")
+        )
+        if prompt is not None and completion is not None:
+            usage = TokenUsage(prompt=int(prompt), completion=int(completion))
+
+    model = getattr(message, "model", None) or (
+        message.get("model") if isinstance(message, dict) else None
+    )
+
+    return ChatResponse(
+        text="".join(text_parts),
+        tool_calls=tool_calls,
+        stop_reason=stop_reason,
+        usage=usage,
+        model=model,
+    )
+
+
+def _normalise_anthropic_stop_reason(
+    reason: str | None,
+) -> Literal["end_turn", "tool_use", "max_tokens", "error"]:
+    if reason in (None, "end_turn", "stop_sequence"):
+        return "end_turn"
+    if reason == "tool_use":
+        return "tool_use"
+    if reason == "max_tokens":
+        return "max_tokens"
+    return "error"

--- a/server/app/services/llm/tool_translation.py
+++ b/server/app/services/llm/tool_translation.py
@@ -156,6 +156,8 @@ def parse_anthropic_response(message: Any) -> ChatResponse:
                 name = getattr(block, "name", None)
                 tool_id = getattr(block, "id", None) or name
                 input_obj = getattr(block, "input", None)
+            if not name or not tool_id:
+                raise ToolTranslationError("Anthropic tool_use block missing id/name")
             tool_calls.append(
                 ToolCall(id=str(tool_id), name=str(name), input=dict(input_obj or {}))
             )

--- a/server/app/services/llm/url_validator.py
+++ b/server/app/services/llm/url_validator.py
@@ -1,0 +1,96 @@
+"""Validate custom OpenAI-compatible base URLs.
+
+Rules (spec §4.7, §6.2):
+- Scheme: only ``http`` or ``https``
+- ``http``: only loopback (127.0.0.1, ::1, localhost) and RFC1918 private ranges
+  (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+- ``https``: any host
+- Reject embedded credentials in the URL (``user:pass@host``)
+- Accept optional path prefix (e.g., ``/v1``) — preserved
+- Reject query strings and fragments
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urlsplit, urlunsplit
+
+# Private network blocks acceptable for plain HTTP base URLs.
+_PRIVATE_NETWORKS = (
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),  # IPv6 unique local
+    ipaddress.ip_network("fe80::/10"),  # IPv6 link-local
+)
+
+
+class InvalidBaseUrlError(ValueError):
+    """Raised when a base URL fails validation."""
+
+
+def validate_compatible_base_url(raw: str) -> str:
+    """Validate and normalise a custom OpenAI-compatible base URL.
+
+    Returns the normalised URL (scheme + host + optional path, no trailing /).
+    Raises :class:`InvalidBaseUrlError` on failure.
+    """
+    if not raw or not isinstance(raw, str):
+        raise InvalidBaseUrlError("base_url is required")
+    raw = raw.strip()
+    if not raw:
+        raise InvalidBaseUrlError("base_url is empty")
+
+    try:
+        parts = urlsplit(raw)
+    except ValueError as exc:
+        raise InvalidBaseUrlError("base_url is malformed") from exc
+
+    scheme = parts.scheme.lower()
+    if scheme not in ("http", "https"):
+        raise InvalidBaseUrlError("base_url scheme must be 'http' or 'https'")
+
+    if not parts.netloc:
+        raise InvalidBaseUrlError("base_url is missing a host")
+
+    if parts.username or parts.password:
+        raise InvalidBaseUrlError(
+            "base_url must not embed credentials — provide a bearer separately"
+        )
+
+    if parts.query or parts.fragment:
+        raise InvalidBaseUrlError("base_url must not include a query string or fragment")
+
+    hostname = (parts.hostname or "").lower()
+    if not hostname:
+        raise InvalidBaseUrlError("base_url has an empty hostname")
+
+    if scheme == "http":
+        if hostname == "localhost":
+            pass
+        else:
+            try:
+                addr = ipaddress.ip_address(hostname)
+            except ValueError as exc:
+                raise InvalidBaseUrlError(
+                    "http:// base_url must be loopback or a private (RFC1918) IP"
+                ) from exc
+            if not any(addr in net for net in _PRIVATE_NETWORKS):
+                raise InvalidBaseUrlError(
+                    "http:// base_url must be loopback or a private (RFC1918) IP"
+                )
+
+    # Preserve path but drop trailing slash for stable storage. Empty path is OK.
+    path = (parts.path or "").rstrip("/")
+
+    # Rebuild without credentials / query / fragment.
+    # Use the netloc minus any user-info (urlsplit accepts these in raw form;
+    # we've already rejected those above, so netloc is host[:port]).
+    netloc = parts.netloc
+    if "@" in netloc:
+        netloc = netloc.rsplit("@", 1)[-1]
+
+    normalised = urlunsplit((scheme, netloc, path, "", ""))
+    return normalised

--- a/server/app/services/recommendation/llm_client.py
+++ b/server/app/services/recommendation/llm_client.py
@@ -1,16 +1,25 @@
-"""LLM client for generating recommendation search queries via Claude Haiku.
+"""LLM client for generating recommendation search queries via the Gateway.
 
-Sends the event's musical profile and the DJ's prompt to Claude,
-which returns structured search queries (with target BPM/key/genre)
-that feed into the existing Tidal/Beatport search pipeline.
+The recommendation engine no longer talks directly to Anthropic — instead it
+calls ``Gateway.dispatch(...)``, which routes to the actor DJ's connector (or
+the org default). The forced tool_use semantics are preserved across providers
+via ``services/llm/tool_translation.py``.
+
+See ``docs/superpowers/specs/2026-05-24-admin-ai-oauth-design.md`` §7.
 """
+
+from __future__ import annotations
 
 import json
 import logging
 
 from anthropic import AsyncAnthropic
+from sqlalchemy.orm import Session
 
 from app.core.config import get_settings
+from app.models.user import User
+from app.services.llm.base import ChatRequest, Message, ToolSpec
+from app.services.llm.gateway import Gateway
 from app.services.recommendation.llm_hooks import LLMSuggestionQuery, LLMSuggestionResult
 from app.services.recommendation.scorer import EventProfile, TrackProfile
 
@@ -76,8 +85,11 @@ Tidal or Beatport. Each query should be a realistic search string
 
 Include brief reasoning explaining why you chose each query."""
 
+# Tool name kept stable so any cached tool_use traces remain decodable.
+SEARCH_QUERIES_TOOL_NAME = "search_queries"
+
 SEARCH_QUERIES_TOOL = {
-    "name": "search_queries",
+    "name": SEARCH_QUERIES_TOOL_NAME,
     "description": (
         "Return structured search queries for finding tracks that match the DJ's intent."
     ),
@@ -191,15 +203,44 @@ def build_user_prompt(
     return "\n".join(parts)
 
 
-def _parse_tool_response(response) -> LLMSuggestionResult:
-    """Parse the Claude API response into an LLMSuggestionResult."""
+def _parse_tool_response(response) -> LLMSuggestionResult:  # noqa: ANN001 — kept for back-compat
+    """Parse a gateway ``ChatResponse`` (or legacy Anthropic Message) into an
+    ``LLMSuggestionResult``.
+
+    Accepts both shapes so existing test fixtures (which mock an Anthropic SDK
+    response object directly) keep working without modification.
+    """
+    from app.services.llm.base import ChatResponse
+
     raw_text = ""
     queries: list[LLMSuggestionQuery] = []
 
-    for block in response.content:
-        if block.type == "text":
-            raw_text += block.text
-        elif block.type == "tool_use" and block.name == "search_queries":
+    # Path 1 — canonical ChatResponse (isinstance, not ducktype, so MagicMocks
+    # in legacy tests fall through to path 2 instead of matching here).
+    if isinstance(response, ChatResponse):
+        if response.text:
+            raw_text += response.text
+        for tc in response.tool_calls or []:
+            if tc.name == SEARCH_QUERIES_TOOL_NAME:
+                raw_text += json.dumps(tc.input)
+                for q in tc.input.get("queries", []):
+                    queries.append(
+                        LLMSuggestionQuery(
+                            search_query=q["search_query"],
+                            target_bpm=q.get("target_bpm"),
+                            target_key=q.get("target_key"),
+                            target_genre=q.get("target_genre"),
+                            reasoning=q.get("reasoning", ""),
+                        )
+                    )
+        return LLMSuggestionResult(queries=queries, raw_response=raw_text)
+
+    # Path 2 — legacy Anthropic SDK Message-like object.
+    for block in getattr(response, "content", []) or []:
+        btype = getattr(block, "type", None)
+        if btype == "text":
+            raw_text += getattr(block, "text", "")
+        elif btype == "tool_use" and getattr(block, "name", "") == SEARCH_QUERIES_TOOL_NAME:
             raw_text += json.dumps(block.input)
             for q in block.input.get("queries", []):
                 queries.append(
@@ -222,19 +263,19 @@ async def call_llm(
     tracks: list[TrackProfile] | None = None,
     rejected_tracks: list[tuple[str, str]] | None = None,
     currently_playing: tuple[str, str, float | None] | None = None,
+    *,
+    db: Session | None = None,
+    actor: User | None = None,
 ) -> LLMSuggestionResult:
-    """Call Claude Haiku to generate search queries from a DJ prompt.
+    """Generate structured search queries via the LLM gateway.
 
-    Returns an LLMSuggestionResult with 1-max_queries structured queries.
-    Raises on API failure (caller should handle).
+    Compatibility shim: existing callers pass only the positional args. New
+    callers pass ``db`` and ``actor`` so the gateway can route to the DJ's
+    connector. When ``db`` is missing we fall back to the legacy env-var path
+    so unit tests that mock ``AsyncAnthropic`` directly keep passing.
+
+    Returns at most ``max_queries`` queries.
     """
-    settings = get_settings()
-
-    client = AsyncAnthropic(
-        api_key=settings.anthropic_api_key,
-        timeout=settings.anthropic_timeout_seconds,
-    )
-
     user_message = build_user_prompt(
         profile,
         dj_prompt,
@@ -243,18 +284,26 @@ async def call_llm(
         currently_playing=currently_playing,
     )
 
-    response = await client.messages.create(
-        model=settings.anthropic_model,
-        max_tokens=settings.anthropic_max_tokens,
-        system=SYSTEM_PROMPT,
-        tools=[SEARCH_QUERIES_TOOL],
-        tool_choice={"type": "tool", "name": "search_queries"},
-        messages=[{"role": "user", "content": user_message}],
-    )
+    if db is None:
+        result = await _legacy_call(user_message)
+    else:
+        chat_request = ChatRequest(
+            messages=[Message(role="user", content=user_message)],
+            system=SYSTEM_PROMPT,
+            tools=[
+                ToolSpec(
+                    name=SEARCH_QUERIES_TOOL_NAME,
+                    description=SEARCH_QUERIES_TOOL["description"],
+                    input_schema=SEARCH_QUERIES_TOOL["input_schema"],
+                )
+            ],
+            force_tool=SEARCH_QUERIES_TOOL_NAME,
+            max_tokens=_resolve_max_tokens(),
+            temperature=None,
+        )
+        response = await Gateway.dispatch(db, actor, chat_request, purpose="recommendation")
+        result = _parse_tool_response(response)
 
-    result = _parse_tool_response(response)
-
-    # Trim to max_queries
     if len(result.queries) > max_queries:
         result = LLMSuggestionResult(
             queries=result.queries[:max_queries],
@@ -268,3 +317,31 @@ async def call_llm(
     )
 
     return result
+
+
+def _resolve_max_tokens() -> int:
+    return get_settings().anthropic_max_tokens or 1024
+
+
+async def _legacy_call(user_message: str) -> LLMSuggestionResult:
+    """Direct-Anthropic fallback used when no ``db`` is supplied.
+
+    Kept so the legacy unit tests in ``server/tests/test_llm_client.py`` (which
+    patch ``AsyncAnthropic`` directly) still pass without modification.
+    """
+    settings = get_settings()
+    client = AsyncAnthropic(
+        api_key=settings.anthropic_api_key,
+        timeout=settings.anthropic_timeout_seconds,
+    )
+
+    response = await client.messages.create(
+        model=settings.anthropic_model,
+        max_tokens=settings.anthropic_max_tokens,
+        system=SYSTEM_PROMPT,
+        tools=[SEARCH_QUERIES_TOOL],
+        tool_choice={"type": "tool", "name": SEARCH_QUERIES_TOOL_NAME},
+        messages=[{"role": "user", "content": user_message}],
+    )
+
+    return _parse_tool_response(response)

--- a/server/app/services/recommendation/llm_hooks.py
+++ b/server/app/services/recommendation/llm_hooks.py
@@ -39,12 +39,15 @@ async def generate_llm_suggestions(
     tracks: list[TrackProfile] | None = None,
     rejected_tracks: list[tuple[str, str]] | None = None,
     currently_playing: tuple[str, str, float | None] | None = None,
+    *,
+    db=None,
+    actor=None,
 ) -> LLMSuggestionResult:
-    """Generate search queries via LLM (Claude Haiku).
+    """Generate search queries via the LLM gateway.
 
-    Calls Claude to interpret the DJ's prompt in context of the event's
-    musical profile and track list, returning structured search queries
-    that feed into the existing search + scoring pipeline.
+    The gateway routes to the actor DJ's connector (or org default). Existing
+    callers that don't pass ``db``/``actor`` fall through to the legacy
+    env-var Anthropic path inside ``call_llm`` — see ``llm_client.py``.
     """
     from app.services.recommendation.llm_client import call_llm
 
@@ -55,24 +58,42 @@ async def generate_llm_suggestions(
         tracks=tracks,
         rejected_tracks=rejected_tracks,
         currently_playing=currently_playing,
+        db=db,
+        actor=actor,
     )
 
 
 def is_llm_available(db=None) -> bool:
     """Check if LLM recommendations are configured and available.
 
-    When db is provided, also checks the DB-backed llm_enabled toggle.
+    Truthy if the admin has enabled LLMs (``SystemSettings.llm_enabled``) AND
+    at least one usable connector exists — either an active connector owned by
+    *any* DJ (admin org default) or a connector for the actor (resolved by the
+    gateway at dispatch time). For backwards-compat we also accept the legacy
+    ``ANTHROPIC_API_KEY`` env var when no DB connectors exist.
     """
     from app.core.config import get_settings
 
-    if not get_settings().anthropic_api_key:
-        return False
-
     if db is not None:
+        from app.models.llm_connector import STATUS_ACTIVE, LlmConnector
+        from app.models.system_settings import SystemSettings
         from app.services.system_settings import get_system_settings
 
         settings = get_system_settings(db)
         if not settings.llm_enabled:
             return False
 
-    return True
+        # Any active connector unlocks the feature (gateway picks at dispatch).
+        any_active = db.query(LlmConnector.id).filter(LlmConnector.status == STATUS_ACTIVE).first()
+        if any_active is not None:
+            return True
+
+        # System default fallback
+        sys_settings = db.query(SystemSettings).first()
+        if sys_settings and sys_settings.llm_default_connector_id:
+            return True
+
+        # Final fallback: legacy env var
+        return bool(get_settings().anthropic_api_key)
+
+    return bool(get_settings().anthropic_api_key)

--- a/server/app/services/recommendation/llm_hooks.py
+++ b/server/app/services/recommendation/llm_hooks.py
@@ -63,14 +63,19 @@ async def generate_llm_suggestions(
     )
 
 
-def is_llm_available(db=None) -> bool:
+def is_llm_available(db=None, actor=None) -> bool:
     """Check if LLM recommendations are configured and available.
 
-    Truthy if the admin has enabled LLMs (``SystemSettings.llm_enabled``) AND
-    at least one usable connector exists — either an active connector owned by
-    *any* DJ (admin org default) or a connector for the actor (resolved by the
-    gateway at dispatch time). For backwards-compat we also accept the legacy
-    ``ANTHROPIC_API_KEY`` env var when no DB connectors exist.
+    Mirrors :func:`app.services.llm.gateway._resolve_connector` semantics so the
+    "feature available" signal aligns with whether dispatch will actually
+    succeed:
+
+    - If ``actor`` is provided: returns True when the actor owns an active
+      connector (matches the per-DJ MRU lookup).
+    - Otherwise (no actor or no actor-owned active connector): returns True
+      when an active system-default connector is configured.
+    - As a last fallback, the legacy ``ANTHROPIC_API_KEY`` env var unlocks
+      the feature for callers that still take the env-var path.
     """
     from app.core.config import get_settings
 
@@ -83,17 +88,27 @@ def is_llm_available(db=None) -> bool:
         if not settings.llm_enabled:
             return False
 
-        # Any active connector unlocks the feature (gateway picks at dispatch).
-        any_active = db.query(LlmConnector.id).filter(LlmConnector.status == STATUS_ACTIVE).first()
-        if any_active is not None:
-            return True
+        # Per-DJ active connector — matches gateway resolver step 1.
+        if actor is not None:
+            actor_active = (
+                db.query(LlmConnector.id)
+                .filter(
+                    LlmConnector.user_id == actor.id,
+                    LlmConnector.status == STATUS_ACTIVE,
+                )
+                .first()
+            )
+            if actor_active is not None:
+                return True
 
-        # System default fallback
+        # System default fallback — matches gateway resolver step 2.
         sys_settings = db.query(SystemSettings).first()
         if sys_settings and sys_settings.llm_default_connector_id:
-            return True
+            default = db.get(LlmConnector, sys_settings.llm_default_connector_id)
+            if default is not None and default.status == STATUS_ACTIVE:
+                return True
 
-        # Final fallback: legacy env var
+        # Final fallback: legacy env var (kept until env-var cleanup ships).
         return bool(get_settings().anthropic_api_key)
 
     return bool(get_settings().anthropic_api_key)

--- a/server/app/services/recommendation/service.py
+++ b/server/app/services/recommendation/service.py
@@ -848,13 +848,16 @@ async def generate_recommendations_from_llm(
         (playing.artist, playing.song_title, getattr(playing, "bpm", None)) if playing else None
     )
 
-    # Step 2: Call LLM (pass enriched tracks + rejected + currently playing)
+    # Step 2: Call LLM (pass enriched tracks + rejected + currently playing).
+    # Route via the gateway by supplying db + actor (the event owner).
     llm_result = await generate_llm_suggestions(
         profile,
         prompt,
         tracks=enriched or None,
         rejected_tracks=rejected_names or None,
         currently_playing=currently_playing,
+        db=db,
+        actor=user,
     )
 
     if not llm_result.queries:

--- a/server/app/services/system_settings.py
+++ b/server/app/services/system_settings.py
@@ -2,6 +2,11 @@ from sqlalchemy.orm import Session
 
 from app.models.system_settings import SystemSettings
 
+# Sentinel for "field intentionally not provided" — distinguishes from explicit
+# None (which means "clear the FK"). update_system_settings uses this for the
+# llm_default_connector_id field which accepts None as a valid value.
+_UNSET: object = object()
+
 
 def get_system_settings(db: Session) -> SystemSettings:
     """Get the singleton system settings row, creating with defaults if missing."""
@@ -19,6 +24,9 @@ def get_system_settings(db: Session) -> SystemSettings:
             llm_enabled=True,
             llm_model="claude-haiku-4-5-20251001",
             llm_rate_limit_per_minute=3,
+            llm_apikey_connectors_enabled=True,
+            llm_compatible_connector_enabled=True,
+            llm_default_connector_id=None,
         )
         db.add(settings)
         db.commit()
@@ -38,6 +46,9 @@ def update_system_settings(
     llm_enabled: bool | None = None,
     llm_model: str | None = None,
     llm_rate_limit_per_minute: int | None = None,
+    llm_apikey_connectors_enabled: bool | None = None,
+    llm_compatible_connector_enabled: bool | None = None,
+    llm_default_connector_id: int | None | object = _UNSET,
 ) -> SystemSettings:
     """Update system settings fields."""
     settings = get_system_settings(db)
@@ -61,6 +72,12 @@ def update_system_settings(
         settings.llm_model = llm_model
     if llm_rate_limit_per_minute is not None:
         settings.llm_rate_limit_per_minute = llm_rate_limit_per_minute
+    if llm_apikey_connectors_enabled is not None:
+        settings.llm_apikey_connectors_enabled = llm_apikey_connectors_enabled
+    if llm_compatible_connector_enabled is not None:
+        settings.llm_compatible_connector_enabled = llm_compatible_connector_enabled
+    if llm_default_connector_id is not _UNSET:
+        settings.llm_default_connector_id = llm_default_connector_id  # type: ignore[assignment]
     db.commit()
     db.refresh(settings)
     return settings

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -172,6 +172,116 @@
         "title": "ActivityLogEntry",
         "type": "object"
       },
+      "AdminConnectorOut": {
+        "description": "Admin view \u2014 adds the DJ's username for display.",
+        "properties": {
+          "base_url_plain": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Url Plain"
+          },
+          "connector_type": {
+            "enum": [
+              "openai_apikey",
+              "anthropic_apikey",
+              "openai_compatible"
+            ],
+            "title": "Connector Type",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "display_name": {
+            "title": "Display Name",
+            "type": "string"
+          },
+          "dj_username": {
+            "title": "Dj Username",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "last_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Error"
+          },
+          "last_used_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Used At"
+          },
+          "model_hint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Hint"
+          },
+          "status": {
+            "enum": [
+              "active",
+              "auth_invalid",
+              "disabled"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "base_url_plain",
+          "connector_type",
+          "created_at",
+          "display_name",
+          "dj_username",
+          "id",
+          "last_error",
+          "last_used_at",
+          "model_hint",
+          "status",
+          "updated_at",
+          "user_id"
+        ],
+        "title": "AdminConnectorOut",
+        "type": "object"
+      },
       "AdminEventOut": {
         "properties": {
           "code": {
@@ -231,6 +341,101 @@
           "request_count"
         ],
         "title": "AdminEventOut",
+        "type": "object"
+      },
+      "AdminPolicyOut": {
+        "properties": {
+          "llm_apikey_connectors_enabled": {
+            "title": "Llm Apikey Connectors Enabled",
+            "type": "boolean"
+          },
+          "llm_compatible_connector_enabled": {
+            "title": "Llm Compatible Connector Enabled",
+            "type": "boolean"
+          },
+          "llm_default_connector_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Default Connector Id"
+          }
+        },
+        "required": [
+          "llm_apikey_connectors_enabled",
+          "llm_compatible_connector_enabled",
+          "llm_default_connector_id"
+        ],
+        "title": "AdminPolicyOut",
+        "type": "object"
+      },
+      "AdminPolicyPatch": {
+        "properties": {
+          "clear_default": {
+            "default": false,
+            "title": "Clear Default",
+            "type": "boolean"
+          },
+          "llm_apikey_connectors_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Apikey Connectors Enabled"
+          },
+          "llm_compatible_connector_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Compatible Connector Enabled"
+          },
+          "llm_default_connector_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Default Connector Id"
+          }
+        },
+        "title": "AdminPolicyPatch",
+        "type": "object"
+      },
+      "AdminUsageOut": {
+        "properties": {
+          "days": {
+            "title": "Days",
+            "type": "integer"
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/UsageRow"
+            },
+            "title": "Rows",
+            "type": "array"
+          }
+        },
+        "required": [
+          "days",
+          "rows"
+        ],
+        "title": "AdminUsageOut",
         "type": "object"
       },
       "AdminUserCreate": {
@@ -1689,6 +1894,295 @@
           "request_id"
         ],
         "title": "CollectVoteRequest",
+        "type": "object"
+      },
+      "ConnectorCreate": {
+        "properties": {
+          "api_key": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Key"
+          },
+          "base_url": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Url"
+          },
+          "bearer": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bearer"
+          },
+          "connector_type": {
+            "enum": [
+              "openai_apikey",
+              "anthropic_apikey",
+              "openai_compatible"
+            ],
+            "title": "Connector Type",
+            "type": "string"
+          },
+          "display_name": {
+            "maxLength": 80,
+            "minLength": 1,
+            "title": "Display Name",
+            "type": "string"
+          },
+          "model_hint": {
+            "anyOf": [
+              {
+                "maxLength": 80,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Hint"
+          }
+        },
+        "required": [
+          "connector_type",
+          "display_name"
+        ],
+        "title": "ConnectorCreate",
+        "type": "object"
+      },
+      "ConnectorCredentialsRotate": {
+        "properties": {
+          "api_key": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Key"
+          },
+          "base_url": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Url"
+          },
+          "bearer": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bearer"
+          }
+        },
+        "title": "ConnectorCredentialsRotate",
+        "type": "object"
+      },
+      "ConnectorOut": {
+        "description": "Public-safe connector view \u2014 never includes the credential blob.",
+        "properties": {
+          "base_url_plain": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Url Plain"
+          },
+          "connector_type": {
+            "enum": [
+              "openai_apikey",
+              "anthropic_apikey",
+              "openai_compatible"
+            ],
+            "title": "Connector Type",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "display_name": {
+            "title": "Display Name",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "last_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Error"
+          },
+          "last_used_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Used At"
+          },
+          "model_hint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Hint"
+          },
+          "status": {
+            "enum": [
+              "active",
+              "auth_invalid",
+              "disabled"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "base_url_plain",
+          "connector_type",
+          "created_at",
+          "display_name",
+          "id",
+          "last_error",
+          "last_used_at",
+          "model_hint",
+          "status",
+          "updated_at",
+          "user_id"
+        ],
+        "title": "ConnectorOut",
+        "type": "object"
+      },
+      "ConnectorPatch": {
+        "description": "Metadata-only patch (no credential rotation here).",
+        "properties": {
+          "display_name": {
+            "anyOf": [
+              {
+                "maxLength": 80,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "model_hint": {
+            "anyOf": [
+              {
+                "maxLength": 80,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Hint"
+          }
+        },
+        "title": "ConnectorPatch",
+        "type": "object"
+      },
+      "ConnectorTestResult": {
+        "properties": {
+          "error_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Code"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          },
+          "ok": {
+            "title": "Ok",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "error_code",
+          "message",
+          "ok"
+        ],
+        "title": "ConnectorTestResult",
         "type": "object"
       },
       "DisplaySettingsResponse": {
@@ -5169,6 +5663,64 @@
         "title": "UpdateCollectionSettings",
         "type": "object"
       },
+      "UsageRow": {
+        "properties": {
+          "connector_id": {
+            "title": "Connector Id",
+            "type": "integer"
+          },
+          "connector_type": {
+            "enum": [
+              "openai_apikey",
+              "anthropic_apikey",
+              "openai_compatible"
+            ],
+            "title": "Connector Type",
+            "type": "string"
+          },
+          "display_name": {
+            "title": "Display Name",
+            "type": "string"
+          },
+          "dj_username": {
+            "title": "Dj Username",
+            "type": "string"
+          },
+          "error_count": {
+            "title": "Error Count",
+            "type": "integer"
+          },
+          "error_rate": {
+            "title": "Error Rate",
+            "type": "number"
+          },
+          "total_calls": {
+            "title": "Total Calls",
+            "type": "integer"
+          },
+          "total_tokens_in": {
+            "title": "Total Tokens In",
+            "type": "integer"
+          },
+          "total_tokens_out": {
+            "title": "Total Tokens Out",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "connector_id",
+          "connector_type",
+          "display_name",
+          "dj_username",
+          "error_count",
+          "error_rate",
+          "total_calls",
+          "total_tokens_in",
+          "total_tokens_out"
+        ],
+        "title": "UsageRow",
+        "type": "object"
+      },
       "UserOut": {
         "properties": {
           "created_at": {
@@ -5885,6 +6437,208 @@
         "summary": "Admin Check Integration",
         "tags": [
           "admin"
+        ]
+      }
+    },
+    "/api/admin/llm/connectors": {
+      "get": {
+        "operationId": "list_connectors_admin_api_admin_llm_connectors_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AdminConnectorOut"
+                  },
+                  "title": "Response List Connectors Admin Api Admin Llm Connectors Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Connectors Admin",
+        "tags": [
+          "admin",
+          "llm"
+        ]
+      }
+    },
+    "/api/admin/llm/connectors/{connector_id}/revoke": {
+      "post": {
+        "operationId": "revoke_connector_admin_api_admin_llm_connectors__connector_id__revoke_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connector_id",
+            "required": true,
+            "schema": {
+              "title": "Connector Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminConnectorOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Revoke Connector Admin",
+        "tags": [
+          "admin",
+          "llm"
+        ]
+      }
+    },
+    "/api/admin/llm/policy": {
+      "get": {
+        "operationId": "get_policy_api_admin_llm_policy_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminPolicyOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Policy",
+        "tags": [
+          "admin",
+          "llm"
+        ]
+      },
+      "patch": {
+        "operationId": "patch_policy_api_admin_llm_policy_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminPolicyPatch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminPolicyOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Patch Policy",
+        "tags": [
+          "admin",
+          "llm"
+        ]
+      }
+    },
+    "/api/admin/llm/usage": {
+      "get": {
+        "operationId": "get_usage_api_admin_llm_usage_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "default": 30,
+              "maximum": 180,
+              "minimum": 1,
+              "title": "Days",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminUsageOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Usage",
+        "tags": [
+          "admin",
+          "llm"
         ]
       }
     },
@@ -9078,6 +9832,279 @@
         ]
       }
     },
+    "/api/llm/connectors": {
+      "get": {
+        "operationId": "list_connectors_api_llm_connectors_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ConnectorOut"
+                  },
+                  "title": "Response List Connectors Api Llm Connectors Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Connectors",
+        "tags": [
+          "llm"
+        ]
+      },
+      "post": {
+        "operationId": "create_connector_endpoint_api_llm_connectors_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Create Connector Endpoint",
+        "tags": [
+          "llm"
+        ]
+      }
+    },
+    "/api/llm/connectors/{connector_id}": {
+      "delete": {
+        "operationId": "delete_connector_endpoint_api_llm_connectors__connector_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connector_id",
+            "required": true,
+            "schema": {
+              "title": "Connector Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Connector Endpoint",
+        "tags": [
+          "llm"
+        ]
+      },
+      "patch": {
+        "operationId": "update_connector_metadata_api_llm_connectors__connector_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connector_id",
+            "required": true,
+            "schema": {
+              "title": "Connector Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorPatch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Connector Metadata",
+        "tags": [
+          "llm"
+        ]
+      }
+    },
+    "/api/llm/connectors/{connector_id}/credentials": {
+      "put": {
+        "operationId": "rotate_connector_credentials_api_llm_connectors__connector_id__credentials_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connector_id",
+            "required": true,
+            "schema": {
+              "title": "Connector Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorCredentialsRotate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Rotate Connector Credentials",
+        "tags": [
+          "llm"
+        ]
+      }
+    },
+    "/api/llm/connectors/{connector_id}/test": {
+      "post": {
+        "operationId": "test_connector_api_llm_connectors__connector_id__test_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connector_id",
+            "required": true,
+            "schema": {
+              "title": "Connector Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorTestResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Test Connector",
+        "tags": [
+          "llm"
+        ]
+      }
+    },
     "/api/public/collect/{code}": {
       "get": {
         "operationId": "preview_api_public_collect__code__get",
@@ -9559,7 +10586,7 @@
     },
     "/api/public/e/{code}/bridge-status": {
       "get": {
-        "description": "Get bridge connection status for public display.\n\nIndependent of track data \u2014 returns bridge connectivity even when\nno track is currently playing.",
+        "description": "Get bridge connection status for public display.\n\nIndependent of track data \u2014 returns bridge connectivity even when\nno track is currently playing. Resolves by join_code: serves guest-facing\nkiosk display + overlay pages.",
         "operationId": "get_public_bridge_status_api_public_e__code__bridge_status_get",
         "parameters": [
           {
@@ -9602,7 +10629,7 @@
     },
     "/api/public/e/{code}/history": {
       "get": {
-        "description": "Get play history for public display.\n\nReturns the list of tracks played during the event, newest first.",
+        "description": "Get play history for public display.\n\nReturns the list of tracks played during the event, newest first.\nResolves by join_code: serves guest-facing kiosk display.",
         "operationId": "get_public_history_api_public_e__code__history_get",
         "parameters": [
           {
@@ -9668,7 +10695,7 @@
     },
     "/api/public/e/{code}/nowplaying": {
       "get": {
-        "description": "Get current now-playing track for public display.\n\nReturns the track currently playing from StageLinQ, or None if nothing playing.",
+        "description": "Get current now-playing track for public display.\n\nReturns the track currently playing from StageLinQ, or None if nothing playing.\n\nResolves by join_code: this endpoint serves the kiosk display + OBS overlay\npages, which route by join_code per the post-PR-#324 public/guest URL contract.",
         "operationId": "get_public_now_playing_api_public_e__code__nowplaying_get",
         "parameters": [
           {

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1897,6 +1897,7 @@
         "type": "object"
       },
       "ConnectorCreate": {
+        "description": "Provider-agnostic create payload.\n\nField requirements vary by ``connector_type``:\n\n- ``openai_apikey`` / ``anthropic_apikey``: ``api_key`` required;\n  ``base_url`` and ``bearer`` are ignored.\n- ``openai_compatible``: ``base_url`` required; ``bearer`` optional;\n  ``api_key`` is ignored.\n\nThe combination is enforced by :meth:`_require_credentials_for_type`.\nSee ``build_create_payload`` in ``services/llm/connector_storage.py``\nfor the full validation flow (including key shape checks).",
         "properties": {
           "api_key": {
             "anyOf": [
@@ -1970,6 +1971,7 @@
         "type": "object"
       },
       "ConnectorCredentialsRotate": {
+        "description": "Rotation payload \u2014 at least one credential field must be supplied.\n\nField semantics mirror :class:`ConnectorCreate`. The actual field required\ndepends on the connector being rotated (validated in ``rotate_credentials``).",
         "properties": {
           "api_key": {
             "anyOf": [

--- a/server/scripts/export_openapi.py
+++ b/server/scripts/export_openapi.py
@@ -84,6 +84,10 @@ def _promote_response_fields_to_required(spec: dict[str, Any]) -> None:
 
 def export() -> Path:
     output = Path(__file__).resolve().parent.parent / "openapi.json"
+    # Force fresh generation — FastAPI caches the schema on `app.openapi_schema`,
+    # which can hide newly-added routes when this script is invoked from a
+    # long-running process.
+    app.openapi_schema = None
     spec = app.openapi()
     _promote_response_fields_to_required(spec)
     output.write_text(json.dumps(spec, indent=2, sort_keys=True) + "\n")

--- a/server/tests/test_llm_adapters.py
+++ b/server/tests/test_llm_adapters.py
@@ -1,0 +1,319 @@
+"""Tests for the OpenAI / OpenAI-compatible / Anthropic adapters.
+
+Each adapter is mocked at the HTTP boundary (httpx for OpenAI, anthropic SDK
+for Anthropic) so we exercise the adapter logic without real network calls.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.services.llm.adapters.anthropic_apikey import AnthropicApiKeyAdapter
+from app.services.llm.adapters.openai_apikey import OpenAIApiKeyAdapter
+from app.services.llm.adapters.openai_compatible import OpenAICompatibleAdapter
+from app.services.llm.base import ChatRequest, Message
+from app.services.llm.exceptions import (
+    AuthInvalid,
+    ProviderUnavailable,
+    QuotaExceeded,
+    RateLimited,
+    ToolTranslationError,
+)
+
+_HTTPX_PATH = "app.services.llm.adapters._httpx_openai.httpx.AsyncClient"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _make_openai_connector():
+    return SimpleNamespace(
+        connector_type="openai_apikey",
+        credentials=json.dumps({"api_key": "sk-test-key-123456789012"}),
+        model_hint="gpt-5-mini",
+        base_url_plain=None,
+    )
+
+
+def _make_compatible_connector(base_url="http://127.0.0.1:11434/v1", bearer=None):
+    creds = {"base_url": base_url, "bearer": bearer}
+    return SimpleNamespace(
+        connector_type="openai_compatible",
+        credentials=json.dumps(creds),
+        model_hint="llama3",
+        base_url_plain=base_url,
+    )
+
+
+def _make_anthropic_connector():
+    return SimpleNamespace(
+        connector_type="anthropic_apikey",
+        credentials=json.dumps({"api_key": "sk-ant-fake-key-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}),
+        model_hint="claude-haiku-4-5-20251001",
+        base_url_plain=None,
+    )
+
+
+def _openai_success_body(text="hi"):
+    return {
+        "model": "gpt-5-mini",
+        "choices": [{"finish_reason": "stop", "message": {"role": "assistant", "content": text}}],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 1},
+    }
+
+
+def _ok_response(json_body):
+    return httpx.Response(
+        200,
+        request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+        json=json_body,
+    )
+
+
+class _AsyncClient:
+    """Minimal httpx.AsyncClient stub for unit tests."""
+
+    def __init__(self, response: httpx.Response | Exception):
+        self._response = response
+        self.calls: list = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    async def post(self, url, json=None, headers=None):
+        self.calls.append({"url": url, "json": json, "headers": headers})
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+
+# ---------------------------------------------------------------------------
+# OpenAI API-key adapter
+# ---------------------------------------------------------------------------
+class TestOpenAIApiKeyAdapter:
+    @pytest.mark.asyncio
+    async def test_happy_path(self):
+        connector = _make_openai_connector()
+        adapter = OpenAIApiKeyAdapter(connector)
+        request = ChatRequest(messages=[Message(role="user", content="hi")])
+
+        client = _AsyncClient(_ok_response(_openai_success_body("pong")))
+        with patch(_HTTPX_PATH, return_value=client):
+            resp = await adapter.chat(request)
+
+        assert resp.text == "pong"
+        assert client.calls[0]["headers"]["Authorization"].startswith("Bearer ")
+        assert client.calls[0]["url"].endswith("/chat/completions")
+
+    @pytest.mark.asyncio
+    async def test_401_maps_to_auth_invalid(self):
+        connector = _make_openai_connector()
+        adapter = OpenAIApiKeyAdapter(connector)
+        resp = httpx.Response(
+            401,
+            request=httpx.Request("POST", "https://example.com"),
+            json={"error": "bad key"},
+        )
+        client = _AsyncClient(resp)
+        with patch(_HTTPX_PATH, return_value=client):
+            with pytest.raises(AuthInvalid):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_429_maps_to_rate_limited_with_retry_after(self):
+        connector = _make_openai_connector()
+        adapter = OpenAIApiKeyAdapter(connector)
+        resp = httpx.Response(
+            429,
+            request=httpx.Request("POST", "https://example.com"),
+            headers={"Retry-After": "42"},
+            json={"error": "ratelimit"},
+        )
+        client = _AsyncClient(resp)
+        with patch(_HTTPX_PATH, return_value=client):
+            with pytest.raises(RateLimited) as exc_info:
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+        assert exc_info.value.retry_after_seconds == 42
+
+    @pytest.mark.asyncio
+    async def test_500_maps_to_provider_unavailable(self):
+        connector = _make_openai_connector()
+        adapter = OpenAIApiKeyAdapter(connector)
+        resp = httpx.Response(
+            502,
+            request=httpx.Request("POST", "https://example.com"),
+            json={"error": "boom"},
+        )
+        client = _AsyncClient(resp)
+        with patch(_HTTPX_PATH, return_value=client):
+            with pytest.raises(ProviderUnavailable):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_402_maps_to_quota_exceeded(self):
+        connector = _make_openai_connector()
+        adapter = OpenAIApiKeyAdapter(connector)
+        resp = httpx.Response(
+            402,
+            request=httpx.Request("POST", "https://example.com"),
+            json={"error": "billing"},
+        )
+        client = _AsyncClient(resp)
+        with patch(_HTTPX_PATH, return_value=client):
+            with pytest.raises(QuotaExceeded):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_timeout_maps_to_provider_unavailable(self):
+        connector = _make_openai_connector()
+        adapter = OpenAIApiKeyAdapter(connector)
+        client = _AsyncClient(httpx.TimeoutException("timeout"))
+        with patch(_HTTPX_PATH, return_value=client):
+            with pytest.raises(ProviderUnavailable):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_malformed_credentials_raise_auth_invalid(self):
+        connector = SimpleNamespace(
+            connector_type="openai_apikey",
+            credentials="not json at all",
+            model_hint="gpt-5-mini",
+            base_url_plain=None,
+        )
+        adapter = OpenAIApiKeyAdapter(connector)
+        with pytest.raises(AuthInvalid):
+            await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_raises_auth_invalid(self):
+        connector = SimpleNamespace(
+            connector_type="openai_apikey",
+            credentials=json.dumps({}),
+            model_hint="gpt-5-mini",
+            base_url_plain=None,
+        )
+        adapter = OpenAIApiKeyAdapter(connector)
+        with pytest.raises(AuthInvalid):
+            await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible adapter
+# ---------------------------------------------------------------------------
+class TestOpenAICompatibleAdapter:
+    @pytest.mark.asyncio
+    async def test_no_bearer_no_auth_header(self):
+        connector = _make_compatible_connector()
+        adapter = OpenAICompatibleAdapter(connector)
+        client = _AsyncClient(_ok_response(_openai_success_body("hello")))
+        with patch(_HTTPX_PATH, return_value=client):
+            resp = await adapter.chat(ChatRequest(messages=[Message(role="user", content="hi")]))
+        assert resp.text == "hello"
+        assert "Authorization" not in client.calls[0]["headers"]
+
+    @pytest.mark.asyncio
+    async def test_with_bearer_sets_authorization(self):
+        connector = _make_compatible_connector(bearer="abc123")
+        adapter = OpenAICompatibleAdapter(connector)
+        client = _AsyncClient(_ok_response(_openai_success_body("hello")))
+        with patch(_HTTPX_PATH, return_value=client):
+            await adapter.chat(ChatRequest(messages=[Message(role="user", content="hi")]))
+        assert client.calls[0]["headers"]["Authorization"] == "Bearer abc123"
+
+
+# ---------------------------------------------------------------------------
+# Anthropic API-key adapter
+# ---------------------------------------------------------------------------
+class TestAnthropicApiKeyAdapter:
+    @pytest.mark.asyncio
+    async def test_happy_path(self):
+        connector = _make_anthropic_connector()
+        adapter = AnthropicApiKeyAdapter(connector)
+
+        fake_message = SimpleNamespace(
+            model="claude-haiku-4-5-20251001",
+            stop_reason="end_turn",
+            content=[SimpleNamespace(type="text", text="hi")],
+            usage=SimpleNamespace(input_tokens=3, output_tokens=1),
+        )
+
+        with patch.object(
+            adapter,
+            "_client",
+            return_value=SimpleNamespace(
+                messages=SimpleNamespace(create=AsyncMock(return_value=fake_message))
+            ),
+        ):
+            resp = await adapter.chat(ChatRequest(messages=[Message(role="user", content="hi")]))
+
+        assert resp.text == "hi"
+        assert resp.usage.prompt == 3
+        assert resp.usage.completion == 1
+
+    @pytest.mark.asyncio
+    async def test_status_error_401_maps_to_auth_invalid(self):
+        from anthropic import APIStatusError
+
+        connector = _make_anthropic_connector()
+        adapter = AnthropicApiKeyAdapter(connector)
+
+        err_response = httpx.Response(
+            401,
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+            json={"error": "bad"},
+        )
+        exc = APIStatusError("auth failed", response=err_response, body=None)
+
+        with patch.object(
+            adapter,
+            "_client",
+            return_value=SimpleNamespace(
+                messages=SimpleNamespace(create=AsyncMock(side_effect=exc))
+            ),
+        ):
+            with pytest.raises(AuthInvalid):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_status_error_429_maps_to_rate_limited(self):
+        from anthropic import APIStatusError
+
+        connector = _make_anthropic_connector()
+        adapter = AnthropicApiKeyAdapter(connector)
+
+        err_response = httpx.Response(
+            429,
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+            headers={"retry-after": "30"},
+            json={"error": "limit"},
+        )
+        exc = APIStatusError("rate limited", response=err_response, body=None)
+
+        with patch.object(
+            adapter,
+            "_client",
+            return_value=SimpleNamespace(
+                messages=SimpleNamespace(create=AsyncMock(side_effect=exc))
+            ),
+        ):
+            with pytest.raises(RateLimited) as info:
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+        assert info.value.retry_after_seconds == 30
+
+    @pytest.mark.asyncio
+    async def test_tool_call_message_requires_tool_call_id(self):
+        connector = _make_anthropic_connector()
+        adapter = AnthropicApiKeyAdapter(connector)
+        # Build a tool message without tool_call_id — should raise
+        with pytest.raises(ToolTranslationError):
+            await adapter.chat(
+                ChatRequest(messages=[Message(role="tool", content="result", tool_call_id=None)])
+            )

--- a/server/tests/test_llm_api.py
+++ b/server/tests/test_llm_api.py
@@ -1,0 +1,395 @@
+"""Tests for the per-DJ LLM connector API + admin oversight API.
+
+Exercises:
+- CRUD endpoints, ownership scoping (404 for other DJs' connectors)
+- policy gating (admin can disable connector types)
+- credential rotation audit
+- admin force-revoke + system default cleanup
+- usage rollup
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.llm_connector import LlmAuditEvent, LlmConnector
+from app.models.user import User
+from app.services.auth import get_password_hash
+
+
+# ---------- helpers ----------
+def _login(client: TestClient, username: str, password: str) -> dict[str, str]:
+    resp = client.post("/api/auth/login", data={"username": username, "password": password})
+    assert resp.status_code == 200, resp.json()
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _make_other_dj(db: Session) -> User:
+    user = User(
+        username="otherdj",
+        password_hash=get_password_hash("otherpassword123"),
+        role="dj",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+# ---------- list / create / scope ----------
+class TestPerDJConnectorsCRUD:
+    def test_list_empty_for_new_user(self, client: TestClient, auth_headers):
+        resp = client.get("/api/llm/connectors", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_create_openai_apikey_happy_path(self, client: TestClient, auth_headers, db):
+        body = {
+            "connector_type": "openai_apikey",
+            "display_name": "My OpenAI",
+            "api_key": "sk-proj-abc1234567890abcdef12",
+            "model_hint": "gpt-5-mini",
+        }
+        resp = client.post("/api/llm/connectors", json=body, headers=auth_headers)
+        assert resp.status_code == 201, resp.json()
+        data = resp.json()
+        assert data["connector_type"] == "openai_apikey"
+        assert data["display_name"] == "My OpenAI"
+        # Credentials never returned
+        assert "credentials" not in data
+        assert "api_key" not in data
+
+        # Audit event recorded
+        event = (
+            db.query(LlmAuditEvent).filter(LlmAuditEvent.target_connector_id == data["id"]).first()
+        )
+        assert event is not None
+        assert event.event_type == "connector_created"
+
+    def test_create_anthropic_apikey_happy_path(self, client: TestClient, auth_headers):
+        body = {
+            "connector_type": "anthropic_apikey",
+            "display_name": "My Claude",
+            "api_key": "sk-ant-1234567890abcdef1234567890abcdef1234567890",
+            "model_hint": "claude-haiku-4-5-20251001",
+        }
+        resp = client.post("/api/llm/connectors", json=body, headers=auth_headers)
+        assert resp.status_code == 201, resp.json()
+
+    def test_create_openai_compatible_happy_path(self, client: TestClient, auth_headers):
+        body = {
+            "connector_type": "openai_compatible",
+            "display_name": "Local Ollama",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "model_hint": "llama3",
+        }
+        resp = client.post("/api/llm/connectors", json=body, headers=auth_headers)
+        assert resp.status_code == 201, resp.json()
+        data = resp.json()
+        assert data["base_url_plain"] == "http://127.0.0.1:11434/v1"
+
+    def test_create_openai_compatible_rejects_public_http(self, client: TestClient, auth_headers):
+        body = {
+            "connector_type": "openai_compatible",
+            "display_name": "Bad URL",
+            "base_url": "http://example.com/v1",
+        }
+        resp = client.post("/api/llm/connectors", json=body, headers=auth_headers)
+        assert resp.status_code == 400
+
+    def test_create_rejects_invalid_key_format(self, client: TestClient, auth_headers):
+        body = {
+            "connector_type": "openai_apikey",
+            "display_name": "Bad Key",
+            "api_key": "not-a-valid-key",
+        }
+        resp = client.post("/api/llm/connectors", json=body, headers=auth_headers)
+        assert resp.status_code == 400
+
+    def test_create_rejects_unknown_type(self, client: TestClient, auth_headers):
+        body = {
+            "connector_type": "gemini_apikey",
+            "display_name": "Future Gemini",
+            "api_key": "sk-anything",
+        }
+        # Pydantic Literal rejects this with 422 before we reach our handler.
+        resp = client.post("/api/llm/connectors", json=body, headers=auth_headers)
+        assert resp.status_code in (400, 422)
+
+    def test_create_blocked_by_admin_policy(
+        self, client: TestClient, auth_headers, db, admin_headers
+    ):
+        # Disable apikey connectors via admin policy
+        resp = client.patch(
+            "/api/admin/llm/policy",
+            json={"llm_apikey_connectors_enabled": False},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+
+        body = {
+            "connector_type": "openai_apikey",
+            "display_name": "Should Fail",
+            "api_key": "sk-proj-abc1234567890abcdef12",
+        }
+        resp = client.post("/api/llm/connectors", json=body, headers=auth_headers)
+        assert resp.status_code == 403
+
+    def test_pending_user_cannot_use_connectors(self, client: TestClient, pending_headers):
+        resp = client.get("/api/llm/connectors", headers=pending_headers)
+        assert resp.status_code == 403
+
+    def test_unauthenticated_cannot_list(self, client: TestClient):
+        resp = client.get("/api/llm/connectors")
+        assert resp.status_code == 401
+
+    def test_list_only_shows_own_connectors(self, client: TestClient, auth_headers, db, test_user):
+        other = _make_other_dj(db)
+        other_row = LlmConnector(
+            user_id=other.id,
+            connector_type="openai_apikey",
+            display_name="Other's connector",
+            status="active",
+            credentials=json.dumps({"api_key": "sk-x"}),
+        )
+        db.add(other_row)
+        db.commit()
+        db.refresh(other_row)
+
+        resp = client.get("/api/llm/connectors", headers=auth_headers)
+        assert resp.status_code == 200
+        assert all(r["user_id"] == test_user.id for r in resp.json())
+
+    def test_404_when_accessing_other_dj_connector(self, client: TestClient, auth_headers, db):
+        other = _make_other_dj(db)
+        other_row = LlmConnector(
+            user_id=other.id,
+            connector_type="openai_apikey",
+            display_name="Other's connector",
+            status="active",
+            credentials=json.dumps({"api_key": "sk-x"}),
+        )
+        db.add(other_row)
+        db.commit()
+        db.refresh(other_row)
+
+        resp = client.delete(f"/api/llm/connectors/{other_row.id}", headers=auth_headers)
+        assert resp.status_code == 404
+
+    def test_delete_own_connector(self, client: TestClient, auth_headers, db, test_user):
+        row = LlmConnector(
+            user_id=test_user.id,
+            connector_type="openai_apikey",
+            display_name="Mine",
+            status="active",
+            credentials=json.dumps({"api_key": "sk-x"}),
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+
+        resp = client.delete(f"/api/llm/connectors/{row.id}", headers=auth_headers)
+        assert resp.status_code == 204
+        # Audit event recorded
+        assert (
+            db.query(LlmAuditEvent).filter(LlmAuditEvent.event_type == "connector_deleted").count()
+            == 1
+        )
+
+    def test_rotate_credentials_audited(self, client: TestClient, auth_headers, db, test_user):
+        row = LlmConnector(
+            user_id=test_user.id,
+            connector_type="openai_apikey",
+            display_name="Mine",
+            status="active",
+            credentials=json.dumps({"api_key": "sk-old1234567890abcdef12"}),
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+
+        resp = client.put(
+            f"/api/llm/connectors/{row.id}/credentials",
+            json={"api_key": "sk-new1234567890abcdef12"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.json()
+        # Audit event for rotation written
+        assert (
+            db.query(LlmAuditEvent)
+            .filter(LlmAuditEvent.event_type == "connector_credentials_rotated")
+            .count()
+            == 1
+        )
+
+
+# ---------- /connectors/{id}/test (health check) ----------
+class TestHealthCheck:
+    def test_test_endpoint_returns_ok(self, client: TestClient, auth_headers, db, test_user):
+        row = LlmConnector(
+            user_id=test_user.id,
+            connector_type="openai_apikey",
+            display_name="Mine",
+            status="active",
+            credentials=json.dumps({"api_key": "sk-key123"}),
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+
+        with patch(
+            "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+            new=AsyncMock(return_value=None),
+        ):
+            resp = client.post(f"/api/llm/connectors/{row.id}/test", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+    def test_test_returns_sanitized_error_on_auth_invalid(
+        self, client: TestClient, auth_headers, db, test_user
+    ):
+        from app.services.llm.exceptions import AuthInvalid
+
+        row = LlmConnector(
+            user_id=test_user.id,
+            connector_type="openai_apikey",
+            display_name="Mine",
+            status="active",
+            credentials=json.dumps({"api_key": "sk-key123"}),
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+
+        with patch(
+            "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+            new=AsyncMock(side_effect=AuthInvalid("upstream secret should not leak")),
+        ):
+            resp = client.post(f"/api/llm/connectors/{row.id}/test", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is False
+        assert data["error_code"] == "auth_invalid"
+        # Sanitised — no raw exception message
+        assert "upstream secret should not leak" not in (data["message"] or "")
+
+        db.refresh(row)
+        assert row.status == "auth_invalid"
+
+
+# ---------- Admin policy / oversight ----------
+class TestAdminLlm:
+    def test_get_policy(self, client: TestClient, admin_headers):
+        resp = client.get("/api/admin/llm/policy", headers=admin_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "llm_apikey_connectors_enabled" in data
+        assert "llm_compatible_connector_enabled" in data
+
+    def test_patch_policy_toggles(self, client: TestClient, admin_headers):
+        resp = client.patch(
+            "/api/admin/llm/policy",
+            json={
+                "llm_apikey_connectors_enabled": False,
+                "llm_compatible_connector_enabled": False,
+            },
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["llm_apikey_connectors_enabled"] is False
+        assert data["llm_compatible_connector_enabled"] is False
+
+    def test_non_admin_cannot_get_policy(self, client: TestClient, auth_headers):
+        resp = client.get("/api/admin/llm/policy", headers=auth_headers)
+        assert resp.status_code == 403
+
+    def test_list_connectors_admin_shows_all(
+        self, client: TestClient, admin_headers, db, test_user
+    ):
+        row = LlmConnector(
+            user_id=test_user.id,
+            connector_type="openai_apikey",
+            display_name="Mine",
+            status="active",
+            credentials=json.dumps({"api_key": "sk-x"}),
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        resp = client.get("/api/admin/llm/connectors", headers=admin_headers)
+        assert resp.status_code == 200
+        users = [r["dj_username"] for r in resp.json()]
+        assert "testuser" in users
+
+    def test_force_revoke_clears_default(self, client: TestClient, admin_headers, db, test_user):
+        row = LlmConnector(
+            user_id=test_user.id,
+            connector_type="openai_apikey",
+            display_name="Mine",
+            status="active",
+            credentials=json.dumps({"api_key": "sk-x"}),
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+
+        # Set as default
+        resp = client.patch(
+            "/api/admin/llm/policy",
+            json={"llm_default_connector_id": row.id},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+
+        # Revoke
+        resp = client.post(f"/api/admin/llm/connectors/{row.id}/revoke", headers=admin_headers)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "disabled"
+
+        # Default cleared
+        resp = client.get("/api/admin/llm/policy", headers=admin_headers)
+        assert resp.json()["llm_default_connector_id"] is None
+
+        # Audit recorded
+        assert (
+            db.query(LlmAuditEvent)
+            .filter(LlmAuditEvent.event_type == "connector_revoked_by_admin")
+            .count()
+            == 1
+        )
+
+    def test_usage_endpoint(self, client: TestClient, admin_headers, db, test_user):
+        # Seed a connector and a call log row
+        row = LlmConnector(
+            user_id=test_user.id,
+            connector_type="openai_apikey",
+            display_name="Mine",
+            status="active",
+            credentials=json.dumps({"api_key": "sk-x"}),
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        from app.services.llm.connector_storage import log_call
+
+        log_call(
+            db,
+            connector_id=row.id,
+            purpose="recommendation",
+            status="ok",
+            latency_ms=100,
+            tokens_in=10,
+            tokens_out=5,
+        )
+        db.commit()
+
+        resp = client.get("/api/admin/llm/usage?days=30", headers=admin_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["days"] == 30
+        assert any(r["connector_id"] == row.id for r in data["rows"])

--- a/server/tests/test_llm_gateway.py
+++ b/server/tests/test_llm_gateway.py
@@ -1,0 +1,272 @@
+"""Tests for the LLM gateway dispatch + connector resolution."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.models.llm_connector import LlmConnector
+from app.models.system_settings import SystemSettings
+from app.models.user import User
+from app.services.auth import get_password_hash
+from app.services.llm.base import ChatRequest, ChatResponse, Message, TokenUsage
+from app.services.llm.exceptions import (
+    AuthInvalid,
+    NoLlmConfigured,
+    ProviderUnavailable,
+    RateLimited,
+)
+from app.services.llm.gateway import Gateway
+
+
+@pytest.fixture
+def dj_user(db) -> User:
+    user = User(
+        username="djuser",
+        password_hash=get_password_hash("password123"),
+        role="dj",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture
+def admin_user_actor(db) -> User:
+    user = User(
+        username="adminactor",
+        password_hash=get_password_hash("password123"),
+        role="admin",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _make_connector(
+    db,
+    user: User,
+    *,
+    connector_type: str = "openai_apikey",
+    display_name: str = "Test connector",
+    status: str = "active",
+    model_hint: str = "gpt-5-mini",
+) -> LlmConnector:
+    row = LlmConnector(
+        user_id=user.id,
+        connector_type=connector_type,
+        display_name=display_name,
+        status=status,
+        credentials=json.dumps({"api_key": "sk-fake-key"}),
+        model_hint=model_hint,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@pytest.fixture
+def gateway_request() -> ChatRequest:
+    return ChatRequest(messages=[Message(role="user", content="hi")])
+
+
+@pytest.mark.asyncio
+async def test_no_actor_no_default_raises(db, gateway_request):
+    with pytest.raises(NoLlmConfigured):
+        await Gateway.dispatch(db, None, gateway_request, purpose="test")
+
+
+@pytest.mark.asyncio
+async def test_actor_with_active_connector_dispatches(db, dj_user, gateway_request):
+    connector = _make_connector(db, dj_user)
+
+    fake_response = ChatResponse(
+        text="ok",
+        tool_calls=[],
+        stop_reason="end_turn",
+        usage=TokenUsage(prompt=5, completion=2),
+    )
+
+    with patch.object(
+        __import__(
+            "app.services.llm.adapters.openai_apikey",
+            fromlist=["OpenAIApiKeyAdapter"],
+        ).OpenAIApiKeyAdapter,
+        "chat",
+        new=AsyncMock(return_value=fake_response),
+    ):
+        resp = await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
+
+    assert resp.text == "ok"
+    db.refresh(connector)
+    assert connector.last_used_at is not None
+    # call log row was inserted
+    from app.models.llm_connector import LlmCallLog
+
+    log = db.query(LlmCallLog).filter(LlmCallLog.connector_id == connector.id).one()
+    assert log.status == "ok"
+    assert log.tokens_in == 5
+    assert log.tokens_out == 2
+
+
+@pytest.mark.asyncio
+async def test_auth_invalid_marks_connector(db, dj_user, gateway_request):
+    connector = _make_connector(db, dj_user)
+    with patch.object(
+        __import__(
+            "app.services.llm.adapters.openai_apikey",
+            fromlist=["OpenAIApiKeyAdapter"],
+        ).OpenAIApiKeyAdapter,
+        "chat",
+        new=AsyncMock(side_effect=AuthInvalid("nope")),
+    ):
+        with pytest.raises(AuthInvalid):
+            await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
+
+    db.refresh(connector)
+    assert connector.status == "auth_invalid"
+
+    from app.models.llm_connector import LlmAuditEvent, LlmCallLog
+
+    log = db.query(LlmCallLog).one()
+    assert log.status == "auth_invalid"
+
+    audit = db.query(LlmAuditEvent).one()
+    assert audit.event_type == "auth_invalid_observed"
+    assert audit.target_connector_id == connector.id
+
+
+@pytest.mark.asyncio
+async def test_rate_limited_logs_and_raises(db, dj_user, gateway_request):
+    _make_connector(db, dj_user)
+    with patch.object(
+        __import__(
+            "app.services.llm.adapters.openai_apikey",
+            fromlist=["OpenAIApiKeyAdapter"],
+        ).OpenAIApiKeyAdapter,
+        "chat",
+        new=AsyncMock(side_effect=RateLimited("slow", retry_after_seconds=12)),
+    ):
+        with pytest.raises(RateLimited) as exc_info:
+            await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
+    assert exc_info.value.retry_after_seconds == 12
+
+    from app.models.llm_connector import LlmCallLog
+
+    log = db.query(LlmCallLog).one()
+    assert log.status == "rate_limited"
+
+
+@pytest.mark.asyncio
+async def test_provider_unavailable_logs_and_raises(db, dj_user, gateway_request):
+    _make_connector(db, dj_user)
+    with patch.object(
+        __import__(
+            "app.services.llm.adapters.openai_apikey",
+            fromlist=["OpenAIApiKeyAdapter"],
+        ).OpenAIApiKeyAdapter,
+        "chat",
+        new=AsyncMock(side_effect=ProviderUnavailable("nope")),
+    ):
+        with pytest.raises(ProviderUnavailable):
+            await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
+
+    from app.models.llm_connector import LlmCallLog
+
+    log = db.query(LlmCallLog).one()
+    assert log.status == "provider_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_disabled_connector_skipped_in_resolution(db, dj_user, gateway_request):
+    # Disabled connector should NOT be returned by the resolver — no default → raise.
+    _make_connector(db, dj_user, status="disabled", display_name="Disabled")
+    with pytest.raises(NoLlmConfigured):
+        await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_system_default(db, admin_user_actor, gateway_request):
+    # admin has no connector of their own — falls back to system default.
+    other_admin = User(
+        username="otheradmin",
+        password_hash=get_password_hash("password123"),
+        role="admin",
+    )
+    db.add(other_admin)
+    db.commit()
+    db.refresh(other_admin)
+    default_connector = _make_connector(db, other_admin, display_name="default-org-connector")
+
+    # Wire the system default
+    ss = db.query(SystemSettings).first()
+    if ss is None:
+        ss = SystemSettings(id=1, llm_default_connector_id=default_connector.id)
+        db.add(ss)
+    else:
+        ss.llm_default_connector_id = default_connector.id
+    db.commit()
+
+    fake_response = ChatResponse(
+        text="ok",
+        tool_calls=[],
+        stop_reason="end_turn",
+        usage=TokenUsage(prompt=1, completion=1),
+    )
+
+    with patch.object(
+        __import__(
+            "app.services.llm.adapters.openai_apikey",
+            fromlist=["OpenAIApiKeyAdapter"],
+        ).OpenAIApiKeyAdapter,
+        "chat",
+        new=AsyncMock(return_value=fake_response),
+    ):
+        resp = await Gateway.dispatch(db, None, gateway_request, purpose="test")
+
+    assert resp.text == "ok"
+
+
+@pytest.mark.asyncio
+async def test_mru_resolution_picks_recent(db, dj_user, gateway_request):
+    """Resolver picks the connector with the most recent last_used_at."""
+    from app.core.time import utcnow
+
+    older = _make_connector(db, dj_user, display_name="older")
+    newer = _make_connector(db, dj_user, display_name="newer")
+
+    older.last_used_at = None
+    from datetime import timedelta
+
+    newer.last_used_at = utcnow() - timedelta(seconds=10)
+    db.commit()
+
+    fake_response = ChatResponse(
+        text="ok",
+        tool_calls=[],
+        stop_reason="end_turn",
+        usage=None,
+    )
+
+    with patch.object(
+        __import__(
+            "app.services.llm.adapters.openai_apikey",
+            fromlist=["OpenAIApiKeyAdapter"],
+        ).OpenAIApiKeyAdapter,
+        "chat",
+        new=AsyncMock(return_value=fake_response),
+    ) as chat_mock:
+        await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
+
+    chat_mock.assert_awaited_once()
+    # Make sure the newer one was chosen
+    db.refresh(newer)
+    db.refresh(older)
+    assert newer.last_used_at is not None
+    # older.last_used_at was never set so should still be None
+    assert older.last_used_at is None

--- a/server/tests/test_llm_hooks.py
+++ b/server/tests/test_llm_hooks.py
@@ -72,6 +72,8 @@ class TestGenerateLLMSuggestions:
             tracks=None,
             rejected_tracks=None,
             currently_playing=None,
+            db=None,
+            actor=None,
         )
 
     @pytest.mark.asyncio
@@ -97,6 +99,8 @@ class TestGenerateLLMSuggestions:
             tracks=tracks,
             rejected_tracks=None,
             currently_playing=None,
+            db=None,
+            actor=None,
         )
 
 

--- a/server/tests/test_llm_recommendation_via_gateway.py
+++ b/server/tests/test_llm_recommendation_via_gateway.py
@@ -1,0 +1,128 @@
+"""Regression: recommendation engine still produces identical output when
+routed through the LLM gateway.
+
+The legacy path (no ``db``/``actor``) and the gateway path receive equivalent
+mock responses; both must yield identical ``LLMSuggestionResult`` queries.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.llm.base import ChatResponse, TokenUsage, ToolCall
+from app.services.recommendation.llm_client import call_llm
+from app.services.recommendation.scorer import EventProfile
+
+
+@pytest.fixture
+def event_profile() -> EventProfile:
+    return EventProfile(
+        avg_bpm=128.0,
+        bpm_range=(120.0, 134.0),
+        dominant_keys=["8A", "9A"],
+        dominant_genres=["Tech House"],
+        track_count=10,
+    )
+
+
+GATEWAY_RESPONSE = ChatResponse(
+    text="",
+    tool_calls=[
+        ToolCall(
+            id="tu_1",
+            name="search_queries",
+            input={
+                "queries": [
+                    {
+                        "search_query": "deadmau5 progressive house",
+                        "target_bpm": 128.0,
+                        "target_key": "8A",
+                        "target_genre": "Progressive House",
+                        "reasoning": "Anchor track style",
+                    },
+                    {
+                        "search_query": "eric prydz",
+                        "reasoning": "Similar artist",
+                    },
+                ]
+            },
+        )
+    ],
+    stop_reason="tool_use",
+    usage=TokenUsage(prompt=50, completion=20),
+)
+
+
+def _legacy_anthropic_response():
+    """Return a mock that mimics the Anthropic SDK response shape."""
+    from types import SimpleNamespace
+
+    tool_block = SimpleNamespace(
+        type="tool_use",
+        name="search_queries",
+        input=GATEWAY_RESPONSE.tool_calls[0].input,
+    )
+    return SimpleNamespace(content=[tool_block])
+
+
+@pytest.mark.asyncio
+async def test_gateway_path_matches_legacy_path_output(db, test_user, event_profile):
+    """The same model output, routed via gateway vs legacy env-var, yields the
+    same canonical ``LLMSuggestionResult``.
+    """
+    # Insert a connector for the actor so the gateway has something to resolve.
+    from app.models.llm_connector import LlmConnector
+
+    connector = LlmConnector(
+        user_id=test_user.id,
+        connector_type="anthropic_apikey",
+        display_name="Test",
+        status="active",
+        credentials=json.dumps({"api_key": "sk-ant-fakefakefakefakefakefakefakefakefakefake"}),
+        model_hint="claude-haiku-4-5-20251001",
+    )
+    db.add(connector)
+    db.commit()
+    db.refresh(connector)
+
+    # Gateway path: mock the adapter's chat method directly.
+    with patch(
+        "app.services.llm.adapters.anthropic_apikey.AnthropicApiKeyAdapter.chat",
+        new=AsyncMock(return_value=GATEWAY_RESPONSE),
+    ):
+        gateway_result = await call_llm(
+            event_profile,
+            "deeper progressive house",
+            db=db,
+            actor=test_user,
+        )
+
+    # Legacy path: mock AsyncAnthropic at module level.
+    legacy_mock = _legacy_anthropic_response()
+    with (
+        patch("app.services.recommendation.llm_client.AsyncAnthropic") as client_cls,
+        patch("app.services.recommendation.llm_client.get_settings") as settings_mock,
+    ):
+        settings_mock.return_value.anthropic_api_key = "sk-ant-fake"
+        settings_mock.return_value.anthropic_model = "claude-haiku-4-5-20251001"
+        settings_mock.return_value.anthropic_max_tokens = 1024
+        settings_mock.return_value.anthropic_timeout_seconds = 15
+        client_inst = client_cls.return_value
+        client_inst.messages.create = AsyncMock(return_value=legacy_mock)
+
+        legacy_result = await call_llm(
+            event_profile,
+            "deeper progressive house",
+        )
+
+    # Identical structured output across both paths.
+    assert len(gateway_result.queries) == len(legacy_result.queries) == 2
+    for gq, lq in zip(gateway_result.queries, legacy_result.queries):
+        assert gq.search_query == lq.search_query
+        assert gq.target_bpm == lq.target_bpm
+        assert gq.target_key == lq.target_key
+        assert gq.target_genre == lq.target_genre
+        assert gq.reasoning == lq.reasoning

--- a/server/tests/test_llm_tool_translation.py
+++ b/server/tests/test_llm_tool_translation.py
@@ -182,3 +182,25 @@ class TestParseAnthropicResponse:
         msg = {"stop_reason": "max_tokens", "content": []}
         resp = parse_anthropic_response(msg)
         assert resp.stop_reason == "max_tokens"
+
+    def test_anthropic_tool_use_missing_id_name_raises(self):
+        """Regression: malformed tool_use without id/name must fail fast.
+
+        Pin per PR #348: previously the parser cast missing values to the
+        string "None", producing invalid canonical ToolCall objects.
+        """
+        msg = {
+            "stop_reason": "tool_use",
+            "content": [{"type": "tool_use", "input": {"ids": ["x"]}}],
+        }
+        with pytest.raises(ToolTranslationError):
+            parse_anthropic_response(msg)
+
+    def test_anthropic_tool_use_empty_name_raises(self):
+        """Empty name with no id to fall back to must raise, not emit 'None'."""
+        msg = {
+            "stop_reason": "tool_use",
+            "content": [{"type": "tool_use", "name": "", "input": {}}],
+        }
+        with pytest.raises(ToolTranslationError):
+            parse_anthropic_response(msg)

--- a/server/tests/test_llm_tool_translation.py
+++ b/server/tests/test_llm_tool_translation.py
@@ -1,0 +1,184 @@
+"""Tests for canonical ToolSpec <-> per-provider translation + response parsing."""
+
+import pytest
+
+from app.services.llm.base import ToolSpec
+from app.services.llm.exceptions import ToolTranslationError
+from app.services.llm.tool_translation import (
+    parse_anthropic_response,
+    parse_openai_response,
+    to_anthropic_tools,
+    to_openai_tools,
+)
+
+TOOL = ToolSpec(
+    name="rank_recommendations",
+    description="Rank the candidates",
+    input_schema={
+        "type": "object",
+        "properties": {"ids": {"type": "array", "items": {"type": "string"}}},
+        "required": ["ids"],
+    },
+)
+
+
+class TestOpenAITools:
+    def test_returns_none_for_no_tools(self):
+        tools, choice = to_openai_tools(None, None)
+        assert tools is None
+        assert choice is None
+
+    def test_translates_tools(self):
+        tools, choice = to_openai_tools([TOOL], None)
+        assert tools is not None
+        assert tools[0]["type"] == "function"
+        assert tools[0]["function"]["name"] == "rank_recommendations"
+        assert tools[0]["function"]["parameters"] == TOOL.input_schema
+        assert choice is None
+
+    def test_force_tool(self):
+        tools, choice = to_openai_tools([TOOL], "rank_recommendations")
+        assert choice == {
+            "type": "function",
+            "function": {"name": "rank_recommendations"},
+        }
+
+    def test_force_tool_not_in_list(self):
+        with pytest.raises(ToolTranslationError):
+            to_openai_tools([TOOL], "does_not_exist")
+
+
+class TestAnthropicTools:
+    def test_returns_none_for_no_tools(self):
+        tools, choice = to_anthropic_tools(None, None)
+        assert tools is None
+        assert choice is None
+
+    def test_translates_tools(self):
+        tools, choice = to_anthropic_tools([TOOL], None)
+        assert tools is not None
+        assert tools[0]["name"] == "rank_recommendations"
+        assert tools[0]["input_schema"] == TOOL.input_schema
+        assert choice is None
+
+    def test_force_tool(self):
+        tools, choice = to_anthropic_tools([TOOL], "rank_recommendations")
+        assert choice == {"type": "tool", "name": "rank_recommendations"}
+
+
+class TestParseOpenAIResponse:
+    def test_text_response(self):
+        body = {
+            "model": "gpt-5-mini",
+            "choices": [
+                {"finish_reason": "stop", "message": {"role": "assistant", "content": "hi"}}
+            ],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 1},
+        }
+        resp = parse_openai_response(body)
+        assert resp.text == "hi"
+        assert resp.stop_reason == "end_turn"
+        assert resp.tool_calls == []
+        assert resp.usage.prompt == 3
+        assert resp.usage.completion == 1
+        assert resp.model == "gpt-5-mini"
+
+    def test_tool_call(self):
+        body = {
+            "model": "gpt-5-mini",
+            "choices": [
+                {
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "rank_recommendations",
+                                    "arguments": '{"ids": ["a", "b"]}',
+                                },
+                            }
+                        ],
+                    },
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        resp = parse_openai_response(body)
+        assert resp.stop_reason == "tool_use"
+        assert len(resp.tool_calls) == 1
+        assert resp.tool_calls[0].name == "rank_recommendations"
+        assert resp.tool_calls[0].input == {"ids": ["a", "b"]}
+        assert resp.tool_calls[0].id == "call_1"
+
+    def test_malformed_response(self):
+        with pytest.raises(ToolTranslationError):
+            parse_openai_response({"foo": "bar"})
+
+    def test_tool_arguments_invalid_json(self):
+        body = {
+            "choices": [
+                {
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "function": {
+                                    "name": "rank",
+                                    "arguments": "{not json",
+                                },
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+        with pytest.raises(ToolTranslationError):
+            parse_openai_response(body)
+
+    def test_finish_reason_length(self):
+        body = {"choices": [{"finish_reason": "length", "message": {"content": "..."}}]}
+        resp = parse_openai_response(body)
+        assert resp.stop_reason == "max_tokens"
+
+
+class TestParseAnthropicResponse:
+    def test_text_response(self):
+        # Use dict shape — adapters accept either SDK objects or dicts.
+        msg = {
+            "model": "claude-haiku",
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "hello"}],
+            "usage": {"input_tokens": 2, "output_tokens": 1},
+        }
+        resp = parse_anthropic_response(msg)
+        assert resp.text == "hello"
+        assert resp.stop_reason == "end_turn"
+        assert resp.usage.prompt == 2
+        assert resp.usage.completion == 1
+
+    def test_tool_use(self):
+        msg = {
+            "stop_reason": "tool_use",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tu_1",
+                    "name": "rank",
+                    "input": {"ids": ["x"]},
+                }
+            ],
+        }
+        resp = parse_anthropic_response(msg)
+        assert resp.stop_reason == "tool_use"
+        assert len(resp.tool_calls) == 1
+        assert resp.tool_calls[0].input == {"ids": ["x"]}
+
+    def test_max_tokens(self):
+        msg = {"stop_reason": "max_tokens", "content": []}
+        resp = parse_anthropic_response(msg)
+        assert resp.stop_reason == "max_tokens"

--- a/server/tests/test_llm_url_validator.py
+++ b/server/tests/test_llm_url_validator.py
@@ -81,3 +81,37 @@ class TestValidateCompatibleBaseUrl:
         assert validate_compatible_base_url("http://127.0.0.1:11434/v1") == (
             "http://127.0.0.1:11434/v1"
         )
+
+    # ---- IPv6 (PR #348) ----
+    def test_http_ipv6_loopback_ok(self):
+        assert validate_compatible_base_url("http://[::1]:8080") == "http://[::1]:8080"
+
+    def test_http_ipv6_unique_local_ok(self):
+        # fc00::/7 - IPv6 unique local addresses
+        assert validate_compatible_base_url("http://[fc00::1]/v1") == "http://[fc00::1]/v1"
+
+    def test_http_ipv6_link_local_ok(self):
+        # fe80::/10 - IPv6 link-local addresses
+        assert validate_compatible_base_url("http://[fe80::1]") == "http://[fe80::1]"
+
+    def test_http_ipv6_public_rejected(self):
+        # 2001:4860:4860::8888 is a public IPv6 address (Google DNS)
+        with pytest.raises(InvalidBaseUrlError):
+            validate_compatible_base_url("http://[2001:4860:4860::8888]")
+
+    # ---- Edge cases (PR #348) ----
+    def test_whitespace_only_rejected(self):
+        with pytest.raises(InvalidBaseUrlError):
+            validate_compatible_base_url("   ")
+
+    def test_case_normalization_scheme(self):
+        # Scheme is lower-cased; netloc and path are preserved as-given.
+        result = validate_compatible_base_url("HTTPS://EXAMPLE.COM/V1")
+        assert result.startswith("https://")
+        assert result.endswith("/V1")
+
+    def test_multi_segment_path_preserved(self):
+        assert (
+            validate_compatible_base_url("https://example.com/v1/chat/completions")
+            == "https://example.com/v1/chat/completions"
+        )

--- a/server/tests/test_llm_url_validator.py
+++ b/server/tests/test_llm_url_validator.py
@@ -1,0 +1,83 @@
+"""Tests for the OpenAI-compatible base URL validator."""
+
+import pytest
+
+from app.services.llm.url_validator import (
+    InvalidBaseUrlError,
+    validate_compatible_base_url,
+)
+
+
+class TestValidateCompatibleBaseUrl:
+    def test_https_any_host_accepted(self):
+        assert validate_compatible_base_url("https://api.openai.com/v1") == (
+            "https://api.openai.com/v1"
+        )
+
+    def test_https_strips_trailing_slash(self):
+        assert validate_compatible_base_url("https://example.com/v1/") == ("https://example.com/v1")
+
+    def test_http_loopback_localhost_ok(self):
+        assert validate_compatible_base_url("http://localhost:8080") == "http://localhost:8080"
+
+    def test_http_loopback_ip_ok(self):
+        assert validate_compatible_base_url("http://127.0.0.1:8000") == ("http://127.0.0.1:8000")
+
+    def test_http_rfc1918_192_ok(self):
+        assert validate_compatible_base_url("http://192.168.1.100") == ("http://192.168.1.100")
+
+    def test_http_rfc1918_10_ok(self):
+        assert validate_compatible_base_url("http://10.0.0.5/v1") == ("http://10.0.0.5/v1")
+
+    def test_http_rfc1918_172_ok(self):
+        assert validate_compatible_base_url("http://172.20.0.1") == "http://172.20.0.1"
+
+    def test_http_public_rejected(self):
+        with pytest.raises(InvalidBaseUrlError):
+            validate_compatible_base_url("http://example.com/v1")
+
+    def test_http_with_8_8_8_8_rejected(self):
+        # public IP — must require HTTPS
+        with pytest.raises(InvalidBaseUrlError):
+            validate_compatible_base_url("http://8.8.8.8")
+
+    def test_embedded_credentials_rejected(self):
+        with pytest.raises(InvalidBaseUrlError):
+            validate_compatible_base_url("https://user:pass@example.com/v1")
+
+    def test_query_string_rejected(self):
+        with pytest.raises(InvalidBaseUrlError):
+            validate_compatible_base_url("https://example.com/v1?api_key=secret")
+
+    def test_fragment_rejected(self):
+        with pytest.raises(InvalidBaseUrlError):
+            validate_compatible_base_url("https://example.com/v1#fragment")
+
+    def test_empty_rejected(self):
+        with pytest.raises(InvalidBaseUrlError):
+            validate_compatible_base_url("")
+
+    def test_missing_scheme_rejected(self):
+        with pytest.raises(InvalidBaseUrlError):
+            validate_compatible_base_url("example.com/v1")
+
+    def test_invalid_scheme_rejected(self):
+        with pytest.raises(InvalidBaseUrlError):
+            validate_compatible_base_url("ftp://example.com")
+
+    def test_missing_host_rejected(self):
+        with pytest.raises(InvalidBaseUrlError):
+            validate_compatible_base_url("https://")
+
+    def test_https_root_no_path_ok(self):
+        # Some servers accept the host root with no path
+        assert validate_compatible_base_url("https://example.com") == ("https://example.com")
+
+    def test_strips_trailing_slash_only(self):
+        # Empty path becomes "" (no slash) per RFC
+        assert validate_compatible_base_url("https://example.com/") == ("https://example.com")
+
+    def test_preserves_port(self):
+        assert validate_compatible_base_url("http://127.0.0.1:11434/v1") == (
+            "http://127.0.0.1:11434/v1"
+        )


### PR DESCRIPTION
Closes #329.

Spec: [docs/superpowers/specs/2026-05-24-admin-ai-oauth-design.md](https://github.com/wrzonance/WrzDJ/blob/main/docs/superpowers/specs/2026-05-24-admin-ai-oauth-design.md)

## Summary

Implements the MVP of the AI Engine back-end redesign — every LLM call now flows through a provider-agnostic gateway that resolves a per-DJ connector (or admin-set org default) and dispatches to one of three pluggable adapters: OpenAI API key, Anthropic API key, or a custom OpenAI-compatible endpoint URL (Hermes Agent / Ollama / vLLM / LMStudio). Credentials are encrypted at rest, validated, and audited end-to-end. The recommendation engine is migrated to the gateway with zero observable behaviour change for existing Anthropic users.

## Components shipped

### Gateway core (`server/app/services/llm/`)
- `gateway.py` — `Gateway.dispatch(db, actor, request, *, purpose)`; resolves connector (per-DJ MRU active → org default → `NoLlmConfigured`), times the call, writes telemetry + audit rows on every code path
- `base.py` — canonical `ChatRequest` / `ChatResponse` / `ToolSpec` / `LlmAdapter` ABC
- `registry.py` — connector_type → adapter class lookup; adapters auto-register on import
- `tool_translation.py` — JSON-Schema `ToolSpec` ↔ per-provider tool/function shape + response parsers
- `url_validator.py` — strict validation for custom base URLs (HTTPS any host; HTTP loopback + RFC1918 only; no embedded creds; no query/fragment)
- `connector_storage.py` — CRUD + input validation + audit/call logging helpers
- `exceptions.py` — typed errors: `AuthInvalid`, `RateLimited`, `QuotaExceeded`, `ProviderUnavailable`, `ToolTranslationError`, `NoLlmConfigured`

### Adapters (`server/app/services/llm/adapters/`)
- `openai_apikey.py` — OpenAI Platform via httpx (shared chat-completions client in `_httpx_openai.py`)
- `openai_compatible.py` — Custom URL + optional bearer (same httpx code path)
- `anthropic_apikey.py` — Anthropic SDK with full exception → typed-error mapping

### Data + migration
- `server/app/models/llm_connector.py` — `LlmConnector` (encrypted credentials via `EncryptedText`), `LlmCallLog` (counts-only — never prompt/completion content), `LlmAuditEvent`
- `server/alembic/versions/046_admin_ai_oauth.py` — creates the 3 tables + 3 `system_settings` columns (`llm_apikey_connectors_enabled`, `llm_compatible_connector_enabled`, `llm_default_connector_id`), then runs a best-effort data migration that converts an `ANTHROPIC_API_KEY` env var into an `anthropic_apikey` connector owned by the first admin user and points the system default at it

### API
- `POST/GET/PATCH/PUT/DELETE /api/llm/connectors[/{id}[/credentials|test]]` — per-DJ self-service, scoped to `user_id = current_user.id`, 404 (not 403) for other-DJ rows
- `GET/PATCH /api/admin/llm/policy` — policy toggles + org default
- `GET /api/admin/llm/connectors` — all DJs' connectors (with `dj_username`)
- `POST /api/admin/llm/connectors/{id}/revoke` — force-revoke + clear system default if it was that connector
- `GET /api/admin/llm/usage?days=30` — per-connector roll-up

### Frontend
- `dashboard/app/(dj)/settings/ai/page.tsx` — DJ self-service: list / add / test / delete, filters connector types by current admin policy, includes Hermes Agent onboarding for ChatGPT-subscription users (per spec §4.7)
- `dashboard/app/admin/ai/page.tsx` — extended with: connector policy card, org default dropdown, per-DJ connectors table with force-revoke, 30-day usage table
- `dashboard/lib/api.ts` — `listLlmConnectors`, `createLlmConnector`, `updateLlmConnector`, `rotateLlmConnectorCredentials`, `testLlmConnector`, `deleteLlmConnector`, `getAdminLlmPolicy`, `updateAdminLlmPolicy`, `listAllLlmConnectors`, `revokeAdminLlmConnector`, `getAdminLlmUsage`

### Recommendation migration
- `services/recommendation/llm_client.py` — when called with `db`/`actor`, routes via `Gateway.dispatch(..., purpose="recommendation")` using the canonical `ToolSpec` shape (forced `tool_use`, schema preserved). Legacy direct-Anthropic path retained as a fallback so old unit tests that patch `AsyncAnthropic` continue to work.
- `services/recommendation/service.py` — `generate_recommendations_from_llm` now passes `db=db, actor=user`
- `services/recommendation/llm_hooks.py` — `is_llm_available(db)` returns truthy when any active connector exists OR a system default is set OR (legacy fallback) `ANTHROPIC_API_KEY` env var is configured

### Docs / env
- `.env.example` — adds an LLM section explaining the env-var deprecation
- `CLAUDE.md` — new "LLM Gateway" subsection under Architecture Patterns

## Security posture

- All credentials encrypted at rest with the existing `EncryptedText` TypeDecorator (Fernet)
- `TOKEN_ENCRYPTION_KEY` is already a production-required env var; no new secret material introduced
- Custom-URL connectors validated server-side (scheme/host/ports/no-creds/no-query)
- All error responses sanitised — upstream error bodies, stack traces, and bearer tokens never reach the client; typed enums + a frontend whitelist
- Multi-tenant isolation: all per-DJ endpoints scope by `current_user.id`; admin endpoints bypass scoping but are gated by `get_current_admin`
- Audit events written for every credential lifecycle event (create / rotate / delete / admin-revoke / auth-invalid-observed / health-check / policy-changed)
- Rate-limited per spec §6.8: create 5/min, test 10/min, rotate 5/min
- No new dependencies (no `openai` SDK, no `litellm` — banned per project memory). `httpx` and `anthropic` were already in tree.

## Test results

| Suite | Status |
| --- | --- |
| `ruff check` | pass |
| `ruff format --check` | pass |
| `bandit -r app -c pyproject.toml` | clean |
| `alembic upgrade head && alembic check` | pass |
| Backend pytest (2106 tests, coverage 86.95%) | pass (above 85% threshold) |
| Frontend ESLint | clean |
| Frontend `tsc --noEmit` | clean |
| Frontend vitest (944 tests) | pass |

New backend tests added (104):
- `tests/test_llm_url_validator.py` (19)
- `tests/test_llm_tool_translation.py` (15)
- `tests/test_llm_gateway.py` (8)
- `tests/test_llm_adapters.py` (14)
- `tests/test_llm_api.py` (22)
- `tests/test_llm_recommendation_via_gateway.py` (1)
- updates to `tests/test_llm_hooks.py` / `tests/test_llm_client.py`

New frontend tests added:
- `dashboard/app/(dj)/settings/ai/__tests__/page.test.tsx` (4)
- `dashboard/app/admin/ai/__tests__/page.test.tsx` (+2 — connector policy/usage cards + force-revoke flow)
- `dashboard/lib/__tests__/api.test.ts` (+4 — LLM connector client methods)

## Design decisions (autonomous, please flag if any look wrong)

1. **System-context audit `actor_user_id` fallback** — spec §4.3 doesn't say which user to record as the actor when `Gateway.dispatch` is called with `actor=None`. I record the connector's `user_id` so the audit trail always points at a real user. Alternative: a sentinel system user.
2. **`fetchPolicySoft()` for DJ page** — DJs hit the admin policy endpoint to know which connector types to show; on 403/network failure the UI falls back to "all types allowed" so the form still renders rather than blocking. Same component handles both DJ and admin contexts.
3. **Legacy `_parse_tool_response` shim** — to keep the existing unit tests (which mock the Anthropic SDK directly) passing without modification, the parser accepts both canonical `ChatResponse` (via `isinstance`) and the legacy SDK shape. `isinstance` is used instead of `hasattr` because `MagicMock` returns truthy for every attribute.
4. **`_check_connector_type_allowed` in `api/llm.py`** — admin policy is enforced at create time only. Existing connectors that became disallowed by a policy change keep working (so a DJ doesn't lose mid-event access). They can still be deleted/tested but not created.
5. **`api/admin_llm.py` revoke clears `llm_default_connector_id`** — spec doesn't explicitly require this, but leaving a disabled connector as the org default would cause `NoLlmConfigured` for every system call. I null it out and let the admin re-pick.
6. **`update_system_settings` `_UNSET` sentinel** — needed to distinguish "don't touch this FK" from "set this FK to NULL" because `None` is a valid value for `llm_default_connector_id`.
7. **`anthropic-apikey` adapter default model `claude-opus-4-7`** — spec §5.1 says "default `claude-opus-4-7`"; I implemented that even though the existing recommendation env var defaults to `claude-haiku-4-5-20251001`. The connector's `model_hint` always wins, so default only matters when neither is set.
8. **`scripts/export_openapi.py` regen-fix** — adding `app.openapi_schema = None` before `app.openapi()` so newly-added routes show up when the script is invoked from a long-running shell session. Unrelated to the spec but needed to regenerate the TypeScript types.
9. **Deferred items NOT filed in this PR** — Spec §10.2 says "the implementer agent must, before opening the MVP PR, create a milestone + Kanban project and file 17 follow-up issues." Per the parent orchestrator's `--yolo` direction, this PR ships just the MVP code; the issue-filing step is left for a follow-up so this PR doesn't gold-plate. If you'd like me to file them, drop a comment.

## Test plan

- [ ] Run all backend + frontend CI suites — see Test results above
- [ ] `alembic upgrade head` runs cleanly on a fresh DB
- [ ] `ANTHROPIC_API_KEY` env-var data migration: set the env var, run the migration, confirm a connector named "Org Default (migrated from env var)" is created and selected as `llm_default_connector_id`
- [ ] As a DJ, hit `/settings/ai`, add an OpenAI connector with a sk-proj key, click "Test", confirm OK
- [ ] As a DJ, add an `openai_compatible` connector pointing at `http://127.0.0.1:11434/v1` (Ollama), click "Test", confirm OK
- [ ] As a DJ, try `http://example.com/v1` — should be rejected with a 400
- [ ] As an admin, hit `/admin/ai`, disable "API-key connectors", confirm a DJ create POST is rejected with 403
- [ ] As an admin, force-revoke a connector that is currently the org default — confirm the default clears
- [ ] AI Assist recommendation flow against an event whose owner has a connector — confirms `Gateway.dispatch` path runs, `llm_call_log` row written, `last_used_at` bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Managed LLM gateway with per-user connectors for OpenAI, Anthropic, and OpenAI-compatible backends
  * Settings → AI providers UI for adding, testing, deleting, and rotating connectors
  * Admin UI for connector policy, org-default connector, per-user connectors, force-revoke, and usage analytics

* **Improvements**
  * Recommendation flow now dispatches via the gateway (uses user/org connector)
  * Usage tracking, audit logging, and sanitized error handling for LLM calls
  * Env example and docs updated; legacy Anthropic env-var marked deprecated

* **Tests**
  * Expanded unit/integration tests covering adapters, gateway, APIs, validation, and recommendation parity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->