### PR TITLE
chore(ai): remove deprecated ANTHROPIC_API_KEY env-var reads (#343)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,18 +121,16 @@ BOOTSTRAP_ADMIN_PASSWORD=your-secure-password
 # =============================================================================
 # LLM / AI providers
 # =============================================================================
-# As of v2026.05.24, LLM credentials are managed per-DJ via the gateway
-# (admin: /admin/ai, DJ: /settings/ai). On first deploy, ANTHROPIC_API_KEY
-# is migrated into a system-default "anthropic_apikey" connector (assigned
-# to the first admin user for management, set as the org-wide default).
-# After the migration runs you can remove ANTHROPIC_API_KEY from this file
-# — a follow-up release will delete the env-var fallback path entirely
-# (tracked under the "AI Engine Back-end Redesign" milestone).
+# LLM credentials are managed per-DJ via the gateway connector system
+# (admin: /admin/ai, DJ: /settings/ai) — there is NO env-var credential path.
+# The recommendation engine routes every call through the gateway, which
+# resolves the actor DJ's connector (or the org default).
 #
-# ANTHROPIC_API_KEY=your-anthropic-key       # DEPRECATED — migrated to connector
-# ANTHROPIC_MODEL=claude-haiku-4-5-20251001
-# ANTHROPIC_MAX_TOKENS=1024
-# ANTHROPIC_TIMEOUT_SECONDS=15
+# Historical note: the one-shot Alembic data migration (046_admin_ai_oauth)
+# reads ANTHROPIC_API_KEY *once* on first upgrade, converting it into a
+# system-default "anthropic_apikey" connector. Once that migration has run on a
+# deploy, the env var is no longer consumed at runtime and can be dropped. The
+# legacy env-var fallback in the recommendation engine was removed in #343.
 
 # =============================================================================
 # Frontend (Next.js)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ NEXT_PUBLIC_API_URL="http://LAN_IP:8000" npm run dev
 - Encryption: `TOKEN_ENCRYPTION_KEY` (Fernet, 44 chars base64) — required in production for OAuth token encryption
 - Beatport: `BEATPORT_CLIENT_ID`, `BEATPORT_CLIENT_SECRET`, `BEATPORT_REDIRECT_URI`, `BEATPORT_AUTH_BASE_URL`
 - Soundcharts: `SOUNDCHARTS_APP_ID`, `SOUNDCHARTS_API_KEY` (song discovery for recommendations)
-- Anthropic (LLM recommendations, legacy): `ANTHROPIC_API_KEY` (**DEPRECATED** — migrated to the LLM Gateway connector system; see `.env.example` LLM section), `ANTHROPIC_MODEL` (default: `claude-haiku-4-5-20251001`), `ANTHROPIC_MAX_TOKENS`, `ANTHROPIC_TIMEOUT_SECONDS`
+- Anthropic (LLM recommendations): credentials live in the LLM Gateway connector system — there is **no env-var credential path**. The one-shot Alembic migration `046_admin_ai_oauth` reads `ANTHROPIC_API_KEY` *once* on first upgrade to seed a connector; the legacy env-var fallback in the recommendation engine was removed in #343. `ANTHROPIC_MODEL` (default: `claude-haiku-4-5-20251001`) is retained only as the default model-name label on recommendation responses and for the admin AI-settings/model-listing endpoints. The `ANTHROPIC_MAX_TOKENS` / `ANTHROPIC_TIMEOUT_SECONDS` settings were removed.
 
 ## Running CI Checks Locally
 
@@ -329,7 +329,7 @@ REJECTED → NEW (re-open)
 - DJ endpoints (`/api/llm/connectors`): list/create/rotate/test/delete (rate-limited, scoped to current user)
 - Admin UI: `/admin/ai` (policy + per-DJ table + usage)
 - DJ UI: `/settings/ai` (connect/test/delete; includes Hermes onboarding for ChatGPT subscription path)
-- The recommendation engine routes through the gateway (`actor = event.created_by`, `purpose = "recommendation"`); the legacy env-var path in `services/recommendation/llm_client.py` remains only as a fallback for callers that don't pass `db`/`actor` (kept until the env-var cleanup follow-up issue ships).
+- The recommendation engine routes through the gateway (`actor = event.created_by`, `purpose = "recommendation"`); `call_llm` now **requires** a `db` session — the legacy direct-Anthropic env-var fallback was removed in #343 (the connector system is the sole credential source).
 
 ### Recommendation Engine
 - `server/app/services/recommendation/` — multi-stage pipeline:
@@ -337,7 +337,7 @@ REJECTED → NEW (re-open)
   - `enrichment.py` — fills missing BPM/key/genre from Beatport/MusicBrainz/Tidal (for recommendations; request-level enrichment is in `sync/orchestrator.py`)
   - `scorer.py` — multi-dimensional scoring: BPM compatibility, harmonic mixing, genre affinity, artist diversity penalties
   - `camelot.py` — harmonic mixing wheel (Camelot key compatibility, half-time/double-time BPM)
-  - `llm_client.py` — gateway-backed query generation (forced `tool_use` schema for structured JSON; legacy direct-Anthropic path retained as fallback for callers without `db`/`actor`)
+  - `llm_client.py` — gateway-backed query generation (forced `tool_use` schema for structured JSON; requires `db` — the legacy direct-Anthropic env-var fallback was removed in #343)
   - `llm_hooks.py` — structured response models for LLM queries
   - `template.py` — playlist-based template recommendations (DJ picks a Tidal/Beatport playlist as "vibe" source)
   - `mb_verify.py` — MusicBrainz artist verification to detect AI-generated filler tracks (cached in DB)

--- a/docs/superpowers/plans/2026-05-26-remove-deprecated-anthropic-env-reads.md
+++ b/docs/superpowers/plans/2026-05-26-remove-deprecated-anthropic-env-reads.md
@@ -1,0 +1,106 @@
+# Remove deprecated ANTHROPIC_API_KEY env-var reads Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the now-dead legacy `ANTHROPIC_API_KEY` env-var fallback path in the recommendation engine, since the LLM Gateway connector system has been the source of truth for credentials since the MVP.
+
+**Architecture:** Every production caller of `call_llm` / `generate_llm_suggestions` passes `db` + `actor`, so the gateway path always runs and the `_legacy_call` direct-Anthropic fallback (and its `anthropic_api_key` / `anthropic_max_tokens` / `anthropic_timeout_seconds` config reads) is dead code. We delete that fallback, the unused config fields, and refresh the legacy unit test to drive the gateway path instead. We deliberately KEEP `config.anthropic_api_key` and `config.anthropic_model` because the admin AI-settings/model-listing endpoints and the recommendation response `llm_model` default still read them — removing those is a cross-cutting frontend+API-contract change out of scope for this backend cleanup.
+
+**Tech Stack:** Python 3.11+, FastAPI, pydantic-settings, pytest.
+
+---
+
+## Design decisions (scope reconciliation)
+
+The issue's literal grep target is the **uppercase env-var name** `ANTHROPIC_API_KEY`. In non-test code that string appears only in:
+- `server/alembic/versions/046_admin_ai_oauth.py` — historical one-shot data migration. **MUST stay** (allowable exception).
+- `server/app/services/recommendation/llm_hooks.py:78` — a docstring mention of the dead fallback. **Removed** here.
+
+The actual env-var *reads* go through the pydantic-settings attribute `config.anthropic_api_key` (lowercase). Mapping every read:
+
+| Location | What it does | Decision |
+|---|---|---|
+| `llm_client._legacy_call` | direct-Anthropic fallback when `db is None` | **REMOVE** — dead; all callers pass `db` |
+| `llm_client._resolve_max_tokens` | reads `anthropic_max_tokens` for gateway `ChatRequest.max_tokens` | **KEEP the cap, drop the config dependency** — inline the `1024` default |
+| `llm_hooks.is_llm_available` final fallback | `bool(get_settings().anthropic_api_key)` | **REMOVE** — gateway connector check is authoritative |
+| `admin._list_anthropic_models` / `/ai/settings` | live admin observability of the legacy key | **KEEP** — powers admin UI + API contract + frontend tests; out of scope |
+| `events.py:986` | `result.llm_model or get_settings().anthropic_model` display default | **KEEP** — `anthropic_model` is a model-name default, not a credential fallback |
+
+Config fields:
+- `anthropic_max_tokens`, `anthropic_timeout_seconds` → **REMOVE** (only the deleted `_legacy_call` / `_resolve_max_tokens` used them).
+- `anthropic_api_key`, `anthropic_model` → **KEEP** (still read by admin + events display).
+
+---
+
+## File Structure
+
+- `server/app/services/recommendation/llm_client.py` — delete `_legacy_call`, the `AsyncAnthropic` import, the `db is None` branch; inline max-tokens default.
+- `server/app/services/recommendation/llm_hooks.py` — drop the `db is None` env-var fallback and the docstring `ANTHROPIC_API_KEY` mention; tighten `is_llm_available` to require `db`.
+- `server/app/core/config.py` — remove `anthropic_max_tokens`, `anthropic_timeout_seconds`.
+- `server/tests/test_llm_client.py` — replace the `AsyncAnthropic`-patching legacy tests with gateway-path tests.
+- `server/tests/test_llm_hooks.py` — drop the env-var-availability assertions.
+- `.env.example` — drop the deprecated `ANTHROPIC_*` lines (keep nothing that's dead).
+- `CLAUDE.md` — update the Environment section + LLM Gateway note.
+
+---
+
+### Task 1: Remove the dead `_legacy_call` fallback in `llm_client.py`
+
+**Files:**
+- Modify: `server/app/services/recommendation/llm_client.py`
+- Test: `server/tests/test_llm_client.py`
+
+- [ ] **Step 1: Rewrite `TestCallLLM` to drive the gateway path**
+
+Replace the two `AsyncAnthropic`-patching tests with tests that pass a fake `db` and patch `Gateway.dispatch`, asserting the parse + trim behavior.
+
+- [ ] **Step 2: Run to verify they fail** (`call_llm` still has the `db is None` branch / `Gateway` not yet the sole path)
+
+Run: `.venv/bin/pytest tests/test_llm_client.py -q`
+
+- [ ] **Step 3: Edit `llm_client.py`**
+  - Remove `from anthropic import AsyncAnthropic`.
+  - Remove the `if db is None: result = await _legacy_call(...)` branch — make the gateway path unconditional; raise/parse via gateway always.
+  - Delete `_legacy_call`.
+  - Replace `_resolve_max_tokens()` body to return a module constant default (`DEFAULT_MAX_TOKENS = 1024`) instead of `get_settings().anthropic_max_tokens`.
+  - Remove the now-unused `get_settings` import if nothing else uses it.
+
+- [ ] **Step 4: Run tests** — `.venv/bin/pytest tests/test_llm_client.py -q` → PASS
+
+- [ ] **Step 5: Commit**
+
+### Task 2: Tighten `is_llm_available` in `llm_hooks.py`
+
+**Files:**
+- Modify: `server/app/services/recommendation/llm_hooks.py`
+- Test: `server/tests/test_llm_hooks.py`
+
+- [ ] **Step 1: Update `test_llm_hooks.py`** — remove the two assertions that `is_llm_available()` (no db) keys off `anthropic_api_key`; keep/adjust the db-based connector tests. `is_llm_available()` with no db now returns `False`.
+- [ ] **Step 2: Run to verify fail.**
+- [ ] **Step 3: Edit `llm_hooks.py`** — drop the final `bool(get_settings().anthropic_api_key)` fallback (both the `db is not None` tail and the no-db return → `False`); remove the `ANTHROPIC_API_KEY` docstring bullet and the `db is None` env-var sentence in `generate_llm_suggestions`; remove the now-unused `get_settings` import.
+- [ ] **Step 4: Run tests** → PASS.
+- [ ] **Step 5: Commit.**
+
+### Task 3: Remove dead config fields
+
+**Files:**
+- Modify: `server/app/core/config.py`
+
+- [ ] **Step 1: Remove `anthropic_max_tokens` and `anthropic_timeout_seconds`** from the `Settings` class. Keep `anthropic_api_key` and `anthropic_model` (still used by admin + events).
+- [ ] **Step 2: Grep** `grep -rn "anthropic_max_tokens\|anthropic_timeout" server/app` → zero hits.
+- [ ] **Step 3: Commit.**
+
+### Task 4: Docs + env example
+
+**Files:**
+- Modify: `.env.example`, `CLAUDE.md`
+
+- [ ] **Step 1: `.env.example`** — remove the deprecated `ANTHROPIC_API_KEY` / `ANTHROPIC_MODEL` / `ANTHROPIC_MAX_TOKENS` / `ANTHROPIC_TIMEOUT_SECONDS` lines and rewrite the surrounding comment to state credentials are connector-only.
+- [ ] **Step 2: `CLAUDE.md`** — update the Anthropic env-var line in the Environment section and the LLM Gateway note (legacy fallback removed).
+- [ ] **Step 3: Commit.**
+
+### Task 5: Full backend CI + acceptance grep
+
+- [ ] `cd server && .venv/bin/ruff check . && .venv/bin/ruff format --check . && .venv/bin/bandit -r app -c pyproject.toml -q && .venv/bin/pytest --tb=short -q`
+- [ ] `grep -rn "ANTHROPIC_API_KEY" server/ | grep -v /tests/` → only the alembic migration hits remain.
+- [ ] `.venv/bin/alembic upgrade head && .venv/bin/alembic check` (config field removal must not drift).

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -128,11 +128,15 @@ class Settings(BaseSettings):
     # ListenBrainz API (artist discovery for recommendations)
     listenbrainz_user_token: str = ""
 
-    # Anthropic API (LLM-powered recommendations)
+    # Anthropic API (LLM-powered recommendations).
+    # NOTE: credentials live in the LLM Gateway connector system (the source of
+    # truth since the MVP). These two fields remain only for admin observability
+    # of the legacy key (admin AI-settings/model-listing endpoints) and as the
+    # default model-name label on recommendation responses. The legacy env-var
+    # *fallback* in the recommendation engine was removed in #343, along with the
+    # now-unused ANTHROPIC_MAX_TOKENS / ANTHROPIC_TIMEOUT_SECONDS settings.
     anthropic_api_key: str = ""
     anthropic_model: str = "claude-haiku-4-5-20251001"
-    anthropic_max_tokens: int = 1024
-    anthropic_timeout_seconds: int = 15
 
     # Cache durations (1 hour for Spotify since popularity changes)
     search_cache_hours: int = 1

--- a/server/app/services/recommendation/llm_client.py
+++ b/server/app/services/recommendation/llm_client.py
@@ -206,6 +206,35 @@ def build_user_prompt(
     return "\n".join(parts)
 
 
+def _parse_query_items(items: object) -> list[LLMSuggestionQuery]:
+    """Defensively convert a tool payload ``queries`` array into query objects.
+
+    The tool output comes from an external LLM provider — including custom
+    OpenAI-compatible endpoints (Ollama, vLLM) that may not enforce the
+    forced-tool JSON schema. Skip any malformed item rather than letting one bad
+    entry crash the whole recommendation flow.
+    """
+    if not isinstance(items, list):
+        return []
+    parsed: list[LLMSuggestionQuery] = []
+    for q in items:
+        if not isinstance(q, dict):
+            continue
+        search_query = q.get("search_query")
+        if not isinstance(search_query, str) or not search_query.strip():
+            continue
+        parsed.append(
+            LLMSuggestionQuery(
+                search_query=search_query,
+                target_bpm=q.get("target_bpm"),
+                target_key=q.get("target_key"),
+                target_genre=q.get("target_genre"),
+                reasoning=q.get("reasoning", "") if isinstance(q.get("reasoning"), str) else "",
+            )
+        )
+    return parsed
+
+
 def _parse_tool_response(response) -> LLMSuggestionResult:  # noqa: ANN001 — dual-shape input
     """Parse a gateway ``ChatResponse`` into an ``LLMSuggestionResult``.
 
@@ -226,17 +255,9 @@ def _parse_tool_response(response) -> LLMSuggestionResult:  # noqa: ANN001 — d
             raw_text += response.text
         for tc in response.tool_calls or []:
             if tc.name == SEARCH_QUERIES_TOOL_NAME:
-                raw_text += json.dumps(tc.input)
-                for q in tc.input.get("queries", []):
-                    queries.append(
-                        LLMSuggestionQuery(
-                            search_query=q["search_query"],
-                            target_bpm=q.get("target_bpm"),
-                            target_key=q.get("target_key"),
-                            target_genre=q.get("target_genre"),
-                            reasoning=q.get("reasoning", ""),
-                        )
-                    )
+                payload = tc.input if isinstance(tc.input, dict) else {}
+                raw_text += json.dumps(payload)
+                queries.extend(_parse_query_items(payload.get("queries", [])))
         return LLMSuggestionResult(queries=queries, raw_response=raw_text, model=response.model)
 
     # Path 2 — legacy Anthropic SDK Message-like object.
@@ -245,17 +266,9 @@ def _parse_tool_response(response) -> LLMSuggestionResult:  # noqa: ANN001 — d
         if btype == "text":
             raw_text += getattr(block, "text", "")
         elif btype == "tool_use" and getattr(block, "name", "") == SEARCH_QUERIES_TOOL_NAME:
-            raw_text += json.dumps(block.input)
-            for q in block.input.get("queries", []):
-                queries.append(
-                    LLMSuggestionQuery(
-                        search_query=q["search_query"],
-                        target_bpm=q.get("target_bpm"),
-                        target_key=q.get("target_key"),
-                        target_genre=q.get("target_genre"),
-                        reasoning=q.get("reasoning", ""),
-                    )
-                )
+            block_input = block.input if isinstance(block.input, dict) else {}
+            raw_text += json.dumps(block_input)
+            queries.extend(_parse_query_items(block_input.get("queries", [])))
 
     return LLMSuggestionResult(
         queries=queries, raw_response=raw_text, model=getattr(response, "model", None)

--- a/server/app/services/recommendation/llm_client.py
+++ b/server/app/services/recommendation/llm_client.py
@@ -13,10 +13,8 @@ from __future__ import annotations
 import json
 import logging
 
-from anthropic import AsyncAnthropic
 from sqlalchemy.orm import Session
 
-from app.core.config import get_settings
 from app.models.user import User
 from app.services.llm.base import ChatRequest, Message, ToolSpec
 from app.services.llm.gateway import Gateway
@@ -24,6 +22,11 @@ from app.services.recommendation.llm_hooks import LLMSuggestionQuery, LLMSuggest
 from app.services.recommendation.scorer import EventProfile, TrackProfile
 
 logger = logging.getLogger(__name__)
+
+# Default max output tokens for query generation. Was previously sourced from
+# the ``ANTHROPIC_MAX_TOKENS`` env var via settings; that legacy env-var path was
+# removed in #343 now that the connector system is the source of truth.
+DEFAULT_MAX_TOKENS = 1024
 
 SYSTEM_PROMPT = """\
 You are a DJ assistant helping curate song suggestions for a live event.
@@ -203,12 +206,13 @@ def build_user_prompt(
     return "\n".join(parts)
 
 
-def _parse_tool_response(response) -> LLMSuggestionResult:  # noqa: ANN001 — kept for back-compat
-    """Parse a gateway ``ChatResponse`` (or legacy Anthropic Message) into an
-    ``LLMSuggestionResult``.
+def _parse_tool_response(response) -> LLMSuggestionResult:  # noqa: ANN001 — dual-shape input
+    """Parse a gateway ``ChatResponse`` into an ``LLMSuggestionResult``.
 
-    Accepts both shapes so existing test fixtures (which mock an Anthropic SDK
-    response object directly) keep working without modification.
+    The gateway is the only producer of responses (the legacy direct-Anthropic
+    path was removed in #343). A defensive second path also handles an
+    Anthropic-SDK ``Message``-like object (``.content`` blocks) so any cached
+    ``tool_use`` traces or hand-constructed fixtures remain decodable.
     """
     from app.services.llm.base import ChatResponse
 
@@ -271,13 +275,18 @@ async def call_llm(
 ) -> LLMSuggestionResult:
     """Generate structured search queries via the LLM gateway.
 
-    Compatibility shim: existing callers pass only the positional args. New
-    callers pass ``db`` and ``actor`` so the gateway can route to the DJ's
-    connector. When ``db`` is missing we fall back to the legacy env-var path
-    so unit tests that mock ``AsyncAnthropic`` directly keep passing.
+    Routes through ``Gateway.dispatch`` so credentials come from the actor DJ's
+    connector (or the org default). ``db`` is required; the legacy
+    direct-Anthropic env-var fallback was removed in #343 now that the connector
+    system is the sole source of truth.
 
     Returns at most ``max_queries`` queries.
     """
+    if db is None:
+        raise ValueError(
+            "call_llm requires a db session — the connector system is the source of truth"
+        )
+
     user_message = build_user_prompt(
         profile,
         dj_prompt,
@@ -286,25 +295,22 @@ async def call_llm(
         currently_playing=currently_playing,
     )
 
-    if db is None:
-        result = await _legacy_call(user_message)
-    else:
-        chat_request = ChatRequest(
-            messages=[Message(role="user", content=user_message)],
-            system=SYSTEM_PROMPT,
-            tools=[
-                ToolSpec(
-                    name=SEARCH_QUERIES_TOOL_NAME,
-                    description=SEARCH_QUERIES_TOOL["description"],
-                    input_schema=SEARCH_QUERIES_TOOL["input_schema"],
-                )
-            ],
-            force_tool=SEARCH_QUERIES_TOOL_NAME,
-            max_tokens=_resolve_max_tokens(),
-            temperature=None,
-        )
-        response = await Gateway.dispatch(db, actor, chat_request, purpose="recommendation")
-        result = _parse_tool_response(response)
+    chat_request = ChatRequest(
+        messages=[Message(role="user", content=user_message)],
+        system=SYSTEM_PROMPT,
+        tools=[
+            ToolSpec(
+                name=SEARCH_QUERIES_TOOL_NAME,
+                description=SEARCH_QUERIES_TOOL["description"],
+                input_schema=SEARCH_QUERIES_TOOL["input_schema"],
+            )
+        ],
+        force_tool=SEARCH_QUERIES_TOOL_NAME,
+        max_tokens=DEFAULT_MAX_TOKENS,
+        temperature=None,
+    )
+    response = await Gateway.dispatch(db, actor, chat_request, purpose="recommendation")
+    result = _parse_tool_response(response)
 
     if len(result.queries) > max_queries:
         result = LLMSuggestionResult(
@@ -320,31 +326,3 @@ async def call_llm(
     )
 
     return result
-
-
-def _resolve_max_tokens() -> int:
-    return get_settings().anthropic_max_tokens or 1024
-
-
-async def _legacy_call(user_message: str) -> LLMSuggestionResult:
-    """Direct-Anthropic fallback used when no ``db`` is supplied.
-
-    Kept so the legacy unit tests in ``server/tests/test_llm_client.py`` (which
-    patch ``AsyncAnthropic`` directly) still pass without modification.
-    """
-    settings = get_settings()
-    client = AsyncAnthropic(
-        api_key=settings.anthropic_api_key,
-        timeout=settings.anthropic_timeout_seconds,
-    )
-
-    response = await client.messages.create(
-        model=settings.anthropic_model,
-        max_tokens=settings.anthropic_max_tokens,
-        system=SYSTEM_PROMPT,
-        tools=[SEARCH_QUERIES_TOOL],
-        tool_choice={"type": "tool", "name": SEARCH_QUERIES_TOOL_NAME},
-        messages=[{"role": "user", "content": user_message}],
-    )
-
-    return _parse_tool_response(response)

--- a/server/app/services/recommendation/llm_hooks.py
+++ b/server/app/services/recommendation/llm_hooks.py
@@ -46,9 +46,9 @@ async def generate_llm_suggestions(
 ) -> LLMSuggestionResult:
     """Generate search queries via the LLM gateway.
 
-    The gateway routes to the actor DJ's connector (or org default). Existing
-    callers that don't pass ``db``/``actor`` fall through to the legacy
-    env-var Anthropic path inside ``call_llm`` — see ``llm_client.py``.
+    The gateway routes to the actor DJ's connector (or org default). ``db`` is
+    required by ``call_llm`` — the legacy direct-Anthropic env-var path was
+    removed in #343 now that the connector system is the source of truth.
     """
     from app.services.recommendation.llm_client import call_llm
 
@@ -75,41 +75,39 @@ def is_llm_available(db=None, actor=None) -> bool:
       connector (matches the per-DJ MRU lookup).
     - Otherwise (no actor or no actor-owned active connector): returns True
       when an active system-default connector is configured.
-    - As a last fallback, the legacy ``ANTHROPIC_API_KEY`` env var unlocks
-      the feature for callers that still take the env-var path.
+
+    Connector-backed only. Without ``db`` no connector can be resolved, so it
+    returns ``False`` — the legacy Anthropic env-var fallback was removed in #343.
     """
-    from app.core.config import get_settings
+    if db is None:
+        return False
 
-    if db is not None:
-        from app.models.llm_connector import STATUS_ACTIVE, LlmConnector
-        from app.models.system_settings import SystemSettings
-        from app.services.system_settings import get_system_settings
+    from app.models.llm_connector import STATUS_ACTIVE, LlmConnector
+    from app.models.system_settings import SystemSettings
+    from app.services.system_settings import get_system_settings
 
-        settings = get_system_settings(db)
-        if not settings.llm_enabled:
-            return False
+    settings = get_system_settings(db)
+    if not settings.llm_enabled:
+        return False
 
-        # Per-DJ active connector — matches gateway resolver step 1.
-        if actor is not None:
-            actor_active = (
-                db.query(LlmConnector.id)
-                .filter(
-                    LlmConnector.user_id == actor.id,
-                    LlmConnector.status == STATUS_ACTIVE,
-                )
-                .first()
+    # Per-DJ active connector — matches gateway resolver step 1.
+    if actor is not None:
+        actor_active = (
+            db.query(LlmConnector.id)
+            .filter(
+                LlmConnector.user_id == actor.id,
+                LlmConnector.status == STATUS_ACTIVE,
             )
-            if actor_active is not None:
-                return True
+            .first()
+        )
+        if actor_active is not None:
+            return True
 
-        # System default fallback — matches gateway resolver step 2.
-        sys_settings = db.query(SystemSettings).first()
-        if sys_settings and sys_settings.llm_default_connector_id:
-            default = db.get(LlmConnector, sys_settings.llm_default_connector_id)
-            if default is not None and default.status == STATUS_ACTIVE:
-                return True
+    # System default fallback — matches gateway resolver step 2.
+    sys_settings = db.query(SystemSettings).first()
+    if sys_settings and sys_settings.llm_default_connector_id:
+        default = db.get(LlmConnector, sys_settings.llm_default_connector_id)
+        if default is not None and default.status == STATUS_ACTIVE:
+            return True
 
-        # Final fallback: legacy env var (kept until env-var cleanup ships).
-        return bool(get_settings().anthropic_api_key)
-
-    return bool(get_settings().anthropic_api_key)
+    return False

--- a/server/tests/test_llm_client.py
+++ b/server/tests/test_llm_client.py
@@ -156,6 +156,106 @@ class TestParseToolResponse:
         assert "Here are my suggestions" in result.raw_response
 
 
+class TestParseToolResponseMalformedPayloads:
+    """Defensive parsing — a malformed provider payload must not crash the flow.
+
+    Custom OpenAI-compatible endpoints (Ollama, vLLM) may not enforce the forced
+    tool JSON schema. Regression for the CodeRabbit "harden tool payload parsing"
+    finding on PR #362: bad items are skipped, valid ones still parse.
+    """
+
+    def _tool_block(self, tool_input):
+        block = MagicMock()
+        block.type = "tool_use"
+        block.name = "search_queries"
+        block.input = tool_input
+        return block
+
+    def test_input_not_a_dict_is_skipped(self):
+        response = MagicMock()
+        response.content = [self._tool_block(["not", "a", "dict"])]
+        result = _parse_tool_response(response)
+        assert result.queries == []
+
+    def test_queries_not_a_list_is_skipped(self):
+        response = MagicMock()
+        response.content = [self._tool_block({"queries": "oops"})]
+        result = _parse_tool_response(response)
+        assert result.queries == []
+
+    def test_non_dict_query_item_is_skipped(self):
+        response = MagicMock()
+        response.content = [
+            self._tool_block(
+                {
+                    "queries": [
+                        "garbage",
+                        {"search_query": "valid query", "reasoning": "ok"},
+                    ]
+                }
+            )
+        ]
+        result = _parse_tool_response(response)
+        assert len(result.queries) == 1
+        assert result.queries[0].search_query == "valid query"
+
+    def test_missing_or_blank_search_query_is_skipped(self):
+        response = MagicMock()
+        response.content = [
+            self._tool_block(
+                {
+                    "queries": [
+                        {"reasoning": "no search_query key"},
+                        {"search_query": "", "reasoning": "blank"},
+                        {"search_query": "   ", "reasoning": "whitespace"},
+                        {"search_query": 123, "reasoning": "not a string"},
+                        {"search_query": "keep me", "reasoning": "good"},
+                    ]
+                }
+            )
+        ]
+        result = _parse_tool_response(response)
+        assert len(result.queries) == 1
+        assert result.queries[0].search_query == "keep me"
+
+    def test_non_string_reasoning_coerced_to_empty(self):
+        response = MagicMock()
+        response.content = [
+            self._tool_block(
+                {"queries": [{"search_query": "valid", "reasoning": {"unexpected": "dict"}}]}
+            )
+        ]
+        result = _parse_tool_response(response)
+        assert len(result.queries) == 1
+        assert result.queries[0].reasoning == ""
+
+    @pytest.mark.asyncio
+    @patch("app.services.recommendation.llm_client.Gateway")
+    async def test_chatresponse_path_skips_malformed_items(self, mock_gateway):
+        response = ChatResponse(
+            tool_calls=[
+                ToolCall(
+                    id="t1",
+                    name="search_queries",
+                    input={
+                        "queries": [
+                            "garbage",
+                            {"search_query": "good one", "reasoning": "ok"},
+                            {"reasoning": "missing search_query"},
+                        ]
+                    },
+                )
+            ],
+            stop_reason="tool_use",
+        )
+        mock_gateway.dispatch = AsyncMock(return_value=response)
+        result = await call_llm(
+            EventProfile(track_count=0), "test", db=MagicMock(), actor=MagicMock()
+        )
+        assert len(result.queries) == 1
+        assert result.queries[0].search_query == "good one"
+
+
 class TestCallLLM:
     """``call_llm`` always routes through the LLM Gateway.
 

--- a/server/tests/test_llm_client.py
+++ b/server/tests/test_llm_client.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.services.llm.base import ChatResponse, ToolCall
 from app.services.recommendation.llm_client import (
     SEARCH_QUERIES_TOOL,
     SYSTEM_PROMPT,
@@ -156,78 +157,75 @@ class TestParseToolResponse:
 
 
 class TestCallLLM:
+    """``call_llm`` always routes through the LLM Gateway.
+
+    The legacy direct-Anthropic env-var fallback was removed in #343 — every
+    production caller supplies ``db`` + ``actor`` and the connector system is
+    the sole source of credentials. These tests patch ``Gateway.dispatch``.
+    """
+
     @pytest.mark.asyncio
-    @patch("app.services.recommendation.llm_client.AsyncAnthropic")
-    @patch("app.services.recommendation.llm_client.get_settings")
-    async def test_calls_api_correctly(self, mock_settings, mock_anthropic_cls):
-        settings = MagicMock()
-        settings.anthropic_api_key = "sk-ant-test-key"
-        settings.anthropic_model = "claude-haiku-4-5-20251001"
-        settings.anthropic_max_tokens = 1024
-        settings.anthropic_timeout_seconds = 15
-        mock_settings.return_value = settings
-
-        # Mock API response
-        tool_block = MagicMock()
-        tool_block.type = "tool_use"
-        tool_block.name = "search_queries"
-        tool_block.input = {
-            "queries": [{"search_query": "chill house", "reasoning": "DJ wants chill vibes"}]
-        }
-        mock_response = MagicMock()
-        mock_response.content = [tool_block]
-
-        mock_client = MagicMock()
-        mock_client.messages.create = AsyncMock(return_value=mock_response)
-        mock_anthropic_cls.return_value = mock_client
-
-        profile = EventProfile(
-            avg_bpm=120.0,
-            dominant_genres=["House"],
-            track_count=5,
+    @patch("app.services.recommendation.llm_client.Gateway")
+    async def test_dispatches_via_gateway(self, mock_gateway):
+        response = ChatResponse(
+            tool_calls=[
+                ToolCall(
+                    id="t1",
+                    name="search_queries",
+                    input={
+                        "queries": [
+                            {"search_query": "chill house", "reasoning": "DJ wants chill vibes"}
+                        ]
+                    },
+                )
+            ],
+            stop_reason="tool_use",
+            model="claude-haiku-4-5-20251001",
         )
+        mock_gateway.dispatch = AsyncMock(return_value=response)
 
-        result = await call_llm(profile, "chill vibes")
+        db = MagicMock()
+        actor = MagicMock()
+        profile = EventProfile(avg_bpm=120.0, dominant_genres=["House"], track_count=5)
+
+        result = await call_llm(profile, "chill vibes", db=db, actor=actor)
 
         assert len(result.queries) == 1
         assert result.queries[0].search_query == "chill house"
+        assert result.model == "claude-haiku-4-5-20251001"
 
-        # Verify API call parameters
-        mock_client.messages.create.assert_called_once()
-        call_kwargs = mock_client.messages.create.call_args[1]
-        assert call_kwargs["model"] == "claude-haiku-4-5-20251001"
-        assert call_kwargs["max_tokens"] == 1024
-        assert call_kwargs["tool_choice"] == {"type": "tool", "name": "search_queries"}
+        mock_gateway.dispatch.assert_awaited_once()
+        # Positional args: (db, actor, chat_request); keyword: purpose.
+        args, kwargs = mock_gateway.dispatch.call_args
+        assert args[0] is db
+        assert args[1] is actor
+        chat_request = args[2]
+        assert chat_request.force_tool == "search_queries"
+        assert chat_request.max_tokens == 1024
+        assert kwargs["purpose"] == "recommendation"
 
     @pytest.mark.asyncio
-    @patch("app.services.recommendation.llm_client.AsyncAnthropic")
-    @patch("app.services.recommendation.llm_client.get_settings")
-    async def test_trims_to_max_queries(self, mock_settings, mock_anthropic_cls):
-        settings = MagicMock()
-        settings.anthropic_api_key = "sk-ant-test-key"
-        settings.anthropic_model = "claude-haiku-4-5-20251001"
-        settings.anthropic_max_tokens = 1024
-        settings.anthropic_timeout_seconds = 15
-        mock_settings.return_value = settings
-
-        # Return 5 queries, request max 2
-        tool_block = MagicMock()
-        tool_block.type = "tool_use"
-        tool_block.name = "search_queries"
-        tool_block.input = {
-            "queries": [
-                {"search_query": f"query {i}", "reasoning": f"reason {i}"} for i in range(5)
-            ]
-        }
-        mock_response = MagicMock()
-        mock_response.content = [tool_block]
-
-        mock_client = MagicMock()
-        mock_client.messages.create = AsyncMock(return_value=mock_response)
-        mock_anthropic_cls.return_value = mock_client
+    @patch("app.services.recommendation.llm_client.Gateway")
+    async def test_trims_to_max_queries(self, mock_gateway):
+        response = ChatResponse(
+            tool_calls=[
+                ToolCall(
+                    id="t1",
+                    name="search_queries",
+                    input={
+                        "queries": [
+                            {"search_query": f"query {i}", "reasoning": f"reason {i}"}
+                            for i in range(5)
+                        ]
+                    },
+                )
+            ],
+            stop_reason="tool_use",
+        )
+        mock_gateway.dispatch = AsyncMock(return_value=response)
 
         profile = EventProfile(track_count=0)
-        result = await call_llm(profile, "test", max_queries=2)
+        result = await call_llm(profile, "test", max_queries=2, db=MagicMock(), actor=MagicMock())
 
         assert len(result.queries) == 2
         assert result.queries[0].search_query == "query 0"

--- a/server/tests/test_llm_hooks.py
+++ b/server/tests/test_llm_hooks.py
@@ -19,36 +19,66 @@ from app.services.recommendation.llm_hooks import (
 from app.services.recommendation.scorer import EventProfile
 
 
-class TestIsLLMAvailable:
-    @patch("app.core.config.get_settings")
-    def test_returns_true_when_key_set(self, mock_settings):
-        mock_settings.return_value.anthropic_api_key = "sk-ant-test"
-        assert is_llm_available() is True
+def _add_active_connector(db, user):
+    """Insert an active LLM connector owned by ``user`` so the gateway resolver
+    (and therefore ``is_llm_available``) sees an available connector."""
+    import json
 
-    @patch("app.core.config.get_settings")
-    def test_returns_false_when_key_empty(self, mock_settings):
-        mock_settings.return_value.anthropic_api_key = ""
+    from app.models.llm_connector import LlmConnector
+
+    connector = LlmConnector(
+        user_id=user.id,
+        connector_type="anthropic_apikey",
+        display_name="Test",
+        status="active",
+        credentials=json.dumps({"api_key": "sk-ant-fakefakefakefakefakefakefakefakefakefake"}),
+        model_hint="claude-haiku-4-5-20251001",
+    )
+    db.add(connector)
+    db.commit()
+    db.refresh(connector)
+    return connector
+
+
+class TestIsLLMAvailable:
+    """``is_llm_available`` is connector-backed only.
+
+    The legacy ``ANTHROPIC_API_KEY`` env-var fallback was removed in #343, so a
+    call without ``db`` can never resolve a connector and returns ``False``.
+    """
+
+    def test_returns_false_without_db(self):
         assert is_llm_available() is False
 
-    @patch("app.core.config.get_settings")
-    def test_returns_false_when_llm_disabled_in_settings(self, mock_settings, db: Session):
-        """When API key is set but llm_enabled is False in DB, returns False."""
-        mock_settings.return_value.anthropic_api_key = "sk-ant-test"
+    def test_returns_false_without_db_even_with_actor(self):
+        from unittest.mock import MagicMock
+
+        assert is_llm_available(actor=MagicMock()) is False
+
+    def test_returns_false_when_llm_disabled_in_settings(self, db: Session, test_user):
+        """When a connector exists but llm_enabled is False in DB, returns False."""
         from app.services.system_settings import update_system_settings
 
+        _add_active_connector(db, test_user)
         update_system_settings(db, llm_enabled=False)
-        assert is_llm_available(db) is False
+        assert is_llm_available(db, actor=test_user) is False
         # Reset
         update_system_settings(db, llm_enabled=True)
 
-    @patch("app.core.config.get_settings")
-    def test_returns_true_when_llm_enabled_and_key_set(self, mock_settings, db: Session):
-        """When API key is set and llm_enabled is True in DB, returns True."""
-        mock_settings.return_value.anthropic_api_key = "sk-ant-test"
+    def test_returns_true_when_llm_enabled_and_actor_connector(self, db: Session, test_user):
+        """When the actor owns an active connector and llm_enabled is True, returns True."""
+        from app.services.system_settings import update_system_settings
+
+        _add_active_connector(db, test_user)
+        update_system_settings(db, llm_enabled=True)
+        assert is_llm_available(db, actor=test_user) is True
+
+    def test_returns_false_without_connector(self, db: Session, test_user):
+        """No connector and no org default -> not available."""
         from app.services.system_settings import update_system_settings
 
         update_system_settings(db, llm_enabled=True)
-        assert is_llm_available(db) is True
+        assert is_llm_available(db, actor=test_user) is False
 
 
 class TestGenerateLLMSuggestions:

--- a/server/tests/test_llm_recommendation_via_gateway.py
+++ b/server/tests/test_llm_recommendation_via_gateway.py
@@ -1,8 +1,10 @@
-"""Regression: recommendation engine still produces identical output when
-routed through the LLM gateway.
+"""Regression: recommendation engine produces canonical output when routed
+through the LLM gateway.
 
-The legacy path (no ``db``/``actor``) and the gateway path receive equivalent
-mock responses; both must yield identical ``LLMSuggestionResult`` queries.
+The gateway is the sole credential path — the legacy direct-Anthropic env-var
+fallback was removed in #343. These tests pin that gateway-dispatched output is
+identical to a direct parse of the equivalent provider response, and that
+``call_llm`` now requires a ``db`` session.
 """
 
 from __future__ import annotations
@@ -87,12 +89,18 @@ def test_parse_tool_response_propagates_provider_model():
 
 
 @pytest.mark.asyncio
-async def test_gateway_path_matches_legacy_path_output(db, test_user, event_profile):
-    """The same model output, routed via gateway vs legacy env-var, yields the
-    same canonical ``LLMSuggestionResult``.
+async def test_gateway_path_matches_canonical_parse(db, test_user, event_profile):
+    """The gateway path yields the same canonical ``LLMSuggestionResult`` as a
+    direct parse of the equivalent provider response.
+
+    The legacy direct-Anthropic env-var path was removed in #343 — the connector
+    system is the sole credential source. This pins that the gateway-dispatched
+    output is identical to what ``_parse_tool_response`` produces for the same
+    model output regardless of the (defensive) input shape it receives.
     """
     # Insert a connector for the actor so the gateway has something to resolve.
     from app.models.llm_connector import LlmConnector
+    from app.services.recommendation.llm_client import _parse_tool_response
 
     connector = LlmConnector(
         user_id=test_user.id,
@@ -118,32 +126,25 @@ async def test_gateway_path_matches_legacy_path_output(db, test_user, event_prof
             actor=test_user,
         )
 
-    # Legacy path: mock AsyncAnthropic at module level.
-    legacy_mock = _legacy_anthropic_response()
-    with (
-        patch("app.services.recommendation.llm_client.AsyncAnthropic") as client_cls,
-        patch("app.services.recommendation.llm_client.get_settings") as settings_mock,
-    ):
-        settings_mock.return_value.anthropic_api_key = "sk-ant-fake"
-        settings_mock.return_value.anthropic_model = "claude-haiku-4-5-20251001"
-        settings_mock.return_value.anthropic_max_tokens = 1024
-        settings_mock.return_value.anthropic_timeout_seconds = 15
-        client_inst = client_cls.return_value
-        client_inst.messages.create = AsyncMock(return_value=legacy_mock)
+    # Canonical parse of the equivalent Anthropic-SDK-shaped response.
+    canonical_result = _parse_tool_response(_legacy_anthropic_response())
 
-        legacy_result = await call_llm(
-            event_profile,
-            "deeper progressive house",
-        )
+    # Identical structured output regardless of response shape.
+    assert len(gateway_result.queries) == len(canonical_result.queries) == 2
+    for gq, cq in zip(gateway_result.queries, canonical_result.queries):
+        assert gq.search_query == cq.search_query
+        assert gq.target_bpm == cq.target_bpm
+        assert gq.target_key == cq.target_key
+        assert gq.target_genre == cq.target_genre
+        assert gq.reasoning == cq.reasoning
 
-    # Identical structured output across both paths.
-    assert len(gateway_result.queries) == len(legacy_result.queries) == 2
-    for gq, lq in zip(gateway_result.queries, legacy_result.queries):
-        assert gq.search_query == lq.search_query
-        assert gq.target_bpm == lq.target_bpm
-        assert gq.target_key == lq.target_key
-        assert gq.target_genre == lq.target_genre
-        assert gq.reasoning == lq.reasoning
+
+@pytest.mark.asyncio
+async def test_call_llm_requires_db(event_profile):
+    """The legacy no-``db`` env-var fallback is gone (#343): callers must supply a
+    db session so the gateway can resolve a connector."""
+    with pytest.raises(ValueError, match="requires a db session"):
+        await call_llm(event_profile, "anything")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #343

## Summary

Follow-up cleanup after the MVP one-shot data migration. The LLM Gateway connector system has been the source of truth for credentials since the MVP, and **every production caller** of the recommendation engine passes `db` + `actor`, so the gateway path always runs. The legacy direct-Anthropic env-var fallback was therefore dead code and is removed here.

- `call_llm` now **requires** a `db` session — removed `_legacy_call()`, the `db is None` branch, and the `AsyncAnthropic` import.
- Inlined `DEFAULT_MAX_TOKENS = 1024` in place of the `anthropic_max_tokens` settings read.
- `is_llm_available()` is connector-backed only; without `db` it returns `False` (removed the final `ANTHROPIC_API_KEY` env-var fallback).
- Removed `config.anthropic_max_tokens` / `anthropic_timeout_seconds` (only the deleted fallback used them).
- Refreshed `.env.example` (dropped the deprecated `ANTHROPIC_*` lines) and `CLAUDE.md`.

No behavior change for any production path — the connector is and was the source of truth.

## Design decisions

The issue's acceptance grep targets the **uppercase env-var literal** `ANTHROPIC_API_KEY`. The actual env-var *reads* go through the lowercase pydantic-settings attribute `config.anthropic_api_key`. I mapped every read before deleting:

**Removed (genuinely-dead recommendation-path env-var reads):**
| Location | What it did | Why dead |
|---|---|---|
| `llm_client._legacy_call` | direct-Anthropic fallback when `db is None` | all production callers (`service.generate_recommendations_from_llm`) pass `db`/`actor` |
| `llm_client._resolve_max_tokens` | read `anthropic_max_tokens` | only the deleted fallback consumed it; inlined the `1024` default |
| `llm_hooks.is_llm_available` final fallback | `bool(get_settings().anthropic_api_key)` | the gateway connector resolver is authoritative; the env fallback could mask a misconfigured connector |
| `config.anthropic_max_tokens`, `config.anthropic_timeout_seconds` | settings fields | only read by the removed code |

**Kept deliberately — and why (legacy-fallback reconciliation):**
| Location | Reason kept |
|---|---|
| `config.anthropic_api_key` + `admin.py` `_list_anthropic_models` / `/ai/settings` | These are **not** a recommendation credential fallback — they power the live admin AI-settings UI (`api_key_configured` / `api_key_masked`) and model listing. Removing them is a cross-cutting **frontend + API-contract** change (regenerate `api-types.generated.ts`, edit `dashboard/app/admin/ai/page.tsx` + tests) outside this backend-only cleanup's scope. Tracking that as a separate frontend-inclusive PR is the safer split. |
| `config.anthropic_model` | A model-name **default label**, not a credential fallback — read by `events.py` (`result.llm_model or get_settings().anthropic_model`) for the recommendation response badge and by the admin model listing. |
| `046_admin_ai_oauth.py` (`ANTHROPIC_API_KEY` reads) | Historical one-shot data migration that seeds a connector from the env var on first upgrade. Must stay intact for replay — the allowable acceptance-grep exception. |

CLAUDE.md previously noted the fallback was "kept until the env-var cleanup follow-up issue ships" — **this PR (#343) is that follow-up**, so the note is updated accordingly.

## Acceptance criteria

- `grep -r ANTHROPIC_API_KEY server/` in non-test files returns only the historical `046_admin_ai_oauth.py` migration (the allowable exception, justified above).
- No behavior change — the connector is the source of truth.

## Test plan

- [x] `ruff check .` — passed
- [x] `ruff format --check .` — passed
- [x] `bandit -r app -c pyproject.toml -q` — exit 0
- [x] `pytest --tb=short -q` — 2302 passed, 87.09% coverage (gate 85%)
- [x] `alembic upgrade head && alembic check` on a fresh isolated Postgres DB — "No new upgrade operations detected"
- [x] Acceptance grep verified (only migration hits remain)
- [ ] CI green on `epic/ai-engine`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Removed deprecated Anthropic environment variables (ANTHROPIC_API_KEY, ANTHROPIC_MAX_TOKENS, ANTHROPIC_TIMEOUT_SECONDS)
  * LLM credentials now managed exclusively through gateway connector system
  * Simplified configuration by removing unused Anthropic settings fields

* **Documentation**
  * Updated environment variable examples and technical guides to reflect gateway-based LLM connector approach

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->