### PR TITLE
feat(ai): LLM adapter plug-in SDK with docs, skeleton, and optional loader

### DIFF
--- a/docs/LLM-PLUGIN.md
+++ b/docs/LLM-PLUGIN.md
@@ -15,7 +15,7 @@ This document is the contract that third-party plug-ins write against.
 
 ## Architecture Overview
 
-```
+```text
 Caller (recommendation engine, agentic feature)
         │
         ▼

--- a/docs/LLM-PLUGIN.md
+++ b/docs/LLM-PLUGIN.md
@@ -1,0 +1,323 @@
+# LLM Adapter Plug-in Guide
+
+The WrzDJ backend dispatches every LLM call through the **LLM Gateway**, which
+selects a connector for the calling user and routes the request through a
+provider-specific **adapter**. The set of adapters is open: forks and
+third-party deployments can add new providers without modifying any file
+under `server/app/services/llm/`.
+
+This document is the contract that third-party plug-ins write against.
+
+> Companion guide: [`docs/PLUGIN-ARCHITECTURE.md`](PLUGIN-ARCHITECTURE.md)
+> describes the bridge-side equipment plug-in system. The LLM plug-in surface
+> follows the same shape: a small ABC, a registry, and a strict typed-error
+> contract.
+
+## Architecture Overview
+
+```
+Caller (recommendation engine, agentic feature)
+        │
+        ▼
+Gateway.dispatch(db, actor, request, *, purpose)
+        │   1. Resolve LlmConnector (per-DJ MRU → org default)
+        │   2. registry.get_adapter_class(connector_type)
+        │   3. adapter = cls(connector); await adapter.chat(request)
+        │   4. Log call + handle fallback policy
+        ▼
+LlmAdapter (your plug-in)
+        │   1. Parse connector.credentials (encrypted JSON blob)
+        │   2. Translate ChatRequest → provider-native request
+        │   3. Translate provider response → ChatResponse
+        │   4. Map provider errors → typed LlmError subclasses
+        ▼
+Provider HTTP endpoint / SDK
+```
+
+| Layer | File | Responsibility |
+|-------|------|----------------|
+| Adapter | `app/services/llm/adapters/*.py` (built-in) <br> `LLM_PLUGIN_DIR/*.py` (third-party) | Convert between canonical and provider-native shapes; map errors |
+| Registry | `app/services/llm/registry.py` | `connector_type` → adapter class lookup |
+| Tool translation | `app/services/llm/tool_translation.py` | JSON-Schema `ToolSpec` ↔ provider tool/function shape |
+| Gateway | `app/services/llm/gateway.py` | Resolve connector, call adapter, log, handle fallback |
+| Models | `app/models/llm_connector.py` | `LlmConnector` row (encrypted credentials), call log, audit log |
+| Exceptions | `app/services/llm/exceptions.py` | Typed error hierarchy adapters must raise |
+
+The connector row stores credentials as **encrypted JSON** via the
+`EncryptedText` SQLAlchemy column type — accessing
+`connector.credentials` returns the decrypted plaintext blob. Your adapter is
+responsible for parsing that blob.
+
+## The `LlmAdapter` ABC
+
+Defined in [`app/services/llm/base.py`](../server/app/services/llm/base.py).
+
+```python
+class LlmAdapter(ABC):
+    connector_type: str = ""  # set on the subclass — registry key
+
+    def __init__(self, connector) -> None:
+        self.connector = connector
+
+    @abstractmethod
+    async def chat(self, request: ChatRequest) -> ChatResponse: ...
+
+    @abstractmethod
+    async def health_check(self) -> None: ...
+```
+
+### Required Class Attribute: `connector_type`
+
+A short, lowercase, snake-case string. The DB column that stores it is 40
+characters; pick something unique and stable (e.g. `mistral_apikey`,
+`groq_apikey`, `local_vllm`). The registry **refuses to bind the same
+`connector_type` to two different classes** — that prevents silent shadowing
+of built-in adapters.
+
+### Required Method: `chat()`
+
+| Property | Contract |
+|----------|----------|
+| Coroutine | Yes — `async def`. The gateway always awaits. |
+| Input | A canonical `ChatRequest`. |
+| Output | A canonical `ChatResponse`. |
+| Errors | One of the typed `LlmError` subclasses (see below). Never a raw HTTP / SDK exception. |
+| Side effects | None other than the upstream network call. Do **not** mutate the connector row. |
+| Logging | Do not log full prompts, completions, or any credential material. |
+
+### Required Method: `health_check()`
+
+Validate the credential against the provider. The gateway calls this from the
+admin "Test connector" path. Returns `None` on success; raises the same typed
+exceptions as `chat()` on failure.
+
+Pattern: issue the cheapest possible call (e.g. `max_tokens=1`). The shared
+helper `build_healthcheck_request()` in
+`app/services/llm/adapters/_httpx_openai.py` is reusable for OpenAI-shaped
+endpoints.
+
+## Canonical Types
+
+Defined in [`app/services/llm/base.py`](../server/app/services/llm/base.py).
+These are **stable** Pydantic models — fields may be added in a minor release
+but never renamed or removed without a major-version bump.
+
+### `ChatRequest`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `messages` | `list[Message]` | Required. `role ∈ {"system", "user", "assistant", "tool"}`. Tool messages carry `tool_call_id`. |
+| `tools` | `list[ToolSpec] \| None` | JSON-Schema shape. Translate via `tool_translation.to_*_tools()`. |
+| `force_tool` | `str \| None` | Forces a specific tool name; raise `ToolTranslationError` if not in `tools`. |
+| `max_tokens` | `int \| None` | Adapters supply a default if `None`. |
+| `temperature` | `float \| None` | Pass through verbatim when not `None`. |
+| `model` | `str \| None` | Overrides `connector.model_hint`. |
+| `timeout_seconds` | `float \| None` | Adapters MAY clamp to a max. |
+| `system` | `str \| None` | Provider-native system prompt. Map to the right surface (OpenAI: first system message; Anthropic: top-level `system`). |
+| `fallback_policy` | `Literal["none", "org_default", "retry_then_org_default"]` | Handled by the gateway, not the adapter. Ignore. |
+
+### `ChatResponse`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `text` | `str` | The textual assistant reply. Empty string if the model only emitted tool calls. |
+| `tool_calls` | `list[ToolCall]` | Empty list when no tools were called. |
+| `stop_reason` | `Literal["end_turn", "tool_use", "max_tokens", "error"]` | Required. Map from the provider's native stop reason. |
+| `usage` | `TokenUsage \| None` | Counts only — never prompt content. Optional. |
+| `model` | `str \| None` | Provider-reported model id (for telemetry). Recommended. |
+
+### `ToolSpec`, `ToolCall`, `Message`
+
+See the source. `ToolSpec.input_schema` is a JSON-Schema dict;
+`tool_translation.py` knows how to translate it for OpenAI / Anthropic /
+Bedrock and parse the response back into canonical `ToolCall` objects.
+Reuse those helpers rather than reimplementing them per adapter.
+
+## Exception Contract
+
+Defined in [`app/services/llm/exceptions.py`](../server/app/services/llm/exceptions.py).
+Every error from the adapter must be one of these. The gateway translates
+them into telemetry, audit events, and HTTP response codes; raw provider
+errors **must not** reach the caller (they often contain bearer tokens in
+error messages — a credential-leak vector).
+
+| Exception | When to raise | Status hint |
+|-----------|---------------|-------------|
+| `AuthInvalid` | Credentials are malformed, missing, or rejected (`401`/`403`). Includes "failed to parse the credential JSON". | Marks connector `status="auth_invalid"`; writes audit event. |
+| `RateLimited(retry_after_seconds=...)` | Provider returned `429`. Pass through `Retry-After` if present. | Gateway logs and surfaces as `429` to the caller. |
+| `QuotaExceeded` | Billing failure (`402`) or provider-specific quota error. | Logged, surfaced as `402` to caller. |
+| `ProviderUnavailable` | `5xx`, network failure, timeout, generic SDK error. | Logged, surfaced as `502`. Eligible for fallback. |
+| `ToolTranslationError` | Unable to translate input tools or parse the response. | Logged, surfaced as `502`. **Not** a fallback trigger. |
+| `NoLlmConfigured` | **Gateway-only.** Adapters should not raise this. | – |
+
+### Mapping example (OpenAI HTTP shape)
+
+```python
+status = response.status_code
+if status in (401, 403):
+    raise AuthInvalid(f"Auth failed (HTTP {status})")
+if status == 402:
+    raise QuotaExceeded("Quota or billing failure")
+if status == 429:
+    retry = response.headers.get("retry-after")
+    raise RateLimited("Rate limited", retry_after_seconds=int(float(retry)) if retry else None)
+if 500 <= status < 600:
+    raise ProviderUnavailable(f"Upstream error (HTTP {status})")
+# 4xx other than the above → almost certainly a translation problem.
+raise ToolTranslationError(f"Upstream rejected request (HTTP {status})")
+```
+
+## Tool Translation
+
+The canonical `ToolSpec` is JSON-Schema. Adapters should delegate to
+[`app/services/llm/tool_translation.py`](../server/app/services/llm/tool_translation.py)
+rather than re-implementing the conversion. The module exposes:
+
+| Helper | Direction |
+|--------|-----------|
+| `to_openai_tools(tools, force)` | Canonical → OpenAI `tools` + `tool_choice` |
+| `parse_openai_response(payload)` | OpenAI body → `ChatResponse` |
+| `to_anthropic_tools(tools, force)` | Canonical → Anthropic `tools` + `tool_choice` |
+| `parse_anthropic_response(message)` | Anthropic SDK message → `ChatResponse` |
+| `to_bedrock_tools(tools, force)` | Canonical → Bedrock Converse `toolConfig` |
+| `parse_bedrock_response(payload)` | Bedrock body → `ChatResponse` |
+
+Adding a new translation pair for a provider whose tool shape genuinely
+differs is allowed — open a PR adding helpers under the same naming
+convention. Until then, do not silently re-shape tools inside your adapter.
+
+## Registration
+
+Register the adapter as the **last statement** of your module:
+
+```python
+register_adapter(MyAdapter.connector_type, MyAdapter)
+```
+
+That call:
+
+- Validates the class subclasses `LlmAdapter`.
+- Rejects empty `connector_type`.
+- Rejects double-binding (a different class trying to take an already-bound
+  key — surfaced as `ValueError` at startup).
+
+Re-registering the *same* class is a no-op (safe for test re-imports).
+
+## Loading Third-Party Plug-ins
+
+There are two supported mechanisms:
+
+1. **Import from your own code.** Add the file to your fork of the backend
+   and ensure it gets imported at startup (e.g. add it to the
+   `app/services/llm/registry.py::_bootstrap` block, or import it from
+   `app/main.py`). This is the recommended path for forks.
+
+2. **`LLM_PLUGIN_DIR` env var.** Set the environment variable to a directory
+   path. At startup the loader
+   ([`app/services/llm/plugin_loader.py`](../server/app/services/llm/plugin_loader.py))
+   imports every `*.py` file in that directory (non-recursive; files starting
+   with `_` are skipped). Each plug-in is responsible for calling
+   `register_adapter()` on import. A broken plug-in is logged with a full
+   stack trace and skipped — it does **not** prevent the rest of the directory
+   or the backend itself from starting.
+
+### Security posture for `LLM_PLUGIN_DIR`
+
+Loading a plug-in grants it the **full privileges of the backend process**.
+There is no sandbox; this is the same trust boundary as `pip install`.
+Operators must:
+
+- Treat the plug-in directory as a privileged path. Only the backend's
+  service account should have write access to it.
+- Audit every plug-in's source the same way they would audit a third-party
+  Python dependency.
+- Never set `LLM_PLUGIN_DIR` to a world-writable or multi-tenant path.
+
+In production we recommend leaving `LLM_PLUGIN_DIR` unset and packaging
+trusted plug-ins as ordinary Python modules. The env-var loader exists to
+make local experimentation and forks ergonomic.
+
+## Stable vs Internal API
+
+The plug-in surface is **the surface listed in this document**. Everything
+else under `app/services/llm/` is internal — including helper modules,
+private functions, and adapter base-class internals not enumerated above.
+
+| Surface | Stability |
+|---------|-----------|
+| `LlmAdapter` ABC method signatures (`chat`, `health_check`, `connector_type`) | **Stable.** Breaking change → major version bump. |
+| `ChatRequest`, `ChatResponse`, `Message`, `ToolSpec`, `ToolCall`, `TokenUsage` field names + types | **Stable.** Field additions in minor versions; never renames/removals without a major bump. |
+| Exception types and their constructor signatures | **Stable.** |
+| `register_adapter`, `get_adapter_class`, `list_connector_types`, `is_registered` | **Stable.** |
+| `tool_translation.to_*_tools` / `parse_*_response` | **Stable** for the providers documented above. |
+| `_httpx_openai`, `url_validator`, `connector_storage` | **Internal.** Reuse at your own risk; may change without notice. |
+| `gateway.dispatch` internals (fallback, logging, audit) | **Internal.** Callers must use the public `Gateway.dispatch` entrypoint. |
+| `LlmConnector` ORM model | **Internal.** Adapters touch only `connector.credentials`, `connector.model_hint`, and `connector.base_url_plain`. |
+
+Schema changes to the `LlmConnector` storage shape (encrypted JSON blob keys)
+are versioned by `connector_type`. Each provider chooses its own blob keys
+in its own migration; the only invariant is that **the blob is a JSON object**.
+
+## Test Matrix
+
+Every registered adapter — built-in or third-party — must pass the
+parametrised contract tests in
+[`server/tests/test_llm_adapter_contract.py`](../server/tests/test_llm_adapter_contract.py).
+The contract covers:
+
+1. The class subclasses `LlmAdapter`.
+2. `connector_type` is non-empty and matches the registration key.
+3. `chat` and `health_check` are async callables.
+4. The constructor accepts a connector row without raising.
+5. `chat()` raises `AuthInvalid` (or another `LlmError`) for malformed
+   credential blobs — never a raw `JSONDecodeError`, `KeyError`, or HTTP
+   exception.
+6. The registry returns classes (not instances) and raises `KeyError` on
+   unknown lookups.
+
+Adapter-specific HTTP and parsing behaviour belongs in a separate test file
+(see the built-in adapters' tests in `test_llm_adapters.py` for the pattern).
+
+Run the contract test against your adapter:
+
+```bash
+cd server
+.venv/bin/pytest tests/test_llm_adapter_contract.py
+```
+
+If a contract test fails on your adapter, **fix the adapter** — do not
+modify the contract. The contract is what lets the gateway dispatch
+generically.
+
+## Reference Skeleton
+
+The minimum working adapter lives at
+[`docs/examples/echo_adapter.py`](examples/echo_adapter.py). It is exercised
+by `test_skeleton_echo_adapter_*` in the contract test file, so any change
+that breaks the documented surface fails CI immediately.
+
+## Adding a Plug-in in 5 Minutes
+
+```bash
+# 1. Copy the skeleton.
+cp docs/examples/echo_adapter.py /opt/wrzdj/llm_plugins/mistral_apikey.py
+
+# 2. Edit it:
+#    - Change `connector_type` to a unique value (e.g. "mistral_apikey").
+#    - Replace the echo body with your provider call.
+#    - Map provider errors to the typed exceptions.
+
+# 3. Point the backend at the plug-in directory.
+export LLM_PLUGIN_DIR=/opt/wrzdj/llm_plugins
+uvicorn app.main:app
+
+# 4. Verify the registry sees it.
+python -c "from app.services.llm.registry import list_connector_types; print(list_connector_types())"
+
+# 5. Run the contract tests.
+cd server && .venv/bin/pytest tests/test_llm_adapter_contract.py
+```
+
+Once your adapter is registered, DJs can create a connector row via
+`POST /api/llm/connectors` with `connector_type="mistral_apikey"` and the
+gateway will route their requests through your adapter automatically.

--- a/docs/examples/echo_adapter.py
+++ b/docs/examples/echo_adapter.py
@@ -1,0 +1,174 @@
+"""Echo adapter — minimal reference implementation of ``LlmAdapter``.
+
+This skeleton is the canonical "blank slate" for third-party LLM provider
+plug-ins. It implements the full :class:`~app.services.llm.base.LlmAdapter`
+contract without making any network calls — every request is echoed back as
+the assistant message body.
+
+Usage in tests::
+
+    # Self-test against the contract — no production import.
+    from docs.examples import echo_adapter  # noqa: F401  (side-effect: register)
+    from app.services.llm.registry import get_adapter_class
+
+    cls = get_adapter_class("echo")
+    response = await cls(connector).chat(request)
+
+Usage in production (third-party plug-ins)::
+
+    # 1. Copy this file under any module path you control.
+    # 2. Customize ``connector_type`` and the body of ``chat()``.
+    # 3. Either:
+    #    a) drop the .py file into the directory pointed to by ``LLM_PLUGIN_DIR``,
+    #       or
+    #    b) import the module from your own bootstrap code at startup.
+    # 4. The :func:`register_adapter` call at the bottom binds the class to the
+    #    registry the moment the module is imported.
+
+See ``docs/LLM-PLUGIN.md`` for the full extension contract.
+
+Security note: this skeleton intentionally does not validate or sanitise the
+input it echoes. Real adapters must:
+- Treat ``connector.credentials`` as untrusted (the encrypted blob can be
+  malformed; raise :class:`AuthInvalid` rather than letting :class:`json.JSONDecodeError`
+  bubble up).
+- Translate upstream HTTP/SDK errors into the typed exception hierarchy
+  (``AuthInvalid`` / ``RateLimited`` / ``QuotaExceeded`` / ``ProviderUnavailable``
+  / ``ToolTranslationError``). Raw provider errors must not reach the caller.
+- Never log secrets, full prompts, or completion bodies (the gateway only
+  logs counts).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from app.services.llm.base import (
+    ChatRequest,
+    ChatResponse,
+    ContentBlock,
+    LlmAdapter,
+    Message,
+    TokenUsage,
+)
+from app.services.llm.exceptions import AuthInvalid
+from app.services.llm.registry import register_adapter
+
+logger = logging.getLogger(__name__)
+
+
+class EchoAdapter(LlmAdapter):
+    """An adapter that echoes the last user message back as the assistant reply.
+
+    Useful for:
+    - Wiring tests for the gateway / connector storage layer end-to-end
+      without depending on a live provider.
+    - Showing third-party plug-in authors the minimum required surface.
+    """
+
+    # The registry key for this adapter. Plug-in authors must change this to a
+    # unique string before publishing — the registry refuses to register two
+    # different classes under the same ``connector_type``.
+    connector_type = "echo"
+
+    # ------------------------------------------------------------------
+    # Credential handling
+    # ------------------------------------------------------------------
+    def _read_credentials(self) -> dict[str, Any]:
+        """Parse the encrypted credential blob, raising AuthInvalid on failure.
+
+        The :class:`~app.models.llm_connector.LlmConnector` row stores
+        credentials as an encrypted JSON string. Accessing ``self.connector.credentials``
+        triggers decryption transparently via the ``EncryptedText`` column
+        type. After that, parsing is the adapter's responsibility — and every
+        failure mode here must surface as :class:`AuthInvalid` so the gateway
+        can mark the connector and emit a clean audit event.
+        """
+        raw = self.connector.credentials or ""
+        try:
+            blob = json.loads(raw)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise AuthInvalid("Connector credentials are malformed") from exc
+        if not isinstance(blob, dict):
+            raise AuthInvalid("Connector credentials shape is invalid")
+        return blob
+
+    # ------------------------------------------------------------------
+    # LlmAdapter — required methods
+    # ------------------------------------------------------------------
+    async def chat(self, request: ChatRequest) -> ChatResponse:
+        """Echo the most recent user message back as the assistant reply.
+
+        Real adapters should:
+        - Translate ``request.messages`` to the provider's native message shape.
+        - Call ``to_<provider>_tools(request.tools, request.force_tool)`` from
+          ``app.services.llm.tool_translation`` to translate tools.
+        - Call ``parse_<provider>_response(...)`` from that same module to
+          translate the response back to ``ChatResponse``.
+        - Map provider HTTP / SDK errors to the typed exception hierarchy.
+        """
+        # We deliberately read credentials before doing any echoing — that way
+        # this skeleton exercises the same boundary (malformed creds raise
+        # AuthInvalid) that real adapters depend on.
+        self._read_credentials()
+
+        last_user = next(
+            (m for m in reversed(request.messages) if m.role == "user"),
+            None,
+        )
+        if last_user is None:
+            text = ""
+        else:
+            text = _flatten_message_text(last_user)
+
+        return ChatResponse(
+            text=text,
+            tool_calls=[],
+            stop_reason="end_turn",
+            usage=TokenUsage(prompt=len(text.split()), completion=len(text.split())),
+            # Surface the resolved model name (request override → connector hint
+            # → adapter default) so call logs and recommendation telemetry stay
+            # accurate. Real adapters should set this to the *provider-reported*
+            # model id from the response payload, not the requested model.
+            model=request.model or self.connector.model_hint or "echo-1",
+        )
+
+    async def health_check(self) -> None:
+        """Validate the credential without exercising the (nonexistent) provider.
+
+        Real adapters should issue a cheap, low-token call (e.g. ``max_tokens=1``)
+        and raise the same typed exceptions as :meth:`chat`.
+        """
+        # No provider to ping — the credential parse step is enough proof that
+        # the connector is wired correctly.
+        self._read_credentials()
+
+
+def _flatten_message_text(msg: Message) -> str:
+    """Collapse a possibly-multi-block message to plain text.
+
+    Real provider adapters typically keep the block structure; this skeleton
+    flattens because a string return matches the simplest possible echo.
+    """
+    content = msg.content
+    if isinstance(content, str):
+        return content
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, ContentBlock):
+            parts.append(block.text)
+        elif isinstance(block, dict):
+            parts.append(block.get("text") or "")
+    return "".join(parts)
+
+
+# The registry call here is what makes the skeleton "live" — importing this
+# module registers the adapter under the ``connector_type`` declared above.
+#
+# Third-party plug-ins follow the same pattern. The registry refuses to bind
+# the same ``connector_type`` to two different classes, so plug-in authors
+# must pick a unique value (the ``LlmConnector.connector_type`` column is 40
+# chars; keep it short, lowercase, snake-case, e.g. ``mistral_apikey``).
+register_adapter(EchoAdapter.connector_type, EchoAdapter)

--- a/server/app/services/llm/plugin_loader.py
+++ b/server/app/services/llm/plugin_loader.py
@@ -1,0 +1,122 @@
+"""Optional filesystem loader for third-party LLM adapter plug-ins.
+
+When the ``LLM_PLUGIN_DIR`` environment variable is set to a directory path,
+:func:`load_plugins_from_env` imports every ``.py`` file (non-recursive,
+excluding files whose names start with ``_``) from that directory at startup.
+
+Each imported plug-in is responsible for calling
+:func:`app.services.llm.registry.register_adapter` at module load time — same
+contract the built-in adapters use. The loader simply triggers the import; it
+performs no monkey-patching, manifest parsing, or sandbox.
+
+Security posture
+----------------
+Loading a plug-in is equivalent to giving the loaded code the full privileges
+of the backend process — same as installing a Python package. There is no
+sandbox. Operators must therefore:
+
+- Treat ``LLM_PLUGIN_DIR`` as a privileged path. Only the same user that owns
+  ``server/`` and its venv should have write access to it.
+- Audit each plug-in's source the same way they would audit a third-party
+  ``pip install``. The skeleton at ``docs/examples/echo_adapter.py`` is
+  reviewed; everything else must be reviewed by whoever sets up the
+  environment.
+- Never set ``LLM_PLUGIN_DIR`` to a world-writable or shared-tenancy path.
+
+In production we recommend leaving ``LLM_PLUGIN_DIR`` unset and packaging
+trusted plug-ins as ordinary Python modules imported from a controlled
+location. The env-var loader exists to make local experimentation and forks
+ergonomic.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import os
+import sys
+import traceback
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+ENV_VAR = "LLM_PLUGIN_DIR"
+
+
+def load_plugins_from_env() -> list[str]:
+    """Load adapters from the directory named by ``LLM_PLUGIN_DIR``.
+
+    Returns the list of module names that were successfully imported (their
+    side-effectful ``register_adapter`` calls will have run by then).
+
+    The loader is intentionally permissive: a single broken plug-in must not
+    prevent the rest of the directory — or the backend process itself — from
+    starting. Each import error is logged with a full stack trace and the
+    plug-in name, then skipped.
+    """
+    dir_path = os.environ.get(ENV_VAR)
+    if not dir_path:
+        return []
+    return load_plugins_from_dir(dir_path)
+
+
+def load_plugins_from_dir(dir_path: str | os.PathLike[str]) -> list[str]:
+    """Same as :func:`load_plugins_from_env` but with an explicit path."""
+    root = Path(dir_path)
+    if not root.is_dir():
+        logger.warning(
+            "%s=%s does not exist or is not a directory; skipping plug-in load",
+            ENV_VAR,
+            dir_path,
+        )
+        return []
+
+    loaded: list[str] = []
+    # Sort for stable load order — useful when one plug-in depends on another
+    # being registered first (the registry rejects double-registration so the
+    # *first* import of any given connector_type wins).
+    for entry in sorted(root.iterdir()):
+        if not _is_loadable(entry):
+            continue
+        # Synthesise a stable, namespaced module name to avoid colliding with
+        # any installed package. We deliberately do NOT add the plug-in dir to
+        # ``sys.path`` — that would also expose every other file in the dir as
+        # an importable module from elsewhere in the codebase.
+        module_name = f"llm_plugins.{entry.stem}"
+        try:
+            spec = importlib.util.spec_from_file_location(module_name, entry)
+            if spec is None or spec.loader is None:
+                logger.warning("Could not build import spec for plug-in %s", entry)
+                continue
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = module
+            spec.loader.exec_module(module)
+        except Exception:
+            # ``traceback.format_exc()`` is logged so operators can debug
+            # plug-in import errors without crashing the backend. We pop the
+            # half-imported module out of ``sys.modules`` so a later retry
+            # (e.g. uvicorn --reload) re-runs the spec from scratch.
+            sys.modules.pop(module_name, None)
+            logger.error(
+                "Failed to load LLM plug-in %s (module=%s):\n%s",
+                entry.name,
+                module_name,
+                traceback.format_exc(),
+            )
+            continue
+        logger.info("Loaded LLM plug-in %s (module=%s)", entry.name, module_name)
+        loaded.append(module_name)
+    return loaded
+
+
+def _is_loadable(entry: Path) -> bool:
+    """Filter the directory listing to plain ``*.py`` source files."""
+    if not entry.is_file():
+        return False
+    if entry.suffix != ".py":
+        return False
+    if entry.name.startswith("_"):
+        # Skip ``__init__.py`` and any conventional "private" leading-underscore
+        # helpers — they are usually shared utilities, not plug-ins.
+        return False
+    return True

--- a/server/app/services/llm/registry.py
+++ b/server/app/services/llm/registry.py
@@ -64,5 +64,15 @@ def _bootstrap() -> None:
         xai_apikey,
     )
 
