### PR TITLE
feat(ai): connector health monitor + admin observability (#340, #346)

### DIFF
--- a/dashboard/app/admin/ai/__tests__/page.test.tsx
+++ b/dashboard/app/admin/ai/__tests__/page.test.tsx
@@ -164,6 +164,8 @@ describe('AdminAISettingsPage', () => {
         last_used_at: null,
         last_error: null,
         is_default: false,
+        last_health_check_at: null,
+        last_health_check_status: null,
       },
     ]);
     vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({
@@ -321,6 +323,8 @@ describe('AdminAISettingsPage', () => {
         last_used_at: null,
         last_error: null,
         is_default: false,
+        last_health_check_at: null,
+        last_health_check_status: null,
       },
     ]);
     vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
@@ -338,6 +342,8 @@ describe('AdminAISettingsPage', () => {
       last_used_at: null,
       last_error: null,
       is_default: false,
+      last_health_check_at: null,
+      last_health_check_status: null,
     });
     vi.spyOn(window, 'confirm').mockReturnValue(true);
 
@@ -469,5 +475,166 @@ describe('AdminAISettingsPage', () => {
         expect.objectContaining({ llm_call_log_retention_days: 7 }),
       ),
     );
+  });
+
+  // -------- issue #346: surface health-check columns in connectors table --------
+  it('renders last-health-check column with a status badge per connector', async () => {
+    vi.spyOn(api, 'getAISettings').mockResolvedValue({
+      llm_enabled: true,
+      llm_model: 'claude-haiku-4-5-20251001',
+      llm_rate_limit_per_minute: 3,
+      api_key_configured: true,
+      api_key_masked: '...abcd',
+    });
+    vi.spyOn(api, 'getAIModels').mockResolvedValue({ models: [] });
+    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: true,
+      llm_compatible_connector_enabled: true,
+      llm_default_connector_id: null,
+      llm_call_log_retention_days: 30,
+    });
+    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([
+      {
+        id: 1,
+        user_id: 1,
+        dj_username: 'alpha',
+        connector_type: 'openai_apikey',
+        display_name: 'Alpha key',
+        status: 'active',
+        base_url_plain: null,
+        model_hint: null,
+        created_at: '2026-05-01T00:00:00Z',
+        updated_at: '2026-05-01T00:00:00Z',
+        last_used_at: null,
+        last_error: null,
+        is_default: false,
+        last_health_check_at: '2026-05-28T10:00:00Z',
+        last_health_check_status: 'ok',
+      },
+      {
+        id: 2,
+        user_id: 2,
+        dj_username: 'bravo',
+        connector_type: 'anthropic_apikey',
+        display_name: 'Bravo key',
+        status: 'auth_invalid',
+        base_url_plain: null,
+        model_hint: null,
+        created_at: '2026-05-01T00:00:00Z',
+        updated_at: '2026-05-01T00:00:00Z',
+        last_used_at: null,
+        last_error: 'auth_invalid',
+        is_default: false,
+        last_health_check_at: '2026-05-28T09:00:00Z',
+        last_health_check_status: 'auth_invalid',
+      },
+      {
+        id: 3,
+        user_id: 3,
+        dj_username: 'charlie',
+        connector_type: 'openai_apikey',
+        display_name: 'Charlie key',
+        status: 'active',
+        base_url_plain: null,
+        model_hint: null,
+        created_at: '2026-05-01T00:00:00Z',
+        updated_at: '2026-05-01T00:00:00Z',
+        last_used_at: null,
+        last_error: null,
+        is_default: false,
+        last_health_check_at: null,
+        last_health_check_status: null,
+      },
+    ]);
+    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
+
+    render(<AdminAISettingsPage />);
+
+    await waitFor(() => expect(screen.getByText('Alpha key')).toBeInTheDocument());
+    // Column header rendered with sortable affordance
+    expect(screen.getByText('Last health check')).toBeInTheDocument();
+    // Each badge visible
+    expect(screen.getByText('OK')).toBeInTheDocument();
+    expect(screen.getByText('Auth invalid')).toBeInTheDocument();
+    expect(screen.getByText('Never checked')).toBeInTheDocument();
+  });
+
+  it('toggles sort direction when clicking the last-health-check header', async () => {
+    vi.spyOn(api, 'getAISettings').mockResolvedValue({
+      llm_enabled: true,
+      llm_model: 'claude-haiku-4-5-20251001',
+      llm_rate_limit_per_minute: 3,
+      api_key_configured: true,
+      api_key_masked: '...abcd',
+    });
+    vi.spyOn(api, 'getAIModels').mockResolvedValue({ models: [] });
+    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: true,
+      llm_compatible_connector_enabled: true,
+      llm_default_connector_id: null,
+      llm_call_log_retention_days: 30,
+    });
+    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([
+      {
+        id: 1,
+        user_id: 1,
+        dj_username: 'older',
+        connector_type: 'openai_apikey',
+        display_name: 'Older check',
+        status: 'active',
+        base_url_plain: null,
+        model_hint: null,
+        created_at: '2026-05-01T00:00:00Z',
+        updated_at: '2026-05-01T00:00:00Z',
+        last_used_at: null,
+        last_error: null,
+        is_default: false,
+        last_health_check_at: '2026-05-01T00:00:00Z',
+        last_health_check_status: 'ok',
+      },
+      {
+        id: 2,
+        user_id: 2,
+        dj_username: 'newer',
+        connector_type: 'openai_apikey',
+        display_name: 'Newer check',
+        status: 'active',
+        base_url_plain: null,
+        model_hint: null,
+        created_at: '2026-05-01T00:00:00Z',
+        updated_at: '2026-05-01T00:00:00Z',
+        last_used_at: null,
+        last_error: null,
+        is_default: false,
+        last_health_check_at: '2026-05-28T00:00:00Z',
+        last_health_check_status: 'ok',
+      },
+    ]);
+    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
+
+    render(<AdminAISettingsPage />);
+
+    await waitFor(() => expect(screen.getByText('Newer check')).toBeInTheDocument());
+
+    const findRow = (text: string) => {
+      const td = screen.getByText(text);
+      const tr = td.closest('tr');
+      if (!tr) throw new Error(`row for ${text} not found`);
+      return tr;
+    };
+
+    // Default sort = last_health_check_at DESC → newer first.
+    const tbody = findRow('Newer check').parentElement!;
+    const beforeRows = Array.from(tbody.querySelectorAll('tr'));
+    const beforeOrder = beforeRows.map((r) => r.querySelector('td')!.textContent);
+    expect(beforeOrder).toEqual(['newer', 'older']);
+
+    // Click the Last health check header → should flip to ASC (older first).
+    fireEvent.click(screen.getByText('Last health check'));
+    await waitFor(() => {
+      const rows = Array.from(tbody.querySelectorAll('tr'));
+      const order = rows.map((r) => r.querySelector('td')!.textContent);
+      expect(order).toEqual(['older', 'newer']);
+    });
   });
 });

