### PR TITLE
feat(ai): configurable llm_call_log retention (#342)

### DIFF
--- a/dashboard/app/admin/ai/__tests__/page.test.tsx
+++ b/dashboard/app/admin/ai/__tests__/page.test.tsx
@@ -147,6 +147,7 @@ describe('AdminAISettingsPage', () => {
       llm_apikey_connectors_enabled: true,
       llm_compatible_connector_enabled: true,
       llm_default_connector_id: null,
+      llm_call_log_retention_days: 30,
     });
     vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([
       {
@@ -192,6 +193,7 @@ describe('AdminAISettingsPage', () => {
       llm_apikey_connectors_enabled: true,
       llm_compatible_connector_enabled: true,
       llm_default_connector_id: null,
+      llm_call_log_retention_days: 30,
     });
     vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([]);
     vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
@@ -240,6 +242,7 @@ describe('AdminAISettingsPage', () => {
       llm_apikey_connectors_enabled: true,
       llm_compatible_connector_enabled: true,
       llm_default_connector_id: null,
+      llm_call_log_retention_days: 30,
     });
     vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([]);
     vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
@@ -300,6 +303,7 @@ describe('AdminAISettingsPage', () => {
       llm_apikey_connectors_enabled: true,
       llm_compatible_connector_enabled: true,
       llm_default_connector_id: null,
+      llm_call_log_retention_days: 30,
     });
     vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([
       {
@@ -339,5 +343,85 @@ describe('AdminAISettingsPage', () => {
     await waitFor(() => expect(screen.getByText('Compromised')).toBeInTheDocument());
     fireEvent.click(screen.getByText('Force-revoke'));
     await waitFor(() => expect(revokeSpy).toHaveBeenCalledWith(9));
+  });
+
+  it('persists call-log retention on blur via the policy patch (issue #342)', async () => {
+    vi.spyOn(api, 'getAISettings').mockResolvedValue({
+      llm_enabled: true,
+      llm_model: 'claude-haiku-4-5-20251001',
+      llm_rate_limit_per_minute: 3,
+      api_key_configured: true,
+      api_key_masked: '...abcd',
+    });
+    vi.spyOn(api, 'getAIModels').mockResolvedValue({ models: [] });
+    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: true,
+      llm_compatible_connector_enabled: true,
+      llm_default_connector_id: null,
+      llm_call_log_retention_days: 30,
+    });
+    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([]);
+    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
+    const patchSpy = vi.spyOn(api, 'updateAdminLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: true,
+      llm_compatible_connector_enabled: true,
+      llm_default_connector_id: null,
+      llm_call_log_retention_days: 90,
+    });
+
+    render(<AdminAISettingsPage />);
+
+    const input = (await screen.findByLabelText(
+      /Call log retention/i,
+    )) as HTMLInputElement;
+    expect(input.value).toBe('30');
+
+    fireEvent.change(input, { target: { value: '90' } });
+    fireEvent.blur(input);
+
+    await waitFor(() =>
+      expect(patchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ llm_call_log_retention_days: 90 }),
+      ),
+    );
+  });
+
+  it('clamps an out-of-range retention value before patching (issue #342)', async () => {
+    vi.spyOn(api, 'getAISettings').mockResolvedValue({
+      llm_enabled: true,
+      llm_model: 'claude-haiku-4-5-20251001',
+      llm_rate_limit_per_minute: 3,
+      api_key_configured: true,
+      api_key_masked: '...abcd',
+    });
+    vi.spyOn(api, 'getAIModels').mockResolvedValue({ models: [] });
+    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: true,
+      llm_compatible_connector_enabled: true,
+      llm_default_connector_id: null,
+      llm_call_log_retention_days: 30,
+    });
+    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([]);
+    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
+    const patchSpy = vi.spyOn(api, 'updateAdminLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: true,
+      llm_compatible_connector_enabled: true,
+      llm_default_connector_id: null,
+      llm_call_log_retention_days: 365,
+    });
+
+    render(<AdminAISettingsPage />);
+
+    const input = (await screen.findByLabelText(
+      /Call log retention/i,
+    )) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '9999' } });
+    fireEvent.blur(input);
+
+    await waitFor(() =>
+      expect(patchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ llm_call_log_retention_days: 365 }),
+      ),
+    );
   });
 });

