### PR TITLE
feat(llm): per-feature connector preference (#337)

### DIFF
--- a/dashboard/components/AiProvidersSection.tsx
+++ b/dashboard/components/AiProvidersSection.tsx
@@ -9,6 +9,8 @@ import type {
   LlmConnectorCreate,
   LlmConnectorType,
   LlmDjPolicy,
+  LlmFeatureKey,
+  LlmFeaturePreferences,
 } from '@/lib/api-types';
 
 const CONNECTOR_TYPE_LABELS: Record<LlmConnectorType, string> = {
@@ -26,6 +28,14 @@ const STATUS_LABELS: Record<string, { text: string; color: string }> = {
   active: { text: 'Active', color: 'var(--color-success)' },
   auth_invalid: { text: 'Auth invalid', color: 'var(--color-danger)' },
   disabled: { text: 'Disabled', color: 'var(--text-secondary)' },
+};
+
+// Human-readable labels for the pinnable agentic features (issue #337). Falls
+// back to the raw feature key for any feature the backend adds before the UI
+// learns its label.
+const FEATURE_LABELS: Record<string, string> = {
+  recommendation: 'Recommendations',
+  set_builder: 'Set builder',
 };
 
 // Provider-specific input placeholders. Missing entries fall back to the
@@ -103,16 +113,18 @@ export default function AiProvidersSection() {
   const [testStateById, setTestStateById] = useState<Record<number, string>>({});
   const [openrouterModels, setOpenrouterModels] = useState<AIModelInfo[]>([]);
   const [openrouterModelsLoaded, setOpenrouterModelsLoaded] = useState(false);
+  const [featurePrefs, setFeaturePrefs] = useState<LlmFeaturePreferences | null>(null);
 
   useEffect(() => {
     let active = true;
     setLoading(true);
     setError('');
-    Promise.all([api.listLlmConnectors(), fetchPolicySoft()])
-      .then(([rows, p]) => {
+    Promise.all([api.listLlmConnectors(), fetchPolicySoft(), fetchFeaturePrefsSoft()])
+      .then(([rows, p, prefs]) => {
         if (!active) return;
         setConnectors(rows);
         setPolicy(p);
+        setFeaturePrefs(prefs);
       })
       .catch((err) => {
         if (!active) return;
@@ -273,6 +285,22 @@ export default function AiProvidersSection() {
     }
   };
 
+  // Per-feature pin (issue #337). An empty select value clears the pin (use the
+  // account default); any connector id sets/replaces it. The endpoint returns
+  // the full updated list, so we store it verbatim.
+  const handleFeaturePrefChange = async (feature: LlmFeatureKey, value: string) => {
+    try {
+      const updated =
+        value === ''
+          ? await api.clearLlmFeaturePreference(feature)
+          : await api.setLlmFeaturePreference({ feature, connector_id: Number(value) });
+      setFeaturePrefs(updated);
+      setError('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update feature default');
+    }
+  };
+
   return (
     <div>
       <h2 style={{ marginTop: 0, marginBottom: '1.25rem', fontSize: '1.1rem' }}>
@@ -404,6 +432,43 @@ export default function AiProvidersSection() {
           );
         })}
       </section>
+
+      {featurePrefs && featurePrefs.known_features.length > 0 && (
+        <section style={{ marginTop: '2rem' }}>
+          <h3 style={{ marginTop: 0 }}>Per-feature defaults</h3>
+          <p style={{ color: 'var(--text-secondary)' }}>
+            Pin a specific provider to each AI feature. Unpinned features use your account
+            default (or most-recently-used) connector. Inactive connectors are skipped
+            automatically.
+          </p>
+          {featurePrefs.known_features.map((feature) => {
+            const current =
+              featurePrefs.preferences.find((p) => p.feature === feature)?.connector_id ?? '';
+            const selectId = `feature-pref-${feature}`;
+            const activeConnectors = connectors.filter((c) => c.status === 'active');
+            return (
+              <div className="form-group" key={feature}>
+                <label htmlFor={selectId}>{FEATURE_LABELS[feature] ?? feature}</label>
+                <select
+                  id={selectId}
+                  className="input"
+                  value={current === '' ? '' : String(current)}
+                  onChange={(e) =>
+                    handleFeaturePrefChange(feature as LlmFeatureKey, e.target.value)
+                  }
+                >
+                  <option value="">Use account default</option>
+                  {activeConnectors.map((c) => (
+                    <option key={c.id} value={String(c.id)}>
+                      {c.display_name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            );
+          })}
+        </section>
+      )}
 
       <section style={{ marginTop: '2rem' }}>
         {allowedTypes.length === 0 && !form.open && !loading && (
@@ -679,6 +744,17 @@ async function fetchPolicySoft(): Promise<LlmDjPolicy | null> {
   // reject it with a 403.
   try {
     return await api.getLlmPolicy();
+  } catch {
+    return null;
+  }
+}
+
+async function fetchFeaturePrefsSoft(): Promise<LlmFeaturePreferences | null> {
+  // Read the DJ's per-feature pins. On any failure we return null and the
+  // "Per-feature defaults" section is simply hidden — it's an enhancement, not
+  // load-bearing, so a transient error must not break the whole page.
+  try {
+    return await api.listLlmFeaturePreferences();
   } catch {
     return null;
   }

--- a/dashboard/components/__tests__/AiProvidersSection.featurePrefs.test.tsx
+++ b/dashboard/components/__tests__/AiProvidersSection.featurePrefs.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+import AiProvidersSection from '../AiProvidersSection';
+import { api } from '@/lib/api';
+import type { LlmConnector } from '@/lib/api-types';
+
+const NOW = new Date().toISOString();
+
+function makeConnector(overrides: Partial<LlmConnector> = {}): LlmConnector {
+  return {
+    id: 1,
+    user_id: 42,
+    connector_type: 'openai_apikey',
+    display_name: 'My OpenAI',
+    status: 'active',
+    base_url_plain: null,
+    model_hint: null,
+    created_at: NOW,
+    updated_at: NOW,
+    last_used_at: null,
+    last_error: null,
+    is_default: false,
+    last_health_check_at: null,
+    last_health_check_status: null,
+    ...overrides,
+  };
+}
+
+describe('AiProvidersSection per-feature defaults', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([makeConnector()]);
+    vi.spyOn(api, 'getLlmPolicy').mockResolvedValue({
+      llm_apikey_connectors_enabled: true,
+      llm_compatible_connector_enabled: true,
+      allowed_connector_types: ['openai_apikey'],
+    });
+    vi.spyOn(api, 'listLlmFeaturePreferences').mockResolvedValue({
+      preferences: [],
+      known_features: ['recommendation', 'set_builder'],
+    });
+  });
+
+  it('renders a picker per known feature and sets a pin', async () => {
+    const setSpy = vi.spyOn(api, 'setLlmFeaturePreference').mockResolvedValue({
+      preferences: [{ feature: 'recommendation', connector_id: 1 }],
+      known_features: ['recommendation', 'set_builder'],
+    });
+
+    render(<AiProvidersSection />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Per-feature defaults')).toBeInTheDocument(),
+    );
+
+    // One picker per known feature.
+    expect(screen.getByLabelText('Recommendations')).toBeInTheDocument();
+    expect(screen.getByLabelText('Set builder')).toBeInTheDocument();
+
+    const select = screen.getByLabelText('Recommendations') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '1' } });
+
+    await waitFor(() =>
+      expect(setSpy).toHaveBeenCalledWith({
+        feature: 'recommendation',
+        connector_id: 1,
+      }),
+    );
+  });
+
+  it('clears a pin when "Use account default" is selected', async () => {
+    vi.spyOn(api, 'listLlmFeaturePreferences').mockResolvedValue({
+      preferences: [{ feature: 'recommendation', connector_id: 1 }],
+      known_features: ['recommendation', 'set_builder'],
+    });
+    const clearSpy = vi.spyOn(api, 'clearLlmFeaturePreference').mockResolvedValue({
+      preferences: [],
+      known_features: ['recommendation', 'set_builder'],
+    });
+
+    render(<AiProvidersSection />);
+    await waitFor(() =>
+      expect(screen.getByText('Per-feature defaults')).toBeInTheDocument(),
+    );
+
+    const select = screen.getByLabelText('Recommendations') as HTMLSelectElement;
+    // The current pin should be reflected as the selected value.
+    expect(select.value).toBe('1');
+
+    fireEvent.change(select, { target: { value: '' } });
+
+    await waitFor(() => expect(clearSpy).toHaveBeenCalledWith('recommendation'));
+  });
+
+  it('hides the section when the preferences fetch fails (fail soft)', async () => {
+    vi.spyOn(api, 'listLlmFeaturePreferences').mockRejectedValue(new Error('boom'));
+
+    render(<AiProvidersSection />);
+
+    // The connectors list still renders…
+    await waitFor(() => expect(screen.getByText('My OpenAI')).toBeInTheDocument());
+    // …but the per-feature section is absent.
+    expect(screen.queryByText('Per-feature defaults')).not.toBeInTheDocument();
+  });
+
+  it('only offers active connectors in the picker', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([
+      makeConnector({ id: 1, display_name: 'Active one', status: 'active' }),
+      makeConnector({ id: 2, display_name: 'Broken one', status: 'auth_invalid' }),
+    ]);
+
+    render(<AiProvidersSection />);
+    await waitFor(() =>
+      expect(screen.getByText('Per-feature defaults')).toBeInTheDocument(),
+    );
+
+    const select = screen.getByLabelText('Recommendations') as HTMLSelectElement;
+    const optionLabels = Array.from(select.options).map((o) => o.textContent);
+    expect(optionLabels).toContain('Active one');
+    expect(optionLabels).not.toContain('Broken one');
+  });
+});

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -1509,6 +1509,55 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/llm/feature-preferences": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Feature Preferences
+         * @description List the DJ's per-feature connector pins (issue #337).
+         */
+        get: operations["list_feature_preferences_api_llm_feature_preferences_get"];
+        put?: never;
+        /**
+         * Set Feature Preference Endpoint
+         * @description Pin (or re-pin) a connector to a feature for the current DJ.
+         *
+         *     Validates connector ownership server-side (404 for IDs the DJ doesn't own,
+         *     so another DJ's connector existence is never leaked) and rejects pinning a
+         *     non-active connector (400) — the gateway would skip it anyway, so silently
+         *     accepting it is a footgun.
+         */
+        post: operations["set_feature_preference_endpoint_api_llm_feature_preferences_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llm/feature-preferences/{feature}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Clear Feature Preference Endpoint
+         * @description Clear the DJ's pin for ``feature`` (no-op if unset). Returns the new list.
+         */
+        delete: operations["clear_feature_preference_endpoint_api_llm_feature_preferences__feature__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/llm/openrouter/models": {
         parameters: {
             query?: never;
@@ -2800,10 +2849,7 @@ export interface components {
         };
         /** Body_upload_banner_api_events__code__banner_post */
         Body_upload_banner_api_events__code__banner_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** BridgeApiKeyResponse */
@@ -3488,6 +3534,42 @@ export interface components {
             expires_at?: string | null;
             /** Name */
             name?: string | null;
+        };
+        /**
+         * FeaturePreferenceOut
+         * @description A single per-feature connector pin (issue #337).
+         */
+        FeaturePreferenceOut: {
+            /** Connector Id */
+            connector_id: number;
+            /**
+             * Feature
+             * @enum {string}
+             */
+            feature: "recommendation" | "set_builder";
+        };
+        /**
+         * FeaturePreferenceSet
+         * @description Set/change a per-feature pin. Upsert — replaces any existing pin.
+         */
+        FeaturePreferenceSet: {
+            /** Connector Id */
+            connector_id: number;
+            /**
+             * Feature
+             * @enum {string}
+             */
+            feature: "recommendation" | "set_builder";
+        };
+        /**
+         * FeaturePreferencesListOut
+         * @description All of a DJ's per-feature pins + the catalogue of pinnable features.
+         */
+        FeaturePreferencesListOut: {
+            /** Known Features */
+            known_features: ("recommendation" | "set_builder")[];
+            /** Preferences */
+            preferences: components["schemas"]["FeaturePreferenceOut"][];
         };
         /** GuestNowPlaying */
         GuestNowPlaying: {
@@ -7364,6 +7446,104 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ConnectorTestResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_feature_preferences_api_llm_feature_preferences_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeaturePreferencesListOut"];
+                };
+            };
+        };
+    };
+    set_feature_preference_endpoint_api_llm_feature_preferences_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FeaturePreferenceSet"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeaturePreferencesListOut"];
+                };
+            };
+            /** @description Connector is not active and cannot be pinned. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Connector not found for current user. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    clear_feature_preference_endpoint_api_llm_feature_preferences__feature__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                feature: "recommendation" | "set_builder";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeaturePreferencesListOut"];
                 };
             };
             /** @description Validation Error */

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -67,6 +67,11 @@ export type LlmUsageRow = Schemas['UsageRow'];
 // LLM audit trail (issue #341)
 export type LlmAdminAudit = Schemas['AdminAuditOut'];
 export type LlmAuditRow = Schemas['AuditEventRow'];
+// Per-feature connector preference (issue #337)
+export type LlmFeaturePreference = Schemas['FeaturePreferenceOut'];
+export type LlmFeaturePreferences = Schemas['FeaturePreferencesListOut'];
+export type LlmFeaturePreferenceSet = Schemas['FeaturePreferenceSet'];
+export type LlmFeatureKey = Schemas['FeaturePreferenceOut']['feature'];
 // Derive from schema so backend enum changes propagate to TS automatically.
 export type LlmConnectorType = Schemas['ConnectorOut']['connector_type'];
 export type LlmConnectorStatus = Schemas['ConnectorOut']['status'];

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -16,6 +16,9 @@ import type {
   LlmConnectorPatch,
   LlmConnectorTestResult,
   LlmDjPolicy,
+  LlmFeatureKey,
+  LlmFeaturePreferences,
+  LlmFeaturePreferenceSet,
   ArchivedEvent,
   BeatportEventSettings,
   BeatportSearchResult,
@@ -74,6 +77,10 @@ export type {
   LlmConnectorTestResult,
   LlmConnectorType,
   LlmDjPolicy,
+  LlmFeatureKey,
+  LlmFeaturePreference,
+  LlmFeaturePreferences,
+  LlmFeaturePreferenceSet,
   LlmUsageRow,
   ArchivedEvent,
   BeatportEventSettings,
@@ -1218,6 +1225,25 @@ class ApiClient {
 
   async unsetLlmConnectorDefault(id: number): Promise<LlmConnector> {
     return this.fetch(`/api/llm/connectors/${id}/default`, { method: 'DELETE' });
+  }
+
+  // ========== Per-feature connector preferences (issue #337) ==========
+
+  async listLlmFeaturePreferences(): Promise<LlmFeaturePreferences> {
+    return this.fetch('/api/llm/feature-preferences');
+  }
+
+  async setLlmFeaturePreference(data: LlmFeaturePreferenceSet): Promise<LlmFeaturePreferences> {
+    return this.fetch('/api/llm/feature-preferences', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async clearLlmFeaturePreference(feature: LlmFeatureKey): Promise<LlmFeaturePreferences> {
+    return this.fetch(`/api/llm/feature-preferences/${feature}`, {
+      method: 'DELETE',
+    });
   }
 
   // ========== Admin LLM policy + oversight ==========

--- a/docs/superpowers/plans/2026-05-28-per-feature-connector-preference.md
+++ b/docs/superpowers/plans/2026-05-28-per-feature-connector-preference.md
@@ -1,0 +1,1314 @@
+# Per-Feature Connector Preference Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let each DJ pin a specific LLM connector to a specific agentic feature (e.g. recommendation → connector A, set_builder → connector B), with graceful fallback when the pinned connector is gone or auth-invalid.
+
+**Architecture:** A new `LlmFeaturePreference` table maps `(user_id, feature) → connector_id` with a UNIQUE constraint. `Gateway.dispatch` already receives `purpose` (the feature key), so resolution gains a new first step: look up the DJ's pinned connector for `purpose`, use it if active, else fall through to the existing chain (per-DJ default → MRU → org default → `NoLlmConfigured`). New `/api/llm/feature-preferences` endpoints (set/clear/list) are scoped to the current DJ and validate connector ownership + feature against an allowlist. The DJ AI settings UI gains a "Per-feature defaults" section.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0, Alembic, slowapi, Pydantic v2, Next.js/React 19/TypeScript, vitest.
+
+---
+
+## File Structure
+
+**Backend (create):**
+- `server/app/models/llm_feature_preference.py` — the new model + feature allowlist constants.
+- `server/alembic/versions/050_llm_feature_preference.py` — migration (down_revision = `049`).
+- `server/tests/test_llm_feature_preference.py` — model + gateway resolution + endpoint tests.
+
+**Backend (modify):**
+- `server/app/models/__init__.py` — register `LlmFeaturePreference`.
+- `server/app/services/llm/connector_storage.py` — feature-preference CRUD helpers.
+- `server/app/services/llm/gateway.py` — add feature-preference as the first resolution step.
+- `server/app/api/llm.py` — set/clear/list feature-preference endpoints.
+- `server/app/schemas/llm.py` — request/response schemas + known-feature constant.
+
+**Frontend (modify):**
+- `dashboard/lib/api.ts` — `listFeaturePreferences`, `setFeaturePreference`, `clearFeaturePreference`.
+- `dashboard/components/AiProvidersSection.tsx` — "Per-feature defaults" section.
+- `dashboard/lib/api-types.ts` — re-export the new generated schema types.
+- `dashboard/lib/api-types.generated.ts` — regenerated from OpenAPI (via `npm run types:export && npm run types:generate`).
+
+**Design decisions (locked in):**
+- Feature key reuses the gateway `purpose` string. Known features allowlist: `{"recommendation", "set_builder"}`. `recommendation` is the only `purpose` in use today; `set_builder` is named in the issue spec for an upcoming feature. The allowlist lives in one place (`schemas/llm.py`) and is imported by both the API validation and the model docstring reference.
+- The endpoint surface is `POST /api/llm/feature-preferences` (upsert set), `DELETE /api/llm/feature-preferences/{feature}` (clear), `GET /api/llm/feature-preferences` (list). Upsert semantics keep "set" and "change" as one operation (the UNIQUE constraint makes change == replace).
+- Ownership: setting a preference validates the connector belongs to the current DJ (404 if not, mirroring the existing connector-ownership 404 convention so another DJ's connector existence is never leaked).
+- Graceful fallback: gateway resolution skips a pinned preference whose connector is deleted (FK row gone) or whose status != `active`. No exception — falls through to the next resolution step.
+- We do NOT add a frontend "set inactive connector" guard beyond what the picker offers; the gateway already skips inactive pins, and the API rejects pinning a non-active connector with 400 (mirrors the per-DJ default endpoint), so a DJ can't silently break their own routing.
+
+---
+
+## Task 1: LlmFeaturePreference model + feature allowlist
+
+**Files:**
+- Create: `server/app/models/llm_feature_preference.py`
+- Modify: `server/app/models/__init__.py`
+- Test: `server/tests/test_llm_feature_preference.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/tests/test_llm_feature_preference.py`:
+
+```python
+"""Tests for per-feature connector preference (issue #337)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.llm_connector import LlmConnector
+from app.models.llm_feature_preference import KNOWN_FEATURES, LlmFeaturePreference
+from app.models.user import User
+from app.services.auth import get_password_hash
+
+
+@pytest.fixture
+def dj_user(db) -> User:
+    user = User(
+        username="prefdj",
+        password_hash=get_password_hash("password123"),
+        role="dj",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _make_connector(db, user, *, display_name="Pref connector", status="active"):
+    row = LlmConnector(
+        user_id=user.id,
+        connector_type="openai_apikey",
+        display_name=display_name,
+        status=status,
+        credentials=json.dumps({"api_key": "sk-fake-key"}),
+        model_hint="gpt-5-mini",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def test_known_features_contains_recommendation_and_set_builder():
+    assert "recommendation" in KNOWN_FEATURES
+    assert "set_builder" in KNOWN_FEATURES
+
+
+def test_unique_constraint_one_pref_per_user_feature(db, dj_user):
+    c1 = _make_connector(db, dj_user, display_name="A")
+    c2 = _make_connector(db, dj_user, display_name="B")
+    db.add(
+        LlmFeaturePreference(user_id=dj_user.id, feature="recommendation", connector_id=c1.id)
+    )
+    db.commit()
+    db.add(
+        LlmFeaturePreference(user_id=dj_user.id, feature="recommendation", connector_id=c2.id)
+    )
+    with pytest.raises(IntegrityError):
+        db.commit()
+    db.rollback()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && .venv/bin/pytest tests/test_llm_feature_preference.py -x -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.models.llm_feature_preference'`
+
+- [ ] **Step 3: Write the model**
+
+Create `server/app/models/llm_feature_preference.py`:
+
+```python
+"""Per-feature connector preference — pins a DJ's connector to a feature.
+
+A DJ can pin the recommendation engine to one connector and the set-builder
+to another. The gateway consults this table first (keyed by ``purpose``)
+before falling back to the per-DJ default / MRU / org-default chain.
+
+See issue #337, spec §11.8.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+# Allowlist of feature keys a DJ may pin. These mirror the gateway ``purpose``
+# strings. ``recommendation`` is the only purpose dispatched today;
+# ``set_builder`` is reserved for the upcoming set-builder feature (issue spec
+# §11.8). Validation of API input against this set lives in ``schemas/llm.py``
+# (KNOWN_FEATURES is re-exported there to keep a single source of truth).
+KNOWN_FEATURES = frozenset({"recommendation", "set_builder"})
+
+
+class LlmFeaturePreference(Base):
+    """Maps ``(user_id, feature)`` to a pinned ``connector_id``.
+
+    At most one row per ``(user_id, feature)`` — enforced by a UNIQUE
+    constraint. Deleting the connector cascades (ON DELETE CASCADE) so a stale
+    preference never points at a missing connector.
+    """
+
+    __tablename__ = "llm_feature_preferences"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    feature: Mapped[str] = mapped_column(String(40), nullable=False)
+    connector_id: Mapped[int] = mapped_column(
+        ForeignKey("llm_connectors.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "feature", name="uq_llm_feature_pref_user_feature"),
+    )
+```
+
+- [ ] **Step 4: Register the model**
+
+Modify `server/app/models/__init__.py` — add the import after the `llm_connector` import line and the name to `__all__` (alphabetical-ish, keep grouped with other Llm names):
+
+```python
+from app.models.llm_connector import LlmAuditEvent, LlmCallLog, LlmConnector
+from app.models.llm_feature_preference import LlmFeaturePreference
+```
+
+And add `"LlmFeaturePreference",` to the `__all__` list (right after `"LlmConnector",`).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd server && .venv/bin/pytest tests/test_llm_feature_preference.py -x -q`
+Expected: PASS (3 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/app/models/llm_feature_preference.py server/app/models/__init__.py server/tests/test_llm_feature_preference.py
+git commit -m "feat(llm): add LlmFeaturePreference model + feature allowlist"
+```
+
+---
+
+## Task 2: Alembic migration
+
+**Files:**
+- Create: `server/alembic/versions/050_llm_feature_preference.py`
+
+- [ ] **Step 1: Write the migration**
+
+Create `server/alembic/versions/050_llm_feature_preference.py`:
+
+```python
+"""Add llm_feature_preferences table.
+
+Revision ID: 050
+Revises: 049
+Create Date: 2026-05-28
+
+Per-feature connector preference (issue #337). Maps ``(user_id, feature)`` to a
+pinned ``connector_id`` with a UNIQUE constraint so a DJ has at most one pinned
+connector per feature. Both FKs cascade on delete so a deleted user or
+connector never leaves a dangling preference.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "050"
+down_revision: str | None = "049"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "llm_feature_preferences",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("feature", sa.String(length=40), nullable=False),
+        sa.Column("connector_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["connector_id"], ["llm_connectors.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "feature", name="uq_llm_feature_pref_user_feature"),
+    )
+    op.create_index(
+        "ix_llm_feature_preferences_user_id",
+        "llm_feature_preferences",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_llm_feature_preferences_connector_id",
+        "llm_feature_preferences",
+        ["connector_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_llm_feature_preferences_connector_id", table_name="llm_feature_preferences")
+    op.drop_index("ix_llm_feature_preferences_user_id", table_name="llm_feature_preferences")
+    op.drop_table("llm_feature_preferences")
+```
+
+- [ ] **Step 2: Run migration + drift check**
+
+Run: `cd server && .venv/bin/alembic upgrade head && .venv/bin/alembic check`
+Expected: `upgrade` runs cleanly to revision `050`, and `alembic check` prints `No new upgrade operations detected.`
+
+If `alembic check` reports drift, reconcile the migration columns/indexes with the model (`index=True` on `user_id` and `connector_id` matches the two `create_index` calls).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/alembic/versions/050_llm_feature_preference.py
+git commit -m "feat(llm): migration 050 for llm_feature_preferences"
+```
+
+---
+
+## Task 3: connector_storage CRUD helpers
+
+**Files:**
+- Modify: `server/app/services/llm/connector_storage.py`
+- Test: `server/tests/test_llm_feature_preference.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/tests/test_llm_feature_preference.py`:
+
+```python
+def test_set_feature_preference_upserts(db, dj_user):
+    from app.services.llm.connector_storage import (
+        get_feature_preferences_for_user,
+        set_feature_preference,
+    )
+
+    c1 = _make_connector(db, dj_user, display_name="A")
+    c2 = _make_connector(db, dj_user, display_name="B")
+
+    set_feature_preference(db, user_id=dj_user.id, feature="recommendation", connector_id=c1.id)
+    db.commit()
+    prefs = get_feature_preferences_for_user(db, dj_user.id)
+    assert {p.feature: p.connector_id for p in prefs} == {"recommendation": c1.id}
+
+    # Re-set the same feature → replace, not duplicate.
+    set_feature_preference(db, user_id=dj_user.id, feature="recommendation", connector_id=c2.id)
+    db.commit()
+    prefs = get_feature_preferences_for_user(db, dj_user.id)
+    assert {p.feature: p.connector_id for p in prefs} == {"recommendation": c2.id}
+
+
+def test_clear_feature_preference_removes_row(db, dj_user):
+    from app.services.llm.connector_storage import (
+        clear_feature_preference,
+        get_feature_preferences_for_user,
+        set_feature_preference,
+    )
+
+    c1 = _make_connector(db, dj_user, display_name="A")
+    set_feature_preference(db, user_id=dj_user.id, feature="recommendation", connector_id=c1.id)
+    db.commit()
+
+    removed = clear_feature_preference(db, user_id=dj_user.id, feature="recommendation")
+    db.commit()
+    assert removed is True
+    assert get_feature_preferences_for_user(db, dj_user.id) == []
+
+    # Clearing a non-existent preference is a no-op (returns False).
+    assert clear_feature_preference(db, user_id=dj_user.id, feature="recommendation") is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && .venv/bin/pytest tests/test_llm_feature_preference.py -x -q`
+Expected: FAIL with `ImportError: cannot import name 'set_feature_preference'`
+
+- [ ] **Step 3: Add the helpers**
+
+In `server/app/services/llm/connector_storage.py`, add the model import to the existing `from app.models.llm_connector import (...)` block is NOT possible (different module). Add a new import near the top imports:
+
+```python
+from app.models.llm_feature_preference import LlmFeaturePreference
+```
+
+Then add these functions (place them after `unset_default_for_user`):
+
+```python
+def get_feature_preferences_for_user(db: Session, user_id: int) -> list[LlmFeaturePreference]:
+    """Return all of a DJ's per-feature connector pins."""
+    return (
+        db.query(LlmFeaturePreference)
+        .filter(LlmFeaturePreference.user_id == user_id)
+        .order_by(LlmFeaturePreference.feature.asc())
+        .all()
+    )
+
+
+def get_feature_preference(
+    db: Session, *, user_id: int, feature: str
+) -> LlmFeaturePreference | None:
+    """Return the DJ's pin for ``feature``, or ``None`` if unset."""
+    return (
+        db.query(LlmFeaturePreference)
+        .filter(
+            LlmFeaturePreference.user_id == user_id,
+            LlmFeaturePreference.feature == feature,
+        )
+        .one_or_none()
+    )
+
+
+def set_feature_preference(
+    db: Session, *, user_id: int, feature: str, connector_id: int
+) -> LlmFeaturePreference:
+    """Upsert the DJ's pin for ``feature`` → ``connector_id``. Caller commits.
+
+    Replace-in-place when a row already exists so the UNIQUE constraint on
+    ``(user_id, feature)`` is never violated.
+    """
+    existing = get_feature_preference(db, user_id=user_id, feature=feature)
+    if existing is not None:
+        existing.connector_id = connector_id
+        db.flush()
+        return existing
+    row = LlmFeaturePreference(user_id=user_id, feature=feature, connector_id=connector_id)
+    db.add(row)
+    db.flush()
+    return row
+
+
+def clear_feature_preference(db: Session, *, user_id: int, feature: str) -> bool:
+    """Delete the DJ's pin for ``feature``. Returns True iff a row was removed.
+
+    Caller commits.
+    """
+    existing = get_feature_preference(db, user_id=user_id, feature=feature)
+    if existing is None:
+        return False
+    db.delete(existing)
+    db.flush()
+    return True
+```
+
+Add the four function names to the `__all__` list alphabetically:
+`"clear_feature_preference",`, `"get_feature_preference",`, `"get_feature_preferences_for_user",`, `"set_feature_preference",`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && .venv/bin/pytest tests/test_llm_feature_preference.py -x -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/services/llm/connector_storage.py server/tests/test_llm_feature_preference.py
+git commit -m "feat(llm): feature-preference CRUD helpers in connector_storage"
+```
+
+---
+
+## Task 4: Gateway resolution — feature preference first
+
+**Files:**
+- Modify: `server/app/services/llm/gateway.py`
+- Test: `server/tests/test_llm_feature_preference.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/tests/test_llm_feature_preference.py`:
+
+```python
+from unittest.mock import AsyncMock, patch  # noqa: E402  (grouped with gateway tests)
+
+from app.services.llm.adapters.openai_apikey import OpenAIApiKeyAdapter  # noqa: E402
+from app.services.llm.base import ChatRequest, ChatResponse, Message, TokenUsage  # noqa: E402
+from app.services.llm.gateway import Gateway  # noqa: E402
+
+
+def _ok_response() -> ChatResponse:
+    return ChatResponse(
+        text="ok", tool_calls=[], stop_reason="end_turn", usage=TokenUsage(prompt=1, completion=1)
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_prefers_feature_pin_over_default(db, dj_user):
+    from app.services.llm.connector_storage import set_default_for_user, set_feature_preference
+
+    pinned = _make_connector(db, dj_user, display_name="pinned")
+    other = _make_connector(db, dj_user, display_name="default")
+    set_default_for_user(db, connector=other)  # per-DJ default points elsewhere
+    set_feature_preference(
+        db, user_id=dj_user.id, feature="recommendation", connector_id=pinned.id
+    )
+    db.commit()
+
+    captured = {}
+
+    async def fake_chat(self, request):  # noqa: ANN001
+        captured["connector_id"] = self.connector.id
+        return _ok_response()
+
+    with patch.object(OpenAIApiKeyAdapter, "chat", new=fake_chat):
+        await Gateway.dispatch(
+            db,
+            dj_user,
+            ChatRequest(messages=[Message(role="user", content="hi")]),
+            purpose="recommendation",
+        )
+    assert captured["connector_id"] == pinned.id
+
+
+@pytest.mark.asyncio
+async def test_gateway_falls_back_when_pinned_connector_auth_invalid(db, dj_user):
+    from app.services.llm.connector_storage import set_default_for_user, set_feature_preference
+
+    pinned = _make_connector(db, dj_user, display_name="pinned", status="auth_invalid")
+    fallback = _make_connector(db, dj_user, display_name="fallback")
+    set_default_for_user(db, connector=fallback)
+    set_feature_preference(
+        db, user_id=dj_user.id, feature="recommendation", connector_id=pinned.id
+    )
+    db.commit()
+
+    captured = {}
+
+    async def fake_chat(self, request):  # noqa: ANN001
+        captured["connector_id"] = self.connector.id
+        return _ok_response()
+
+    with patch.object(OpenAIApiKeyAdapter, "chat", new=fake_chat):
+        await Gateway.dispatch(
+            db,
+            dj_user,
+            ChatRequest(messages=[Message(role="user", content="hi")]),
+            purpose="recommendation",
+        )
+    # Skips the auth_invalid pin, falls through to the per-DJ default.
+    assert captured["connector_id"] == fallback.id
+
+
+@pytest.mark.asyncio
+async def test_gateway_ignores_pin_for_unknown_feature(db, dj_user):
+    """A pin set for one feature must not leak into another purpose."""
+    from app.services.llm.connector_storage import set_feature_preference
+
+    pinned = _make_connector(db, dj_user, display_name="pinned")
+    mru = _make_connector(db, dj_user, display_name="mru")
+    set_feature_preference(
+        db, user_id=dj_user.id, feature="recommendation", connector_id=pinned.id
+    )
+    db.commit()
+
+    captured = {}
+
+    async def fake_chat(self, request):  # noqa: ANN001
+        captured["connector_id"] = self.connector.id
+        return _ok_response()
+
+    with patch.object(OpenAIApiKeyAdapter, "chat", new=fake_chat):
+        await Gateway.dispatch(
+            db,
+            dj_user,
+            ChatRequest(messages=[Message(role="user", content="hi")]),
+            purpose="set_builder",
+        )
+    # No pin for set_builder → MRU resolution (most recently created here is `mru`).
+    assert captured["connector_id"] == mru.id
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && .venv/bin/pytest tests/test_llm_feature_preference.py -x -q -k gateway`
+Expected: FAIL — the pin is ignored because `_resolve_connector` doesn't know about `purpose`.
+
+- [ ] **Step 3: Thread purpose into resolution**
+
+In `server/app/services/llm/gateway.py`:
+
+Add the storage import near the existing imports:
+
+```python
+from app.services.llm.connector_storage import audit_event, get_feature_preference, log_call
+```
+
+(modify the existing `from app.services.llm.connector_storage import audit_event, log_call` line)
+
+In `Gateway.dispatch`, change the resolve call to pass `purpose`:
+
+```python
+        primary = _resolve_connector(db, actor, purpose=purpose)
+```
+
+Update `_resolve_connector`'s signature and add the feature-preference step as the FIRST check inside the `if actor is not None:` block:
+
+```python
+def _resolve_connector(db: Session, actor: User | None, *, purpose: str) -> LlmConnector:
+    if actor is not None:
+        # 0. Per-feature pin (issue #337) takes precedence over the per-DJ
+        #    default and MRU. Skipped gracefully when the pinned connector was
+        #    deleted (FK row gone) or is no longer active, so a stale/broken
+        #    pin never silently breaks the DJ — resolution falls through.
+        pref = get_feature_preference(db, user_id=actor.id, feature=purpose)
+        if pref is not None:
+            pinned = db.get(LlmConnector, pref.connector_id)
+            if (
+                pinned is not None
+                and pinned.user_id == actor.id
+                and pinned.status == STATUS_ACTIVE
+            ):
+                return pinned
+
+        # Per-DJ explicit default takes precedence over MRU (issue #336).
+        ...
+```
+
+(Leave the rest of `_resolve_connector` unchanged — the `pinned` default block, the MRU block, the org-default fallback.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && .venv/bin/pytest tests/test_llm_feature_preference.py -x -q -k gateway`
+Expected: PASS
+
+Then run the full gateway suite to confirm no regression:
+Run: `cd server && .venv/bin/pytest tests/test_llm_gateway.py tests/test_llm_default_connector.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Update gateway module docstring**
+
+In `server/app/services/llm/gateway.py`, update the "Resolution order" docstring at the top to list the feature-preference step first:
+
+```
+Resolution order:
+1. If ``actor`` is not ``None``:
+   a. The DJ's per-feature pin for ``purpose`` if set and the pinned connector
+      is active (``LlmFeaturePreference`` — issue #337).
+   b. Else: the DJ's explicit default active connector if one is pinned
+      (``LlmConnector.is_default = True``) — issue #336.
+   c. Else: most-recently-used active connector for the DJ.
+2. Else: ``SystemSettings.llm_default_connector_id`` if set and active.
+3. Else: raise :class:`NoLlmConfigured`.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/app/services/llm/gateway.py server/tests/test_llm_feature_preference.py
+git commit -m "feat(llm): gateway resolves per-feature pin first, falls back gracefully"
+```
+
+---
+
+## Task 5: API schemas
+
+**Files:**
+- Modify: `server/app/schemas/llm.py`
+
+- [ ] **Step 1: Add the schemas + feature literal**
+
+In `server/app/schemas/llm.py`, after the existing imports add the known-feature import + a `Literal`-derived alias. Near the top (after `from typing import Literal`):
+
+```python
+from app.models.llm_feature_preference import KNOWN_FEATURES
+
+# Sorted tuple so the OpenAPI enum + frontend list are deterministic.
+KNOWN_FEATURE_VALUES: tuple[str, ...] = tuple(sorted(KNOWN_FEATURES))
+FeatureKey = Literal["recommendation", "set_builder"]
+```
+
+At the end of the file add:
+
+```python
+class FeaturePreferenceOut(BaseModel):
+    """A single per-feature connector pin."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    feature: FeatureKey
+    connector_id: int
+
+
+class FeaturePreferencesListOut(BaseModel):
+    """All of a DJ's per-feature pins + the catalogue of pinnable features."""
+
+    preferences: list[FeaturePreferenceOut]
+    known_features: list[FeatureKey]
+
+
+class FeaturePreferenceSet(BaseModel):
+    """Set/change a per-feature pin. Upsert — replaces any existing pin."""
+
+    feature: FeatureKey
+    connector_id: int = Field(..., ge=1)
+```
+
+> Note: `FeatureKey` is hand-maintained to match `KNOWN_FEATURES` (Pydantic `Literal` can't be built from a runtime frozenset and still emit a static OpenAPI enum). The model docstring in `llm_feature_preference.py` flags that both must stay in sync; a test in Task 7 asserts they match.
+
+- [ ] **Step 2: Verify it imports**
+
+Run: `cd server && .venv/bin/python -c "from app.schemas.llm import FeaturePreferenceSet, FeaturePreferencesListOut, KNOWN_FEATURE_VALUES; print(KNOWN_FEATURE_VALUES)"`
+Expected: prints `('recommendation', 'set_builder')`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/app/schemas/llm.py
+git commit -m "feat(llm): feature-preference API schemas"
+```
+
+---
+
+## Task 6: API endpoints
+
+**Files:**
+- Modify: `server/app/api/llm.py`
+- Test: `server/tests/test_llm_feature_preference.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/tests/test_llm_feature_preference.py`:
+
+```python
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+def _login(client: TestClient, username: str, password: str) -> dict[str, str]:
+    resp = client.post("/api/auth/login", data={"username": username, "password": password})
+    assert resp.status_code == 200, resp.json()
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def test_set_list_clear_feature_preference_endpoints(client, db, test_user, auth_headers):
+    c = _make_connector(db, test_user, display_name="Endpoint connector")
+
+    # Set
+    resp = client.post(
+        "/api/llm/feature-preferences",
+        json={"feature": "recommendation", "connector_id": c.id},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.json()
+    body = resp.json()
+    assert {p["feature"]: p["connector_id"] for p in body["preferences"]} == {
+        "recommendation": c.id
+    }
+    assert "set_builder" in body["known_features"]
+
+    # List
+    resp = client.get("/api/llm/feature-preferences", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["preferences"][0]["connector_id"] == c.id
+
+    # Clear
+    resp = client.delete("/api/llm/feature-preferences/recommendation", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["preferences"] == []
+
+
+def test_set_feature_preference_rejects_unknown_feature(client, db, test_user, auth_headers):
+    c = _make_connector(db, test_user, display_name="X")
+    resp = client.post(
+        "/api/llm/feature-preferences",
+        json={"feature": "totally_made_up", "connector_id": c.id},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422  # Pydantic Literal rejects it
+
+
+def test_set_feature_preference_rejects_other_djs_connector(
+    client, db, test_user, auth_headers
+):
+    # Another DJ owns this connector.
+    other = User(
+        username="otherdj", password_hash=get_password_hash("password123"), role="dj"
+    )
+    db.add(other)
+    db.commit()
+    db.refresh(other)
+    foreign = _make_connector(db, other, display_name="Not yours")
+
+    resp = client.post(
+        "/api/llm/feature-preferences",
+        json={"feature": "recommendation", "connector_id": foreign.id},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404  # ownership not leaked
+
+
+def test_set_feature_preference_rejects_inactive_connector(
+    client, db, test_user, auth_headers
+):
+    c = _make_connector(db, test_user, display_name="Broken", status="auth_invalid")
+    resp = client.post(
+        "/api/llm/feature-preferences",
+        json={"feature": "recommendation", "connector_id": c.id},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_clear_unknown_feature_returns_422(client, auth_headers):
+    resp = client.delete("/api/llm/feature-preferences/bogus", headers=auth_headers)
+    assert resp.status_code == 422
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && .venv/bin/pytest tests/test_llm_feature_preference.py -x -q -k endpoint`
+Expected: FAIL with 404 (route not found) on the first POST.
+
+- [ ] **Step 3: Add the endpoints**
+
+In `server/app/api/llm.py`:
+
+Add to the schema import block:
+
+```python
+from app.schemas.llm import (
+    ConnectorCreate,
+    ConnectorCredentialsRotate,
+    ConnectorOut,
+    ConnectorPatch,
+    ConnectorTestResult,
+    DjPolicyOut,
+    FeatureKey,
+    FeaturePreferenceSet,
+    FeaturePreferencesListOut,
+)
+```
+
+Add to the connector_storage import block:
+
+```python
+from app.services.llm.connector_storage import (
+    ...existing names...,
+    clear_feature_preference,
+    get_feature_preferences_for_user,
+    set_feature_preference,
+)
+```
+
+Add a small helper near `_get_owned_connector_or_404`:
+
+```python
+def _feature_prefs_response(db: Session, user_id: int) -> FeaturePreferencesListOut:
+    """Build the list response: the DJ's current pins + the pinnable catalogue."""
+    from app.schemas.llm import KNOWN_FEATURE_VALUES, FeaturePreferenceOut
+
+    rows = get_feature_preferences_for_user(db, user_id)
+    return FeaturePreferencesListOut(
+        preferences=[FeaturePreferenceOut.model_validate(r) for r in rows],
+        known_features=list(KNOWN_FEATURE_VALUES),  # type: ignore[arg-type]
+    )
+```
+
+Add the three endpoints (place after the unset-default endpoint, before the delete-connector endpoint):
+
+```python
+@router.get("/feature-preferences", response_model=FeaturePreferencesListOut)
+@limiter.limit("60/minute")
+def list_feature_preferences(
+    request: FastAPIRequest,
+    user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+) -> FeaturePreferencesListOut:
+    """List the DJ's per-feature connector pins (issue #337)."""
+    return _feature_prefs_response(db, user.id)
+
+
+@router.post(
+    "/feature-preferences",
+    response_model=FeaturePreferencesListOut,
+    responses={
+        400: {"description": "Connector is not active and cannot be pinned."},
+        404: {"description": "Connector not found for current user."},
+    },
+)
+@limiter.limit("30/minute")
+def set_feature_preference_endpoint(
+    request: FastAPIRequest,
+    payload: FeaturePreferenceSet,
+    user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+) -> FeaturePreferencesListOut:
+    """Pin (or re-pin) a connector to a feature for the current DJ.
+
+    Validates connector ownership server-side (404 for IDs the DJ doesn't own,
+    so another DJ's connector existence is never leaked) and rejects pinning a
+    non-active connector (400) — the gateway would skip it anyway, so silently
+    accepting it is a footgun.
+    """
+    row = _get_owned_connector_or_404(db, payload.connector_id, user.id)
+    if row.status != "active":
+        raise HTTPException(
+            status_code=400,
+            detail="Only an active connector can be pinned to a feature",
+        )
+    set_feature_preference(
+        db, user_id=user.id, feature=payload.feature, connector_id=row.id
+    )
+    db.commit()
+    return _feature_prefs_response(db, user.id)
+
+
+@router.delete("/feature-preferences/{feature}", response_model=FeaturePreferencesListOut)
+@limiter.limit("30/minute")
+def clear_feature_preference_endpoint(
+    request: FastAPIRequest,
+    feature: FeatureKey,
+    user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+) -> FeaturePreferencesListOut:
+    """Clear the DJ's pin for ``feature`` (no-op if unset). Returns the new list."""
+    clear_feature_preference(db, user_id=user.id, feature=feature)
+    db.commit()
+    return _feature_prefs_response(db, user.id)
+```
+
+> Path-param `feature: FeatureKey` makes FastAPI return 422 for unknown features automatically.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && .venv/bin/pytest tests/test_llm_feature_preference.py -x -q -k "endpoint or feature"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/api/llm.py server/tests/test_llm_feature_preference.py
+git commit -m "feat(llm): set/clear/list feature-preference endpoints"
+```
+
+---
+
+## Task 7: Consistency guard + full backend CI
+
+**Files:**
+- Test: `server/tests/test_llm_feature_preference.py`
+
+- [ ] **Step 1: Add a guard test that FeatureKey == KNOWN_FEATURES**
+
+Append to `server/tests/test_llm_feature_preference.py`:
+
+```python
+def test_feature_key_literal_matches_known_features():
+    """FeatureKey (the OpenAPI enum) must stay in sync with KNOWN_FEATURES."""
+    import typing
+
+    from app.schemas.llm import FeatureKey
+
+    literal_values = set(typing.get_args(FeatureKey))
+    assert literal_values == set(KNOWN_FEATURES)
+```
+
+- [ ] **Step 2: Run the full new test file**
+
+Run: `cd server && .venv/bin/pytest tests/test_llm_feature_preference.py -q`
+Expected: PASS (all tests)
+
+- [ ] **Step 3: Run full backend CI**
+
+```bash
+cd server
+.venv/bin/ruff check .
+.venv/bin/ruff format --check .
+.venv/bin/bandit -r app -c pyproject.toml -q
+.venv/bin/alembic upgrade head && .venv/bin/alembic check
+.venv/bin/pytest --tb=short -q
+```
+
+Expected: ruff clean, bandit clean, alembic check clean, pytest passes with coverage ≥ gate. Fix any failures before committing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/tests/test_llm_feature_preference.py
+git commit -m "test(llm): guard FeatureKey/KNOWN_FEATURES sync"
+```
+
+---
+
+## Task 8: Frontend — regenerate types + api.ts methods
+
+**Files:**
+- Modify: `dashboard/lib/api-types.generated.ts` (regenerated), `dashboard/lib/api-types.ts`, `dashboard/lib/api.ts`
+
+- [ ] **Step 1: Regenerate OpenAPI types**
+
+```bash
+cd dashboard
+npm run types:export
+npm run types:generate
+git checkout ../dashboard/next-env.d.ts 2>/dev/null || true
+```
+
+Expected: `lib/api-types.generated.ts` now contains `FeaturePreferenceOut`, `FeaturePreferencesListOut`, `FeaturePreferenceSet` schemas.
+
+- [ ] **Step 2: Re-export the new types**
+
+In `dashboard/lib/api-types.ts`, in the LLM gateway block, add:
+
+```typescript
+export type LlmFeaturePreference = Schemas['FeaturePreferenceOut'];
+export type LlmFeaturePreferences = Schemas['FeaturePreferencesListOut'];
+export type LlmFeaturePreferenceSet = Schemas['FeaturePreferenceSet'];
+export type LlmFeatureKey = Schemas['FeaturePreferenceOut']['feature'];
+```
+
+- [ ] **Step 3: Add api.ts methods**
+
+In `dashboard/lib/api.ts`, add the type imports to the existing LLM import + re-export blocks:
+`LlmFeaturePreferences`, `LlmFeaturePreferenceSet`, `LlmFeatureKey`.
+
+Then add methods after `unsetLlmConnectorDefault`:
+
+```typescript
+  async listLlmFeaturePreferences(): Promise<LlmFeaturePreferences> {
+    return this.fetch('/api/llm/feature-preferences');
+  }
+
+  async setLlmFeaturePreference(
+    data: LlmFeaturePreferenceSet,
+  ): Promise<LlmFeaturePreferences> {
+    return this.fetch('/api/llm/feature-preferences', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async clearLlmFeaturePreference(
+    feature: LlmFeatureKey,
+  ): Promise<LlmFeaturePreferences> {
+    return this.fetch(`/api/llm/feature-preferences/${feature}`, {
+      method: 'DELETE',
+    });
+  }
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd dashboard && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/lib/api-types.generated.ts dashboard/lib/api-types.ts dashboard/lib/api.ts server/openapi.json
+git commit -m "feat(ai-ui): api client methods + types for feature preferences"
+```
+
+---
+
+## Task 9: Frontend — "Per-feature defaults" section
+
+**Files:**
+- Modify: `dashboard/components/AiProvidersSection.tsx`
+- Test: `dashboard/components/__tests__/AiProvidersSection.featurePrefs.test.tsx` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Check first whether a test file already exists for this component:
+Run: `ls dashboard/components/__tests__/ 2>/dev/null | grep -i aiprovider || ls dashboard/**/__tests__/ 2>/dev/null`
+
+Create `dashboard/components/__tests__/AiProvidersSection.featurePrefs.test.tsx`:
+
+```tsx
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import AiProvidersSection from '../AiProvidersSection';
+import { api } from '@/lib/api';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    listLlmConnectors: vi.fn(),
+    getLlmPolicy: vi.fn(),
+    listOpenRouterModels: vi.fn(),
+    listLlmFeaturePreferences: vi.fn(),
+    setLlmFeaturePreference: vi.fn(),
+    clearLlmFeaturePreference: vi.fn(),
+  },
+}));
+
+const connector = {
+  id: 1,
+  user_id: 1,
+  connector_type: 'openai_apikey',
+  display_name: 'My OpenAI',
+  status: 'active',
+  base_url_plain: null,
+  model_hint: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  last_used_at: null,
+  last_error: null,
+  is_default: false,
+  last_health_check_at: null,
+  last_health_check_status: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (api.listLlmConnectors as any).mockResolvedValue([connector]);
+  (api.getLlmPolicy as any).mockResolvedValue({
+    llm_apikey_connectors_enabled: true,
+    llm_compatible_connector_enabled: true,
+    allowed_connector_types: ['openai_apikey'],
+  });
+  (api.listLlmFeaturePreferences as any).mockResolvedValue({
+    preferences: [],
+    known_features: ['recommendation', 'set_builder'],
+  });
+});
+
+describe('AiProvidersSection per-feature defaults', () => {
+  it('renders a picker per known feature and sets a pin', async () => {
+    (api.setLlmFeaturePreference as any).mockResolvedValue({
+      preferences: [{ feature: 'recommendation', connector_id: 1 }],
+      known_features: ['recommendation', 'set_builder'],
+    });
+
+    render(<AiProvidersSection />);
+
+    await waitFor(() => expect(screen.getByText(/Per-feature defaults/i)).toBeInTheDocument());
+
+    const select = screen.getByLabelText(/recommendation/i) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '1' } });
+
+    await waitFor(() =>
+      expect(api.setLlmFeaturePreference).toHaveBeenCalledWith({
+        feature: 'recommendation',
+        connector_id: 1,
+      }),
+    );
+  });
+
+  it('clears a pin when "Use account default" is selected', async () => {
+    (api.listLlmFeaturePreferences as any).mockResolvedValue({
+      preferences: [{ feature: 'recommendation', connector_id: 1 }],
+      known_features: ['recommendation', 'set_builder'],
+    });
+    (api.clearLlmFeaturePreference as any).mockResolvedValue({
+      preferences: [],
+      known_features: ['recommendation', 'set_builder'],
+    });
+
+    render(<AiProvidersSection />);
+    await waitFor(() => expect(screen.getByText(/Per-feature defaults/i)).toBeInTheDocument());
+
+    const select = screen.getByLabelText(/recommendation/i) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '' } });
+
+    await waitFor(() =>
+      expect(api.clearLlmFeaturePreference).toHaveBeenCalledWith('recommendation'),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dashboard && npm test -- --run AiProvidersSection.featurePrefs`
+Expected: FAIL — no "Per-feature defaults" section yet.
+
+- [ ] **Step 3: Implement the section**
+
+In `dashboard/components/AiProvidersSection.tsx`:
+
+Add to the type import block:
+
+```typescript
+import type {
+  AIModelInfo,
+  LlmConnector,
+  LlmConnectorCreate,
+  LlmConnectorType,
+  LlmDjPolicy,
+  LlmFeaturePreferences,
+  LlmFeatureKey,
+} from '@/lib/api-types';
+```
+
+Add a human-readable feature label map near `CONNECTOR_TYPE_LABELS`:
+
+```typescript
+const FEATURE_LABELS: Record<string, string> = {
+  recommendation: 'Recommendations',
+  set_builder: 'Set builder',
+};
+```
+
+Add state inside the component (next to the other `useState` hooks):
+
+```typescript
+  const [featurePrefs, setFeaturePrefs] = useState<LlmFeaturePreferences | null>(null);
+```
+
+Add `api.listLlmFeaturePreferences()` to the initial `Promise.all`:
+
+```typescript
+    Promise.all([api.listLlmConnectors(), fetchPolicySoft(), fetchFeaturePrefsSoft()])
+      .then(([rows, p, prefs]) => {
+        if (!active) return;
+        setConnectors(rows);
+        setPolicy(p);
+        setFeaturePrefs(prefs);
+      })
+```
+
+Add handlers near `handleUnsetDefault`:
+
+```typescript
+  const handleFeaturePrefChange = async (feature: LlmFeatureKey, value: string) => {
+    try {
+      const updated =
+        value === ''
+          ? await api.clearLlmFeaturePreference(feature)
+          : await api.setLlmFeaturePreference({
+              feature,
+              connector_id: Number(value),
+            });
+      setFeaturePrefs(updated);
+      setError('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update feature default');
+    }
+  };
+```
+
+Add the section JSX after the "Connected providers" `</section>` (before the "Add provider" section). Only render it when there is at least one active connector to pin:
+
+```tsx
+      {featurePrefs && featurePrefs.known_features.length > 0 && (
+        <section style={{ marginTop: '2rem' }}>
+          <h3 style={{ marginTop: 0 }}>Per-feature defaults</h3>
+          <p style={{ color: 'var(--text-secondary)' }}>
+            Pin a specific provider to each AI feature. Unpinned features use your account
+            default (or most-recently-used) connector. Inactive connectors are skipped
+            automatically.
+          </p>
+          {featurePrefs.known_features.map((feature) => {
+            const current =
+              featurePrefs.preferences.find((p) => p.feature === feature)?.connector_id ?? '';
+            const selectId = `feature-pref-${feature}`;
+            const activeConnectors = connectors.filter((c) => c.status === 'active');
+            return (
+              <div className="form-group" key={feature}>
+                <label htmlFor={selectId}>{FEATURE_LABELS[feature] ?? feature}</label>
+                <select
+                  id={selectId}
+                  className="input"
+                  value={current === '' ? '' : String(current)}
+                  onChange={(e) =>
+                    handleFeaturePrefChange(feature as LlmFeatureKey, e.target.value)
+                  }
+                >
+                  <option value="">Use account default</option>
+                  {activeConnectors.map((c) => (
+                    <option key={c.id} value={String(c.id)}>
+                      {c.display_name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            );
+          })}
+        </section>
+      )}
+```
+
+Add the soft-fetch helper near `fetchPolicySoft` at the bottom:
+
+```typescript
+async function fetchFeaturePrefsSoft(): Promise<LlmFeaturePreferences | null> {
+  try {
+    return await api.listLlmFeaturePreferences();
+  } catch {
+    return null;
+  }
+}
+```
+
+> Design note: the `<label htmlFor>` text is the feature label ("Recommendations") so `getByLabelText(/recommendation/i)` in the test matches. The picker uses connector_id values as strings; empty string = "Use account default" → clears the pin.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dashboard && npm test -- --run AiProvidersSection.featurePrefs`
+Expected: PASS
+
+- [ ] **Step 5: Run full frontend CI**
+
+```bash
+cd dashboard
+npm run lint
+npx tsc --noEmit
+npm test -- --run
+git checkout lib/../next-env.d.ts 2>/dev/null || git checkout next-env.d.ts 2>/dev/null || true
+```
+
+Expected: lint clean, tsc clean, all vitest pass. (Coverage thresholds enforced — if the new component branch drops coverage, the existing tests + the two new tests should cover the added code paths.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/components/AiProvidersSection.tsx dashboard/components/__tests__/AiProvidersSection.featurePrefs.test.tsx
+git commit -m "feat(ai-ui): per-feature defaults section on DJ AI settings"
+```
+
+---
+
+## Task 10: Final verification + PR
+
+- [ ] **Step 1: Full backend + frontend CI once more (all green)**
+
+```bash
+cd server && .venv/bin/ruff check . && .venv/bin/ruff format --check . && .venv/bin/bandit -r app -c pyproject.toml -q && .venv/bin/alembic upgrade head && .venv/bin/alembic check && .venv/bin/pytest --tb=short -q
+cd ../dashboard && npm run lint && npx tsc --noEmit && npm test -- --run
+git -C .. checkout dashboard/next-env.d.ts 2>/dev/null || true
+```
+
+- [ ] **Step 2: Push + open PR (use superpowers:finishing-a-development-branch, option 2)**
+
+```bash
+git push -u origin feat/issue-337
+gh pr create --base epic/ai-engine --title "feat(llm): per-feature connector preference (#337)" --body "..."
+```
+
+PR body MUST include `Closes #337`, a `## Design decisions` section, and a note that it targets `epic/ai-engine`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- New `LlmFeaturePreference` model (id, user_id, feature, connector_id, created_at) — Task 1. ✓
+- UNIQUE (user_id, feature) — Task 1 (`__table_args__`) + Task 2 (migration). ✓
+- Migration off rev 049, named `050_*` — Task 2. ✓
+- Resolution order feature → per-DJ default → MRU → org default → NoLlmConfigured — Task 4. ✓
+- Graceful fallback when pinned connector deleted or auth_invalid — Task 4 (tests + skip logic). ✓
+- Endpoints set/change/clear scoped to current user, rate-limited, feature allowlist — Tasks 5+6. ✓
+- Connector ownership validation (no cross-DJ pin) — Task 6 (404 test). ✓
+- Frontend "Per-feature defaults" section + api.ts methods + api-types — Tasks 8+9. ✓
+- DJ can set, change, clear a pin (acceptance) — Tasks 6 (set=upsert covers change) + 9. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full content. PR body content deferred to Task 10 (acceptable — it's prose, drafted at PR time from commit history).
+
+**Type consistency:** `set_feature_preference`, `clear_feature_preference`, `get_feature_preferences_for_user`, `get_feature_preference` used consistently across Tasks 3/4/6. `FeatureKey` / `FeaturePreferenceSet` / `FeaturePreferencesListOut` / `FeaturePreferenceOut` consistent across Tasks 5/6/8. `LlmFeaturePreferences` / `LlmFeatureKey` / `LlmFeaturePreferenceSet` consistent across Tasks 8/9.

--- a/server/alembic/versions/050_llm_feature_preference.py
+++ b/server/alembic/versions/050_llm_feature_preference.py
@@ -1,0 +1,56 @@
+"""Add llm_feature_preferences table.
+
+Revision ID: 050
+Revises: 049
+Create Date: 2026-05-28
+
+Per-feature connector preference (issue #337). Maps ``(user_id, feature)`` to a
+pinned ``connector_id`` with a UNIQUE constraint so a DJ has at most one pinned
+connector per feature. Both FKs cascade on delete so a deleted user or
+connector never leaves a dangling preference.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "050"
+down_revision: str | None = "049"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "llm_feature_preferences",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("feature", sa.String(length=40), nullable=False),
+        sa.Column("connector_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["connector_id"], ["llm_connectors.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "feature", name="uq_llm_feature_pref_user_feature"),
+    )
+    op.create_index(
+        "ix_llm_feature_preferences_user_id",
+        "llm_feature_preferences",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_llm_feature_preferences_connector_id",
+        "llm_feature_preferences",
+        ["connector_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_llm_feature_preferences_connector_id", table_name="llm_feature_preferences")
+    op.drop_index("ix_llm_feature_preferences_user_id", table_name="llm_feature_preferences")
+    op.drop_table("llm_feature_preferences")

--- a/server/app/api/llm.py
+++ b/server/app/api/llm.py
@@ -26,12 +26,17 @@ from app.models.llm_connector import (
 from app.models.user import User
 from app.schemas.ai_settings import AIModelsResponse
 from app.schemas.llm import (
+    KNOWN_FEATURE_VALUES,
     ConnectorCreate,
     ConnectorCredentialsRotate,
     ConnectorOut,
     ConnectorPatch,
     ConnectorTestResult,
     DjPolicyOut,
+    FeatureKey,
+    FeaturePreferenceOut,
+    FeaturePreferenceSet,
+    FeaturePreferencesListOut,
 )
 from app.services.llm.connector_storage import (
     AUDIT_CREATED,
@@ -41,12 +46,15 @@ from app.services.llm.connector_storage import (
     AUDIT_DELETED,
     audit_event,
     build_create_payload,
+    clear_feature_preference,
     create_connector,
     delete_connector,
     get_connector_for_user,
+    get_feature_preferences_for_user,
     list_connectors_for_user,
     rotate_credentials,
     set_default_for_user,
+    set_feature_preference,
     unset_default_for_user,
     update_metadata,
 )
@@ -121,6 +129,15 @@ def _audit_and_return(
     db.commit()
     db.refresh(row)
     return ConnectorOut.model_validate(row)
+
+
+def _feature_prefs_response(db: Session, user_id: int) -> FeaturePreferencesListOut:
+    """Build the list response: the DJ's current pins + the pinnable catalogue."""
+    rows = get_feature_preferences_for_user(db, user_id)
+    return FeaturePreferencesListOut(
+        preferences=[FeaturePreferenceOut.model_validate(r) for r in rows],
+        known_features=list(KNOWN_FEATURE_VALUES),  # type: ignore[arg-type]
+    )
 
 
 def _raise_if_duplicate_label(exc: Exception) -> None:
@@ -396,6 +413,64 @@ def unset_connector_as_default(
 
     unset_default_for_user(db, connector=row)
     return _audit_and_return(db, row, actor_user_id=user.id, event_type=AUDIT_DEFAULT_UNSET)
+
+
+@router.get("/feature-preferences", response_model=FeaturePreferencesListOut)
+@limiter.limit("60/minute")
+def list_feature_preferences(
+    request: FastAPIRequest,
+    user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+) -> FeaturePreferencesListOut:
+    """List the DJ's per-feature connector pins (issue #337)."""
+    return _feature_prefs_response(db, user.id)
+
+
+@router.post(
+    "/feature-preferences",
+    response_model=FeaturePreferencesListOut,
+    responses={
+        400: {"description": "Connector is not active and cannot be pinned."},
+        404: {"description": "Connector not found for current user."},
+    },
+)
+@limiter.limit("30/minute")
+def set_feature_preference_endpoint(
+    request: FastAPIRequest,
+    payload: FeaturePreferenceSet,
+    user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+) -> FeaturePreferencesListOut:
+    """Pin (or re-pin) a connector to a feature for the current DJ.
+
+    Validates connector ownership server-side (404 for IDs the DJ doesn't own,
+    so another DJ's connector existence is never leaked) and rejects pinning a
+    non-active connector (400) — the gateway would skip it anyway, so silently
+    accepting it is a footgun.
+    """
+    row = _get_owned_connector_or_404(db, payload.connector_id, user.id)
+    if row.status != "active":
+        raise HTTPException(
+            status_code=400,
+            detail="Only an active connector can be pinned to a feature",
+        )
+    set_feature_preference(db, user_id=user.id, feature=payload.feature, connector_id=row.id)
+    db.commit()
+    return _feature_prefs_response(db, user.id)
+
+
+@router.delete("/feature-preferences/{feature}", response_model=FeaturePreferencesListOut)
+@limiter.limit("30/minute")
+def clear_feature_preference_endpoint(
+    request: FastAPIRequest,
+    feature: FeatureKey,
+    user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+) -> FeaturePreferencesListOut:
+    """Clear the DJ's pin for ``feature`` (no-op if unset). Returns the new list."""
+    clear_feature_preference(db, user_id=user.id, feature=feature)
+    db.commit()
+    return _feature_prefs_response(db, user.id)
 
 
 @router.delete("/connectors/{connector_id}", status_code=204)

--- a/server/app/models/__init__.py
+++ b/server/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.guest import Guest
 from app.models.guest_profile import GuestProfile  # noqa: F401
 from app.models.kiosk import Kiosk
 from app.models.llm_connector import LlmAuditEvent, LlmCallLog, LlmConnector
+from app.models.llm_feature_preference import LlmFeaturePreference
 from app.models.mb_artist_cache import MbArtistCache
 from app.models.now_playing import NowPlaying
 from app.models.pending_email_change import PendingEmailChange
@@ -27,6 +28,7 @@ __all__ = [
     "LlmAuditEvent",
     "LlmCallLog",
     "LlmConnector",
+    "LlmFeaturePreference",
     "MbArtistCache",
     "NowPlaying",
     "PendingEmailChange",

--- a/server/app/models/llm_feature_preference.py
+++ b/server/app/models/llm_feature_preference.py
@@ -1,0 +1,49 @@
+"""Per-feature connector preference — pins a DJ's connector to a feature.
+
+A DJ can pin the recommendation engine to one connector and the set-builder
+to another. The gateway consults this table first (keyed by ``purpose``)
+before falling back to the per-DJ default / MRU / org-default chain.
+
+See issue #337, spec §11.8.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+# Allowlist of feature keys a DJ may pin. These mirror the gateway ``purpose``
+# strings. ``recommendation`` is the only purpose dispatched today;
+# ``set_builder`` is reserved for the upcoming set-builder feature (issue spec
+# §11.8). Validation of API input against this set lives in ``schemas/llm.py``
+# (the ``FeatureKey`` Literal must stay in sync — guarded by a test).
+KNOWN_FEATURES = frozenset({"recommendation", "set_builder"})
+
+
+class LlmFeaturePreference(Base):
+    """Maps ``(user_id, feature)`` to a pinned ``connector_id``.
+
+    At most one row per ``(user_id, feature)`` — enforced by a UNIQUE
+    constraint. Deleting the connector cascades (ON DELETE CASCADE) so a stale
+    preference never points at a missing connector.
+    """
+
+    __tablename__ = "llm_feature_preferences"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    feature: Mapped[str] = mapped_column(String(40), nullable=False)
+    connector_id: Mapped[int] = mapped_column(
+        ForeignKey("llm_connectors.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "feature", name="uq_llm_feature_pref_user_feature"),
+    )

--- a/server/app/schemas/llm.py
+++ b/server/app/schemas/llm.py
@@ -7,6 +7,18 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from app.models.llm_feature_preference import KNOWN_FEATURES
+
+# Feature keys a DJ may pin a connector to (issue #337). ``FeatureKey`` is the
+# static Literal used in the request/response schemas (so the OpenAPI spec
+# emits a proper enum and FastAPI rejects unknown values at the boundary).
+# ``KNOWN_FEATURE_VALUES`` is the sorted runtime tuple returned to the
+# frontend so the picker is deterministic. A test
+# (``test_feature_key_literal_matches_known_features``) guards that the Literal
+# and ``KNOWN_FEATURES`` never drift apart.
+FeatureKey = Literal["recommendation", "set_builder"]
+KNOWN_FEATURE_VALUES: tuple[str, ...] = tuple(sorted(KNOWN_FEATURES))
+
 ConnectorType = Literal[
     "openai_apikey",
     "anthropic_apikey",
@@ -298,3 +310,26 @@ class AdminAuditOut(BaseModel):
     total: int
     limit: int
     offset: int
+
+
+class FeaturePreferenceOut(BaseModel):
+    """A single per-feature connector pin (issue #337)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    feature: FeatureKey
+    connector_id: int
+
+
+class FeaturePreferencesListOut(BaseModel):
+    """All of a DJ's per-feature pins + the catalogue of pinnable features."""
+
+    preferences: list[FeaturePreferenceOut]
+    known_features: list[FeatureKey]
+
+
+class FeaturePreferenceSet(BaseModel):
+    """Set/change a per-feature pin. Upsert — replaces any existing pin."""
+
+    feature: FeatureKey
+    connector_id: int = Field(..., ge=1)

--- a/server/app/services/llm/connector_storage.py
+++ b/server/app/services/llm/connector_storage.py
@@ -7,6 +7,8 @@ import logging
 from typing import Any
 
 from sqlalchemy import case, delete, func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session
 
 from app.models.llm_connector import (
@@ -554,15 +556,29 @@ def set_feature_preference(
 
     Replace-in-place when a row already exists so the UNIQUE constraint on
     ``(user_id, feature)`` is never violated.
+
+    Concurrency-safe via a DB-native ``ON CONFLICT … DO UPDATE`` upsert keyed on
+    ``(user_id, feature)``. Two requests racing to pin the same feature resolve
+    deterministically (last writer wins) in a single atomic statement, instead
+    of one of them tripping ``uq_llm_feature_pref_user_feature`` and bubbling a
+    500. Works on both Postgres (prod) and SQLite (tests).
     """
-    existing = get_feature_preference(db, user_id=user_id, feature=feature)
-    if existing is not None:
-        existing.connector_id = connector_id
-        db.flush()
-        return existing
-    row = LlmFeaturePreference(user_id=user_id, feature=feature, connector_id=connector_id)
-    db.add(row)
+    table = LlmFeaturePreference.__table__
+    dialect = db.bind.dialect.name if db.bind is not None else ""
+    insert_fn = pg_insert if dialect == "postgresql" else sqlite_insert
+    stmt = insert_fn(table).values(user_id=user_id, feature=feature, connector_id=connector_id)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=[table.c.user_id, table.c.feature],
+        set_={"connector_id": connector_id},
+    )
+    db.execute(stmt)
     db.flush()
+    row = get_feature_preference(db, user_id=user_id, feature=feature)
+    if row is None:  # pragma: no cover - the upsert guarantees the row exists
+        raise RuntimeError("feature preference upsert did not persist a row")
+    # ON CONFLICT DO UPDATE bypasses the ORM, so an already-loaded row may hold a
+    # stale connector_id — refresh just this instance, not the whole session.
+    db.refresh(row)
     return row
 
 

--- a/server/app/services/llm/connector_storage.py
+++ b/server/app/services/llm/connector_storage.py
@@ -35,6 +35,7 @@ from app.models.llm_connector import (
     LlmCallLog,
     LlmConnector,
 )
+from app.models.llm_feature_preference import LlmFeaturePreference
 from app.models.user import User
 from app.services.llm.url_validator import (
     InvalidBaseUrlError,
@@ -522,6 +523,62 @@ def revoke_connector(connector: LlmConnector) -> LlmConnector:
     return connector
 
 
+def get_feature_preferences_for_user(db: Session, user_id: int) -> list[LlmFeaturePreference]:
+    """Return all of a DJ's per-feature connector pins (issue #337)."""
+    return (
+        db.query(LlmFeaturePreference)
+        .filter(LlmFeaturePreference.user_id == user_id)
+        .order_by(LlmFeaturePreference.feature.asc())
+        .all()
+    )
+
+
+def get_feature_preference(
+    db: Session, *, user_id: int, feature: str
+) -> LlmFeaturePreference | None:
+    """Return the DJ's pin for ``feature``, or ``None`` if unset."""
+    return (
+        db.query(LlmFeaturePreference)
+        .filter(
+            LlmFeaturePreference.user_id == user_id,
+            LlmFeaturePreference.feature == feature,
+        )
+        .one_or_none()
+    )
+
+
+def set_feature_preference(
+    db: Session, *, user_id: int, feature: str, connector_id: int
+) -> LlmFeaturePreference:
+    """Upsert the DJ's pin for ``feature`` → ``connector_id``. Caller commits.
+
+    Replace-in-place when a row already exists so the UNIQUE constraint on
+    ``(user_id, feature)`` is never violated.
+    """
+    existing = get_feature_preference(db, user_id=user_id, feature=feature)
+    if existing is not None:
+        existing.connector_id = connector_id
+        db.flush()
+        return existing
+    row = LlmFeaturePreference(user_id=user_id, feature=feature, connector_id=connector_id)
+    db.add(row)
+    db.flush()
+    return row
+
+
+def clear_feature_preference(db: Session, *, user_id: int, feature: str) -> bool:
+    """Delete the DJ's pin for ``feature``. Returns True iff a row was removed.
+
+    Caller commits.
+    """
+    existing = get_feature_preference(db, user_id=user_id, feature=feature)
+    if existing is None:
+        return False
+    db.delete(existing)
+    db.flush()
+    return True
+
+
 def audit_event(
     db: Session,
     *,
@@ -645,10 +702,13 @@ __all__ = [
     "CreateConnectorPayload",
     "audit_event",
     "build_create_payload",
+    "clear_feature_preference",
     "create_connector",
     "delete_connector",
     "get_connector",
     "get_connector_for_user",
+    "get_feature_preference",
+    "get_feature_preferences_for_user",
     "get_usage_stats",
     "get_user_label",
     "list_all_connectors",
@@ -658,6 +718,7 @@ __all__ = [
     "revoke_connector",
     "rotate_credentials",
     "set_default_for_user",
+    "set_feature_preference",
     "unset_default_for_user",
     "update_metadata",
 ]

--- a/server/app/services/llm/gateway.py
+++ b/server/app/services/llm/gateway.py
@@ -4,9 +4,12 @@ See spec §4.3.
 
 Resolution order:
 1. If ``actor`` is not ``None``:
-   a. The DJ's explicit default active connector if one is pinned
+   a. The DJ's per-feature pin for ``purpose`` if set and the pinned connector
+      is active (``LlmFeaturePreference`` — issue #337). Skipped gracefully when
+      the pinned connector was deleted or is no longer active.
+   b. Else: the DJ's explicit default active connector if one is pinned
       (``LlmConnector.is_default = True``) — issue #336.
-   b. Else: most-recently-used active connector for the DJ.
+   c. Else: most-recently-used active connector for the DJ.
 2. Else: ``SystemSettings.llm_default_connector_id`` if set and active.
 3. Else: raise :class:`NoLlmConfigured`.
 
@@ -37,7 +40,7 @@ from app.models.llm_connector import (
 from app.models.system_settings import SystemSettings
 from app.models.user import User
 from app.services.llm.base import ChatRequest, ChatResponse
-from app.services.llm.connector_storage import audit_event, log_call
+from app.services.llm.connector_storage import audit_event, get_feature_preference, log_call
 from app.services.llm.exceptions import (
     AuthInvalid,
     LlmError,
@@ -87,7 +90,7 @@ class Gateway:
         *,
         purpose: str,
     ) -> ChatResponse:
-        primary = _resolve_connector(db, actor)
+        primary = _resolve_connector(db, actor, purpose=purpose)
         actor_id = actor.id if actor else _system_actor_id(db, primary)
 
         # Attempt 1: primary connector.
@@ -251,8 +254,23 @@ async def _attempt(
     return response
 
 
-def _resolve_connector(db: Session, actor: User | None) -> LlmConnector:
+def _resolve_connector(db: Session, actor: User | None, *, purpose: str) -> LlmConnector:
     if actor is not None:
+        # 0. Per-feature pin (issue #337) takes precedence over the per-DJ
+        #    default and MRU. Skipped gracefully when the pinned connector was
+        #    deleted (FK row gone) or is no longer active, so a stale/broken
+        #    pin never silently breaks the DJ — resolution falls through to the
+        #    per-DJ default / MRU / org-default chain below.
+        pref = get_feature_preference(db, user_id=actor.id, feature=purpose)
+        if pref is not None:
+            pinned_feature = db.get(LlmConnector, pref.connector_id)
+            if (
+                pinned_feature is not None
+                and pinned_feature.user_id == actor.id
+                and pinned_feature.status == STATUS_ACTIVE
+            ):
+                return pinned_feature
+
         # Per-DJ explicit default takes precedence over MRU (issue #336).
         # Falls through to MRU if the DJ hasn't pinned a default or the pinned
         # connector is no longer active (so DJs aren't silently broken when

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1023,7 +1023,7 @@
       "Body_upload_banner_api_events__code__banner_post": {
         "properties": {
           "file": {
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File",
             "type": "string"
           }
@@ -3172,6 +3172,82 @@
           }
         },
         "title": "EventUpdate",
+        "type": "object"
+      },
+      "FeaturePreferenceOut": {
+        "description": "A single per-feature connector pin (issue #337).",
+        "properties": {
+          "connector_id": {
+            "title": "Connector Id",
+            "type": "integer"
+          },
+          "feature": {
+            "enum": [
+              "recommendation",
+              "set_builder"
+            ],
+            "title": "Feature",
+            "type": "string"
+          }
+        },
+        "required": [
+          "connector_id",
+          "feature"
+        ],
+        "title": "FeaturePreferenceOut",
+        "type": "object"
+      },
+      "FeaturePreferenceSet": {
+        "description": "Set/change a per-feature pin. Upsert \u2014 replaces any existing pin.",
+        "properties": {
+          "connector_id": {
+            "minimum": 1.0,
+            "title": "Connector Id",
+            "type": "integer"
+          },
+          "feature": {
+            "enum": [
+              "recommendation",
+              "set_builder"
+            ],
+            "title": "Feature",
+            "type": "string"
+          }
+        },
+        "required": [
+          "feature",
+          "connector_id"
+        ],
+        "title": "FeaturePreferenceSet",
+        "type": "object"
+      },
+      "FeaturePreferencesListOut": {
+        "description": "All of a DJ's per-feature pins + the catalogue of pinnable features.",
+        "properties": {
+          "known_features": {
+            "items": {
+              "enum": [
+                "recommendation",
+                "set_builder"
+              ],
+              "type": "string"
+            },
+            "title": "Known Features",
+            "type": "array"
+          },
+          "preferences": {
+            "items": {
+              "$ref": "#/components/schemas/FeaturePreferenceOut"
+            },
+            "title": "Preferences",
+            "type": "array"
+          }
+        },
+        "required": [
+          "known_features",
+          "preferences"
+        ],
+        "title": "FeaturePreferencesListOut",
         "type": "object"
       },
       "GuestNowPlaying": {
@@ -10860,6 +10936,136 @@
           }
         ],
         "summary": "Test Connector",
+        "tags": [
+          "llm"
+        ]
+      }
+    },
+    "/api/llm/feature-preferences": {
+      "get": {
+        "description": "List the DJ's per-feature connector pins (issue #337).",
+        "operationId": "list_feature_preferences_api_llm_feature_preferences_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeaturePreferencesListOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Feature Preferences",
+        "tags": [
+          "llm"
+        ]
+      },
+      "post": {
+        "description": "Pin (or re-pin) a connector to a feature for the current DJ.\n\nValidates connector ownership server-side (404 for IDs the DJ doesn't own,\nso another DJ's connector existence is never leaked) and rejects pinning a\nnon-active connector (400) \u2014 the gateway would skip it anyway, so silently\naccepting it is a footgun.",
+        "operationId": "set_feature_preference_endpoint_api_llm_feature_preferences_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FeaturePreferenceSet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeaturePreferencesListOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Connector is not active and cannot be pinned."
+          },
+          "404": {
+            "description": "Connector not found for current user."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Set Feature Preference Endpoint",
+        "tags": [
+          "llm"
+        ]
+      }
+    },
+    "/api/llm/feature-preferences/{feature}": {
+      "delete": {
+        "description": "Clear the DJ's pin for ``feature`` (no-op if unset). Returns the new list.",
+        "operationId": "clear_feature_preference_endpoint_api_llm_feature_preferences__feature__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "feature",
+            "required": true,
+            "schema": {
+              "enum": [
+                "recommendation",
+                "set_builder"
+              ],
+              "title": "Feature",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeaturePreferencesListOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Clear Feature Preference Endpoint",
         "tags": [
           "llm"
         ]

--- a/server/tests/test_llm_feature_preference.py
+++ b/server/tests/test_llm_feature_preference.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -11,6 +12,9 @@ from app.models.llm_connector import LlmConnector
 from app.models.llm_feature_preference import KNOWN_FEATURES, LlmFeaturePreference
 from app.models.user import User
 from app.services.auth import get_password_hash
+from app.services.llm.adapters.openai_apikey import OpenAIApiKeyAdapter
+from app.services.llm.base import ChatRequest, ChatResponse, Message, TokenUsage
+from app.services.llm.gateway import Gateway
 
 
 @pytest.fixture
@@ -96,3 +100,127 @@ def test_clear_feature_preference_removes_row(db, dj_user):
 
     # Clearing a non-existent preference is a no-op (returns False).
     assert clear_feature_preference(db, user_id=dj_user.id, feature="recommendation") is False
+
+
+# ---------- gateway resolution ----------
+def _ok_response() -> ChatResponse:
+    return ChatResponse(
+        text="ok",
+        tool_calls=[],
+        stop_reason="end_turn",
+        usage=TokenUsage(prompt=1, completion=1),
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_prefers_feature_pin_over_default(db, dj_user):
+    from app.services.llm.connector_storage import set_default_for_user, set_feature_preference
+
+    pinned = _make_connector(db, dj_user, display_name="pinned")
+    other = _make_connector(db, dj_user, display_name="default")
+    set_default_for_user(db, connector=other)  # per-DJ default points elsewhere
+    set_feature_preference(db, user_id=dj_user.id, feature="recommendation", connector_id=pinned.id)
+    db.commit()
+
+    captured = {}
+
+    async def fake_chat(self, request):  # noqa: ANN001
+        captured["connector_id"] = self.connector.id
+        return _ok_response()
+
+    with patch.object(OpenAIApiKeyAdapter, "chat", new=fake_chat):
+        await Gateway.dispatch(
+            db,
+            dj_user,
+            ChatRequest(messages=[Message(role="user", content="hi")]),
+            purpose="recommendation",
+        )
+    assert captured["connector_id"] == pinned.id
+
+
+@pytest.mark.asyncio
+async def test_gateway_falls_back_when_pinned_connector_auth_invalid(db, dj_user):
+    from app.services.llm.connector_storage import set_default_for_user, set_feature_preference
+
+    pinned = _make_connector(db, dj_user, display_name="pinned", status="auth_invalid")
+    fallback = _make_connector(db, dj_user, display_name="fallback")
+    set_default_for_user(db, connector=fallback)
+    set_feature_preference(db, user_id=dj_user.id, feature="recommendation", connector_id=pinned.id)
+    db.commit()
+
+    captured = {}
+
+    async def fake_chat(self, request):  # noqa: ANN001
+        captured["connector_id"] = self.connector.id
+        return _ok_response()
+
+    with patch.object(OpenAIApiKeyAdapter, "chat", new=fake_chat):
+        await Gateway.dispatch(
+            db,
+            dj_user,
+            ChatRequest(messages=[Message(role="user", content="hi")]),
+            purpose="recommendation",
+        )
+    # Skips the auth_invalid pin, falls through to the per-DJ default.
+    assert captured["connector_id"] == fallback.id
+
+
+@pytest.mark.asyncio
+async def test_gateway_falls_back_when_pinned_connector_deleted(db, dj_user):
+    """A pin whose connector was deleted is skipped (graceful fallback)."""
+    from app.services.llm.connector_storage import set_default_for_user, set_feature_preference
+
+    pinned = _make_connector(db, dj_user, display_name="pinned")
+    fallback = _make_connector(db, dj_user, display_name="fallback")
+    set_default_for_user(db, connector=fallback)
+    set_feature_preference(db, user_id=dj_user.id, feature="recommendation", connector_id=pinned.id)
+    db.commit()
+
+    # Delete the pinned connector directly (simulating a stale FK target). The
+    # ON DELETE CASCADE removes the preference row too, so this exercises the
+    # "pref row gone" path; the status-flip test above covers "pref points at
+    # an inactive connector".
+    db.delete(pinned)
+    db.commit()
+
+    captured = {}
+
+    async def fake_chat(self, request):  # noqa: ANN001
+        captured["connector_id"] = self.connector.id
+        return _ok_response()
+
+    with patch.object(OpenAIApiKeyAdapter, "chat", new=fake_chat):
+        await Gateway.dispatch(
+            db,
+            dj_user,
+            ChatRequest(messages=[Message(role="user", content="hi")]),
+            purpose="recommendation",
+        )
+    assert captured["connector_id"] == fallback.id
+
+
+@pytest.mark.asyncio
+async def test_gateway_ignores_pin_for_unknown_feature(db, dj_user):
+    """A pin set for one feature must not leak into another purpose."""
+    from app.services.llm.connector_storage import set_feature_preference
+
+    pinned = _make_connector(db, dj_user, display_name="pinned")
+    mru = _make_connector(db, dj_user, display_name="mru")
+    set_feature_preference(db, user_id=dj_user.id, feature="recommendation", connector_id=pinned.id)
+    db.commit()
+
+    captured = {}
+
+    async def fake_chat(self, request):  # noqa: ANN001
+        captured["connector_id"] = self.connector.id
+        return _ok_response()
+
+    with patch.object(OpenAIApiKeyAdapter, "chat", new=fake_chat):
+        await Gateway.dispatch(
+            db,
+            dj_user,
+            ChatRequest(messages=[Message(role="user", content="hi")]),
+            purpose="set_builder",
+        )
+    # No pin for set_builder → MRU resolution (most recently created here is `mru`).
+    assert captured["connector_id"] == mru.id

--- a/server/tests/test_llm_feature_preference.py
+++ b/server/tests/test_llm_feature_preference.py
@@ -224,3 +224,105 @@ async def test_gateway_ignores_pin_for_unknown_feature(db, dj_user):
         )
     # No pin for set_builder → MRU resolution (most recently created here is `mru`).
     assert captured["connector_id"] == mru.id
+
+
+# ---------- API endpoints ----------
+def test_set_list_clear_feature_preference_endpoints(client, db, test_user, auth_headers):
+    c = _make_connector(db, test_user, display_name="Endpoint connector")
+
+    # Set
+    resp = client.post(
+        "/api/llm/feature-preferences",
+        json={"feature": "recommendation", "connector_id": c.id},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.json()
+    body = resp.json()
+    assert {p["feature"]: p["connector_id"] for p in body["preferences"]} == {
+        "recommendation": c.id
+    }
+    assert "set_builder" in body["known_features"]
+
+    # List
+    resp = client.get("/api/llm/feature-preferences", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["preferences"][0]["connector_id"] == c.id
+
+    # Change (re-pin same feature to a second connector → replace, not duplicate)
+    c2 = _make_connector(db, test_user, display_name="Second connector")
+    resp = client.post(
+        "/api/llm/feature-preferences",
+        json={"feature": "recommendation", "connector_id": c2.id},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert {p["feature"]: p["connector_id"] for p in resp.json()["preferences"]} == {
+        "recommendation": c2.id
+    }
+
+    # Clear
+    resp = client.delete("/api/llm/feature-preferences/recommendation", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["preferences"] == []
+
+
+def test_set_feature_preference_rejects_unknown_feature(client, db, test_user, auth_headers):
+    c = _make_connector(db, test_user, display_name="X")
+    resp = client.post(
+        "/api/llm/feature-preferences",
+        json={"feature": "totally_made_up", "connector_id": c.id},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422  # Pydantic Literal rejects it
+
+
+def test_set_feature_preference_rejects_other_djs_connector(client, db, test_user, auth_headers):
+    # Another DJ owns this connector.
+    other = User(username="otherdj", password_hash=get_password_hash("password123"), role="dj")
+    db.add(other)
+    db.commit()
+    db.refresh(other)
+    foreign = _make_connector(db, other, display_name="Not yours")
+
+    resp = client.post(
+        "/api/llm/feature-preferences",
+        json={"feature": "recommendation", "connector_id": foreign.id},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404  # ownership not leaked
+
+
+def test_set_feature_preference_rejects_inactive_connector(client, db, test_user, auth_headers):
+    c = _make_connector(db, test_user, display_name="Broken", status="auth_invalid")
+    resp = client.post(
+        "/api/llm/feature-preferences",
+        json={"feature": "recommendation", "connector_id": c.id},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_clear_unknown_feature_returns_422(client, auth_headers):
+    resp = client.delete("/api/llm/feature-preferences/bogus", headers=auth_headers)
+    assert resp.status_code == 422
+
+
+def test_feature_preference_requires_auth(client, db, test_user):
+    c = _make_connector(db, test_user, display_name="Y")
+    # No auth headers → 401.
+    resp = client.post(
+        "/api/llm/feature-preferences",
+        json={"feature": "recommendation", "connector_id": c.id},
+    )
+    assert resp.status_code == 401
+
+
+# ---------- consistency guard ----------
+def test_feature_key_literal_matches_known_features():
+    """FeatureKey (the OpenAPI enum) must stay in sync with KNOWN_FEATURES."""
+    import typing
+
+    from app.schemas.llm import FeatureKey
+
+    literal_values = set(typing.get_args(FeatureKey))
+    assert literal_values == set(KNOWN_FEATURES)

--- a/server/tests/test_llm_feature_preference.py
+++ b/server/tests/test_llm_feature_preference.py
@@ -55,3 +55,44 @@ def test_unique_constraint_one_pref_per_user_feature(db, dj_user):
     with pytest.raises(IntegrityError):
         db.commit()
     db.rollback()
+
+
+def test_set_feature_preference_upserts(db, dj_user):
+    from app.services.llm.connector_storage import (
+        get_feature_preferences_for_user,
+        set_feature_preference,
+    )
+
+    c1 = _make_connector(db, dj_user, display_name="A")
+    c2 = _make_connector(db, dj_user, display_name="B")
+
+    set_feature_preference(db, user_id=dj_user.id, feature="recommendation", connector_id=c1.id)
+    db.commit()
+    prefs = get_feature_preferences_for_user(db, dj_user.id)
+    assert {p.feature: p.connector_id for p in prefs} == {"recommendation": c1.id}
+
+    # Re-set the same feature → replace, not duplicate.
+    set_feature_preference(db, user_id=dj_user.id, feature="recommendation", connector_id=c2.id)
+    db.commit()
+    prefs = get_feature_preferences_for_user(db, dj_user.id)
+    assert {p.feature: p.connector_id for p in prefs} == {"recommendation": c2.id}
+
+
+def test_clear_feature_preference_removes_row(db, dj_user):
+    from app.services.llm.connector_storage import (
+        clear_feature_preference,
+        get_feature_preferences_for_user,
+        set_feature_preference,
+    )
+
+    c1 = _make_connector(db, dj_user, display_name="A")
+    set_feature_preference(db, user_id=dj_user.id, feature="recommendation", connector_id=c1.id)
+    db.commit()
+
+    removed = clear_feature_preference(db, user_id=dj_user.id, feature="recommendation")
+    db.commit()
+    assert removed is True
+    assert get_feature_preferences_for_user(db, dj_user.id) == []
+
+    # Clearing a non-existent preference is a no-op (returns False).
+    assert clear_feature_preference(db, user_id=dj_user.id, feature="recommendation") is False

--- a/server/tests/test_llm_feature_preference.py
+++ b/server/tests/test_llm_feature_preference.py
@@ -1,0 +1,57 @@
+"""Tests for per-feature connector preference (issue #337)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.llm_connector import LlmConnector
+from app.models.llm_feature_preference import KNOWN_FEATURES, LlmFeaturePreference
+from app.models.user import User
+from app.services.auth import get_password_hash
+
+
+@pytest.fixture
+def dj_user(db) -> User:
+    user = User(
+        username="prefdj",
+        password_hash=get_password_hash("password123"),
+        role="dj",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _make_connector(db, user, *, display_name="Pref connector", status="active"):
+    row = LlmConnector(
+        user_id=user.id,
+        connector_type="openai_apikey",
+        display_name=display_name,
+        status=status,
+        credentials=json.dumps({"api_key": "sk-fake-key"}),
+        model_hint="gpt-5-mini",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def test_known_features_contains_recommendation_and_set_builder():
+    assert "recommendation" in KNOWN_FEATURES
+    assert "set_builder" in KNOWN_FEATURES
+
+
+def test_unique_constraint_one_pref_per_user_feature(db, dj_user):
+    c1 = _make_connector(db, dj_user, display_name="A")
+    c2 = _make_connector(db, dj_user, display_name="B")
+    db.add(LlmFeaturePreference(user_id=dj_user.id, feature="recommendation", connector_id=c1.id))
+    db.commit()
+    db.add(LlmFeaturePreference(user_id=dj_user.id, feature="recommendation", connector_id=c2.id))
+    with pytest.raises(IntegrityError):
+        db.commit()
+    db.rollback()

--- a/server/tests/test_llm_feature_preference.py
+++ b/server/tests/test_llm_feature_preference.py
@@ -82,6 +82,39 @@ def test_set_feature_preference_upserts(db, dj_user):
     assert {p.feature: p.connector_id for p in prefs} == {"recommendation": c2.id}
 
 
+def test_set_feature_preference_is_conflict_safe_upsert(db, dj_user):
+    """Regression: a re-pin must not trip the UNIQUE constraint (CodeRabbit PR #378).
+
+    ``set_feature_preference`` is a DB-native ``ON CONFLICT DO UPDATE`` upsert,
+    so re-pinning an already-pinned (user, feature) — the case a concurrent
+    second request would hit — resolves to last-writer-wins in one atomic
+    statement instead of raising ``IntegrityError`` (which previously bubbled a
+    500). It must leave exactly one row and return the re-pinned connector.
+    """
+    from app.services.llm.connector_storage import (
+        get_feature_preferences_for_user,
+        set_feature_preference,
+    )
+
+    c1 = _make_connector(db, dj_user, display_name="first")
+    c2 = _make_connector(db, dj_user, display_name="second")
+
+    # A row already exists for (dj_user, "recommendation") — exactly the state a
+    # concurrent winner would have committed before the loser's upsert lands.
+    db.add(LlmFeaturePreference(user_id=dj_user.id, feature="recommendation", connector_id=c1.id))
+    db.commit()
+
+    result = set_feature_preference(
+        db, user_id=dj_user.id, feature="recommendation", connector_id=c2.id
+    )
+    db.commit()
+
+    # Last writer wins, and there is still exactly one row for the pair.
+    assert result.connector_id == c2.id
+    prefs = get_feature_preferences_for_user(db, dj_user.id)
+    assert {p.feature: p.connector_id for p in prefs} == {"recommendation": c2.id}
+
+
 def test_clear_feature_preference_removes_row(db, dj_user):
     from app.services.llm.connector_storage import (
         clear_feature_preference,


### PR DESCRIPTION
Closes #337

> **Targets `epic/ai-engine`, not `main`.** This is part of the AI-engine epic.

## Summary

Lets each DJ pin a specific LLM connector to a specific agentic feature (e.g. recommendation engine → connector A, set-builder → connector B). Resolution now consults the per-feature pin first, falling back gracefully through the existing chain when the pin is missing, deleted, or its connector is no longer active.

**Resolution order (per DJ):** per-feature pin → per-DJ default (#336) → MRU → org default → `NoLlmConfigured`.

## What changed

**Backend**
- New `LlmFeaturePreference` model (`server/app/models/llm_feature_preference.py`): `id`, `user_id` (FK users, CASCADE), `feature` (String 40), `connector_id` (FK llm_connectors, CASCADE), `created_at`, with a `UNIQUE(user_id, feature)` constraint — at most one pinned connector per feature per DJ. Feature allowlist `{recommendation, set_builder}` lives in the model.
- Migration `050_llm_feature_preference.py` (down_revision `049`) creates the table + the two FK indexes. `alembic upgrade head && alembic check` verified clean on a fresh Postgres DB (no model/migration drift).
- `Gateway.dispatch` threads the dispatch `purpose` into `_resolve_connector`, which checks the DJ's pin for that feature first. A pin whose connector was deleted or whose status != `active` is skipped silently so a stale/broken pin never breaks the DJ.
- CRUD helpers in `connector_storage.py`: `set_feature_preference` (upsert), `clear_feature_preference`, `get_feature_preference(s)`.
- Endpoints under `/api/llm/feature-preferences` (`api/llm.py`): `GET` (list), `POST` (set/change — upsert), `DELETE /{feature}` (clear). Scoped to `get_current_active_user`, rate-limited like the existing connector endpoints. POST validates connector ownership (404, not leaking another DJ's connectors) and rejects pinning a non-active connector (400). The `{feature}` path param is the `FeatureKey` Literal, so unknown features 422 at the boundary.
- Schemas `FeaturePreferenceOut` / `FeaturePreferencesListOut` / `FeaturePreferenceSet` + `FeatureKey` Literal, with a guard test asserting `FeatureKey` stays in sync with `KNOWN_FEATURES`.

**Frontend**
- `dashboard/lib/api.ts`: `listLlmFeaturePreferences`, `setLlmFeaturePreference`, `clearLlmFeaturePreference` + regenerated OpenAPI types.
- `dashboard/components/AiProvidersSection.tsx`: a "Per-feature defaults" section — one connector picker per known feature; selecting a connector pins it, "Use account default" clears it. Only active connectors are offered. The section fetches soft and hides itself if the endpoint is unavailable.

## Design decisions

- **Feature key == gateway `purpose`.** Reusing the existing dispatch `purpose` string (rather than a separate enum) means the pin applies automatically to any feature that routes through the gateway. `recommendation` is the only `purpose` dispatched today; `set_builder` is reserved per spec §11.8.
- **Allowlist + static Literal.** Validation uses a Pydantic `Literal` (`FeatureKey`) so the OpenAPI spec emits a proper enum and FastAPI rejects unknown features at the boundary. A test guards that the Literal never drifts from the runtime `KNOWN_FEATURES` frozenset.
- **Graceful fallback over hard failure.** A pin pointing at a deleted or `auth_invalid` connector is skipped, never raised — the DJ falls through to their default/MRU. The set endpoint also rejects pinning a non-active connector (400), mirroring the per-DJ default endpoint, so DJs can't silently break their own routing.
- **Ownership scoped server-side.** Setting a pin re-fetches the connector scoped to the current user; a foreign connector id returns 404 (existence not leaked), consistent with the existing connector-ownership convention.
- **Upsert = set + change.** One POST handles both "set" and "change" (the UNIQUE constraint makes a change a replace), keeping the API surface minimal.

## Test plan

- [x] Backend: `ruff check`, `ruff format --check`, `bandit`, `alembic upgrade head && alembic check` (fresh DB, no drift) — all clean.
- [x] Backend: full `pytest` suite — 2444 passed, coverage 87.63% (gate 85%). New file `tests/test_llm_feature_preference.py` covers model UNIQUE constraint, CRUD upsert/clear, gateway resolution (pin preferred over default, fallback on auth_invalid + on deleted connector, no leak across features), and all endpoints (set/list/change/clear, unknown-feature 422, cross-DJ 404, inactive 400, unauth 401).
- [x] Frontend: `npm run lint`, `npx tsc --noEmit`, full `vitest` — 970 passed (coverage gate satisfied). New `AiProvidersSection.featurePrefs.test.tsx` covers picker render, set, clear, fail-soft hide, and active-only filtering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-feature AI connector selection: Users can now set different AI providers for specific features (e.g., recommendations, set builder) while falling back to account defaults when no preference is set.
  * New "Per-feature defaults" section in the AI Providers dashboard for managing feature-specific connector preferences with a simplified "Use account default" option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->