### PR TITLE
feat(ai): DJ-readable LLM connector policy endpoint (#355)

### DIFF
--- a/dashboard/app/(dj)/settings/ai/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/settings/ai/__tests__/page.test.tsx
@@ -3,7 +3,33 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
 import SettingsAIPage from '../page';
 import { api } from '@/lib/api';
-import type { LlmConnector } from '@/lib/api-types';
+import type { LlmConnector, LlmConnectorType, LlmDjPolicy } from '@/lib/api-types';
+
+const ALL_APIKEY_TYPES: LlmConnectorType[] = [
+  'openai_apikey',
+  'anthropic_apikey',
+  'openrouter_apikey',
+  'xai_apikey',
+  'bedrock',
+  'azure_openai',
+  'gemini_apikey',
+];
+
+// Build a DJ policy payload. `allowed_connector_types` is what the server
+// computes from the two toggles; the page renders exactly this set.
+function makePolicy(
+  apikeyEnabled: boolean,
+  compatibleEnabled: boolean,
+): LlmDjPolicy {
+  const allowed: LlmConnectorType[] = [];
+  if (apikeyEnabled) allowed.push(...ALL_APIKEY_TYPES);
+  if (compatibleEnabled) allowed.push('openai_compatible');
+  return {
+    llm_apikey_connectors_enabled: apikeyEnabled,
+    llm_compatible_connector_enabled: compatibleEnabled,
+    allowed_connector_types: allowed,
+  };
+}
 
 vi.mock('@/lib/auth', () => ({
   useAuth: () => ({
@@ -57,7 +83,7 @@ describe('SettingsAIPage', () => {
         model_hint: 'claude-haiku',
       }),
     ]);
-    vi.spyOn(api, 'getAdminLlmPolicy').mockRejectedValue(new Error('forbidden'));
+    vi.spyOn(api, 'getLlmPolicy').mockRejectedValue(new Error('forbidden'));
 
     render(<SettingsAIPage />);
 
@@ -67,11 +93,7 @@ describe('SettingsAIPage', () => {
 
   it('respects admin policy when filtering allowed connector types', async () => {
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: false,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
-    });
+    vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(false, true));
 
     render(<SettingsAIPage />);
 
@@ -84,13 +106,52 @@ describe('SettingsAIPage', () => {
     expect(optionValues).toEqual(['openai_compatible']);
   });
 
+  it('reads the DJ-scoped policy endpoint (not the admin one)', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
+    const policySpy = vi
+      .spyOn(api, 'getLlmPolicy')
+      .mockResolvedValue(makePolicy(true, true));
+
+    render(<SettingsAIPage />);
+
+    await waitFor(() => expect(policySpy).toHaveBeenCalled());
+  });
+
+  it('fails closed: hides all provider types when policy fetch fails', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
+    // Simulate the DJ policy endpoint being unavailable.
+    vi.spyOn(api, 'getLlmPolicy').mockRejectedValue(new Error('unavailable'));
+
+    render(<SettingsAIPage />);
+
+    // No "+ Add provider" button — the picker is hidden entirely.
+    await waitFor(() =>
+      expect(
+        screen.getByText('Connector creation is currently disabled by admin policy.'),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByText('+ Add provider')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Provider')).not.toBeInTheDocument();
+  });
+
+  it('fails closed: only api-key types when compatible is disabled (no leak of all)', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
+    vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(true, false));
+
+    render(<SettingsAIPage />);
+
+    await waitFor(() => expect(screen.getByText('+ Add provider')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('+ Add provider'));
+
+    const select = screen.getByLabelText('Provider') as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).not.toContain('openai_compatible');
+    expect(optionValues).toContain('openai_apikey');
+  });
+
   it('offers Azure OpenAI and reveals its config fields', async () => {
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
-    });
+    vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(true, true));
 
     render(<SettingsAIPage />);
 
@@ -111,11 +172,7 @@ describe('SettingsAIPage', () => {
 
   it('sends Azure config fields on create', async () => {
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
-    });
+    vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(true, true));
     const createSpy = vi
       .spyOn(api, 'createLlmConnector')
       .mockResolvedValue(makeConnector({ connector_type: 'azure_openai' }));
@@ -160,11 +217,7 @@ describe('SettingsAIPage', () => {
 
   it('offers AWS Bedrock when api-key connectors are enabled', async () => {
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: false,
-      llm_default_connector_id: null,
-    });
+    vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(true, false));
 
     render(<SettingsAIPage />);
 
@@ -187,11 +240,7 @@ describe('SettingsAIPage', () => {
   it('runs Test and surfaces the result', async () => {
     const row = makeConnector();
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([row]);
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
-    });
+    vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(true, true));
     const testSpy = vi.spyOn(api, 'testLlmConnector').mockResolvedValue({
       ok: true,
       error_code: null,
@@ -211,11 +260,7 @@ describe('SettingsAIPage', () => {
 
   it('offers OpenRouter and fetches its model dropdown', async () => {
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: false,
-      llm_default_connector_id: null,
-    });
+    vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(true, false));
     const modelsSpy = vi.spyOn(api, 'listOpenRouterModels').mockResolvedValue({
       models: [
         { id: 'openai/gpt-4o-mini', name: 'GPT-4o mini' },
@@ -246,11 +291,7 @@ describe('SettingsAIPage', () => {
 
   it('creates an OpenRouter connector with the selected model', async () => {
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: false,
-      llm_default_connector_id: null,
-    });
+    vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(true, false));
     vi.spyOn(api, 'listOpenRouterModels').mockResolvedValue({
       models: [{ id: 'openai/gpt-4o-mini', name: 'GPT-4o mini' }],
     });
@@ -297,7 +338,7 @@ describe('SettingsAIPage', () => {
 
   it('deletes after confirmation', async () => {
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([makeConnector()]);
-    vi.spyOn(api, 'getAdminLlmPolicy').mockRejectedValue(new Error('nope'));
+    vi.spyOn(api, 'getLlmPolicy').mockRejectedValue(new Error('nope'));
     const delSpy = vi.spyOn(api, 'deleteLlmConnector').mockResolvedValue();
     vi.spyOn(window, 'confirm').mockReturnValue(true);
 

--- a/dashboard/app/(dj)/settings/ai/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/settings/ai/__tests__/page.test.tsx
@@ -108,6 +108,9 @@ describe('SettingsAIPage', () => {
 
   it('reads the DJ-scoped policy endpoint (not the admin one)', async () => {
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
+    const adminPolicySpy = vi
+      .spyOn(api, 'getAdminLlmPolicy')
+      .mockRejectedValue(new Error('should not be called'));
     const policySpy = vi
       .spyOn(api, 'getLlmPolicy')
       .mockResolvedValue(makePolicy(true, true));
@@ -115,6 +118,7 @@ describe('SettingsAIPage', () => {
     render(<SettingsAIPage />);
 
     await waitFor(() => expect(policySpy).toHaveBeenCalled());
+    expect(adminPolicySpy).not.toHaveBeenCalled();
   });
 
   it('fails closed: hides all provider types when policy fetch fails', async () => {

--- a/dashboard/app/(dj)/settings/ai/page.tsx
+++ b/dashboard/app/(dj)/settings/ai/page.tsx
@@ -7,10 +7,10 @@ import { useEffect, useMemo, useState } from 'react';
 import { api } from '@/lib/api';
 import type {
   AIModelInfo,
-  LlmAdminPolicy,
   LlmConnector,
   LlmConnectorCreate,
   LlmConnectorType,
+  LlmDjPolicy,
 } from '@/lib/api-types';
 import { useAuth } from '@/lib/auth';
 
@@ -69,7 +69,7 @@ export default function SettingsAIPage() {
   const router = useRouter();
   const { isAuthenticated, isLoading } = useAuth();
 
-  const [policy, setPolicy] = useState<LlmAdminPolicy | null>(null);
+  const [policy, setPolicy] = useState<LlmDjPolicy | null>(null);
   const [connectors, setConnectors] = useState<LlmConnector[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -125,22 +125,12 @@ export default function SettingsAIPage() {
       });
   }, [wantsOpenrouterModels, openrouterModelsLoaded]);
 
-  const allowedTypes = useMemo(() => {
-    if (!policy) return Object.keys(CONNECTOR_TYPE_LABELS) as LlmConnectorType[];
-    const out: LlmConnectorType[] = [];
-    if (policy.llm_apikey_connectors_enabled) {
-      out.push(
-        'openai_apikey',
-        'anthropic_apikey',
-        'openrouter_apikey',
-        'xai_apikey',
-        'bedrock',
-        'azure_openai',
-        'gemini_apikey',
-      );
-    }
-    if (policy.llm_compatible_connector_enabled) out.push('openai_compatible');
-    return out;
+  const allowedTypes = useMemo<LlmConnectorType[]>(() => {
+    // Fail closed: when the policy can't be read, offer no providers rather than
+    // surfacing every type and letting the DJ pick one the admin disabled (the
+    // create call would 403). The server is the source of truth for the set.
+    if (!policy) return [];
+    return policy.allowed_connector_types as LlmConnectorType[];
   }, [policy]);
 
   if (isLoading || !isAuthenticated) return null;
@@ -583,12 +573,13 @@ export default function SettingsAIPage() {
   );
 }
 
-async function fetchPolicySoft(): Promise<LlmAdminPolicy | null> {
-  // DJ users don't have access to the admin policy endpoint — return null so
-  // the UI falls back to "all types allowed" defaults. Admins get the real
-  // payload (the same component is used in the admin /admin/ai page).
+async function fetchPolicySoft(): Promise<LlmDjPolicy | null> {
+  // Read the DJ-scoped policy endpoint. On any failure we return null and the
+  // UI fails *closed* (no providers offered) — see `allowedTypes`. This avoids
+  // showing a DJ a provider the admin disabled, only to have the create call
+  // reject it with a 403.
   try {
-    return await api.getAdminLlmPolicy();
+    return await api.getLlmPolicy();
   } catch {
     return null;
   }

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -7102,6 +7102,20 @@ export interface operations {
                     "application/json": components["schemas"]["DjPolicyOut"];
                 };
             };
+            /** @description Not authenticated (missing or invalid bearer token). */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Authenticated but not an active DJ (e.g. pending approval). */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     preview_api_public_collect__code__get: {

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -1446,6 +1446,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/llm/policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Dj Policy
+         * @description DJ-readable connector policy (non-sensitive subset).
+         *
+         *     The settings/ai page consumes this to fail *closed* — hiding connector
+         *     types the admin has disabled rather than showing every provider and only
+         *     discovering the block when the create call returns 403. Admin-only fields
+         *     (e.g. ``llm_default_connector_id``) are intentionally excluded.
+         */
+        get: operations["get_dj_policy_api_llm_policy_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/public/collect/{code}": {
         parameters: {
             query?: never;
@@ -3135,6 +3160,28 @@ export interface components {
             now_playing_hidden?: boolean | null;
             /** Requests Open */
             requests_open?: boolean | null;
+        };
+        /**
+         * DjPolicyOut
+         * @description DJ-readable connector policy — the non-sensitive subset of the admin
+         *     policy surface.
+         *
+         *     Lets the settings/ai page fail *closed*: a normal DJ can learn which
+         *     connector types the admin has enabled (so disallowed providers are hidden
+         *     in the picker) without exposing admin-only fields such as
+         *     ``llm_default_connector_id``.
+         *
+         *     ``allowed_connector_types`` is the pre-computed set of connector types a DJ
+         *     may create given the two toggles, so the frontend doesn't have to hard-code
+         *     the api-key-vs-compatible mapping.
+         */
+        DjPolicyOut: {
+            /** Allowed Connector Types */
+            allowed_connector_types: ("openai_apikey" | "anthropic_apikey" | "openai_compatible" | "openrouter_apikey" | "xai_apikey" | "bedrock" | "azure_openai" | "gemini_apikey")[];
+            /** Llm Apikey Connectors Enabled */
+            llm_apikey_connectors_enabled: boolean;
+            /** Llm Compatible Connector Enabled */
+            llm_compatible_connector_enabled: boolean;
         };
         /** EnrichPreviewItem */
         EnrichPreviewItem: {
@@ -7033,6 +7080,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AIModelsResponse"];
+                };
+            };
+        };
+    };
+    get_dj_policy_api_llm_policy_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DjPolicyOut"];
                 };
             };
         };

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -61,6 +61,7 @@ export type LlmConnectorCredentialsRotate = Schemas['ConnectorCredentialsRotate'
 export type LlmConnectorTestResult = Schemas['ConnectorTestResult'];
 export type LlmAdminPolicy = Schemas['AdminPolicyOut'];
 export type LlmAdminPolicyPatch = Schemas['AdminPolicyPatch'];
+export type LlmDjPolicy = Schemas['DjPolicyOut'];
 export type LlmAdminUsage = Schemas['AdminUsageOut'];
 export type LlmUsageRow = Schemas['UsageRow'];
 // Derive from schema so backend enum changes propagate to TS automatically.

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -14,6 +14,7 @@ import type {
   LlmConnectorCredentialsRotate,
   LlmConnectorPatch,
   LlmConnectorTestResult,
+  LlmDjPolicy,
   ArchivedEvent,
   BeatportEventSettings,
   BeatportSearchResult,
@@ -69,6 +70,7 @@ export type {
   LlmConnectorStatus,
   LlmConnectorTestResult,
   LlmConnectorType,
+  LlmDjPolicy,
   LlmUsageRow,
   ArchivedEvent,
   BeatportEventSettings,
@@ -1148,6 +1150,13 @@ class ApiClient {
 
   async listLlmConnectors(): Promise<LlmConnector[]> {
     return this.fetch('/api/llm/connectors');
+  }
+
+  // DJ-readable connector policy (non-sensitive subset). The settings/ai page
+  // uses this to fail closed — hiding connector types the admin disabled —
+  // instead of falling back to "all types allowed" on the admin-only endpoint.
+  async getLlmPolicy(): Promise<LlmDjPolicy> {
+    return this.fetch('/api/llm/policy');
   }
 
   async listOpenRouterModels(): Promise<AIModelsResponse> {

--- a/server/app/api/llm.py
+++ b/server/app/api/llm.py
@@ -134,7 +134,14 @@ def list_connectors(
     return [ConnectorOut.model_validate(r) for r in rows]
 
 
-@router.get("/policy", response_model=DjPolicyOut)
+@router.get(
+    "/policy",
+    response_model=DjPolicyOut,
+    responses={
+        401: {"description": "Not authenticated (missing or invalid bearer token)."},
+        403: {"description": "Authenticated but not an active DJ (e.g. pending approval)."},
+    },
+)
 @limiter.limit("60/minute")
 def get_dj_policy(
     request: FastAPIRequest,

--- a/server/app/api/llm.py
+++ b/server/app/api/llm.py
@@ -31,6 +31,7 @@ from app.schemas.llm import (
     ConnectorOut,
     ConnectorPatch,
     ConnectorTestResult,
+    DjPolicyOut,
 )
 from app.services.llm.connector_storage import (
     AUDIT_CREATED,
@@ -61,6 +62,28 @@ from app.services.system_settings import get_system_settings
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+# API-key connector types (everything that isn't the custom OpenAI-compatible
+# endpoint). Gated by the single ``llm_apikey_connectors_enabled`` flag, mirroring
+# ``_check_connector_type_allowed`` below. Sorted for a deterministic response.
+_APIKEY_CONNECTOR_TYPES: tuple[str, ...] = tuple(
+    sorted(VALID_CONNECTOR_TYPES - {CONNECTOR_TYPE_OPENAI_COMPATIBLE})
+)
+
+
+def _allowed_connector_types(*, apikey_enabled: bool, compatible_enabled: bool) -> list[str]:
+    """Compute the connector types a DJ may create under the given policy.
+
+    Kept consistent with ``_check_connector_type_allowed`` so the advertised set
+    exactly matches what the create endpoint will accept (no UX/enforcement drift).
+    """
+    allowed: list[str] = []
+    if apikey_enabled:
+        allowed.extend(_APIKEY_CONNECTOR_TYPES)
+    if compatible_enabled:
+        allowed.append(CONNECTOR_TYPE_OPENAI_COMPATIBLE)
+    return allowed
 
 
 def _check_connector_type_allowed(db: Session, connector_type: str) -> None:
@@ -109,6 +132,31 @@ def list_connectors(
 ) -> list[ConnectorOut]:
     rows = list_connectors_for_user(db, user.id)
     return [ConnectorOut.model_validate(r) for r in rows]
+
+
+@router.get("/policy", response_model=DjPolicyOut)
+@limiter.limit("60/minute")
+def get_dj_policy(
+    request: FastAPIRequest,
+    _user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+) -> DjPolicyOut:
+    """DJ-readable connector policy (non-sensitive subset).
+
+    The settings/ai page consumes this to fail *closed* — hiding connector
+    types the admin has disabled rather than showing every provider and only
+    discovering the block when the create call returns 403. Admin-only fields
+    (e.g. ``llm_default_connector_id``) are intentionally excluded.
+    """
+    settings = get_system_settings(db)
+    return DjPolicyOut(
+        llm_apikey_connectors_enabled=settings.llm_apikey_connectors_enabled,
+        llm_compatible_connector_enabled=settings.llm_compatible_connector_enabled,
+        allowed_connector_types=_allowed_connector_types(
+            apikey_enabled=settings.llm_apikey_connectors_enabled,
+            compatible_enabled=settings.llm_compatible_connector_enabled,
+        ),  # type: ignore[arg-type]
+    )
 
 
 @router.get("/openrouter/models", response_model=AIModelsResponse)

--- a/server/app/schemas/llm.py
+++ b/server/app/schemas/llm.py
@@ -201,6 +201,25 @@ class AdminPolicyOut(BaseModel):
     llm_default_connector_id: int | None
 
 
+class DjPolicyOut(BaseModel):
+    """DJ-readable connector policy — the non-sensitive subset of the admin
+    policy surface.
+
+    Lets the settings/ai page fail *closed*: a normal DJ can learn which
+    connector types the admin has enabled (so disallowed providers are hidden
+    in the picker) without exposing admin-only fields such as
+    ``llm_default_connector_id``.
+
+    ``allowed_connector_types`` is the pre-computed set of connector types a DJ
+    may create given the two toggles, so the frontend doesn't have to hard-code
+    the api-key-vs-compatible mapping.
+    """
+
+    llm_apikey_connectors_enabled: bool
+    llm_compatible_connector_enabled: bool
+    allowed_connector_types: list[ConnectorType]
+
+
 class AdminPolicyPatch(BaseModel):
     llm_apikey_connectors_enabled: bool | None = None
     llm_compatible_connector_enabled: bool | None = None

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -10373,6 +10373,12 @@
               }
             },
             "description": "Successful Response"
+          },
+          "401": {
+            "description": "Not authenticated (missing or invalid bearer token)."
+          },
+          "403": {
+            "description": "Authenticated but not an active DJ (e.g. pending approval)."
           }
         },
         "security": [

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -2461,6 +2461,43 @@
         "title": "DisplaySettingsUpdate",
         "type": "object"
       },
+      "DjPolicyOut": {
+        "description": "DJ-readable connector policy \u2014 the non-sensitive subset of the admin\npolicy surface.\n\nLets the settings/ai page fail *closed*: a normal DJ can learn which\nconnector types the admin has enabled (so disallowed providers are hidden\nin the picker) without exposing admin-only fields such as\n``llm_default_connector_id``.\n\n``allowed_connector_types`` is the pre-computed set of connector types a DJ\nmay create given the two toggles, so the frontend doesn't have to hard-code\nthe api-key-vs-compatible mapping.",
+        "properties": {
+          "allowed_connector_types": {
+            "items": {
+              "enum": [
+                "openai_apikey",
+                "anthropic_apikey",
+                "openai_compatible",
+                "openrouter_apikey",
+                "xai_apikey",
+                "bedrock",
+                "azure_openai",
+                "gemini_apikey"
+              ],
+              "type": "string"
+            },
+            "title": "Allowed Connector Types",
+            "type": "array"
+          },
+          "llm_apikey_connectors_enabled": {
+            "title": "Llm Apikey Connectors Enabled",
+            "type": "boolean"
+          },
+          "llm_compatible_connector_enabled": {
+            "title": "Llm Compatible Connector Enabled",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "allowed_connector_types",
+          "llm_apikey_connectors_enabled",
+          "llm_compatible_connector_enabled"
+        ],
+        "title": "DjPolicyOut",
+        "type": "object"
+      },
       "EnrichPreviewItem": {
         "properties": {
           "artist": {
@@ -10317,6 +10354,33 @@
           }
         ],
         "summary": "List Openrouter Models",
+        "tags": [
+          "llm"
+        ]
+      }
+    },
+    "/api/llm/policy": {
+      "get": {
+        "description": "DJ-readable connector policy (non-sensitive subset).\n\nThe settings/ai page consumes this to fail *closed* \u2014 hiding connector\ntypes the admin has disabled rather than showing every provider and only\ndiscovering the block when the create call returns 403. Admin-only fields\n(e.g. ``llm_default_connector_id``) are intentionally excluded.",
+        "operationId": "get_dj_policy_api_llm_policy_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DjPolicyOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Dj Policy",
         "tags": [
           "llm"
         ]

--- a/server/tests/test_llm_api.py
+++ b/server/tests/test_llm_api.py
@@ -781,3 +781,93 @@ class TestAdminLlm:
         data = resp.json()
         assert data["days"] == 30
         assert any(r["connector_id"] == row.id for r in data["rows"])
+
+
+# ---------- DJ-readable policy endpoint (issue #355) ----------
+class TestDjPolicyEndpoint:
+    """GET /api/llm/policy — DJ-scoped, non-sensitive policy surface.
+
+    A normal DJ must be able to read which connector types the admin has
+    enabled so the settings/ai page can fail closed instead of offering
+    providers that the server will reject at create time.
+    """
+
+    def test_dj_can_read_policy_defaults_all_allowed(self, client: TestClient, auth_headers):
+        resp = client.get("/api/llm/policy", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        # Defaults: both flags enabled.
+        assert data["llm_apikey_connectors_enabled"] is True
+        assert data["llm_compatible_connector_enabled"] is True
+        # The allowed-types set must cover every valid connector type by default.
+        assert set(data["allowed_connector_types"]) == {
+            "openai_apikey",
+            "anthropic_apikey",
+            "openai_compatible",
+            "gemini_apikey",
+            "azure_openai",
+            "bedrock",
+            "openrouter_apikey",
+            "xai_apikey",
+        }
+        # Must NOT leak the sensitive admin-only default-connector pointer.
+        assert "llm_default_connector_id" not in data
+
+    def test_policy_reflects_apikey_disabled(self, client: TestClient, auth_headers, admin_headers):
+        resp = client.patch(
+            "/api/admin/llm/policy",
+            json={"llm_apikey_connectors_enabled": False},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+
+        resp = client.get("/api/llm/policy", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["llm_apikey_connectors_enabled"] is False
+        assert data["llm_compatible_connector_enabled"] is True
+        # Only the openai_compatible type remains allowed.
+        assert data["allowed_connector_types"] == ["openai_compatible"]
+
+    def test_policy_reflects_compatible_disabled(
+        self, client: TestClient, auth_headers, admin_headers
+    ):
+        resp = client.patch(
+            "/api/admin/llm/policy",
+            json={"llm_compatible_connector_enabled": False},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+
+        resp = client.get("/api/llm/policy", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["llm_compatible_connector_enabled"] is False
+        assert "openai_compatible" not in data["allowed_connector_types"]
+        # API-key types still present.
+        assert "openai_apikey" in data["allowed_connector_types"]
+
+    def test_policy_all_disabled_yields_empty_allowed(
+        self, client: TestClient, auth_headers, admin_headers
+    ):
+        resp = client.patch(
+            "/api/admin/llm/policy",
+            json={
+                "llm_apikey_connectors_enabled": False,
+                "llm_compatible_connector_enabled": False,
+            },
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+
+        resp = client.get("/api/llm/policy", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["allowed_connector_types"] == []
+
+    def test_pending_user_cannot_read_policy(self, client: TestClient, pending_headers):
+        resp = client.get("/api/llm/policy", headers=pending_headers)
+        assert resp.status_code == 403
+
+    def test_unauthenticated_cannot_read_policy(self, client: TestClient):
+        resp = client.get("/api/llm/policy")
+        assert resp.status_code == 401


### PR DESCRIPTION
Closes #355

## Summary
Adds a DJ-scoped policy endpoint so the AI settings page can fail *closed* instead of relying on the admin-only policy endpoint (which always 403s for a normal DJ, causing the page to treat the null as "all connector types allowed").

- **Backend**: new `GET /api/llm/policy` (`get_current_active_user` — rejects `pending`) returning the non-sensitive policy subset: `llm_apikey_connectors_enabled`, `llm_compatible_connector_enabled`, and a server-computed `allowed_connector_types` list. Admin-only `llm_default_connector_id` is intentionally excluded.
- **Frontend**: `/settings/ai` now consumes the DJ endpoint via a new `api.getLlmPolicy()` client method and **fails closed** — when the policy fetch fails it offers *no* providers, rather than the old "show everything" fallback.
- No DB migration: reads the existing `SystemSettings` policy flags.

## Design decisions
- **`allowed_connector_types` computed server-side** (rather than re-deriving the api-key-vs-compatible mapping in the frontend). This keeps the advertised set in lock-step with `_check_connector_type_allowed` in `create_connector_endpoint`, eliminating UX/enforcement drift if a new connector type is added later. The helper `_allowed_connector_types()` lives beside the enforcement check for exactly this reason.
- **Fail-closed = empty set, not "api-key only"**: when the policy is unreadable the page hides the entire "+ Add provider" affordance and shows the existing "disabled by admin policy" copy. This is the safest interpretation per the issue ("hides api-key connector types (fail closed) rather than showing all").
- **Did not delete `getAdminLlmPolicy()`** from the API client. It's still used by the admin `/admin/ai` page (off-limits in this PR's footprint), so removing it would break another surface / cause merge conflicts.
- **Reused the single `llm_apikey_connectors_enabled` flag** for all api-key provider types (OpenAI/Anthropic/OpenRouter/xAI/Gemini/Bedrock/Azure), matching the existing create-time enforcement — no new per-provider flags.
- **Regenerated `openapi.json` + `api-types.generated.ts`** (additive only) so the `DjPolicyOut` type flows through to TypeScript and CI sees zero drift.

## Test plan
- [x] Backend: endpoint authz — DJ 200, `pending` 403, unauthenticated 401
- [x] Backend: policy reflects each toggle (apikey off → only `openai_compatible`; compatible off → no `openai_compatible`; all off → empty); response omits `llm_default_connector_id`
- [x] Frontend: page reads the DJ endpoint; fails closed (no providers) on fetch failure; only api-key types when compatible disabled
- [x] Full local CI green — backend ruff/format/bandit/pytest (2263 passed, 86.91% cov); frontend lint/tsc/vitest (952 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AI settings now use DJ-scoped policy endpoint for connector availability, ensuring appropriate access control
  * Server-provided connector types now determine which providers are available in the AI settings page

* **Bug Fixes**
  * Provider picker now fails securely by hiding options when policy fetch fails

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->