### PR TITLE
refactor(tests): parametrize + dedupe LLM test boilerplate (wave 4/4)

### DIFF
--- a/server/tests/test_llm_bedrock_adapter.py
+++ b/server/tests/test_llm_bedrock_adapter.py
@@ -81,6 +81,15 @@ def _ok(json_body):
     )
 
 
+def _err(status, headers=None):
+    return httpx.Response(
+        status,
+        request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/x"),
+        headers=headers or {},
+        json={"message": "x"},
+    )
+
+
 class _AsyncClient:
     def __init__(self, response):
         self._response = response
@@ -245,78 +254,36 @@ class TestBedrockLlama:
 # Error mapping (shared) — exercised via the Claude family
 # ---------------------------------------------------------------------------
 class TestBedrockErrorMapping:
-    def _err(self, status, headers=None):
-        return httpx.Response(
-            status,
-            request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/x"),
-            headers=headers or {},
-            json={"message": "x"},
-        )
-
+    @pytest.mark.parametrize(
+        ("response", "expected"),
+        [
+            (_err(401), AuthInvalid),
+            (_err(403), AuthInvalid),
+            # 400 + ThrottlingException error-type header → treated as rate limiting.
+            (_err(400, {"x-amzn-errortype": "ThrottlingException"}), RateLimited),
+            (_err(402), QuotaExceeded),
+            (_err(503), ProviderUnavailable),
+            (httpx.TimeoutException("timeout"), ProviderUnavailable),
+            # 400 without a throttle header → malformed input.
+            (_err(400), ToolTranslationError),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_401_maps_to_auth_invalid(self):
+    async def test_status_maps_to_exception(self, response, expected):
         adapter = BedrockAdapter(_bedrock_connector())
-        client = _AsyncClient(self._err(401))
+        client = _AsyncClient(response)
         with patch(_HTTPX_PATH, return_value=client):
-            with pytest.raises(AuthInvalid):
+            with pytest.raises(expected):
                 await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
 
     @pytest.mark.asyncio
-    async def test_403_maps_to_auth_invalid(self):
+    async def test_429_maps_to_rate_limited_with_retry_after(self):
         adapter = BedrockAdapter(_bedrock_connector())
-        client = _AsyncClient(self._err(403))
-        with patch(_HTTPX_PATH, return_value=client):
-            with pytest.raises(AuthInvalid):
-                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
-
-    @pytest.mark.asyncio
-    async def test_429_maps_to_rate_limited(self):
-        adapter = BedrockAdapter(_bedrock_connector())
-        client = _AsyncClient(self._err(429, headers={"Retry-After": "12"}))
+        client = _AsyncClient(_err(429, headers={"Retry-After": "12"}))
         with patch(_HTTPX_PATH, return_value=client):
             with pytest.raises(RateLimited) as info:
                 await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
         assert info.value.retry_after_seconds == 12
-
-    @pytest.mark.asyncio
-    async def test_throttling_exception_400_maps_to_rate_limited(self):
-        adapter = BedrockAdapter(_bedrock_connector())
-        client = _AsyncClient(self._err(400, headers={"x-amzn-errortype": "ThrottlingException"}))
-        with patch(_HTTPX_PATH, return_value=client):
-            with pytest.raises(RateLimited):
-                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
-
-    @pytest.mark.asyncio
-    async def test_402_maps_to_quota_exceeded(self):
-        adapter = BedrockAdapter(_bedrock_connector())
-        client = _AsyncClient(self._err(402))
-        with patch(_HTTPX_PATH, return_value=client):
-            with pytest.raises(QuotaExceeded):
-                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
-
-    @pytest.mark.asyncio
-    async def test_500_maps_to_provider_unavailable(self):
-        adapter = BedrockAdapter(_bedrock_connector())
-        client = _AsyncClient(self._err(503))
-        with patch(_HTTPX_PATH, return_value=client):
-            with pytest.raises(ProviderUnavailable):
-                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
-
-    @pytest.mark.asyncio
-    async def test_timeout_maps_to_provider_unavailable(self):
-        adapter = BedrockAdapter(_bedrock_connector())
-        client = _AsyncClient(httpx.TimeoutException("timeout"))
-        with patch(_HTTPX_PATH, return_value=client):
-            with pytest.raises(ProviderUnavailable):
-                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
-
-    @pytest.mark.asyncio
-    async def test_malformed_body_400_maps_to_tool_translation_error(self):
-        adapter = BedrockAdapter(_bedrock_connector())
-        client = _AsyncClient(self._err(400))  # no throttle header
-        with patch(_HTTPX_PATH, return_value=client):
-            with pytest.raises(ToolTranslationError):
-                await adapter.chat(ChatRequest(messages=[Message(role="user", content="x")]))
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_llm_gateway.py
+++ b/server/tests/test_llm_gateway.py
@@ -11,6 +11,7 @@ from app.models.llm_connector import LlmConnector
 from app.models.system_settings import SystemSettings
 from app.models.user import User
 from app.services.auth import get_password_hash
+from app.services.llm.adapters.openai_apikey import OpenAIApiKeyAdapter
 from app.services.llm.base import ChatRequest, ChatResponse, Message, TokenUsage
 from app.services.llm.exceptions import (
     AuthInvalid,
@@ -19,6 +20,11 @@ from app.services.llm.exceptions import (
     RateLimited,
 )
 from app.services.llm.gateway import Gateway
+
+
+def _patch_chat(mock):
+    """Patch the (only) adapter the gateway dispatches to in these tests."""
+    return patch.object(OpenAIApiKeyAdapter, "chat", new=mock)
 
 
 @pytest.fixture
@@ -92,14 +98,7 @@ async def test_actor_with_active_connector_dispatches(db, dj_user, gateway_reque
         usage=TokenUsage(prompt=5, completion=2),
     )
 
-    with patch.object(
-        __import__(
-            "app.services.llm.adapters.openai_apikey",
-            fromlist=["OpenAIApiKeyAdapter"],
-        ).OpenAIApiKeyAdapter,
-        "chat",
-        new=AsyncMock(return_value=fake_response),
-    ):
+    with _patch_chat(AsyncMock(return_value=fake_response)):
         resp = await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
 
     assert resp.text == "ok"
@@ -117,14 +116,7 @@ async def test_actor_with_active_connector_dispatches(db, dj_user, gateway_reque
 @pytest.mark.asyncio
 async def test_auth_invalid_marks_connector(db, dj_user, gateway_request):
     connector = _make_connector(db, dj_user)
-    with patch.object(
-        __import__(
-            "app.services.llm.adapters.openai_apikey",
-            fromlist=["OpenAIApiKeyAdapter"],
-        ).OpenAIApiKeyAdapter,
-        "chat",
-        new=AsyncMock(side_effect=AuthInvalid("nope")),
-    ):
+    with _patch_chat(AsyncMock(side_effect=AuthInvalid("nope"))):
         with pytest.raises(AuthInvalid):
             await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
 
@@ -144,14 +136,7 @@ async def test_auth_invalid_marks_connector(db, dj_user, gateway_request):
 @pytest.mark.asyncio
 async def test_rate_limited_logs_and_raises(db, dj_user, gateway_request):
     _make_connector(db, dj_user)
-    with patch.object(
-        __import__(
-            "app.services.llm.adapters.openai_apikey",
-            fromlist=["OpenAIApiKeyAdapter"],
-        ).OpenAIApiKeyAdapter,
-        "chat",
-        new=AsyncMock(side_effect=RateLimited("slow", retry_after_seconds=12)),
-    ):
+    with _patch_chat(AsyncMock(side_effect=RateLimited("slow", retry_after_seconds=12))):
         with pytest.raises(RateLimited) as exc_info:
             await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
     assert exc_info.value.retry_after_seconds == 12
@@ -165,14 +150,7 @@ async def test_rate_limited_logs_and_raises(db, dj_user, gateway_request):
 @pytest.mark.asyncio
 async def test_provider_unavailable_logs_and_raises(db, dj_user, gateway_request):
     _make_connector(db, dj_user)
-    with patch.object(
-        __import__(
-            "app.services.llm.adapters.openai_apikey",
-            fromlist=["OpenAIApiKeyAdapter"],
-        ).OpenAIApiKeyAdapter,
-        "chat",
-        new=AsyncMock(side_effect=ProviderUnavailable("nope")),
-    ):
+    with _patch_chat(AsyncMock(side_effect=ProviderUnavailable("nope"))):
         with pytest.raises(ProviderUnavailable):
             await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
 
@@ -219,14 +197,7 @@ async def test_falls_back_to_system_default(db, admin_user_actor, gateway_reques
         usage=TokenUsage(prompt=1, completion=1),
     )
 
-    with patch.object(
-        __import__(
-            "app.services.llm.adapters.openai_apikey",
-            fromlist=["OpenAIApiKeyAdapter"],
-        ).OpenAIApiKeyAdapter,
-        "chat",
-        new=AsyncMock(return_value=fake_response),
-    ):
+    with _patch_chat(AsyncMock(return_value=fake_response)):
         resp = await Gateway.dispatch(db, None, gateway_request, purpose="test")
 
     assert resp.text == "ok"
@@ -242,6 +213,21 @@ def _wire_system_default(db, connector: LlmConnector) -> None:
     db.commit()
 
 
+def _make_org_default(db, username: str) -> LlmConnector:
+    """Create an admin-owned org connector and wire it as the system default."""
+    owner = User(
+        username=username,
+        password_hash=get_password_hash("password123"),
+        role="admin",
+    )
+    db.add(owner)
+    db.commit()
+    db.refresh(owner)
+    connector = _make_connector(db, owner, display_name="org-default")
+    _wire_system_default(db, connector)
+    return connector
+
+
 @pytest.mark.asyncio
 async def test_fallback_org_default_on_rate_limit(db, dj_user):
     """429 on DJ connector → falls back to org default → audit event written."""
@@ -249,16 +235,7 @@ async def test_fallback_org_default_on_rate_limit(db, dj_user):
 
     _make_connector(db, dj_user, display_name="dj-primary")
 
-    org_owner = User(
-        username="orgowner",
-        password_hash=get_password_hash("password123"),
-        role="admin",
-    )
-    db.add(org_owner)
-    db.commit()
-    db.refresh(org_owner)
-    org_connector = _make_connector(db, org_owner, display_name="org-default")
-    _wire_system_default(db, org_connector)
+    org_connector = _make_org_default(db, "orgowner")
 
     fallback_response = ChatResponse(
         text="from-fallback",
@@ -271,14 +248,7 @@ async def test_fallback_org_default_on_rate_limit(db, dj_user):
     chat_mock = AsyncMock(
         side_effect=[RateLimited("slow", retry_after_seconds=5), fallback_response]
     )
-    with patch.object(
-        __import__(
-            "app.services.llm.adapters.openai_apikey",
-            fromlist=["OpenAIApiKeyAdapter"],
-        ).OpenAIApiKeyAdapter,
-        "chat",
-        new=chat_mock,
-    ):
+    with _patch_chat(chat_mock):
         req = ChatRequest(
             messages=[Message(role="user", content="hi")],
             fallback_policy="org_default",
@@ -304,26 +274,10 @@ async def test_fallback_none_surfaces_original_error(db, dj_user):
 
     _make_connector(db, dj_user, display_name="dj-primary")
 
-    org_owner = User(
-        username="orgowner2",
-        password_hash=get_password_hash("password123"),
-        role="admin",
-    )
-    db.add(org_owner)
-    db.commit()
-    db.refresh(org_owner)
-    org_connector = _make_connector(db, org_owner, display_name="org-default")
-    _wire_system_default(db, org_connector)
+    _make_org_default(db, "orgowner2")
 
     chat_mock = AsyncMock(side_effect=RateLimited("slow", retry_after_seconds=5))
-    with patch.object(
-        __import__(
-            "app.services.llm.adapters.openai_apikey",
-            fromlist=["OpenAIApiKeyAdapter"],
-        ).OpenAIApiKeyAdapter,
-        "chat",
-        new=chat_mock,
-    ):
+    with _patch_chat(chat_mock):
         req = ChatRequest(
             messages=[Message(role="user", content="hi")],
             fallback_policy="none",
@@ -345,14 +299,7 @@ async def test_fallback_org_default_when_no_default_reraises(db, dj_user):
     _make_connector(db, dj_user, display_name="dj-primary")
 
     chat_mock = AsyncMock(side_effect=ProviderUnavailable("down"))
-    with patch.object(
-        __import__(
-            "app.services.llm.adapters.openai_apikey",
-            fromlist=["OpenAIApiKeyAdapter"],
-        ).OpenAIApiKeyAdapter,
-        "chat",
-        new=chat_mock,
-    ):
+    with _patch_chat(chat_mock):
         req = ChatRequest(
             messages=[Message(role="user", content="hi")],
             fallback_policy="org_default",
@@ -370,14 +317,7 @@ async def test_fallback_skipped_when_primary_is_org_default(db, dj_user):
     _wire_system_default(db, dj_connector)
 
     chat_mock = AsyncMock(side_effect=RateLimited("slow"))
-    with patch.object(
-        __import__(
-            "app.services.llm.adapters.openai_apikey",
-            fromlist=["OpenAIApiKeyAdapter"],
-        ).OpenAIApiKeyAdapter,
-        "chat",
-        new=chat_mock,
-    ):
+    with _patch_chat(chat_mock):
         req = ChatRequest(
             messages=[Message(role="user", content="hi")],
             fallback_policy="org_default",
@@ -393,28 +333,12 @@ async def test_retry_then_org_default_retries_same_then_falls_back(db, dj_user):
     """retry_then_org_default: same connector retried once, then org default."""
     _make_connector(db, dj_user, display_name="dj-primary")
 
-    org_owner = User(
-        username="orgowner3",
-        password_hash=get_password_hash("password123"),
-        role="admin",
-    )
-    db.add(org_owner)
-    db.commit()
-    db.refresh(org_owner)
-    org_connector = _make_connector(db, org_owner, display_name="org-default")
-    _wire_system_default(db, org_connector)
+    _make_org_default(db, "orgowner3")
 
     ok = ChatResponse(text="recovered", tool_calls=[], stop_reason="end_turn", usage=None)
     # attempt 1 (primary) 429, attempt 2 (primary retry) 429, attempt 3 (org default) ok
     chat_mock = AsyncMock(side_effect=[RateLimited("slow"), RateLimited("slow"), ok])
-    with patch.object(
-        __import__(
-            "app.services.llm.adapters.openai_apikey",
-            fromlist=["OpenAIApiKeyAdapter"],
-        ).OpenAIApiKeyAdapter,
-        "chat",
-        new=chat_mock,
-    ):
+    with _patch_chat(chat_mock):
         req = ChatRequest(
             messages=[Message(role="user", content="hi")],
             fallback_policy="retry_then_org_default",
@@ -433,14 +357,7 @@ async def test_retry_then_org_default_succeeds_on_retry(db, dj_user):
 
     ok = ChatResponse(text="retry-ok", tool_calls=[], stop_reason="end_turn", usage=None)
     chat_mock = AsyncMock(side_effect=[ProviderUnavailable("blip"), ok])
-    with patch.object(
-        __import__(
-            "app.services.llm.adapters.openai_apikey",
-            fromlist=["OpenAIApiKeyAdapter"],
-        ).OpenAIApiKeyAdapter,
-        "chat",
-        new=chat_mock,
-    ):
+    with _patch_chat(chat_mock):
         req = ChatRequest(
             messages=[Message(role="user", content="hi")],
             fallback_policy="retry_then_org_default",
@@ -458,27 +375,11 @@ async def test_fallback_not_triggered_for_auth_invalid_when_policy_org_default(d
 
     dj_connector = _make_connector(db, dj_user, display_name="dj-primary")
 
-    org_owner = User(
-        username="orgowner4",
-        password_hash=get_password_hash("password123"),
-        role="admin",
-    )
-    db.add(org_owner)
-    db.commit()
-    db.refresh(org_owner)
-    org_connector = _make_connector(db, org_owner, display_name="org-default")
-    _wire_system_default(db, org_connector)
+    org_connector = _make_org_default(db, "orgowner4")
 
     ok = ChatResponse(text="recovered", tool_calls=[], stop_reason="end_turn", usage=None)
     chat_mock = AsyncMock(side_effect=[AuthInvalid("expired"), ok])
-    with patch.object(
-        __import__(
-            "app.services.llm.adapters.openai_apikey",
-            fromlist=["OpenAIApiKeyAdapter"],
-        ).OpenAIApiKeyAdapter,
-        "chat",
-        new=chat_mock,
-    ):
+    with _patch_chat(chat_mock):
         req = ChatRequest(
             messages=[Message(role="user", content="hi")],
             fallback_policy="org_default",
@@ -504,26 +405,10 @@ async def test_fallback_not_eligible_for_tool_translation_error(db, dj_user):
 
     _make_connector(db, dj_user, display_name="dj-primary")
 
-    org_owner = User(
-        username="orgowner5",
-        password_hash=get_password_hash("password123"),
-        role="admin",
-    )
-    db.add(org_owner)
-    db.commit()
-    db.refresh(org_owner)
-    org_connector = _make_connector(db, org_owner, display_name="org-default")
-    _wire_system_default(db, org_connector)
+    _make_org_default(db, "orgowner5")
 
     chat_mock = AsyncMock(side_effect=ToolTranslationError("bad schema"))
-    with patch.object(
-        __import__(
-            "app.services.llm.adapters.openai_apikey",
-            fromlist=["OpenAIApiKeyAdapter"],
-        ).OpenAIApiKeyAdapter,
-        "chat",
-        new=chat_mock,
-    ):
+    with _patch_chat(chat_mock):
         req = ChatRequest(
             messages=[Message(role="user", content="hi")],
             fallback_policy="retry_then_org_default",
@@ -539,28 +424,12 @@ async def test_fallback_failure_surfaces_fallback_error(db, dj_user):
     """If the fallback connector also fails, the fallback's error surfaces."""
     _make_connector(db, dj_user, display_name="dj-primary")
 
-    org_owner = User(
-        username="orgowner6",
-        password_hash=get_password_hash("password123"),
-        role="admin",
-    )
-    db.add(org_owner)
-    db.commit()
-    db.refresh(org_owner)
-    org_connector = _make_connector(db, org_owner, display_name="org-default")
-    _wire_system_default(db, org_connector)
+    _make_org_default(db, "orgowner6")
 
     chat_mock = AsyncMock(
         side_effect=[RateLimited("primary-slow"), ProviderUnavailable("fallback-down")]
     )
-    with patch.object(
-        __import__(
-            "app.services.llm.adapters.openai_apikey",
-            fromlist=["OpenAIApiKeyAdapter"],
-        ).OpenAIApiKeyAdapter,
-        "chat",
-        new=chat_mock,
-    ):
+    with _patch_chat(chat_mock):
         req = ChatRequest(
             messages=[Message(role="user", content="hi")],
             fallback_policy="org_default",
@@ -593,14 +462,8 @@ async def test_mru_resolution_picks_recent(db, dj_user, gateway_request):
         usage=None,
     )
 
-    with patch.object(
-        __import__(
-            "app.services.llm.adapters.openai_apikey",
-            fromlist=["OpenAIApiKeyAdapter"],
-        ).OpenAIApiKeyAdapter,
-        "chat",
-        new=AsyncMock(return_value=fake_response),
-    ) as chat_mock:
+    chat_mock = AsyncMock(return_value=fake_response)
+    with _patch_chat(chat_mock):
         await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
 
     chat_mock.assert_awaited_once()

--- a/server/tests/test_llm_url_validator.py
+++ b/server/tests/test_llm_url_validator.py
@@ -9,109 +9,53 @@ from app.services.llm.url_validator import (
 
 
 class TestValidateCompatibleBaseUrl:
-    def test_https_any_host_accepted(self):
-        assert validate_compatible_base_url("https://api.openai.com/v1") == (
-            "https://api.openai.com/v1"
-        )
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://api.openai.com/v1", "https://api.openai.com/v1"),
+            ("https://example.com/v1/", "https://example.com/v1"),  # strips trailing slash
+            ("http://localhost:8080", "http://localhost:8080"),  # loopback hostname
+            ("http://127.0.0.1:8000", "http://127.0.0.1:8000"),  # loopback IP
+            ("http://192.168.1.100", "http://192.168.1.100"),  # RFC1918 192.168/16
+            ("http://10.0.0.5/v1", "http://10.0.0.5/v1"),  # RFC1918 10/8
+            ("http://172.20.0.1", "http://172.20.0.1"),  # RFC1918 172.16/12
+            ("https://example.com", "https://example.com"),  # host root, no path
+            ("https://example.com/", "https://example.com"),  # empty path → no slash
+            ("http://127.0.0.1:11434/v1", "http://127.0.0.1:11434/v1"),  # preserves port
+            ("http://[::1]:8080", "http://[::1]:8080"),  # IPv6 loopback
+            ("http://[fc00::1]/v1", "http://[fc00::1]/v1"),  # IPv6 unique-local fc00::/7
+            ("http://[fe80::1]", "http://[fe80::1]"),  # IPv6 link-local fe80::/10
+            (
+                "https://example.com/v1/chat/completions",
+                "https://example.com/v1/chat/completions",
+            ),  # multi-segment path preserved
+        ],
+    )
+    def test_accepts_and_normalises(self, url, expected):
+        assert validate_compatible_base_url(url) == expected
 
-    def test_https_strips_trailing_slash(self):
-        assert validate_compatible_base_url("https://example.com/v1/") == ("https://example.com/v1")
-
-    def test_http_loopback_localhost_ok(self):
-        assert validate_compatible_base_url("http://localhost:8080") == "http://localhost:8080"
-
-    def test_http_loopback_ip_ok(self):
-        assert validate_compatible_base_url("http://127.0.0.1:8000") == ("http://127.0.0.1:8000")
-
-    def test_http_rfc1918_192_ok(self):
-        assert validate_compatible_base_url("http://192.168.1.100") == ("http://192.168.1.100")
-
-    def test_http_rfc1918_10_ok(self):
-        assert validate_compatible_base_url("http://10.0.0.5/v1") == ("http://10.0.0.5/v1")
-
-    def test_http_rfc1918_172_ok(self):
-        assert validate_compatible_base_url("http://172.20.0.1") == "http://172.20.0.1"
-
-    def test_http_public_rejected(self):
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://example.com/v1",  # public host must use HTTPS
+            "http://8.8.8.8",  # public IP must use HTTPS
+            "https://user:pass@example.com/v1",  # embedded credentials
+            "https://example.com/v1?api_key=secret",  # query string
+            "https://example.com/v1#fragment",  # fragment
+            "",  # empty
+            "example.com/v1",  # missing scheme
+            "ftp://example.com",  # invalid scheme
+            "https://",  # missing host
+            "http://[2001:4860:4860::8888]",  # public IPv6 (Google DNS)
+            "   ",  # whitespace only
+        ],
+    )
+    def test_rejects(self, url):
         with pytest.raises(InvalidBaseUrlError):
-            validate_compatible_base_url("http://example.com/v1")
-
-    def test_http_with_8_8_8_8_rejected(self):
-        # public IP — must require HTTPS
-        with pytest.raises(InvalidBaseUrlError):
-            validate_compatible_base_url("http://8.8.8.8")
-
-    def test_embedded_credentials_rejected(self):
-        with pytest.raises(InvalidBaseUrlError):
-            validate_compatible_base_url("https://user:pass@example.com/v1")
-
-    def test_query_string_rejected(self):
-        with pytest.raises(InvalidBaseUrlError):
-            validate_compatible_base_url("https://example.com/v1?api_key=secret")
-
-    def test_fragment_rejected(self):
-        with pytest.raises(InvalidBaseUrlError):
-            validate_compatible_base_url("https://example.com/v1#fragment")
-
-    def test_empty_rejected(self):
-        with pytest.raises(InvalidBaseUrlError):
-            validate_compatible_base_url("")
-
-    def test_missing_scheme_rejected(self):
-        with pytest.raises(InvalidBaseUrlError):
-            validate_compatible_base_url("example.com/v1")
-
-    def test_invalid_scheme_rejected(self):
-        with pytest.raises(InvalidBaseUrlError):
-            validate_compatible_base_url("ftp://example.com")
-
-    def test_missing_host_rejected(self):
-        with pytest.raises(InvalidBaseUrlError):
-            validate_compatible_base_url("https://")
-
-    def test_https_root_no_path_ok(self):
-        # Some servers accept the host root with no path
-        assert validate_compatible_base_url("https://example.com") == ("https://example.com")
-
-    def test_strips_trailing_slash_only(self):
-        # Empty path becomes "" (no slash) per RFC
-        assert validate_compatible_base_url("https://example.com/") == ("https://example.com")
-
-    def test_preserves_port(self):
-        assert validate_compatible_base_url("http://127.0.0.1:11434/v1") == (
-            "http://127.0.0.1:11434/v1"
-        )
-
-    # ---- IPv6 (PR #348) ----
-    def test_http_ipv6_loopback_ok(self):
-        assert validate_compatible_base_url("http://[::1]:8080") == "http://[::1]:8080"
-
-    def test_http_ipv6_unique_local_ok(self):
-        # fc00::/7 - IPv6 unique local addresses
-        assert validate_compatible_base_url("http://[fc00::1]/v1") == "http://[fc00::1]/v1"
-
-    def test_http_ipv6_link_local_ok(self):
-        # fe80::/10 - IPv6 link-local addresses
-        assert validate_compatible_base_url("http://[fe80::1]") == "http://[fe80::1]"
-
-    def test_http_ipv6_public_rejected(self):
-        # 2001:4860:4860::8888 is a public IPv6 address (Google DNS)
-        with pytest.raises(InvalidBaseUrlError):
-            validate_compatible_base_url("http://[2001:4860:4860::8888]")
-
-    # ---- Edge cases (PR #348) ----
-    def test_whitespace_only_rejected(self):
-        with pytest.raises(InvalidBaseUrlError):
-            validate_compatible_base_url("   ")
+            validate_compatible_base_url(url)
 
     def test_case_normalization_scheme(self):
         # Scheme is lower-cased; netloc and path are preserved as-given.
         result = validate_compatible_base_url("HTTPS://EXAMPLE.COM/V1")
         assert result.startswith("https://")
         assert result.endswith("/V1")
-
-    def test_multi_segment_path_preserved(self):
-        assert (
-            validate_compatible_base_url("https://example.com/v1/chat/completions")
-            == "https://example.com/v1/chat/completions"
-        )


### PR DESCRIPTION
## Wave 4 of 4 — epic/ai-engine slop-reduction refactor

Largest contraction of the series — test boilerplate. **Behavior-preserving: identical case counts, zero assertions dropped.**

### Changes
- **`test_llm_url_validator.py`** — 26 single-assert methods → 2 `@pytest.mark.parametrize` tables (accept/normalise + reject), keeping `case_normalization` standalone (its `startswith`/`endswith` asserts deliberately don't pin netloc casing).
- **`test_llm_bedrock_adapter.py`** — `TestBedrockErrorMapping`'s 8 methods → one parametrized `status→exception` test (7 cases) + a separate 429 test (it additionally asserts `retry_after_seconds`). `_err` lifted to module scope so parametrize args resolve at collection time.
- **`test_llm_gateway.py`** — `_patch_chat()` replaces the 6-line `patch.object(__import__("…openai_apikey", …).OpenAIApiKeyAdapter, "chat")` dance (×15) via a plain top-level import; `_make_org_default()` dedupes the org-owner + connector + wire-default setup (×6). No assertion touched — pure setup dedup (the 9 fallback tests are assertion-divergent, so they stay distinct).

### Deliberately NOT collapsed (verifier-flagged coverage risk)
- Cross-adapter error matrix in `test_llm_adapters.py`, `test_llm_api.py` happy-path/policy (two distinct setup mechanisms), per-provider `test_llm_tool_translation.py` — assertion-divergent; parametrizing would silently drop distinct cases. CLAUDE.md: coverage is a diagnostic, not a target.

### Verification
- Net **−226 LOC** (gateway −137, url_validator −56, bedrock −33).
- `ruff` clean. **2429 backend tests pass — same count as before** (no case lost), coverage 87.94%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)