### PR TITLE
refactor(ai-ui): data-drive placeholders + dedupe handlers/headers (wave 3/4)

### DIFF
--- a/dashboard/app/admin/ai/page.tsx
+++ b/dashboard/app/admin/ai/page.tsx
@@ -113,6 +113,11 @@ function sortConnectors(
   return copy;
 }
 
+// Format a nullable ISO timestamp for table cells; em-dash when absent.
+function formatTimestamp(ts: string | null | undefined): string {
+  return ts ? new Date(ts).toLocaleString() : '—';
+}
+
 function PlainHeader({ label }: { label: string }) {
   return (
     <th
@@ -314,6 +319,13 @@ export default function AdminAISettingsPage() {
       active = false;
     };
   }, [buildAuditFilters]);
+
+  // Any audit-filter change resets pagination to the first page before applying
+  // the new value, so the offset never points past a now-shorter result set.
+  const onAuditFilterChange = (apply: () => void) => {
+    setAuditPage(0);
+    apply();
+  };
 
   const handleExportCsv = async () => {
     setExporting(true);
@@ -676,12 +688,10 @@ export default function AdminAISettingsPage() {
                     <td style={{ padding: '0.5rem' }}>{c.display_name}</td>
                     <td style={{ padding: '0.5rem' }}>{c.status}</td>
                     <td style={{ padding: '0.5rem', color: 'var(--text-secondary)' }}>
-                      {c.last_used_at ? new Date(c.last_used_at).toLocaleString() : '—'}
+                      {formatTimestamp(c.last_used_at)}
                     </td>
                     <td style={{ padding: '0.5rem', color: 'var(--text-secondary)' }}>
-                      {c.last_health_check_at
-                        ? new Date(c.last_health_check_at).toLocaleString()
-                        : '—'}
+                      {formatTimestamp(c.last_health_check_at)}
                     </td>
                     <td style={{ padding: '0.5rem' }}>
                       <HealthBadge status={c.last_health_check_status ?? null} />
@@ -713,9 +723,7 @@ export default function AdminAISettingsPage() {
                 <thead>
                   <tr>
                     {['DJ', 'Connector', 'Calls', 'Tokens in', 'Tokens out', 'Error rate'].map((h) => (
-                      <th key={h} style={{ textAlign: 'left', padding: '0.5rem', borderBottom: '1px solid var(--border-color)' }}>
-                        {h}
-                      </th>
+                      <PlainHeader key={h} label={h} />
                     ))}
                   </tr>
                 </thead>
@@ -763,10 +771,7 @@ export default function AdminAISettingsPage() {
               id="audit-event-type"
               className="input"
               value={auditEventType}
-              onChange={(e) => {
-                setAuditPage(0);
-                setAuditEventType(e.target.value);
-              }}
+              onChange={(e) => onAuditFilterChange(() => setAuditEventType(e.target.value))}
             >
               <option value="">All event types</option>
               {AUDIT_EVENT_TYPES.map((t) => (
@@ -785,10 +790,7 @@ export default function AdminAISettingsPage() {
               style={{ maxWidth: '160px' }}
               placeholder="Any"
               value={auditActorId}
-              onChange={(e) => {
-                setAuditPage(0);
-                setAuditActorId(e.target.value);
-              }}
+              onChange={(e) => onAuditFilterChange(() => setAuditActorId(e.target.value))}
             />
           </div>
 
@@ -798,10 +800,7 @@ export default function AdminAISettingsPage() {
               id="audit-connector"
               className="input"
               value={auditConnectorId}
-              onChange={(e) => {
-                setAuditPage(0);
-                setAuditConnectorId(e.target.value);
-              }}
+              onChange={(e) => onAuditFilterChange(() => setAuditConnectorId(e.target.value))}
             >
               <option value="">All connectors</option>
               {connectors.map((c) => (
@@ -818,10 +817,7 @@ export default function AdminAISettingsPage() {
               id="audit-days"
               className="input"
               value={auditDays}
-              onChange={(e) => {
-                setAuditPage(0);
-                setAuditDays(parseInt(e.target.value, 10));
-              }}
+              onChange={(e) => onAuditFilterChange(() => setAuditDays(parseInt(e.target.value, 10)))}
             >
               {AUDIT_DAY_OPTIONS.map((d) => (
                 <option key={d.value} value={d.value}>{d.label}</option>
@@ -845,9 +841,7 @@ export default function AdminAISettingsPage() {
                 <thead>
                   <tr>
                     {['Timestamp', 'Actor', 'Event type', 'Connector', 'Notes'].map((h) => (
-                      <th key={h} style={{ textAlign: 'left', padding: '0.5rem', borderBottom: '1px solid var(--border-color)' }}>
-                        {h}
-                      </th>
+                      <PlainHeader key={h} label={h} />
                     ))}
                   </tr>
                 </thead>
@@ -855,7 +849,7 @@ export default function AdminAISettingsPage() {
                   {audit.rows.map((row) => (
                     <tr key={row.id}>
                       <td style={{ padding: '0.5rem', color: 'var(--text-secondary)' }}>
-                        {new Date(row.created_at).toLocaleString()}
+                        {formatTimestamp(row.created_at)}
                       </td>
                       <td style={{ padding: '0.5rem' }}>{row.actor_username}</td>
                       <td style={{ padding: '0.5rem' }}>{row.event_type}</td>

--- a/dashboard/components/AiProvidersSection.tsx
+++ b/dashboard/components/AiProvidersSection.tsx
@@ -28,6 +28,26 @@ const STATUS_LABELS: Record<string, { text: string; color: string }> = {
   disabled: { text: 'Disabled', color: 'var(--text-secondary)' },
 };
 
+// Provider-specific input placeholders. Missing entries fall back to the
+// per-field default below (openai_apikey for the key, openai_compatible for
+// the model hint), preserving the previous nested-ternary behavior.
+const API_KEY_PLACEHOLDERS: Partial<Record<LlmConnectorType, string>> = {
+  anthropic_apikey: 'sk-ant-…',
+  openrouter_apikey: 'sk-or-…',
+  xai_apikey: 'xai-…',
+  gemini_apikey: 'AIza…',
+};
+const API_KEY_PLACEHOLDER_DEFAULT = 'sk-proj-… / sk-…';
+
+const MODEL_HINT_PLACEHOLDERS: Partial<Record<LlmConnectorType, string>> = {
+  anthropic_apikey: 'claude-haiku-4-5-20251001',
+  openai_apikey: 'gpt-5-mini',
+  openrouter_apikey: 'e.g. openai/gpt-4o-mini',
+  xai_apikey: 'grok-3-mini',
+  gemini_apikey: 'gemini-2.5-flash',
+};
+const MODEL_HINT_PLACEHOLDER_DEFAULT = 'e.g. llama3';
+
 interface FormState {
   open: boolean;
   connector_type: LlmConnectorType;
@@ -128,6 +148,14 @@ export default function AiProvidersSection() {
     if (!policy) return [];
     return policy.allowed_connector_types as LlmConnectorType[];
   }, [policy]);
+
+  // onChange factory for the plain string form fields — every text input/select
+  // updates exactly one FormState key with the raw value. connector_type stays
+  // inline because it needs a cast to LlmConnectorType.
+  const handleField =
+    (key: Exclude<keyof FormState, 'open' | 'connector_type'>) =>
+    (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
+      setForm((f) => ({ ...f, [key]: e.target.value }));
 
   const handleOpenForm = () => {
     if (allowedTypes.length === 0) {
@@ -416,7 +444,7 @@ export default function AiProvidersSection() {
                 id="display_name"
                 className="input"
                 value={form.display_name}
-                onChange={(e) => setForm({ ...form, display_name: e.target.value })}
+                onChange={handleField('display_name')}
                 placeholder="e.g. My OpenAI"
                 maxLength={80}
                 required
@@ -431,7 +459,7 @@ export default function AiProvidersSection() {
                     id="aws_access_key_id"
                     className="input"
                     value={form.aws_access_key_id}
-                    onChange={(e) => setForm({ ...form, aws_access_key_id: e.target.value })}
+                    onChange={handleField('aws_access_key_id')}
                     placeholder="AKIA…"
                     autoComplete="off"
                     required
@@ -444,7 +472,7 @@ export default function AiProvidersSection() {
                     className="input"
                     type="password"
                     value={form.aws_secret_access_key}
-                    onChange={(e) => setForm({ ...form, aws_secret_access_key: e.target.value })}
+                    onChange={handleField('aws_secret_access_key')}
                     autoComplete="off"
                     required
                   />
@@ -455,7 +483,7 @@ export default function AiProvidersSection() {
                     id="aws_region"
                     className="input"
                     value={form.aws_region}
-                    onChange={(e) => setForm({ ...form, aws_region: e.target.value })}
+                    onChange={handleField('aws_region')}
                     placeholder="us-east-1"
                     required
                   />
@@ -466,7 +494,7 @@ export default function AiProvidersSection() {
                     id="aws_model_id"
                     className="input"
                     value={form.aws_model_id}
-                    onChange={(e) => setForm({ ...form, aws_model_id: e.target.value })}
+                    onChange={handleField('aws_model_id')}
                     placeholder="anthropic.claude-3-5-sonnet-20241022-v2:0"
                     required
                   />
@@ -486,7 +514,7 @@ export default function AiProvidersSection() {
                     className="input"
                     type="password"
                     value={form.api_key}
-                    onChange={(e) => setForm({ ...form, api_key: e.target.value })}
+                    onChange={handleField('api_key')}
                     placeholder="Azure OpenAI key"
                     required
                   />
@@ -497,9 +525,7 @@ export default function AiProvidersSection() {
                     id="azure_resource_name"
                     className="input"
                     value={form.azure_resource_name}
-                    onChange={(e) =>
-                      setForm({ ...form, azure_resource_name: e.target.value })
-                    }
+                    onChange={handleField('azure_resource_name')}
                     placeholder="e.g. my-company"
                     required
                   />
@@ -514,9 +540,7 @@ export default function AiProvidersSection() {
                     id="azure_deployment_name"
                     className="input"
                     value={form.azure_deployment_name}
-                    onChange={(e) =>
-                      setForm({ ...form, azure_deployment_name: e.target.value })
-                    }
+                    onChange={handleField('azure_deployment_name')}
                     placeholder="e.g. gpt-4o-prod"
                     required
                   />
@@ -527,9 +551,7 @@ export default function AiProvidersSection() {
                     id="azure_api_version"
                     className="input"
                     value={form.azure_api_version}
-                    onChange={(e) =>
-                      setForm({ ...form, azure_api_version: e.target.value })
-                    }
+                    onChange={handleField('azure_api_version')}
                     placeholder="e.g. 2024-06-01"
                     required
                   />
@@ -543,17 +565,9 @@ export default function AiProvidersSection() {
                   className="input"
                   type="password"
                   value={form.api_key}
-                  onChange={(e) => setForm({ ...form, api_key: e.target.value })}
+                  onChange={handleField('api_key')}
                   placeholder={
-                    form.connector_type === 'anthropic_apikey'
-                      ? 'sk-ant-…'
-                      : form.connector_type === 'openrouter_apikey'
-                      ? 'sk-or-…'
-                      : form.connector_type === 'xai_apikey'
-                      ? 'xai-…'
-                      : form.connector_type === 'gemini_apikey'
-                      ? 'AIza…'
-                      : 'sk-proj-… / sk-…'
+                    API_KEY_PLACEHOLDERS[form.connector_type] ?? API_KEY_PLACEHOLDER_DEFAULT
                   }
                   required
                 />
@@ -566,7 +580,7 @@ export default function AiProvidersSection() {
                     id="base_url"
                     className="input"
                     value={form.base_url}
-                    onChange={(e) => setForm({ ...form, base_url: e.target.value })}
+                    onChange={handleField('base_url')}
                     placeholder="http://127.0.0.1:11434/v1"
                     required
                   />
@@ -582,7 +596,7 @@ export default function AiProvidersSection() {
                     className="input"
                     type="password"
                     value={form.bearer}
-                    onChange={(e) => setForm({ ...form, bearer: e.target.value })}
+                    onChange={handleField('bearer')}
                   />
                 </div>
                 <details style={{ marginTop: '1rem' }}>
@@ -615,7 +629,7 @@ export default function AiProvidersSection() {
                       id="model_hint"
                       className="input"
                       value={form.model_hint}
-                      onChange={(e) => setForm({ ...form, model_hint: e.target.value })}
+                      onChange={handleField('model_hint')}
                     >
                       <option value="">Default (openai/gpt-4o-mini)</option>
                       {openrouterModels.map((m) => (
@@ -634,19 +648,9 @@ export default function AiProvidersSection() {
                     id="model_hint"
                     className="input"
                     value={form.model_hint}
-                    onChange={(e) => setForm({ ...form, model_hint: e.target.value })}
+                    onChange={handleField('model_hint')}
                     placeholder={
-                      form.connector_type === 'anthropic_apikey'
-                        ? 'claude-haiku-4-5-20251001'
-                        : form.connector_type === 'openai_apikey'
-                        ? 'gpt-5-mini'
-                        : form.connector_type === 'openrouter_apikey'
-                        ? 'e.g. openai/gpt-4o-mini'
-                        : form.connector_type === 'xai_apikey'
-                        ? 'grok-3-mini'
-                        : form.connector_type === 'gemini_apikey'
-                        ? 'gemini-2.5-flash'
-                        : 'e.g. llama3'
+                      MODEL_HINT_PLACEHOLDERS[form.connector_type] ?? MODEL_HINT_PLACEHOLDER_DEFAULT
                     }
                   />
                 )}


### PR DESCRIPTION
## Wave 3 of 4 — epic/ai-engine slop-reduction refactor

Behavior-preserving DRY cleanup of the two AI dashboard surfaces. Rendered DOM + behavior unchanged → **zero test changes**.

### AiProvidersSection.tsx
- Two nested-ternary placeholder chains → `API_KEY_PLACEHOLDERS` / `MODEL_HINT_PLACEHOLDERS` lookup tables (with explicit defaults preserving prior fallbacks).
- 15 per-field `onChange` closures → one `handleField(key)` factory. `connector_type` stays inline (needs the `LlmConnectorType` cast).

### admin/ai/page.tsx
- `formatTimestamp()` for the 3 `toLocaleString` cells (nullable-safe, em-dash fallback preserved).
- Reuse the existing `PlainHeader` component in the Usage + Audit tables instead of repeating the inline `<th>` style.
- `onAuditFilterChange()` for the 4 filter handlers that all reset pagination to page 0.

### Deliberately skipped (verifier-flagged)
- `PROVIDER_FIELDS` form-block data-driving: bedrock/azure/apikey/compatible blocks genuinely diverge (SigV4 help text, Hermes `<details>`, select-vs-input model hint). A descriptor system would cost ~as much as it saves and risk shifting the DOM the 446-line component test queries.

### Verification
- Net **−2 LOC** (DRY-focused, not a big contraction — like Wave 2, UI boilerplate dedup is LOC-neutral but removes repeated style strings / nested ternaries / handler duplication).
- `npm run lint` (0 errors) · `tsc --noEmit` clean · **966 tests pass** · coverage above thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)