### PR TITLE
feat(ai): auto-fallback policy in gateway (#338)

### DIFF
--- a/server/app/services/llm/base.py
+++ b/server/app/services/llm/base.py
@@ -66,6 +66,16 @@ class ChatRequest(BaseModel):
     # Optional system prompt — adapters surface this as the provider's native
     # system role (Anthropic top-level system; OpenAI as the first system msg).
     system: str | None = None
+    # Automatic-fallback behaviour when the resolved connector fails with a
+    # transient/credential error (rate-limited, auth-expired, provider-down,
+    # quota-exceeded). Default "none" preserves the original fail-fast behaviour.
+    #   - "none": never fall back; surface the original error.
+    #   - "org_default": on a fallback-eligible error, retry once on the
+    #     org-default connector (if different from the one that failed).
+    #   - "retry_then_org_default": first retry once on the SAME connector, then
+    #     fall back to the org-default connector. Retries are bounded — at most
+    #     one same-connector retry and one org-default attempt; never loops.
+    fallback_policy: Literal["none", "org_default", "retry_then_org_default"] = "none"
 
 
 class ChatResponse(BaseModel):

--- a/server/app/services/llm/gateway.py
+++ b/server/app/services/llm/gateway.py
@@ -6,6 +6,14 @@ Resolution order:
 1. If ``actor`` is not ``None``: most-recently-used active connector for the DJ.
 2. Else: ``SystemSettings.llm_default_connector_id`` if set and active.
 3. Else: raise :class:`NoLlmConfigured`.
+
+Auto-fallback (issue #338):
+When ``ChatRequest.fallback_policy`` is not ``"none"`` and the resolved
+connector fails with a transient / credential error (rate-limited, auth
+expired, provider unavailable, quota exceeded), the gateway optionally falls
+back to the org-default connector. Retries are explicitly bounded — at most one
+same-connector retry (for ``retry_then_org_default``) plus one org-default
+attempt; the chain never loops.
 """
 
 from __future__ import annotations
@@ -40,6 +48,30 @@ from app.services.llm.registry import get_adapter_class
 
 logger = logging.getLogger(__name__)
 
+# Audit event type prefix for auto-fallback. The trigger reason is appended
+# (e.g. ``fallback_triggered:rate_limited``) so it fits the existing
+# ``llm_audit_event.event_type`` String(60) column without a migration. The
+# audit row's ``target_connector_id`` points at the fallback connector.
+AUDIT_FALLBACK_TRIGGERED = "fallback_triggered"
+
+# Maps fallback-eligible exception types → the trigger token recorded in the
+# audit event. Errors NOT in this map (ToolTranslationError, generic LlmError)
+# are never fallback-eligible: a different connector would hit the same problem.
+_FALLBACK_TRIGGERS: dict[type[LlmError], str] = {
+    RateLimited: "rate_limited",
+    AuthInvalid: "auth_invalid",
+    ProviderUnavailable: "provider_unavailable",
+    QuotaExceeded: "quota_exceeded",
+}
+
+
+def _fallback_trigger(exc: LlmError) -> str | None:
+    """Return the trigger token for a fallback-eligible error, else ``None``."""
+    for exc_type, token in _FALLBACK_TRIGGERS.items():
+        if isinstance(exc, exc_type):
+            return token
+    return None
+
 
 class Gateway:
     """Single dispatch entrypoint."""
@@ -52,106 +84,168 @@ class Gateway:
         *,
         purpose: str,
     ) -> ChatResponse:
-        connector = _resolve_connector(db, actor)
-        adapter_cls = get_adapter_class(connector.connector_type)
-        adapter = adapter_cls(connector)
+        primary = _resolve_connector(db, actor)
+        actor_id = actor.id if actor else _system_actor_id(db, primary)
 
-        started = monotonic()
+        # Attempt 1: primary connector.
         try:
-            response = await adapter.chat(request)
-        except AuthInvalid:
-            connector.status = STATUS_AUTH_INVALID
-            connector.last_error = "auth_invalid"
-            db.commit()
-            log_call(
-                db,
-                connector_id=connector.id,
-                purpose=purpose,
-                status="auth_invalid",
-                latency_ms=int((monotonic() - started) * 1000),
-                error_code="401",
+            return await _attempt(db, primary, request, purpose=purpose, actor_id=actor_id)
+        except LlmError as exc:
+            trigger = _fallback_trigger(exc)
+            policy = request.fallback_policy
+            if policy == "none" or trigger is None:
+                raise
+
+            # Attempt 2 (retry_then_org_default only): one bounded retry on the
+            # SAME connector before falling back.
+            if policy == "retry_then_org_default":
+                try:
+                    return await _attempt(db, primary, request, purpose=purpose, actor_id=actor_id)
+                except LlmError as retry_exc:
+                    retry_trigger = _fallback_trigger(retry_exc)
+                    if retry_trigger is None:
+                        raise
+                    # Carry the retry's trigger forward to the fallback step.
+                    exc, trigger = retry_exc, retry_trigger
+
+            # Attempt 3: org-default fallback (one bounded attempt).
+            fallback = _resolve_org_default(db)
+            if fallback is None or fallback.id == primary.id:
+                # No distinct org default to fall back to — surface the original.
+                raise
+
+            logger.info(
+                "llm fallback: primary connector %s failed (%s); "
+                "falling back to org-default connector %s",
+                primary.id,
+                trigger,
+                fallback.id,
             )
+            # Record the fallback before attempting it, referencing the fallback
+            # connector + the trigger. Reuses the existing audit-write path.
             audit_event(
                 db,
-                actor_user_id=actor.id if actor else _system_actor_id(db, connector),
-                target_connector_id=connector.id,
-                event_type=AUDIT_AUTH_INVALID_OBSERVED,
+                actor_user_id=actor_id,
+                target_connector_id=fallback.id,
+                event_type=f"{AUDIT_FALLBACK_TRIGGERED}:{trigger}",
             )
             db.commit()
-            raise
-        except RateLimited as exc:
-            log_call(
-                db,
-                connector_id=connector.id,
-                purpose=purpose,
-                status="rate_limited",
-                latency_ms=int((monotonic() - started) * 1000),
-                error_code=str(exc.retry_after_seconds or ""),
-            )
-            db.commit()
-            raise
-        except QuotaExceeded:
-            log_call(
-                db,
-                connector_id=connector.id,
-                purpose=purpose,
-                status="quota_exceeded",
-                latency_ms=int((monotonic() - started) * 1000),
-                error_code="402",
-            )
-            db.commit()
-            raise
-        except ProviderUnavailable as exc:
-            log_call(
-                db,
-                connector_id=connector.id,
-                purpose=purpose,
-                status="provider_unavailable",
-                latency_ms=int((monotonic() - started) * 1000),
-                error_code=type(exc).__name__,
-            )
-            db.commit()
-            raise
-        except ToolTranslationError:
-            log_call(
-                db,
-                connector_id=connector.id,
-                purpose=purpose,
-                status="tool_translation_error",
-                latency_ms=int((monotonic() - started) * 1000),
-                error_code="translation",
-            )
-            db.commit()
-            raise
-        except LlmError:
-            log_call(
-                db,
-                connector_id=connector.id,
-                purpose=purpose,
-                status="error",
-                latency_ms=int((monotonic() - started) * 1000),
-                error_code="llm_error",
-            )
-            db.commit()
-            raise
+            # A failure here surfaces the fallback's own error (no further retry).
+            return await _attempt(db, fallback, request, purpose=purpose, actor_id=actor_id)
 
-        # success path
-        connector.last_used_at = utcnow()
-        connector.last_error = None
-        latency_ms = int((monotonic() - started) * 1000)
-        tokens_in = response.usage.prompt if response.usage else None
-        tokens_out = response.usage.completion if response.usage else None
+
+async def _attempt(
+    db: Session,
+    connector: LlmConnector,
+    request: ChatRequest,
+    *,
+    purpose: str,
+    actor_id: int,
+) -> ChatResponse:
+    """Run a single adapter call against ``connector``, logging the outcome.
+
+    Raises the same typed exceptions the adapter raises after logging the call
+    (and, for auth failures, marking the connector + writing an audit event).
+    """
+    adapter_cls = get_adapter_class(connector.connector_type)
+    adapter = adapter_cls(connector)
+
+    started = monotonic()
+    try:
+        response = await adapter.chat(request)
+    except AuthInvalid:
+        connector.status = STATUS_AUTH_INVALID
+        connector.last_error = "auth_invalid"
+        db.commit()
         log_call(
             db,
             connector_id=connector.id,
             purpose=purpose,
-            status="ok",
-            latency_ms=latency_ms,
-            tokens_in=tokens_in,
-            tokens_out=tokens_out,
+            status="auth_invalid",
+            latency_ms=int((monotonic() - started) * 1000),
+            error_code="401",
+        )
+        audit_event(
+            db,
+            actor_user_id=actor_id,
+            target_connector_id=connector.id,
+            event_type=AUDIT_AUTH_INVALID_OBSERVED,
         )
         db.commit()
-        return response
+        raise
+    except RateLimited as exc:
+        log_call(
+            db,
+            connector_id=connector.id,
+            purpose=purpose,
+            status="rate_limited",
+            latency_ms=int((monotonic() - started) * 1000),
+            error_code=str(exc.retry_after_seconds or ""),
+        )
+        db.commit()
+        raise
+    except QuotaExceeded:
+        log_call(
+            db,
+            connector_id=connector.id,
+            purpose=purpose,
+            status="quota_exceeded",
+            latency_ms=int((monotonic() - started) * 1000),
+            error_code="402",
+        )
+        db.commit()
+        raise
+    except ProviderUnavailable as exc:
+        log_call(
+            db,
+            connector_id=connector.id,
+            purpose=purpose,
+            status="provider_unavailable",
+            latency_ms=int((monotonic() - started) * 1000),
+            error_code=type(exc).__name__,
+        )
+        db.commit()
+        raise
+    except ToolTranslationError:
+        log_call(
+            db,
+            connector_id=connector.id,
+            purpose=purpose,
+            status="tool_translation_error",
+            latency_ms=int((monotonic() - started) * 1000),
+            error_code="translation",
+        )
+        db.commit()
+        raise
+    except LlmError:
+        log_call(
+            db,
+            connector_id=connector.id,
+            purpose=purpose,
+            status="error",
+            latency_ms=int((monotonic() - started) * 1000),
+            error_code="llm_error",
+        )
+        db.commit()
+        raise
+
+    # success path
+    connector.last_used_at = utcnow()
+    connector.last_error = None
+    latency_ms = int((monotonic() - started) * 1000)
+    tokens_in = response.usage.prompt if response.usage else None
+    tokens_out = response.usage.completion if response.usage else None
+    log_call(
+        db,
+        connector_id=connector.id,
+        purpose=purpose,
+        status="ok",
+        latency_ms=latency_ms,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+    )
+    db.commit()
+    return response
 
 
 def _resolve_connector(db: Session, actor: User | None) -> LlmConnector:
@@ -168,13 +262,21 @@ def _resolve_connector(db: Session, actor: User | None) -> LlmConnector:
         if row is not None:
             return row
 
+    default = _resolve_org_default(db)
+    if default is not None:
+        return default
+
+    raise NoLlmConfigured("No active LLM connector for this DJ and no system default configured")
+
+
+def _resolve_org_default(db: Session) -> LlmConnector | None:
+    """Return the active org-default connector, or ``None`` if unset/inactive."""
     settings = db.query(SystemSettings).first()
     if settings and settings.llm_default_connector_id:
         default = db.get(LlmConnector, settings.llm_default_connector_id)
         if default is not None and default.status == STATUS_ACTIVE:
             return default
-
-    raise NoLlmConfigured("No active LLM connector for this DJ and no system default configured")
+    return None
 
 
 def _system_actor_id(db: Session, connector: LlmConnector) -> int:

--- a/server/tests/test_llm_gateway.py
+++ b/server/tests/test_llm_gateway.py
@@ -232,6 +232,346 @@ async def test_falls_back_to_system_default(db, admin_user_actor, gateway_reques
     assert resp.text == "ok"
 
 
+def _wire_system_default(db, connector: LlmConnector) -> None:
+    ss = db.query(SystemSettings).first()
+    if ss is None:
+        ss = SystemSettings(id=1, llm_default_connector_id=connector.id)
+        db.add(ss)
+    else:
+        ss.llm_default_connector_id = connector.id
+    db.commit()
+
+
+@pytest.mark.asyncio
+async def test_fallback_org_default_on_rate_limit(db, dj_user):
+    """429 on DJ connector → falls back to org default → audit event written."""
+    from app.models.llm_connector import LlmAuditEvent
+
+    _make_connector(db, dj_user, display_name="dj-primary")
+
+    org_owner = User(
+        username="orgowner",
+        password_hash=get_password_hash("password123"),
+        role="admin",
+    )
+    db.add(org_owner)
+    db.commit()
+    db.refresh(org_owner)
+    org_connector = _make_connector(db, org_owner, display_name="org-default")
+    _wire_system_default(db, org_connector)
+
+    fallback_response = ChatResponse(
+        text="from-fallback",
+        tool_calls=[],
+        stop_reason="end_turn",
+        usage=TokenUsage(prompt=3, completion=4),
+    )
+
+    # First call (DJ connector) → 429; second call (org default) → success.
+    chat_mock = AsyncMock(
+        side_effect=[RateLimited("slow", retry_after_seconds=5), fallback_response]
+    )
+    with patch.object(
+        __import__(
+            "app.services.llm.adapters.openai_apikey",
+            fromlist=["OpenAIApiKeyAdapter"],
+        ).OpenAIApiKeyAdapter,
+        "chat",
+        new=chat_mock,
+    ):
+        req = ChatRequest(
+            messages=[Message(role="user", content="hi")],
+            fallback_policy="org_default",
+        )
+        resp = await Gateway.dispatch(db, dj_user, req, purpose="test")
+
+    assert resp.text == "from-fallback"
+    assert chat_mock.await_count == 2
+
+    # A fallback_triggered audit event referencing the fallback connector + trigger.
+    audit = (
+        db.query(LlmAuditEvent).filter(LlmAuditEvent.event_type.like("fallback_triggered%")).one()
+    )
+    assert audit.event_type == "fallback_triggered:rate_limited"
+    assert audit.target_connector_id == org_connector.id
+    assert audit.actor_user_id == dj_user.id
+
+
+@pytest.mark.asyncio
+async def test_fallback_none_surfaces_original_error(db, dj_user):
+    """fallback_policy='none' (default) surfaces the original error, no fallback."""
+    from app.models.llm_connector import LlmAuditEvent
+
+    _make_connector(db, dj_user, display_name="dj-primary")
+
+    org_owner = User(
+        username="orgowner2",
+        password_hash=get_password_hash("password123"),
+        role="admin",
+    )
+    db.add(org_owner)
+    db.commit()
+    db.refresh(org_owner)
+    org_connector = _make_connector(db, org_owner, display_name="org-default")
+    _wire_system_default(db, org_connector)
+
+    chat_mock = AsyncMock(side_effect=RateLimited("slow", retry_after_seconds=5))
+    with patch.object(
+        __import__(
+            "app.services.llm.adapters.openai_apikey",
+            fromlist=["OpenAIApiKeyAdapter"],
+        ).OpenAIApiKeyAdapter,
+        "chat",
+        new=chat_mock,
+    ):
+        req = ChatRequest(
+            messages=[Message(role="user", content="hi")],
+            fallback_policy="none",
+        )
+        with pytest.raises(RateLimited):
+            await Gateway.dispatch(db, dj_user, req, purpose="test")
+
+    # Only one attempt — no fallback.
+    assert chat_mock.await_count == 1
+    assert (
+        db.query(LlmAuditEvent).filter(LlmAuditEvent.event_type.like("fallback_triggered%")).count()
+        == 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_fallback_org_default_when_no_default_reraises(db, dj_user):
+    """org_default policy with no org default configured → original error surfaces."""
+    _make_connector(db, dj_user, display_name="dj-primary")
+
+    chat_mock = AsyncMock(side_effect=ProviderUnavailable("down"))
+    with patch.object(
+        __import__(
+            "app.services.llm.adapters.openai_apikey",
+            fromlist=["OpenAIApiKeyAdapter"],
+        ).OpenAIApiKeyAdapter,
+        "chat",
+        new=chat_mock,
+    ):
+        req = ChatRequest(
+            messages=[Message(role="user", content="hi")],
+            fallback_policy="org_default",
+        )
+        with pytest.raises(ProviderUnavailable):
+            await Gateway.dispatch(db, dj_user, req, purpose="test")
+
+    assert chat_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_fallback_skipped_when_primary_is_org_default(db, dj_user):
+    """If the failing connector IS the org default, there is nothing to fall back to."""
+    dj_connector = _make_connector(db, dj_user, display_name="dj-and-org-default")
+    _wire_system_default(db, dj_connector)
+
+    chat_mock = AsyncMock(side_effect=RateLimited("slow"))
+    with patch.object(
+        __import__(
+            "app.services.llm.adapters.openai_apikey",
+            fromlist=["OpenAIApiKeyAdapter"],
+        ).OpenAIApiKeyAdapter,
+        "chat",
+        new=chat_mock,
+    ):
+        req = ChatRequest(
+            messages=[Message(role="user", content="hi")],
+            fallback_policy="org_default",
+        )
+        with pytest.raises(RateLimited):
+            await Gateway.dispatch(db, dj_user, req, purpose="test")
+
+    assert chat_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_then_org_default_retries_same_then_falls_back(db, dj_user):
+    """retry_then_org_default: same connector retried once, then org default."""
+    _make_connector(db, dj_user, display_name="dj-primary")
+
+    org_owner = User(
+        username="orgowner3",
+        password_hash=get_password_hash("password123"),
+        role="admin",
+    )
+    db.add(org_owner)
+    db.commit()
+    db.refresh(org_owner)
+    org_connector = _make_connector(db, org_owner, display_name="org-default")
+    _wire_system_default(db, org_connector)
+
+    ok = ChatResponse(text="recovered", tool_calls=[], stop_reason="end_turn", usage=None)
+    # attempt 1 (primary) 429, attempt 2 (primary retry) 429, attempt 3 (org default) ok
+    chat_mock = AsyncMock(side_effect=[RateLimited("slow"), RateLimited("slow"), ok])
+    with patch.object(
+        __import__(
+            "app.services.llm.adapters.openai_apikey",
+            fromlist=["OpenAIApiKeyAdapter"],
+        ).OpenAIApiKeyAdapter,
+        "chat",
+        new=chat_mock,
+    ):
+        req = ChatRequest(
+            messages=[Message(role="user", content="hi")],
+            fallback_policy="retry_then_org_default",
+        )
+        resp = await Gateway.dispatch(db, dj_user, req, purpose="test")
+
+    assert resp.text == "recovered"
+    # Bounded: exactly 3 attempts (1 primary + 1 retry + 1 fallback). Never loops.
+    assert chat_mock.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_then_org_default_succeeds_on_retry(db, dj_user):
+    """retry_then_org_default: same-connector retry succeeds → no fallback needed."""
+    _make_connector(db, dj_user, display_name="dj-primary")
+
+    ok = ChatResponse(text="retry-ok", tool_calls=[], stop_reason="end_turn", usage=None)
+    chat_mock = AsyncMock(side_effect=[ProviderUnavailable("blip"), ok])
+    with patch.object(
+        __import__(
+            "app.services.llm.adapters.openai_apikey",
+            fromlist=["OpenAIApiKeyAdapter"],
+        ).OpenAIApiKeyAdapter,
+        "chat",
+        new=chat_mock,
+    ):
+        req = ChatRequest(
+            messages=[Message(role="user", content="hi")],
+            fallback_policy="retry_then_org_default",
+        )
+        resp = await Gateway.dispatch(db, dj_user, req, purpose="test")
+
+    assert resp.text == "retry-ok"
+    assert chat_mock.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_fallback_not_triggered_for_auth_invalid_when_policy_org_default(db, dj_user):
+    """auth_invalid is fallback-eligible: marks primary invalid, falls back."""
+    from app.models.llm_connector import LlmAuditEvent
+
+    dj_connector = _make_connector(db, dj_user, display_name="dj-primary")
+
+    org_owner = User(
+        username="orgowner4",
+        password_hash=get_password_hash("password123"),
+        role="admin",
+    )
+    db.add(org_owner)
+    db.commit()
+    db.refresh(org_owner)
+    org_connector = _make_connector(db, org_owner, display_name="org-default")
+    _wire_system_default(db, org_connector)
+
+    ok = ChatResponse(text="recovered", tool_calls=[], stop_reason="end_turn", usage=None)
+    chat_mock = AsyncMock(side_effect=[AuthInvalid("expired"), ok])
+    with patch.object(
+        __import__(
+            "app.services.llm.adapters.openai_apikey",
+            fromlist=["OpenAIApiKeyAdapter"],
+        ).OpenAIApiKeyAdapter,
+        "chat",
+        new=chat_mock,
+    ):
+        req = ChatRequest(
+            messages=[Message(role="user", content="hi")],
+            fallback_policy="org_default",
+        )
+        resp = await Gateway.dispatch(db, dj_user, req, purpose="test")
+
+    assert resp.text == "recovered"
+    # Primary connector marked auth_invalid; fallback audit + the auth_invalid audit both present.
+    db.refresh(dj_connector)
+    assert dj_connector.status == "auth_invalid"
+    fallback_audit = (
+        db.query(LlmAuditEvent)
+        .filter(LlmAuditEvent.event_type == "fallback_triggered:auth_invalid")
+        .one()
+    )
+    assert fallback_audit.target_connector_id == org_connector.id
+
+
+@pytest.mark.asyncio
+async def test_fallback_not_eligible_for_tool_translation_error(db, dj_user):
+    """ToolTranslationError is NOT fallback-eligible — a different connector won't help."""
+    from app.services.llm.exceptions import ToolTranslationError
+
+    _make_connector(db, dj_user, display_name="dj-primary")
+
+    org_owner = User(
+        username="orgowner5",
+        password_hash=get_password_hash("password123"),
+        role="admin",
+    )
+    db.add(org_owner)
+    db.commit()
+    db.refresh(org_owner)
+    org_connector = _make_connector(db, org_owner, display_name="org-default")
+    _wire_system_default(db, org_connector)
+
+    chat_mock = AsyncMock(side_effect=ToolTranslationError("bad schema"))
+    with patch.object(
+        __import__(
+            "app.services.llm.adapters.openai_apikey",
+            fromlist=["OpenAIApiKeyAdapter"],
+        ).OpenAIApiKeyAdapter,
+        "chat",
+        new=chat_mock,
+    ):
+        req = ChatRequest(
+            messages=[Message(role="user", content="hi")],
+            fallback_policy="retry_then_org_default",
+        )
+        with pytest.raises(ToolTranslationError):
+            await Gateway.dispatch(db, dj_user, req, purpose="test")
+
+    assert chat_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_fallback_failure_surfaces_fallback_error(db, dj_user):
+    """If the fallback connector also fails, the fallback's error surfaces."""
+    _make_connector(db, dj_user, display_name="dj-primary")
+
+    org_owner = User(
+        username="orgowner6",
+        password_hash=get_password_hash("password123"),
+        role="admin",
+    )
+    db.add(org_owner)
+    db.commit()
+    db.refresh(org_owner)
+    org_connector = _make_connector(db, org_owner, display_name="org-default")
+    _wire_system_default(db, org_connector)
+
+    chat_mock = AsyncMock(
+        side_effect=[RateLimited("primary-slow"), ProviderUnavailable("fallback-down")]
+    )
+    with patch.object(
+        __import__(
+            "app.services.llm.adapters.openai_apikey",
+            fromlist=["OpenAIApiKeyAdapter"],
+        ).OpenAIApiKeyAdapter,
+        "chat",
+        new=chat_mock,
+    ):
+        req = ChatRequest(
+            messages=[Message(role="user", content="hi")],
+            fallback_policy="org_default",
+        )
+        with pytest.raises(ProviderUnavailable):
+            await Gateway.dispatch(db, dj_user, req, purpose="test")
+
+    # primary + fallback, bounded.
+    assert chat_mock.await_count == 2
+
+
 @pytest.mark.asyncio
 async def test_mru_resolution_picks_recent(db, dj_user, gateway_request):
     """Resolver picks the connector with the most recent last_used_at."""


### PR DESCRIPTION
## Summary
Adds an optional auto-fallback to the LLM gateway so a DJ's connector that fails mid-event (rate-limited, auth expired, provider down, quota exceeded) can fall back to the org-default connector instead of failing the call.

- New `ChatRequest.fallback_policy: Literal["none", "org_default", "retry_then_org_default"] = "none"`. Default preserves the current fail-fast behavior; callers opt in per-call.
- Gateway refactored to extract a single-attempt helper (`_attempt`, all existing logging/audit behavior preserved) and a bounded fallback chain.
- Fallback chain is explicitly bounded — never loops:
  - `org_default`: on a fallback-eligible error, one attempt on the org-default connector.
  - `retry_then_org_default`: one retry on the **same** connector first, then one org-default attempt.
- Fallback-eligible triggers map from existing exceptions: `RateLimited`→`rate_limited`, `AuthInvalid`→`auth_invalid`, `ProviderUnavailable`→`provider_unavailable`, `QuotaExceeded`→`quota_exceeded`. `ToolTranslationError` / generic `LlmError` are **not** eligible (a different connector would hit the same problem).
- Writes a `fallback_triggered:<trigger>` `LlmAuditEvent` via the existing `audit_event` helper, with `target_connector_id` pointing at the fallback connector.

Closes #338

## Design decisions
- **Audit trigger encoding (no migration).** `LlmAuditEvent` has no detail/metadata column, only `event_type String(60)` + `target_connector_id`. To satisfy "writes a `fallback_triggered` event with the trigger and the fallback connector ID" without a schema change (wave no-migration guarantee), the trigger is encoded into the event_type string as `fallback_triggered:<trigger>` (max ~39 chars, well under 60) and `target_connector_id` points at the fallback connector. The `AUDIT_FALLBACK_TRIGGERED` constant lives in `gateway.py` (not the off-limits model file).
- **Which errors are fallback-eligible.** Only transient/credential failures fall back. `ToolTranslationError` and the generic `LlmError` base are excluded because they indicate a request-shape/translation problem a sibling connector would also hit — retrying elsewhere just wastes a second call.
- **Bounded retries.** At most one same-connector retry (`retry_then_org_default` only) plus one org-default attempt. The fallback attempt itself is never retried; if it fails, its own error surfaces.
- **No-fallback edge cases re-raise the original error.** If there is no org default configured, or the failing connector *is* the org default, the original error is surfaced unchanged.
- **`auth_invalid` still marks the primary connector.** The primary's `_attempt` marks it `auth_invalid` and writes the existing `auth_invalid_observed` audit row before the fallback path runs, so the credential-lifecycle trail is preserved in addition to the new `fallback_triggered:auth_invalid` row.

## Test plan
- [x] Connector returns 429 → `org_default` policy falls back → `fallback_triggered:rate_limited` audit row written targeting the fallback connector → caller receives the fallback `ChatResponse`.
- [x] `fallback_policy="none"` (default) surfaces the original error; no fallback, no audit row.
- [x] `retry_then_org_default` retries the same connector once, then falls back (exactly 3 bounded attempts).
- [x] `retry_then_org_default` where the same-connector retry succeeds → no fallback.
- [x] `auth_invalid` is fallback-eligible: primary marked `auth_invalid`, falls back successfully.
- [x] `ToolTranslationError` is NOT fallback-eligible → single attempt, error surfaces.
- [x] No org default configured / primary is the org default → original error surfaces (single attempt).
- [x] Fallback connector also fails → fallback's own error surfaces (bounded, 2 attempts).
- [x] Local CI green: `ruff check`, `ruff format --check`, `bandit`, full `pytest` (2266 passed, coverage 86.96% ≥ 85% gate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic fallback policies for improved LLM connector reliability. New "retry_then_org_default" and "org_default" fallback modes enable bounded retries and fallback to organization defaults when primary connectors fail due to transient issues, credential errors, availability problems, or rate limits. Default "none" preserves existing fail-fast behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->