### PR TITLE
feat(ai): add AWS Bedrock provider adapter

### DIFF
--- a/dashboard/app/(dj)/settings/ai/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/settings/ai/__tests__/page.test.tsx
@@ -84,6 +84,32 @@ describe('SettingsAIPage', () => {
     expect(optionValues).toEqual(['openai_compatible']);
   });
 
+  it('offers AWS Bedrock when api-key connectors are enabled', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
+    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: true,
+      llm_compatible_connector_enabled: false,
+      llm_default_connector_id: null,
+    });
+
+    render(<SettingsAIPage />);
+
+    await waitFor(() => expect(screen.getByText('+ Add provider')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('+ Add provider'));
+
+    const select = screen.getByLabelText('Provider') as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).toContain('bedrock');
+    expect(optionValues).not.toContain('openai_compatible');
+
+    // Selecting Bedrock reveals the four AWS credential inputs.
+    fireEvent.change(select, { target: { value: 'bedrock' } });
+    expect(screen.getByLabelText('AWS access key ID')).toBeInTheDocument();
+    expect(screen.getByLabelText('AWS secret access key')).toBeInTheDocument();
+    expect(screen.getByLabelText('AWS region')).toBeInTheDocument();
+    expect(screen.getByLabelText('Bedrock model ID')).toBeInTheDocument();
+  });
+
   it('runs Test and surfaces the result', async () => {
     const row = makeConnector();
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([row]);

--- a/dashboard/app/(dj)/settings/ai/page.tsx
+++ b/dashboard/app/(dj)/settings/ai/page.tsx
@@ -136,7 +136,9 @@ export default function SettingsAIPage() {
     const payload: LlmConnectorCreate = {
       connector_type: form.connector_type,
       display_name: form.display_name,
-      model_hint: form.model_hint || null,
+      // Bedrock has no model_hint field (it uses aws_model_id); never post a
+      // stale hint left over from a prior connector-type selection.
+      model_hint: isBedrock ? null : form.model_hint || null,
       api_key: isApiKey ? form.api_key : null,
       base_url: isCompatible ? form.base_url : null,
       bearer: isCompatible ? form.bearer || null : null,

--- a/dashboard/app/(dj)/settings/ai/page.tsx
+++ b/dashboard/app/(dj)/settings/ai/page.tsx
@@ -17,6 +17,7 @@ const CONNECTOR_TYPE_LABELS: Record<LlmConnectorType, string> = {
   openai_apikey: 'OpenAI API key',
   anthropic_apikey: 'Anthropic API key',
   openai_compatible: 'Custom OpenAI-compatible endpoint',
+  bedrock: 'AWS Bedrock',
 };
 
 const STATUS_LABELS: Record<string, { text: string; color: string }> = {
@@ -33,6 +34,10 @@ interface FormState {
   base_url: string;
   bearer: string;
   model_hint: string;
+  aws_access_key_id: string;
+  aws_secret_access_key: string;
+  aws_region: string;
+  aws_model_id: string;
 }
 
 const EMPTY_FORM: FormState = {
@@ -43,6 +48,10 @@ const EMPTY_FORM: FormState = {
   base_url: '',
   bearer: '',
   model_hint: '',
+  aws_access_key_id: '',
+  aws_secret_access_key: '',
+  aws_region: '',
+  aws_model_id: '',
 };
 
 export default function SettingsAIPage() {
@@ -92,7 +101,7 @@ export default function SettingsAIPage() {
     if (!policy) return Object.keys(CONNECTOR_TYPE_LABELS) as LlmConnectorType[];
     const out: LlmConnectorType[] = [];
     if (policy.llm_apikey_connectors_enabled) {
-      out.push('openai_apikey', 'anthropic_apikey');
+      out.push('openai_apikey', 'anthropic_apikey', 'bedrock');
     }
     if (policy.llm_compatible_connector_enabled) out.push('openai_compatible');
     return out;
@@ -121,16 +130,20 @@ export default function SettingsAIPage() {
     setSubmitting(true);
     setSubmitMessage('');
     setSubmitError('');
+    const isCompatible = form.connector_type === 'openai_compatible';
+    const isBedrock = form.connector_type === 'bedrock';
+    const isApiKey = !isCompatible && !isBedrock;
     const payload: LlmConnectorCreate = {
       connector_type: form.connector_type,
       display_name: form.display_name,
       model_hint: form.model_hint || null,
-      api_key:
-        form.connector_type === 'openai_compatible' ? null : form.api_key,
-      base_url:
-        form.connector_type === 'openai_compatible' ? form.base_url : null,
-      bearer:
-        form.connector_type === 'openai_compatible' ? form.bearer || null : null,
+      api_key: isApiKey ? form.api_key : null,
+      base_url: isCompatible ? form.base_url : null,
+      bearer: isCompatible ? form.bearer || null : null,
+      aws_access_key_id: isBedrock ? form.aws_access_key_id : null,
+      aws_secret_access_key: isBedrock ? form.aws_secret_access_key : null,
+      aws_region: isBedrock ? form.aws_region : null,
+      aws_model_id: isBedrock ? form.aws_model_id : null,
     };
     try {
       const created = await api.createLlmConnector(payload);
@@ -281,7 +294,61 @@ export default function SettingsAIPage() {
               />
             </div>
 
-            {form.connector_type !== 'openai_compatible' ? (
+            {form.connector_type === 'bedrock' ? (
+              <>
+                <div className="form-group">
+                  <label htmlFor="aws_access_key_id">AWS access key ID</label>
+                  <input
+                    id="aws_access_key_id"
+                    className="input"
+                    value={form.aws_access_key_id}
+                    onChange={(e) => setForm({ ...form, aws_access_key_id: e.target.value })}
+                    placeholder="AKIA…"
+                    autoComplete="off"
+                    required
+                  />
+                </div>
+                <div className="form-group">
+                  <label htmlFor="aws_secret_access_key">AWS secret access key</label>
+                  <input
+                    id="aws_secret_access_key"
+                    className="input"
+                    type="password"
+                    value={form.aws_secret_access_key}
+                    onChange={(e) => setForm({ ...form, aws_secret_access_key: e.target.value })}
+                    autoComplete="off"
+                    required
+                  />
+                </div>
+                <div className="form-group">
+                  <label htmlFor="aws_region">AWS region</label>
+                  <input
+                    id="aws_region"
+                    className="input"
+                    value={form.aws_region}
+                    onChange={(e) => setForm({ ...form, aws_region: e.target.value })}
+                    placeholder="us-east-1"
+                    required
+                  />
+                </div>
+                <div className="form-group">
+                  <label htmlFor="aws_model_id">Bedrock model ID</label>
+                  <input
+                    id="aws_model_id"
+                    className="input"
+                    value={form.aws_model_id}
+                    onChange={(e) => setForm({ ...form, aws_model_id: e.target.value })}
+                    placeholder="anthropic.claude-3-5-sonnet-20241022-v2:0"
+                    required
+                  />
+                  <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', margin: '0.5rem 0 0' }}>
+                    Calls are signed with AWS SigV4 and billed to your AWS account.
+                    Claude (<code>anthropic.*</code>) and Llama (<code>meta.*</code>)
+                    model families are supported.
+                  </p>
+                </div>
+              </>
+            ) : form.connector_type !== 'openai_compatible' ? (
               <div className="form-group">
                 <label htmlFor="api_key">API key</label>
                 <input
@@ -346,22 +413,24 @@ export default function SettingsAIPage() {
               </>
             )}
 
-            <div className="form-group">
-              <label htmlFor="model_hint">Model (optional)</label>
-              <input
-                id="model_hint"
-                className="input"
-                value={form.model_hint}
-                onChange={(e) => setForm({ ...form, model_hint: e.target.value })}
-                placeholder={
-                  form.connector_type === 'anthropic_apikey'
-                    ? 'claude-haiku-4-5-20251001'
-                    : form.connector_type === 'openai_apikey'
-                    ? 'gpt-5-mini'
-                    : 'e.g. llama3'
-                }
-              />
-            </div>
+            {form.connector_type !== 'bedrock' && (
+              <div className="form-group">
+                <label htmlFor="model_hint">Model (optional)</label>
+                <input
+                  id="model_hint"
+                  className="input"
+                  value={form.model_hint}
+                  onChange={(e) => setForm({ ...form, model_hint: e.target.value })}
+                  placeholder={
+                    form.connector_type === 'anthropic_apikey'
+                      ? 'claude-haiku-4-5-20251001'
+                      : form.connector_type === 'openai_apikey'
+                      ? 'gpt-5-mini'
+                      : 'e.g. llama3'
+                  }
+                />
+              </div>
+            )}
 
             <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
               <button type="submit" className="btn btn-primary" disabled={submitting}>

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -2352,7 +2352,7 @@ export interface components {
              * Connector Type
              * @enum {string}
              */
-            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible";
+            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible" | "bedrock";
             /**
              * Created At
              * Format: date-time
@@ -2940,6 +2940,8 @@ export interface components {
          *       ``base_url`` and ``bearer`` are ignored.
          *     - ``openai_compatible``: ``base_url`` required; ``bearer`` optional;
          *       ``api_key`` is ignored.
+         *     - ``bedrock``: ``aws_access_key_id``, ``aws_secret_access_key``,
+         *       ``aws_region`` and ``aws_model_id`` required; other fields ignored.
          *
          *     The combination is enforced by :meth:`_require_credentials_for_type`.
          *     See ``build_create_payload`` in ``services/llm/connector_storage.py``
@@ -2948,6 +2950,14 @@ export interface components {
         ConnectorCreate: {
             /** Api Key */
             api_key?: string | null;
+            /** Aws Access Key Id */
+            aws_access_key_id?: string | null;
+            /** Aws Model Id */
+            aws_model_id?: string | null;
+            /** Aws Region */
+            aws_region?: string | null;
+            /** Aws Secret Access Key */
+            aws_secret_access_key?: string | null;
             /** Base Url */
             base_url?: string | null;
             /** Bearer */
@@ -2956,7 +2966,7 @@ export interface components {
              * Connector Type
              * @enum {string}
              */
-            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible";
+            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible" | "bedrock";
             /** Display Name */
             display_name: string;
             /** Model Hint */
@@ -2972,6 +2982,14 @@ export interface components {
         ConnectorCredentialsRotate: {
             /** Api Key */
             api_key?: string | null;
+            /** Aws Access Key Id */
+            aws_access_key_id?: string | null;
+            /** Aws Model Id */
+            aws_model_id?: string | null;
+            /** Aws Region */
+            aws_region?: string | null;
+            /** Aws Secret Access Key */
+            aws_secret_access_key?: string | null;
             /** Base Url */
             base_url?: string | null;
             /** Bearer */
@@ -2988,7 +3006,7 @@ export interface components {
              * Connector Type
              * @enum {string}
              */
-            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible";
+            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible" | "bedrock";
             /**
              * Created At
              * Format: date-time
@@ -4174,7 +4192,7 @@ export interface components {
              * Connector Type
              * @enum {string}
              */
-            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible";
+            connector_type: "openai_apikey" | "anthropic_apikey" | "openai_compatible" | "bedrock";
             /** Display Name */
             display_name: string;
             /** Dj Username */

--- a/server/app/api/llm.py
+++ b/server/app/api/llm.py
@@ -127,6 +127,10 @@ def create_connector_endpoint(
             base_url=payload.base_url,
             bearer=payload.bearer,
             model_hint=payload.model_hint,
+            aws_access_key_id=payload.aws_access_key_id,
+            aws_secret_access_key=payload.aws_secret_access_key,
+            aws_region=payload.aws_region,
+            aws_model_id=payload.aws_model_id,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -207,6 +211,10 @@ def rotate_connector_credentials(
             api_key=payload.api_key,
             base_url=payload.base_url,
             bearer=payload.bearer,
+            aws_access_key_id=payload.aws_access_key_id,
+            aws_secret_access_key=payload.aws_secret_access_key,
+            aws_region=payload.aws_region,
+            aws_model_id=payload.aws_model_id,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/server/app/models/llm_connector.py
+++ b/server/app/models/llm_connector.py
@@ -28,12 +28,14 @@ from app.models.base import Base
 CONNECTOR_TYPE_OPENAI_APIKEY = "openai_apikey"
 CONNECTOR_TYPE_ANTHROPIC_APIKEY = "anthropic_apikey"
 CONNECTOR_TYPE_OPENAI_COMPATIBLE = "openai_compatible"
+CONNECTOR_TYPE_BEDROCK = "bedrock"
 
 VALID_CONNECTOR_TYPES = frozenset(
     {
         CONNECTOR_TYPE_OPENAI_APIKEY,
         CONNECTOR_TYPE_ANTHROPIC_APIKEY,
         CONNECTOR_TYPE_OPENAI_COMPATIBLE,
+        CONNECTOR_TYPE_BEDROCK,
     }
 )
 
@@ -58,6 +60,8 @@ class LlmConnector(Base):
     `credentials` is a JSON string encrypted via Fernet. Shape varies by type:
     - openai_apikey / anthropic_apikey: {"api_key": "..."}
     - openai_compatible: {"base_url": "...", "bearer": "..." | null}
+    - bedrock: {"aws_access_key_id": "...", "aws_secret_access_key": "...",
+      "aws_region": "...", "aws_model_id": "..."}
 
     `base_url_plain` mirrors the openai_compatible base_url in plaintext so admin
     listing can render without decrypting. Contains no credentials.

--- a/server/app/schemas/llm.py
+++ b/server/app/schemas/llm.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-ConnectorType = Literal["openai_apikey", "anthropic_apikey", "openai_compatible"]
+ConnectorType = Literal["openai_apikey", "anthropic_apikey", "openai_compatible", "bedrock"]
 ConnectorStatus = Literal["active", "auth_invalid", "disabled"]
 
 
@@ -44,6 +44,8 @@ class ConnectorCreate(BaseModel):
       ``base_url`` and ``bearer`` are ignored.
     - ``openai_compatible``: ``base_url`` required; ``bearer`` optional;
       ``api_key`` is ignored.
+    - ``bedrock``: ``aws_access_key_id``, ``aws_secret_access_key``,
+      ``aws_region`` and ``aws_model_id`` required; other fields ignored.
 
     The combination is enforced by :meth:`_require_credentials_for_type`.
     See ``build_create_payload`` in ``services/llm/connector_storage.py``
@@ -61,6 +63,12 @@ class ConnectorCreate(BaseModel):
     base_url: str | None = Field(default=None, max_length=512)
     bearer: str | None = Field(default=None, max_length=512)
 
+    # Set for bedrock (AWS SigV4 — billed to the DJ's AWS account)
+    aws_access_key_id: str | None = Field(default=None, max_length=128)
+    aws_secret_access_key: str | None = Field(default=None, max_length=512)
+    aws_region: str | None = Field(default=None, max_length=64)
+    aws_model_id: str | None = Field(default=None, max_length=128)
+
     @model_validator(mode="after")
     def _require_credentials_for_type(self) -> ConnectorCreate:
         if self.connector_type in ("openai_apikey", "anthropic_apikey"):
@@ -69,6 +77,19 @@ class ConnectorCreate(BaseModel):
         elif self.connector_type == "openai_compatible":
             if not self.base_url:
                 raise ValueError("base_url is required for openai_compatible connectors")
+        elif self.connector_type == "bedrock":
+            missing = [
+                name
+                for name, value in (
+                    ("aws_access_key_id", self.aws_access_key_id),
+                    ("aws_secret_access_key", self.aws_secret_access_key),
+                    ("aws_region", self.aws_region),
+                    ("aws_model_id", self.aws_model_id),
+                )
+                if not value
+            ]
+            if missing:
+                raise ValueError("bedrock connectors require " + ", ".join(missing))
         return self
 
 
@@ -90,10 +111,24 @@ class ConnectorCredentialsRotate(BaseModel):
     base_url: str | None = Field(default=None, max_length=512)
     bearer: str | None = Field(default=None, max_length=512)
 
+    # Set when rotating bedrock credentials.
+    aws_access_key_id: str | None = Field(default=None, max_length=128)
+    aws_secret_access_key: str | None = Field(default=None, max_length=512)
+    aws_region: str | None = Field(default=None, max_length=64)
+    aws_model_id: str | None = Field(default=None, max_length=128)
+
     @model_validator(mode="after")
     def _require_at_least_one(self) -> ConnectorCredentialsRotate:
-        if not (self.api_key or self.base_url or self.bearer):
-            raise ValueError("At least one of api_key, base_url, or bearer must be provided")
+        if not (
+            self.api_key
+            or self.base_url
+            or self.bearer
+            or self.aws_access_key_id
+            or self.aws_secret_access_key
+            or self.aws_region
+            or self.aws_model_id
+        ):
+            raise ValueError("At least one credential field must be provided")
         return self
 
 

--- a/server/app/services/llm/adapters/bedrock.py
+++ b/server/app/services/llm/adapters/bedrock.py
@@ -172,7 +172,9 @@ class BedrockAdapter(LlmAdapter):
         return body, None
 
     def _build_llama_body(self, request: ChatRequest) -> tuple[dict, set[str] | None]:
-        tool_names = {t.name for t in request.tools} if request.tools else None
+        # When no tools are configured, pass an empty set (not None) so generated
+        # {"name","input"} JSON is never misclassified as a tool call.
+        tool_names = {t.name for t in request.tools} if request.tools else set()
         tool_instructions = render_llama_tool_instructions(request.tools, request.force_tool)
         prompt = _render_llama_prompt(request, tool_instructions)
         body: dict[str, Any] = {"prompt": prompt}

--- a/server/app/services/llm/adapters/bedrock.py
+++ b/server/app/services/llm/adapters/bedrock.py
@@ -1,0 +1,290 @@
+"""AWS Bedrock adapter — SigV4-signed ``InvokeModel`` over httpx (no boto3).
+
+Billing flows to the DJ's own AWS account. Auth is AWS Signature V4 (not a
+Bearer token), implemented manually in ``services/llm/sigv4.py`` so we add no
+new dependency.
+
+Per-family request/response handling, keyed off ``aws_model_id``:
+
+- ``anthropic.*`` (Claude on Bedrock) — uses the Anthropic Messages body
+  (``anthropic_version`` + ``messages`` + ``tools``), so it reuses the existing
+  Anthropic tool-schema translation and response parser.
+- ``meta.*`` / ``llama*`` (Llama on Bedrock) — uses the Llama prompt body.
+  Llama has no structured tool field, so tools are described in the system
+  prompt and tool calls are parsed out of the generated text.
+
+Other families are rejected with a ``ToolTranslationError`` (clear message)
+rather than guessing a body shape.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import httpx
+
+from app.core.time import utcnow
+from app.services.llm.base import ChatRequest, ChatResponse, LlmAdapter, Message
+from app.services.llm.exceptions import (
+    AuthInvalid,
+    ProviderUnavailable,
+    QuotaExceeded,
+    RateLimited,
+    ToolTranslationError,
+)
+from app.services.llm.registry import register_adapter
+from app.services.llm.sigv4 import sign_request
+from app.services.llm.tool_translation import (
+    parse_anthropic_response,
+    parse_llama_response,
+    render_llama_tool_instructions,
+    to_anthropic_tools,
+)
+
+logger = logging.getLogger(__name__)
+
+ANTHROPIC_BEDROCK_VERSION = "bedrock-2023-05-31"
+DEFAULT_MAX_TOKENS = 1024
+DEFAULT_TIMEOUT_SECONDS = 30.0
+MAX_TIMEOUT_SECONDS = 120.0
+
+FAMILY_ANTHROPIC = "anthropic"
+FAMILY_LLAMA = "llama"
+
+
+def model_family(model_id: str) -> str:
+    """Map a Bedrock model id (or inference-profile id) to a request family."""
+    mid = (model_id or "").lower()
+    # Inference profiles prefix the region, e.g. "us.anthropic.claude-...".
+    if "anthropic." in mid:
+        return FAMILY_ANTHROPIC
+    if "meta." in mid or "llama" in mid:
+        return FAMILY_LLAMA
+    raise ToolTranslationError(f"Unsupported Bedrock model family for model_id={model_id!r}")
+
+
+class BedrockAdapter(LlmAdapter):
+    connector_type = "bedrock"
+
+    def _extract_credentials(self) -> dict[str, str]:
+        raw = self.connector.credentials or ""
+        try:
+            blob = json.loads(raw)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise AuthInvalid("Connector credentials are malformed") from exc
+        if not isinstance(blob, dict):
+            raise AuthInvalid("Connector credentials shape is invalid")
+        for field in ("aws_access_key_id", "aws_secret_access_key", "aws_region", "aws_model_id"):
+            if not blob.get(field):
+                raise AuthInvalid(f"Connector is missing {field}")
+        return {k: str(v) for k, v in blob.items()}
+
+    def _resolve_model_id(self, request: ChatRequest, creds: dict[str, str]) -> str:
+        # ChatRequest.model / model_hint override the stored aws_model_id.
+        return request.model or self.connector.model_hint or creds["aws_model_id"]
+
+    async def chat(self, request: ChatRequest) -> ChatResponse:
+        creds = self._extract_credentials()
+        model_id = self._resolve_model_id(request, creds)
+        family = model_family(model_id)
+
+        if family == FAMILY_ANTHROPIC:
+            body, tool_names = self._build_anthropic_body(request)
+        else:  # FAMILY_LLAMA
+            body, tool_names = self._build_llama_body(request)
+
+        payload = json.dumps(body).encode("utf-8")
+        timeout = min(
+            max(request.timeout_seconds or DEFAULT_TIMEOUT_SECONDS, 1.0),
+            MAX_TIMEOUT_SECONDS,
+        )
+
+        region = creds["aws_region"]
+        host = f"bedrock-runtime.{region}.amazonaws.com"
+        canonical_uri = f"/model/{model_id}/invoke"
+        url = f"https://{host}{canonical_uri}"
+
+        signed_headers = sign_request(
+            access_key_id=creds["aws_access_key_id"],
+            secret_access_key=creds["aws_secret_access_key"],
+            region=region,
+            host=host,
+            canonical_uri=canonical_uri,
+            body=payload,
+            now=utcnow(),
+        )
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            **signed_headers,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.post(url, content=payload, headers=headers)
+        except httpx.TimeoutException as exc:
+            raise ProviderUnavailable("Upstream timeout") from exc
+        except httpx.HTTPError as exc:
+            raise ProviderUnavailable("Upstream network error") from exc
+
+        _raise_for_status(resp)
+
+        try:
+            response_body = resp.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ToolTranslationError("Upstream returned non-JSON body") from exc
+
+        if family == FAMILY_ANTHROPIC:
+            parsed = parse_anthropic_response(response_body)
+        else:
+            parsed = parse_llama_response(response_body, tool_names=tool_names)
+        # The Bedrock model id is the source of truth for telemetry — the
+        # InvokeModel body doesn't reliably echo the full id.
+        parsed.model = model_id
+        return parsed
+
+    async def health_check(self) -> None:
+        ping = ChatRequest(
+            messages=[Message(role="user", content="ping")],
+            max_tokens=1,
+            temperature=0.0,
+        )
+        await self.chat(ping)
+
+    # -- Per-family request bodies -----------------------------------------
+    def _build_anthropic_body(self, request: ChatRequest) -> tuple[dict, set[str] | None]:
+        tools, choice = to_anthropic_tools(request.tools, request.force_tool)
+        body: dict[str, Any] = {
+            "anthropic_version": ANTHROPIC_BEDROCK_VERSION,
+            "max_tokens": request.max_tokens or DEFAULT_MAX_TOKENS,
+            "messages": self._anthropic_messages(request.messages),
+        }
+        if request.system:
+            body["system"] = request.system
+        if request.temperature is not None:
+            body["temperature"] = request.temperature
+        if tools:
+            body["tools"] = tools
+        if choice is not None:
+            body["tool_choice"] = choice
+        return body, None
+
+    def _build_llama_body(self, request: ChatRequest) -> tuple[dict, set[str] | None]:
+        tool_names = {t.name for t in request.tools} if request.tools else None
+        tool_instructions = render_llama_tool_instructions(request.tools, request.force_tool)
+        prompt = _render_llama_prompt(request, tool_instructions)
+        body: dict[str, Any] = {"prompt": prompt}
+        if request.max_tokens is not None:
+            body["max_gen_len"] = request.max_tokens
+        if request.temperature is not None:
+            body["temperature"] = request.temperature
+        return body, tool_names
+
+    @staticmethod
+    def _anthropic_messages(messages: list[Message]) -> list[dict]:
+        out: list[dict] = []
+        for m in messages:
+            if m.role == "system":
+                continue
+            content = m.content
+            if isinstance(content, list):
+                text = "".join(getattr(b, "text", "") or "" for b in content)
+            else:
+                text = content or ""
+            if m.role == "tool":
+                if not m.tool_call_id:
+                    raise ToolTranslationError("Tool message missing tool_call_id")
+                out.append(
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": m.tool_call_id,
+                                "content": text,
+                            }
+                        ],
+                    }
+                )
+                continue
+            role = "assistant" if m.role == "assistant" else "user"
+            out.append({"role": role, "content": text})
+        return out
+
+
+def _render_llama_prompt(request: ChatRequest, tool_instructions: str | None) -> str:
+    """Render canonical messages into Llama 3's instruction-tuned chat format."""
+    parts: list[str] = ["<|begin_of_text|>"]
+
+    system_chunks: list[str] = []
+    if request.system:
+        system_chunks.append(request.system)
+    if tool_instructions:
+        system_chunks.append(tool_instructions)
+    for m in request.messages:
+        if m.role == "system":
+            system_chunks.append(_message_text(m))
+    if system_chunks:
+        parts.append(
+            "<|start_header_id|>system<|end_header_id|>\n\n"
+            + "\n\n".join(system_chunks)
+            + "<|eot_id|>"
+        )
+
+    for m in request.messages:
+        if m.role == "system":
+            continue
+        role = "assistant" if m.role == "assistant" else "user"
+        parts.append(f"<|start_header_id|>{role}<|end_header_id|>\n\n{_message_text(m)}<|eot_id|>")
+
+    parts.append("<|start_header_id|>assistant<|end_header_id|>\n\n")
+    return "".join(parts)
+
+
+def _message_text(m: Message) -> str:
+    content = m.content
+    if isinstance(content, list):
+        return "".join(getattr(b, "text", "") or "" for b in content)
+    return content or ""
+
+
+def _raise_for_status(resp: httpx.Response) -> None:
+    if 200 <= resp.status_code < 300:
+        return
+    code = resp.status_code
+    if code in (401, 403):
+        raise AuthInvalid(f"Auth failed (HTTP {code})")
+    if code == 402:
+        raise QuotaExceeded("Quota or billing failure (HTTP 402)")
+    # Bedrock throttling can arrive as 429, or as 400 with a ThrottlingException
+    # error-type header. Treat both as rate-limited so callers back off.
+    if code == 429 or (code == 400 and _is_throttle(resp)):
+        retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
+        raise RateLimited("Rate limited (HTTP 429)", retry_after_seconds=retry_after)
+    if 500 <= code < 600:
+        raise ProviderUnavailable(f"Upstream error (HTTP {code})")
+    raise ToolTranslationError(f"Upstream rejected request (HTTP {code})")
+
+
+def _is_throttle(resp: httpx.Response) -> bool:
+    """Bedrock signals throttling via the ``ThrottlingException`` error type.
+
+    It can arrive as HTTP 429 or, on some paths, HTTP 400 with an
+    ``x-amzn-errortype`` header. Detect both so callers back off correctly.
+    """
+    err_type = resp.headers.get("x-amzn-errortype") or resp.headers.get("X-Amzn-ErrorType") or ""
+    return "throttl" in err_type.lower()
+
+
+def _parse_retry_after(value: str | None) -> int | None:
+    if not value:
+        return None
+    try:
+        return int(float(value))
+    except ValueError:
+        return None
+
+
+register_adapter("bedrock", BedrockAdapter)

--- a/server/app/services/llm/connector_storage.py
+++ b/server/app/services/llm/connector_storage.py
@@ -18,6 +18,7 @@ from app.models.llm_connector import (
     AUDIT_POLICY_CHANGED,
     AUDIT_REVOKED_BY_ADMIN,
     CONNECTOR_TYPE_ANTHROPIC_APIKEY,
+    CONNECTOR_TYPE_BEDROCK,
     CONNECTOR_TYPE_OPENAI_APIKEY,
     CONNECTOR_TYPE_OPENAI_COMPATIBLE,
     STATUS_ACTIVE,
@@ -95,6 +96,10 @@ def build_create_payload(
     base_url: str | None = None,
     bearer: str | None = None,
     model_hint: str | None = None,
+    aws_access_key_id: str | None = None,
+    aws_secret_access_key: str | None = None,
+    aws_region: str | None = None,
+    aws_model_id: str | None = None,
 ) -> CreateConnectorPayload:
     """Translate request fields into a validated ``CreateConnectorPayload``.
 
@@ -143,6 +148,13 @@ def build_create_payload(
         except InvalidBaseUrlError as exc:
             raise ValueError(str(exc)) from exc
         creds = {"base_url": plain_base_url, "bearer": bearer or None}
+    elif connector_type == CONNECTOR_TYPE_BEDROCK:
+        creds = _build_bedrock_creds(
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_region=aws_region,
+            aws_model_id=aws_model_id,
+        )
     else:  # pragma: no cover — guarded by the membership check above
         raise ValueError(f"Unsupported connector_type: {connector_type!r}")
 
@@ -163,6 +175,57 @@ _SAFE_MODEL_CHARS = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012
 
 def _is_safe_model_hint(s: str) -> bool:
     return all(c in _SAFE_MODEL_CHARS for c in s)
+
+
+# AWS region tokens are lowercase alnum + hyphen (e.g. us-east-1, eu-central-1).
+_AWS_REGION_CHARS = set("abcdefghijklmnopqrstuvwxyz0123456789-")
+# Bedrock model ids look like "anthropic.claude-3-5-sonnet-20241022-v2:0" or
+# "meta.llama3-70b-instruct-v1:0" — allow the inference-profile/ARN-ish chars.
+_AWS_MODEL_ID_CHARS = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.:/")
+
+
+def _build_bedrock_creds(
+    *,
+    aws_access_key_id: str | None,
+    aws_secret_access_key: str | None,
+    aws_region: str | None,
+    aws_model_id: str | None,
+) -> dict[str, str]:
+    """Validate + assemble the bedrock credentials blob.
+
+    Raises :class:`ValueError` (→ HTTP 400) on any malformed field. No AWS
+    dependency: the access key id / secret are opaque strings; we only sanity
+    check shape and reject obviously-bad input before persisting.
+    """
+    access_key = (aws_access_key_id or "").strip()
+    secret_key = (aws_secret_access_key or "").strip()
+    region = (aws_region or "").strip()
+    model_id = (aws_model_id or "").strip()
+
+    if not access_key:
+        raise ValueError("aws_access_key_id is required")
+    if not secret_key:
+        raise ValueError("aws_secret_access_key is required")
+    if not region:
+        raise ValueError("aws_region is required")
+    if not model_id:
+        raise ValueError("aws_model_id is required")
+
+    if " " in access_key or "\n" in access_key or not all(c in _SAFE_CHARS for c in access_key):
+        raise ValueError("aws_access_key_id format is invalid")
+    if " " in secret_key or "\n" in secret_key:
+        raise ValueError("aws_secret_access_key format is invalid")
+    if not all(c in _AWS_REGION_CHARS for c in region):
+        raise ValueError("aws_region format is invalid")
+    if not all(c in _AWS_MODEL_ID_CHARS for c in model_id):
+        raise ValueError("aws_model_id format is invalid")
+
+    return {
+        "aws_access_key_id": access_key,
+        "aws_secret_access_key": secret_key,
+        "aws_region": region,
+        "aws_model_id": model_id,
+    }
 
 
 def _looks_like_api_key(connector_type: str, key: str) -> bool:
@@ -202,6 +265,10 @@ def rotate_credentials(
     api_key: str | None = None,
     base_url: str | None = None,
     bearer: str | None = None,
+    aws_access_key_id: str | None = None,
+    aws_secret_access_key: str | None = None,
+    aws_region: str | None = None,
+    aws_model_id: str | None = None,
 ) -> LlmConnector:
     """Rotate the credential blob in-place. Caller commits."""
     blob: dict[str, Any]
@@ -224,6 +291,21 @@ def rotate_credentials(
             raise ValueError(str(exc)) from exc
         blob = {"base_url": base_url, "bearer": bearer or None}
         connector.base_url_plain = base_url
+    elif connector.connector_type == CONNECTOR_TYPE_BEDROCK:
+        # Partial rotation: keep existing fields when a new value isn't supplied.
+        existing: dict[str, Any] = {}
+        try:
+            parsed = json.loads(connector.credentials or "{}")
+            if isinstance(parsed, dict):
+                existing = parsed
+        except (json.JSONDecodeError, TypeError):
+            existing = {}
+        blob = _build_bedrock_creds(
+            aws_access_key_id=aws_access_key_id or existing.get("aws_access_key_id"),
+            aws_secret_access_key=(aws_secret_access_key or existing.get("aws_secret_access_key")),
+            aws_region=aws_region or existing.get("aws_region"),
+            aws_model_id=aws_model_id or existing.get("aws_model_id"),
+        )
     else:  # pragma: no cover
         raise ValueError(f"Unsupported connector_type: {connector.connector_type!r}")
 

--- a/server/app/services/llm/registry.py
+++ b/server/app/services/llm/registry.py
@@ -55,6 +55,7 @@ def _bootstrap() -> None:
     # Local imports keep the registry module dependency-free at import time.
     from app.services.llm.adapters import (  # noqa: F401
         anthropic_apikey,
+        bedrock,
         openai_apikey,
         openai_compatible,
     )

--- a/server/app/services/llm/sigv4.py
+++ b/server/app/services/llm/sigv4.py
@@ -1,0 +1,141 @@
+"""Minimal AWS Signature Version 4 (SigV4) signing — dependency-free.
+
+We deliberately avoid ``boto3``/``botocore`` (per the CLAUDE.md CVE/dependency
+rule) and implement just enough of SigV4 to sign a single ``POST`` request to
+the Bedrock runtime ``InvokeModel`` endpoint over the existing ``httpx`` client.
+
+Reference: https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+
+This module is pure stdlib (``hashlib`` / ``hmac`` / ``datetime`` / ``urllib``)
+so it adds no new third-party surface area. It only signs the request shape the
+Bedrock adapter produces — it is not a general-purpose AWS signer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from datetime import datetime
+from urllib.parse import quote
+
+_ALGORITHM = "AWS4-HMAC-SHA256"
+_SERVICE = "bedrock"
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _hmac_sha256(key: bytes, msg: str) -> bytes:
+    return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
+
+
+def _signing_key(secret_key: str, date_stamp: str, region: str, service: str) -> bytes:
+    """Derive the SigV4 signing key (the chained-HMAC ``kSigning``)."""
+    k_date = _hmac_sha256(("AWS4" + secret_key).encode("utf-8"), date_stamp)
+    k_region = _hmac_sha256(k_date, region)
+    k_service = _hmac_sha256(k_region, service)
+    return _hmac_sha256(k_service, "aws4_request")
+
+
+def sign_request(
+    *,
+    access_key_id: str,
+    secret_access_key: str,
+    region: str,
+    host: str,
+    canonical_uri: str,
+    body: bytes,
+    now: datetime,
+    service: str = _SERVICE,
+    content_type: str = "application/json",
+    session_token: str | None = None,
+) -> dict[str, str]:
+    """Return the headers required to authenticate a signed ``POST`` request.
+
+    ``canonical_uri`` is the request path (already percent-encoded as needed,
+    e.g. ``/model/anthropic.claude-3-5-sonnet-20241022-v2:0/invoke``). The
+    caller supplies the request ``body`` bytes; we hash and sign them.
+
+    The returned dict includes ``Authorization``, ``X-Amz-Date``,
+    ``X-Amz-Content-Sha256`` (and ``X-Amz-Security-Token`` when a session token
+    is provided). Callers merge these with ``Content-Type``/``Accept``.
+    """
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+    date_stamp = now.strftime("%Y%m%d")
+
+    payload_hash = _sha256_hex(body)
+
+    # --- Canonical request -------------------------------------------------
+    # Headers must be sorted by lowercased name and trimmed. We sign the
+    # minimal set: host, content-type, x-amz-content-sha256, x-amz-date
+    # (+ x-amz-security-token when present).
+    canonical_headers_map = {
+        "content-type": content_type,
+        "host": host,
+        "x-amz-content-sha256": payload_hash,
+        "x-amz-date": amz_date,
+    }
+    if session_token:
+        canonical_headers_map["x-amz-security-token"] = session_token
+
+    signed_headers = ";".join(sorted(canonical_headers_map))
+    canonical_headers = "".join(
+        f"{name}:{canonical_headers_map[name]}\n" for name in sorted(canonical_headers_map)
+    )
+
+    canonical_request = "\n".join(
+        [
+            "POST",
+            _canonicalize_uri(canonical_uri),
+            "",  # no query string
+            canonical_headers,
+            signed_headers,
+            payload_hash,
+        ]
+    )
+
+    # --- String to sign ----------------------------------------------------
+    credential_scope = f"{date_stamp}/{region}/{service}/aws4_request"
+    string_to_sign = "\n".join(
+        [
+            _ALGORITHM,
+            amz_date,
+            credential_scope,
+            _sha256_hex(canonical_request.encode("utf-8")),
+        ]
+    )
+
+    # --- Signature ---------------------------------------------------------
+    signing_key = _signing_key(secret_access_key, date_stamp, region, service)
+    signature = hmac.new(signing_key, string_to_sign.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    authorization = (
+        f"{_ALGORITHM} "
+        f"Credential={access_key_id}/{credential_scope}, "
+        f"SignedHeaders={signed_headers}, "
+        f"Signature={signature}"
+    )
+
+    headers = {
+        "Authorization": authorization,
+        "X-Amz-Date": amz_date,
+        "X-Amz-Content-Sha256": payload_hash,
+    }
+    if session_token:
+        headers["X-Amz-Security-Token"] = session_token
+    return headers
+
+
+def _canonicalize_uri(path: str) -> str:
+    """Percent-encode each path segment per SigV4 rules (keeps ``/`` separators).
+
+    Bedrock model ids contain characters like ``:`` (e.g. ``...-v2:0``) which
+    must be encoded in the canonical URI even though they are valid in the URL.
+    """
+    if not path:
+        return "/"
+    segments = path.split("/")
+    # quote() leaves unreserved chars + nothing in safe=""; encode ':' too.
+    encoded = [quote(seg, safe="") for seg in segments]
+    return "/".join(encoded)

--- a/server/app/services/llm/tool_translation.py
+++ b/server/app/services/llm/tool_translation.py
@@ -210,3 +210,133 @@ def _normalise_anthropic_stop_reason(
     if reason == "max_tokens":
         return "max_tokens"
     return "error"
+
+
+# ---------------------------------------------------------------------------
+# Bedrock — Llama family
+#
+# Llama models on Bedrock (meta.llama*) have no structured tool/function field
+# in the InvokeModel request. The convention (matching Meta's tool-use prompt
+# format) is to describe the available tools inside the system prompt and ask
+# the model to emit a single JSON object as its reply. We then parse that JSON
+# back into a canonical ``ToolCall``.
+# ---------------------------------------------------------------------------
+def render_llama_tool_instructions(tools: list[ToolSpec] | None, force: str | None) -> str | None:
+    """Build a system-prompt fragment describing the available tools.
+
+    Returns ``None`` when there are no tools. When ``force`` is set, the
+    fragment instructs the model to call exactly that tool.
+    """
+    if not tools:
+        return None
+    if force is not None and not any(t.name == force for t in tools):
+        raise ToolTranslationError(f"force_tool={force!r} not in tools list")
+
+    lines = [
+        "You have access to the following tools. To call a tool, respond with "
+        "ONLY a single JSON object and no other text, of the form: "
+        '{"name": "<tool_name>", "input": {<arguments>}}.',
+    ]
+    for t in tools:
+        lines.append(
+            f"- {t.name}: {t.description} "
+            f"(input JSON schema: {json.dumps(t.input_schema, sort_keys=True)})"
+        )
+    if force is not None:
+        lines.append(f"You MUST call the tool named {force!r}.")
+    return "\n".join(lines)
+
+
+def parse_llama_response(payload: dict, tool_names: set[str] | None = None) -> ChatResponse:
+    """Parse a Bedrock Llama InvokeModel response body.
+
+    Bedrock Llama returns ``{"generation": "...", "stop_reason": "stop|length",
+    "prompt_token_count": int, "generation_token_count": int}``. When the
+    generated text is a tool-call JSON object whose ``name`` is one of the
+    expected tools, surface it as a ``ToolCall``.
+    """
+    if not isinstance(payload, dict):
+        raise ToolTranslationError("Bedrock Llama response is not a JSON object")
+
+    generation = payload.get("generation")
+    if generation is None:
+        raise ToolTranslationError("Bedrock Llama response missing 'generation'")
+    text = str(generation)
+
+    stop_reason = _normalise_llama_stop_reason(payload.get("stop_reason"))
+
+    usage = None
+    prompt_tokens = payload.get("prompt_token_count")
+    completion_tokens = payload.get("generation_token_count")
+    if prompt_tokens is not None and completion_tokens is not None:
+        usage = TokenUsage(prompt=int(prompt_tokens), completion=int(completion_tokens))
+
+    tool_calls: list[ToolCall] = []
+    parsed = _try_parse_tool_json(text)
+    if parsed is not None:
+        name = parsed.get("name")
+        tool_input = parsed.get("input")
+        if (
+            isinstance(name, str)
+            and name
+            and isinstance(tool_input, dict)
+            and (tool_names is None or name in tool_names)
+        ):
+            tool_calls.append(ToolCall(id=name, name=name, input=tool_input))
+            stop_reason = "tool_use"
+            text = ""
+
+    return ChatResponse(
+        text=text,
+        tool_calls=tool_calls,
+        stop_reason=stop_reason,
+        usage=usage,
+        model=None,
+    )
+
+
+def _try_parse_tool_json(text: str) -> dict | None:
+    """Best-effort extraction of a single ``{"name":..., "input":...}`` object.
+
+    Llama sometimes wraps the JSON in prose or code fences; we extract the first
+    balanced ``{...}`` span and attempt to decode it.
+    """
+    candidate = text.strip()
+    if not candidate:
+        return None
+    # Strip ``` fences if present.
+    if candidate.startswith("```"):
+        candidate = candidate.strip("`")
+        # drop a leading "json" language tag
+        if candidate.lower().startswith("json"):
+            candidate = candidate[4:]
+        candidate = candidate.strip()
+
+    start = candidate.find("{")
+    if start == -1:
+        return None
+    depth = 0
+    for i in range(start, len(candidate)):
+        ch = candidate[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                blob = candidate[start : i + 1]
+                try:
+                    obj = json.loads(blob)
+                except json.JSONDecodeError:
+                    return None
+                return obj if isinstance(obj, dict) else None
+    return None
+
+
+def _normalise_llama_stop_reason(
+    reason: str | None,
+) -> Literal["end_turn", "tool_use", "max_tokens", "error"]:
+    if reason in (None, "stop"):
+        return "end_turn"
+    if reason == "length":
+        return "max_tokens"
+    return "error"

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -190,7 +190,8 @@
             "enum": [
               "openai_apikey",
               "anthropic_apikey",
-              "openai_compatible"
+              "openai_compatible",
+              "bedrock"
             ],
             "title": "Connector Type",
             "type": "string"
@@ -1897,7 +1898,7 @@
         "type": "object"
       },
       "ConnectorCreate": {
-        "description": "Provider-agnostic create payload.\n\nField requirements vary by ``connector_type``:\n\n- ``openai_apikey`` / ``anthropic_apikey``: ``api_key`` required;\n  ``base_url`` and ``bearer`` are ignored.\n- ``openai_compatible``: ``base_url`` required; ``bearer`` optional;\n  ``api_key`` is ignored.\n\nThe combination is enforced by :meth:`_require_credentials_for_type`.\nSee ``build_create_payload`` in ``services/llm/connector_storage.py``\nfor the full validation flow (including key shape checks).",
+        "description": "Provider-agnostic create payload.\n\nField requirements vary by ``connector_type``:\n\n- ``openai_apikey`` / ``anthropic_apikey``: ``api_key`` required;\n  ``base_url`` and ``bearer`` are ignored.\n- ``openai_compatible``: ``base_url`` required; ``bearer`` optional;\n  ``api_key`` is ignored.\n- ``bedrock``: ``aws_access_key_id``, ``aws_secret_access_key``,\n  ``aws_region`` and ``aws_model_id`` required; other fields ignored.\n\nThe combination is enforced by :meth:`_require_credentials_for_type`.\nSee ``build_create_payload`` in ``services/llm/connector_storage.py``\nfor the full validation flow (including key shape checks).",
         "properties": {
           "api_key": {
             "anyOf": [
@@ -1910,6 +1911,54 @@
               }
             ],
             "title": "Api Key"
+          },
+          "aws_access_key_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aws Access Key Id"
+          },
+          "aws_model_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aws Model Id"
+          },
+          "aws_region": {
+            "anyOf": [
+              {
+                "maxLength": 64,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aws Region"
+          },
+          "aws_secret_access_key": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aws Secret Access Key"
           },
           "base_url": {
             "anyOf": [
@@ -1939,7 +1988,8 @@
             "enum": [
               "openai_apikey",
               "anthropic_apikey",
-              "openai_compatible"
+              "openai_compatible",
+              "bedrock"
             ],
             "title": "Connector Type",
             "type": "string"
@@ -1984,6 +2034,54 @@
               }
             ],
             "title": "Api Key"
+          },
+          "aws_access_key_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aws Access Key Id"
+          },
+          "aws_model_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aws Model Id"
+          },
+          "aws_region": {
+            "anyOf": [
+              {
+                "maxLength": 64,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aws Region"
+          },
+          "aws_secret_access_key": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aws Secret Access Key"
           },
           "base_url": {
             "anyOf": [
@@ -2031,7 +2129,8 @@
             "enum": [
               "openai_apikey",
               "anthropic_apikey",
-              "openai_compatible"
+              "openai_compatible",
+              "bedrock"
             ],
             "title": "Connector Type",
             "type": "string"
@@ -5675,7 +5774,8 @@
             "enum": [
               "openai_apikey",
               "anthropic_apikey",
-              "openai_compatible"
+              "openai_compatible",
+              "bedrock"
             ],
             "title": "Connector Type",
             "type": "string"

--- a/server/tests/test_llm_api.py
+++ b/server/tests/test_llm_api.py
@@ -111,6 +111,7 @@ class TestPerDJConnectorsCRUD:
         row = db.query(LlmConnector).filter(LlmConnector.id == data["id"]).one()
         blob = json.loads(row.credentials)
         assert blob["aws_access_key_id"] == "AKIAEXAMPLEKEY12345"
+        assert blob["aws_secret_access_key"] == "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
         assert blob["aws_region"] == "us-east-1"
         assert blob["aws_model_id"] == "anthropic.claude-3-5-sonnet-20241022-v2:0"
 
@@ -177,6 +178,7 @@ class TestPerDJConnectorsCRUD:
         assert blob["aws_secret_access_key"] == "newsecret"
         assert blob["aws_access_key_id"] == "AKIAOLDKEY1234567890"
         assert blob["aws_region"] == "us-east-1"
+        assert blob["aws_model_id"] == "anthropic.claude-3-5-sonnet-20241022-v2:0"
 
     def test_create_openai_compatible_rejects_public_http(self, client: TestClient, auth_headers):
         body = {

--- a/server/tests/test_llm_api.py
+++ b/server/tests/test_llm_api.py
@@ -92,6 +92,92 @@ class TestPerDJConnectorsCRUD:
         data = resp.json()
         assert data["base_url_plain"] == "http://127.0.0.1:11434/v1"
 
+    def test_create_bedrock_happy_path(self, client: TestClient, auth_headers, db, test_user):
+        body = {
+            "connector_type": "bedrock",
+            "display_name": "My Bedrock",
+            "aws_access_key_id": "AKIAEXAMPLEKEY12345",
+            "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            "aws_region": "us-east-1",
+            "aws_model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        }
+        resp = client.post("/api/llm/connectors", json=body, headers=auth_headers)
+        assert resp.status_code == 201, resp.json()
+        data = resp.json()
+        assert data["connector_type"] == "bedrock"
+        # base_url_plain stays null — no plaintext credential surface for bedrock.
+        assert data["base_url_plain"] is None
+        # Verify the encrypted blob round-trips with all four AWS fields.
+        row = db.query(LlmConnector).filter(LlmConnector.id == data["id"]).one()
+        blob = json.loads(row.credentials)
+        assert blob["aws_access_key_id"] == "AKIAEXAMPLEKEY12345"
+        assert blob["aws_region"] == "us-east-1"
+        assert blob["aws_model_id"] == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+
+    def test_create_bedrock_requires_all_aws_fields(self, client: TestClient, auth_headers):
+        body = {
+            "connector_type": "bedrock",
+            "display_name": "Incomplete",
+            "aws_access_key_id": "AKIAEXAMPLEKEY12345",
+            "aws_secret_access_key": "secret",
+            # missing aws_region + aws_model_id
+        }
+        resp = client.post("/api/llm/connectors", json=body, headers=auth_headers)
+        # model_validator → ValueError → 422 (pydantic) before our handler
+        assert resp.status_code in (400, 422)
+
+    def test_create_bedrock_blocked_when_apikey_connectors_disabled(
+        self, client: TestClient, auth_headers, db
+    ):
+        from app.services.system_settings import get_system_settings
+
+        settings = get_system_settings(db)
+        settings.llm_apikey_connectors_enabled = False
+        db.commit()
+
+        body = {
+            "connector_type": "bedrock",
+            "display_name": "Blocked Bedrock",
+            "aws_access_key_id": "AKIAEXAMPLEKEY12345",
+            "aws_secret_access_key": "secret",
+            "aws_region": "us-east-1",
+            "aws_model_id": "meta.llama3-70b-instruct-v1:0",
+        }
+        resp = client.post("/api/llm/connectors", json=body, headers=auth_headers)
+        assert resp.status_code == 403
+
+    def test_rotate_bedrock_credentials(self, client: TestClient, auth_headers, db, test_user):
+        row = LlmConnector(
+            user_id=test_user.id,
+            connector_type="bedrock",
+            display_name="Rotatable",
+            status="active",
+            credentials=json.dumps(
+                {
+                    "aws_access_key_id": "AKIAOLDKEY1234567890",
+                    "aws_secret_access_key": "oldsecret",
+                    "aws_region": "us-east-1",
+                    "aws_model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+                }
+            ),
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+
+        # Rotate only the secret — other fields must be preserved.
+        resp = client.put(
+            f"/api/llm/connectors/{row.id}/credentials",
+            json={"aws_secret_access_key": "newsecret"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.json()
+        db.refresh(row)
+        blob = json.loads(row.credentials)
+        assert blob["aws_secret_access_key"] == "newsecret"
+        assert blob["aws_access_key_id"] == "AKIAOLDKEY1234567890"
+        assert blob["aws_region"] == "us-east-1"
+
     def test_create_openai_compatible_rejects_public_http(self, client: TestClient, auth_headers):
         body = {
             "connector_type": "openai_compatible",

--- a/server/tests/test_llm_bedrock_adapter.py
+++ b/server/tests/test_llm_bedrock_adapter.py
@@ -1,0 +1,363 @@
+"""Tests for the AWS Bedrock adapter (SigV4 over httpx, no boto3).
+
+The HTTP boundary is mocked — we never reach real AWS. Both Bedrock Claude
+(``anthropic.*``) and Bedrock Llama (``meta.*``) model families are exercised
+because their request bodies and tool semantics differ.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from app.services.llm.adapters.bedrock import BedrockAdapter, model_family
+from app.services.llm.base import ChatRequest, Message, ToolSpec
+from app.services.llm.exceptions import (
+    AuthInvalid,
+    ProviderUnavailable,
+    QuotaExceeded,
+    RateLimited,
+    ToolTranslationError,
+)
+
+_HTTPX_PATH = "app.services.llm.adapters.bedrock.httpx.AsyncClient"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _bedrock_connector(model_id="anthropic.claude-3-5-sonnet-20241022-v2:0"):
+    return SimpleNamespace(
+        connector_type="bedrock",
+        credentials=json.dumps(
+            {
+                "aws_access_key_id": "AKIDEXAMPLE",
+                "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                "aws_region": "us-east-1",
+                "aws_model_id": model_id,
+            }
+        ),
+        model_hint=None,
+        base_url_plain=None,
+    )
+
+
+def _anthropic_body(text="hi"):
+    return {
+        "model": "claude",
+        "stop_reason": "end_turn",
+        "content": [{"type": "text", "text": text}],
+        "usage": {"input_tokens": 3, "output_tokens": 1},
+    }
+
+
+def _anthropic_tool_body(name, tool_input):
+    return {
+        "model": "claude",
+        "stop_reason": "tool_use",
+        "content": [{"type": "tool_use", "id": "tu_1", "name": name, "input": tool_input}],
+        "usage": {"input_tokens": 5, "output_tokens": 2},
+    }
+
+
+def _llama_body(generation, stop_reason="stop"):
+    return {
+        "generation": generation,
+        "stop_reason": stop_reason,
+        "prompt_token_count": 7,
+        "generation_token_count": 4,
+    }
+
+
+def _ok(json_body):
+    return httpx.Response(
+        200,
+        request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/x"),
+        json=json_body,
+    )
+
+
+class _AsyncClient:
+    def __init__(self, response):
+        self._response = response
+        self.calls: list = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    async def post(self, url, content=None, headers=None):
+        self.calls.append({"url": url, "content": content, "headers": headers})
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+
+# ---------------------------------------------------------------------------
+# model family detection
+# ---------------------------------------------------------------------------
+class TestModelFamily:
+    def test_anthropic_family(self):
+        assert model_family("anthropic.claude-3-5-sonnet-20241022-v2:0") == "anthropic"
+
+    def test_anthropic_inference_profile_prefix(self):
+        assert model_family("us.anthropic.claude-3-5-haiku-20241022-v1:0") == "anthropic"
+
+    def test_llama_family_meta_prefix(self):
+        assert model_family("meta.llama3-70b-instruct-v1:0") == "llama"
+
+    def test_llama_family_name_match(self):
+        assert model_family("us.meta.llama3-1-8b-instruct-v1:0") == "llama"
+
+    def test_unknown_family_raises(self):
+        with pytest.raises(ToolTranslationError):
+            model_family("amazon.titan-text-express-v1")
+
+
+# ---------------------------------------------------------------------------
+# Bedrock Claude (anthropic.*)
+# ---------------------------------------------------------------------------
+class TestBedrockClaude:
+    @pytest.mark.asyncio
+    async def test_happy_path_signs_and_parses(self):
+        adapter = BedrockAdapter(_bedrock_connector())
+        client = _AsyncClient(_ok(_anthropic_body("pong")))
+        with patch(_HTTPX_PATH, return_value=client):
+            resp = await adapter.chat(ChatRequest(messages=[Message(role="user", content="hi")]))
+
+        assert resp.text == "pong"
+        assert resp.usage.prompt == 3
+        assert resp.usage.completion == 1
+        assert resp.model == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+        # SigV4 auth — not a bearer token.
+        auth = client.calls[0]["headers"]["Authorization"]
+        assert auth.startswith("AWS4-HMAC-SHA256 ")
+        assert "X-Amz-Date" in client.calls[0]["headers"]
+        assert client.calls[0]["url"].endswith(
+            "/model/anthropic.claude-3-5-sonnet-20241022-v2:0/invoke"
+        )
+
+    @pytest.mark.asyncio
+    async def test_request_body_uses_anthropic_schema(self):
+        adapter = BedrockAdapter(_bedrock_connector())
+        client = _AsyncClient(_ok(_anthropic_body()))
+        with patch(_HTTPX_PATH, return_value=client):
+            await adapter.chat(
+                ChatRequest(messages=[Message(role="user", content="hi")], system="be terse")
+            )
+        body = json.loads(client.calls[0]["content"])
+        assert body["anthropic_version"] == "bedrock-2023-05-31"
+        assert body["system"] == "be terse"
+        assert body["messages"] == [{"role": "user", "content": "hi"}]
+
+    @pytest.mark.asyncio
+    async def test_tool_use_reuses_anthropic_translation(self):
+        adapter = BedrockAdapter(_bedrock_connector())
+        tool = ToolSpec(name="pick", description="pick a song", input_schema={"type": "object"})
+        client = _AsyncClient(_ok(_anthropic_tool_body("pick", {"q": "house"})))
+        with patch(_HTTPX_PATH, return_value=client):
+            resp = await adapter.chat(
+                ChatRequest(
+                    messages=[Message(role="user", content="hi")],
+                    tools=[tool],
+                    force_tool="pick",
+                )
+            )
+        assert resp.stop_reason == "tool_use"
+        assert resp.tool_calls[0].name == "pick"
+        assert resp.tool_calls[0].input == {"q": "house"}
+        body = json.loads(client.calls[0]["content"])
+        assert body["tools"][0]["name"] == "pick"
+        assert body["tool_choice"] == {"type": "tool", "name": "pick"}
+
+
+# ---------------------------------------------------------------------------
+# Bedrock Llama (meta.*)
+# ---------------------------------------------------------------------------
+class TestBedrockLlama:
+    @pytest.mark.asyncio
+    async def test_happy_path_prompt_body(self):
+        adapter = BedrockAdapter(_bedrock_connector("meta.llama3-70b-instruct-v1:0"))
+        client = _AsyncClient(_ok(_llama_body("hello there")))
+        with patch(_HTTPX_PATH, return_value=client):
+            resp = await adapter.chat(ChatRequest(messages=[Message(role="user", content="hi")]))
+        assert resp.text == "hello there"
+        assert resp.stop_reason == "end_turn"
+        assert resp.usage.prompt == 7
+        assert resp.usage.completion == 4
+        assert resp.model == "meta.llama3-70b-instruct-v1:0"
+        body = json.loads(client.calls[0]["content"])
+        # Llama uses a prompt string, not anthropic messages.
+        assert "prompt" in body
+        assert "anthropic_version" not in body
+        assert "<|begin_of_text|>" in body["prompt"]
+
+    @pytest.mark.asyncio
+    async def test_length_stop_reason_maps_to_max_tokens(self):
+        adapter = BedrockAdapter(_bedrock_connector("meta.llama3-70b-instruct-v1:0"))
+        client = _AsyncClient(_ok(_llama_body("partial", stop_reason="length")))
+        with patch(_HTTPX_PATH, return_value=client):
+            resp = await adapter.chat(ChatRequest(messages=[Message(role="user", content="hi")]))
+        assert resp.stop_reason == "max_tokens"
+
+    @pytest.mark.asyncio
+    async def test_tool_call_parsed_from_generation_json(self):
+        adapter = BedrockAdapter(_bedrock_connector("meta.llama3-1-70b-instruct-v1:0"))
+        tool = ToolSpec(name="pick", description="pick", input_schema={"type": "object"})
+        generation = '{"name": "pick", "input": {"q": "techno"}}'
+        client = _AsyncClient(_ok(_llama_body(generation)))
+        with patch(_HTTPX_PATH, return_value=client):
+            resp = await adapter.chat(
+                ChatRequest(
+                    messages=[Message(role="user", content="hi")],
+                    tools=[tool],
+                    force_tool="pick",
+                )
+            )
+        assert resp.stop_reason == "tool_use"
+        assert resp.tool_calls[0].name == "pick"
+        assert resp.tool_calls[0].input == {"q": "techno"}
+        # Tool instructions are embedded in the prompt for Llama.
+        body = json.loads(client.calls[0]["content"])
+        assert "pick" in body["prompt"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_name_in_generation_is_plain_text(self):
+        adapter = BedrockAdapter(_bedrock_connector("meta.llama3-70b-instruct-v1:0"))
+        tool = ToolSpec(name="pick", description="pick", input_schema={"type": "object"})
+        generation = '{"name": "other", "input": {}}'
+        client = _AsyncClient(_ok(_llama_body(generation)))
+        with patch(_HTTPX_PATH, return_value=client):
+            resp = await adapter.chat(
+                ChatRequest(messages=[Message(role="user", content="hi")], tools=[tool])
+            )
+        assert resp.tool_calls == []
+        assert resp.text == generation
+
+
+# ---------------------------------------------------------------------------
+# Error mapping (shared) — exercised via the Claude family
+# ---------------------------------------------------------------------------
+class TestBedrockErrorMapping:
+    def _err(self, status, headers=None):
+        return httpx.Response(
+            status,
+            request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/x"),
+            headers=headers or {},
+            json={"message": "x"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_401_maps_to_auth_invalid(self):
+        adapter = BedrockAdapter(_bedrock_connector())
+        client = _AsyncClient(self._err(401))
+        with patch(_HTTPX_PATH, return_value=client):
+            with pytest.raises(AuthInvalid):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_403_maps_to_auth_invalid(self):
+        adapter = BedrockAdapter(_bedrock_connector())
+        client = _AsyncClient(self._err(403))
+        with patch(_HTTPX_PATH, return_value=client):
+            with pytest.raises(AuthInvalid):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_429_maps_to_rate_limited(self):
+        adapter = BedrockAdapter(_bedrock_connector())
+        client = _AsyncClient(self._err(429, headers={"Retry-After": "12"}))
+        with patch(_HTTPX_PATH, return_value=client):
+            with pytest.raises(RateLimited) as info:
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+        assert info.value.retry_after_seconds == 12
+
+    @pytest.mark.asyncio
+    async def test_throttling_exception_400_maps_to_rate_limited(self):
+        adapter = BedrockAdapter(_bedrock_connector())
+        client = _AsyncClient(self._err(400, headers={"x-amzn-errortype": "ThrottlingException"}))
+        with patch(_HTTPX_PATH, return_value=client):
+            with pytest.raises(RateLimited):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_402_maps_to_quota_exceeded(self):
+        adapter = BedrockAdapter(_bedrock_connector())
+        client = _AsyncClient(self._err(402))
+        with patch(_HTTPX_PATH, return_value=client):
+            with pytest.raises(QuotaExceeded):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_500_maps_to_provider_unavailable(self):
+        adapter = BedrockAdapter(_bedrock_connector())
+        client = _AsyncClient(self._err(503))
+        with patch(_HTTPX_PATH, return_value=client):
+            with pytest.raises(ProviderUnavailable):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_timeout_maps_to_provider_unavailable(self):
+        adapter = BedrockAdapter(_bedrock_connector())
+        client = _AsyncClient(httpx.TimeoutException("timeout"))
+        with patch(_HTTPX_PATH, return_value=client):
+            with pytest.raises(ProviderUnavailable):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_malformed_body_400_maps_to_tool_translation_error(self):
+        adapter = BedrockAdapter(_bedrock_connector())
+        client = _AsyncClient(self._err(400))  # no throttle header
+        with patch(_HTTPX_PATH, return_value=client):
+            with pytest.raises(ToolTranslationError):
+                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+
+# ---------------------------------------------------------------------------
+# Credential extraction
+# ---------------------------------------------------------------------------
+class TestBedrockCredentials:
+    @pytest.mark.asyncio
+    async def test_malformed_credentials_raise_auth_invalid(self):
+        connector = SimpleNamespace(
+            connector_type="bedrock",
+            credentials="not json",
+            model_hint=None,
+            base_url_plain=None,
+        )
+        adapter = BedrockAdapter(connector)
+        with pytest.raises(AuthInvalid):
+            await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_missing_field_raises_auth_invalid(self):
+        connector = SimpleNamespace(
+            connector_type="bedrock",
+            credentials=json.dumps(
+                {
+                    "aws_access_key_id": "AKID",
+                    "aws_secret_access_key": "secret",
+                    "aws_region": "us-east-1",
+                    # missing aws_model_id
+                }
+            ),
+            model_hint=None,
+            base_url_plain=None,
+        )
+        adapter = BedrockAdapter(connector)
+        with pytest.raises(AuthInvalid):
+            await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
+
+    @pytest.mark.asyncio
+    async def test_health_check_pings(self):
+        adapter = BedrockAdapter(_bedrock_connector())
+        client = _AsyncClient(_ok(_anthropic_body("ok")))
+        with patch(_HTTPX_PATH, return_value=client):
+            await adapter.health_check()
+        assert len(client.calls) == 1

--- a/server/tests/test_llm_sigv4.py
+++ b/server/tests/test_llm_sigv4.py
@@ -1,0 +1,78 @@
+"""Tests for the dependency-free AWS SigV4 signer (``services/llm/sigv4.py``).
+
+The signing-key derivation is pinned against AWS's published test vector, and
+a full request signature is pinned to a deterministic fixture so any change to
+the canonicalization or signing logic is caught.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.services.llm.sigv4 import _canonicalize_uri, _signing_key, sign_request
+
+
+def test_signing_key_matches_aws_published_vector():
+    # https://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html
+    key = _signing_key("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", "20150830", "us-east-1", "iam")
+    assert key.hex() == "c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9"
+
+
+def test_sign_request_is_deterministic_fixture():
+    body = b'{"prompt": "hi"}'
+    headers = sign_request(
+        access_key_id="AKIDEXAMPLE",
+        secret_access_key="wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+        region="us-east-1",
+        host="bedrock-runtime.us-east-1.amazonaws.com",
+        canonical_uri="/model/anthropic.claude-3-5-sonnet-20241022-v2:0/invoke",
+        body=body,
+        now=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+    )
+    assert headers["X-Amz-Date"] == "20250101T000000Z"
+    assert headers["X-Amz-Content-Sha256"] == (
+        "bbab304eadd046fe16c34bcfe99be2e82011d02a07dfb1974414bd13c0e34720"
+    )
+    assert headers["Authorization"] == (
+        "AWS4-HMAC-SHA256 "
+        "Credential=AKIDEXAMPLE/20250101/us-east-1/bedrock/aws4_request, "
+        "SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, "
+        "Signature=8941eee088c2d5ff883e65e9aba29f3b653bea15791a13874201fccefe768fa9"
+    )
+
+
+def test_sign_request_includes_security_token_when_present():
+    headers = sign_request(
+        access_key_id="AKIDEXAMPLE",
+        secret_access_key="secret",
+        region="us-west-2",
+        host="bedrock-runtime.us-west-2.amazonaws.com",
+        canonical_uri="/model/meta.llama3-70b-instruct-v1:0/invoke",
+        body=b"{}",
+        now=datetime(2025, 1, 1, tzinfo=UTC),
+        session_token="FwoGZXIvYXdz",
+    )
+    assert headers["X-Amz-Security-Token"] == "FwoGZXIvYXdz"
+    assert "x-amz-security-token" in headers["Authorization"]
+
+
+def test_signature_changes_when_body_changes():
+    common = dict(
+        access_key_id="AKIDEXAMPLE",
+        secret_access_key="secret",
+        region="us-east-1",
+        host="bedrock-runtime.us-east-1.amazonaws.com",
+        canonical_uri="/model/anthropic.claude-3-5-sonnet-20241022-v2:0/invoke",
+        now=datetime(2025, 1, 1, tzinfo=UTC),
+    )
+    a = sign_request(body=b'{"a":1}', **common)["Authorization"]
+    b = sign_request(body=b'{"a":2}', **common)["Authorization"]
+    assert a != b
+
+
+def test_canonicalize_uri_encodes_colon_in_model_id():
+    # The ':' in "...-v2:0" must be percent-encoded in the canonical URI.
+    encoded = _canonicalize_uri("/model/anthropic.claude-3-5-sonnet-v2:0/invoke")
+    assert "%3A0" in encoded
+    assert encoded.startswith("/model/")
+    assert encoded.endswith("/invoke")


### PR DESCRIPTION
## Summary
Adds a `bedrock` connector type to the provider-agnostic LLM gateway so DJs can route AI features to their own AWS Bedrock account (AWS-billed inference). Auth is AWS SigV4 (not Bearer), implemented manually over the existing httpx client — no boto3.

Closes #334

## Changes
- **`services/llm/adapters/bedrock.py`** — new adapter; signs `InvokeModel` requests with SigV4 and dispatches per model family.
- **`services/llm/sigv4.py`** — dependency-free SigV4 signer (stdlib `hashlib`/`hmac`/`urllib` only).
- **`services/llm/tool_translation.py`** — adds Llama tool-instruction rendering + tool-call JSON parsing.
- **`models/llm_connector.py`** — `CONNECTOR_TYPE_BEDROCK` + `VALID_CONNECTOR_TYPES`.
- **`schemas/llm.py`** — `"bedrock"` in `ConnectorType`; `aws_*` fields + validation on create/rotate.
- **`services/llm/connector_storage.py`** — build/rotate the bedrock creds blob (partial rotation supported).
- **`api/llm.py`** — threads the `aws_*` fields through create + rotate.
- **`registry.py`** — registers the bedrock adapter.
- **Frontend `/settings/ai`** — Bedrock option (gated like other api-key connectors) + four AWS credential inputs. OpenAPI + generated TS types regenerated.

## Design decisions
- **Reused the generic admin flag** `llm_apikey_connectors_enabled` (gated in `_check_connector_type_allowed`) — no per-provider flag. The stale issue-body per-provider flag is intentionally ignored.
- **No new DB columns / no Alembic migration.** Config (`aws_region`, `aws_model_id`) and creds (`aws_access_key_id`, `aws_secret_access_key`) all live in the encrypted `credentials` blob. `alembic check` reports no drift.
- **No boto3 / no new dependency.** SigV4 is signed manually over httpx; the signing-key derivation is pinned against AWS's published test vector.
- **Per-family tool translation by `aws_model_id`**: `anthropic.*` reuses the Anthropic Messages body + tool schema/parser; `meta.*`/`llama*` uses a Llama prompt body with tools described in the system prompt and tool calls parsed from the generation. Unknown families (e.g. Titan) raise a clear `ToolTranslationError`.
- Credentials rotate via the existing `PUT /credentials` route (partial rotation preserves untouched fields).

## Test plan
- [x] Backend: `ruff check` + `ruff format --check` clean
- [x] Backend: `bandit` clean
- [x] Backend: full pytest suite — 2147 passed, coverage 86.62% (gate 85%)
- [x] Adapter matrix mocked at the HTTP boundary: happy / 401 / 403 / 429 / throttle-as-400 / 402 / 5xx / timeout / malformed, for **both** Bedrock Claude and Bedrock Llama families
- [x] SigV4 signature pinned to a deterministic fixture + AWS published signing-key vector
- [x] API tests: create / require-all-fields / policy-gated / rotate (partial) for bedrock
- [x] `alembic upgrade head && alembic check` — no drift
- [x] Frontend: `tsc --noEmit`, `eslint`, vitest (945 passed incl. new bedrock UI test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS Bedrock added as a supported LLM provider; UI lets admins add Bedrock connectors with AWS credentials (access key ID, secret access key, region, model ID). Bedrock-specific model selection and credential form are shown when selected.

* **Tests**
  * Added comprehensive Bedrock-focused tests covering connector creation, validation, credential rotation, SigV4 signing, adapter behavior, model-family routing, tool handling, and health checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->