### PR TITLE
feat(ai): add Azure OpenAI provider adapter

### DIFF
--- a/dashboard/app/(dj)/settings/ai/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/settings/ai/__tests__/page.test.tsx
@@ -84,6 +84,80 @@ describe('SettingsAIPage', () => {
     expect(optionValues).toEqual(['openai_compatible']);
   });
 
+  it('offers Azure OpenAI and reveals its config fields', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
+    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: true,
+      llm_compatible_connector_enabled: true,
+      llm_default_connector_id: null,
+    });
+
+    render(<SettingsAIPage />);
+
+    await waitFor(() => expect(screen.getByText('+ Add provider')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('+ Add provider'));
+
+    const select = screen.getByLabelText('Provider') as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).toContain('azure_openai');
+
+    // Switching to Azure surfaces the resource/deployment/api-version inputs.
+    fireEvent.change(select, { target: { value: 'azure_openai' } });
+    expect(screen.getByLabelText('API key')).toBeInTheDocument();
+    expect(screen.getByLabelText('Resource name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Deployment name')).toBeInTheDocument();
+    expect(screen.getByLabelText('API version')).toBeInTheDocument();
+  });
+
+  it('sends Azure config fields on create', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
+    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: true,
+      llm_compatible_connector_enabled: true,
+      llm_default_connector_id: null,
+    });
+    const createSpy = vi
+      .spyOn(api, 'createLlmConnector')
+      .mockResolvedValue(makeConnector({ connector_type: 'azure_openai' }));
+
+    render(<SettingsAIPage />);
+
+    await waitFor(() => expect(screen.getByText('+ Add provider')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('+ Add provider'));
+
+    fireEvent.change(screen.getByLabelText('Provider'), {
+      target: { value: 'azure_openai' },
+    });
+    fireEvent.change(screen.getByLabelText('Display name'), {
+      target: { value: 'Venue Azure' },
+    });
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'azure-secret' },
+    });
+    fireEvent.change(screen.getByLabelText('Resource name'), {
+      target: { value: 'venue-co' },
+    });
+    fireEvent.change(screen.getByLabelText('Deployment name'), {
+      target: { value: 'gpt4o-prod' },
+    });
+    fireEvent.change(screen.getByLabelText('API version'), {
+      target: { value: '2024-06-01' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(createSpy).toHaveBeenCalled());
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connector_type: 'azure_openai',
+        api_key: 'azure-secret',
+        azure_resource_name: 'venue-co',
+        azure_deployment_name: 'gpt4o-prod',
+        azure_api_version: '2024-06-01',
+      }),
+    );
+  });
+
   it('runs Test and surfaces the result', async () => {
     const row = makeConnector();
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([row]);

--- a/dashboard/app/(dj)/settings/ai/page.tsx
+++ b/dashboard/app/(dj)/settings/ai/page.tsx
@@ -17,6 +17,7 @@ const CONNECTOR_TYPE_LABELS: Record<LlmConnectorType, string> = {
   openai_apikey: 'OpenAI API key',
   anthropic_apikey: 'Anthropic API key',
   openai_compatible: 'Custom OpenAI-compatible endpoint',
+  azure_openai: 'Azure OpenAI',
 };
 
 const STATUS_LABELS: Record<string, { text: string; color: string }> = {
@@ -33,6 +34,9 @@ interface FormState {
   base_url: string;
   bearer: string;
   model_hint: string;
+  azure_resource_name: string;
+  azure_deployment_name: string;
+  azure_api_version: string;
 }
 
 const EMPTY_FORM: FormState = {
@@ -43,6 +47,9 @@ const EMPTY_FORM: FormState = {
   base_url: '',
   bearer: '',
   model_hint: '',
+  azure_resource_name: '',
+  azure_deployment_name: '',
+  azure_api_version: '',
 };
 
 export default function SettingsAIPage() {
@@ -92,7 +99,7 @@ export default function SettingsAIPage() {
     if (!policy) return Object.keys(CONNECTOR_TYPE_LABELS) as LlmConnectorType[];
     const out: LlmConnectorType[] = [];
     if (policy.llm_apikey_connectors_enabled) {
-      out.push('openai_apikey', 'anthropic_apikey');
+      out.push('openai_apikey', 'anthropic_apikey', 'azure_openai');
     }
     if (policy.llm_compatible_connector_enabled) out.push('openai_compatible');
     return out;
@@ -121,6 +128,7 @@ export default function SettingsAIPage() {
     setSubmitting(true);
     setSubmitMessage('');
     setSubmitError('');
+    const isAzure = form.connector_type === 'azure_openai';
     const payload: LlmConnectorCreate = {
       connector_type: form.connector_type,
       display_name: form.display_name,
@@ -131,6 +139,9 @@ export default function SettingsAIPage() {
         form.connector_type === 'openai_compatible' ? form.base_url : null,
       bearer:
         form.connector_type === 'openai_compatible' ? form.bearer || null : null,
+      azure_resource_name: isAzure ? form.azure_resource_name : null,
+      azure_deployment_name: isAzure ? form.azure_deployment_name : null,
+      azure_api_version: isAzure ? form.azure_api_version : null,
     };
     try {
       const created = await api.createLlmConnector(payload);
@@ -282,22 +293,73 @@ export default function SettingsAIPage() {
             </div>
 
             {form.connector_type !== 'openai_compatible' ? (
-              <div className="form-group">
-                <label htmlFor="api_key">API key</label>
-                <input
-                  id="api_key"
-                  className="input"
-                  type="password"
-                  value={form.api_key}
-                  onChange={(e) => setForm({ ...form, api_key: e.target.value })}
-                  placeholder={
-                    form.connector_type === 'anthropic_apikey'
-                      ? 'sk-ant-…'
-                      : 'sk-proj-… / sk-…'
-                  }
-                  required
-                />
-              </div>
+              <>
+                <div className="form-group">
+                  <label htmlFor="api_key">API key</label>
+                  <input
+                    id="api_key"
+                    className="input"
+                    type="password"
+                    value={form.api_key}
+                    onChange={(e) => setForm({ ...form, api_key: e.target.value })}
+                    placeholder={
+                      form.connector_type === 'anthropic_apikey'
+                        ? 'sk-ant-…'
+                        : form.connector_type === 'azure_openai'
+                        ? 'Azure OpenAI key'
+                        : 'sk-proj-… / sk-…'
+                    }
+                    required
+                  />
+                </div>
+                {form.connector_type === 'azure_openai' && (
+                  <>
+                    <div className="form-group">
+                      <label htmlFor="azure_resource_name">Resource name</label>
+                      <input
+                        id="azure_resource_name"
+                        className="input"
+                        value={form.azure_resource_name}
+                        onChange={(e) =>
+                          setForm({ ...form, azure_resource_name: e.target.value })
+                        }
+                        placeholder="e.g. my-company"
+                        required
+                      />
+                      <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', margin: '0.5rem 0 0' }}>
+                        The resource subdomain in{' '}
+                        <code>https://&lt;resource&gt;.openai.azure.com</code>.
+                      </p>
+                    </div>
+                    <div className="form-group">
+                      <label htmlFor="azure_deployment_name">Deployment name</label>
+                      <input
+                        id="azure_deployment_name"
+                        className="input"
+                        value={form.azure_deployment_name}
+                        onChange={(e) =>
+                          setForm({ ...form, azure_deployment_name: e.target.value })
+                        }
+                        placeholder="e.g. gpt-4o-prod"
+                        required
+                      />
+                    </div>
+                    <div className="form-group">
+                      <label htmlFor="azure_api_version">API version</label>
+                      <input
+                        id="azure_api_version"
+                        className="input"
+                        value={form.azure_api_version}
+                        onChange={(e) =>
+                          setForm({ ...form, azure_api_version: e.target.value })
+                        }
+                        placeholder="e.g. 2024-06-01"
+                        required
+                      />
+                    </div>
+                  </>
+                )}
+              </>
             ) : (
               <>
                 <div className="form-group">

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -2352,7 +2352,7 @@ export interface components {
              * Connector Type
              * @enum {string}
              */
-            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible";
+            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible" | "azure_openai";
             /**
              * Created At
              * Format: date-time
@@ -2940,6 +2940,8 @@ export interface components {
          *       ``base_url`` and ``bearer`` are ignored.
          *     - ``openai_compatible``: ``base_url`` required; ``bearer`` optional;
          *       ``api_key`` is ignored.
+         *     - ``azure_openai``: ``api_key``, ``azure_resource_name``,
+         *       ``azure_deployment_name`` and ``azure_api_version`` all required.
          *
          *     The combination is enforced by :meth:`_require_credentials_for_type`.
          *     See ``build_create_payload`` in ``services/llm/connector_storage.py``
@@ -2948,6 +2950,12 @@ export interface components {
         ConnectorCreate: {
             /** Api Key */
             api_key?: string | null;
+            /** Azure Api Version */
+            azure_api_version?: string | null;
+            /** Azure Deployment Name */
+            azure_deployment_name?: string | null;
+            /** Azure Resource Name */
+            azure_resource_name?: string | null;
             /** Base Url */
             base_url?: string | null;
             /** Bearer */
@@ -2956,7 +2964,7 @@ export interface components {
              * Connector Type
              * @enum {string}
              */
-            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible";
+            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible" | "azure_openai";
             /** Display Name */
             display_name: string;
             /** Model Hint */
@@ -2972,6 +2980,12 @@ export interface components {
         ConnectorCredentialsRotate: {
             /** Api Key */
             api_key?: string | null;
+            /** Azure Api Version */
+            azure_api_version?: string | null;
+            /** Azure Deployment Name */
+            azure_deployment_name?: string | null;
+            /** Azure Resource Name */
+            azure_resource_name?: string | null;
             /** Base Url */
             base_url?: string | null;
             /** Bearer */
@@ -2988,7 +3002,7 @@ export interface components {
              * Connector Type
              * @enum {string}
              */
-            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible";
+            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible" | "azure_openai";
             /**
              * Created At
              * Format: date-time
@@ -4174,7 +4188,7 @@ export interface components {
              * Connector Type
              * @enum {string}
              */
-            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible";
+            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible" | "azure_openai";
             /** Display Name */
             display_name: string;
             /** Dj Username */

--- a/server/app/api/llm.py
+++ b/server/app/api/llm.py
@@ -127,6 +127,9 @@ def create_connector_endpoint(
             base_url=payload.base_url,
             bearer=payload.bearer,
             model_hint=payload.model_hint,
+            azure_resource_name=payload.azure_resource_name,
+            azure_deployment_name=payload.azure_deployment_name,
+            azure_api_version=payload.azure_api_version,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -207,6 +210,9 @@ def rotate_connector_credentials(
             api_key=payload.api_key,
             base_url=payload.base_url,
             bearer=payload.bearer,
+            azure_resource_name=payload.azure_resource_name,
+            azure_deployment_name=payload.azure_deployment_name,
+            azure_api_version=payload.azure_api_version,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/server/app/models/llm_connector.py
+++ b/server/app/models/llm_connector.py
@@ -28,12 +28,14 @@ from app.models.base import Base
 CONNECTOR_TYPE_OPENAI_APIKEY = "openai_apikey"
 CONNECTOR_TYPE_ANTHROPIC_APIKEY = "anthropic_apikey"
 CONNECTOR_TYPE_OPENAI_COMPATIBLE = "openai_compatible"
+CONNECTOR_TYPE_AZURE_OPENAI = "azure_openai"
 
 VALID_CONNECTOR_TYPES = frozenset(
     {
         CONNECTOR_TYPE_OPENAI_APIKEY,
         CONNECTOR_TYPE_ANTHROPIC_APIKEY,
         CONNECTOR_TYPE_OPENAI_COMPATIBLE,
+        CONNECTOR_TYPE_AZURE_OPENAI,
     }
 )
 
@@ -58,6 +60,8 @@ class LlmConnector(Base):
     `credentials` is a JSON string encrypted via Fernet. Shape varies by type:
     - openai_apikey / anthropic_apikey: {"api_key": "..."}
     - openai_compatible: {"base_url": "...", "bearer": "..." | null}
+    - azure_openai: {"api_key": "...", "azure_resource_name": "...",
+      "azure_deployment_name": "...", "azure_api_version": "..."}
 
     `base_url_plain` mirrors the openai_compatible base_url in plaintext so admin
     listing can render without decrypting. Contains no credentials.

--- a/server/app/schemas/llm.py
+++ b/server/app/schemas/llm.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-ConnectorType = Literal["openai_apikey", "anthropic_apikey", "openai_compatible"]
+ConnectorType = Literal["openai_apikey", "anthropic_apikey", "openai_compatible", "azure_openai"]
 ConnectorStatus = Literal["active", "auth_invalid", "disabled"]
 
 
@@ -44,6 +44,8 @@ class ConnectorCreate(BaseModel):
       ``base_url`` and ``bearer`` are ignored.
     - ``openai_compatible``: ``base_url`` required; ``bearer`` optional;
       ``api_key`` is ignored.
+    - ``azure_openai``: ``api_key``, ``azure_resource_name``,
+      ``azure_deployment_name`` and ``azure_api_version`` all required.
 
     The combination is enforced by :meth:`_require_credentials_for_type`.
     See ``build_create_payload`` in ``services/llm/connector_storage.py``
@@ -54,12 +56,17 @@ class ConnectorCreate(BaseModel):
     display_name: str = Field(..., min_length=1, max_length=80)
     model_hint: str | None = Field(default=None, max_length=80)
 
-    # Set for apikey types
+    # Set for apikey types (and azure_openai)
     api_key: str | None = Field(default=None, max_length=512)
 
     # Set for openai_compatible
     base_url: str | None = Field(default=None, max_length=512)
     bearer: str | None = Field(default=None, max_length=512)
+
+    # Set for azure_openai (stored in the encrypted credentials blob, not columns)
+    azure_resource_name: str | None = Field(default=None, max_length=120)
+    azure_deployment_name: str | None = Field(default=None, max_length=120)
+    azure_api_version: str | None = Field(default=None, max_length=40)
 
     @model_validator(mode="after")
     def _require_credentials_for_type(self) -> ConnectorCreate:
@@ -69,6 +76,19 @@ class ConnectorCreate(BaseModel):
         elif self.connector_type == "openai_compatible":
             if not self.base_url:
                 raise ValueError("base_url is required for openai_compatible connectors")
+        elif self.connector_type == "azure_openai":
+            missing = [
+                name
+                for name, value in (
+                    ("api_key", self.api_key),
+                    ("azure_resource_name", self.azure_resource_name),
+                    ("azure_deployment_name", self.azure_deployment_name),
+                    ("azure_api_version", self.azure_api_version),
+                )
+                if not value
+            ]
+            if missing:
+                raise ValueError("azure_openai connectors require: " + ", ".join(missing))
         return self
 
 
@@ -90,10 +110,23 @@ class ConnectorCredentialsRotate(BaseModel):
     base_url: str | None = Field(default=None, max_length=512)
     bearer: str | None = Field(default=None, max_length=512)
 
+    # azure_openai rotation — admins can swap resource/deployment/version
+    # without recreating the connector (all live in the encrypted blob).
+    azure_resource_name: str | None = Field(default=None, max_length=120)
+    azure_deployment_name: str | None = Field(default=None, max_length=120)
+    azure_api_version: str | None = Field(default=None, max_length=40)
+
     @model_validator(mode="after")
     def _require_at_least_one(self) -> ConnectorCredentialsRotate:
-        if not (self.api_key or self.base_url or self.bearer):
-            raise ValueError("At least one of api_key, base_url, or bearer must be provided")
+        if not (
+            self.api_key
+            or self.base_url
+            or self.bearer
+            or self.azure_resource_name
+            or self.azure_deployment_name
+            or self.azure_api_version
+        ):
+            raise ValueError("At least one credential field must be provided")
         return self
 
 

--- a/server/app/schemas/llm.py
+++ b/server/app/schemas/llm.py
@@ -11,6 +11,15 @@ ConnectorType = Literal["openai_apikey", "anthropic_apikey", "openai_compatible"
 ConnectorStatus = Literal["active", "auth_invalid", "disabled"]
 
 
+def _provided(value: str | None) -> bool:
+    """True only when ``value`` is a non-blank string.
+
+    Used by the credential validators so whitespace-only inputs (``"   "``) are
+    treated as missing rather than passing a bare truthiness check.
+    """
+    return isinstance(value, str) and value.strip() != ""
+
+
 class ConnectorOut(BaseModel):
     """Public-safe connector view — never includes the credential blob."""
 
@@ -71,10 +80,10 @@ class ConnectorCreate(BaseModel):
     @model_validator(mode="after")
     def _require_credentials_for_type(self) -> ConnectorCreate:
         if self.connector_type in ("openai_apikey", "anthropic_apikey"):
-            if not self.api_key:
+            if not _provided(self.api_key):
                 raise ValueError("api_key is required for API-key connectors")
         elif self.connector_type == "openai_compatible":
-            if not self.base_url:
+            if not _provided(self.base_url):
                 raise ValueError("base_url is required for openai_compatible connectors")
         elif self.connector_type == "azure_openai":
             missing = [
@@ -85,7 +94,7 @@ class ConnectorCreate(BaseModel):
                     ("azure_deployment_name", self.azure_deployment_name),
                     ("azure_api_version", self.azure_api_version),
                 )
-                if not value
+                if not _provided(value)
             ]
             if missing:
                 raise ValueError("azure_openai connectors require: " + ", ".join(missing))
@@ -118,13 +127,16 @@ class ConnectorCredentialsRotate(BaseModel):
 
     @model_validator(mode="after")
     def _require_at_least_one(self) -> ConnectorCredentialsRotate:
-        if not (
-            self.api_key
-            or self.base_url
-            or self.bearer
-            or self.azure_resource_name
-            or self.azure_deployment_name
-            or self.azure_api_version
+        if not any(
+            _provided(v)
+            for v in (
+                self.api_key,
+                self.base_url,
+                self.bearer,
+                self.azure_resource_name,
+                self.azure_deployment_name,
+                self.azure_api_version,
+            )
         ):
             raise ValueError("At least one credential field must be provided")
         return self

--- a/server/app/services/llm/adapters/azure_openai.py
+++ b/server/app/services/llm/adapters/azure_openai.py
@@ -1,0 +1,136 @@
+"""Azure OpenAI adapter.
+
+Azure OpenAI exposes the same Chat Completions *body* as the OpenAI Platform
+API, but differs on two axes that prevent reusing the OpenAI-compatible code
+path directly:
+
+1. **URL** — per-deployment endpoint:
+   ``https://<resource>.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=<ver>``
+2. **Auth header** — ``api-key: <key>`` (NOT ``Authorization: Bearer``).
+
+We therefore build the URL + headers ourselves and only share the request-body
+shaping (``_build_payload``) and response parsing (``parse_openai_response``)
+with the OpenAI helper, plus the HTTP status → typed-exception mapping.
+
+All configuration (resource name, deployment name, api version) **and** the
+api key live in the encrypted ``credentials`` blob — there are no dedicated
+columns. This lets admins rotate any of them via the existing
+``PUT /credentials`` route without recreating the connector.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import httpx
+
+from app.services.llm.adapters._httpx_openai import (
+    DEFAULT_TIMEOUT_SECONDS,
+    MAX_TIMEOUT_SECONDS,
+    _build_payload,
+    _raise_for_status,
+    build_healthcheck_request,
+)
+from app.services.llm.base import ChatRequest, ChatResponse, LlmAdapter
+from app.services.llm.exceptions import AuthInvalid, ProviderUnavailable, ToolTranslationError
+from app.services.llm.registry import register_adapter
+from app.services.llm.tool_translation import parse_openai_response
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "gpt-4o-mini"
+
+
+def _build_azure_endpoint(resource_name: str, deployment_name: str, api_version: str) -> str:
+    """Compose the per-deployment Azure Chat Completions URL.
+
+    ``resource_name`` is the bare resource (e.g. ``my-co``), NOT a full host.
+    """
+    return (
+        f"https://{resource_name}.openai.azure.com"
+        f"/openai/deployments/{deployment_name}/chat/completions"
+        f"?api-version={api_version}"
+    )
+
+
+class AzureOpenAIAdapter(LlmAdapter):
+    connector_type = "azure_openai"
+
+    def _extract_credentials(self) -> dict[str, str]:
+        """Return the validated config dict from the encrypted blob.
+
+        Keys: api_key, azure_resource_name, azure_deployment_name,
+        azure_api_version.
+        """
+        raw = self.connector.credentials or ""
+        try:
+            blob = json.loads(raw)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise AuthInvalid("Connector credentials are malformed") from exc
+        if not isinstance(blob, dict):
+            raise AuthInvalid("Connector credentials shape is invalid")
+
+        api_key = blob.get("api_key")
+        resource = blob.get("azure_resource_name")
+        deployment = blob.get("azure_deployment_name")
+        api_version = blob.get("azure_api_version")
+        if not (api_key and resource and deployment and api_version):
+            raise AuthInvalid("Connector is missing Azure OpenAI configuration")
+        return {
+            "api_key": str(api_key),
+            "azure_resource_name": str(resource),
+            "azure_deployment_name": str(deployment),
+            "azure_api_version": str(api_version),
+        }
+
+    async def _call(self, request: ChatRequest) -> ChatResponse:
+        creds = self._extract_credentials()
+        endpoint = _build_azure_endpoint(
+            creds["azure_resource_name"],
+            creds["azure_deployment_name"],
+            creds["azure_api_version"],
+        )
+
+        # Azure routes by deployment, so the body `model` is largely cosmetic,
+        # but the shared payload builder requires a non-None model. Default to
+        # the deployment name when no explicit model/hint is supplied.
+        model = request.model or self.connector.model_hint or creds["azure_deployment_name"]
+        payload = _build_payload(request, model)
+
+        headers: dict[str, str] = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "api-key": creds["api_key"],
+        }
+
+        timeout = request.timeout_seconds or DEFAULT_TIMEOUT_SECONDS
+        timeout = min(max(timeout, 1.0), MAX_TIMEOUT_SECONDS)
+
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.post(endpoint, json=payload, headers=headers)
+        except httpx.TimeoutException as exc:
+            raise ProviderUnavailable("Upstream timeout") from exc
+        except httpx.HTTPError as exc:
+            raise ProviderUnavailable("Upstream network error") from exc
+
+        _raise_for_status(resp)
+
+        try:
+            body: Any = resp.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ToolTranslationError("Upstream returned non-JSON body") from exc
+
+        return parse_openai_response(body)
+
+    async def chat(self, request: ChatRequest) -> ChatResponse:
+        return await self._call(request)
+
+    async def health_check(self) -> None:
+        # 1-token ping exercises the URL + api-key auth path.
+        await self._call(build_healthcheck_request())
+
+
+register_adapter("azure_openai", AzureOpenAIAdapter)

--- a/server/app/services/llm/adapters/azure_openai.py
+++ b/server/app/services/llm/adapters/azure_openai.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any
+from urllib.parse import quote, urlencode
 
 import httpx
 
@@ -42,16 +44,41 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL = "gpt-4o-mini"
 
+# Azure naming rules: resource is a DNS host label (letters/digits/hyphen);
+# deployment + api-version are token-ish. These mirror the storage-layer
+# validators in connector_storage.py and provide defense-in-depth at the
+# URL-composition boundary against component injection (CLAUDE.md: validate at
+# system boundaries — never trust the credential blob implicitly).
+_RESOURCE_RE = re.compile(r"^[A-Za-z0-9-]+$")
+_DEPLOYMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_API_VERSION_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
 
 def _build_azure_endpoint(resource_name: str, deployment_name: str, api_version: str) -> str:
     """Compose the per-deployment Azure Chat Completions URL.
 
     ``resource_name`` is the bare resource (e.g. ``my-co``), NOT a full host.
+
+    The three components are validated and the path/query parts URL-encoded so a
+    malformed credential blob cannot rewrite the authority/path/query and route
+    requests to an unintended endpoint.
     """
+    resource_name = resource_name.strip()
+    deployment_name = deployment_name.strip()
+    api_version = api_version.strip()
+    if not _RESOURCE_RE.fullmatch(resource_name):
+        raise AuthInvalid("Invalid Azure resource name")
+    if not _DEPLOYMENT_RE.fullmatch(deployment_name):
+        raise AuthInvalid("Invalid Azure deployment name")
+    if not _API_VERSION_RE.fullmatch(api_version):
+        raise AuthInvalid("Invalid Azure API version")
+
+    deployment_segment = quote(deployment_name, safe="")
+    query = urlencode({"api-version": api_version})
     return (
         f"https://{resource_name}.openai.azure.com"
-        f"/openai/deployments/{deployment_name}/chat/completions"
-        f"?api-version={api_version}"
+        f"/openai/deployments/{deployment_segment}/chat/completions"
+        f"?{query}"
     )
 
 

--- a/server/app/services/llm/connector_storage.py
+++ b/server/app/services/llm/connector_storage.py
@@ -306,13 +306,26 @@ def rotate_credentials(
         # Partial rotation: any omitted field keeps its current value, so an
         # admin can swap just the resource/deployment/version (or just the key)
         # without recreating the connector.
+        # Only None means "field omitted, keep current value". An explicit ""
+        # is passed through to _build_azure_creds() so it is rejected rather
+        # than silently preserving the old value.
         current = _load_existing_blob(connector)
-        new_api_key = (api_key.strip() if api_key else None) or current.get("api_key")
+        new_api_key = current.get("api_key") if api_key is None else api_key.strip()
         blob = _build_azure_creds(
             api_key=new_api_key,
-            azure_resource_name=azure_resource_name or current.get("azure_resource_name"),
-            azure_deployment_name=azure_deployment_name or current.get("azure_deployment_name"),
-            azure_api_version=azure_api_version or current.get("azure_api_version"),
+            azure_resource_name=(
+                current.get("azure_resource_name")
+                if azure_resource_name is None
+                else azure_resource_name
+            ),
+            azure_deployment_name=(
+                current.get("azure_deployment_name")
+                if azure_deployment_name is None
+                else azure_deployment_name
+            ),
+            azure_api_version=(
+                current.get("azure_api_version") if azure_api_version is None else azure_api_version
+            ),
         )
     else:  # pragma: no cover
         raise ValueError(f"Unsupported connector_type: {connector.connector_type!r}")

--- a/server/app/services/llm/connector_storage.py
+++ b/server/app/services/llm/connector_storage.py
@@ -18,6 +18,7 @@ from app.models.llm_connector import (
     AUDIT_POLICY_CHANGED,
     AUDIT_REVOKED_BY_ADMIN,
     CONNECTOR_TYPE_ANTHROPIC_APIKEY,
+    CONNECTOR_TYPE_AZURE_OPENAI,
     CONNECTOR_TYPE_OPENAI_APIKEY,
     CONNECTOR_TYPE_OPENAI_COMPATIBLE,
     STATUS_ACTIVE,
@@ -95,6 +96,9 @@ def build_create_payload(
     base_url: str | None = None,
     bearer: str | None = None,
     model_hint: str | None = None,
+    azure_resource_name: str | None = None,
+    azure_deployment_name: str | None = None,
+    azure_api_version: str | None = None,
 ) -> CreateConnectorPayload:
     """Translate request fields into a validated ``CreateConnectorPayload``.
 
@@ -143,6 +147,16 @@ def build_create_payload(
         except InvalidBaseUrlError as exc:
             raise ValueError(str(exc)) from exc
         creds = {"base_url": plain_base_url, "bearer": bearer or None}
+    elif connector_type == CONNECTOR_TYPE_AZURE_OPENAI:
+        if not api_key:
+            raise ValueError("api_key is required")
+        api_key = api_key.strip()
+        creds = _build_azure_creds(
+            api_key=api_key,
+            azure_resource_name=azure_resource_name,
+            azure_deployment_name=azure_deployment_name,
+            azure_api_version=azure_api_version,
+        )
     else:  # pragma: no cover — guarded by the membership check above
         raise ValueError(f"Unsupported connector_type: {connector_type!r}")
 
@@ -178,6 +192,67 @@ def _looks_like_api_key(connector_type: str, key: str) -> bool:
     return False
 
 
+# Azure resource/deployment names: letters, digits, hyphen (Azure naming rules).
+_AZURE_NAME_CHARS = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-")
+# api-version is a date-ish token, optionally with a -preview suffix.
+_AZURE_VERSION_CHARS = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-.")
+
+
+def _validate_azure_field(name: str, value: str | None, allowed: set[str], max_len: int) -> str:
+    if not value:
+        raise ValueError(f"{name} is required")
+    value = value.strip()
+    if not value:
+        raise ValueError(f"{name} is required")
+    if len(value) > max_len:
+        raise ValueError(f"{name} must be {max_len} characters or fewer")
+    if not all(c in allowed for c in value):
+        raise ValueError(f"{name} contains invalid characters")
+    return value
+
+
+def _build_azure_creds(
+    *,
+    api_key: str | None,
+    azure_resource_name: str | None,
+    azure_deployment_name: str | None,
+    azure_api_version: str | None,
+) -> dict[str, Any]:
+    """Validate + assemble the Azure OpenAI credential blob.
+
+    All four fields (api_key + the three azure_* config values) are stored in
+    the encrypted blob — there are no dedicated DB columns.
+    """
+    if not api_key or not api_key.strip():
+        raise ValueError("api_key is required")
+    return {
+        "api_key": api_key.strip(),
+        "azure_resource_name": _validate_azure_field(
+            "azure_resource_name", azure_resource_name, _AZURE_NAME_CHARS, 120
+        ),
+        "azure_deployment_name": _validate_azure_field(
+            "azure_deployment_name", azure_deployment_name, _AZURE_NAME_CHARS, 120
+        ),
+        "azure_api_version": _validate_azure_field(
+            "azure_api_version", azure_api_version, _AZURE_VERSION_CHARS, 40
+        ),
+    }
+
+
+def _load_existing_blob(connector: LlmConnector) -> dict[str, Any]:
+    """Decode the connector's current credential blob (best-effort).
+
+    Returns an empty dict when the blob is missing or malformed so callers can
+    treat absent values as "no prior value" during partial rotation.
+    """
+    raw = connector.credentials or ""
+    try:
+        blob = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return blob if isinstance(blob, dict) else {}
+
+
 def create_connector(db: Session, *, user_id: int, payload: CreateConnectorPayload) -> LlmConnector:
     """Persist a new connector. Caller is responsible for audit event + commit."""
     row = LlmConnector(
@@ -202,6 +277,9 @@ def rotate_credentials(
     api_key: str | None = None,
     base_url: str | None = None,
     bearer: str | None = None,
+    azure_resource_name: str | None = None,
+    azure_deployment_name: str | None = None,
+    azure_api_version: str | None = None,
 ) -> LlmConnector:
     """Rotate the credential blob in-place. Caller commits."""
     blob: dict[str, Any]
@@ -224,6 +302,18 @@ def rotate_credentials(
             raise ValueError(str(exc)) from exc
         blob = {"base_url": base_url, "bearer": bearer or None}
         connector.base_url_plain = base_url
+    elif connector.connector_type == CONNECTOR_TYPE_AZURE_OPENAI:
+        # Partial rotation: any omitted field keeps its current value, so an
+        # admin can swap just the resource/deployment/version (or just the key)
+        # without recreating the connector.
+        current = _load_existing_blob(connector)
+        new_api_key = (api_key.strip() if api_key else None) or current.get("api_key")
+        blob = _build_azure_creds(
+            api_key=new_api_key,
+            azure_resource_name=azure_resource_name or current.get("azure_resource_name"),
+            azure_deployment_name=azure_deployment_name or current.get("azure_deployment_name"),
+            azure_api_version=azure_api_version or current.get("azure_api_version"),
+        )
     else:  # pragma: no cover
         raise ValueError(f"Unsupported connector_type: {connector.connector_type!r}")
 

--- a/server/app/services/llm/registry.py
+++ b/server/app/services/llm/registry.py
@@ -55,6 +55,7 @@ def _bootstrap() -> None:
     # Local imports keep the registry module dependency-free at import time.
     from app.services.llm.adapters import (  # noqa: F401
         anthropic_apikey,
+        azure_openai,
         openai_apikey,
         openai_compatible,
     )

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -190,7 +190,8 @@
             "enum": [
               "openai_apikey",
               "anthropic_apikey",
-              "openai_compatible"
+              "openai_compatible",
+              "azure_openai"
             ],
             "title": "Connector Type",
             "type": "string"
@@ -1897,7 +1898,7 @@
         "type": "object"
       },
       "ConnectorCreate": {
-        "description": "Provider-agnostic create payload.\n\nField requirements vary by ``connector_type``:\n\n- ``openai_apikey`` / ``anthropic_apikey``: ``api_key`` required;\n  ``base_url`` and ``bearer`` are ignored.\n- ``openai_compatible``: ``base_url`` required; ``bearer`` optional;\n  ``api_key`` is ignored.\n\nThe combination is enforced by :meth:`_require_credentials_for_type`.\nSee ``build_create_payload`` in ``services/llm/connector_storage.py``\nfor the full validation flow (including key shape checks).",
+        "description": "Provider-agnostic create payload.\n\nField requirements vary by ``connector_type``:\n\n- ``openai_apikey`` / ``anthropic_apikey``: ``api_key`` required;\n  ``base_url`` and ``bearer`` are ignored.\n- ``openai_compatible``: ``base_url`` required; ``bearer`` optional;\n  ``api_key`` is ignored.\n- ``azure_openai``: ``api_key``, ``azure_resource_name``,\n  ``azure_deployment_name`` and ``azure_api_version`` all required.\n\nThe combination is enforced by :meth:`_require_credentials_for_type`.\nSee ``build_create_payload`` in ``services/llm/connector_storage.py``\nfor the full validation flow (including key shape checks).",
         "properties": {
           "api_key": {
             "anyOf": [
@@ -1910,6 +1911,42 @@
               }
             ],
             "title": "Api Key"
+          },
+          "azure_api_version": {
+            "anyOf": [
+              {
+                "maxLength": 40,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Azure Api Version"
+          },
+          "azure_deployment_name": {
+            "anyOf": [
+              {
+                "maxLength": 120,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Azure Deployment Name"
+          },
+          "azure_resource_name": {
+            "anyOf": [
+              {
+                "maxLength": 120,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Azure Resource Name"
           },
           "base_url": {
             "anyOf": [
@@ -1939,7 +1976,8 @@
             "enum": [
               "openai_apikey",
               "anthropic_apikey",
-              "openai_compatible"
+              "openai_compatible",
+              "azure_openai"
             ],
             "title": "Connector Type",
             "type": "string"
@@ -1984,6 +2022,42 @@
               }
             ],
             "title": "Api Key"
+          },
+          "azure_api_version": {
+            "anyOf": [
+              {
+                "maxLength": 40,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Azure Api Version"
+          },
+          "azure_deployment_name": {
+            "anyOf": [
+              {
+                "maxLength": 120,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Azure Deployment Name"
+          },
+          "azure_resource_name": {
+            "anyOf": [
+              {
+                "maxLength": 120,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Azure Resource Name"
           },
           "base_url": {
             "anyOf": [
@@ -2031,7 +2105,8 @@
             "enum": [
               "openai_apikey",
               "anthropic_apikey",
-              "openai_compatible"
+              "openai_compatible",
+              "azure_openai"
             ],
             "title": "Connector Type",
             "type": "string"
@@ -5675,7 +5750,8 @@
             "enum": [
               "openai_apikey",
               "anthropic_apikey",
-              "openai_compatible"
+              "openai_compatible",
+              "azure_openai"
             ],
             "title": "Connector Type",
             "type": "string"

--- a/server/tests/test_llm_adapters.py
+++ b/server/tests/test_llm_adapters.py
@@ -14,7 +14,7 @@ import httpx
 import pytest
 
 from app.services.llm.adapters.anthropic_apikey import AnthropicApiKeyAdapter
-from app.services.llm.adapters.azure_openai import AzureOpenAIAdapter
+from app.services.llm.adapters.azure_openai import AzureOpenAIAdapter, _build_azure_endpoint
 from app.services.llm.adapters.openai_apikey import OpenAIApiKeyAdapter
 from app.services.llm.adapters.openai_compatible import OpenAICompatibleAdapter
 from app.services.llm.base import ChatRequest, Message
@@ -463,3 +463,25 @@ class TestAzureOpenAIAdapter:
         adapter = AzureOpenAIAdapter(connector)
         with pytest.raises(AuthInvalid):
             await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    def test_build_endpoint_encodes_and_validates(self):
+        # Valid components compose the expected URL with the query encoded.
+        url = _build_azure_endpoint("acme", "gpt-4o", "2024-06-01")
+        assert url == (
+            "https://acme.openai.azure.com/openai/deployments/gpt-4o"
+            "/chat/completions?api-version=2024-06-01"
+        )
+
+    @pytest.mark.parametrize(
+        ("resource", "deployment", "version"),
+        [
+            ("acme.evil.com/x", "gpt-4o", "2024-06-01"),  # authority rewrite
+            ("acme", "../../admin", "2024-06-01"),  # path traversal
+            ("acme", "gpt-4o", "2024-06-01&inject=1"),  # query injection
+            ("acme/", "gpt-4o", "2024-06-01"),  # trailing slash in host
+            ("acme", "gpt 4o", "2024-06-01"),  # whitespace in deployment
+        ],
+    )
+    def test_build_endpoint_rejects_url_injection(self, resource, deployment, version):
+        with pytest.raises(AuthInvalid):
+            _build_azure_endpoint(resource, deployment, version)

--- a/server/tests/test_llm_adapters.py
+++ b/server/tests/test_llm_adapters.py
@@ -14,6 +14,7 @@ import httpx
 import pytest
 
 from app.services.llm.adapters.anthropic_apikey import AnthropicApiKeyAdapter
+from app.services.llm.adapters.azure_openai import AzureOpenAIAdapter
 from app.services.llm.adapters.openai_apikey import OpenAIApiKeyAdapter
 from app.services.llm.adapters.openai_compatible import OpenAICompatibleAdapter
 from app.services.llm.base import ChatRequest, Message
@@ -26,6 +27,7 @@ from app.services.llm.exceptions import (
 )
 
 _HTTPX_PATH = "app.services.llm.adapters._httpx_openai.httpx.AsyncClient"
+_AZURE_HTTPX_PATH = "app.services.llm.adapters.azure_openai.httpx.AsyncClient"
 
 
 # ---------------------------------------------------------------------------
@@ -47,6 +49,26 @@ def _make_compatible_connector(base_url="http://127.0.0.1:11434/v1", bearer=None
         credentials=json.dumps(creds),
         model_hint="llama3",
         base_url_plain=base_url,
+    )
+
+
+def _make_azure_connector(
+    api_key="azure-secret-key",
+    resource="my-resource",
+    deployment="gpt4o",
+    api_version="2024-06-01",
+):
+    creds = {
+        "api_key": api_key,
+        "azure_resource_name": resource,
+        "azure_deployment_name": deployment,
+        "azure_api_version": api_version,
+    }
+    return SimpleNamespace(
+        connector_type="azure_openai",
+        credentials=json.dumps(creds),
+        model_hint=None,
+        base_url_plain=None,
     )
 
 
@@ -317,3 +339,127 @@ class TestAnthropicApiKeyAdapter:
             await adapter.chat(
                 ChatRequest(messages=[Message(role="tool", content="result", tool_call_id=None)])
             )
+
+
+# ---------------------------------------------------------------------------
+# Azure OpenAI adapter
+# ---------------------------------------------------------------------------
+class TestAzureOpenAIAdapter:
+    @pytest.mark.asyncio
+    async def test_happy_path_url_and_api_key_header(self):
+        connector = _make_azure_connector(
+            resource="acme", deployment="gpt4o", api_version="2024-06-01"
+        )
+        adapter = AzureOpenAIAdapter(connector)
+        client = _AsyncClient(_ok_response(_openai_success_body("pong")))
+        with patch(_AZURE_HTTPX_PATH, return_value=client):
+            resp = await adapter.chat(ChatRequest(messages=[Message(role="user", content="hi")]))
+
+        assert resp.text == "pong"
+        call = client.calls[0]
+        # Per-deployment URL with api-version query string.
+        assert call["url"] == (
+            "https://acme.openai.azure.com/openai/deployments/gpt4o"
+            "/chat/completions?api-version=2024-06-01"
+        )
+        # Azure uses the `api-key` header, NOT `Authorization: Bearer`.
+        assert call["headers"]["api-key"] == "azure-secret-key"
+        assert "Authorization" not in call["headers"]
+
+    @pytest.mark.asyncio
+    async def test_health_check_succeeds(self):
+        connector = _make_azure_connector()
+        adapter = AzureOpenAIAdapter(connector)
+        client = _AsyncClient(_ok_response(_openai_success_body("ok")))
+        with patch(_AZURE_HTTPX_PATH, return_value=client):
+            await adapter.health_check()
+        assert client.calls[0]["headers"]["api-key"] == "azure-secret-key"
+
+    @pytest.mark.asyncio
+    async def test_401_maps_to_auth_invalid(self):
+        adapter = AzureOpenAIAdapter(_make_azure_connector())
+        resp = httpx.Response(
+            401, request=httpx.Request("POST", "https://acme.openai.azure.com"), json={}
+        )
+        with patch(_AZURE_HTTPX_PATH, return_value=_AsyncClient(resp)):
+            with pytest.raises(AuthInvalid):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_429_maps_to_rate_limited_with_retry_after(self):
+        adapter = AzureOpenAIAdapter(_make_azure_connector())
+        resp = httpx.Response(
+            429,
+            request=httpx.Request("POST", "https://acme.openai.azure.com"),
+            headers={"Retry-After": "17"},
+            json={},
+        )
+        with patch(_AZURE_HTTPX_PATH, return_value=_AsyncClient(resp)):
+            with pytest.raises(RateLimited) as info:
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+        assert info.value.retry_after_seconds == 17
+
+    @pytest.mark.asyncio
+    async def test_5xx_maps_to_provider_unavailable(self):
+        adapter = AzureOpenAIAdapter(_make_azure_connector())
+        resp = httpx.Response(
+            503, request=httpx.Request("POST", "https://acme.openai.azure.com"), json={}
+        )
+        with patch(_AZURE_HTTPX_PATH, return_value=_AsyncClient(resp)):
+            with pytest.raises(ProviderUnavailable):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_402_maps_to_quota_exceeded(self):
+        adapter = AzureOpenAIAdapter(_make_azure_connector())
+        resp = httpx.Response(
+            402, request=httpx.Request("POST", "https://acme.openai.azure.com"), json={}
+        )
+        with patch(_AZURE_HTTPX_PATH, return_value=_AsyncClient(resp)):
+            with pytest.raises(QuotaExceeded):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_timeout_maps_to_provider_unavailable(self):
+        adapter = AzureOpenAIAdapter(_make_azure_connector())
+        client = _AsyncClient(httpx.TimeoutException("timeout"))
+        with patch(_AZURE_HTTPX_PATH, return_value=client):
+            with pytest.raises(ProviderUnavailable):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_body_raises_tool_translation_error(self):
+        adapter = AzureOpenAIAdapter(_make_azure_connector())
+        resp = httpx.Response(
+            200,
+            request=httpx.Request("POST", "https://acme.openai.azure.com"),
+            content=b"not json",
+            headers={"Content-Type": "application/json"},
+        )
+        with patch(_AZURE_HTTPX_PATH, return_value=_AsyncClient(resp)):
+            with pytest.raises(ToolTranslationError):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_missing_config_raises_auth_invalid(self):
+        connector = SimpleNamespace(
+            connector_type="azure_openai",
+            credentials=json.dumps({"api_key": "k"}),  # missing azure_* fields
+            model_hint=None,
+            base_url_plain=None,
+        )
+        adapter = AzureOpenAIAdapter(connector)
+        with pytest.raises(AuthInvalid):
+            await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_malformed_credentials_raise_auth_invalid(self):
+        connector = SimpleNamespace(
+            connector_type="azure_openai",
+            credentials="not json",
+            model_hint=None,
+            base_url_plain=None,
+        )
+        adapter = AzureOpenAIAdapter(connector)
+        with pytest.raises(AuthInvalid):
+            await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))

--- a/server/tests/test_llm_api.py
+++ b/server/tests/test_llm_api.py
@@ -101,6 +101,70 @@ class TestPerDJConnectorsCRUD:
         resp = client.post("/api/llm/connectors", json=body, headers=auth_headers)
         assert resp.status_code == 400
 
+    def test_create_azure_openai_happy_path(self, client: TestClient, auth_headers):
+        body = {
+            "connector_type": "azure_openai",
+            "display_name": "Venue Azure",
+            "api_key": "azure-secret-key-12345",
+            "azure_resource_name": "venue-co",
+            "azure_deployment_name": "gpt4o-prod",
+            "azure_api_version": "2024-06-01",
+        }
+        resp = client.post("/api/llm/connectors", json=body, headers=auth_headers)
+        assert resp.status_code == 201, resp.json()
+        data = resp.json()
+        assert data["connector_type"] == "azure_openai"
+        # Credentials (incl. azure config) are never echoed back.
+        assert "api_key" not in data
+        assert "azure_resource_name" not in data
+        assert data["base_url_plain"] is None
+
+    def test_create_azure_openai_requires_all_config_fields(self, client: TestClient, auth_headers):
+        body = {
+            "connector_type": "azure_openai",
+            "display_name": "Incomplete Azure",
+            "api_key": "azure-secret-key-12345",
+            "azure_resource_name": "venue-co",
+            # missing deployment + api_version
+        }
+        resp = client.post("/api/llm/connectors", json=body, headers=auth_headers)
+        assert resp.status_code in (400, 422)
+
+    def test_rotate_azure_openai_config_without_recreating(
+        self, client: TestClient, auth_headers, db, test_user
+    ):
+        create_body = {
+            "connector_type": "azure_openai",
+            "display_name": "Rotatable Azure",
+            "api_key": "azure-secret-key-12345",
+            "azure_resource_name": "old-resource",
+            "azure_deployment_name": "old-deployment",
+            "azure_api_version": "2024-02-01",
+        }
+        created = client.post("/api/llm/connectors", json=create_body, headers=auth_headers)
+        assert created.status_code == 201, created.json()
+        connector_id = created.json()["id"]
+
+        # Rotate ONLY the deployment + resource — api_key omitted, must be kept.
+        rotate = client.put(
+            f"/api/llm/connectors/{connector_id}/credentials",
+            json={
+                "azure_resource_name": "new-resource",
+                "azure_deployment_name": "new-deployment",
+            },
+            headers=auth_headers,
+        )
+        assert rotate.status_code == 200, rotate.json()
+
+        # Verify the persisted blob carried forward the api_key + version.
+        row = db.get(LlmConnector, connector_id)
+        db.refresh(row)
+        blob = json.loads(row.credentials)
+        assert blob["api_key"] == "azure-secret-key-12345"
+        assert blob["azure_resource_name"] == "new-resource"
+        assert blob["azure_deployment_name"] == "new-deployment"
+        assert blob["azure_api_version"] == "2024-02-01"
+
     def test_create_rejects_invalid_key_format(self, client: TestClient, auth_headers):
         body = {
             "connector_type": "openai_apikey",

--- a/server/tests/test_llm_api.py
+++ b/server/tests/test_llm_api.py
@@ -165,6 +165,53 @@ class TestPerDJConnectorsCRUD:
         assert blob["azure_deployment_name"] == "new-deployment"
         assert blob["azure_api_version"] == "2024-02-01"
 
+    def test_create_azure_openai_rejects_whitespace_only_config(
+        self, client: TestClient, auth_headers
+    ):
+        body = {
+            "connector_type": "azure_openai",
+            "display_name": "Blank Azure",
+            "api_key": "azure-secret-key-12345",
+            "azure_resource_name": "venue-co",
+            "azure_deployment_name": "   ",  # whitespace-only must be rejected
+            "azure_api_version": "2024-06-01",
+        }
+        resp = client.post("/api/llm/connectors", json=body, headers=auth_headers)
+        assert resp.status_code in (400, 422), resp.json()
+
+    def test_rotate_azure_openai_rejects_explicit_empty_field(
+        self, client: TestClient, auth_headers, db, test_user
+    ):
+        create_body = {
+            "connector_type": "azure_openai",
+            "display_name": "Rotatable Azure",
+            "api_key": "azure-secret-key-12345",
+            "azure_resource_name": "old-resource",
+            "azure_deployment_name": "old-deployment",
+            "azure_api_version": "2024-02-01",
+        }
+        created = client.post("/api/llm/connectors", json=create_body, headers=auth_headers)
+        assert created.status_code == 201, created.json()
+        connector_id = created.json()["id"]
+
+        # An explicit "" for one field must be rejected by the storage layer
+        # (passed through to _build_azure_creds), not silently treated as
+        # "omitted". A second valid field satisfies the schema-level
+        # "at least one provided" check so the request reaches rotate_credentials.
+        rotate = client.put(
+            f"/api/llm/connectors/{connector_id}/credentials",
+            json={"azure_resource_name": "", "azure_deployment_name": "still-valid"},
+            headers=auth_headers,
+        )
+        assert rotate.status_code in (400, 422), rotate.json()
+
+        # The original blob is untouched.
+        row = db.get(LlmConnector, connector_id)
+        db.refresh(row)
+        blob = json.loads(row.credentials)
+        assert blob["azure_resource_name"] == "old-resource"
+        assert blob["azure_deployment_name"] == "old-deployment"
+
     def test_create_rejects_invalid_key_format(self, client: TestClient, auth_headers):
         body = {
             "connector_type": "openai_apikey",


### PR DESCRIPTION
Closes #333.

Adds an `azure_openai` connector type to the LLM gateway so enterprise/venue deployments with Azure subscriptions can route AI features through their own Azure OpenAI resource.

## Summary
- New adapter `server/app/services/llm/adapters/azure_openai.py` — builds the per-deployment URL (`https://<resource>.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=<ver>`) and authenticates with the `api-key` header (NOT `Authorization: Bearer`). Reuses the shared OpenAI request-body builder + response parser; overrides only URL construction and the auth header.
- Connector type wired into the model (`VALID_CONNECTOR_TYPES`), registry bootstrap, schemas (`ConnectorType` literal + create/rotate validation), and `connector_storage` (build + rotate credential blob).
- Frontend `/settings/ai` adds an Azure OpenAI option with resource name / deployment / api version inputs (gated like the other API-key connectors).
- Regenerated `openapi.json` + `api-types.generated.ts`.

## Design decisions
- **Reused the generic admin flag.** No per-provider flag. Azure is gated by the existing `llm_apikey_connectors_enabled` policy via the `connector_type in VALID_CONNECTOR_TYPES` branch in `_check_connector_type_allowed` (the issue body's per-provider flag is stale per the epic brief).
- **No new DB columns, no Alembic migration.** All Azure config (`azure_resource_name`, `azure_deployment_name`, `azure_api_version`) **and** the api key live in the existing encrypted `credentials` blob (`EncryptedText`). `alembic check` is clean (single head 046).
- **Custom URL + `api-key` header** instead of `Authorization: Bearer`, since Azure cannot share the OpenAI-compatible auth path.
- **Credential rotation without recreating the connector.** `rotate_credentials` supports partial Azure rotation — any omitted field is carried forward from the current blob, so admins can swap just the resource/deployment/version (or just the key) via the existing `PUT /credentials` route.

## Test plan
- [x] Adapter matrix (`test_llm_adapters.py`): happy path (verifies Azure URL + `api-key` header, no Bearer), 401, 429 (retry-after), 5xx, 402, timeout, malformed JSON, missing config, malformed credentials, health check
- [x] API (`test_llm_api.py`): azure create happy path (creds not echoed), missing-config rejection, rotation carries forward api_key/version without recreating
- [x] Frontend (`page.test.tsx`): Azure option present, config fields revealed on select, create sends azure fields
- [x] Backend full suite: 2128 passed, 86.76% coverage (>=85% gate); ruff/format/bandit clean; alembic single head no drift
- [x] Frontend: tsc clean, eslint clean, vitest 946 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Azure OpenAI as an LLM connector type, including Azure-specific configuration inputs (resource name, deployment name, API version).
  * Updated settings page to allow creating and managing Azure OpenAI connectors.

* **Tests**
  * Added comprehensive test coverage for Azure OpenAI connector creation, validation, and credential rotation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->