### PR TITLE
feat(ai): per-DJ explicit default LLM connector (#336)

### DIFF
--- a/dashboard/app/admin/ai/__tests__/page.test.tsx
+++ b/dashboard/app/admin/ai/__tests__/page.test.tsx
@@ -163,6 +163,7 @@ describe('AdminAISettingsPage', () => {
         updated_at: '2026-05-01T00:00:00Z',
         last_used_at: null,
         last_error: null,
+        is_default: false,
       },
     ]);
     vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({
@@ -319,6 +320,7 @@ describe('AdminAISettingsPage', () => {
         updated_at: '2026-05-01T00:00:00Z',
         last_used_at: null,
         last_error: null,
+        is_default: false,
       },
     ]);
     vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
@@ -335,6 +337,7 @@ describe('AdminAISettingsPage', () => {
       updated_at: '2026-05-01T00:00:00Z',
       last_used_at: null,
       last_error: null,
+      is_default: false,
     });
     vi.spyOn(window, 'confirm').mockReturnValue(true);
 

--- a/dashboard/components/AiProvidersSection.tsx
+++ b/dashboard/components/AiProvidersSection.tsx
@@ -216,6 +216,35 @@ export default function AiProvidersSection() {
     }
   };
 
+  // Set / unset the per-DJ explicit default (issue #336). Optimistic update on
+  // the full list keeps the radio state consistent (exactly one row is default
+  // at any time) without waiting for a refetch.
+  const handleSetDefault = async (id: number) => {
+    try {
+      const updated = await api.setLlmConnectorDefault(id);
+      setConnectors((prev) =>
+        prev.map((c) =>
+          c.id === updated.id
+            ? updated
+            : c.user_id === updated.user_id
+            ? { ...c, is_default: false }
+            : c,
+        ),
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to set default');
+    }
+  };
+
+  const handleUnsetDefault = async (id: number) => {
+    try {
+      const updated = await api.unsetLlmConnectorDefault(id);
+      setConnectors((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to clear default');
+    }
+  };
+
   return (
     <div>
       <h2 style={{ marginTop: 0, marginBottom: '1.25rem', fontSize: '1.1rem' }}>
@@ -244,11 +273,34 @@ export default function AiProvidersSection() {
         )}
         {connectors.map((c) => {
           const status = STATUS_LABELS[c.status] ?? { text: c.status, color: 'var(--text-secondary)' };
+          // Pin / unpin is only meaningful for active connectors — the gateway
+          // skips inactive defaults, so don't let the DJ pin a row that
+          // resolution would silently bypass.
+          const canPin = c.status === 'active';
+          const radioId = `connector-default-${c.id}`;
           return (
             <div key={c.id} className="card" style={{ marginTop: '1rem' }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
                 <div>
-                  <div style={{ fontWeight: 600 }}>{c.display_name}</div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+                    <div style={{ fontWeight: 600 }}>{c.display_name}</div>
+                    {c.is_default && (
+                      <span
+                        style={{
+                          fontSize: '0.7rem',
+                          padding: '0.125rem 0.5rem',
+                          borderRadius: '0.5rem',
+                          background: 'var(--color-success)',
+                          color: '#0a0a0a',
+                          fontWeight: 700,
+                          textTransform: 'uppercase',
+                          letterSpacing: '0.05em',
+                        }}
+                      >
+                        Default
+                      </span>
+                    )}
+                  </div>
                   <div style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
                     {CONNECTOR_TYPE_LABELS[c.connector_type as LlmConnectorType] ?? c.connector_type}
                     {c.model_hint ? ` · ${c.model_hint}` : ''}
@@ -258,6 +310,58 @@ export default function AiProvidersSection() {
                     {status.text}
                     {testStateById[c.id] ? ` · ${testStateById[c.id]}` : ''}
                   </div>
+                  {/* Radio for "Set as default" — exactly one connector per DJ may be pinned. */}
+                  <label
+                    htmlFor={radioId}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '0.4rem',
+                      marginTop: '0.5rem',
+                      fontSize: '0.85rem',
+                      color: canPin ? 'var(--text)' : 'var(--text-secondary)',
+                      cursor: canPin ? 'pointer' : 'not-allowed',
+                    }}
+                  >
+                    <input
+                      id={radioId}
+                      type="radio"
+                      name="llm-connector-default"
+                      checked={c.is_default}
+                      disabled={!canPin && !c.is_default}
+                      onChange={() => {
+                        if (canPin) {
+                          handleSetDefault(c.id);
+                        }
+                      }}
+                    />
+                    {c.is_default ? (
+                      <>
+                        Pinned as default ·{' '}
+                        <button
+                          type="button"
+                          className="btn-link"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            handleUnsetDefault(c.id);
+                          }}
+                          style={{
+                            background: 'none',
+                            border: 'none',
+                            padding: 0,
+                            color: 'var(--text-secondary)',
+                            textDecoration: 'underline',
+                            cursor: 'pointer',
+                            font: 'inherit',
+                          }}
+                        >
+                          Unpin
+                        </button>
+                      </>
+                    ) : (
+                      <span>Set as default</span>
+                    )}
+                  </label>
                 </div>
                 <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
                   <button className="btn btn-secondary" onClick={() => handleTest(c.id)}>

--- a/dashboard/components/__tests__/AiProvidersSection.test.tsx
+++ b/dashboard/components/__tests__/AiProvidersSection.test.tsx
@@ -46,6 +46,7 @@ function makeConnector(overrides: Partial<LlmConnector> = {}): LlmConnector {
     updated_at: NOW,
     last_used_at: null,
     last_error: null,
+    is_default: false,
     ...overrides,
   };
 }
@@ -329,6 +330,103 @@ describe('AiProvidersSection', () => {
         model_hint: 'openai/gpt-4o-mini',
       }),
     );
+  });
+
+  // ---------- per-DJ default (issue #336) ----------
+
+  it('shows the Default badge on the pinned connector', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([
+      makeConnector({ id: 1, display_name: 'Pinned', is_default: true }),
+      makeConnector({ id: 2, display_name: 'Other', is_default: false }),
+    ]);
+    vi.spyOn(api, 'getLlmPolicy').mockRejectedValue(new Error('forbidden'));
+
+    render(<AiProvidersSection />);
+
+    await waitFor(() => expect(screen.getByText('Pinned')).toBeInTheDocument());
+    // The badge is rendered next to the display name.
+    expect(screen.getByText('Default')).toBeInTheDocument();
+  });
+
+  it('clicking the radio on an unpinned connector calls setDefault', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([
+      makeConnector({ id: 1, display_name: 'A', is_default: true }),
+      makeConnector({ id: 2, display_name: 'B', is_default: false }),
+    ]);
+    vi.spyOn(api, 'getLlmPolicy').mockRejectedValue(new Error('forbidden'));
+    const setSpy = vi
+      .spyOn(api, 'setLlmConnectorDefault')
+      .mockResolvedValue(
+        makeConnector({ id: 2, display_name: 'B', is_default: true }),
+      );
+
+    render(<AiProvidersSection />);
+
+    await waitFor(() => expect(screen.getByText('B')).toBeInTheDocument());
+    // The radio for connector B is unchecked; click to pin it.
+    const radioB = screen.getByLabelText('Set as default');
+    fireEvent.click(radioB);
+
+    await waitFor(() => expect(setSpy).toHaveBeenCalledWith(2));
+  });
+
+  it('clicking Unpin on the pinned connector calls unsetDefault', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([
+      makeConnector({ id: 1, display_name: 'A', is_default: true }),
+    ]);
+    vi.spyOn(api, 'getLlmPolicy').mockRejectedValue(new Error('forbidden'));
+    const unsetSpy = vi
+      .spyOn(api, 'unsetLlmConnectorDefault')
+      .mockResolvedValue(makeConnector({ id: 1, display_name: 'A', is_default: false }));
+
+    render(<AiProvidersSection />);
+
+    await waitFor(() => expect(screen.getByText('A')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'Unpin' }));
+
+    await waitFor(() => expect(unsetSpy).toHaveBeenCalledWith(1));
+  });
+
+  it('disables the radio on inactive connectors', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([
+      makeConnector({
+        id: 1,
+        display_name: 'Broken',
+        status: 'auth_invalid',
+        is_default: false,
+      }),
+    ]);
+    vi.spyOn(api, 'getLlmPolicy').mockRejectedValue(new Error('forbidden'));
+
+    render(<AiProvidersSection />);
+
+    await waitFor(() => expect(screen.getByText('Broken')).toBeInTheDocument());
+    const radio = screen.getByLabelText('Set as default') as HTMLInputElement;
+    expect(radio).toBeDisabled();
+  });
+
+  it('optimistically clears the previous default when pinning a new one', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([
+      makeConnector({ id: 1, user_id: 42, display_name: 'A', is_default: true }),
+      makeConnector({ id: 2, user_id: 42, display_name: 'B', is_default: false }),
+    ]);
+    vi.spyOn(api, 'getLlmPolicy').mockRejectedValue(new Error('forbidden'));
+    vi.spyOn(api, 'setLlmConnectorDefault').mockResolvedValue(
+      makeConnector({ id: 2, user_id: 42, display_name: 'B', is_default: true }),
+    );
+
+    render(<AiProvidersSection />);
+
+    await waitFor(() => expect(screen.getByText('B')).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText('Set as default'));
+
+    // After the optimistic update, the Default badge should sit next to B, not A.
+    await waitFor(() => {
+      const badge = screen.getByText('Default');
+      // Badge is right beside the display name — walk up to the card.
+      const card = badge.closest('.card');
+      expect(card?.textContent).toContain('B');
+    });
   });
 
   it('deletes after confirmation', async () => {

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -1453,6 +1453,37 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/llm/connectors/{connector_id}/default": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Set Connector As Default
+         * @description Pin this connector as the DJ's explicit default (issue #336).
+         *
+         *     Atomically clears any other defaults the DJ owns before flipping this row,
+         *     so the partial unique index never sees two True rows for the same user.
+         *
+         *     Setting a disabled / auth_invalid connector as default is rejected with 400
+         *     so DJs don't silently break their own routing — a default that the gateway
+         *     would skip anyway is a footgun.
+         */
+        post: operations["set_connector_as_default_api_llm_connectors__connector_id__default_post"];
+        /**
+         * Unset Connector As Default
+         * @description Clear the explicit default — gateway resolution falls back to MRU.
+         */
+        delete: operations["unset_connector_as_default_api_llm_connectors__connector_id__default_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/llm/connectors/{connector_id}/test": {
         parameters: {
             query?: never;
@@ -1852,6 +1883,14 @@ export interface paths {
          *     the endpoint had no rate limit and no existence check, allowing
          *     unauthenticated DoS (unlimited long-lived connections exhausting FDs)
          *     and passive eavesdropping via 6-char event-code brute force.
+         *
+         *     POOL SAFETY (issue #356): the one-shot existence/auth check runs inside a
+         *     short-lived ``with SessionLocal()`` block whose pooled connection is
+         *     returned BEFORE the EventSourceResponse is returned. An EventSource
+         *     connection can stay open indefinitely, so we must NOT hold a
+         *     request-scoped ``get_db`` session across the stream lifetime — doing so
+         *     pinned one pooled connection per open stream and exhausted the QueuePool
+         *     (size 5 + overflow 10 = 15 connections) under modest guest load.
          *
          *     Event types:
          *     - request_created: New request submitted
@@ -2477,6 +2516,11 @@ export interface components {
             dj_username: string;
             /** Id */
             id: number;
+            /**
+             * Is Default
+             * @default false
+             */
+            is_default: boolean;
             /** Last Error */
             last_error: string | null;
             /** Last Used At */
@@ -3176,6 +3220,11 @@ export interface components {
             display_name: string;
             /** Id */
             id: number;
+            /**
+             * Is Default
+             * @default false
+             */
+            is_default: boolean;
             /** Last Error */
             last_error: string | null;
             /** Last Used At */
@@ -7177,6 +7226,68 @@ export interface operations {
                 "application/json": components["schemas"]["ConnectorCredentialsRotate"];
             };
         };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectorOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    set_connector_as_default_api_llm_connectors__connector_id__default_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                connector_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectorOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unset_connector_as_default_api_llm_connectors__connector_id__default_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                connector_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -7267,6 +7267,20 @@ export interface operations {
                     "application/json": components["schemas"]["ConnectorOut"];
                 };
             };
+            /** @description Connector cannot be set as default (e.g. disabled or auth_invalid). */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Connector not found for current user. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -7297,6 +7311,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["ConnectorOut"];
                 };
+            };
+            /** @description Connector not found for current user. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1209,6 +1209,17 @@ class ApiClient {
     await this.fetch(`/api/llm/connectors/${id}`, { method: 'DELETE' });
   }
 
+  // Pin / unpin a connector as the DJ's explicit default (issue #336). When
+  // pinned, the gateway routes through this connector regardless of which one
+  // is most-recently-used.
+  async setLlmConnectorDefault(id: number): Promise<LlmConnector> {
+    return this.fetch(`/api/llm/connectors/${id}/default`, { method: 'POST' });
+  }
+
+  async unsetLlmConnectorDefault(id: number): Promise<LlmConnector> {
+    return this.fetch(`/api/llm/connectors/${id}/default`, { method: 'DELETE' });
+  }
+
   // ========== Admin LLM policy + oversight ==========
 
   async getAdminLlmPolicy(): Promise<LlmAdminPolicy> {

--- a/server/alembic/versions/048_llm_connector_is_default.py
+++ b/server/alembic/versions/048_llm_connector_is_default.py
@@ -1,0 +1,128 @@
+"""Per-DJ explicit default connector toggle (issue #336).
+
+Revision ID: 048
+Revises: 047
+Create Date: 2026-05-28
+
+Adds llm_connectors.is_default (bool, NOT NULL, default false) plus a partial
+unique index enforcing at most one default per user. Backfills by marking each
+DJ's MRU active connector as default on first deploy so resolution behavior is
+unchanged for existing users (they keep getting their previous most-recently
+used connector — now pinned).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "048"
+down_revision: str | None = "047"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger(__name__)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "llm_connectors",
+        sa.Column(
+            "is_default",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    # Partial unique index: at most one default per user_id. Both Postgres and
+    # SQLite (3.8+) support the partial-index WHERE clause; other dialects skip
+    # the index — the service layer still enforces single-default semantics.
+    if dialect == "postgresql":
+        op.create_index(
+            "ix_llm_connectors_user_default_unique",
+            "llm_connectors",
+            ["user_id"],
+            unique=True,
+            postgresql_where=sa.text("is_default"),
+        )
+    elif dialect == "sqlite":
+        op.create_index(
+            "ix_llm_connectors_user_default_unique",
+            "llm_connectors",
+            ["user_id"],
+            unique=True,
+            sqlite_where=sa.text("is_default"),
+        )
+    else:  # pragma: no cover — production runs Postgres; SQLite is tests
+        # Fall back to a non-unique covering index so resolver lookups stay
+        # cheap. The service layer (clear-then-set) still enforces uniqueness.
+        op.create_index(
+            "ix_llm_connectors_user_default_unique",
+            "llm_connectors",
+            ["user_id"],
+        )
+
+    _backfill_mru_defaults(bind)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_llm_connectors_user_default_unique", table_name="llm_connectors")
+    op.drop_column("llm_connectors", "is_default")
+
+
+def _backfill_mru_defaults(bind: sa.engine.Connection) -> None:
+    """Mark each user's MRU active connector as default (one per user).
+
+    MRU = ``last_used_at`` DESC NULLS LAST, ``id`` DESC — same ordering the
+    gateway resolver uses. Skips users that have no active connector. Idempotent
+    on re-run: if a user already has any default, leaves it alone.
+    """
+    user_rows = bind.execute(
+        sa.text("SELECT DISTINCT user_id FROM llm_connectors WHERE status = 'active'")
+    ).all()
+
+    for (user_id,) in user_rows:
+        existing_default = bind.execute(
+            sa.text(
+                "SELECT id FROM llm_connectors "
+                "WHERE user_id = :uid AND is_default = :truthy AND status = 'active' "
+                "LIMIT 1"
+            ),
+            {"uid": user_id, "truthy": True},
+        ).first()
+        if existing_default is not None:
+            continue
+
+        # ORDER BY last_used_at DESC NULLS LAST is portable via the CASE trick
+        # so the migration works on both Postgres and SQLite (the latter's
+        # NULLS handling differs by default).
+        mru = bind.execute(
+            sa.text(
+                "SELECT id FROM llm_connectors "
+                "WHERE user_id = :uid AND status = 'active' "
+                "ORDER BY CASE WHEN last_used_at IS NULL THEN 1 ELSE 0 END, "
+                "last_used_at DESC, id DESC "
+                "LIMIT 1"
+            ),
+            {"uid": user_id},
+        ).first()
+        if mru is None:
+            continue
+
+        bind.execute(
+            sa.text("UPDATE llm_connectors SET is_default = :truthy WHERE id = :cid"),
+            {"truthy": True, "cid": mru[0]},
+        )
+        logger.info(
+            "048_llm_connector_is_default: backfilled is_default=True for "
+            "connector_id=%s user_id=%s",
+            mru[0],
+            user_id,
+        )

--- a/server/app/api/llm.py
+++ b/server/app/api/llm.py
@@ -36,6 +36,8 @@ from app.schemas.llm import (
 from app.services.llm.connector_storage import (
     AUDIT_CREATED,
     AUDIT_CREDENTIALS_ROTATED,
+    AUDIT_DEFAULT_SET,
+    AUDIT_DEFAULT_UNSET,
     AUDIT_DELETED,
     AUDIT_HEALTH_CHECK,
     audit_event,
@@ -45,6 +47,8 @@ from app.services.llm.connector_storage import (
     get_connector_for_user,
     list_connectors_for_user,
     rotate_credentials,
+    set_default_for_user,
+    unset_default_for_user,
     update_metadata,
 )
 from app.services.llm.exceptions import (
@@ -356,6 +360,79 @@ async def test_connector(
         row.status = "active"
     db.commit()
     return ConnectorTestResult(ok=True)
+
+
+@router.post("/connectors/{connector_id}/default", response_model=ConnectorOut)
+@limiter.limit("30/minute")
+def set_connector_as_default(
+    request: FastAPIRequest,
+    connector_id: int,
+    user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+) -> ConnectorOut:
+    """Pin this connector as the DJ's explicit default (issue #336).
+
+    Atomically clears any other defaults the DJ owns before flipping this row,
+    so the partial unique index never sees two True rows for the same user.
+
+    Setting a disabled / auth_invalid connector as default is rejected with 400
+    so DJs don't silently break their own routing — a default that the gateway
+    would skip anyway is a footgun.
+    """
+    row = get_connector_for_user(db, connector_id, user.id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Connector not found")
+    if row.status != "active":
+        raise HTTPException(
+            status_code=400,
+            detail="Only an active connector can be set as default",
+        )
+
+    try:
+        set_default_for_user(db, connector=row)
+    except Exception as exc:
+        db.rollback()
+        logger.exception("Failed to set LLM connector as default")
+        raise HTTPException(status_code=500, detail="Failed to set default") from exc
+
+    audit_event(
+        db,
+        actor_user_id=user.id,
+        target_connector_id=row.id,
+        event_type=AUDIT_DEFAULT_SET,
+    )
+    db.commit()
+    db.refresh(row)
+    return ConnectorOut.model_validate(row)
+
+
+@router.delete("/connectors/{connector_id}/default", response_model=ConnectorOut)
+@limiter.limit("30/minute")
+def unset_connector_as_default(
+    request: FastAPIRequest,
+    connector_id: int,
+    user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+) -> ConnectorOut:
+    """Clear the explicit default — gateway resolution falls back to MRU."""
+    row = get_connector_for_user(db, connector_id, user.id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Connector not found")
+
+    # No-op fast path: don't write an audit row if nothing changed.
+    if not row.is_default:
+        return ConnectorOut.model_validate(row)
+
+    unset_default_for_user(db, connector=row)
+    audit_event(
+        db,
+        actor_user_id=user.id,
+        target_connector_id=row.id,
+        event_type=AUDIT_DEFAULT_UNSET,
+    )
+    db.commit()
+    db.refresh(row)
+    return ConnectorOut.model_validate(row)
 
 
 @router.delete("/connectors/{connector_id}", status_code=204)

--- a/server/app/api/llm.py
+++ b/server/app/api/llm.py
@@ -362,7 +362,14 @@ async def test_connector(
     return ConnectorTestResult(ok=True)
 
 
-@router.post("/connectors/{connector_id}/default", response_model=ConnectorOut)
+@router.post(
+    "/connectors/{connector_id}/default",
+    response_model=ConnectorOut,
+    responses={
+        400: {"description": "Connector cannot be set as default (e.g. disabled or auth_invalid)."},
+        404: {"description": "Connector not found for current user."},
+    },
+)
 @limiter.limit("30/minute")
 def set_connector_as_default(
     request: FastAPIRequest,
@@ -406,7 +413,13 @@ def set_connector_as_default(
     return ConnectorOut.model_validate(row)
 
 
-@router.delete("/connectors/{connector_id}/default", response_model=ConnectorOut)
+@router.delete(
+    "/connectors/{connector_id}/default",
+    response_model=ConnectorOut,
+    responses={
+        404: {"description": "Connector not found for current user."},
+    },
+)
 @limiter.limit("30/minute")
 def unset_connector_as_default(
     request: FastAPIRequest,

--- a/server/app/models/llm_connector.py
+++ b/server/app/models/llm_connector.py
@@ -11,6 +11,7 @@ See docs/superpowers/specs/2026-05-24-admin-ai-oauth-design.md §4.2.
 from datetime import datetime
 
 from sqlalchemy import (
+    Boolean,
     DateTime,
     ForeignKey,
     Index,
@@ -18,6 +19,7 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -60,6 +62,8 @@ AUDIT_REVOKED_BY_ADMIN = "connector_revoked_by_admin"
 AUDIT_AUTH_INVALID_OBSERVED = "auth_invalid_observed"
 AUDIT_POLICY_CHANGED = "policy_changed"
 AUDIT_HEALTH_CHECK = "connector_health_check"
+AUDIT_DEFAULT_SET = "connector_default_set"
+AUDIT_DEFAULT_UNSET = "connector_default_unset"
 
 
 class LlmConnector(Base):
@@ -102,9 +106,33 @@ class LlmConnector(Base):
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     last_error: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
+    # Per-DJ explicit default. At most one connector per user_id may have
+    # is_default=True — enforced at the DB layer via a partial unique index
+    # (Postgres) and at the service layer via clear-then-set semantics. When
+    # set, the gateway prefers this connector over the MRU heuristic. See
+    # issue #336.
+    is_default: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=text("false"),
+    )
+
     __table_args__ = (
         UniqueConstraint("user_id", "connector_type", "display_name", name="uq_dj_connector_label"),
         Index("ix_user_active", "user_id", "status"),
+        # Partial unique index — only enforced on Postgres. SQLite ignores
+        # the postgresql_where clause but still creates an unfiltered index;
+        # since the service layer clears siblings before flipping a row to
+        # True, that is harmless. The migration uses the same clause so the
+        # CI ``alembic check`` step stays clean on Postgres.
+        Index(
+            "ix_llm_connectors_user_default_unique",
+            "user_id",
+            unique=True,
+            postgresql_where=text("is_default"),
+            sqlite_where=text("is_default"),
+        ),
     )
 
 

--- a/server/app/schemas/llm.py
+++ b/server/app/schemas/llm.py
@@ -45,6 +45,10 @@ class ConnectorOut(BaseModel):
     updated_at: datetime
     last_used_at: datetime | None = None
     last_error: str | None = None
+    # Per-DJ explicit default flag (issue #336). When True, the gateway pins
+    # routing to this connector for the owning DJ instead of falling back to
+    # most-recently-used resolution.
+    is_default: bool = False
 
 
 class AdminConnectorOut(ConnectorOut):

--- a/server/app/services/llm/connector_storage.py
+++ b/server/app/services/llm/connector_storage.py
@@ -13,6 +13,8 @@ from app.models.llm_connector import (
     AUDIT_AUTH_INVALID_OBSERVED,
     AUDIT_CREATED,
     AUDIT_CREDENTIALS_ROTATED,
+    AUDIT_DEFAULT_SET,
+    AUDIT_DEFAULT_UNSET,
     AUDIT_DELETED,
     AUDIT_HEALTH_CHECK,
     AUDIT_POLICY_CHANGED,
@@ -475,6 +477,37 @@ def delete_connector(db: Session, connector: LlmConnector) -> None:
     db.delete(connector)
 
 
+def set_default_for_user(db: Session, *, connector: LlmConnector) -> LlmConnector:
+    """Mark ``connector`` as the DJ's default and clear any sibling defaults.
+
+    Atomic clear-then-set: all other rows for ``connector.user_id`` are flipped
+    to ``is_default = False`` in a single UPDATE before the target row is
+    flipped to True. This sidesteps the partial unique index race that would
+    otherwise occur if two SET requests landed concurrently — the worst case
+    is the second request overwriting the first, which is the user's intent.
+    The caller commits and writes the audit event.
+
+    No-ops gracefully when ``connector.is_default`` is already True (the
+    sibling clear still runs to fix any drift, e.g. a stale row left behind
+    by an aborted migration backfill).
+    """
+    db.query(LlmConnector).filter(
+        LlmConnector.user_id == connector.user_id,
+        LlmConnector.id != connector.id,
+        LlmConnector.is_default == True,  # noqa: E712
+    ).update({LlmConnector.is_default: False}, synchronize_session=False)
+    connector.is_default = True
+    db.flush()
+    return connector
+
+
+def unset_default_for_user(db: Session, *, connector: LlmConnector) -> LlmConnector:
+    """Clear the explicit-default flag. Caller commits + audits."""
+    connector.is_default = False
+    db.flush()
+    return connector
+
+
 def revoke_connector(connector: LlmConnector) -> LlmConnector:
     """Admin-only: mark a connector disabled. Caller commits + audits."""
     connector.status = STATUS_DISABLED
@@ -595,6 +628,8 @@ __all__ = [
     "AUDIT_AUTH_INVALID_OBSERVED",
     "AUDIT_CREATED",
     "AUDIT_CREDENTIALS_ROTATED",
+    "AUDIT_DEFAULT_SET",
+    "AUDIT_DEFAULT_UNSET",
     "AUDIT_DELETED",
     "AUDIT_HEALTH_CHECK",
     "AUDIT_POLICY_CHANGED",
@@ -614,5 +649,7 @@ __all__ = [
     "purge_call_log_older_than",
     "revoke_connector",
     "rotate_credentials",
+    "set_default_for_user",
+    "unset_default_for_user",
     "update_metadata",
 ]

--- a/server/app/services/llm/gateway.py
+++ b/server/app/services/llm/gateway.py
@@ -3,7 +3,10 @@
 See spec §4.3.
 
 Resolution order:
-1. If ``actor`` is not ``None``: most-recently-used active connector for the DJ.
+1. If ``actor`` is not ``None``:
+   a. The DJ's explicit default active connector if one is pinned
+      (``LlmConnector.is_default = True``) — issue #336.
+   b. Else: most-recently-used active connector for the DJ.
 2. Else: ``SystemSettings.llm_default_connector_id`` if set and active.
 3. Else: raise :class:`NoLlmConfigured`.
 
@@ -250,6 +253,22 @@ async def _attempt(
 
 def _resolve_connector(db: Session, actor: User | None) -> LlmConnector:
     if actor is not None:
+        # Per-DJ explicit default takes precedence over MRU (issue #336).
+        # Falls through to MRU if the DJ hasn't pinned a default or the pinned
+        # connector is no longer active (so DJs aren't silently broken when
+        # their default's status flips to ``auth_invalid`` / ``disabled``).
+        pinned = (
+            db.query(LlmConnector)
+            .filter(
+                LlmConnector.user_id == actor.id,
+                LlmConnector.status == STATUS_ACTIVE,
+                LlmConnector.is_default == True,  # noqa: E712 (SQLAlchemy comparison)
+            )
+            .first()
+        )
+        if pinned is not None:
+            return pinned
+
         row = (
             db.query(LlmConnector)
             .filter(

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -10674,6 +10674,9 @@
             },
             "description": "Successful Response"
           },
+          "404": {
+            "description": "Connector not found for current user."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -10719,6 +10722,12 @@
               }
             },
             "description": "Successful Response"
+          },
+          "400": {
+            "description": "Connector cannot be set as default (e.g. disabled or auth_invalid)."
+          },
+          "404": {
+            "description": "Connector not found for current user."
           },
           "422": {
             "content": {

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -249,6 +249,11 @@
             "title": "Id",
             "type": "integer"
           },
+          "is_default": {
+            "default": false,
+            "title": "Is Default",
+            "type": "boolean"
+          },
           "last_error": {
             "anyOf": [
               {
@@ -309,6 +314,7 @@
           "display_name",
           "dj_username",
           "id",
+          "is_default",
           "last_error",
           "last_used_at",
           "model_hint",
@@ -2353,6 +2359,11 @@
             "title": "Id",
             "type": "integer"
           },
+          "is_default": {
+            "default": false,
+            "title": "Is Default",
+            "type": "boolean"
+          },
           "last_error": {
             "anyOf": [
               {
@@ -2412,6 +2423,7 @@
           "created_at",
           "display_name",
           "id",
+          "is_default",
           "last_error",
           "last_used_at",
           "model_hint",
@@ -10636,6 +10648,100 @@
         ]
       }
     },
+    "/api/llm/connectors/{connector_id}/default": {
+      "delete": {
+        "description": "Clear the explicit default \u2014 gateway resolution falls back to MRU.",
+        "operationId": "unset_connector_as_default_api_llm_connectors__connector_id__default_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connector_id",
+            "required": true,
+            "schema": {
+              "title": "Connector Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Unset Connector As Default",
+        "tags": [
+          "llm"
+        ]
+      },
+      "post": {
+        "description": "Pin this connector as the DJ's explicit default (issue #336).\n\nAtomically clears any other defaults the DJ owns before flipping this row,\nso the partial unique index never sees two True rows for the same user.\n\nSetting a disabled / auth_invalid connector as default is rejected with 400\nso DJs don't silently break their own routing \u2014 a default that the gateway\nwould skip anyway is a footgun.",
+        "operationId": "set_connector_as_default_api_llm_connectors__connector_id__default_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connector_id",
+            "required": true,
+            "schema": {
+              "title": "Connector Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Set Connector As Default",
+        "tags": [
+          "llm"
+        ]
+      }
+    },
     "/api/llm/connectors/{connector_id}/test": {
       "post": {
         "operationId": "test_connector_api_llm_connectors__connector_id__test_post",
@@ -11556,7 +11662,7 @@
     },
     "/api/public/events/{code}/stream": {
       "get": {
-        "description": "Public SSE endpoint for real-time event updates.\n\nSECURITY (CRIT-5): rate-limited and existence-checked. Before this fix,\nthe endpoint had no rate limit and no existence check, allowing\nunauthenticated DoS (unlimited long-lived connections exhausting FDs)\nand passive eavesdropping via 6-char event-code brute force.\n\nEvent types:\n- request_created: New request submitted\n- request_status_changed: Request status update\n- now_playing_changed: Now-playing track update\n- requests_bulk_update: Batch accept/reject\n- bridge_status_changed: Bridge connect/disconnect",
+        "description": "Public SSE endpoint for real-time event updates.\n\nSECURITY (CRIT-5): rate-limited and existence-checked. Before this fix,\nthe endpoint had no rate limit and no existence check, allowing\nunauthenticated DoS (unlimited long-lived connections exhausting FDs)\nand passive eavesdropping via 6-char event-code brute force.\n\nPOOL SAFETY (issue #356): the one-shot existence/auth check runs inside a\nshort-lived ``with SessionLocal()`` block whose pooled connection is\nreturned BEFORE the EventSourceResponse is returned. An EventSource\nconnection can stay open indefinitely, so we must NOT hold a\nrequest-scoped ``get_db`` session across the stream lifetime \u2014 doing so\npinned one pooled connection per open stream and exhausted the QueuePool\n(size 5 + overflow 10 = 15 connections) under modest guest load.\n\nEvent types:\n- request_created: New request submitted\n- request_status_changed: Request status update\n- now_playing_changed: Now-playing track update\n- requests_bulk_update: Batch accept/reject\n- bridge_status_changed: Bridge connect/disconnect",
         "operationId": "event_stream_api_public_events__code__stream_get",
         "parameters": [
           {

--- a/server/tests/test_llm_default_connector.py
+++ b/server/tests/test_llm_default_connector.py
@@ -1,0 +1,538 @@
+"""Tests for per-DJ explicit default connector (issue #336).
+
+Covers:
+- Gateway resolution prefers the pinned default over MRU.
+- Falls through to MRU when no default is set.
+- Falls through to MRU when the pinned default is no longer active.
+- API endpoints: POST /default sets and atomically clears siblings.
+- API endpoints: DELETE /default clears the flag.
+- Ownership scoping: 404 for other DJ's connectors.
+- Audit events written for set / unset.
+- Setting an inactive connector as default is rejected with 400.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.llm_connector import LlmAuditEvent, LlmConnector
+from app.models.user import User
+from app.services.auth import get_password_hash
+from app.services.llm.base import ChatRequest, ChatResponse, Message, TokenUsage
+from app.services.llm.exceptions import NoLlmConfigured
+from app.services.llm.gateway import Gateway
+
+
+# ---------- helpers ----------
+def _login(client: TestClient, username: str, password: str) -> dict[str, str]:
+    resp = client.post("/api/auth/login", data={"username": username, "password": password})
+    assert resp.status_code == 200, resp.json()
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _make_connector(
+    db: Session,
+    user: User,
+    *,
+    display_name: str = "Test connector",
+    status: str = "active",
+    is_default: bool = False,
+) -> LlmConnector:
+    row = LlmConnector(
+        user_id=user.id,
+        connector_type="openai_apikey",
+        display_name=display_name,
+        status=status,
+        credentials=json.dumps({"api_key": "sk-fake-key"}),
+        model_hint="gpt-5-mini",
+        is_default=is_default,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@pytest.fixture
+def dj_user(db) -> User:
+    user = User(
+        username="djdefault",
+        password_hash=get_password_hash("password123"),
+        role="dj",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture
+def other_dj(db) -> User:
+    user = User(
+        username="otherdjdefault",
+        password_hash=get_password_hash("password123"),
+        role="dj",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+# ---------- gateway resolver behavior ----------
+class TestGatewayResolverPrefersDefault:
+    @pytest.mark.asyncio
+    async def test_default_picked_over_mru(self, db, dj_user):
+        """An explicit default beats the MRU heuristic even when MRU is more recent."""
+        from datetime import timedelta
+
+        from app.core.time import utcnow
+
+        # Pinned default — older last_used_at to prove the pin wins.
+        pinned = _make_connector(db, dj_user, display_name="pinned", is_default=True)
+        pinned.last_used_at = utcnow() - timedelta(hours=1)
+        # MRU candidate — more recent activity but not pinned.
+        mru = _make_connector(db, dj_user, display_name="mru-but-not-default")
+        mru.last_used_at = utcnow()
+        db.commit()
+
+        fake = ChatResponse(text="ok", tool_calls=[], stop_reason="end_turn", usage=None)
+        with patch.object(
+            __import__(
+                "app.services.llm.adapters.openai_apikey",
+                fromlist=["OpenAIApiKeyAdapter"],
+            ).OpenAIApiKeyAdapter,
+            "chat",
+            new=AsyncMock(return_value=fake),
+        ):
+            await Gateway.dispatch(
+                db,
+                dj_user,
+                ChatRequest(messages=[Message(role="user", content="hi")]),
+                purpose="test",
+            )
+
+        # The pinned row got its last_used_at bumped — the MRU sibling didn't.
+        db.refresh(pinned)
+        db.refresh(mru)
+        prior_mru_ts = mru.last_used_at
+        assert pinned.last_used_at is not None
+        # The MRU row's timestamp should be older than pinned's (i.e. the pin
+        # was used, not the MRU). We compare via prior_mru_ts which was set
+        # before dispatch — pinned was dispatched so its ts > prior_mru_ts.
+        assert pinned.last_used_at >= prior_mru_ts
+
+    @pytest.mark.asyncio
+    async def test_default_skipped_when_inactive_falls_back_to_mru(self, db, dj_user):
+        """A disabled / auth_invalid default doesn't block MRU resolution."""
+        # Pinned but auth_invalid — gateway must skip it.
+        _make_connector(
+            db, dj_user, display_name="pinned-broken", is_default=True, status="auth_invalid"
+        )
+        mru = _make_connector(db, dj_user, display_name="mru-active")
+
+        fake = ChatResponse(
+            text="from-mru",
+            tool_calls=[],
+            stop_reason="end_turn",
+            usage=TokenUsage(prompt=1, completion=1),
+        )
+        with patch.object(
+            __import__(
+                "app.services.llm.adapters.openai_apikey",
+                fromlist=["OpenAIApiKeyAdapter"],
+            ).OpenAIApiKeyAdapter,
+            "chat",
+            new=AsyncMock(return_value=fake),
+        ):
+            resp = await Gateway.dispatch(
+                db,
+                dj_user,
+                ChatRequest(messages=[Message(role="user", content="hi")]),
+                purpose="test",
+            )
+
+        assert resp.text == "from-mru"
+        db.refresh(mru)
+        assert mru.last_used_at is not None
+
+    @pytest.mark.asyncio
+    async def test_no_default_uses_mru_unchanged(self, db, dj_user):
+        """Existing MRU semantics still apply when no default is pinned."""
+        from datetime import timedelta
+
+        from app.core.time import utcnow
+
+        older = _make_connector(db, dj_user, display_name="older")
+        newer = _make_connector(db, dj_user, display_name="newer")
+        older.last_used_at = utcnow() - timedelta(hours=1)
+        newer.last_used_at = utcnow()
+        db.commit()
+
+        fake = ChatResponse(text="ok", tool_calls=[], stop_reason="end_turn", usage=None)
+        with patch.object(
+            __import__(
+                "app.services.llm.adapters.openai_apikey",
+                fromlist=["OpenAIApiKeyAdapter"],
+            ).OpenAIApiKeyAdapter,
+            "chat",
+            new=AsyncMock(return_value=fake),
+        ):
+            await Gateway.dispatch(
+                db,
+                dj_user,
+                ChatRequest(messages=[Message(role="user", content="hi")]),
+                purpose="test",
+            )
+
+        db.refresh(newer)
+        db.refresh(older)
+        # newer has the bumped ts because MRU picked it.
+        assert newer.last_used_at is not None
+        assert newer.last_used_at >= older.last_used_at
+
+    @pytest.mark.asyncio
+    async def test_all_inactive_raises_no_llm_configured(self, db, dj_user):
+        """Pinned-but-broken + no other active = NoLlmConfigured."""
+        _make_connector(
+            db, dj_user, display_name="pinned-broken", is_default=True, status="disabled"
+        )
+        with pytest.raises(NoLlmConfigured):
+            await Gateway.dispatch(
+                db,
+                dj_user,
+                ChatRequest(messages=[Message(role="user", content="hi")]),
+                purpose="test",
+            )
+
+
+# ---------- POST /default ----------
+class TestSetDefault:
+    def test_set_default_marks_row(self, client: TestClient, auth_headers, db, test_user):
+        row = _make_connector(db, test_user, display_name="A")
+
+        resp = client.post(f"/api/llm/connectors/{row.id}/default", headers=auth_headers)
+        assert resp.status_code == 200, resp.json()
+        assert resp.json()["is_default"] is True
+
+        db.refresh(row)
+        assert row.is_default is True
+
+    def test_set_default_clears_other_defaults_for_same_user(
+        self, client: TestClient, auth_headers, db, test_user
+    ):
+        a = _make_connector(db, test_user, display_name="A", is_default=True)
+        b = _make_connector(db, test_user, display_name="B")
+
+        resp = client.post(f"/api/llm/connectors/{b.id}/default", headers=auth_headers)
+        assert resp.status_code == 200
+
+        db.refresh(a)
+        db.refresh(b)
+        assert a.is_default is False
+        assert b.is_default is True
+
+    def test_set_default_does_not_touch_other_dj(
+        self, client: TestClient, auth_headers, db, test_user, other_dj
+    ):
+        their_default = _make_connector(db, other_dj, display_name="theirs", is_default=True)
+        mine = _make_connector(db, test_user, display_name="mine")
+
+        client.post(f"/api/llm/connectors/{mine.id}/default", headers=auth_headers)
+
+        db.refresh(their_default)
+        assert their_default.is_default is True  # Untouched
+
+    def test_set_default_404_for_other_users_connector(
+        self, client: TestClient, auth_headers, db, other_dj
+    ):
+        theirs = _make_connector(db, other_dj, display_name="not yours")
+
+        resp = client.post(f"/api/llm/connectors/{theirs.id}/default", headers=auth_headers)
+        assert resp.status_code == 404
+
+        # The other DJ's connector wasn't flipped.
+        db.refresh(theirs)
+        assert theirs.is_default is False
+
+    def test_set_default_404_for_unknown_id(self, client: TestClient, auth_headers):
+        resp = client.post("/api/llm/connectors/999999/default", headers=auth_headers)
+        assert resp.status_code == 404
+
+    def test_set_default_rejects_inactive_connector(
+        self, client: TestClient, auth_headers, db, test_user
+    ):
+        row = _make_connector(db, test_user, display_name="broken", status="auth_invalid")
+        resp = client.post(f"/api/llm/connectors/{row.id}/default", headers=auth_headers)
+        assert resp.status_code == 400
+
+        db.refresh(row)
+        assert row.is_default is False
+
+    def test_set_default_writes_audit_event(self, client: TestClient, auth_headers, db, test_user):
+        row = _make_connector(db, test_user, display_name="A")
+        client.post(f"/api/llm/connectors/{row.id}/default", headers=auth_headers)
+
+        audit = (
+            db.query(LlmAuditEvent)
+            .filter(
+                LlmAuditEvent.target_connector_id == row.id,
+                LlmAuditEvent.event_type == "connector_default_set",
+            )
+            .one_or_none()
+        )
+        assert audit is not None
+        assert audit.actor_user_id == test_user.id
+
+    def test_set_default_requires_auth(self, client: TestClient, db, test_user):
+        row = _make_connector(db, test_user, display_name="A")
+        resp = client.post(f"/api/llm/connectors/{row.id}/default")
+        assert resp.status_code == 401
+
+    def test_set_default_persists_across_list_calls(
+        self, client: TestClient, auth_headers, db, test_user
+    ):
+        """Acceptance criterion: setting a default sticks across sessions."""
+        row = _make_connector(db, test_user, display_name="sticks")
+        client.post(f"/api/llm/connectors/{row.id}/default", headers=auth_headers)
+
+        # Simulate a fresh page load: list connectors.
+        listed = client.get("/api/llm/connectors", headers=auth_headers).json()
+        match = next(c for c in listed if c["id"] == row.id)
+        assert match["is_default"] is True
+
+
+# ---------- DELETE /default ----------
+class TestUnsetDefault:
+    def test_unset_default_clears_flag(self, client: TestClient, auth_headers, db, test_user):
+        row = _make_connector(db, test_user, display_name="A", is_default=True)
+        resp = client.delete(f"/api/llm/connectors/{row.id}/default", headers=auth_headers)
+        assert resp.status_code == 200, resp.json()
+        assert resp.json()["is_default"] is False
+
+        db.refresh(row)
+        assert row.is_default is False
+
+    def test_unset_default_is_noop_when_not_default(
+        self, client: TestClient, auth_headers, db, test_user
+    ):
+        row = _make_connector(db, test_user, display_name="A", is_default=False)
+        resp = client.delete(f"/api/llm/connectors/{row.id}/default", headers=auth_headers)
+        # Successful no-op — no error, no audit row.
+        assert resp.status_code == 200
+        assert resp.json()["is_default"] is False
+        assert (
+            db.query(LlmAuditEvent)
+            .filter(LlmAuditEvent.event_type == "connector_default_unset")
+            .count()
+            == 0
+        )
+
+    def test_unset_default_writes_audit_event(
+        self, client: TestClient, auth_headers, db, test_user
+    ):
+        row = _make_connector(db, test_user, display_name="A", is_default=True)
+        client.delete(f"/api/llm/connectors/{row.id}/default", headers=auth_headers)
+
+        audit = (
+            db.query(LlmAuditEvent)
+            .filter(
+                LlmAuditEvent.target_connector_id == row.id,
+                LlmAuditEvent.event_type == "connector_default_unset",
+            )
+            .one_or_none()
+        )
+        assert audit is not None
+        assert audit.actor_user_id == test_user.id
+
+    def test_unset_default_404_for_other_users_connector(
+        self, client: TestClient, auth_headers, db, other_dj
+    ):
+        theirs = _make_connector(db, other_dj, display_name="not yours", is_default=True)
+        resp = client.delete(f"/api/llm/connectors/{theirs.id}/default", headers=auth_headers)
+        assert resp.status_code == 404
+        db.refresh(theirs)
+        assert theirs.is_default is True
+
+    def test_unset_falls_back_to_mru_on_next_dispatch(
+        self, client: TestClient, auth_headers, db, test_user
+    ):
+        """Acceptance criterion: unsetting falls back to MRU."""
+        from datetime import timedelta
+
+        from app.core.time import utcnow
+
+        pinned = _make_connector(db, test_user, display_name="pinned", is_default=True)
+        pinned.last_used_at = utcnow() - timedelta(hours=2)
+        mru = _make_connector(db, test_user, display_name="mru-recent")
+        mru.last_used_at = utcnow()
+        db.commit()
+
+        client.delete(f"/api/llm/connectors/{pinned.id}/default", headers=auth_headers)
+        db.refresh(pinned)
+        assert pinned.is_default is False
+
+        # After unsetting, gateway picks the MRU.
+        import asyncio
+
+        fake = ChatResponse(text="mru-served", tool_calls=[], stop_reason="end_turn", usage=None)
+        with patch.object(
+            __import__(
+                "app.services.llm.adapters.openai_apikey",
+                fromlist=["OpenAIApiKeyAdapter"],
+            ).OpenAIApiKeyAdapter,
+            "chat",
+            new=AsyncMock(return_value=fake),
+        ):
+            resp = asyncio.run(
+                Gateway.dispatch(
+                    db,
+                    test_user,
+                    ChatRequest(messages=[Message(role="user", content="hi")]),
+                    purpose="test",
+                )
+            )
+
+        assert resp.text == "mru-served"
+        db.refresh(mru)
+        # MRU got the bump; pinned did not because it wasn't chosen this time.
+        assert mru.last_used_at is not None
+
+
+# ---------- ConnectorOut surfaces is_default ----------
+class TestListSurfacesIsDefault:
+    def test_list_exposes_is_default_flag(self, client: TestClient, auth_headers, db, test_user):
+        _make_connector(db, test_user, display_name="A", is_default=True)
+        _make_connector(db, test_user, display_name="B")
+
+        rows = client.get("/api/llm/connectors", headers=auth_headers).json()
+        by_name = {r["display_name"]: r for r in rows}
+        assert by_name["A"]["is_default"] is True
+        assert by_name["B"]["is_default"] is False
+
+
+# ---------- service layer invariants ----------
+class TestServiceLayer:
+    def test_set_default_for_user_clears_siblings(self, db, dj_user):
+        from app.services.llm.connector_storage import set_default_for_user
+
+        a = _make_connector(db, dj_user, display_name="A", is_default=True)
+        b = _make_connector(db, dj_user, display_name="B")
+
+        set_default_for_user(db, connector=b)
+        db.commit()
+
+        db.refresh(a)
+        db.refresh(b)
+        assert a.is_default is False
+        assert b.is_default is True
+
+    def test_set_default_idempotent_when_already_default(self, db, dj_user):
+        """Calling set on a row that's already default is a quiet no-op."""
+        from app.services.llm.connector_storage import set_default_for_user
+
+        a = _make_connector(db, dj_user, display_name="A", is_default=True)
+        result = set_default_for_user(db, connector=a)
+        db.commit()
+
+        assert result.id == a.id
+        db.refresh(a)
+        assert a.is_default is True
+
+    def test_unset_default_clears_flag(self, db, dj_user):
+        from app.services.llm.connector_storage import unset_default_for_user
+
+        a = _make_connector(db, dj_user, display_name="A", is_default=True)
+        unset_default_for_user(db, connector=a)
+        db.commit()
+        db.refresh(a)
+        assert a.is_default is False
+
+
+def _load_migration_048():
+    """Import the 048 migration module by file path so the backfill helper is
+    callable from tests (alembic versions/ has no ``__init__.py``).
+    """
+    import importlib.util
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "alembic"
+        / "versions"
+        / "048_llm_connector_is_default.py"
+    )
+    spec = importlib.util.spec_from_file_location("_migration_048", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestMigrationBackfill:
+    """Smoke-test the migration's backfill helper against an in-memory DB.
+
+    The helper picks the MRU active connector per user. The migration runs
+    against a bind connection, so we exercise it the same way here. Skipped
+    users (no active connector, or already has a default) must be untouched.
+    """
+
+    def test_backfill_marks_mru_for_each_user(self, db, dj_user, other_dj):
+        from datetime import timedelta
+
+        from app.core.time import utcnow
+
+        migration = _load_migration_048()
+
+        # User A: two active connectors, neither default. MRU = newer.
+        older_a = _make_connector(db, dj_user, display_name="A-older")
+        newer_a = _make_connector(db, dj_user, display_name="A-newer")
+        older_a.last_used_at = utcnow() - timedelta(hours=2)
+        newer_a.last_used_at = utcnow()
+
+        # User B: one active connector with no last_used_at — gets defaulted.
+        only_b = _make_connector(db, other_dj, display_name="B-only")
+        only_b.last_used_at = None
+
+        db.commit()
+
+        migration._backfill_mru_defaults(db.connection())
+        db.commit()
+
+        db.refresh(older_a)
+        db.refresh(newer_a)
+        db.refresh(only_b)
+        assert newer_a.is_default is True
+        assert older_a.is_default is False
+        assert only_b.is_default is True
+
+    def test_backfill_skips_users_with_existing_default(self, db, dj_user):
+        migration = _load_migration_048()
+
+        already = _make_connector(db, dj_user, display_name="already", is_default=True)
+        also = _make_connector(db, dj_user, display_name="also")
+
+        migration._backfill_mru_defaults(db.connection())
+        db.commit()
+
+        db.refresh(already)
+        db.refresh(also)
+        assert already.is_default is True
+        assert also.is_default is False  # Untouched
+
+    def test_backfill_skips_inactive_only(self, db, dj_user):
+        migration = _load_migration_048()
+
+        broken = _make_connector(db, dj_user, display_name="only-broken", status="auth_invalid")
+
+        migration._backfill_mru_defaults(db.connection())
+        db.commit()
+
+        db.refresh(broken)
+        # No active connector → user is skipped, no default created.
+        assert broken.is_default is False


### PR DESCRIPTION
Closes #336

## Summary

Adds an explicit per-DJ "pinned default" connector. The gateway now prefers a pinned default over the MRU heuristic so DJs can force routing through (e.g.) "always OpenAI for recommendations, always Anthropic for agents" instead of relying on whichever connector happened to run last.

## Changes

### Backend
- `LlmConnector.is_default` column (bool, NOT NULL, default `false`).
- Partial unique index `ix_llm_connectors_user_default_unique` on `user_id WHERE is_default` — enforces single-default per DJ at the DB layer (Postgres + SQLite via `postgresql_where`/`sqlite_where`).
- Service helpers `set_default_for_user` / `unset_default_for_user` with **atomic clear-then-set** semantics — siblings are flipped to `False` in a single UPDATE before the target is flipped to `True`, so the partial unique index never sees two `True` rows for the same user.
- Gateway resolver (`_resolve_connector` in `server/app/services/llm/gateway.py`) now: pinned-default → MRU → org default → `NoLlmConfigured`. A pinned-but-inactive default is **skipped** so DJs aren't silently broken when their default's status flips.
- API endpoints:
  - `POST /api/llm/connectors/{id}/default` — pin (200 with `ConnectorOut`)
  - `DELETE /api/llm/connectors/{id}/default` — unpin (200 with `ConnectorOut`)
  - Both rate-limited 30/min, scoped by `user_id`, return 404 for other DJs' connectors.
  - `POST` returns 400 when the target is `auth_invalid` / `disabled` (footgun guard — a default the gateway would skip anyway is just confusing UX).
- Audit events: `connector_default_set`, `connector_default_unset`.
- `ConnectorOut` Pydantic schema gains `is_default: bool`.

### Migration (`048_llm_connector_is_default`)
- Adds the column + partial unique index.
- **Backfill**: for each user with active connectors, marks the MRU one (`last_used_at DESC NULLS LAST, id DESC` — same ordering as the gateway resolver) as default so resolution behavior is unchanged for existing users. Skips users that already have a default or no active connectors. Idempotent.

### Frontend (`AiProvidersSection.tsx`)
- Each connector card gets a "Set as default" radio (single-selection across the list) plus a "Default" badge + "Unpin" link on the pinned row.
- Radio is disabled on inactive connectors.
- Optimistic update — the previous default's badge disappears immediately on click without waiting for the refetch.
- New API client methods `setLlmConnectorDefault(id)` / `unsetLlmConnectorDefault(id)`.

## Design decisions

- **Atomic clear-then-set vs. transaction-only enforcement**: The partial unique index alone would race under concurrent SET requests (two `True` rows could land in the same instant). Doing the sibling-clear inside the same UPDATE (no app-side ordering reliance) keeps the index meaningful and concurrent-safe; the worst case is the second request winning, which matches the DJ's intent.
- **Rejecting pin-of-inactive**: An inactive default would be silently skipped by the gateway. Rather than let DJs pin a row that does nothing, the endpoint returns 400. Status flips that happen *after* pinning (`auth_invalid` from a credential expiry) still cause the gateway to fall through to MRU at dispatch time — that branch is tested.
- **Skip-when-inactive in the resolver**: When the pinned connector is no longer active, fall through to MRU rather than raise `NoLlmConfigured` immediately. This preserves liveness — a DJ doesn't lose AI features just because their default rotated out of validity.
- **Single-default radio (UI) vs. multi-select**: Issue body asked for a radio per card. Implemented as a `name="llm-connector-default"` radio group with optional "Unpin" link so the DJ can explicitly clear without picking another row.
- **Backfill ordering**: MRU (`last_used_at DESC NULLS LAST, id DESC`) intentionally mirrors the resolver's tiebreak so existing routing behavior carries forward unchanged after the migration runs.
- **Audit event naming**: `connector_default_set` / `connector_default_unset` follows the existing `connector_<verb>` pattern (`connector_created`, `connector_revoked_by_admin`, etc.) — no new convention introduced.
- **Partial unique index portability**: Postgres uses `postgresql_where`, SQLite uses `sqlite_where`. Both are supported by SQLAlchemy / Alembic. The model declares both so `alembic check` stays clean on Postgres CI.

## Test plan
- [x] Backend `pytest` (2347 passed, 25 new in `test_llm_default_connector.py`).
- [x] Backend `ruff check` / `ruff format --check` / `bandit` clean.
- [x] `alembic upgrade head && alembic check` on a fresh Postgres DB — no drift.
- [x] Frontend `npm test` (964 passed including 4 new UI tests).
- [x] Frontend `npx tsc --noEmit` clean.
- [x] Frontend `npm run lint` clean (only pre-existing warning, unrelated).
- [x] Backfill helper unit-tested in isolation (MRU pick, skip-existing-default, skip-inactive-only).

## Notes
- Epic-base PR — Actions CI does NOT auto-trigger here. Will request CodeRabbit review manually in a follow-up comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user AI connector default: pin/unpin a provider from the UI; pinned connector is visually marked and prioritized for selection.
  * Only active connectors can be set as default; inactive connectors show a disabled control.

* **Chores**
  * Database migration backfills a sensible default for existing users so providers behave consistently after upgrade.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->