--- a/dashboard/app/admin/ai/__tests__/page.test.tsx
+++ b/dashboard/app/admin/ai/__tests__/page.test.tsx
@@ -424,4 +424,47 @@ describe('AdminAISettingsPage', () => {
       ),
     );
   });
+
+  // Use 5 (not 0) for the below-min value: the onChange handler treats a falsy
+  // parsed value as "no change" (`parseInt(...) || policy.value`), so 0 would be
+  // coerced back to the current policy before blur ever sees it. 5 is a genuine
+  // below-min entry that the blur clamp must lift to 7.
+  it('clamps a below-min retention value before patching (issue #342)', async () => {
+    vi.spyOn(api, 'getAISettings').mockResolvedValue({
+      llm_enabled: true,
+      llm_model: 'claude-haiku-4-5-20251001',
+      llm_rate_limit_per_minute: 3,
+      api_key_configured: true,
+      api_key_masked: '...abcd',
+    });
+    vi.spyOn(api, 'getAIModels').mockResolvedValue({ models: [] });
+    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: true,
+      llm_compatible_connector_enabled: true,
+      llm_default_connector_id: null,
+      llm_call_log_retention_days: 30,
+    });
+    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([]);
+    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
+    const patchSpy = vi.spyOn(api, 'updateAdminLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: true,
+      llm_compatible_connector_enabled: true,
+      llm_default_connector_id: null,
+      llm_call_log_retention_days: 7,
+    });
+
+    render(<AdminAISettingsPage />);
+
+    const input = (await screen.findByLabelText(
+      /Call log retention/i,
+    )) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '5' } });
+    fireEvent.blur(input);
+
+    await waitFor(() =>
+      expect(patchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ llm_call_log_retention_days: 7 }),
+      ),
+    );
+  });
 });

--- a/dashboard/app/admin/ai/page.tsx
+++ b/dashboard/app/admin/ai/page.tsx
@@ -455,7 +455,9 @@ export default function AdminAISettingsPage() {
               }
               onBlur={(e) => {
                 const raw = parseInt(e.target.value, 10);
-                const clamped = Number.isNaN(raw) ? 30 : Math.min(365, Math.max(7, raw));
+                const clamped = Number.isNaN(raw)
+                  ? policy.llm_call_log_retention_days
+                  : Math.min(365, Math.max(7, raw));
                 handlePolicyPatch({ llm_call_log_retention_days: clamped });
               }}
             />

--- a/dashboard/app/admin/ai/page.tsx
+++ b/dashboard/app/admin/ai/page.tsx
@@ -215,6 +215,7 @@ export default function AdminAISettingsPage() {
         llm_compatible_connector_enabled: optimistic.llm_compatible_connector_enabled,
         llm_default_connector_id: optimistic.llm_default_connector_id,
         clear_default: optimistic.llm_default_connector_id === null,
+        llm_call_log_retention_days: optimistic.llm_call_log_retention_days,
       });
       setPolicy(updated);
       setPolicyMessage('Policy saved');
@@ -430,6 +431,34 @@ export default function AdminAISettingsPage() {
                   </option>
                 ))}
             </select>
