### PR TITLE
feat(ai): move DJ AI settings into account page (#357)

### DIFF
--- a/dashboard/app/(dj)/account/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/account/__tests__/page.test.tsx
@@ -20,6 +20,11 @@ vi.mock('@/lib/api', () => ({
     getMe: () => mockGetMe(),
     changePassword: (...args: unknown[]) => mockChangePassword(...args),
     requestEmailChange: (...args: unknown[]) => mockRequestEmailChange(...args),
+    // The AI providers section (relocated from /settings/ai, #357) mounts
+    // inside the account page. Stub its API surface so the section can render
+    // without network access. getLlmPolicy rejects → fail-closed (no extra UI).
+    listLlmConnectors: () => Promise.resolve([]),
+    getLlmPolicy: () => Promise.reject(new Error('forbidden')),
   },
 }));
 
@@ -41,6 +46,13 @@ describe('AccountPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Change Password')).toBeInTheDocument();
       expect(screen.getByText('Change Email')).toBeInTheDocument();
+    });
+  });
+
+  it('renders the relocated AI / Model providers section', async () => {
+    render(<AccountPage />);
+    await waitFor(() => {
+      expect(screen.getByText('AI / Model providers')).toBeInTheDocument();
     });
   });
 

--- a/dashboard/app/(dj)/account/page.tsx
+++ b/dashboard/app/(dj)/account/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 
 import { useAuth } from '@/lib/auth';
 import { api } from '@/lib/api';
+import AiProvidersSection from '@/components/AiProvidersSection';
 
 export default function AccountPage() {
   const router = useRouter();
@@ -93,7 +94,7 @@ export default function AccountPage() {
   if (isLoading || !isAuthenticated) return null;
 
   return (
-    <main style={{ maxWidth: '480px', margin: '0 auto', padding: '2rem 1rem' }}>
+    <main style={{ maxWidth: '720px', margin: '0 auto', padding: '2rem 1rem' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '2rem' }}>
         <Link href="/dashboard" style={{ color: 'var(--text-secondary)', textDecoration: 'none', fontSize: '0.875rem' }}>
           ← Dashboard
@@ -199,6 +200,10 @@ export default function AccountPage() {
             </button>
           </form>
         )}
+      </div>
+
+      <div style={{ background: 'var(--card)', borderRadius: '0.75rem', padding: '1.5rem', marginTop: '1.5rem' }}>
+        <AiProvidersSection />
       </div>
     </main>
   );

--- a/dashboard/components/AiProvidersSection.tsx
+++ b/dashboard/components/AiProvidersSection.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 
 import { api } from '@/lib/api';
@@ -12,7 +10,6 @@ import type {
   LlmConnectorType,
   LlmDjPolicy,
 } from '@/lib/api-types';
-import { useAuth } from '@/lib/auth';
 
 const CONNECTOR_TYPE_LABELS: Record<LlmConnectorType, string> = {
   openai_apikey: 'OpenAI API key',
@@ -65,10 +62,16 @@ const EMPTY_FORM: FormState = {
   azure_api_version: '',
 };
 
-export default function SettingsAIPage() {
-  const router = useRouter();
-  const { isAuthenticated, isLoading } = useAuth();
-
+/**
+ * DJ-facing AI connector management UI (connect / test / delete, model hint,
+ * Hermes onboarding). Relocated from the standalone `/settings/ai` route into
+ * the `/account` page (issue #357). The component assumes the parent already
+ * enforces authentication — it does no auth gating of its own.
+ *
+ * Fail-closed behavior is preserved: when the DJ-scoped policy endpoint can't
+ * be read, NO provider types are offered rather than leaking every type.
+ */
+export default function AiProvidersSection() {
   const [policy, setPolicy] = useState<LlmDjPolicy | null>(null);
   const [connectors, setConnectors] = useState<LlmConnector[]>([]);
   const [loading, setLoading] = useState(true);
@@ -82,14 +85,7 @@ export default function SettingsAIPage() {
   const [openrouterModelsLoaded, setOpenrouterModelsLoaded] = useState(false);
 
   useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
-      router.push('/login');
-    }
-  }, [isAuthenticated, isLoading, router]);
-
-  useEffect(() => {
     let active = true;
-    if (!isAuthenticated) return;
     setLoading(true);
     setError('');
     Promise.all([api.listLlmConnectors(), fetchPolicySoft()])
@@ -108,7 +104,7 @@ export default function SettingsAIPage() {
     return () => {
       active = false;
     };
-  }, [isAuthenticated]);
+  }, []);
 
   // Lazily fetch the OpenRouter model catalogue the first time a DJ opens the
   // form on the OpenRouter type. Best-effort: an empty list (or a failed fetch)
@@ -132,8 +128,6 @@ export default function SettingsAIPage() {
     if (!policy) return [];
     return policy.allowed_connector_types as LlmConnectorType[];
   }, [policy]);