--- a/dashboard/app/admin/ai/page.tsx
+++ b/dashboard/app/admin/ai/page.tsx
@@ -49,6 +49,151 @@ const AUDIT_EVENT_TYPES: Array<{ value: string; label: string }> = [
 
 const AUDIT_PAGE_SIZE = 50;
 
+// Map health-check status to a colour family. Active=green, transient/quota
+// issues=amber, auth/error=red. ``null`` (never checked) is treated as
+// "neutral" so the table doesn't scream red on first load.
+const HEALTH_BADGE_STYLES: Record<
+  string,
+  { background: string; color: string; label: string }
+> = {
+  ok: { background: 'var(--color-success-subtle)', color: 'var(--color-success)', label: 'OK' },
+  auth_invalid: {
+    background: 'var(--color-danger-subtle)',
+    color: 'var(--color-danger)',
+    label: 'Auth invalid',
+  },
+  error: {
+    background: 'var(--color-danger-subtle)',
+    color: 'var(--color-danger)',
+    label: 'Error',
+  },
+  rate_limited: {
+    background: 'var(--color-warning-subtle, #2a2418)',
+    color: 'var(--color-warning, #c08418)',
+    label: 'Rate limited',
+  },
+  quota_exceeded: {
+    background: 'var(--color-warning-subtle, #2a2418)',
+    color: 'var(--color-warning, #c08418)',
+    label: 'Quota exceeded',
+  },
+  provider_unavailable: {
+    background: 'var(--color-warning-subtle, #2a2418)',
+    color: 'var(--color-warning, #c08418)',
+    label: 'Provider down',
+  },
+};
+
+type ConnectorSortKey = 'dj_username' | 'last_used_at' | 'last_health_check_at';
+
+function sortConnectors(
+  rows: LlmAdminConnector[],
+  sort: { key: ConnectorSortKey; direction: 'asc' | 'desc' },
+): LlmAdminConnector[] {
+  const factor = sort.direction === 'asc' ? 1 : -1;
+  // Treat ``null`` timestamps as "always last" regardless of direction so an
+  // admin sorting by recency doesn't get a wall of "never checked" rows at
+  // the top — they live below the real signal.
+  const tsValue = (v: string | null | undefined): number => {
+    if (!v) return sort.direction === 'asc' ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+    return new Date(v).getTime();
+  };
+  const copy = [...rows];
+  copy.sort((a, b) => {
+    if (sort.key === 'dj_username') {
+      const cmp = a.dj_username.localeCompare(b.dj_username);
+      if (cmp !== 0) return cmp * factor;
+    } else {
+      const cmp = tsValue(a[sort.key]) - tsValue(b[sort.key]);
+      if (cmp !== 0) return cmp * factor;
+    }
+    // Stable tiebreak on id so re-renders don't reshuffle equal-keyed rows.
+    return a.id - b.id;
+  });
+  return copy;
+}
+
+function PlainHeader({ label }: { label: string }) {
+  return (
+    <th
+      style={{ textAlign: 'left', padding: '0.5rem', borderBottom: '1px solid var(--border-color)' }}
+    >
+      {label}
+    </th>
+  );
+}
+
+function SortableHeader({
+  label,
+  sortKey,
+  activeKey,
+  direction,
+  onSort,
+}: {
+  label: string;
+  sortKey: ConnectorSortKey;
+  activeKey: ConnectorSortKey;
+  direction: 'asc' | 'desc';
+  onSort: (key: ConnectorSortKey, direction: 'asc' | 'desc') => void;
+}) {
+  const isActive = activeKey === sortKey;
+  const arrow = isActive ? (direction === 'asc' ? '▲' : '▼') : '';
+  return (
+    <th
+      onClick={() => {
+        if (isActive) {
+          onSort(sortKey, direction === 'asc' ? 'desc' : 'asc');
+        } else {
+          // First click on a new column goes to descending — newest-first is
+          // the more useful default for both ``last_used_at`` and
+          // ``last_health_check_at``.
+          onSort(sortKey, 'desc');
+        }
+      }}
+      style={{
+        textAlign: 'left',
+        padding: '0.5rem',
+        borderBottom: '1px solid var(--border-color)',
+        cursor: 'pointer',
+        userSelect: 'none',
+      }}
+      aria-sort={isActive ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'}
+    >
+      {label}
+      {arrow ? <span style={{ marginLeft: '0.25rem', fontSize: '0.75rem' }}>{arrow}</span> : null}
+    </th>
+  );
+}
+
+function HealthBadge({ status }: { status: string | null }) {
+  if (!status) {
+    return (
+      <span style={{ color: 'var(--text-secondary)', fontSize: '0.75rem' }}>Never checked</span>
+    );
+  }
+  const style = HEALTH_BADGE_STYLES[status] ?? {
+    background: 'var(--color-warning-subtle, #2a2418)',
+    color: 'var(--text-secondary)',
+    label: status,
+  };
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '0.15rem 0.6rem',
+        borderRadius: '9999px',
+        fontSize: '0.75rem',
+        fontWeight: 600,
+        background: style.background,
+        color: style.color,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {style.label}
+    </span>
+  );
+}
+
 const AUDIT_DAY_OPTIONS: Array<{ value: number; label: string }> = [
   { value: 7, label: 'Last 7 days' },
   { value: 30, label: 'Last 30 days' },
@@ -68,6 +213,14 @@ export default function AdminAISettingsPage() {
   const [connectors, setConnectors] = useState<LlmAdminConnector[]>([]);
   const [usage, setUsage] = useState<LlmAdminUsage | null>(null);
   const [policyMessage, setPolicyMessage] = useState('');
+
+  // Connectors-table sort state (issue #346)
+  // Default-sort by health-check-recency so an admin scanning the table sees
+  // the most-recently-verified rows up top — easiest first-pass triage.
+  const [connectorSort, setConnectorSort] = useState<{
+    key: ConnectorSortKey;
+    direction: 'asc' | 'desc';
+  }>({ key: 'last_health_check_at', direction: 'desc' });
 
   // Audit trail state (issue #341)
   const [audit, setAudit] = useState<LlmAdminAudit | null>(null);
@@ -473,6 +626,11 @@ export default function AdminAISettingsPage() {
       {/* ====== Per-DJ connectors table ====== */}
       <div className="card" style={{ marginTop: '2rem' }}>
         <h2 style={{ marginTop: 0 }}>Per-DJ connectors</h2>
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginTop: 0 }}>
+          Background monitor verifies each connector every {' '}
+          <code>LLM_HEALTH_CHECK_INTERVAL_HOURS</code> hours (default 6). DJ-triggered
+          tests update the same columns.
+        </p>
         {connectors.length === 0 ? (
           <p style={{ color: 'var(--text-secondary)' }}>No DJs have connected an LLM yet.</p>
         ) : (
@@ -480,15 +638,36 @@ export default function AdminAISettingsPage() {
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>
               <thead>
                 <tr>
-                  {['DJ', 'Type', 'Name', 'Status', 'Last used', 'Actions'].map((h) => (
-                    <th key={h} style={{ textAlign: 'left', padding: '0.5rem', borderBottom: '1px solid var(--border-color)' }}>
-                      {h}
-                    </th>
-                  ))}
+                  <SortableHeader
+                    label="DJ"
+                    sortKey="dj_username"
+                    activeKey={connectorSort.key}
+                    direction={connectorSort.direction}
+                    onSort={(k, d) => setConnectorSort({ key: k, direction: d })}
+                  />
+                  <PlainHeader label="Type" />
+                  <PlainHeader label="Name" />
+                  <PlainHeader label="Status" />
+                  <SortableHeader
+                    label="Last used"
+                    sortKey="last_used_at"
+                    activeKey={connectorSort.key}
+                    direction={connectorSort.direction}
+                    onSort={(k, d) => setConnectorSort({ key: k, direction: d })}
+                  />
+                  <SortableHeader
+                    label="Last health check"
+                    sortKey="last_health_check_at"
+                    activeKey={connectorSort.key}
+                    direction={connectorSort.direction}
+                    onSort={(k, d) => setConnectorSort({ key: k, direction: d })}
+                  />
+                  <PlainHeader label="Result" />
+                  <PlainHeader label="Actions" />
                 </tr>
               </thead>
               <tbody>
-                {connectors.map((c) => (
+                {sortConnectors(connectors, connectorSort).map((c) => (
                   <tr key={c.id}>
                     <td style={{ padding: '0.5rem' }}>{c.dj_username}</td>
                     <td style={{ padding: '0.5rem' }}>
@@ -498,6 +677,14 @@ export default function AdminAISettingsPage() {
                     <td style={{ padding: '0.5rem' }}>{c.status}</td>
                     <td style={{ padding: '0.5rem', color: 'var(--text-secondary)' }}>
                       {c.last_used_at ? new Date(c.last_used_at).toLocaleString() : '—'}
+                    </td>
+                    <td style={{ padding: '0.5rem', color: 'var(--text-secondary)' }}>
+                      {c.last_health_check_at
+                        ? new Date(c.last_health_check_at).toLocaleString()
+                        : '—'}
+                    </td>
+                    <td style={{ padding: '0.5rem' }}>
+                      <HealthBadge status={c.last_health_check_status ?? null} />
                     </td>
                     <td style={{ padding: '0.5rem' }}>
                       {c.status !== 'disabled' && (

--- a/dashboard/components/__tests__/AiProvidersSection.test.tsx
+++ b/dashboard/components/__tests__/AiProvidersSection.test.tsx
@@ -47,6 +47,8 @@ function makeConnector(overrides: Partial<LlmConnector> = {}): LlmConnector {
     last_used_at: null,
     last_error: null,
     is_default: false,
+    last_health_check_at: null,
+    last_health_check_status: null,
     ...overrides,
   };
 }

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -1493,7 +1493,15 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Test Connector */
+        /**
+         * Test Connector
+         * @description Run a health check and return a sanitised result.
+         *
+         *     Behaviour identical to the background monitor (issue #340), so the
+         *     ``last_health_check_at`` / ``last_health_check_status`` columns and audit
+         *     rows are written the same way on every invocation regardless of trigger
+         *     source. See ``services/llm/health_check.py`` for the shared helper.
+         */
         post: operations["test_connector_api_llm_connectors__connector_id__test_post"];
         delete?: never;
         options?: never;
@@ -2523,6 +2531,10 @@ export interface components {
             is_default: boolean;
             /** Last Error */
             last_error: string | null;
+            /** Last Health Check At */
+            last_health_check_at: string | null;
+            /** Last Health Check Status */
+            last_health_check_status: ("ok" | "auth_invalid" | "rate_limited" | "quota_exceeded" | "provider_unavailable" | "error") | null;
             /** Last Used At */
             last_used_at: string | null;
             /** Model Hint */
@@ -3227,6 +3239,10 @@ export interface components {
             is_default: boolean;
             /** Last Error */
             last_error: string | null;
+            /** Last Health Check At */
+            last_health_check_at: string | null;
+            /** Last Health Check Status */
+            last_health_check_status: ("ok" | "auth_invalid" | "rate_limited" | "quota_exceeded" | "provider_unavailable" | "error") | null;
             /** Last Used At */
             last_used_at: string | null;
             /** Model Hint */

--- a/server/alembic/versions/049_llm_connector_health_check_columns.py
+++ b/server/alembic/versions/049_llm_connector_health_check_columns.py
@@ -1,0 +1,42 @@
+"""Add last_health_check_at + last_health_check_status to llm_connectors.
+
+Revision ID: 049
+Revises: 048
+Create Date: 2026-05-28
+
+Adds two health-check observability columns to ``llm_connectors``:
+
+- ``last_health_check_at`` (DateTime, nullable) — UTC timestamp of the most
+  recent health check (DJ-triggered "Test" button OR the background monitor).
+- ``last_health_check_status`` (String(20), nullable) — outcome of that
+  health check. One of: ``"ok"``, ``"auth_invalid"``, ``"rate_limited"``,
+  ``"provider_unavailable"``, ``"quota_exceeded"``, ``"error"``. Allowed
+  values are enforced at the application layer (see ``connector_storage``).
+
+Both columns are nullable because existing rows have no prior health check.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "049"
+down_revision: str | None = "048"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "llm_connectors",
+        sa.Column("last_health_check_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "llm_connectors",
+        sa.Column("last_health_check_status", sa.String(length=20), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("llm_connectors", "last_health_check_status")
+    op.drop_column("llm_connectors", "last_health_check_at")

--- a/server/app/api/llm.py
+++ b/server/app/api/llm.py
@@ -20,7 +20,6 @@ from app.api.deps import get_current_active_user, get_db
 from app.core.rate_limit import limiter
 from app.models.llm_connector import (
     CONNECTOR_TYPE_OPENAI_COMPATIBLE,
-    STATUS_DISABLED,
     VALID_CONNECTOR_TYPES,
 )
 from app.models.user import User
@@ -39,7 +38,6 @@ from app.services.llm.connector_storage import (
     AUDIT_DEFAULT_SET,
     AUDIT_DEFAULT_UNSET,
     AUDIT_DELETED,
-    AUDIT_HEALTH_CHECK,
     audit_event,
     build_create_payload,
     create_connector,
@@ -51,16 +49,7 @@ from app.services.llm.connector_storage import (
     unset_default_for_user,
     update_metadata,
 )
-from app.services.llm.exceptions import (
-    AuthInvalid,
-    LlmError,
-    ProviderUnavailable,
-    QuotaExceeded,
-    RateLimited,
-    ToolTranslationError,
-)
 from app.services.llm.openrouter_models import get_openrouter_models
-from app.services.llm.registry import get_adapter_class
 from app.services.system_settings import get_system_settings
 
 logger = logging.getLogger(__name__)
@@ -105,26 +94,6 @@ def _check_connector_type_allowed(db: Session, connector_type: str) -> None:
                 status_code=403,
                 detail="API-key connectors are disabled by admin policy",
             )
-
-
-def _sanitize_error(exc: Exception) -> tuple[str, str]:
-    """Map an LLM exception to (error_code, user-friendly message).
-
-    Upstream error bodies / stack traces are deliberately NOT included.
-    """
-    if isinstance(exc, AuthInvalid):
-        return "auth_invalid", "Authentication failed against the provider"
-    if isinstance(exc, RateLimited):
-        return "rate_limited", "Provider rate limited the request"
-    if isinstance(exc, QuotaExceeded):
-        return "quota_exceeded", "Provider quota or billing failure"
-    if isinstance(exc, ProviderUnavailable):
-        return "provider_unavailable", "Provider unreachable or timed out"
-    if isinstance(exc, ToolTranslationError):
-        return "tool_translation_error", "Unexpected response shape"
-    if isinstance(exc, LlmError):
-        return "llm_error", "LLM error"
-    return "unknown", "Unknown error"
 
 
 @router.get("/connectors", response_model=list[ConnectorOut])
@@ -323,43 +292,38 @@ async def test_connector(
     user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db),
 ) -> ConnectorTestResult:
+    """Run a health check and return a sanitised result.
+
+    Behaviour identical to the background monitor (issue #340), so the
+    ``last_health_check_at`` / ``last_health_check_status`` columns and audit
+    rows are written the same way on every invocation regardless of trigger
+    source. See ``services/llm/health_check.py`` for the shared helper.
+    """
+    from app.services.llm.health_check import run_health_check
+
     row = get_connector_for_user(db, connector_id, user.id)
     if row is None:
         raise HTTPException(status_code=404, detail="Connector not found")
 
-    adapter_cls = get_adapter_class(row.connector_type)
-    adapter = adapter_cls(row)
-
-    audit_event(
-        db,
-        actor_user_id=user.id,
-        target_connector_id=row.id,
-        event_type=AUDIT_HEALTH_CHECK,
-    )
-
-    try:
-        await adapter.health_check()
-    except AuthInvalid as exc:
-        row.status = "auth_invalid"
-        row.last_error = "auth_invalid"
-        db.commit()
-        code, message = _sanitize_error(exc)
-        return ConnectorTestResult(ok=False, error_code=code, message=message)
-    except LlmError as exc:
-        # Don't flip status for transient errors — DJ will see message + retry.
-        code, message = _sanitize_error(exc)
-        db.commit()
-        return ConnectorTestResult(ok=False, error_code=code, message=message)
-    except Exception:  # noqa: BLE001 — sanitised
-        logger.exception("Connector health check failed unexpectedly")
-        db.commit()
-        return ConnectorTestResult(ok=False, error_code="unknown", message="Unknown error")
-
-    row.last_error = None
-    if row.status != STATUS_DISABLED:
-        row.status = "active"
+    outcome = await run_health_check(db, row, actor_user_id=user.id)
     db.commit()
-    return ConnectorTestResult(ok=True)
+
+    if outcome.ok:
+        return ConnectorTestResult(ok=True)
+    # Reuse the same code → message mapping the gateway uses for transient
+    # errors. The helper has already sanitised any upstream payload.
+    message = {
+        "auth_invalid": "Authentication failed against the provider",
+        "rate_limited": "Provider rate limited the request",
+        "quota_exceeded": "Provider quota or billing failure",
+        "provider_unavailable": "Provider unreachable or timed out",
+        "error": "Unknown error",
+    }.get(outcome.status, "Unknown error")
+    return ConnectorTestResult(
+        ok=False,
+        error_code=outcome.error_code or outcome.status,
+        message=message,
+    )
 
 
 @router.post(

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -110,9 +110,14 @@ async def lifespan(app: FastAPI):
         lg = logging.getLogger(name)
         lg.handlers.clear()
         lg.propagate = True
+    # Import lazily so test runs that mock out the loop module don't trigger
+    # adapter imports at startup-time.
+    from app.services.llm.health_monitor import health_monitor_loop
+
     tasks = [
         asyncio.create_task(_tidal_collection_poll_loop()),
         asyncio.create_task(_llm_call_log_cleanup_loop()),
+        asyncio.create_task(health_monitor_loop()),
     ]
     try:
         yield

--- a/server/app/models/llm_connector.py
+++ b/server/app/models/llm_connector.py
@@ -54,6 +54,29 @@ STATUS_ACTIVE = "active"
 STATUS_AUTH_INVALID = "auth_invalid"
 STATUS_DISABLED = "disabled"
 
+# Health-check status values written to ``last_health_check_status``. Kept here
+# so the API/background loop/admin UI all use the same vocabulary. These are
+# *outcomes*, not connector statuses — a single connector accumulates many
+# health-check rows over its lifetime; only the most recent outcome is stored
+# on the row itself (audit_event rows preserve the full history).
+HEALTH_CHECK_OK = "ok"
+HEALTH_CHECK_AUTH_INVALID = "auth_invalid"
+HEALTH_CHECK_RATE_LIMITED = "rate_limited"
+HEALTH_CHECK_QUOTA_EXCEEDED = "quota_exceeded"
+HEALTH_CHECK_PROVIDER_UNAVAILABLE = "provider_unavailable"
+HEALTH_CHECK_ERROR = "error"
+
+VALID_HEALTH_CHECK_STATUSES = frozenset(
+    {
+        HEALTH_CHECK_OK,
+        HEALTH_CHECK_AUTH_INVALID,
+        HEALTH_CHECK_RATE_LIMITED,
+        HEALTH_CHECK_QUOTA_EXCEEDED,
+        HEALTH_CHECK_PROVIDER_UNAVAILABLE,
+        HEALTH_CHECK_ERROR,
+    }
+)
+
 # Audit event types
 AUDIT_CREATED = "connector_created"
 AUDIT_CREDENTIALS_ROTATED = "connector_credentials_rotated"
@@ -64,6 +87,11 @@ AUDIT_POLICY_CHANGED = "policy_changed"
 AUDIT_HEALTH_CHECK = "connector_health_check"
 AUDIT_DEFAULT_SET = "connector_default_set"
 AUDIT_DEFAULT_UNSET = "connector_default_unset"
+# Emitted by the background monitor when a periodic health check flips a
+# previously-active connector into ``auth_invalid``. Distinct from
+# ``AUDIT_HEALTH_CHECK`` (which is fired on EVERY check, OK or not) so admins
+# can filter to the credential-lifecycle subset.
+AUDIT_HEALTH_CHECK_FAILED = "connector_health_check_failed"
 
 
 class LlmConnector(Base):
@@ -117,6 +145,13 @@ class LlmConnector(Base):
         default=False,
         server_default=text("false"),
     )
+
+    # Health-check observability (issue #346 + #340).
+    # ``last_health_check_at`` is written by every health-check invocation —
+    # the DJ-triggered Test button AND the background monitor. ``last_health_check_status``
+    # records the outcome (see HEALTH_CHECK_* constants).
+    last_health_check_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    last_health_check_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
 
     __table_args__ = (
         UniqueConstraint("user_id", "connector_type", "display_name", name="uq_dj_connector_label"),

--- a/server/app/schemas/llm.py
+++ b/server/app/schemas/llm.py
@@ -29,6 +29,16 @@ def _provided(value: str | None) -> bool:
     return isinstance(value, str) and value.strip() != ""
 
 
+HealthCheckStatus = Literal[
+    "ok",
+    "auth_invalid",
+    "rate_limited",
+    "quota_exceeded",
+    "provider_unavailable",
+    "error",
+]
+
+
 class ConnectorOut(BaseModel):
     """Public-safe connector view — never includes the credential blob."""
 
@@ -49,6 +59,9 @@ class ConnectorOut(BaseModel):
     # routing to this connector for the owning DJ instead of falling back to
     # most-recently-used resolution.
     is_default: bool = False
+    # Health-check observability (issues #340 + #346).
+    last_health_check_at: datetime | None = None
+    last_health_check_status: HealthCheckStatus | None = None
 
 
 class AdminConnectorOut(ConnectorOut):

--- a/server/app/services/email_sender.py
+++ b/server/app/services/email_sender.py
@@ -78,3 +78,59 @@ def send_email_confirmation(to_address: str, confirmation_url: str) -> None:
         raise EmailSendError(str(exc)) from exc
 
     _logger.info("email.confirmation_sent to_hash=%s", to_address[:3] + "***")
+
+
+def send_connector_auth_invalid_notification(
+    to_address: str, display_name: str, connector_type: str
+) -> None:
+    """Notify a DJ that their LLM connector failed a background health check.
+
+    Triggered by the periodic connector health monitor (issue #340) when a
+    previously-active connector transitions to ``auth_invalid``. Never
+    includes credential material — only the display name and provider type
+    so the DJ can identify which key to rotate.
+    """
+    settings = get_settings()
+
+    if not settings.resend_api_key or not settings.email_from_address:
+        raise EmailNotConfiguredError("Resend API key or from address is not configured")
+
+    # Strip control characters defensively — display_name is user-supplied
+    # (DJ-set) and already validated at creation, but the connector_type comes
+    # from the registry. Belt-and-braces for an email body.
+    safe_display = "".join(c for c in (display_name or "") if c.isprintable())
+    safe_type = "".join(c for c in (connector_type or "") if c.isprintable())
+
+    resend.api_key = settings.resend_api_key
+
+    try:
+        resend.Emails.send(
+            {
+                "from": settings.email_from_address,
+                "to": [to_address],
+                "subject": "Your WrzDJ AI connector needs attention",
+                "text": (
+                    f'Your AI connector "{safe_display}" ({safe_type}) failed a '
+                    f"health check and was marked invalid.\n\n"
+                    f"This usually means the API key was revoked, expired, or the "
+                    f"upstream account is no longer in good standing.\n\n"
+                    f"To restore AI features, sign in to WrzDJ and rotate the "
+                    f"credentials on your AI Settings page.\n\n"
+                    f"If this looks wrong, you can re-test the connector from the "
+                    f"same page — a successful test restores its status automatically.\n"
+                ),
+            }
+        )
+    except Exception as exc:
+        _logger.error(
+            "email.connector_auth_invalid_send_failed to_hash=%s error=%s",
+            to_address[:3] + "***",
+            exc,
+        )
+        raise EmailSendError(str(exc)) from exc
+
+    _logger.info(
+        "email.connector_auth_invalid_sent to_hash=%s connector_type=%s",
+        to_address[:3] + "***",
+        safe_type,
+    )

--- a/server/app/services/llm/health_check.py
+++ b/server/app/services/llm/health_check.py
@@ -1,0 +1,173 @@
+"""Shared connector health-check helper.
+
+Used by:
+- ``POST /api/llm/connectors/{id}/test`` (DJ-triggered manual test)
+- ``connector_health_monitor`` background task (issue #340)
+
+Every invocation:
+1. Stamps ``last_health_check_at = utcnow()`` and the outcome on
+   ``last_health_check_status`` (see :data:`HEALTH_CHECK_*` constants).
+2. On auth failure, flips ``status`` to ``auth_invalid`` and writes a
+   ``connector_health_check_failed`` audit row alongside the existing
+   ``connector_health_check`` audit row.
+3. Never raises — always returns the outcome. The caller decides whether to
+   surface the error.
+
+The helper does NOT commit. The caller owns the transaction so it can roll
+back or combine with other writes (e.g. the background loop commits in a
+single transaction per connector).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.models.llm_connector import (
+    AUDIT_AUTH_INVALID_OBSERVED,
+    AUDIT_HEALTH_CHECK,
+    AUDIT_HEALTH_CHECK_FAILED,
+    HEALTH_CHECK_AUTH_INVALID,
+    HEALTH_CHECK_ERROR,
+    HEALTH_CHECK_OK,
+    HEALTH_CHECK_PROVIDER_UNAVAILABLE,
+    HEALTH_CHECK_QUOTA_EXCEEDED,
+    HEALTH_CHECK_RATE_LIMITED,
+    STATUS_ACTIVE,
+    STATUS_AUTH_INVALID,
+    STATUS_DISABLED,
+    LlmConnector,
+)
+from app.services.llm.connector_storage import audit_event
+from app.services.llm.exceptions import (
+    AuthInvalid,
+    ProviderUnavailable,
+    QuotaExceeded,
+    RateLimited,
+)
+from app.services.llm.registry import get_adapter_class
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class HealthCheckOutcome:
+    """Result of a single connector health-check invocation."""
+
+    ok: bool
+    status: str
+    """One of the HEALTH_CHECK_* constants."""
+    error_code: str | None = None
+    """Sanitised provider-class label; never includes a credential or upstream body."""
+    status_flipped_to_auth_invalid: bool = False
+    """True iff this call flipped the connector from ``active`` to ``auth_invalid``.
+
+    The background monitor uses this to decide whether to notify the DJ —
+    sending a notification on every periodic check would be noisy when the
+    connector was already broken on the prior pass.
+    """
+
+
+async def run_health_check(
+    db: Session,
+    connector: LlmConnector,
+    *,
+    actor_user_id: int,
+) -> HealthCheckOutcome:
+    """Run ``adapter.health_check()`` against ``connector`` and record the outcome.
+
+    Writes (caller commits):
+    - ``connector.last_health_check_at`` (always)
+    - ``connector.last_health_check_status`` (always)
+    - One ``llm_audit_event`` row of type ``connector_health_check`` (always)
+    - If auth failed: flips ``connector.status`` to ``auth_invalid`` (unless
+      already disabled), sets ``last_error``, and writes a second audit row
+      of type ``auth_invalid_observed``.
+    - If the auth failure was a transition (was active, now auth_invalid),
+      writes a third ``connector_health_check_failed`` audit row so admins can
+      filter on "the moment this connector broke".
+
+    Never raises.
+    """
+    # Always write the AUDIT_HEALTH_CHECK row before the call so we have a
+    # record even if the worker crashes mid-flight.
+    audit_event(
+        db,
+        actor_user_id=actor_user_id,
+        target_connector_id=connector.id,
+        event_type=AUDIT_HEALTH_CHECK,
+    )
+
+    adapter_cls = get_adapter_class(connector.connector_type)
+    adapter = adapter_cls(connector)
+
+    now = utcnow()
+    connector.last_health_check_at = now
+
+    was_active = connector.status == STATUS_ACTIVE
+
+    try:
+        await adapter.health_check()
+    except AuthInvalid:
+        connector.last_health_check_status = HEALTH_CHECK_AUTH_INVALID
+        flipped = False
+        if connector.status != STATUS_DISABLED:
+            if was_active:
+                flipped = True
+            connector.status = STATUS_AUTH_INVALID
+            connector.last_error = "auth_invalid"
+        audit_event(
+            db,
+            actor_user_id=actor_user_id,
+            target_connector_id=connector.id,
+            event_type=AUDIT_AUTH_INVALID_OBSERVED,
+        )
+        if flipped:
+            # Distinct event so admins can filter "monitor caught a break"
+            # separately from the "every check fires AUDIT_HEALTH_CHECK" noise.
+            audit_event(
+                db,
+                actor_user_id=actor_user_id,
+                target_connector_id=connector.id,
+                event_type=AUDIT_HEALTH_CHECK_FAILED,
+            )
+        return HealthCheckOutcome(
+            ok=False,
+            status=HEALTH_CHECK_AUTH_INVALID,
+            error_code="auth_invalid",
+            status_flipped_to_auth_invalid=flipped,
+        )
+    except RateLimited:
+        # Transient — don't flip status. Record the outcome and move on.
+        connector.last_health_check_status = HEALTH_CHECK_RATE_LIMITED
+        return HealthCheckOutcome(
+            ok=False, status=HEALTH_CHECK_RATE_LIMITED, error_code="rate_limited"
+        )
+    except QuotaExceeded:
+        connector.last_health_check_status = HEALTH_CHECK_QUOTA_EXCEEDED
+        return HealthCheckOutcome(
+            ok=False, status=HEALTH_CHECK_QUOTA_EXCEEDED, error_code="quota_exceeded"
+        )
+    except ProviderUnavailable:
+        connector.last_health_check_status = HEALTH_CHECK_PROVIDER_UNAVAILABLE
+        return HealthCheckOutcome(
+            ok=False,
+            status=HEALTH_CHECK_PROVIDER_UNAVAILABLE,
+            error_code="provider_unavailable",
+        )
+    except Exception:  # noqa: BLE001 — adapter contract is broad; sanitised below
+        # Don't leak the upstream exception text — it may include API keys.
+        logger.exception("Connector health check failed unexpectedly")
+        connector.last_health_check_status = HEALTH_CHECK_ERROR
+        return HealthCheckOutcome(ok=False, status=HEALTH_CHECK_ERROR, error_code="unknown")
+
+    # Success path
+    connector.last_health_check_status = HEALTH_CHECK_OK
+    connector.last_error = None
+    # Clear auth_invalid on a successful check (mirrors test_connector behavior).
+    if connector.status == STATUS_AUTH_INVALID:
+        connector.status = STATUS_ACTIVE
+    return HealthCheckOutcome(ok=True, status=HEALTH_CHECK_OK)

--- a/server/app/services/llm/health_monitor.py
+++ b/server/app/services/llm/health_monitor.py
@@ -1,0 +1,261 @@
+"""Background connector health monitor (issue #340).
+
+Scheduled task that periodically runs ``health_check`` on every
+``status="active"`` connector to catch expired / revoked credentials before
+a DJ tries to use one mid-event.
+
+Design:
+- Loop wakes every ``HEALTH_MONITOR_SCAN_INTERVAL_SECONDS`` (5 min).
+- For each active connector whose ``last_health_check_at`` is older than
+  ``effective_interval_seconds(connector)`` ago, run a check.
+- Per-connector jitter (±30%) staggers checks so a fleet of N connectors
+  doesn't all hit one provider at once (avoid a thundering-herd 429).
+- Sequential within a pass: one connector at a time, with a small sleep
+  between calls, so we respect per-provider rate limits even when all DJs
+  share a single upstream account.
+- On a transition active → auth_invalid, notify the DJ:
+    1. Email via Resend if configured AND the user has an email.
+    2. Otherwise, log a warning.
+  The flipped status itself is the in-app banner (the DJ's /settings/ai page
+  surfaces ``status`` per connector, and the recommendation engine raises
+  ``NoLlmConfigured`` when no active connector exists).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import logging
+import os
+
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.models.llm_connector import STATUS_ACTIVE, LlmConnector
+from app.models.user import User
+from app.services.llm.health_check import HealthCheckOutcome, run_health_check
+
+logger = logging.getLogger(__name__)
+
+# Default check interval in hours; overridable via env var
+# ``LLM_HEALTH_CHECK_INTERVAL_HOURS``. Six hours = four checks per day, which
+# is well under any provider's per-key rate limit but still catches breakage
+# inside a single working day.
+_DEFAULT_INTERVAL_HOURS = 6
+_HEALTH_CHECK_INTERVAL_HOURS_ENV = "LLM_HEALTH_CHECK_INTERVAL_HOURS"
+
+# How often the loop wakes to look for due connectors. Shorter than the
+# interval so jitter is smooth; the cost is one tiny SELECT per scan.
+HEALTH_MONITOR_SCAN_INTERVAL_SECONDS = 300
+
+# Sleep between consecutive health-check calls within a single scan pass.
+# Spreads load across the upstream providers and limits the per-DJ impact of
+# the monitor when many connectors are due at once.
+_PER_CHECK_SLEEP_SECONDS = 1.0
+
+
+def _get_interval_seconds() -> int:
+    """Read the configured interval from the env, clamped to safe bounds.
+
+    A non-positive or absurdly large value falls back to the default so a
+    misconfigured ``.env`` can never disable the monitor or DoS providers.
+    """
+    raw = os.environ.get(_HEALTH_CHECK_INTERVAL_HOURS_ENV)
+    if not raw:
+        hours = _DEFAULT_INTERVAL_HOURS
+    else:
+        try:
+            hours = int(raw)
+        except ValueError:
+            logger.warning(
+                "Invalid %s=%r; falling back to %s",
+                _HEALTH_CHECK_INTERVAL_HOURS_ENV,
+                raw,
+                _DEFAULT_INTERVAL_HOURS,
+            )
+            hours = _DEFAULT_INTERVAL_HOURS
+    # Floor: 1 hour (faster = wastes upstream rate limit).
+    # Ceiling: 168 hours / 7 days (slower = defeats the purpose).
+    hours = max(1, min(168, hours))
+    return hours * 3600
+
+
+def _jitter_factor(connector_id: int) -> float:
+    """Per-connector deterministic jitter in [0.7, 1.3].
+
+    Deterministic-by-id so successive scans don't reshuffle the schedule on
+    every wake (which would mean some connectors get hit far more often than
+    intended). The hash spreads connectors uniformly across the 30% band.
+    """
+    # SHA-256 is overkill cryptographically, but it's already in the stdlib
+    # and gives a clean uniform distribution. The first 4 bytes are plenty.
+    h = hashlib.sha256(str(connector_id).encode("ascii")).digest()
+    n = int.from_bytes(h[:4], "big")
+    # Map [0, 2**32) → [0, 1)
+    frac = n / float(1 << 32)
+    # Map [0, 1) → [0.7, 1.3)
+    return 0.7 + (frac * 0.6)
+
+
+def effective_interval_seconds(connector: LlmConnector) -> int:
+    """Effective check interval for ``connector`` (base × per-connector jitter)."""
+    return int(_get_interval_seconds() * _jitter_factor(connector.id))
+
+
+def _is_due(connector: LlmConnector) -> bool:
+    """True iff ``connector`` is overdue for a periodic health check."""
+    if connector.last_health_check_at is None:
+        return True
+    elapsed = (utcnow() - connector.last_health_check_at).total_seconds()
+    return elapsed >= effective_interval_seconds(connector)
+
+
+def _select_due_connectors(db: Session) -> list[LlmConnector]:
+    """Return active connectors whose last check is older than their effective interval.
+
+    Filtering ``status == STATUS_ACTIVE`` cheaply in SQL avoids reading
+    disabled rows. The per-row jitter calculation is done in Python because
+    SQLite (used in tests) lacks a stable hash function.
+    """
+    active = (
+        db.query(LlmConnector)
+        .filter(LlmConnector.status == STATUS_ACTIVE)
+        .order_by(LlmConnector.last_health_check_at.asc().nulls_first())
+        .all()
+    )
+    return [c for c in active if _is_due(c)]
+
+
+def _notify_dj_auth_invalid(db: Session, connector: LlmConnector) -> None:
+    """Best-effort email notification when the monitor flips a connector to auth_invalid.
+
+    Channels tried (in order):
+    1. Email via Resend, if the user has a non-empty ``email`` AND Resend is
+       configured (the sender raises ``EmailNotConfiguredError`` otherwise).
+    2. Logs at WARNING. The connector's flipped status itself surfaces in
+       the DJ's settings UI on next login.
+
+    Never raises — notification failures must not block subsequent health
+    checks in the same pass.
+    """
+    try:
+        user = db.get(User, connector.user_id)
+    except Exception:  # noqa: BLE001 — defensive: DB hiccup must not kill the loop
+        logger.exception("health monitor: failed to load user for connector %s", connector.id)
+        user = None
+
+    if user is None or not user.email:
+        logger.warning(
+            "health monitor: connector %s (user_id=%s) flipped to auth_invalid; "
+            "no email on file — DJ will see the banner on next login.",
+            connector.id,
+            connector.user_id,
+        )
+        return
+
+    try:
+        from app.services.email_sender import (
+            EmailNotConfiguredError,
+            EmailSendError,
+            send_connector_auth_invalid_notification,
+        )
+
+        send_connector_auth_invalid_notification(
+            to_address=user.email,
+            display_name=connector.display_name,
+            connector_type=connector.connector_type,
+        )
+    except EmailNotConfiguredError:
+        logger.warning(
+            "health monitor: connector %s flipped to auth_invalid; "
+            "email not configured — DJ will see the banner on next login.",
+            connector.id,
+        )
+    except EmailSendError:
+        logger.exception(
+            "health monitor: failed to send auth_invalid email for connector %s",
+            connector.id,
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "health monitor: unexpected error notifying DJ of connector %s",
+            connector.id,
+        )
+
+
+async def _check_one(db: Session, connector: LlmConnector) -> HealthCheckOutcome:
+    """Run a health check on ``connector``, commit, and notify if it just broke.
+
+    The audit row is written with ``actor_user_id = connector.user_id``
+    because the periodic check is *on behalf of* the DJ (vs the manual test
+    button, where the actor is whoever clicked it). This keeps the audit
+    trail attributable.
+    """
+    outcome = await run_health_check(db, connector, actor_user_id=connector.user_id)
+    db.commit()
+    if outcome.status_flipped_to_auth_invalid:
+        _notify_dj_auth_invalid(db, connector)
+    return outcome
+
+
+async def run_monitor_pass(db: Session) -> int:
+    """Run one full pass of the monitor: check every due connector.
+
+    Returns the number of connectors checked. Exposed for tests and for the
+    background loop. Sequential — see module docstring.
+    """
+    due = _select_due_connectors(db)
+    if not due:
+        return 0
+
+    checked = 0
+    for connector in due:
+        try:
+            await _check_one(db, connector)
+        except Exception:  # noqa: BLE001 — keep the loop alive
+            logger.exception("health monitor: error checking connector %s", connector.id)
+            # Defensive: rollback any half-applied state from the failed check
+            # so the next connector starts on a clean session.
+            with contextlib.suppress(Exception):
+                db.rollback()
+        checked += 1
+        if _PER_CHECK_SLEEP_SECONDS > 0 and checked < len(due):
+            await asyncio.sleep(_PER_CHECK_SLEEP_SECONDS)
+    return checked
+
+
+def _run_monitor_pass_sync() -> int:
+    """Synchronous wrapper for ``run_monitor_pass`` used by the background loop.
+
+    Each pass opens its own ``SessionLocal`` so the loop doesn't hold a
+    long-lived connection between scans. ``asyncio.run`` is fine here
+    because this function is executed in ``asyncio.to_thread`` from the
+    main event loop, not on the loop thread itself.
+    """
+    from app.db.session import SessionLocal
+
+    db = SessionLocal()
+    try:
+        return asyncio.run(run_monitor_pass(db))
+    finally:
+        db.close()
+
+
+async def health_monitor_loop() -> None:
+    """Background task — runs forever, scanning every ``HEALTH_MONITOR_SCAN_INTERVAL_SECONDS``.
+
+    Wrapped in a try/except so a single bug doesn't kill the loop; logs the
+    exception and sleeps before retrying.
+    """
+    # First sleep before first pass so startup isn't blocked by N upstream
+    # round-trips on cold boot.
+    await asyncio.sleep(HEALTH_MONITOR_SCAN_INTERVAL_SECONDS)
+    while True:
+        try:
+            checked = await asyncio.to_thread(_run_monitor_pass_sync)
+            if checked:
+                logger.info("llm health monitor pass: checked %s connectors", checked)
+        except Exception:  # noqa: BLE001 — loop must survive any error
+            logger.exception("llm health monitor loop error")
+        await asyncio.sleep(HEALTH_MONITOR_SCAN_INTERVAL_SECONDS)

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -265,6 +265,37 @@
             ],
             "title": "Last Error"
           },
+          "last_health_check_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Health Check At"
+          },
+          "last_health_check_status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "ok",
+                  "auth_invalid",
+                  "rate_limited",
+                  "quota_exceeded",
+                  "provider_unavailable",
+                  "error"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Health Check Status"
+          },
           "last_used_at": {
             "anyOf": [
               {
@@ -316,6 +347,8 @@
           "id",
           "is_default",
           "last_error",
+          "last_health_check_at",
+          "last_health_check_status",
           "last_used_at",
           "model_hint",
           "status",
@@ -2375,6 +2408,37 @@
             ],
             "title": "Last Error"
           },
+          "last_health_check_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Health Check At"
+          },
+          "last_health_check_status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "ok",
+                  "auth_invalid",
+                  "rate_limited",
+                  "quota_exceeded",
+                  "provider_unavailable",
+                  "error"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Health Check Status"
+          },
           "last_used_at": {
             "anyOf": [
               {
@@ -2425,6 +2489,8 @@
           "id",
           "is_default",
           "last_error",
+          "last_health_check_at",
+          "last_health_check_status",
           "last_used_at",
           "model_hint",
           "status",
@@ -10753,6 +10819,7 @@
     },
     "/api/llm/connectors/{connector_id}/test": {
       "post": {
+        "description": "Run a health check and return a sanitised result.\n\nBehaviour identical to the background monitor (issue #340), so the\n``last_health_check_at`` / ``last_health_check_status`` columns and audit\nrows are written the same way on every invocation regardless of trigger\nsource. See ``services/llm/health_check.py`` for the shared helper.",
         "operationId": "test_connector_api_llm_connectors__connector_id__test_post",
         "parameters": [
           {

--- a/server/tests/test_llm_health_check.py
+++ b/server/tests/test_llm_health_check.py
@@ -1,0 +1,304 @@
+"""Tests for the shared connector health-check helper (issues #340 + #346).
+
+Covers:
+- ``last_health_check_at`` / ``last_health_check_status`` are written on every
+  invocation (success and failure).
+- AuthInvalid flips ``status`` to ``auth_invalid`` and writes the
+  ``connector_health_check_failed`` audit row only on the active→invalid
+  transition (not when already invalid).
+- Transient failures (rate_limited, provider_unavailable, quota_exceeded) do
+  NOT flip the connector status — they only record the outcome.
+- The manual /test endpoint produces the same observability columns and
+  audit rows as the background monitor (no behavior drift between the two).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.time import utcnow
+from app.models.llm_connector import (
+    AUDIT_AUTH_INVALID_OBSERVED,
+    AUDIT_HEALTH_CHECK,
+    AUDIT_HEALTH_CHECK_FAILED,
+    HEALTH_CHECK_AUTH_INVALID,
+    HEALTH_CHECK_ERROR,
+    HEALTH_CHECK_OK,
+    HEALTH_CHECK_PROVIDER_UNAVAILABLE,
+    HEALTH_CHECK_QUOTA_EXCEEDED,
+    HEALTH_CHECK_RATE_LIMITED,
+    STATUS_ACTIVE,
+    STATUS_AUTH_INVALID,
+    STATUS_DISABLED,
+    LlmAuditEvent,
+    LlmConnector,
+)
+from app.services.llm.exceptions import (
+    AuthInvalid,
+    ProviderUnavailable,
+    QuotaExceeded,
+    RateLimited,
+)
+
+
+def _make_connector(db, user_id: int, *, status: str = STATUS_ACTIVE) -> LlmConnector:
+    row = LlmConnector(
+        user_id=user_id,
+        connector_type="openai_apikey",
+        display_name="Tested",
+        status=status,
+        credentials=json.dumps({"api_key": "sk-key12345678901234567890"}),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _audit_types(db, connector_id: int) -> list[str]:
+    rows = (
+        db.query(LlmAuditEvent)
+        .filter(LlmAuditEvent.target_connector_id == connector_id)
+        .order_by(LlmAuditEvent.id.asc())
+        .all()
+    )
+    return [r.event_type for r in rows]
+
+
+# ---------- helper API (shared between manual + background) ----------
+
+
+class TestRunHealthCheckHelper:
+    @pytest.mark.asyncio
+    async def test_success_writes_columns_and_audit(self, db, test_user):
+        from app.services.llm.health_check import run_health_check
+
+        row = _make_connector(db, test_user.id)
+        before = utcnow() - timedelta(seconds=1)
+
+        with patch(
+            "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+            new=AsyncMock(return_value=None),
+        ):
+            outcome = await run_health_check(db, row, actor_user_id=test_user.id)
+        db.commit()
+
+        assert outcome.ok is True
+        assert outcome.status == HEALTH_CHECK_OK
+        assert outcome.status_flipped_to_auth_invalid is False
+
+        db.refresh(row)
+        assert row.last_health_check_status == HEALTH_CHECK_OK
+        assert row.last_health_check_at is not None
+        assert row.last_health_check_at >= before
+        assert row.status == STATUS_ACTIVE
+        assert row.last_error is None
+
+        assert _audit_types(db, row.id) == [AUDIT_HEALTH_CHECK]
+
+    @pytest.mark.asyncio
+    async def test_auth_invalid_flips_status_and_emits_flipped_audit(self, db, test_user):
+        from app.services.llm.health_check import run_health_check
+
+        row = _make_connector(db, test_user.id, status=STATUS_ACTIVE)
+
+        with patch(
+            "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+            new=AsyncMock(side_effect=AuthInvalid("nope")),
+        ):
+            outcome = await run_health_check(db, row, actor_user_id=test_user.id)
+        db.commit()
+
+        assert outcome.ok is False
+        assert outcome.status == HEALTH_CHECK_AUTH_INVALID
+        assert outcome.status_flipped_to_auth_invalid is True
+
+        db.refresh(row)
+        assert row.status == STATUS_AUTH_INVALID
+        assert row.last_health_check_status == HEALTH_CHECK_AUTH_INVALID
+        assert row.last_error == "auth_invalid"
+
+        types = _audit_types(db, row.id)
+        assert AUDIT_HEALTH_CHECK in types
+        assert AUDIT_AUTH_INVALID_OBSERVED in types
+        assert AUDIT_HEALTH_CHECK_FAILED in types
+
+    @pytest.mark.asyncio
+    async def test_auth_invalid_does_not_re_emit_flipped_when_already_invalid(self, db, test_user):
+        from app.services.llm.health_check import run_health_check
+
+        row = _make_connector(db, test_user.id, status=STATUS_AUTH_INVALID)
+
+        with patch(
+            "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+            new=AsyncMock(side_effect=AuthInvalid("still broken")),
+        ):
+            outcome = await run_health_check(db, row, actor_user_id=test_user.id)
+        db.commit()
+
+        assert outcome.status_flipped_to_auth_invalid is False
+        db.refresh(row)
+        assert row.status == STATUS_AUTH_INVALID
+        # health_check_failed should NOT be present — already broken on prior pass.
+        types = _audit_types(db, row.id)
+        assert AUDIT_HEALTH_CHECK_FAILED not in types
+
+    @pytest.mark.asyncio
+    async def test_auth_invalid_leaves_disabled_connector_disabled(self, db, test_user):
+        from app.services.llm.health_check import run_health_check
+
+        row = _make_connector(db, test_user.id, status=STATUS_DISABLED)
+
+        with patch(
+            "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+            new=AsyncMock(side_effect=AuthInvalid("nope")),
+        ):
+            await run_health_check(db, row, actor_user_id=test_user.id)
+        db.commit()
+
+        db.refresh(row)
+        # Disabled must stay disabled — admin force-revoke takes precedence.
+        assert row.status == STATUS_DISABLED
+
+    @pytest.mark.parametrize(
+        ("exc", "expected_status"),
+        [
+            (RateLimited("slow down"), HEALTH_CHECK_RATE_LIMITED),
+            (QuotaExceeded("quota"), HEALTH_CHECK_QUOTA_EXCEEDED),
+            (ProviderUnavailable("5xx"), HEALTH_CHECK_PROVIDER_UNAVAILABLE),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_transient_failures_record_outcome_but_do_not_flip_status(
+        self, db, test_user, exc, expected_status
+    ):
+        from app.services.llm.health_check import run_health_check
+
+        row = _make_connector(db, test_user.id, status=STATUS_ACTIVE)
+
+        with patch(
+            "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+            new=AsyncMock(side_effect=exc),
+        ):
+            outcome = await run_health_check(db, row, actor_user_id=test_user.id)
+        db.commit()
+
+        assert outcome.ok is False
+        assert outcome.status == expected_status
+
+        db.refresh(row)
+        # Transient — status stays active so the gateway will still try it.
+        assert row.status == STATUS_ACTIVE
+        assert row.last_health_check_status == expected_status
+
+    @pytest.mark.asyncio
+    async def test_unexpected_exception_records_error_and_does_not_raise(self, db, test_user):
+        from app.services.llm.health_check import run_health_check
+
+        row = _make_connector(db, test_user.id, status=STATUS_ACTIVE)
+
+        with patch(
+            "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+            new=AsyncMock(side_effect=RuntimeError("totally unexpected")),
+        ):
+            outcome = await run_health_check(db, row, actor_user_id=test_user.id)
+        db.commit()
+
+        assert outcome.ok is False
+        assert outcome.status == HEALTH_CHECK_ERROR
+        db.refresh(row)
+        # Status not flipped on truly unknown errors — DJ retries.
+        assert row.status == STATUS_ACTIVE
+        assert row.last_health_check_status == HEALTH_CHECK_ERROR
+
+    @pytest.mark.asyncio
+    async def test_success_after_auth_invalid_clears_status(self, db, test_user):
+        from app.services.llm.health_check import run_health_check
+
+        row = _make_connector(db, test_user.id, status=STATUS_AUTH_INVALID)
+        row.last_error = "auth_invalid"
+        db.commit()
+
+        with patch(
+            "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+            new=AsyncMock(return_value=None),
+        ):
+            outcome = await run_health_check(db, row, actor_user_id=test_user.id)
+        db.commit()
+
+        assert outcome.ok is True
+        db.refresh(row)
+        assert row.status == STATUS_ACTIVE
+        assert row.last_error is None
+        assert row.last_health_check_status == HEALTH_CHECK_OK
+
+
+# ---------- manual /test endpoint parity ----------
+
+
+class TestManualTestEndpointParity:
+    """The DJ-triggered test button must produce the same observability + audit
+    rows as the background monitor — that's the whole point of issue #346.
+    """
+
+    def test_test_endpoint_writes_health_columns_on_success(
+        self, client: TestClient, auth_headers, db, test_user
+    ):
+        row = _make_connector(db, test_user.id)
+
+        with patch(
+            "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+            new=AsyncMock(return_value=None),
+        ):
+            resp = client.post(f"/api/llm/connectors/{row.id}/test", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+        db.refresh(row)
+        assert row.last_health_check_status == HEALTH_CHECK_OK
+        assert row.last_health_check_at is not None
+        assert AUDIT_HEALTH_CHECK in _audit_types(db, row.id)
+
+    def test_test_endpoint_writes_health_columns_on_auth_invalid(
+        self, client: TestClient, auth_headers, db, test_user
+    ):
+        row = _make_connector(db, test_user.id)
+
+        with patch(
+            "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+            new=AsyncMock(side_effect=AuthInvalid("nope")),
+        ):
+            resp = client.post(f"/api/llm/connectors/{row.id}/test", headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is False
+        assert body["error_code"] == "auth_invalid"
+
+        db.refresh(row)
+        assert row.status == STATUS_AUTH_INVALID
+        assert row.last_health_check_status == HEALTH_CHECK_AUTH_INVALID
+
+    def test_test_endpoint_response_exposes_new_columns_via_listing(
+        self, client: TestClient, auth_headers, db, test_user
+    ):
+        row = _make_connector(db, test_user.id)
+
+        with patch(
+            "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+            new=AsyncMock(return_value=None),
+        ):
+            client.post(f"/api/llm/connectors/{row.id}/test", headers=auth_headers)
+
+        # The DJ listing now exposes the two new columns
+        resp = client.get("/api/llm/connectors", headers=auth_headers)
+        assert resp.status_code == 200
+        entries = resp.json()
+        assert len(entries) == 1
+        e = entries[0]
+        assert e["last_health_check_status"] == HEALTH_CHECK_OK
+        assert e["last_health_check_at"] is not None

--- a/server/tests/test_llm_health_monitor.py
+++ b/server/tests/test_llm_health_monitor.py
@@ -1,0 +1,301 @@
+"""Tests for the background connector health monitor (issue #340).
+
+Covers:
+- Only active connectors that are overdue get checked.
+- Disabled / fresh connectors are skipped.
+- A successful pass writes ``last_health_check_at`` on each due connector.
+- A flip from active → auth_invalid triggers a notification.
+- A pass survives an adapter exception on one connector and keeps going.
+- Per-connector jitter is deterministic so the schedule doesn't shuffle.
+- The env-var interval is clamped to safe bounds.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core.time import utcnow
+from app.models.llm_connector import (
+    HEALTH_CHECK_AUTH_INVALID,
+    HEALTH_CHECK_OK,
+    STATUS_ACTIVE,
+    STATUS_AUTH_INVALID,
+    STATUS_DISABLED,
+    LlmConnector,
+)
+from app.services.llm.exceptions import AuthInvalid
+from app.services.llm.health_monitor import (
+    _get_interval_seconds,
+    _is_due,
+    _jitter_factor,
+    _select_due_connectors,
+    run_monitor_pass,
+)
+
+_counter = {"n": 0}
+
+
+def _make(db, user_id: int, *, status: str = STATUS_ACTIVE, last_check: object = None):
+    _counter["n"] += 1
+    row = LlmConnector(
+        user_id=user_id,
+        connector_type="openai_apikey",
+        display_name=f"user{user_id}-conn-{_counter['n']}",
+        status=status,
+        credentials=json.dumps({"api_key": "sk-key12345678901234567890"}),
+        last_health_check_at=last_check,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+# ---------- env-var interval ----------
+
+
+class TestIntervalConfig:
+    def test_default_interval_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("LLM_HEALTH_CHECK_INTERVAL_HOURS", raising=False)
+        assert _get_interval_seconds() == 6 * 3600
+
+    def test_env_override_applied(self, monkeypatch):
+        monkeypatch.setenv("LLM_HEALTH_CHECK_INTERVAL_HOURS", "12")
+        assert _get_interval_seconds() == 12 * 3600
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("LLM_HEALTH_CHECK_INTERVAL_HOURS", "not-a-number")
+        assert _get_interval_seconds() == 6 * 3600
+
+    def test_too_low_clamped_to_floor(self, monkeypatch):
+        monkeypatch.setenv("LLM_HEALTH_CHECK_INTERVAL_HOURS", "0")
+        assert _get_interval_seconds() == 3600  # 1h floor
+
+    def test_too_high_clamped_to_ceiling(self, monkeypatch):
+        monkeypatch.setenv("LLM_HEALTH_CHECK_INTERVAL_HOURS", "9999")
+        assert _get_interval_seconds() == 168 * 3600  # 7d ceiling
+
+
+# ---------- jitter ----------
+
+
+class TestJitter:
+    def test_jitter_is_deterministic_per_id(self):
+        assert _jitter_factor(1) == _jitter_factor(1)
+        assert _jitter_factor(42) == _jitter_factor(42)
+
+    def test_jitter_within_bounds(self):
+        # All factors in [0.7, 1.3) per the docstring contract.
+        for i in range(1, 100):
+            f = _jitter_factor(i)
+            assert 0.7 <= f < 1.3
+
+    def test_jitter_spreads_connectors(self):
+        # Sample a few hundred ids — the band should be reasonably populated
+        # (not all clumped at one end).
+        factors = [_jitter_factor(i) for i in range(1, 300)]
+        low = sum(1 for f in factors if f < 1.0)
+        high = sum(1 for f in factors if f >= 1.0)
+        # Not a statistics test — just confirms the hash isn't a constant.
+        assert low > 50
+        assert high > 50
+
+
+# ---------- _is_due / _select_due_connectors ----------
+
+
+class TestDueSelection:
+    def test_never_checked_is_due(self, db, test_user):
+        row = _make(db, test_user.id, last_check=None)
+        assert _is_due(row) is True
+
+    def test_recently_checked_is_not_due(self, db, test_user):
+        row = _make(db, test_user.id, last_check=utcnow() - timedelta(minutes=5))
+        assert _is_due(row) is False
+
+    def test_overdue_is_due(self, db, test_user, monkeypatch):
+        # Force a tight interval so overdue triggers reliably regardless of jitter.
+        monkeypatch.setenv("LLM_HEALTH_CHECK_INTERVAL_HOURS", "1")
+        row = _make(db, test_user.id, last_check=utcnow() - timedelta(hours=24))
+        assert _is_due(row) is True
+
+    def test_select_due_skips_disabled(self, db, test_user):
+        active = _make(db, test_user.id, status=STATUS_ACTIVE, last_check=None)
+        _make(db, test_user.id, status=STATUS_DISABLED, last_check=None)
+        _make(db, test_user.id, status=STATUS_AUTH_INVALID, last_check=None)
+
+        due = _select_due_connectors(db)
+        due_ids = [c.id for c in due]
+        assert active.id in due_ids
+        # auth_invalid + disabled are excluded — the monitor only re-checks
+        # active connectors. (auth_invalid stays invalid until the DJ rotates.)
+        assert len(due) == 1
+
+
+# ---------- run_monitor_pass ----------
+
+
+@pytest.mark.asyncio
+async def test_monitor_pass_checks_every_due_connector(db, test_user):
+    a = _make(db, test_user.id, last_check=None)
+    b = _make(db, test_user.id, last_check=None)
+    c = _make(db, test_user.id, status=STATUS_DISABLED, last_check=None)
+
+    with (
+        patch(
+            "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.llm.health_monitor._PER_CHECK_SLEEP_SECONDS",
+            0,
+        ),
+    ):
+        checked = await run_monitor_pass(db)
+
+    assert checked == 2
+    db.refresh(a)
+    db.refresh(b)
+    db.refresh(c)
+    assert a.last_health_check_status == HEALTH_CHECK_OK
+    assert b.last_health_check_status == HEALTH_CHECK_OK
+    assert c.last_health_check_at is None  # disabled — skipped
+
+
+@pytest.mark.asyncio
+async def test_monitor_pass_notifies_on_first_flip_to_auth_invalid(db, test_user):
+    row = _make(db, test_user.id, last_check=None)
+
+    with (
+        patch(
+            "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+            new=AsyncMock(side_effect=AuthInvalid("revoked upstream")),
+        ),
+        patch(
+            "app.services.llm.health_monitor._PER_CHECK_SLEEP_SECONDS",
+            0,
+        ),
+        patch(
+            "app.services.llm.health_monitor._notify_dj_auth_invalid",
+        ) as notify,
+    ):
+        await run_monitor_pass(db)
+
+    db.refresh(row)
+    assert row.status == STATUS_AUTH_INVALID
+    assert row.last_health_check_status == HEALTH_CHECK_AUTH_INVALID
+    notify.assert_called_once()
+    notified_connector = notify.call_args.args[1]
+    assert notified_connector.id == row.id
+
+
+@pytest.mark.asyncio
+async def test_monitor_pass_survives_individual_failure(db, test_user):
+    good = _make(db, test_user.id, last_check=None)
+    bad = _make(db, test_user.id, last_check=None)
+
+    call_count = {"n": 0}
+
+    async def fake_check(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("first one explodes")
+        return None
+
+    with (
+        patch(
+            "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+            new=fake_check,
+        ),
+        patch(
+            "app.services.llm.health_monitor._PER_CHECK_SLEEP_SECONDS",
+            0,
+        ),
+    ):
+        checked = await run_monitor_pass(db)
+
+    # Both checks were attempted (even after the first one's adapter raised).
+    assert checked == 2
+    # At least one of the two was successfully updated.
+    db.refresh(good)
+    db.refresh(bad)
+    statuses = [good.last_health_check_status, bad.last_health_check_status]
+    assert HEALTH_CHECK_OK in statuses
+
+
+@pytest.mark.asyncio
+async def test_monitor_pass_no_due_connectors_returns_zero(db, test_user):
+    # Just-checked connector — not due.
+    _make(db, test_user.id, last_check=utcnow() - timedelta(minutes=1))
+
+    with patch(
+        "app.services.llm.adapters.openai_apikey.OpenAIApiKeyAdapter.health_check",
+        new=AsyncMock(return_value=None),
+    ):
+        checked = await run_monitor_pass(db)
+    assert checked == 0
+
+
+# ---------- notification ----------
+
+
+def test_notify_dj_falls_back_to_log_when_email_not_configured(db, test_user, caplog):
+    from app.services.email_sender import EmailNotConfiguredError
+    from app.services.llm.health_monitor import _notify_dj_auth_invalid
+
+    # User HAS an email — the failure is at the sender layer (no Resend key).
+    test_user.email = "dj@example.com"
+    db.commit()
+    row = _make(db, test_user.id)
+
+    with patch(
+        "app.services.email_sender.send_connector_auth_invalid_notification",
+        side_effect=EmailNotConfiguredError("nope"),
+    ):
+        with caplog.at_level("WARNING"):
+            _notify_dj_auth_invalid(db, row)
+
+    assert any("email not configured" in r.message.lower() for r in caplog.records)
+
+
+def test_notify_dj_logs_when_user_has_no_email(db, caplog):
+    from app.models.user import User
+    from app.services.llm.health_monitor import _notify_dj_auth_invalid
+
+    user_noemail = User(
+        username="silent",
+        password_hash="x",
+        email=None,
+        role="dj",
+    )
+    db.add(user_noemail)
+    db.commit()
+    db.refresh(user_noemail)
+    row = _make(db, user_noemail.id)
+
+    with caplog.at_level("WARNING"):
+        _notify_dj_auth_invalid(db, row)
+    assert any("no email on file" in r.message.lower() for r in caplog.records)
+
+
+def test_notify_dj_sends_email_when_configured(db, test_user):
+    from app.services.llm.health_monitor import _notify_dj_auth_invalid
+
+    test_user.email = "dj@example.com"
+    db.commit()
+    row = _make(db, test_user.id)
+
+    with patch(
+        "app.services.email_sender.send_connector_auth_invalid_notification",
+    ) as sender:
+        _notify_dj_auth_invalid(db, row)
+
+    sender.assert_called_once()
+    kwargs = sender.call_args.kwargs
+    assert kwargs["to_address"] == "dj@example.com"
+    assert kwargs["display_name"] == row.display_name
+    assert kwargs["connector_type"] == row.connector_type


### PR DESCRIPTION
## Summary

- Background task periodically runs `health_check` on every active LLM connector to catch expired/revoked credentials before a DJ tries to use one mid-event.
- Adds two columns to `llm_connectors` — `last_health_check_at` + `last_health_check_status` — populated by **both** the DJ-triggered Test button and the background monitor (no behaviour drift between manual and periodic checks).
- Surfaces the new columns in the admin per-DJ connectors table with a colour-coded status badge and sortable headers; default-sort is most-recently-checked first.

Closes #340
Closes #346

## Why combined

Both issues add the **same two columns** to `llm_connectors`. Splitting them across two PRs guarantees an Alembic collision (047→048 from each PR with conflicting downgrades). This PR ships the schema, the monitor, and the admin surface atomically so the epic branch never sees a half-state.

## Design decisions

- **Notification channel** — Reuse the existing `services/email_sender.py` Resend wiring. New helper `send_connector_auth_invalid_notification(to, display_name, connector_type)` sends a no-credentials email when the monitor flips a connector to `auth_invalid`. Falls back to a `WARNING` log entry when the DJ has no email on file **or** Resend isn't configured. The connector's flipped `status` itself is the in-app banner: `/settings/ai` (DJ) and `/admin/ai` (admin) already render `status` per row; no new `notifications` table introduced for MVP.
- **Notification gating** — Email is sent only on the **transition** active → auth_invalid (`HealthCheckOutcome.status_flipped_to_auth_invalid`). The monitor doesn't re-spam the DJ every 6 hours while a key is still broken.
- **Jitter** — Per-connector deterministic factor from `sha256(str(id))[:4]` mapped to `[0.7, 1.3)`. Deterministic-by-id so the schedule doesn't reshuffle every wake. The first 4 bytes of SHA-256 give a uniform spread across the 30% band.
- **Per-provider rate limits** — Sequential within a pass (no `asyncio.gather`), plus a 1.0s sleep between checks. Cheap and correct even when several DJs share one upstream account.
- **Interval clamp** — `LLM_HEALTH_CHECK_INTERVAL_HOURS` env var (default 6) is clamped to `[1, 168]` hours. A non-positive or absurdly large value falls back to the default so a misconfigured `.env` can never disable the monitor or DoS providers.
- **Disabled connectors** — Skipped entirely. The monitor only re-checks `status="active"`; `auth_invalid` rows stay invalid until the DJ rotates the key; `disabled` is admin-revoked and shouldn't be probed.
- **Audit trail** — Every check writes `connector_health_check` (already existed). On an active→auth_invalid transition the helper writes an extra `connector_health_check_failed` row so admins can filter the "moment of breakage" separately from per-pass noise.
- **No new schemas/columns for retries** — Transient failures (`rate_limited`, `quota_exceeded`, `provider_unavailable`) record the outcome on `last_health_check_status` but do **not** flip `status`. The gateway will keep using the connector and the next periodic pass re-checks.

## Files of note

- `server/alembic/versions/048_llm_connector_health_check_columns.py` — single migration, both columns
- `server/app/services/llm/health_check.py` — shared helper (`run_health_check`) used by both code paths
- `server/app/services/llm/health_monitor.py` — background loop + jitter + per-connector check
- `server/app/main.py` — wires `health_monitor_loop` into the lifespan tasks
- `server/app/api/llm.py` — manual `/test` endpoint refactored to use the shared helper
- `server/app/services/email_sender.py` — new `send_connector_auth_invalid_notification`
- `dashboard/app/admin/ai/page.tsx` — sortable headers, `HealthBadge` component, new columns

## Test plan

- [x] `pytest --tb=short -q` — 2353 passed, 87.28% coverage
- [x] `npm test -- --run` (dashboard) — 961 passed
- [x] `npx tsc --noEmit` — both `dashboard/` and `bridge`/`bridge-app`
- [x] `ruff check . && ruff format --check .` — clean
- [x] `bandit -r app -c pyproject.toml -q` — no new findings
- [x] `alembic upgrade head && alembic check` — no drift
- [x] OpenAPI regenerated; no TS type drift
- [ ] Manual smoke: run the app with an intentionally-bad API key and verify the monitor flips the status within the configured interval

## CodeRabbit

Epic-branch PRs don't auto-trigger CodeRabbit. Will post `@coderabbitai review` as a follow-up comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health status monitoring for LLM connectors displaying timestamp and status.
  * New sortable "Last health check" column in the admin connectors table with status badges (OK, auth invalid, never checked).
  * Background health monitor periodically checks connector health automatically.
  * Email notifications alert DJs when connector authentication becomes invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->