+          </div>
+
+          <div className="form-group" style={{ marginTop: '1.5rem' }}>
+            <label htmlFor="call-log-retention">Call log retention (days)</label>
+            <div style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '0.5rem' }}>
+              How long per-call telemetry (counts only, never prompt content) is kept before
+              the daily cleanup deletes it. Range: 7–365 days. Changes take effect within 24 hours.
+            </div>
+            <input
+              id="call-log-retention"
+              type="number"
+              className="input"
+              style={{ maxWidth: '200px' }}
+              min={7}
+              max={365}
+              value={policy.llm_call_log_retention_days}
+              onChange={(e) =>
+                setPolicy({
+                  ...policy,
+                  llm_call_log_retention_days: parseInt(e.target.value, 10) || policy.llm_call_log_retention_days,
+                })
+              }
+              onBlur={(e) => {
+                const raw = parseInt(e.target.value, 10);
+                const clamped = Number.isNaN(raw) ? 30 : Math.min(365, Math.max(7, raw));
+                handlePolicyPatch({ llm_call_log_retention_days: clamped });
+              }}
+            />
           </div>
 
           <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginTop: '1rem' }}>

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -2532,6 +2532,8 @@ export interface components {
         AdminPolicyOut: {
             /** Llm Apikey Connectors Enabled */
             llm_apikey_connectors_enabled: boolean;
+            /** Llm Call Log Retention Days */
+            llm_call_log_retention_days: number;
             /** Llm Compatible Connector Enabled */
             llm_compatible_connector_enabled: boolean;
             /** Llm Default Connector Id */
@@ -2546,6 +2548,8 @@ export interface components {
             clear_default: boolean;
             /** Llm Apikey Connectors Enabled */
             llm_apikey_connectors_enabled?: boolean | null;
+            /** Llm Call Log Retention Days */
+            llm_call_log_retention_days?: number | null;
             /** Llm Compatible Connector Enabled */
             llm_compatible_connector_enabled?: boolean | null;
             /** Llm Default Connector Id */

--- a/server/alembic/versions/047_llm_call_log_retention.py
+++ b/server/alembic/versions/047_llm_call_log_retention.py
@@ -1,0 +1,35 @@
+"""Configurable llm_call_log retention.
+
+Revision ID: 047
+Revises: 046
+Create Date: 2026-05-26
+
+Adds system_settings.llm_call_log_retention_days (int, default 30, NOT NULL).
+The daily cleanup job reads this value each run; sanity bounds (7..365) are
+enforced at the API level, not the database.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "047"
+down_revision: str | None = "046"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "system_settings",
+        sa.Column(
+            "llm_call_log_retention_days",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("30"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("system_settings", "llm_call_log_retention_days")

--- a/server/app/api/admin_llm.py
+++ b/server/app/api/admin_llm.py
@@ -104,6 +104,7 @@ def get_policy(
         llm_apikey_connectors_enabled=settings.llm_apikey_connectors_enabled,
         llm_compatible_connector_enabled=settings.llm_compatible_connector_enabled,
         llm_default_connector_id=settings.llm_default_connector_id,
+        llm_call_log_retention_days=settings.llm_call_log_retention_days,
     )
 
 
@@ -120,6 +121,8 @@ def patch_policy(
         update_kwargs["llm_apikey_connectors_enabled"] = payload.llm_apikey_connectors_enabled
     if payload.llm_compatible_connector_enabled is not None:
         update_kwargs["llm_compatible_connector_enabled"] = payload.llm_compatible_connector_enabled
+    if payload.llm_call_log_retention_days is not None:
+        update_kwargs["llm_call_log_retention_days"] = payload.llm_call_log_retention_days
 
     # Default connector handling:
     # - clear_default=True takes precedence and sets to NULL
@@ -154,6 +157,7 @@ def patch_policy(
         llm_apikey_connectors_enabled=settings.llm_apikey_connectors_enabled,
         llm_compatible_connector_enabled=settings.llm_compatible_connector_enabled,
         llm_default_connector_id=settings.llm_default_connector_id,
+        llm_call_log_retention_days=settings.llm_call_log_retention_days,
     )
 
 

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -30,6 +30,42 @@ logger = logging.getLogger(__name__)
 CORS_ALLOW_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
 
 TIDAL_COLLECTION_POLL_INTERVAL_SECONDS = 300  # 5 minutes
+LLM_CALL_LOG_CLEANUP_INTERVAL_SECONDS = 86400  # 24 hours
+
+
+def _run_llm_call_log_cleanup() -> None:
+    """Synchronous daily cleanup of expired llm_call_log rows.
+
+    Reads ``llm_call_log_retention_days`` from system settings each run, so an
+    admin change to the retention window takes effect on the next pass (within
+    24h) without a restart. Executed in a thread to avoid blocking the loop.
+    """
+    from app.db.session import SessionLocal
+    from app.services.llm.connector_storage import purge_call_log_older_than
+    from app.services.system_settings import get_system_settings
+
+    db = SessionLocal()
+    try:
+        retention_days = get_system_settings(db).llm_call_log_retention_days
+        deleted = purge_call_log_older_than(db, retention_days=retention_days)
+        db.commit()
+        if deleted:
+            logger.info(
+                "llm_call_log cleanup deleted %s rows older than %s days",
+                deleted,
+                retention_days,
+            )
+    finally:
+        db.close()
+
+
+async def _llm_call_log_cleanup_loop() -> None:
+    while True:
+        try:
+            await asyncio.to_thread(_run_llm_call_log_cleanup)
+        except Exception:
+            logger.exception("llm_call_log cleanup loop error")
+        await asyncio.sleep(LLM_CALL_LOG_CLEANUP_INTERVAL_SECONDS)
 
 
 def _run_tidal_collection_poll() -> None:
@@ -74,13 +110,18 @@ async def lifespan(app: FastAPI):
         lg = logging.getLogger(name)
         lg.handlers.clear()
         lg.propagate = True
-    task = asyncio.create_task(_tidal_collection_poll_loop())
+    tasks = [
+        asyncio.create_task(_tidal_collection_poll_loop()),
+        asyncio.create_task(_llm_call_log_cleanup_loop()),
+    ]
     try:
         yield
     finally:
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
 
 
 app = FastAPI(

--- a/server/app/models/system_settings.py
+++ b/server/app/models/system_settings.py
@@ -26,6 +26,12 @@ class SystemSettings(Base):
     llm_model: Mapped[str] = mapped_column(String(100), default="claude-haiku-4-5-20251001")
     llm_rate_limit_per_minute: Mapped[int] = mapped_column(Integer, default=3)
 
+    # llm_call_log retention (days). Daily cleanup deletes rows older than this.
+    # Bounds (7..365) are enforced at the API level, not the DB.
+    llm_call_log_retention_days: Mapped[int] = mapped_column(
+        Integer, default=30, server_default=text("30")
+    )
+
     # LLM gateway connector policy (admin-controlled)
     # See docs/superpowers/specs/2026-05-24-admin-ai-oauth-design.md §4.2
     llm_apikey_connectors_enabled: Mapped[bool] = mapped_column(

--- a/server/app/schemas/llm.py
+++ b/server/app/schemas/llm.py
@@ -199,6 +199,7 @@ class AdminPolicyOut(BaseModel):
     llm_apikey_connectors_enabled: bool
     llm_compatible_connector_enabled: bool
     llm_default_connector_id: int | None
+    llm_call_log_retention_days: int
 
 
 class DjPolicyOut(BaseModel):
@@ -226,6 +227,9 @@ class AdminPolicyPatch(BaseModel):
     # Use a sentinel sentinel: clients can send null to clear, or omit to leave unchanged
     llm_default_connector_id: int | None = None
     clear_default: bool = False
+    # Sanity bounds: minimum 7 days (data minimization floor), maximum 365 days
+    # (reporting ceiling). Out-of-range values are rejected at the API level.
+    llm_call_log_retention_days: int | None = Field(None, ge=7, le=365)
 
     @model_validator(mode="after")
     def _check_default_consistency(self) -> AdminPolicyPatch:

--- a/server/app/services/llm/connector_storage.py
+++ b/server/app/services/llm/connector_storage.py
@@ -6,7 +6,7 @@ import json
 import logging
 from typing import Any
 
-from sqlalchemy import case, func, select
+from sqlalchemy import case, delete, func, select
 from sqlalchemy.orm import Session
 
 from app.models.llm_connector import (
@@ -523,6 +523,23 @@ def log_call(
     return row
 
 
+def purge_call_log_older_than(db: Session, *, retention_days: int) -> int:
+    """Delete llm_call_log rows older than ``retention_days``.
+
+    Returns the number of rows deleted. The caller owns the transaction
+    (commits). ``retention_days`` is supplied by the caller (which reads it
+    from system settings each run) so the retention window stays configurable
+    without a hardcoded constant.
+    """
+    from datetime import timedelta
+
+    from app.core.time import utcnow
+
+    cutoff = utcnow() - timedelta(days=retention_days)
+    result = db.execute(delete(LlmCallLog).where(LlmCallLog.created_at < cutoff))
+    return result.rowcount or 0
+
+
 def get_user_label(db: Session, user_id: int) -> str:
     user = db.get(User, user_id)
     return user.username if user else f"user#{user_id}"
@@ -586,6 +603,7 @@ __all__ = [
     "list_all_connectors",
     "list_connectors_for_user",
     "log_call",
+    "purge_call_log_older_than",
     "revoke_connector",
     "rotate_credentials",
     "update_metadata",

--- a/server/app/services/llm/connector_storage.py
+++ b/server/app/services/llm/connector_storage.py
@@ -535,6 +535,14 @@ def purge_call_log_older_than(db: Session, *, retention_days: int) -> int:
 
     from app.core.time import utcnow
 
+    # Fail closed on out-of-bounds windows. A non-positive value would push the
+    # cutoff to now/future and delete nearly all history; an oversized value is
+    # equally suspect. The admin UI/schema clamp to 7-365, so a value outside
+    # that range means a corrupt or tampered persisted setting — refuse rather
+    # than over-delete. The daily cleanup loop catches this and retries next pass.
+    if not 7 <= retention_days <= 365:
+        raise ValueError("retention_days must be between 7 and 365")
+
     cutoff = utcnow() - timedelta(days=retention_days)
     result = db.execute(delete(LlmCallLog).where(LlmCallLog.created_at < cutoff))
     return result.rowcount or 0

--- a/server/app/services/system_settings.py
+++ b/server/app/services/system_settings.py
@@ -27,6 +27,7 @@ def get_system_settings(db: Session) -> SystemSettings:
             llm_apikey_connectors_enabled=True,
             llm_compatible_connector_enabled=True,
             llm_default_connector_id=None,
+            llm_call_log_retention_days=30,
         )
         db.add(settings)
         db.commit()
@@ -49,6 +50,7 @@ def update_system_settings(
     llm_apikey_connectors_enabled: bool | None = None,
     llm_compatible_connector_enabled: bool | None = None,
     llm_default_connector_id: int | None | object = _UNSET,
+    llm_call_log_retention_days: int | None = None,
 ) -> SystemSettings:
     """Update system settings fields."""
     settings = get_system_settings(db)
@@ -78,6 +80,8 @@ def update_system_settings(
         settings.llm_compatible_connector_enabled = llm_compatible_connector_enabled
     if llm_default_connector_id is not _UNSET:
         settings.llm_default_connector_id = llm_default_connector_id  # type: ignore[assignment]
+    if llm_call_log_retention_days is not None:
+        settings.llm_call_log_retention_days = llm_call_log_retention_days
     db.commit()
     db.refresh(settings)
     return settings

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -386,6 +386,10 @@
             "title": "Llm Apikey Connectors Enabled",
             "type": "boolean"
           },
+          "llm_call_log_retention_days": {
+            "title": "Llm Call Log Retention Days",
+            "type": "integer"
+          },
           "llm_compatible_connector_enabled": {
             "title": "Llm Compatible Connector Enabled",
             "type": "boolean"
@@ -404,6 +408,7 @@
         },
         "required": [
           "llm_apikey_connectors_enabled",
+          "llm_call_log_retention_days",
           "llm_compatible_connector_enabled",
           "llm_default_connector_id"
         ],
@@ -427,6 +432,19 @@
               }
             ],
             "title": "Llm Apikey Connectors Enabled"
+          },
+          "llm_call_log_retention_days": {
+            "anyOf": [
+              {
+                "maximum": 365.0,
+                "minimum": 7.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Call Log Retention Days"
           },
           "llm_compatible_connector_enabled": {
             "anyOf": [

--- a/server/tests/test_llm_api.py
+++ b/server/tests/test_llm_api.py
@@ -696,6 +696,57 @@ class TestAdminLlm:
         )
         assert resp.status_code == 422
 
+    def test_policy_exposes_retention_default(self, client: TestClient, admin_headers):
+        # Issue #342: retention is surfaced via the policy endpoint and defaults to 30.
+        resp = client.get("/api/admin/llm/policy", headers=admin_headers)
+        assert resp.status_code == 200
+        assert resp.json()["llm_call_log_retention_days"] == 30
+
+    def test_patch_retention_persists(self, client: TestClient, admin_headers, db):
+        resp = client.patch(
+            "/api/admin/llm/policy",
+            json={"llm_call_log_retention_days": 90},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["llm_call_log_retention_days"] == 90
+
+        # Persisted to the DB-backed singleton, visible on a fresh GET.
+        resp = client.get("/api/admin/llm/policy", headers=admin_headers)
+        assert resp.json()["llm_call_log_retention_days"] == 90
+
+        from app.services.system_settings import get_system_settings
+
+        assert get_system_settings(db).llm_call_log_retention_days == 90
+
+    def test_patch_retention_below_min_rejected(self, client: TestClient, admin_headers):
+        # Sanity bound: minimum 7 days. Rejected at the API level (422).
+        resp = client.patch(
+            "/api/admin/llm/policy",
+            json={"llm_call_log_retention_days": 6},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 422
+
+    def test_patch_retention_above_max_rejected(self, client: TestClient, admin_headers):
+        # Sanity bound: maximum 365 days. Rejected at the API level (422).
+        resp = client.patch(
+            "/api/admin/llm/policy",
+            json={"llm_call_log_retention_days": 366},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 422
+
+    def test_patch_retention_accepts_boundaries(self, client: TestClient, admin_headers):
+        for value in (7, 365):
+            resp = client.patch(
+                "/api/admin/llm/policy",
+                json={"llm_call_log_retention_days": value},
+                headers=admin_headers,
+            )
+            assert resp.status_code == 200
+            assert resp.json()["llm_call_log_retention_days"] == value
+
     def test_list_connectors_admin_shows_all(
         self, client: TestClient, admin_headers, db, test_user
     ):

--- a/server/tests/test_llm_call_log_retention.py
+++ b/server/tests/test_llm_call_log_retention.py
@@ -1,0 +1,135 @@
+"""Tests for configurable llm_call_log retention (issue #342).
+
+Covers:
+- The purge helper deletes only rows older than the supplied window.
+- The daily cleanup job reads the retention window from system settings each
+  run (no hardcoded constant), so an admin change takes effect on the next pass.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.models.llm_connector import LlmCallLog, LlmConnector
+from app.services.llm.connector_storage import purge_call_log_older_than
+from app.services.system_settings import update_system_settings
+
+
+def _make_connector(db: Session, user_id: int) -> LlmConnector:
+    row = LlmConnector(
+        user_id=user_id,
+        connector_type="openai_apikey",
+        display_name="Mine",
+        status="active",
+        credentials=json.dumps({"api_key": "sk-x"}),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _seed_call_log(db: Session, connector_id: int, *, age_days: int) -> LlmCallLog:
+    # Set created_at explicitly at construction so the backdated timestamp wins
+    # over the column's server_default.
+    row = LlmCallLog(
+        connector_id=connector_id,
+        purpose="recommendation",
+        status="ok",
+        latency_ms=100,
+        tokens_in=10,
+        tokens_out=5,
+        created_at=utcnow() - timedelta(days=age_days),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+class TestPurgeHelper:
+    def test_deletes_only_older_than_window(self, db: Session, test_user):
+        connector = _make_connector(db, test_user.id)
+        old = _seed_call_log(db, connector.id, age_days=40)
+        recent = _seed_call_log(db, connector.id, age_days=5)
+        # Capture ids before the bulk delete — accessing attributes on a deleted
+        # ORM instance afterwards would trigger a reload error.
+        old_id, recent_id = old.id, recent.id
+
+        deleted = purge_call_log_older_than(db, retention_days=30)
+        db.commit()
+
+        assert deleted == 1
+        ids = {r.id for r in db.query(LlmCallLog.id).all()}
+        assert recent_id in ids
+        assert old_id not in ids
+
+    def test_no_rows_to_delete_returns_zero(self, db: Session, test_user):
+        connector = _make_connector(db, test_user.id)
+        _seed_call_log(db, connector.id, age_days=5)
+
+        deleted = purge_call_log_older_than(db, retention_days=30)
+        db.commit()
+
+        assert deleted == 0
+        assert db.query(LlmCallLog).count() == 1
+
+    def test_boundary_row_at_exactly_window_kept(self, db: Session, test_user):
+        # A row aged just under the window must be kept; just over must go.
+        connector = _make_connector(db, test_user.id)
+        just_under = _seed_call_log(db, connector.id, age_days=29)
+        just_over = _seed_call_log(db, connector.id, age_days=31)
+        under_id, over_id = just_under.id, just_over.id
+
+        purge_call_log_older_than(db, retention_days=30)
+        db.commit()
+
+        ids = {r.id for r in db.query(LlmCallLog.id).all()}
+        assert under_id in ids
+        assert over_id not in ids
+
+
+class TestCleanupReadsSettings:
+    """The daily cleanup job must read the retention window from settings each
+    run, not from a hardcoded constant."""
+
+    def test_cleanup_honors_admin_changed_window(self, db: Session, test_user, monkeypatch):
+        connector = _make_connector(db, test_user.id)
+        # A row aged 20 days survives the default 30-day window but should be
+        # purged once the admin shortens retention to 7 days.
+        _seed_call_log(db, connector.id, age_days=20)
+
+        # Admin shortens retention.
+        update_system_settings(db, llm_call_log_retention_days=7)
+
+        # The cleanup job opens its own session via `from app.db.session import
+        # SessionLocal`; point that factory at the test session so the in-memory
+        # SQLite state is shared.
+        import app.main as main_module
+
+        monkeypatch.setattr("app.db.session.SessionLocal", lambda: db, raising=False)
+
+        # Prevent the job's db.close() from tearing down the shared test session.
+        monkeypatch.setattr(db, "close", lambda: None)
+
+        main_module._run_llm_call_log_cleanup()
+
+        assert db.query(LlmCallLog).count() == 0
+
+    def test_cleanup_keeps_rows_within_window(self, db: Session, test_user, monkeypatch):
+        connector = _make_connector(db, test_user.id)
+        _seed_call_log(db, connector.id, age_days=20)
+
+        # Default window (30) keeps the 20-day-old row.
+        import app.main as main_module
+
+        monkeypatch.setattr("app.db.session.SessionLocal", lambda: db, raising=False)
+        monkeypatch.setattr(db, "close", lambda: None)
+
+        main_module._run_llm_call_log_cleanup()
+
+        assert db.query(LlmCallLog).count() == 1

--- a/server/tests/test_llm_call_log_retention.py
+++ b/server/tests/test_llm_call_log_retention.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 from datetime import timedelta
 
+import pytest
 from sqlalchemy.orm import Session
 
 from app.core.time import utcnow
@@ -76,6 +77,20 @@ class TestPurgeHelper:
         db.commit()
 
         assert deleted == 0
+        assert db.query(LlmCallLog).count() == 1
+
+    def test_rejects_out_of_bounds_window_without_deleting(self, db: Session, test_user):
+        # A corrupt/tampered persisted value outside the 7-365 contract must fail
+        # closed: raise before deleting, never push the cutoff to now/future and
+        # wipe history. The daily cleanup loop catches this and retries next pass.
+        connector = _make_connector(db, test_user.id)
+        _seed_call_log(db, connector.id, age_days=5)
+
+        for bad in (0, -1, 6, 366, 100000):
+            with pytest.raises(ValueError):
+                purge_call_log_older_than(db, retention_days=bad)
+            db.rollback()
+
         assert db.query(LlmCallLog).count() == 1
 
     def test_boundary_row_at_exactly_window_kept(self, db: Session, test_user):


### PR DESCRIPTION
Closes #342

## Summary

MVP hardcoded 30-day `llm_call_log` retention. This makes it admin-configurable (7–365 days) and wires up the daily cleanup job that the `LlmCallLog` model docstring referenced but which did not actually exist yet.

- **Model + migration**: `SystemSettings.llm_call_log_retention_days` (int, default 30, NOT NULL) + alembic `047` (`server_default 30`). `alembic upgrade head && alembic check` passes (no drift).
- **API**: retention is surfaced on the existing LLM policy endpoint (`/api/admin/llm/policy`). PATCH validates bounds via Pydantic `Field(ge=7, le=365)`, so out-of-range values are rejected at the API level (422).
- **Cleanup job**: new daily (24h) loop in the FastAPI `lifespan`, alongside the existing Tidal poll loop. Reads the retention window from settings **on each run**, so an admin change is honored within 24h without a restart.
- **Frontend**: "Call log retention (days)" number input on the `/admin/ai` Connector policy card; clamps to 7–365 and patches on blur. Regenerated OpenAPI TS types (the bounds are now captured in the spec).

## Design decisions

- **Where the setting lives**: placed on the LLM policy surface (`AdminPolicyOut`/`AdminPolicyPatch`, `/api/admin/llm/policy`) rather than the generic `/api/admin/settings`. It is an LLM-gateway concern, and the `/admin/ai` page already consumes the policy endpoint for its "Connector policy" card — so it slots in next to the org-default connector with no new endpoint.
- **Per-run read (not materialized)**: the cleanup loop calls `get_system_settings(db).llm_call_log_retention_days` every pass. No restart needed to pick up a change; satisfies the "honors the new value within 24h" acceptance criterion directly.
- **Validation approach**: bounds enforced server-side with a Pydantic constrained type (`Field(None, ge=7, le=365)`) — the authoritative gate. The DB column has no CHECK constraint (kept portable across SQLite/Postgres); the frontend additionally clamps on blur for UX, but the API is the source of truth.
- **Scheduler status**: there was previously **no** cleanup job — only a docstring reference and a hardcoded "30-day" mention. This PR adds the actual job (lifespan async loop + `purge_call_log_older_than` helper), so the feature is now end-to-end rather than just config plumbing. `LlmAuditEvent` retention is unchanged (indefinite, by design).
- **Default unchanged**: 30 days, so existing deployments behave identically until an admin opts to change it.

## Test plan

- [x] Backend: `ruff check`, `ruff format --check`, `bandit`, full `pytest` (2310 passed, 87.13% coverage ≥ 85% gate)
- [x] Backend: `alembic upgrade head && alembic check` (no drift)
- [x] Frontend: `npm run lint` (0 errors), `tsc --noEmit`, `npm test` (956 passed)
- [x] API bounds rejected (6 → 422, 366 → 422; 7/365 accepted); retention persists across GET
- [x] Cleanup honors an admin-shortened window and keeps in-window rows
- [x] Frontend retention input persists on blur and clamps out-of-range input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable LLM call log retention period (7–365 days, default 30) to admin settings.
  * Automatic daily cleanup of expired call logs based on the configured retention window.

* **Tests**
  * Added comprehensive test coverage for retention configuration and cleanup behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->