-
-  if (isLoading || !isAuthenticated) return null;
 
   const handleOpenForm = () => {
     if (allowedTypes.length === 0) {
@@ -223,13 +217,10 @@ export default function SettingsAIPage() {
   };
 
   return (
-    <main style={{ maxWidth: '720px', margin: '0 auto', padding: '2rem 1rem' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '2rem' }}>
-        <Link href="/dashboard" style={{ color: 'var(--text-secondary)', textDecoration: 'none', fontSize: '0.875rem' }}>
-          ← Dashboard
-        </Link>
-        <h1 style={{ margin: 0 }}>AI providers</h1>
-      </div>
+    <div>
+      <h2 style={{ marginTop: 0, marginBottom: '1.25rem', fontSize: '1.1rem' }}>
+        AI / Model providers
+      </h2>
 
       <p style={{ color: 'var(--text-secondary)' }}>
         Connect your own LLM provider so AI-assisted features (recommendations, etc.) bill to
@@ -247,7 +238,7 @@ export default function SettingsAIPage() {
       )}
 
       <section style={{ marginTop: '2rem' }}>
-        <h2>Connected providers</h2>
+        <h3 style={{ marginTop: 0 }}>Connected providers</h3>
         {connectors.length === 0 && !loading && (
           <p style={{ color: 'var(--text-secondary)' }}>No connectors yet.</p>
         )}
@@ -295,7 +286,7 @@ export default function SettingsAIPage() {
         )}
         {form.open && (
           <form className="card" onSubmit={handleCreate} style={{ marginTop: '1rem' }}>
-            <h2 style={{ marginTop: 0 }}>Add provider</h2>
+            <h3 style={{ marginTop: 0 }}>Add provider</h3>
 
             <div className="form-group">
               <label htmlFor="connector_type">Provider</label>
@@ -569,7 +560,7 @@ export default function SettingsAIPage() {
           </form>
         )}
       </section>
-    </main>
+    </div>
   );
 }
 

--- a/dashboard/components/__tests__/AiProvidersSection.test.tsx
+++ b/dashboard/components/__tests__/AiProvidersSection.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
-import SettingsAIPage from '../page';
+import AiProvidersSection from '../AiProvidersSection';
 import { api } from '@/lib/api';
 import type { LlmConnector, LlmConnectorType, LlmDjPolicy } from '@/lib/api-types';
 
@@ -16,7 +16,7 @@ const ALL_APIKEY_TYPES: LlmConnectorType[] = [
 ];
 
 // Build a DJ policy payload. `allowed_connector_types` is what the server
-// computes from the two toggles; the page renders exactly this set.
+// computes from the two toggles; the section renders exactly this set.
 function makePolicy(
   apikeyEnabled: boolean,
   compatibleEnabled: boolean,
@@ -30,24 +30,6 @@ function makePolicy(
     allowed_connector_types: allowed,
   };
 }
