### PR TITLE
refactor(llm): extract shared adapter helpers (wave 1/4)

### DIFF
--- a/server/app/services/llm/adapters/_httpx_openai.py
+++ b/server/app/services/llm/adapters/_httpx_openai.py
@@ -18,15 +18,14 @@ from typing import Any
 
 import httpx
 
+from app.services.llm.adapters._shared import raise_for_status
 from app.services.llm.base import ChatRequest, ChatResponse, Message
-from app.services.llm.exceptions import (
-    AuthInvalid,
-    ProviderUnavailable,
-    QuotaExceeded,
-    RateLimited,
-    ToolTranslationError,
+from app.services.llm.exceptions import ProviderUnavailable, ToolTranslationError
+from app.services.llm.tool_translation import (
+    content_to_text,
+    parse_openai_response,
+    to_openai_tools,
 )
-from app.services.llm.tool_translation import parse_openai_response, to_openai_tools
 
 logger = logging.getLogger(__name__)
 
@@ -41,32 +40,14 @@ def _messages_to_openai(req: ChatRequest) -> list[dict]:
         out.append({"role": "system", "content": req.system})
 
     for m in req.messages:
-        content = m.content
-        if isinstance(content, list):
-            # Concatenate text blocks — MVP is text-only. Blocks may be dicts
-            # (e.g. {"type": "text", "text": "..."}) or objects with a .text attr.
-            parts: list[str] = []
-            for b in content:
-                if isinstance(b, dict):
-                    parts.append(b.get("text") or "")
-                else:
-                    parts.append(getattr(b, "text", "") or "")
-            text = "".join(parts)
-        else:
-            text = content or ""
-
-        msg: dict[str, Any] = {"role": _normalise_role(m.role), "content": text}
+        # OpenAI uses identical role names for system/user/assistant/tool.
+        msg: dict[str, Any] = {"role": m.role, "content": content_to_text(m.content)}
         if m.role == "tool":
             if not m.tool_call_id:
                 raise ToolTranslationError("Tool result message missing tool_call_id")
             msg["tool_call_id"] = m.tool_call_id
         out.append(msg)
     return out
-
-
-def _normalise_role(role: str) -> str:
-    # OpenAI uses identical role names for system/user/assistant/tool.
-    return role
 
 
 def _build_payload(req: ChatRequest, model: str | None, *, max_tokens_field: str) -> dict:
@@ -133,7 +114,7 @@ async def call_openai_chat(
     except httpx.HTTPError as exc:
         raise ProviderUnavailable("Upstream network error") from exc
 
-    _raise_for_status(resp)
+    raise_for_status(resp)
 
     try:
         body = resp.json()
@@ -150,34 +131,6 @@ def _build_chat_endpoint(base_url: str) -> str:
     if base.endswith("/chat/completions"):
         return base
     return f"{base}/chat/completions"
-
-
-def _raise_for_status(resp: httpx.Response) -> None:
-    if 200 <= resp.status_code < 300:
-        return
-
-    code = resp.status_code
-    if code in (401, 403):
-        raise AuthInvalid(f"Auth failed (HTTP {code})")
-    if code == 402:
-        raise QuotaExceeded("Quota or billing failure (HTTP 402)")
-    if code == 429:
-        retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
-        raise RateLimited("Rate limited (HTTP 429)", retry_after_seconds=retry_after)
-    if 500 <= code < 600:
-        raise ProviderUnavailable(f"Upstream error (HTTP {code})")
-    # 4xx other than the above → treat as a malformed input / translation error
-    # since the gateway only emits known shapes.
-    raise ToolTranslationError(f"Upstream rejected request (HTTP {code})")
-
-
-def _parse_retry_after(value: str | None) -> int | None:
-    if not value:
-        return None
-    try:
-        return int(float(value))
-    except ValueError:
-        return None
 
 
 def build_healthcheck_request() -> ChatRequest:

--- a/server/app/services/llm/adapters/_shared.py
+++ b/server/app/services/llm/adapters/_shared.py
@@ -1,0 +1,103 @@
+"""Shared primitives for the httpx-backed LLM adapters.
+
+Centralises three pieces that were copy-pasted across the OpenAI-wire, Gemini
+and Bedrock adapters:
+
+- ``parse_retry_after`` — HTTP ``Retry-After`` header → ``int`` seconds.
+- ``raise_for_status`` — httpx status code → canonical typed exception.
+- ``extract_api_key`` / ``extract_fixed_base_credentials`` — parse the encrypted
+  ``{"api_key": "..."}`` credential blob.
+
+The Anthropic adapter talks to the official SDK (``APIStatusError``), not httpx,
+so it keeps its own status mapping; the two api-key extractors intentionally
+differ in how they treat a non-dict blob (see ``extract_fixed_base_credentials``)
+to preserve each adapter's established error message.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import httpx
+
+from app.services.llm.exceptions import (
+    AuthInvalid,
+    ProviderUnavailable,
+    QuotaExceeded,
+    RateLimited,
+    ToolTranslationError,
+)
+
+
+def parse_retry_after(value: str | None) -> int | None:
+    if not value:
+        return None
+    try:
+        return int(float(value))
+    except ValueError:
+        return None
+
+
+def raise_for_status(
+    resp: httpx.Response,
+    *,
+    throttle_detector: Callable[[httpx.Response], bool] | None = None,
+) -> None:
+    """Map a non-2xx httpx response to a canonical adapter exception.
+
+    ``throttle_detector`` lets Bedrock treat an HTTP 400 carrying a
+    ``ThrottlingException`` error-type header as rate-limiting; the default
+    ``None`` preserves the plain OpenAI/Gemini mapping.
+    """
+    if 200 <= resp.status_code < 300:
+        return
+
+    code = resp.status_code
+    if code in (401, 403):
+        raise AuthInvalid(f"Auth failed (HTTP {code})")
+    if code == 402:
+        raise QuotaExceeded("Quota or billing failure (HTTP 402)")
+    if code == 429 or (code == 400 and throttle_detector is not None and throttle_detector(resp)):
+        retry_after = parse_retry_after(resp.headers.get("Retry-After"))
+        raise RateLimited("Rate limited (HTTP 429)", retry_after_seconds=retry_after)
+    if 500 <= code < 600:
+        raise ProviderUnavailable(f"Upstream error (HTTP {code})")
+    # 4xx other than the above → treat as a malformed input / translation error
+    # since the gateway only emits known shapes.
+    raise ToolTranslationError(f"Upstream rejected request (HTTP {code})")
+
+
+def extract_api_key(raw: str) -> str:
+    """Parse an ``{"api_key": "..."}`` credential blob → bare api key.
+
+    Used by the OpenAI / Gemini / Anthropic api-key adapters. A non-dict blob
+    falls through to the missing-key path (matching their established behaviour).
+    """
+    try:
+        blob = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise AuthInvalid("Connector credentials are malformed") from exc
+    api_key = blob.get("api_key") if isinstance(blob, dict) else None
+    if not api_key:
+        raise AuthInvalid("Connector is missing an api_key")
+    return str(api_key)
+
+
+def extract_fixed_base_credentials(raw: str, base_url: str) -> tuple[str, str]:
+    """Parse an ``{"api_key": "..."}`` blob for fixed-base-URL adapters.
+
+    Used by xAI and OpenRouter, whose base URL is pinned (never user-supplied).
+    Stricter than :func:`extract_api_key`: a non-dict blob raises
+    ``"Connector credentials shape is invalid"`` rather than falling through.
+    """
+    try:
+        blob = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise AuthInvalid("Connector credentials are malformed") from exc
+    if not isinstance(blob, dict):
+        raise AuthInvalid("Connector credentials shape is invalid")
+    api_key = blob.get("api_key")
+    if not api_key:
+        raise AuthInvalid("Connector is missing an api_key")
+    return base_url, str(api_key)

--- a/server/app/services/llm/adapters/anthropic_apikey.py
+++ b/server/app/services/llm/adapters/anthropic_apikey.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any
 
@@ -14,6 +13,7 @@ from anthropic import (
     AsyncAnthropic,
 )
 
+from app.services.llm.adapters._shared import extract_api_key
 from app.services.llm.base import ChatRequest, ChatResponse, LlmAdapter, Message
 from app.services.llm.exceptions import (
     AuthInvalid,
@@ -25,6 +25,7 @@ from app.services.llm.exceptions import (
 from app.services.llm.registry import register_adapter
 from app.services.llm.tool_translation import (
     parse_anthropic_response,
+    to_anthropic_messages,
     to_anthropic_tools,
 )
 
@@ -40,15 +41,7 @@ class AnthropicApiKeyAdapter(LlmAdapter):
     connector_type = "anthropic_apikey"
 
     def _extract_api_key(self) -> str:
-        raw = self.connector.credentials or ""
-        try:
-            blob = json.loads(raw)
-        except (json.JSONDecodeError, TypeError) as exc:
-            raise AuthInvalid("Connector credentials are malformed") from exc
-        api_key = blob.get("api_key") if isinstance(blob, dict) else None
-        if not api_key:
-            raise AuthInvalid("Connector is missing an api_key")
-        return str(api_key)
+        return extract_api_key(self.connector.credentials or "")
 
     def _client(self, *, timeout: float) -> AsyncAnthropic:
         return AsyncAnthropic(api_key=self._extract_api_key(), timeout=timeout)
@@ -61,7 +54,7 @@ class AnthropicApiKeyAdapter(LlmAdapter):
             MAX_TIMEOUT_SECONDS,
         )
 
-        anthropic_messages = self._translate_messages(request.messages)
+        anthropic_messages = to_anthropic_messages(request.messages)
         tools, choice = to_anthropic_tools(request.tools, request.force_tool)
 
         kwargs: dict[str, Any] = {
@@ -100,54 +93,6 @@ class AnthropicApiKeyAdapter(LlmAdapter):
             temperature=0.0,
         )
         await self.chat(ping)
-
-    @staticmethod
-    def _translate_messages(messages: list[Message]) -> list[dict]:
-        """Translate canonical messages to Anthropic's user/assistant shape.
-
-        System messages are pulled out by the caller (``request.system``).
-        Tool-result messages map to ``role=user`` with a ``tool_result`` block.
-        """
-        out: list[dict] = []
-        for m in messages:
-            if m.role == "system":
-                # Ignored here — must be passed via request.system. We swallow
-                # it silently to avoid a hard error on legacy callers.
-                continue
-            content = m.content
-            if isinstance(content, list):
-                # Blocks may be dicts (e.g. {"type": "text", "text": "..."}) or
-                # objects with a .text attr — handle both.
-                parts: list[str] = []
-                for b in content:
-                    if isinstance(b, dict):
-                        parts.append(b.get("text") or "")
-                    else:
-                        parts.append(getattr(b, "text", "") or "")
-                text = "".join(parts)
-            else:
-                text = content or ""
-
-            if m.role == "tool":
-                if not m.tool_call_id:
-                    raise ToolTranslationError("Tool message missing tool_call_id")
-                out.append(
-                    {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "tool_result",
-                                "tool_use_id": m.tool_call_id,
-                                "content": text,
-                            }
-                        ],
-                    }
-                )
-                continue
-
-            role = "assistant" if m.role == "assistant" else "user"
-            out.append({"role": role, "content": text})
-        return out
 
     @staticmethod
     def _raise_for_status(exc: APIStatusError) -> None:

--- a/server/app/services/llm/adapters/azure_openai.py
+++ b/server/app/services/llm/adapters/azure_openai.py
@@ -32,9 +32,9 @@ from app.services.llm.adapters._httpx_openai import (
     DEFAULT_TIMEOUT_SECONDS,
     MAX_TIMEOUT_SECONDS,
     _build_payload,
-    _raise_for_status,
     build_healthcheck_request,
 )
+from app.services.llm.adapters._shared import raise_for_status
 from app.services.llm.base import ChatRequest, ChatResponse, LlmAdapter
 from app.services.llm.exceptions import AuthInvalid, ProviderUnavailable, ToolTranslationError
 from app.services.llm.registry import register_adapter
@@ -145,7 +145,7 @@ class AzureOpenAIAdapter(LlmAdapter):
         except httpx.HTTPError as exc:
             raise ProviderUnavailable("Upstream network error") from exc
 
-        _raise_for_status(resp)
+        raise_for_status(resp)
 
         try:
             body: Any = resp.json()

--- a/server/app/services/llm/adapters/bedrock.py
+++ b/server/app/services/llm/adapters/bedrock.py
@@ -26,20 +26,17 @@ from typing import Any
 import httpx
 
 from app.core.time import utcnow
+from app.services.llm.adapters._shared import raise_for_status
 from app.services.llm.base import ChatRequest, ChatResponse, LlmAdapter, Message
-from app.services.llm.exceptions import (
-    AuthInvalid,
-    ProviderUnavailable,
-    QuotaExceeded,
-    RateLimited,
-    ToolTranslationError,
-)
+from app.services.llm.exceptions import AuthInvalid, ProviderUnavailable, ToolTranslationError
 from app.services.llm.registry import register_adapter
 from app.services.llm.sigv4 import sign_request
 from app.services.llm.tool_translation import (
+    content_to_text,
     parse_anthropic_response,
     parse_llama_response,
     render_llama_tool_instructions,
+    to_anthropic_messages,
     to_anthropic_tools,
 )
 
@@ -132,7 +129,7 @@ class BedrockAdapter(LlmAdapter):
         except httpx.HTTPError as exc:
             raise ProviderUnavailable("Upstream network error") from exc
 
-        _raise_for_status(resp)
+        raise_for_status(resp, throttle_detector=_is_throttle)
 
         try:
             response_body = resp.json()
@@ -162,7 +159,7 @@ class BedrockAdapter(LlmAdapter):
         body: dict[str, Any] = {
             "anthropic_version": ANTHROPIC_BEDROCK_VERSION,
             "max_tokens": request.max_tokens or DEFAULT_MAX_TOKENS,
-            "messages": self._anthropic_messages(request.messages),
+            "messages": to_anthropic_messages(request.messages),
         }
         if request.system:
             body["system"] = request.system
@@ -187,33 +184,6 @@ class BedrockAdapter(LlmAdapter):
             body["temperature"] = request.temperature
         return body, tool_names
 
-    @staticmethod
-    def _anthropic_messages(messages: list[Message]) -> list[dict]:
-        out: list[dict] = []
-        for m in messages:
-            if m.role == "system":
-                continue
-            text = _message_text(m)
-            if m.role == "tool":
-                if not m.tool_call_id:
-                    raise ToolTranslationError("Tool message missing tool_call_id")
-                out.append(
-                    {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "tool_result",
-                                "tool_use_id": m.tool_call_id,
-                                "content": text,
-                            }
-                        ],
-                    }
-                )
-                continue
-            role = "assistant" if m.role == "assistant" else "user"
-            out.append({"role": role, "content": text})
-        return out
-
 
 def _render_llama_prompt(request: ChatRequest, tool_instructions: str | None) -> str:
     """Render canonical messages into Llama 3's instruction-tuned chat format."""
@@ -226,7 +196,7 @@ def _render_llama_prompt(request: ChatRequest, tool_instructions: str | None) ->
         system_chunks.append(tool_instructions)
     for m in request.messages:
         if m.role == "system":
-            system_chunks.append(_message_text(m))
+            system_chunks.append(content_to_text(m.content))
     if system_chunks:
         parts.append(
             "<|start_header_id|>system<|end_header_id|>\n\n"
@@ -238,43 +208,12 @@ def _render_llama_prompt(request: ChatRequest, tool_instructions: str | None) ->
         if m.role == "system":
             continue
         role = "assistant" if m.role == "assistant" else "user"
-        parts.append(f"<|start_header_id|>{role}<|end_header_id|>\n\n{_message_text(m)}<|eot_id|>")
+        parts.append(
+            f"<|start_header_id|>{role}<|end_header_id|>\n\n{content_to_text(m.content)}<|eot_id|>"
+        )
 
     parts.append("<|start_header_id|>assistant<|end_header_id|>\n\n")
     return "".join(parts)
-
-
-def _message_text(m: Message) -> str:
-    content = m.content
-    if isinstance(content, list):
-        # Blocks may be dicts (e.g. {"type": "text", "text": "..."}) or objects
-        # with a .text attr — handle both.
-        parts: list[str] = []
-        for b in content:
-            if isinstance(b, dict):
-                parts.append(b.get("text") or "")
-            else:
-                parts.append(getattr(b, "text", "") or "")
-        return "".join(parts)
-    return content or ""
-
-
-def _raise_for_status(resp: httpx.Response) -> None:
-    if 200 <= resp.status_code < 300:
-        return
-    code = resp.status_code
-    if code in (401, 403):
-        raise AuthInvalid(f"Auth failed (HTTP {code})")
-    if code == 402:
-        raise QuotaExceeded("Quota or billing failure (HTTP 402)")
-    # Bedrock throttling can arrive as 429, or as 400 with a ThrottlingException
-    # error-type header. Treat both as rate-limited so callers back off.
-    if code == 429 or (code == 400 and _is_throttle(resp)):
-        retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
-        raise RateLimited("Rate limited (HTTP 429)", retry_after_seconds=retry_after)
-    if 500 <= code < 600:
-        raise ProviderUnavailable(f"Upstream error (HTTP {code})")
-    raise ToolTranslationError(f"Upstream rejected request (HTTP {code})")
 
 
 def _is_throttle(resp: httpx.Response) -> bool:
@@ -285,15 +224,6 @@ def _is_throttle(resp: httpx.Response) -> bool:
     """
     err_type = resp.headers.get("x-amzn-errortype") or resp.headers.get("X-Amzn-ErrorType") or ""
     return "throttl" in err_type.lower()
-
-
-def _parse_retry_after(value: str | None) -> int | None:
-    if not value:
-        return None
-    try:
-        return int(float(value))
-    except ValueError:
-        return None
 
 
 register_adapter("bedrock", BedrockAdapter)

--- a/server/app/services/llm/adapters/gemini_apikey.py
+++ b/server/app/services/llm/adapters/gemini_apikey.py
@@ -20,14 +20,9 @@ from typing import Any
 
 import httpx
 
+from app.services.llm.adapters._shared import extract_api_key, raise_for_status
 from app.services.llm.base import ChatRequest, ChatResponse, LlmAdapter, Message
-from app.services.llm.exceptions import (
-    AuthInvalid,
-    ProviderUnavailable,
-    QuotaExceeded,
-    RateLimited,
-    ToolTranslationError,
-)
+from app.services.llm.exceptions import ProviderUnavailable, ToolTranslationError
 from app.services.llm.registry import register_adapter
 from app.services.llm.tool_translation import parse_gemini_response, to_gemini_tools
 
@@ -43,15 +38,7 @@ class GeminiApiKeyAdapter(LlmAdapter):
     connector_type = "gemini_apikey"
 
     def _extract_api_key(self) -> str:
-        raw = self.connector.credentials or ""
-        try:
-            blob = json.loads(raw)
-        except (json.JSONDecodeError, TypeError) as exc:
-            raise AuthInvalid("Connector credentials are malformed") from exc
-        api_key = blob.get("api_key") if isinstance(blob, dict) else None
-        if not api_key:
-            raise AuthInvalid("Connector is missing an api_key")
-        return str(api_key)
+        return extract_api_key(self.connector.credentials or "")
 
     async def chat(self, request: ChatRequest) -> ChatResponse:
         api_key = self._extract_api_key()
@@ -79,7 +66,7 @@ class GeminiApiKeyAdapter(LlmAdapter):
         except httpx.HTTPError as exc:
             raise ProviderUnavailable("Upstream network error") from exc
 
-        _raise_for_status(resp)
+        raise_for_status(resp)
 
         try:
             body = resp.json()
@@ -166,32 +153,6 @@ class GeminiApiKeyAdapter(LlmAdapter):
             role = "model" if m.role == "assistant" else "user"
             out.append({"role": role, "parts": [{"text": text}]})
         return out
-
-
-def _raise_for_status(resp: httpx.Response) -> None:
-    if 200 <= resp.status_code < 300:
-        return
-
-    code = resp.status_code
-    if code in (401, 403):
-        raise AuthInvalid(f"Auth failed (HTTP {code})")
-    if code == 402:
-        raise QuotaExceeded("Quota or billing failure (HTTP 402)")
-    if code == 429:
-        retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
-        raise RateLimited("Rate limited (HTTP 429)", retry_after_seconds=retry_after)
-    if 500 <= code < 600:
-        raise ProviderUnavailable(f"Upstream error (HTTP {code})")
-    raise ToolTranslationError(f"Upstream rejected request (HTTP {code})")
-
-
-def _parse_retry_after(value: str | None) -> int | None:
-    if not value:
-        return None
-    try:
-        return int(float(value))
-    except ValueError:
-        return None
 
 
 register_adapter("gemini_apikey", GeminiApiKeyAdapter)

--- a/server/app/services/llm/adapters/openai_apikey.py
+++ b/server/app/services/llm/adapters/openai_apikey.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-import json
 import logging
 
 from app.services.llm.adapters._httpx_openai import (
     build_healthcheck_request,
     call_openai_chat,
 )
+from app.services.llm.adapters._shared import extract_api_key
 from app.services.llm.base import ChatRequest, ChatResponse, LlmAdapter
-from app.services.llm.exceptions import AuthInvalid
 from app.services.llm.registry import register_adapter
 
 logger = logging.getLogger(__name__)
@@ -29,15 +28,7 @@ class OpenAIApiKeyAdapter(LlmAdapter):
     connector_type = "openai_apikey"
 
     def _extract_api_key(self) -> str:
-        raw = self.connector.credentials or ""
-        try:
-            blob = json.loads(raw)
-        except (json.JSONDecodeError, TypeError) as exc:
-            raise AuthInvalid("Connector credentials are malformed") from exc
-        api_key = blob.get("api_key") if isinstance(blob, dict) else None
-        if not api_key:
-            raise AuthInvalid("Connector is missing an api_key")
-        return str(api_key)
+        return extract_api_key(self.connector.credentials or "")
 
     async def chat(self, request: ChatRequest) -> ChatResponse:
         api_key = self._extract_api_key()

--- a/server/app/services/llm/adapters/openrouter_apikey.py
+++ b/server/app/services/llm/adapters/openrouter_apikey.py
@@ -15,16 +15,15 @@ request/response + error-mapping pipeline. It differs only in:
 
 from __future__ import annotations
 
-import json
 import logging
 
 from app.services.llm.adapters._httpx_openai import (
     build_healthcheck_request,
     call_openai_chat,
 )
+from app.services.llm.adapters._shared import extract_fixed_base_credentials
 from app.services.llm.adapters.openai_compatible import OpenAICompatibleAdapter
 from app.services.llm.base import ChatRequest, ChatResponse
-from app.services.llm.exceptions import AuthInvalid
 from app.services.llm.registry import register_adapter
 
 logger = logging.getLogger(__name__)
@@ -68,17 +67,7 @@ class OpenRouterApiKeyAdapter(OpenAICompatibleAdapter):
         OpenRouter endpoint — never user-supplied — which removes the SSRF
         surface of arbitrary base URLs.
         """
-        raw = self.connector.credentials or ""
-        try:
-            blob = json.loads(raw)
-        except (json.JSONDecodeError, TypeError) as exc:
-            raise AuthInvalid("Connector credentials are malformed") from exc
-        if not isinstance(blob, dict):
-            raise AuthInvalid("Connector credentials shape is invalid")
-        api_key = blob.get("api_key")
-        if not api_key:
-            raise AuthInvalid("Connector is missing an api_key")
-        return OPENROUTER_BASE_URL, str(api_key)
+        return extract_fixed_base_credentials(self.connector.credentials or "", OPENROUTER_BASE_URL)
 
 
 register_adapter("openrouter_apikey", OpenRouterApiKeyAdapter)

--- a/server/app/services/llm/adapters/xai_apikey.py
+++ b/server/app/services/llm/adapters/xai_apikey.py
@@ -15,16 +15,16 @@ Tool-use mirrors OpenAI function-calling and is handled entirely by the inherite
 
 from __future__ import annotations
 
-import json
 import logging
 
 from app.services.llm.adapters._httpx_openai import (
     build_healthcheck_request,
     call_openai_chat,
 )
+from app.services.llm.adapters._shared import extract_fixed_base_credentials
 from app.services.llm.adapters.openai_compatible import OpenAICompatibleAdapter
 from app.services.llm.base import ChatRequest, ChatResponse
-from app.services.llm.exceptions import AuthInvalid, ProviderUnavailable
+from app.services.llm.exceptions import ProviderUnavailable
 from app.services.llm.registry import register_adapter
 
 logger = logging.getLogger(__name__)
@@ -46,17 +46,7 @@ class XaiApiKeyAdapter(OpenAICompatibleAdapter):
         ``{"api_key": "..."}`` blob (the same shape as the other api-key
         connectors) and the base URL is pinned — it is never user-supplied.
         """
-        raw = self.connector.credentials or ""
-        try:
-            blob = json.loads(raw)
-        except (json.JSONDecodeError, TypeError) as exc:
-            raise AuthInvalid("Connector credentials are malformed") from exc
-        if not isinstance(blob, dict):
-            raise AuthInvalid("Connector credentials shape is invalid")
-        api_key = blob.get("api_key")
-        if not api_key:
-            raise AuthInvalid("Connector is missing an api_key")
-        return XAI_BASE_URL, str(api_key)
+        return extract_fixed_base_credentials(self.connector.credentials or "", XAI_BASE_URL)
 
     async def chat(self, request: ChatRequest) -> ChatResponse:
         base_url, api_key = self._extract_credentials()

--- a/server/app/services/llm/tool_translation.py
+++ b/server/app/services/llm/tool_translation.py
@@ -13,10 +13,91 @@ import json
 import logging
 from typing import Any, Literal
 
-from app.services.llm.base import ChatResponse, TokenUsage, ToolCall, ToolSpec
+from app.services.llm.base import ChatResponse, Message, TokenUsage, ToolCall, ToolSpec
 from app.services.llm.exceptions import ToolTranslationError
 
 logger = logging.getLogger(__name__)
+
+CanonicalStopReason = Literal["end_turn", "tool_use", "max_tokens", "error"]
+
+# Per-provider native-finish-reason → canonical mapping. ``None`` always means
+# "end_turn"; any reason absent from a table maps to "error".
+_FINISH_REASON_OPENAI = {
+    "stop": "end_turn",
+    "tool_calls": "tool_use",
+    "function_call": "tool_use",
+    "length": "max_tokens",
+}
+_FINISH_REASON_ANTHROPIC = {
+    "end_turn": "end_turn",
+    "stop_sequence": "end_turn",
+    "tool_use": "tool_use",
+    "max_tokens": "max_tokens",
+}
+_FINISH_REASON_GEMINI = {"STOP": "end_turn", "MAX_TOKENS": "max_tokens"}
+_FINISH_REASON_LLAMA = {"stop": "end_turn", "length": "max_tokens"}
+
+
+def _normalise_finish_reason(reason: str | None, mapping: dict[str, str]) -> CanonicalStopReason:
+    if reason is None:
+        return "end_turn"
+    return mapping.get(reason, "error")  # type: ignore[return-value]
+
+
+def _validate_force(tools: list[ToolSpec], force: str | None) -> None:
+    """Raise if ``force`` names a tool not present in ``tools`` (no-op when None)."""
+    if force is not None and not any(t.name == force for t in tools):
+        raise ToolTranslationError(f"force_tool={force!r} not in tools list")
+
+
+def content_to_text(content: str | list | None) -> str:
+    """Flatten a ``Message.content`` (str or list of text blocks) to plain text.
+
+    Blocks may be dicts (``{"type": "text", "text": "..."}``) or objects with a
+    ``.text`` attr. Shared by the OpenAI, Anthropic and Bedrock translators.
+    """
+    if isinstance(content, list):
+        parts: list[str] = []
+        for b in content:
+            if isinstance(b, dict):
+                parts.append(b.get("text") or "")
+            else:
+                parts.append(getattr(b, "text", "") or "")
+        return "".join(parts)
+    return content or ""
+
+
+def to_anthropic_messages(messages: list[Message]) -> list[dict]:
+    """Translate canonical messages to Anthropic's user/assistant shape.
+
+    System messages are pulled out by the caller (``request.system``).
+    Tool-result messages map to ``role=user`` with a ``tool_result`` block.
+    Shared by the Anthropic SDK adapter and the Bedrock anthropic-family path.
+    """
+    out: list[dict] = []
+    for m in messages:
+        if m.role == "system":
+            continue
+        text = content_to_text(m.content)
+        if m.role == "tool":
+            if not m.tool_call_id:
+                raise ToolTranslationError("Tool message missing tool_call_id")
+            out.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": m.tool_call_id,
+                            "content": text,
+                        }
+                    ],
+                }
+            )
+            continue
+        role = "assistant" if m.role == "assistant" else "user"
+        out.append({"role": role, "content": text})
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -38,10 +119,9 @@ def to_openai_tools(
         }
         for t in tools
     ]
+    _validate_force(tools, force)
     choice: Any = None
     if force is not None:
-        if not any(t.name == force for t in tools):
-            raise ToolTranslationError(f"force_tool={force!r} not in tools list")
         choice = {"type": "function", "function": {"name": force}}
     return fns, choice
 
@@ -85,7 +165,7 @@ def parse_openai_response(payload: dict) -> ChatResponse:
             raise ToolTranslationError("OpenAI tool_call arguments must be an object")
         tool_calls.append(ToolCall(id=str(tc.get("id") or name), name=name, input=input_obj))
 
-    stop_reason = _normalise_openai_finish_reason(choice.get("finish_reason"))
+    stop_reason = _normalise_finish_reason(choice.get("finish_reason"), _FINISH_REASON_OPENAI)
     usage_payload = payload.get("usage") or {}
     usage = None
     if usage_payload:
@@ -108,18 +188,6 @@ def parse_openai_response(payload: dict) -> ChatResponse:
     )
 
 
-def _normalise_openai_finish_reason(
-    reason: str | None,
-) -> Literal["end_turn", "tool_use", "max_tokens", "error"]:
-    if reason in (None, "stop"):
-        return "end_turn"
-    if reason == "tool_calls" or reason == "function_call":
-        return "tool_use"
-    if reason == "length":
-        return "max_tokens"
-    return "error"
-
-
 # ---------------------------------------------------------------------------
 # Anthropic
 # ---------------------------------------------------------------------------
@@ -136,10 +204,9 @@ def to_anthropic_tools(
         }
         for t in tools
     ]
+    _validate_force(tools, force)
     choice: Any = None
     if force is not None:
-        if not any(t.name == force for t in tools):
-            raise ToolTranslationError(f"force_tool={force!r} not in tools list")
         choice = {"type": "tool", "name": force}
     return anthropic_tools, choice
 
@@ -182,7 +249,7 @@ def parse_anthropic_response(message: Any) -> ChatResponse:
     stop_raw = getattr(message, "stop_reason", None) or (
         message.get("stop_reason") if isinstance(message, dict) else None
     )
-    stop_reason = _normalise_anthropic_stop_reason(stop_raw)
+    stop_reason = _normalise_finish_reason(stop_raw, _FINISH_REASON_ANTHROPIC)
     if tool_calls and stop_reason != "tool_use":
         stop_reason = "tool_use"
 
@@ -217,18 +284,6 @@ def parse_anthropic_response(message: Any) -> ChatResponse:
     )
 
 
-def _normalise_anthropic_stop_reason(
-    reason: str | None,
-) -> Literal["end_turn", "tool_use", "max_tokens", "error"]:
-    if reason in (None, "end_turn", "stop_sequence"):
-        return "end_turn"
-    if reason == "tool_use":
-        return "tool_use"
-    if reason == "max_tokens":
-        return "max_tokens"
-    return "error"
-
-
 # ---------------------------------------------------------------------------
 # Google Gemini (native generativelanguage API)
 # ---------------------------------------------------------------------------
@@ -252,10 +307,9 @@ def to_gemini_tools(
         for t in tools
     ]
     gemini_tools = [{"function_declarations": declarations}]
+    _validate_force(tools, force)
     tool_config: Any = None
     if force is not None:
-        if not any(t.name == force for t in tools):
-            raise ToolTranslationError(f"force_tool={force!r} not in tools list")
         tool_config = {
             "function_calling_config": {
                 "mode": "ANY",
@@ -305,7 +359,7 @@ def parse_gemini_response(payload: dict) -> ChatResponse:
         elif "text" in part:
             text_parts.append(part.get("text") or "")
 
-    stop_reason = _normalise_gemini_finish_reason(candidate.get("finishReason"))
+    stop_reason = _normalise_finish_reason(candidate.get("finishReason"), _FINISH_REASON_GEMINI)
     if tool_calls and stop_reason != "tool_use":
         stop_reason = "tool_use"
 
@@ -326,17 +380,6 @@ def parse_gemini_response(payload: dict) -> ChatResponse:
     )
 
 
-def _normalise_gemini_finish_reason(
-    reason: str | None,
-) -> Literal["end_turn", "tool_use", "max_tokens", "error"]:
-    if reason in (None, "STOP"):
-        return "end_turn"
-    if reason == "MAX_TOKENS":
-        return "max_tokens"
-    # SAFETY, RECITATION, OTHER, etc. — treat as error.
-    return "error"
-
-
 # ---------------------------------------------------------------------------
 # Bedrock — Llama family
 #
@@ -354,8 +397,7 @@ def render_llama_tool_instructions(tools: list[ToolSpec] | None, force: str | No
     """
     if not tools:
         return None
-    if force is not None and not any(t.name == force for t in tools):
-        raise ToolTranslationError(f"force_tool={force!r} not in tools list")
+    _validate_force(tools, force)
 
     lines = [
         "You have access to the following tools. To call a tool, respond with "
@@ -388,7 +430,7 @@ def parse_llama_response(payload: dict, tool_names: set[str] | None = None) -> C
         raise ToolTranslationError("Bedrock Llama response missing 'generation'")
     text = str(generation)
 
-    stop_reason = _normalise_llama_stop_reason(payload.get("stop_reason"))
+    stop_reason = _normalise_finish_reason(payload.get("stop_reason"), _FINISH_REASON_LLAMA)
 
     usage = None
     prompt_tokens = payload.get("prompt_token_count")
@@ -455,13 +497,3 @@ def _try_parse_tool_json(text: str) -> dict | None:
                     return None
                 return obj if isinstance(obj, dict) else None
     return None
-
-
-def _normalise_llama_stop_reason(
-    reason: str | None,
-) -> Literal["end_turn", "tool_use", "max_tokens", "error"]:
-    if reason in (None, "stop"):
-        return "end_turn"
-    if reason == "length":
-        return "max_tokens"
-    return "error"


### PR DESCRIPTION
## Wave 1 of 4 — epic/ai-engine slop-reduction refactor

First wave of a deliberate, **behavior-preserving** LOC contraction of the AI engine. Targets byte-identical logic copy-pasted across the LLM adapters (the "one file per provider" pattern earlier model iterations produced).

### Changes
- **new `adapters/_shared.py`** — single home for `parse_retry_after`, `raise_for_status` (optional `throttle_detector` preserves Bedrock's HTTP-400-throttle path), `extract_api_key`, `extract_fixed_base_credentials`.
- **`tool_translation.py`** — `content_to_text` + `to_anthropic_messages` (shared by the Anthropic SDK adapter and Bedrock's anthropic family), `_validate_force`, and one table-driven `_normalise_finish_reason` replacing four near-identical per-provider normalizers.
- removed dead `_normalise_role` passthrough.

### Deliberately NOT merged (verifier-flagged as behavior-changing)
- Anthropic's SDK-based `_raise_for_status` (operates on `APIStatusError`, not httpx) — left separate.
- Gemini's `str()`-wrapping message translator and the two api-key-extractor *shapes* (one folds non-dict → "missing api_key", the other → "shape invalid") — preserved exactly.

### Verification
- Net **−106 LOC** across `services/llm/` (incl. the new 103-line shared module).
- `ruff check` / `ruff format --check` / `bandit` clean.
- **2429 backend tests pass, coverage 87.78%** (gate 85%). No test changes needed — all shared symbols stay internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)