+    # Optional third-party plug-in load: if LLM_PLUGIN_DIR is set, import every
+    # .py file in that directory. Built-in adapters are loaded first so a
+    # plug-in can never shadow a built-in (the registry refuses
+    # double-registration, surfacing a clear startup error instead of silently
+    # overriding the production adapter). Plug-in load failures are logged but
+    # never crash the backend — see app.services.llm.plugin_loader.
+    from app.services.llm.plugin_loader import load_plugins_from_env
+
+    load_plugins_from_env()
+
 
 _bootstrap()

--- a/server/tests/test_llm_adapter_contract.py
+++ b/server/tests/test_llm_adapter_contract.py
@@ -1,0 +1,257 @@
+"""Adapter contract tests — parametrised over every registered adapter.
+
+This test file defines the *public extension surface* for LLM adapters. Any
+adapter (built-in or third-party plug-in) that subclasses ``LlmAdapter`` and
+registers via :func:`register_adapter` must pass every test here.
+
+The contract intentionally tests structural and exception-mapping invariants
+only — it never makes network calls. Provider-specific HTTP and parsing
+behaviour belongs in per-adapter test files (e.g. ``test_llm_adapters.py``,
+``test_llm_bedrock_adapter.py``).
+
+If you are adding a new adapter:
+
+1. Register it via ``register_adapter("<connector_type>", YourClass)``.
+2. Run this file: ``pytest tests/test_llm_adapter_contract.py``.
+3. Every test must pass without modification.
+
+If a test does *not* apply to your adapter, the right answer is to discuss it
+in a PR — not to silently skip the contract. The contract is what lets the
+gateway dispatch generically.
+"""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.llm.base import ChatRequest, LlmAdapter, Message
+from app.services.llm.exceptions import AuthInvalid, LlmError
+from app.services.llm.registry import get_adapter_class, list_connector_types
+
+
+# ---------------------------------------------------------------------------
+# Parametrisation — runs against every registered connector_type.
+# ---------------------------------------------------------------------------
+def _all_connector_types() -> list[str]:
+    """Snapshot the registry at collection time.
+
+    The registry is populated by ``app.services.llm.registry._bootstrap()``
+    which eagerly imports the built-in adapters package. Any third-party
+    adapter loaded via ``LLM_PLUGIN_DIR`` is also discovered here.
+    """
+    return list_connector_types()
+
+
+@pytest.fixture
+def malformed_connector():
+    """A connector row whose ``credentials`` blob is not valid JSON.
+
+    Every adapter must reject this without crashing, raising :class:`AuthInvalid`
+    rather than leaking a ``JSONDecodeError`` or hitting the network.
+    """
+    return SimpleNamespace(
+        connector_type="contract-test",
+        credentials="this is not valid json",
+        model_hint=None,
+        base_url_plain=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Structural contract — class-level guarantees.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("connector_type", _all_connector_types())
+def test_adapter_subclasses_llm_adapter(connector_type: str):
+    """Every registered adapter must subclass the ``LlmAdapter`` ABC."""
+    cls = get_adapter_class(connector_type)
+    assert issubclass(cls, LlmAdapter), (
+        f"{cls.__name__} is registered as {connector_type!r} but does not subclass LlmAdapter"
+    )
+
+
+@pytest.mark.parametrize("connector_type", _all_connector_types())
+def test_adapter_declares_connector_type(connector_type: str):
+    """Each adapter class must declare a non-empty ``connector_type`` attr.
+
+    The registry uses this string to dispatch; an empty value would shadow
+    every other adapter or fail in surprising ways.
+    """
+    cls = get_adapter_class(connector_type)
+    assert getattr(cls, "connector_type", ""), (
+        f"{cls.__name__} must set a class-level connector_type attribute"
+    )
+    # The class attribute must match the registration key. Otherwise an admin
+    # toggling per-DJ MRU lookup will pull the wrong adapter for the row.
+    assert cls.connector_type == connector_type, (
+        f"{cls.__name__}.connector_type is {cls.connector_type!r} but "
+        f"registered as {connector_type!r}"
+    )
+
+
+@pytest.mark.parametrize("connector_type", _all_connector_types())
+def test_adapter_defines_chat_and_health_check(connector_type: str):
+    """Both abstract methods must be implemented as async callables."""
+    cls = get_adapter_class(connector_type)
+    chat = getattr(cls, "chat", None)
+    health = getattr(cls, "health_check", None)
+    assert callable(chat), f"{cls.__name__}.chat must be defined"
+    assert callable(health), f"{cls.__name__}.health_check must be defined"
+    assert inspect.iscoroutinefunction(chat), (
+        f"{cls.__name__}.chat must be `async def` — the gateway awaits it"
+    )
+    assert inspect.iscoroutinefunction(health), f"{cls.__name__}.health_check must be `async def`"
+
+
+@pytest.mark.parametrize("connector_type", _all_connector_types())
+def test_adapter_constructor_accepts_connector(connector_type: str):
+    """Adapters are instantiated as ``cls(connector)`` by the gateway."""
+    cls = get_adapter_class(connector_type)
+    connector = SimpleNamespace(
+        connector_type=connector_type,
+        credentials="{}",
+        model_hint=None,
+        base_url_plain=None,
+    )
+    # Must not raise — credential decoding is deferred until chat()/health().
+    instance = cls(connector)
+    assert instance.connector is connector
+
+
+# ---------------------------------------------------------------------------
+# Exception contract — typed errors only, no provider leakage.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("connector_type", _all_connector_types())
+async def test_adapter_raises_typed_error_on_malformed_credentials(
+    connector_type: str, malformed_connector
+):
+    """An adapter handed a malformed credential blob must raise a typed
+    :class:`LlmError` (specifically :class:`AuthInvalid`) — never a bare
+    :class:`json.JSONDecodeError`, :class:`KeyError`, or a network exception.
+
+    This is the boundary that keeps provider internals from leaking into
+    API error responses.
+    """
+    cls = get_adapter_class(connector_type)
+    adapter = cls(malformed_connector)
+    request = ChatRequest(
+        messages=[Message(role="user", content="ping")],
+        max_tokens=1,
+    )
+
+    # We expect AuthInvalid (the most specific subtype). Some adapters with
+    # additional credential fields might raise a different LlmError subclass —
+    # accept any of them, but never a non-LlmError.
+    with pytest.raises(LlmError) as exc_info:
+        await adapter.chat(request)
+    # Most adapters surface this as AuthInvalid. Make that the default
+    # expectation; sub-typing keeps the contract precise.
+    assert isinstance(exc_info.value, AuthInvalid | LlmError)
+
+
+# ---------------------------------------------------------------------------
+# Registry contract — third-party adapters reach the gateway via this path.
+# ---------------------------------------------------------------------------
+def test_registry_returns_classes_not_instances():
+    """``get_adapter_class`` must return a *class*, not an instance.
+
+    The gateway calls ``cls(connector)`` per dispatch; returning an instance
+    here would silently share state across DJs.
+    """
+    for connector_type in _all_connector_types():
+        cls = get_adapter_class(connector_type)
+        assert inspect.isclass(cls), (
+            f"Registry returned a non-class for {connector_type!r}: {cls!r}"
+        )
+
+
+def test_registry_lookup_raises_keyerror_for_unknown():
+    """Unknown ``connector_type`` lookups raise :class:`KeyError`.
+
+    The gateway relies on this to surface ``NoLlmConfigured`` cleanly.
+    """
+    with pytest.raises(KeyError):
+        get_adapter_class("definitely-not-a-real-connector-type")
+
+
+# ---------------------------------------------------------------------------
+# Skeleton contract — proves the documented reference adapter satisfies the
+# same surface as the built-in providers.
+# ---------------------------------------------------------------------------
+def _import_echo_adapter():
+    """Import the docs-tree skeleton adapter as a regular module.
+
+    The skeleton lives outside the ``app`` package (``docs/examples/``), so we
+    register a one-off path entry to import it. We do this *inside* the test
+    rather than at module load time so the registry stays clean for parametrised
+    runs above (the skeleton is also asserted to register cleanly on import).
+    """
+    import importlib
+    import os
+    import sys
+
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    if repo_root not in sys.path:
+        sys.path.insert(0, repo_root)
+    return importlib.import_module("docs.examples.echo_adapter")
+
+
+def test_skeleton_echo_adapter_satisfies_contract():
+    """The documented skeleton must pass the same structural contract above.
+
+    This is what guarantees the ``docs/LLM-PLUGIN.md`` "quick start" actually
+    works — a third-party author copying the skeleton gets a registered,
+    contract-compliant adapter without modifying any core file.
+    """
+    module = _import_echo_adapter()
+    echo_cls = module.EchoAdapter
+
+    # Same structural checks the parametrised tests above run, applied directly
+    # so this test still fires when the skeleton is not pre-registered.
+    assert issubclass(echo_cls, LlmAdapter)
+    assert echo_cls.connector_type == "echo"
+    assert inspect.iscoroutinefunction(echo_cls.chat)
+    assert inspect.iscoroutinefunction(echo_cls.health_check)
+
+    # Registry hit via the public surface.
+    assert get_adapter_class("echo") is echo_cls
+
+
+async def test_skeleton_echo_adapter_round_trip():
+    """Smoke-test the echo skeleton end-to-end through ``chat()``.
+
+    Importantly this avoids any network call — proving that the skeleton can
+    be used as a deterministic stand-in for gateway tests.
+    """
+    module = _import_echo_adapter()
+    connector = SimpleNamespace(
+        connector_type="echo",
+        credentials="{}",
+        model_hint="echo-1",
+        base_url_plain=None,
+    )
+    adapter = module.EchoAdapter(connector)
+    request = ChatRequest(
+        messages=[Message(role="user", content="hello world")],
+        max_tokens=8,
+    )
+    response = await adapter.chat(request)
+    assert response.text == "hello world"
+    assert response.stop_reason == "end_turn"
+    assert response.model == "echo-1"
+
+
+async def test_skeleton_echo_adapter_health_check_validates_credentials():
+    """``health_check()`` must raise :class:`AuthInvalid` for malformed creds."""
+    module = _import_echo_adapter()
+    connector = SimpleNamespace(
+        connector_type="echo",
+        credentials="not-json",
+        model_hint=None,
+        base_url_plain=None,
+    )
+    adapter = module.EchoAdapter(connector)
+    with pytest.raises(AuthInvalid):
+        await adapter.health_check()

--- a/server/tests/test_llm_adapter_contract.py
+++ b/server/tests/test_llm_adapter_contract.py
@@ -143,12 +143,11 @@ async def test_adapter_raises_typed_error_on_malformed_credentials(
 
     # We expect AuthInvalid (the most specific subtype). Some adapters with
     # additional credential fields might raise a different LlmError subclass —
-    # accept any of them, but never a non-LlmError.
-    with pytest.raises(LlmError) as exc_info:
+    # accept any of them, but never a non-LlmError. The pytest.raises(LlmError)
+    # context manager is the only assertion needed: a non-LlmError exception
+    # would propagate out and fail the test.
+    with pytest.raises(LlmError):
         await adapter.chat(request)
-    # Most adapters surface this as AuthInvalid. Make that the default
-    # expectation; sub-typing keeps the contract precise.
-    assert isinstance(exc_info.value, AuthInvalid | LlmError)
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_llm_plugin_loader.py
+++ b/server/tests/test_llm_plugin_loader.py
@@ -1,0 +1,116 @@
+"""Tests for the ``LLM_PLUGIN_DIR`` filesystem plug-in loader.
+
+The loader is an optional surface — production deploys typically leave the
+env var unset and ship trusted adapters as ordinary Python modules. These
+tests pin its documented behaviour:
+
+- Importable ``.py`` files are loaded.
+- Files starting with ``_`` and any non-``.py`` files are skipped.
+- A single broken plug-in logs an error and does **not** stop loading the
+  rest of the directory.
+- The loader does not mutate ``sys.path`` (no namespace leakage).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+import pytest
+
+from app.services.llm import plugin_loader
+
+
+@pytest.fixture
+def isolated_sys_path():
+    """Snapshot and restore ``sys.path`` around each loader test.
+
+    The loader is explicitly documented to *not* add the plug-in directory to
+    ``sys.path``. Snapshotting here lets us assert that no entry leaks out.
+    """
+    before = list(sys.path)
+    yield
+    sys.path[:] = before
+
+
+@pytest.fixture
+def cleanup_test_modules():
+    """Drop any ``llm_plugins.*`` modules between tests so re-imports re-execute."""
+    yield
+    for name in list(sys.modules):
+        if name.startswith("llm_plugins."):
+            sys.modules.pop(name, None)
+
+
+def _write_plugin(dir_path, name: str, body: str) -> None:
+    (dir_path / name).write_text(body)
+
+
+def test_no_env_var_loads_nothing(monkeypatch):
+    monkeypatch.delenv(plugin_loader.ENV_VAR, raising=False)
+    assert plugin_loader.load_plugins_from_env() == []
+
+
+def test_nonexistent_directory_is_skipped_with_warning(monkeypatch, tmp_path, caplog):
+    missing = tmp_path / "does-not-exist"
+    monkeypatch.setenv(plugin_loader.ENV_VAR, str(missing))
+    with caplog.at_level(logging.WARNING):
+        assert plugin_loader.load_plugins_from_env() == []
+    assert any("does not exist" in r.message for r in caplog.records)
+
+
+def test_loads_py_files_skipping_underscore_and_non_py(
+    monkeypatch, tmp_path, isolated_sys_path, cleanup_test_modules
+):
+    # A loadable plug-in — registers nothing, just imports cleanly. We use a
+    # noop body to keep the assertion focused on file selection rather than
+    # registry side-effects (the contract test in test_llm_adapter_contract.py
+    # already covers the end-to-end registration path via the docs skeleton).
+    _write_plugin(tmp_path, "good.py", "X = 1\n")
+    # Anything starting with ``_`` is skipped (e.g. shared helpers).
+    _write_plugin(tmp_path, "_helper.py", "raise RuntimeError('should not load')\n")
+    # Non-``.py`` files are skipped.
+    _write_plugin(tmp_path, "README.md", "not python\n")
+    # Subdirectories are skipped (no recursion).
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "subdir" / "nested.py").write_text("X = 2\n")
+
+    monkeypatch.setenv(plugin_loader.ENV_VAR, str(tmp_path))
+    loaded = plugin_loader.load_plugins_from_env()
+    assert loaded == ["llm_plugins.good"]
+    # The loader must not contaminate sys.path with the plug-in directory.
+    assert str(tmp_path) not in sys.path
+
+
+def test_one_broken_plugin_does_not_block_others(
+    monkeypatch, tmp_path, isolated_sys_path, cleanup_test_modules, caplog
+):
+    # Sorted load order: 'a' then 'z'. 'a' is broken; 'z' must still load.
+    _write_plugin(tmp_path, "a_broken.py", "raise ValueError('boom at import')\n")
+    _write_plugin(tmp_path, "z_good.py", "X = 1\n")
+
+    monkeypatch.setenv(plugin_loader.ENV_VAR, str(tmp_path))
+    with caplog.at_level(logging.ERROR):
+        loaded = plugin_loader.load_plugins_from_env()
+
+    assert loaded == ["llm_plugins.z_good"]
+    # The error log should include the offending file name AND the stack
+    # trace; operators rely on this to diagnose third-party imports.
+    error_messages = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+    assert any("a_broken.py" in m for m in error_messages)
+    assert any("ValueError" in m and "boom at import" in m for m in error_messages)
+
+
+def test_failed_plugin_does_not_leak_into_sys_modules(
+    monkeypatch, tmp_path, isolated_sys_path, cleanup_test_modules
+):
+    _write_plugin(tmp_path, "broken.py", "raise RuntimeError('nope')\n")
+    monkeypatch.setenv(plugin_loader.ENV_VAR, str(tmp_path))
+    plugin_loader.load_plugins_from_env()
+    assert "llm_plugins.broken" not in sys.modules
+
+
+def test_load_from_dir_accepts_explicit_path(tmp_path, isolated_sys_path, cleanup_test_modules):
+    _write_plugin(tmp_path, "direct.py", "X = 1\n")
+    loaded = plugin_loader.load_plugins_from_dir(tmp_path)
+    assert loaded == ["llm_plugins.direct"]


### PR DESCRIPTION
Closes #344

## Summary

Publishes the LLM adapter extension surface as a public plug-in SDK so forks and community contributors can add new providers without modifying any file under `server/app/services/llm/`.

The contract was already implicit in the code (it had to be — that's how the 8 built-in adapters share a dispatch path); this PR makes it explicit, testable, and documented.

## What landed

- **`docs/LLM-PLUGIN.md`** — full extension surface contract:
  - `LlmAdapter` ABC: `chat()`, `health_check()`, `connector_type` semantics
  - Canonical types: `ChatRequest` / `ChatResponse` / `Message` / `ToolSpec` / `ToolCall` / `TokenUsage` field tables
  - Exception contract: which typed `LlmError` to raise for `401/403`, `402`, `429`, `5xx`, parse errors
  - **Stable vs internal API** table — pins what's allowed to change between minor versions
  - Tool-translation delegation guidance (point at `tool_translation.py` helpers, do not re-implement)
  - Registration mechanics + the "no double-bind" invariant
  - Test matrix link
  - Quick-start (`## Adding a Plug-in in 5 Minutes`)
- **`docs/examples/echo_adapter.py`** — minimal `LlmAdapter` skeleton that registers via the public registry and round-trips through `chat()` with no network call. Exercised directly by the contract test so it can't silently rot.
- **`server/app/services/llm/plugin_loader.py`** — optional `LLM_PLUGIN_DIR` env-var loader. Imports every `*.py` in the dir (non-recursive, skips `_`-prefixed files), fails open on broken plug-ins with a logged stack trace, never mutates `sys.path`.
- **`server/app/services/llm/registry.py`** — wires the loader into `_bootstrap()`, after built-in adapters. A plug-in cannot shadow a built-in because the registry refuses double-registration.
- **`server/tests/test_llm_adapter_contract.py`** — parametrised contract test running against every registered adapter (8 built-ins + the docs skeleton). 45 tests, all green.
- **`server/tests/test_llm_plugin_loader.py`** — 6 tests pinning loader behaviour.

## Design decisions

### Stable vs internal API split

The doc's "Stable vs Internal API" table draws the line at the surfaces a plug-in author actually touches:

| Stable (semver-protected) | Internal (may change without notice) |
|---------------------------|--------------------------------------|
| `LlmAdapter` method signatures | `_httpx_openai`, `url_validator`, `connector_storage` |
| Canonical type fields | Gateway internals (fallback / logging / audit) |
| Exception types + constructors | `LlmConnector` ORM internals (plug-ins only touch 3 attrs) |
| `register_adapter`, `get_adapter_class`, `list_connector_types`, `is_registered` | |
| `tool_translation.to_*_tools` / `parse_*_response` for documented providers | |

This is the minimum surface needed for a plug-in to be functional — wider exposure would force every refactor of internals to break third parties.

### Added the `LLM_PLUGIN_DIR` loader

Issue said this was optional; I added it because it makes the 5-minute quick-start actually 5 minutes (no fork required). The loader is **off by default** — if `LLM_PLUGIN_DIR` is unset, nothing changes about backend startup.

Operational defaults:
- Non-recursive (no surprise loads from nested dirs)
- Sorted load order (deterministic)
- Files starting with `_` are skipped (private helpers stay private)
- Broken plug-in → ERROR-level log with full stack trace, no crash
- Failed import → module pulled back out of `sys.modules` (lets `uvicorn --reload` retry cleanly)
- Does **not** mutate `sys.path` (no namespace leak into the rest of the codebase)

### Security posture — yes, plug-ins run arbitrary code

This is **inherent** to the model. Loading a plug-in is the same trust boundary as `pip install`: the plug-in author owns the import-time code path and runs with the backend's privileges. There is no sandbox.

The doc states this plainly under "Security posture for `LLM_PLUGIN_DIR`" and recommends:
- Treat the plug-in dir as a privileged path (only the backend service account writes)
- Audit every plug-in the same way you'd audit a third-party dep
- Production deployments stay safest by keeping `LLM_PLUGIN_DIR` unset and shipping trusted plug-ins as ordinary Python modules

### Contract test scope

Structural + exception-contract only (no network calls). Provider-specific HTTP wire behaviour stays in `test_llm_adapters.py`. This is intentional — it's the boundary every adapter MUST honour, regardless of provider. The contract refuses to skip individual adapters, so a future regression in any single adapter (e.g. accidentally raising `json.JSONDecodeError` on a malformed blob) fails CI immediately.

### "Depends on: MVP merged AND ≥2 post-MVP adapters merged"

Satisfied. MVP adapters at the tip of `epic/ai-engine` are `anthropic_apikey`, `openai_apikey`, `openai_compatible`. Post-MVP adapters already merged on the epic: `azure_openai`, `bedrock`, `gemini_apikey`, `openrouter_apikey`, `xai_apikey` — five additional providers across three distinct shapes (Bedrock SigV4, Azure resource-based URL, Gemini's REST schema). That's enough divergence to be confident the ABC + tool translation surface captures the right invariants.

## Adding a plugin in 5 minutes

```bash
# 1. Copy the skeleton
cp docs/examples/echo_adapter.py /opt/wrzdj/llm_plugins/mistral_apikey.py

# 2. Edit it:
#    - Change `connector_type` to a unique value (e.g. "mistral_apikey")
#    - Replace the echo body with your provider call
#    - Map provider errors to the typed exceptions

# 3. Point the backend at the plug-in directory
export LLM_PLUGIN_DIR=/opt/wrzdj/llm_plugins
uvicorn app.main:app

# 4. Verify the registry sees it
python -c "from app.services.llm.registry import list_connector_types; print(list_connector_types())"

# 5. Run the contract tests
cd server && .venv/bin/pytest tests/test_llm_adapter_contract.py
```

Once registered, DJs can `POST /api/llm/connectors` with `connector_type="mistral_apikey"` and the gateway routes through your adapter automatically.

## Test plan

- [x] Contract test passes for every built-in adapter (8 connector types × 5 contract tests = 40 cases)
- [x] Contract test passes for the docs skeleton (5 cases, including async round-trip)
- [x] Plug-in loader handles: missing env var, missing dir, file-selection rules, broken plug-in resilience, `sys.modules` cleanup, `sys.path` isolation (6 tests)
- [x] Full backend suite: `2373 passed, 87.33% coverage`
- [x] `ruff check`, `ruff format --check`, `bandit -r app` — all clean
- [x] `alembic upgrade head && alembic check` — clean
- [ ] Smoke a real third-party plug-in once we have an external contributor

## Epic-branch CI note

This PR targets `epic/ai-engine`, which does **not** trigger GitHub Actions CI and does **not** auto-invoke CodeRabbit. All checks were run locally; CodeRabbit will be triggered manually with `@coderabbitai review` after open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for loading third‑party LLM adapter plug-ins from a configurable filesystem directory at startup.

* **Documentation**
  * Added comprehensive adapter contract docs: adapter interface, expected request/response shapes, typed error mapping, registration and loading behavior, security/trust notes, and an end‑to‑end walkthrough.
  * Included a minimal reference "echo" adapter example.

* **Tests**
  * Added contract tests validating all registered adapters.
  * Added tests covering the plugin loader’s file discovery, error handling, and isolation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->