-
-vi.mock('@/lib/auth', () => ({
-  useAuth: () => ({
-    isAuthenticated: true,
-    isLoading: false,
-    role: 'dj',
-    logout: vi.fn(),
-  }),
-}));
-
-vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn() }),
-  usePathname: () => '/settings/ai',
-}));
-
-vi.mock('next/link', () => ({
-  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
 
 const NOW = new Date().toISOString();
 
@@ -68,9 +50,18 @@ function makeConnector(overrides: Partial<LlmConnector> = {}): LlmConnector {
   };
 }
 
-describe('SettingsAIPage', () => {
+describe('AiProvidersSection', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('renders the section heading', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
+    vi.spyOn(api, 'getLlmPolicy').mockRejectedValue(new Error('forbidden'));
+
+    render(<AiProvidersSection />);
+
+    expect(screen.getByText('AI / Model providers')).toBeInTheDocument();
   });
 
   it('lists existing connectors', async () => {
@@ -85,7 +76,7 @@ describe('SettingsAIPage', () => {
     ]);
     vi.spyOn(api, 'getLlmPolicy').mockRejectedValue(new Error('forbidden'));
 
-    render(<SettingsAIPage />);
+    render(<AiProvidersSection />);
 
     await waitFor(() => expect(screen.getByText('My OpenAI')).toBeInTheDocument());
     expect(screen.getByText('My Claude')).toBeInTheDocument();
@@ -95,7 +86,7 @@ describe('SettingsAIPage', () => {
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
     vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(false, true));
 
-    render(<SettingsAIPage />);
+    render(<AiProvidersSection />);
 
     await waitFor(() => expect(screen.getByText('+ Add provider')).toBeInTheDocument());
     fireEvent.click(screen.getByText('+ Add provider'));
@@ -115,7 +106,7 @@ describe('SettingsAIPage', () => {
       .spyOn(api, 'getLlmPolicy')
       .mockResolvedValue(makePolicy(true, true));
 
-    render(<SettingsAIPage />);
+    render(<AiProvidersSection />);
 
     await waitFor(() => expect(policySpy).toHaveBeenCalled());
     expect(adminPolicySpy).not.toHaveBeenCalled();
@@ -126,7 +117,7 @@ describe('SettingsAIPage', () => {
     // Simulate the DJ policy endpoint being unavailable.
     vi.spyOn(api, 'getLlmPolicy').mockRejectedValue(new Error('unavailable'));
 
-    render(<SettingsAIPage />);
+    render(<AiProvidersSection />);
 
     // No "+ Add provider" button — the picker is hidden entirely.
     await waitFor(() =>
@@ -142,7 +133,7 @@ describe('SettingsAIPage', () => {
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
     vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(true, false));
 
-    render(<SettingsAIPage />);
+    render(<AiProvidersSection />);
 
     await waitFor(() => expect(screen.getByText('+ Add provider')).toBeInTheDocument());
     fireEvent.click(screen.getByText('+ Add provider'));
@@ -157,7 +148,7 @@ describe('SettingsAIPage', () => {
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
     vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(true, true));
 
-    render(<SettingsAIPage />);
+    render(<AiProvidersSection />);
 
     await waitFor(() => expect(screen.getByText('+ Add provider')).toBeInTheDocument());
     fireEvent.click(screen.getByText('+ Add provider'));
@@ -181,7 +172,7 @@ describe('SettingsAIPage', () => {
       .spyOn(api, 'createLlmConnector')
       .mockResolvedValue(makeConnector({ connector_type: 'azure_openai' }));
 
-    render(<SettingsAIPage />);
+    render(<AiProvidersSection />);
 
     await waitFor(() => expect(screen.getByText('+ Add provider')).toBeInTheDocument());
     fireEvent.click(screen.getByText('+ Add provider'));
@@ -223,7 +214,7 @@ describe('SettingsAIPage', () => {
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
     vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(true, false));
 
-    render(<SettingsAIPage />);
+    render(<AiProvidersSection />);
 
     await waitFor(() => expect(screen.getByText('+ Add provider')).toBeInTheDocument());
     fireEvent.click(screen.getByText('+ Add provider'));
@@ -253,7 +244,7 @@ describe('SettingsAIPage', () => {
     // The refresh after Test re-lists connectors
     vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([row]);
 
-    render(<SettingsAIPage />);
+    render(<AiProvidersSection />);
 
     await waitFor(() => expect(screen.getByText('My OpenAI')).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: 'Test' }));
@@ -272,7 +263,7 @@ describe('SettingsAIPage', () => {
       ],
     });
 
-    render(<SettingsAIPage />);
+    render(<AiProvidersSection />);
 
     await waitFor(() => expect(screen.getByText('+ Add provider')).toBeInTheDocument());
     fireEvent.click(screen.getByText('+ Add provider'));
@@ -307,7 +298,7 @@ describe('SettingsAIPage', () => {
       }),
     );
 
-    render(<SettingsAIPage />);
+    render(<AiProvidersSection />);
     await waitFor(() => expect(screen.getByText('+ Add provider')).toBeInTheDocument());
     fireEvent.click(screen.getByText('+ Add provider'));
 
@@ -346,7 +337,7 @@ describe('SettingsAIPage', () => {
     const delSpy = vi.spyOn(api, 'deleteLlmConnector').mockResolvedValue();
     vi.spyOn(window, 'confirm').mockReturnValue(true);
 
-    render(<SettingsAIPage />);
+    render(<AiProvidersSection />);
 
     await waitFor(() => expect(screen.getByText('My OpenAI')).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));

--- a/dashboard/next.config.js
+++ b/dashboard/next.config.js
@@ -15,6 +15,13 @@ const csp = [
 const nextConfig = {
   output: 'standalone',
   allowedDevOrigins: ['192.168.*.*'],
+  async redirects() {
+    return [
+      // DJ AI connector/model settings moved into the account page (#357).
+      // Keep old bookmarks/links working with a permanent (308) redirect.
+      { source: '/settings/ai', destination: '/account', permanent: true },
+    ];
+  },
   async headers() {
     return [
       {

--- a/docs/superpowers/plans/2026-05-26-move-dj-ai-settings-to-account.md
+++ b/docs/superpowers/plans/2026-05-26-move-dj-ai-settings-to-account.md
@@ -1,0 +1,96 @@
+# Move DJ AI connector/model settings into the account page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Relocate the DJ-facing AI connector UI (connect/test/rotate/delete, model hint, Hermes onboarding) from `/settings/ai` into the existing `/account` page, redirect the old route, and update tests — keeping the admin `/admin/ai` UI untouched.
+
+**Architecture:** Extract the existing `/settings/ai` page body into a reusable client component `components/AiProvidersSection.tsx`. Render it as a third inline card section inside `/account`. Delete the old `/settings/ai` route and add a server-side redirect in `next.config.js` so bookmarks 308 to `/account`. Preserve fail-closed policy behavior verbatim (it moves with the component).
+
+**Tech Stack:** Next.js 16 (App Router), React 19, TypeScript (strict), vanilla CSS + inline styles, Vitest + Testing Library.
+
+---
+
+### Task 1: Extract AI providers UI into a reusable component
+
+**Files:**
+- Create: `dashboard/components/AiProvidersSection.tsx`
+- Reference (source of logic): `dashboard/app/(dj)/settings/ai/page.tsx`
+
+The component contains ALL connector logic from the current page: policy fetch (`fetchPolicySoft` → `getLlmPolicy`), `allowedTypes` fail-closed memo, connectors list, create form (all provider types incl. bedrock/azure/openai_compatible/openrouter dropdown), test, delete. It must NOT include the page-level `<main>` wrapper, the "← Dashboard" link header, the `useAuth`/`useRouter` auth-redirect (those stay at the page level — `/account` already does the auth gate). It exports a default React component `AiProvidersSection` rendering a `<section>` that begins with an `<h2>AI / Model providers</h2>` and the existing intro paragraph, then "Connected providers" and the add-provider form.
+
+- [ ] **Step 1: Create the component** by moving the body. Keep every form field, label text (e.g. `Provider`, `Display name`, `API key`, `Resource name`, `Bedrock model ID`, `Model (optional)`), the OpenRouter model fetch effect, and the fail-closed `allowedTypes` logic identical so existing test assertions still hold. The top of the rendered output is an intro `<h2>` + `<p>`; the rest is the two `<section>`s. Wrap all of it in a single fragment/section with `style={{ marginTop: '2rem' }}` matching the account-page card rhythm (it will live inside its own card in Task 2, so use a plain wrapper, not a `.card`).
+
+- [ ] **Step 2: Type-check** — `cd dashboard && npx tsc --noEmit`. Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/components/AiProvidersSection.tsx
+git commit -m "refactor(ai): extract AI providers UI into reusable component"
+```
+
+---
+
+### Task 2: Render the AI section inside /account and delete old route
+
+**Files:**
+- Modify: `dashboard/app/(dj)/account/page.tsx`
+- Modify: `dashboard/next.config.js` (add `redirects()`)
+- Delete: `dashboard/app/(dj)/settings/ai/page.tsx`
+- Delete: `dashboard/app/(dj)/settings/ai/__tests__/page.test.tsx` (logic re-tested via component in Task 3)
+- Delete dir if empty: `dashboard/app/(dj)/settings/`
+
+- [ ] **Step 1: Import and render** `AiProvidersSection` in `/account`. Add a third card `<div>` (same wrapper style as Change Email card: `{ background: 'var(--card)', borderRadius: '0.75rem', padding: '1.5rem', marginTop: '1.5rem' }`) below Change Email, containing `<AiProvidersSection />`. Widen the page `<main>` maxWidth from `480px` to `720px` so the provider form (which used `720px`) is not cramped.
+
+- [ ] **Step 2: Add redirect** in `next.config.js`:
+
+```js
+async redirects() {
+  return [
+    { source: '/settings/ai', destination: '/account', permanent: true },
+  ];
+},
+```
+
+- [ ] **Step 3: Delete** the old route file, its test, and the now-empty `settings/` dir.
+
+- [ ] **Step 4: Grep** `grep -rn "/settings/ai" dashboard/ --include="*.ts" --include="*.tsx" | grep -v node_modules` → expect no remaining nav/link hits (only possibly api-types doc comments, which are fine).
+
+- [ ] **Step 5: Type-check + lint** — `cd dashboard && npx tsc --noEmit && npm run lint`. Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/app/\(dj\)/account/page.tsx dashboard/next.config.js
+git add -u dashboard/app/\(dj\)/settings
+git commit -m "feat(ai): move DJ AI settings into account page; redirect old route (#357)"
+```
+
+---
+
+### Task 3: Move/adapt the AI tests to the component + account page
+
+**Files:**
+- Create: `dashboard/components/__tests__/AiProvidersSection.test.tsx` (port the old settings/ai tests, importing the component instead of the page; drop the `next/navigation`/`useAuth` mocks that the page-level no longer needs but keep `next/link` mock if used)
+- Modify: `dashboard/app/(dj)/account/__tests__/page.test.tsx` (add the AI api methods to the `@/lib/api` mock so the section can mount inside the account page without throwing, and assert the AI heading renders)
+
+- [ ] **Step 1: Port connector tests** to `AiProvidersSection.test.tsx` — same assertions (lists connectors, fail-closed hides providers, policy filtering, azure/bedrock/openrouter fields, test, delete). Render `<AiProvidersSection />` directly. Keep `vi.mock('next/link', ...)` if the component still uses `Link` (it should NOT — Link header stays on the page; remove the import). Mock `@/lib/api` methods used: `listLlmConnectors`, `getLlmPolicy`, `createLlmConnector`, `testLlmConnector`, `deleteLlmConnector`, `listOpenRouterModels`, `getAdminLlmPolicy` (for the "reads DJ-scoped not admin" test).
+
+- [ ] **Step 2: Update account page test** — extend the existing `vi.mock('@/lib/api', ...)` to add `listLlmConnectors: () => Promise.resolve([])` and `getLlmPolicy: () => Promise.reject(new Error('x'))` (fail-closed, no extra UI). Add a test: AI heading `AI / Model providers` is in the document.
+
+- [ ] **Step 3: Run frontend tests** — `cd dashboard && npm test -- --run`. Expected: PASS, coverage thresholds met.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dashboard/components/__tests__/AiProvidersSection.test.tsx dashboard/app/\(dj\)/account/__tests__/page.test.tsx
+git commit -m "test(ai): relocate AI provider tests to component + account page (#357)"
+```
+
+---
+
+## Self-Review
+
+- Spec coverage: relocate UI (Task 1+2) ✓; update nav/links (Task 2 grep — only the page itself referenced it) ✓; redirect old route (Task 2) ✓; admin /admin/ai untouched (not touched by any task) ✓; tests moved (Task 3) ✓; fail-closed preserved (logic moved verbatim, retested) ✓.
+- Placeholder scan: none.
+- Type consistency: component name `AiProvidersSection` used consistently in Tasks 1–3.


### PR DESCRIPTION
Closes #357

## Summary
- Relocate the DJ-facing AI connector UI (connect / test / delete, model hint, Hermes onboarding) from the standalone `/settings/ai` route into the existing `/account` page.
- The connector UI is extracted into a reusable `components/AiProvidersSection.tsx` and rendered as an inline **"AI / Model providers"** card section in `/account`, alongside Change Password and Change Email.
- Old `/settings/ai` route is removed; a permanent (308) redirect `/settings/ai -> /account` is added in `next.config.js` so existing bookmarks/links don't 404.
- Admin policy/usage UI at `/admin/ai` is **unchanged** — this is purely the per-DJ settings location.

## Design decisions
- **Inline section vs tab in `/account`:** chose an **inline card section** ("AI / Model providers") rather than introducing a tab system. The account page is already a vertical stack of card sections (Change Password, Change Email); a third card fits the existing information architecture with zero new navigation primitives. The page `<main>` maxWidth was widened from 480px to 720px so the provider form (originally 720px wide) isn't cramped.
- **Redirect implementation:** used a server-side `redirects()` entry in `next.config.js` (308 permanent) instead of a client-side redirect page. This avoids a render flash, returns a proper HTTP redirect for crawlers/bookmarks, and lets the old route be fully deleted (no orphan `page.tsx`). Permanent (308) is appropriate because the move is a stable IA change, not temporary.
- **Component extraction + auth gating:** the connector logic moved verbatim into `AiProvidersSection`, but the page-level auth-redirect (`useAuth`/`useRouter` -> `/login`) and the "← Dashboard" header were left at the page level. `/account` already enforces auth, so the section does no auth gating of its own — avoids a duplicate/competing redirect.
- **Fail-closed preserved (pairs with #355):** the `fetchPolicySoft()` -> `getLlmPolicy()` read and the `allowedTypes` memo are copied unchanged. When the DJ-scoped policy endpoint can't be read, **no** provider types are offered (rather than leaking every type). Regression tests for this behavior were ported to the component test and a fail-closed mock was added to the account-page test.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (only a pre-existing unrelated warning in `useHumanVerification.ts`)
- [x] `npm test -- --run` — 956 tests pass across 67 files
- [x] `npm test -- --run --coverage` — coverage thresholds met (branches 68.7/68, functions 72.07/65, lines 80.64/78, statements 78.87/77)
- [x] Connector CRUD/test tests ported to `components/__tests__/AiProvidersSection.test.tsx` (lists, fail-closed hide-all, policy filtering, Azure/Bedrock/OpenRouter fields, create, test, delete)
- [x] `/account` page test asserts the relocated "AI / Model providers" section renders
- [ ] Manual: visit `/account`, confirm AI section CRUD/test/delete work; confirm `/settings/ai` 308-redirects to `/account`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI and model provider management has been relocated to the account page for easier access and consolidated settings management.

* **Improvements**
  * Account page layout expanded to accommodate the new provider settings section.
  * Previous direct links to AI settings automatically redirect to the account page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->