### PR TITLE
test(verification): fix flaky tamper vector in verify-status test

### DIFF
--- a/server/tests/test_verify_status_endpoint.py
+++ b/server/tests/test_verify_status_endpoint.py
@@ -93,15 +93,27 @@ class TestVerifyStatusEndpoint:
     def test_tampered_signature_returns_false(self, client: TestClient, db: Session):
         from fastapi import Response
 
-        from app.services.human_verification import COOKIE_NAME, issue_human_cookie
+        from app.services.human_verification import (
+            COOKIE_NAME,
+            _b64decode,
+            _b64encode,
+            issue_human_cookie,
+        )
 
         guest = _make_guest(db, "tamper")
         helper_resp = Response()
         issue_human_cookie(helper_resp, guest.id)
         raw = helper_resp.headers["set-cookie"]
         cookie_value = raw.split(f"{COOKIE_NAME}=", 1)[1].split(";", 1)[0]
-        # Flip the last char of the signature portion
-        bad = cookie_value[:-1] + ("A" if cookie_value[-1] != "A" else "B")
+        # Tamper at the decoded-bytes level so the mutation is guaranteed to
+        # change sig_bytes. Flipping the last base64url char only touches the
+        # high bits of the trailing byte (low bits are discarded on decode), so
+        # it frequently round-trips to the SAME signature — that was the flaky
+        # tamper vector. Flip a whole byte instead. (Regression for #364.)
+        payload_part, sig_part = cookie_value.rsplit(".", 1)
+        sig = bytearray(_b64decode(sig_part))
+        sig[0] ^= 0xFF
+        bad = f"{payload_part}.{_b64encode(bytes(sig))}"
 
         client.cookies.clear()
         client.cookies.set(COOKIE_NAME, bad)


### PR DESCRIPTION
## Summary
Fixes the intermittently-flaky `test_tampered_signature_returns_false` (~2/5 failures in isolated runs on `epic/ai-engine`). The flakiness was a weak test-only tamper vector, **not** a production bug.

**Production code (`server/app/services/human_verification.py`) is unchanged** — its HMAC-SHA256 + `compare_digest` check was always correct.

## Root cause
The `wrzdj_human` cookie is `{base64url(payload)}.{base64url(sig)}` with padding stripped. The old test tampered by flipping the **last base64url character** of the signature:

```python
bad = cookie_value[:-1] + ("A" if cookie_value[-1] != "A" else "B")
```

base64url's final character only encodes the **high bits** of the last decoded byte; the low bits are discarded on decode, and `_b64decode()` re-pads before decoding. So flipping that last character frequently decodes back to the **same** `sig_bytes`. When it did, `hmac.compare_digest(expected_sig, sig_bytes)` returned `True`, the cookie validated, the endpoint returned `verified: true`, and the `verified is False` assertion failed. The outcome was data-dependent on the random signature's trailing byte.

## Fix
Tamper at the decoded-bytes level so the mutation is guaranteed to change `sig_bytes`. Import the module's own `_b64decode`/`_b64encode` helpers so the encoding matches production exactly, decode the signature, flip a whole byte, and re-encode:

```python
payload_part, sig_part = cookie_value.rsplit(".", 1)
sig = bytearray(_b64decode(sig_part))
sig[0] ^= 0xFF
bad = f"{payload_part}.{_b64encode(bytes(sig))}"
```

The assertion `verified is False` is preserved. Per CLAUDE.md testing philosophy, this **pins a regression** for the flaky tamper vector.

## Design decisions
- **Reused the module's `_b64decode`/`_b64encode`** (imported into the test) rather than re-implementing base64 in the test, so the round-trip encoding is byte-identical to what production issues/validates.
- **Flipped byte index 0** (`sig[0] ^= 0xFF`) — a full-byte XOR guarantees the decoded signature differs every run regardless of the random signature contents. The issue suggested index 0 or a middle byte; either works.
- **No production change.** The bug was a weak assertion, not a security hole in `verify_human_cookie()`.

## Test plan
- [x] `test_tampered_signature_returns_false` run 20x in a loop — **0 failures / 20** (coverage gate disabled to isolate the test result; the full per-file pytest run trips the 85% `--cov-fail-under` gate, which is expected for a single-file run).
- [x] Full `tests/test_verify_status_endpoint.py` — 5 passed.
- [x] `ruff check .` and `ruff format --check .` from `server/` — clean.

Closes #364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of cookie signature verification test through a more deterministic tampering method.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->