### PR TITLE
feat(join): frictionless live-event guest flow (#369)

### DIFF
--- a/dashboard/app/(dj)/account/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/account/__tests__/page.test.tsx
@@ -11,16 +11,28 @@ vi.mock('@/lib/auth', () => ({
   useAuth: () => ({ isAuthenticated: true, isLoading: false }),
 }));
 
-const mockChangePassword = vi.fn();
-const mockRequestEmailChange = vi.fn();
-const mockGetMe = vi.fn();
+const { mockGetMe, mockChangePassword, mockRequestEmailChange, mockUpdateMyPreferences, mockApi } =
+  vi.hoisted(() => {
+    const getMe = vi.fn();
+    const changePassword = vi.fn();
+    const requestEmailChange = vi.fn();
+    const updateMyPreferences = vi.fn();
+    return {
+      mockGetMe: getMe,
+      mockChangePassword: changePassword,
+      mockRequestEmailChange: requestEmailChange,
+      mockUpdateMyPreferences: updateMyPreferences,
+      mockApi: {
+        getMe: () => getMe(),
+        changePassword: (...args: unknown[]) => changePassword(...args),
+        requestEmailChange: (...args: unknown[]) => requestEmailChange(...args),
+        updateMyPreferences: (...args: unknown[]) => updateMyPreferences(...args),
+      },
+    };
+  });
 
 vi.mock('@/lib/api', () => ({
-  api: {
-    getMe: () => mockGetMe(),
-    changePassword: (...args: unknown[]) => mockChangePassword(...args),
-    requestEmailChange: (...args: unknown[]) => mockRequestEmailChange(...args),
-  },
+  api: mockApi,
 }));
 
 describe('AccountPage', () => {
@@ -33,7 +45,9 @@ describe('AccountPage', () => {
       help_pages_seen: [],
       pending_email: null,
       email: null,
+      frictionless_join_default: false,
     });
+    mockUpdateMyPreferences.mockResolvedValue(undefined);
   });
 
   it('renders Change Password and Change Email headings', async () => {
@@ -121,6 +135,23 @@ describe('AccountPage', () => {
       expect(screen.getByText('new@example.com')).toBeInTheDocument();
       expect(screen.getByText(/Check your inbox/)).toBeInTheDocument();
     });
+  });
+
+  it('toggles frictionless_join_default and saves', async () => {
+    mockGetMe.mockResolvedValue({
+      id: 1,
+      username: 'dj',
+      role: 'dj',
+      help_pages_seen: [],
+      pending_email: null,
+      email: null,
+      frictionless_join_default: false,
+    });
+    const update = vi.spyOn(mockApi, 'updateMyPreferences').mockResolvedValue(undefined as never);
+    render(<AccountPage />);
+    const toggle = await screen.findByLabelText(/Frictionless join by default/i);
+    fireEvent.click(toggle);
+    await waitFor(() => expect(update).toHaveBeenCalledWith({ frictionless_join_default: true }));
   });
 
   it('shows pending email from getMe on load', async () => {

--- a/dashboard/app/(dj)/account/page.tsx
+++ b/dashboard/app/(dj)/account/page.tsx
@@ -24,6 +24,9 @@ export default function AccountPage() {
   const [emailPending, setEmailPending] = useState<string | null>(null);
   const [emailLoading, setEmailLoading] = useState(false);
 
+  const [frictionlessDefault, setFrictionlessDefault] = useState(false);
+  const [savingPref, setSavingPref] = useState(false);
+
   const redirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -42,7 +45,11 @@ export default function AccountPage() {
     if (isAuthenticated) {
       let isActive = true;
       api.getMe()
-        .then(user => { if (isActive) setEmailPending(prev => prev ?? (user.pending_email ?? null)); })
+        .then(user => {
+          if (!isActive) return;
+          setEmailPending(prev => prev ?? (user.pending_email ?? null));
+          setFrictionlessDefault(user.frictionless_join_default);
+        })
         .catch(() => {});
       return () => { isActive = false; };
     }
@@ -87,6 +94,17 @@ export default function AccountPage() {
       setEmailError(err instanceof Error ? err.message : 'Request failed');
     } finally {
       setEmailLoading(false);
+    }
+  };
+
+  const handleToggleFrictionless = async () => {
+    const next = !frictionlessDefault;
+    setSavingPref(true);
+    try {
+      await api.updateMyPreferences({ frictionless_join_default: next });
+      setFrictionlessDefault(next);
+    } finally {
+      setSavingPref(false);
     }
   };
 
@@ -199,6 +217,26 @@ export default function AccountPage() {
             </button>
           </form>
         )}
+      </div>
+
+      <div style={{ background: 'var(--card)', borderRadius: '0.75rem', padding: '1.5rem', marginTop: '1.5rem' }}>
+        <h2 style={{ marginTop: 0, marginBottom: '1.25rem', fontSize: '1.1rem' }}>Guest Experience</h2>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <input
+            type="checkbox"
+            checked={frictionlessDefault}
+            disabled={savingPref}
+            onChange={handleToggleFrictionless}
+            aria-label="Frictionless join by default"
+          />
+          <span>
+            Frictionless join by default (new events)
+            <br />
+            <span style={{ color: 'var(--text-secondary)', fontSize: '0.85rem' }}>
+              New events let guests skip the nickname/email step and get an auto-generated name.
+            </span>
+          </span>
+        </label>
       </div>
     </main>
   );

--- a/dashboard/app/(dj)/account/page.tsx
+++ b/dashboard/app/(dj)/account/page.tsx
@@ -26,6 +26,7 @@ export default function AccountPage() {
 
   const [frictionlessDefault, setFrictionlessDefault] = useState(false);
   const [savingPref, setSavingPref] = useState(false);
+  const [prefError, setPrefError] = useState('');
 
   const redirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -100,9 +101,12 @@ export default function AccountPage() {
   const handleToggleFrictionless = async () => {
     const next = !frictionlessDefault;
     setSavingPref(true);
+    setPrefError('');
     try {
       await api.updateMyPreferences({ frictionless_join_default: next });
       setFrictionlessDefault(next);
+    } catch (err: unknown) {
+      setPrefError(err instanceof Error ? err.message : 'Could not save preference');
     } finally {
       setSavingPref(false);
     }
@@ -237,6 +241,11 @@ export default function AccountPage() {
             </span>
           </span>
         </label>
+        {prefError && (
+          <p style={{ color: 'var(--color-danger)', fontSize: '0.875rem', marginTop: '0.75rem' }}>
+            {prefError}
+          </p>
+        )}
       </div>
     </main>
   );

--- a/dashboard/app/(dj)/dashboard/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/dashboard/__tests__/page.test.tsx
@@ -84,6 +84,7 @@ function mockEvent(overrides = {}) {
     banner_kiosk_url: null,
     banner_colors: null,
     requests_open: true,
+    frictionless_join: false,
     collection_opens_at: null,
     live_starts_at: null,
     submission_cap_per_guest: 15,

--- a/dashboard/app/(dj)/events/[code]/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/__tests__/page.test.tsx
@@ -189,6 +189,7 @@ function mockEvent(overrides = {}) {
       collect_url: null, name: 'Test Event',
     created_at: '2026-01-01T00:00:00Z', expires_at: '2026-12-31T00:00:00Z',
     is_active: true, join_url: null, requests_open: true,
+    frictionless_join: false,
     tidal_sync_enabled: false, tidal_playlist_id: null,
     beatport_sync_enabled: false, beatport_playlist_id: null,
     banner_url: null, banner_kiosk_url: null, banner_colors: null,

--- a/dashboard/app/(dj)/events/[code]/components/EventManagementTab.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/EventManagementTab.tsx
@@ -38,6 +38,9 @@ interface EventManagementTabProps {
   kioskDisplayOnly: boolean;
   togglingDisplayOnly: boolean;
   onToggleDisplayOnly: () => void;
+  frictionlessJoin: boolean;
+  togglingFrictionless: boolean;
+  onToggleFrictionless: () => void;
   tidalStatus: TidalStatus | null;
   tidalSyncEnabled: boolean;
   togglingTidalSync: boolean;
@@ -78,6 +81,9 @@ export function EventManagementTab(props: EventManagementTabProps) {
           kioskDisplayOnly={props.kioskDisplayOnly}
           togglingDisplayOnly={props.togglingDisplayOnly}
           onToggleDisplayOnly={props.onToggleDisplayOnly}
+          frictionlessJoin={props.frictionlessJoin}
+          togglingFrictionless={props.togglingFrictionless}
+          onToggleFrictionless={props.onToggleFrictionless}
         />
       </HelpSpot>
 

--- a/dashboard/app/(dj)/events/[code]/components/KioskControlsCard.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/KioskControlsCard.tsx
@@ -17,6 +17,9 @@ interface KioskControlsCardProps {
   kioskDisplayOnly: boolean;
   togglingDisplayOnly: boolean;
   onToggleDisplayOnly: () => void;
+  frictionlessJoin: boolean;
+  togglingFrictionless: boolean;
+  onToggleFrictionless: () => void;
 }
 
 export function KioskControlsCard({
@@ -36,6 +39,9 @@ export function KioskControlsCard({
   kioskDisplayOnly,
   togglingDisplayOnly,
   onToggleDisplayOnly,
+  frictionlessJoin,
+  togglingFrictionless,
+  onToggleFrictionless,
 }: KioskControlsCardProps) {
   return (
     <div className="card" style={{ marginBottom: '1rem', padding: '1rem' }}>
@@ -85,6 +91,22 @@ export function KioskControlsCard({
         >
           {togglingDisplayOnly ? '...' : kioskDisplayOnly ? 'On' : 'Off'}
         </button>
+      </div>
+
+      {/* Frictionless join */}
+      <div style={{ borderTop: '1px solid var(--border)', paddingTop: '1rem', marginBottom: '1rem' }}>
+        <button
+          type="button"
+          className={`btn btn-sm ${frictionlessJoin ? 'btn-primary' : ''}`}
+          style={{ minWidth: '180px', background: frictionlessJoin ? undefined : 'var(--surface-raised)' }}
+          disabled={togglingFrictionless}
+          onClick={onToggleFrictionless}
+        >
+          {togglingFrictionless ? '...' : `Frictionless join: ${frictionlessJoin ? 'On' : 'Off'}`}
+        </button>
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.8125rem', margin: '0.5rem 0 0' }}>
+          Guests skip the nickname/email step and get an auto-generated name. Good for weddings &amp; private parties.
+        </p>
       </div>
 
       {/* Auto-hide timeout */}

--- a/dashboard/app/(dj)/events/[code]/components/__tests__/EventManagementTab.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/__tests__/EventManagementTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { EventManagementTab } from '../EventManagementTab';
 
 vi.mock('@/lib/help/HelpContext', () => ({
@@ -13,7 +13,20 @@ vi.mock('@/lib/help/HelpContext', () => ({
 }));
 
 vi.mock('../KioskControlsCard', () => ({
-  KioskControlsCard: () => <div data-testid="kiosk-controls">KioskControls</div>,
+  KioskControlsCard: ({
+    frictionlessJoin,
+    onToggleFrictionless,
+  }: {
+    frictionlessJoin: boolean;
+    onToggleFrictionless: () => void;
+  }) => (
+    <div data-testid="kiosk-controls">
+      KioskControls
+      <button type="button" onClick={onToggleFrictionless}>
+        Frictionless join: {frictionlessJoin ? 'On' : 'Off'}
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('../StreamOverlayCard', () => ({
@@ -63,6 +76,9 @@ const baseProps = {
   kioskDisplayOnly: false,
   togglingDisplayOnly: false,
   onToggleDisplayOnly: vi.fn(),
+  frictionlessJoin: false,
+  togglingFrictionless: false,
+  onToggleFrictionless: vi.fn(),
   uploadingBanner: false,
   onBannerSelect: vi.fn(),
   onDeleteBanner: vi.fn(),
@@ -94,5 +110,19 @@ describe('EventManagementTab', () => {
   it('renders EventCustomizationCard', () => {
     render(<EventManagementTab {...baseProps} />);
     expect(screen.getByTestId('event-customization')).toBeInTheDocument();
+  });
+
+  it('renders Frictionless join toggle and fires handler', () => {
+    const onToggleFrictionless = vi.fn();
+    render(
+      <EventManagementTab
+        {...baseProps}
+        frictionlessJoin={false}
+        togglingFrictionless={false}
+        onToggleFrictionless={onToggleFrictionless}
+      />
+    );
+    fireEvent.click(screen.getByText(/Frictionless join/i));
+    expect(onToggleFrictionless).toHaveBeenCalled();
   });
 });

--- a/dashboard/app/(dj)/events/[code]/page.tsx
+++ b/dashboard/app/(dj)/events/[code]/page.tsx
@@ -73,6 +73,10 @@ export default function EventQueuePage() {
   const [kioskDisplayOnly, setKioskDisplayOnly] = useState(false);
   const [togglingDisplayOnly, setTogglingDisplayOnly] = useState(false);
 
+  // Frictionless join (per-event)
+  const [frictionlessJoin, setFrictionlessJoin] = useState(false);
+  const [togglingFrictionless, setTogglingFrictionless] = useState(false);
+
   // Bridge / now-playing state
   const [bridgeConnected, setBridgeConnected] = useState(false);
   const [nowPlaying, setNowPlaying] = useState<NowPlayingInfo | null>(null);
@@ -271,6 +275,7 @@ export default function EventQueuePage() {
       if (!savingAutoHide) {
         setAutoHideInput(String(serverAutoHide));
       }
+      setFrictionlessJoin(eventData.frictionless_join ?? false);
       setTidalStatus(tidalStatusData);
       setTidalSyncEnabled(eventData.tidal_sync_enabled ?? false);
       setBeatportStatus(beatportStatusData);
@@ -486,6 +491,20 @@ export default function EventQueuePage() {
       // Silently fail — next poll will restore the server state
     } finally {
       setTogglingDisplayOnly(false);
+    }
+  };
+
+  const handleToggleFrictionless = async () => {
+    if (!event) return;
+    setTogglingFrictionless(true);
+    try {
+      const updated = await api.updateEvent(event.code, { frictionless_join: !frictionlessJoin });
+      setFrictionlessJoin(updated.frictionless_join);
+      setEvent(updated);
+    } catch {
+      // Silently fail — next poll will restore the server state
+    } finally {
+      setTogglingFrictionless(false);
     }
   };
 
@@ -1078,6 +1097,9 @@ export default function EventQueuePage() {
               kioskDisplayOnly={kioskDisplayOnly}
               togglingDisplayOnly={togglingDisplayOnly}
               onToggleDisplayOnly={handleToggleDisplayOnly}
+              frictionlessJoin={frictionlessJoin}
+              togglingFrictionless={togglingFrictionless}
+              onToggleFrictionless={handleToggleFrictionless}
               tidalStatus={tidalStatus}
               tidalSyncEnabled={tidalSyncEnabled}
               togglingTidalSync={togglingTidalSync}

--- a/dashboard/app/join/[code]/__tests__/page.test.tsx
+++ b/dashboard/app/join/[code]/__tests__/page.test.tsx
@@ -22,6 +22,8 @@ const { mockApi, MockApiError } = vi.hoisted(() => {
     publicVoteRequest: vi.fn(),
     eventSearch: vi.fn(),
     search: vi.fn(),
+    getJoinConfig: vi.fn(),
+    ensureGuestName: vi.fn(),
   };
 
   return { mockApi, MockApiError };
@@ -36,6 +38,7 @@ vi.mock('@/lib/use-guest-identity', () => ({
     guestId: 1,
     isReturning: false,
     reconcileHint: false,
+    isLoading: false,
     refresh: vi.fn().mockResolvedValue(undefined),
   })),
 }));
@@ -113,6 +116,9 @@ function setupDefaultMocks() {
   });
   mockApi.getPublicRequests.mockResolvedValue({ requests: [], now_playing: null });
   mockApi.getMyRequests.mockResolvedValue({ requests: [] });
+  // Default: not frictionless, so existing tests still render NicknameGate.
+  mockApi.getJoinConfig.mockResolvedValue({ frictionless_join: false });
+  mockApi.ensureGuestName.mockResolvedValue({ nickname: 'AutoName', auto_generated: true });
 }
 
 describe('JoinEventPage — NicknameGate wiring', () => {
@@ -683,6 +689,27 @@ describe('JoinEventPage — vote flow', () => {
     await waitFor(() => {
       expect(mockApi.publicVoteRequest).toHaveBeenCalled();
     });
+  });
+});
+
+describe('JoinEventPage — frictionless join', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  it('skips NicknameGate and auto-names when frictionless_join is on', async () => {
+    mockApi.getJoinConfig.mockResolvedValue({ frictionless_join: true });
+    mockApi.ensureGuestName.mockResolvedValue({ nickname: 'DancingPanda', auto_generated: true });
+    mockApi.getEvent.mockResolvedValue({
+      id: 1, code: 'TEST01', join_code: 'TEST01', name: 'Party', requests_open: true,
+      frictionless_join: true,
+    } as never);
+    mockApi.checkHasRequested.mockResolvedValue({ has_requested: false } as never);
+    render(<JoinEventPage />);
+    // No "What's your nickname?" gate; the auto-name shows in the identity bar.
+    await waitFor(() => expect(screen.getByText(/DancingPanda/)).toBeInTheDocument());
+    expect(screen.queryByText(/What's your nickname/i)).not.toBeInTheDocument();
   });
 });
 

--- a/dashboard/app/join/[code]/page.tsx
+++ b/dashboard/app/join/[code]/page.tsx
@@ -54,7 +54,7 @@ export default function JoinEventPage() {
   const params = useParams();
   const code = params.code as string;
 
-  const { reconcileHint, refresh: refreshIdentity } = useGuestIdentity();
+  const { reconcileHint, refresh: refreshIdentity, isLoading: identityLoading } = useGuestIdentity();
   const { state: humanState, reverify, widgetContainerRef } = useHumanVerification();
   const [recoveryOpen, setRecoveryOpen] = useState(false);
 
@@ -109,10 +109,49 @@ export default function JoinEventPage() {
 
   /* Gate */
   const [gateComplete, setGateComplete] = useState(false);
+  const [autoNamed, setAutoNamed] = useState(false);
+  /* Whether the frictionless-vs-nickname decision has resolved. NicknameGate
+     must not render (and fire onComplete) until we've confirmed the event is
+     not frictionless — otherwise a frictionless event would briefly show the
+     gate. */
+  const [gateDecided, setGateDecided] = useState(false);
   const handleGateComplete = (result: GateResult) => {
     setNickname(result.nickname);
     setGateComplete(true);
   };
+
+  /* Decide gate mode on load. Frictionless events skip NicknameGate entirely:
+     the guest gets an auto-generated name and lands straight on search. */
+  useEffect(() => {
+    if (gateComplete || identityLoading) return;
+    let active = true;
+    (async () => {
+      try {
+        const cfg = await api.getJoinConfig(code);
+        if (!active) return;
+        if (!cfg.frictionless_join) {
+          setGateDecided(true); // not frictionless -> NicknameGate renders
+          return;
+        }
+        const res = await api.ensureGuestName(code, reverify);
+        if (!active) return;
+        setNickname(res.nickname);
+        setAutoNamed(res.auto_generated);
+        setGateComplete(true);
+      } catch {
+        // On any failure, fall back to the normal NicknameGate flow.
+        if (active) setGateDecided(true);
+      }
+    })();
+    return () => { active = false; };
+  }, [code, gateComplete, identityLoading, reverify]);
+
+  /* Rename affordance for auto-named (frictionless) guests. */
+  const handleRename = useCallback(async (newName: string) => {
+    await api.ensureGuestName(code, reverify, newName);
+    setNickname(newName);
+    setAutoNamed(false);
+  }, [code, reverify]);
 
   /* Pre-event collect phase */
   const [collectPhase, setCollectPhase] = useState<
@@ -387,6 +426,17 @@ export default function JoinEventPage() {
   /* ── Early returns ──────────────────────────────────────────── */
 
   if (!gateComplete) {
+    // Wait for the frictionless decision before rendering the nickname gate,
+    // so frictionless events never flash the gate on their way to auto-name.
+    if (!gateDecided) {
+      return (
+        <div className="guest-tower" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 13.3, color: 'rgba(255,255,255,0.4)', letterSpacing: 2 }}>
+            LOADING…
+          </div>
+        </div>
+      );
+    }
     return <NicknameGate code={code} onComplete={handleGateComplete} reverify={reverify} />;
   }
 
@@ -427,7 +477,7 @@ export default function JoinEventPage() {
       <div className="guest-tower">
         {event.banner_url && <BannerBg url={event.banner_url} />}
         {nickname && (
-          <IdentityBar nickname={nickname} emailVerified={emailVerified} onVerified={() => setEmailVerified(true)} forceDark />
+          <IdentityBar nickname={nickname} emailVerified={emailVerified} onVerified={() => setEmailVerified(true)} autoNamed={autoNamed} onRename={handleRename} forceDark />
         )}
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '100dvh', padding: '2rem' }}>
           <div style={{ textAlign: 'center', maxWidth: 360 }}>
@@ -482,7 +532,7 @@ export default function JoinEventPage() {
 
       {/* Identity bar */}
       {nickname && (
-        <IdentityBar nickname={nickname} emailVerified={emailVerified} onVerified={() => setEmailVerified(true)} forceDark />
+        <IdentityBar nickname={nickname} emailVerified={emailVerified} onVerified={() => setEmailVerified(true)} autoNamed={autoNamed} onRename={handleRename} forceDark />
       )}
 
       {/* Hidden tracker for my-request IDs + SSE updates */}

--- a/dashboard/app/join/[code]/page.tsx
+++ b/dashboard/app/join/[code]/page.tsx
@@ -148,8 +148,8 @@ export default function JoinEventPage() {
 
   /* Rename affordance for auto-named (frictionless) guests. */
   const handleRename = useCallback(async (newName: string) => {
-    await api.ensureGuestName(code, reverify, newName);
-    setNickname(newName);
+    const res = await api.ensureGuestName(code, reverify, newName);
+    setNickname(res.nickname);
     setAutoNamed(false);
   }, [code, reverify]);
 

--- a/dashboard/app/join/[code]/page.tsx
+++ b/dashboard/app/join/[code]/page.tsx
@@ -334,8 +334,8 @@ export default function JoinEventPage() {
       try {
         const results = await api.search(searchQuery);
         setSearchResults(results);
-      } catch (err) {
-        console.error('Search failed:', err);
+      } catch {
+        // Both search paths failed; leave results empty and clear the spinner.
       }
     } finally {
       setSearching(false);

--- a/dashboard/components/IdentityBar.tsx
+++ b/dashboard/components/IdentityBar.tsx
@@ -9,10 +9,23 @@ interface Props {
   onVerified: () => void;
   picksLabel?: string;
   forceDark?: boolean;
+  autoNamed?: boolean;
+  onRename?: (newName: string) => Promise<void> | void;
 }
 
-export function IdentityBar({ nickname, emailVerified, onVerified, picksLabel, forceDark }: Props) {
+export function IdentityBar({
+  nickname,
+  emailVerified,
+  onVerified,
+  picksLabel,
+  forceDark,
+  autoNamed,
+  onRename,
+}: Props) {
   const [showEmailForm, setShowEmailForm] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [savingName, setSavingName] = useState(false);
 
   const darkVars = forceDark ? ({
     '--card': '#1a1a1a',
@@ -23,6 +36,34 @@ export function IdentityBar({ nickname, emailVerified, onVerified, picksLabel, f
   return (
     <div className="identity-bar" style={darkVars}>
       <span className="identity-bar-name">👤 {nickname}</span>
+      {autoNamed && onRename && !renaming && (
+        <button className="identity-bar-action" onClick={() => { setDraft(''); setRenaming(true); }}>
+          Add a name
+        </button>
+      )}
+      {renaming && (
+        <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+          <input
+            className="input"
+            placeholder="Your name"
+            value={draft}
+            maxLength={30}
+            onChange={(e) => setDraft(e.target.value)}
+            autoFocus
+          />
+          <button
+            className="btn btn-primary"
+            disabled={!draft.trim() || savingName}
+            onClick={async () => {
+              setSavingName(true);
+              try { await onRename!(draft.trim()); setRenaming(false); }
+              finally { setSavingName(false); }
+            }}
+          >
+            Save
+          </button>
+        </span>
+      )}
       {emailVerified ? (
         <span className="identity-bar-verified">✓ Verified</span>
       ) : showEmailForm ? (

--- a/dashboard/components/IdentityBar.tsx
+++ b/dashboard/components/IdentityBar.tsx
@@ -45,6 +45,7 @@ export function IdentityBar({
         <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
           <input
             className="input"
+            aria-label="Your name"
             placeholder="Your name"
             value={draft}
             maxLength={30}

--- a/dashboard/components/__tests__/IdentityBar.test.tsx
+++ b/dashboard/components/__tests__/IdentityBar.test.tsx
@@ -113,3 +113,22 @@ describe('IdentityBar', () => {
     expect(root.style.getPropertyValue('--card')).toBe('');
   });
 });
+
+describe('IdentityBar rename', () => {
+  it('shows "Add a name" when autoNamed and calls onRename', async () => {
+    const onRename = vi.fn().mockResolvedValue(undefined);
+    render(
+      <IdentityBar nickname="DancingPanda" emailVerified={false} onVerified={() => {}}
+        autoNamed onRename={onRename} />
+    );
+    fireEvent.click(screen.getByText(/Add a name/i));
+    fireEvent.change(screen.getByPlaceholderText(/your name/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByText(/^Save$/));
+    await waitFor(() => expect(onRename).toHaveBeenCalledWith('Alex'));
+  });
+
+  it('does not show "Add a name" when not autoNamed', () => {
+    render(<IdentityBar nickname="Alex" emailVerified={false} onVerified={() => {}} />);
+    expect(screen.queryByText(/Add a name/i)).not.toBeInTheDocument();
+  });
+});

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -2251,4 +2251,55 @@ describe('ApiClient', () => {
       });
     });
   });
+
+  describe('frictionless join api', () => {
+    it('getJoinConfig hits the public collect endpoint', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ frictionless_join: true }), { status: 200 }),
+      );
+      const res = await api.getJoinConfig('CODE01');
+      expect(res.frictionless_join).toBe(true);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/public/collect/CODE01/join-config');
+    });
+
+    it('ensureGuestName posts to the ensure-name endpoint', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ nickname: 'DancingPanda', auto_generated: true }),
+          { status: 200 },
+        ),
+      );
+      const res = await api.ensureGuestName('CODE01');
+      expect(res.nickname).toBe('DancingPanda');
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/public/collect/CODE01/guest/ensure-name');
+      expect(init.method).toBe('POST');
+    });
+
+    it('ensureGuestName sends the chosen nickname when renaming', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ nickname: 'Alex', auto_generated: false }),
+          { status: 200 },
+        ),
+      );
+      const res = await api.ensureGuestName('CODE01', undefined, 'Alex');
+      expect(res.nickname).toBe('Alex');
+      const [, init] = mockFetch.mock.calls[0];
+      expect(JSON.parse(init.body)).toEqual({ nickname: 'Alex' });
+    });
+
+    it('updateMyPreferences PATCHes the preferences endpoint', async () => {
+      api.setToken('test-token');
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ frictionless_join_default: true }), { status: 200 }),
+      );
+      await api.updateMyPreferences({ frictionless_join_default: true });
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/auth/me/preferences');
+      expect(init.method).toBe('PATCH');
+      expect(JSON.parse(init.body)).toEqual({ frictionless_join_default: true });
+    });
+  });
 });

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -368,6 +368,23 @@ export interface paths {
         patch: operations["change_password_api_auth_me_password_patch"];
         trace?: never;
     };
+    "/api/auth/me/preferences": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update Me Preferences */
+        patch: operations["update_me_preferences_api_auth_me_preferences_patch"];
+        trace?: never;
+    };
     "/api/auth/register": {
         parameters: {
             query?: never;
@@ -1319,6 +1336,48 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/public/collect/{code}/guest/ensure-name": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Ensure Name
+         * @description Frictionless-join name management. Auto-generates a nickname when none is
+         *     set, or applies a manual rename. Gated on event.frictionless_join so it can
+         *     never bypass email verification on a hardened (non-frictionless) event.
+         */
+        post: operations["ensure_name_api_public_collect__code__guest_ensure_name_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/public/collect/{code}/join-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Join Config
+         * @description Public, unauthenticated: lets the join page decide its gate mode on load.
+         */
+        get: operations["join_config_api_public_collect__code__join_config_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/public/collect/{code}/leaderboard": {
         parameters: {
             query?: never;
@@ -1459,7 +1518,8 @@ export interface paths {
          * @description Get bridge connection status for public display.
          *
          *     Independent of track data — returns bridge connectivity even when
-         *     no track is currently playing.
+         *     no track is currently playing. Resolves by join_code: serves guest-facing
+         *     kiosk display + overlay pages.
          */
         get: operations["get_public_bridge_status_api_public_e__code__bridge_status_get"];
         put?: never;
@@ -1482,6 +1542,7 @@ export interface paths {
          * @description Get play history for public display.
          *
          *     Returns the list of tracks played during the event, newest first.
+         *     Resolves by join_code: serves guest-facing kiosk display.
          */
         get: operations["get_public_history_api_public_e__code__history_get"];
         put?: never;
@@ -1504,6 +1565,9 @@ export interface paths {
          * @description Get current now-playing track for public display.
          *
          *     Returns the track currently playing from StageLinQ, or None if nothing playing.
+         *
+         *     Resolves by join_code: this endpoint serves the kiosk display + OBS overlay
+         *     pages, which route by join_code per the post-PR-#324 public/guest URL contract.
          */
         get: operations["get_public_now_playing_api_public_e__code__nowplaying_get"];
         put?: never;
@@ -2383,10 +2447,7 @@ export interface components {
         };
         /** Body_upload_banner_api_events__code__banner_post */
         Body_upload_banner_api_events__code__banner_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** BridgeApiKeyResponse */
@@ -2788,6 +2849,18 @@ export interface components {
             /** Title */
             title: string;
         };
+        /** EnsureNameRequest */
+        EnsureNameRequest: {
+            /** Nickname */
+            nickname?: string | null;
+        };
+        /** EnsureNameResponse */
+        EnsureNameResponse: {
+            /** Auto Generated */
+            auto_generated: boolean;
+            /** Nickname */
+            nickname: string;
+        };
         /** EventCreate */
         EventCreate: {
             /**
@@ -2856,6 +2929,11 @@ export interface components {
             created_at: string;
             /** Expires At */
             expires_at: string;
+            /**
+             * Frictionless Join
+             * @default false
+             */
+            frictionless_join: boolean;
             /** Id */
             id: number;
             /** Is Active */
@@ -2899,6 +2977,8 @@ export interface components {
         EventUpdate: {
             /** Expires At */
             expires_at?: string | null;
+            /** Frictionless Join */
+            frictionless_join?: boolean | null;
             /** Name */
             name?: string | null;
         };
@@ -3049,6 +3129,11 @@ export interface components {
             /** Service */
             service: string;
         };
+        /** JoinConfigResponse */
+        JoinConfigResponse: {
+            /** Frictionless Join */
+            frictionless_join: boolean;
+        };
         /**
          * KioskAssignRequest
          * @description Body for reassigning a kiosk to a different event.
@@ -3192,6 +3277,11 @@ export interface components {
         LiveJoinCodeResponse: {
             /** Join Code */
             join_code: string;
+        };
+        /** MePreferencesUpdate */
+        MePreferencesUpdate: {
+            /** Frictionless Join Default */
+            frictionless_join_default: boolean;
         };
         /** MyRequestInfo */
         MyRequestInfo: {
@@ -3853,6 +3943,11 @@ export interface components {
             created_at: string;
             /** Email */
             email: string | null;
+            /**
+             * Frictionless Join Default
+             * @default false
+             */
+            frictionless_join_default: boolean;
             /**
              * Help Pages Seen
              * @default []
@@ -4640,6 +4735,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["StatusMessageResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_me_preferences_api_auth_me_preferences_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MePreferencesUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserOut"];
                 };
             };
             /** @description Validation Error */
@@ -6348,6 +6476,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["EnrichPreviewResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    ensure_name_api_public_collect__code__guest_ensure_name_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                code: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EnsureNameRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EnsureNameResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    join_config_api_public_collect__code__join_config_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                code: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JoinConfigResponse"];
                 };
             };
             /** @description Validation Error */

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -1350,6 +1350,11 @@ export interface paths {
          * @description Frictionless-join name management. Auto-generates a nickname when none is
          *     set, or applies a manual rename. Gated on event.frictionless_join so it can
          *     never bypass email verification on a hardened (non-frictionless) event.
+         *
+         *     Not anonymous: requires the `wrzdj_human` HMAC-signed verified-human cookie
+         *     (set via Turnstile) through `require_verified_human_soft`. Calls without a
+         *     resolvable verified-human guest are rejected with 403
+         *     `human_verification_required`.
          */
         post: operations["ensure_name_api_public_collect__code__guest_ensure_name_post"];
         delete?: never;

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -405,6 +405,7 @@ class ApiClient {
     help_pages_seen: string[];
     pending_email: string | null;
     email: string | null;
+    frictionless_join_default: boolean;
   }> {
     return this.fetch('/api/auth/me');
   }
@@ -1217,6 +1218,32 @@ class ApiClient {
     );
     if (!res.ok) throw new ApiError(`getCollectLeaderboard failed: ${res.status}`, res.status);
     return res.json();
+  }
+
+  async getJoinConfig(code: string): Promise<{ frictionless_join: boolean }> {
+    return this.publicFetch(`${getApiUrl()}/api/public/collect/${code}/join-config`);
+  }
+
+  async ensureGuestName(
+    code: string,
+    reverify?: () => Promise<void>,
+    nickname?: string,
+  ): Promise<{ nickname: string; auto_generated: boolean }> {
+    const doFetch = () =>
+      fetch(`${getApiUrl()}/api/public/collect/${code}/guest/ensure-name`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(nickname ? { nickname } : {}),
+      });
+    return withHumanRetry(doFetch, reverify ?? (async () => {}));
+  }
+
+  async updateMyPreferences(prefs: { frictionless_join_default: boolean }): Promise<void> {
+    await this.fetch('/api/auth/me/preferences', {
+      method: 'PATCH',
+      body: JSON.stringify(prefs),
+    });
   }
 
   async getCollectProfile(code: string): Promise<CollectProfileResponse> {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -532,7 +532,10 @@ class ApiClient {
     return this.fetch(`/api/events/${code}`);
   }
 
-  async updateEvent(code: string, data: { expires_at?: string; name?: string }): Promise<Event> {
+  async updateEvent(
+    code: string,
+    data: { expires_at?: string; name?: string; frictionless_join?: boolean },
+  ): Promise<Event> {
     return this.fetch(`/api/events/${code}`, {
       method: 'PATCH',
       body: JSON.stringify(data),

--- a/docs/superpowers/plans/2026-05-29-frictionless-join.md
+++ b/docs/superpowers/plans/2026-05-29-frictionless-join.md
@@ -1,0 +1,1314 @@
+# Frictionless Join Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a DJ mark an event "frictionless join" so live-event guests land straight on song search with an auto-generated username — no nickname/email step — while `/collect` stays fully hardened.
+
+**Architecture:** A per-event boolean `Event.frictionless_join` (snapshot-seeded at creation from the DJ's `User.frictionless_join_default`) is read by the `/join` page. When true, the page skips `NicknameGate` and calls a new server endpoint that auto-generates a unique nickname (via `coolname`) on the existing per-event `GuestProfile`. The auto-name + optional rename path is gated by the soft human-cookie check **and** by `event.frictionless_join` (so it can never bypass email verification on non-frictionless events). `/collect` endpoints and their `require_email_verified` gates are untouched.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2.0 + Alembic (backend), Next.js 16 / React 19 + vanilla CSS (frontend), pytest + vitest, `coolname` (BSD-2-Clause, zero-dep name generator), OpenAPI-generated TS types.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-frictionless-join-design.md`
+
+## Routing resolution note (read before coding)
+
+The `/join/[code]` page currently calls **both** `/api/events/{code}/*` (collection-code lookup) and `/api/public/collect/{code}/*` (collection-code lookup via `NicknameGate`) successfully with one `code` param. This plan therefore anchors all new guest endpoints to the **collect router** (`/api/public/collect`, resolved via `collect.py:_get_event_or_404` → `Event.code == code`), the identical resolution path `NicknameGate` already uses. This guarantees the new endpoints resolve the same event row the existing gate does, independent of the latent collection-vs-join code routing quirk (pre-existing, out of scope for #369).
+
+## File structure
+
+**Backend (create):**
+- `server/app/services/guest_names.py` — auto-name generator (one responsibility)
+
+**Backend (modify):**
+- `server/app/models/user.py` — add `frictionless_join_default`
+- `server/app/models/event.py` — add `frictionless_join`
+- `server/alembic/versions/<new>_add_frictionless_join.py` — migration
+- `server/pyproject.toml` — add `coolname` dependency
+- `server/app/schemas/event.py` — `EventOut` + `EventUpdate`
+- `server/app/schemas/user.py` — `UserOut`
+- `server/app/schemas/collect.py` — `EnsureNameRequest` / `EnsureNameResponse` / `JoinConfigResponse`
+- `server/app/services/event.py` — `create_event` seed + `update_event` apply
+- `server/app/services/account.py` — `update_preferences`
+- `server/app/api/collect.py` — `ensure_name` + `join_config` endpoints
+- `server/app/api/auth.py` — `PATCH /me/preferences`
+
+**Frontend (modify):**
+- `dashboard/lib/api-types.generated.ts` — regenerated (do not hand-edit)
+- `dashboard/lib/api.ts` — `getJoinConfig`, `ensureGuestName`, `updateMyPreferences`, `getMe` field
+- `dashboard/app/join/[code]/page.tsx` — gate-mode decision + auto-name
+- `dashboard/components/IdentityBar.tsx` — "Add a name" rename affordance
+- `dashboard/app/(dj)/events/[code]/page.tsx` — frictionless toggle state + handler
+- `dashboard/app/(dj)/events/[code]/components/EventManagementTab.tsx` — pass-through props
+- `dashboard/app/(dj)/events/[code]/components/KioskControlsCard.tsx` — render toggle
+- `dashboard/app/(dj)/account/page.tsx` — "Guest Experience" card
+
+---
+
+## Task 1: Data model columns + migration
+
+**Files:**
+- Modify: `server/app/models/user.py` (after `help_pages_seen`, ~line 52)
+- Modify: `server/app/models/event.py` (after `kiosk_display_only`, ~line 61)
+- Create: `server/alembic/versions/<generated>_add_frictionless_join.py`
+- Test: `server/tests/test_frictionless_model.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# server/tests/test_frictionless_model.py
+from app.models.event import Event
+from app.models.user import User
+
+
+def test_user_frictionless_default_defaults_false(db):
+    user = User(username="dj_fric", password_hash="x", role="dj")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    assert user.frictionless_join_default is False
+
+
+def test_event_frictionless_join_defaults_false(db, test_user: User):
+    from app.services.event import create_event
+
+    event = create_event(db, "Frictionless Test", test_user)
+    assert event.frictionless_join is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_model.py -q`
+Expected: FAIL — `AttributeError: 'User' object has no attribute 'frictionless_join_default'`
+
+- [ ] **Step 3: Add the model columns**
+
+In `server/app/models/user.py`, after the `help_pages_seen` column:
+
+```python
+    # Frictionless join: DJ default applied to new events (snapshot at creation).
+    frictionless_join_default: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="0"
+    )
+```
+
+In `server/app/models/event.py`, after the `kiosk_display_only` column block:
+
+```python
+    # Frictionless join: guests skip nickname/email and get an auto-generated name.
+    # Seeded from the creator's frictionless_join_default at event creation.
+    frictionless_join: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="0"
+    )
+```
+
+(`Boolean` is already imported in both files.)
+
+- [ ] **Step 4: Generate the migration skeleton**
+
+Run: `cd server && .venv/bin/alembic revision -m "add frictionless join flags"`
+This creates a new file under `server/alembic/versions/` with `revision`/`down_revision` already linked to the current head. Open it and replace the `upgrade`/`downgrade` bodies:
+
+```python
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("frictionless_join_default", sa.Boolean(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "events",
+        sa.Column("frictionless_join", sa.Boolean(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("events", "frictionless_join")
+    op.drop_column("users", "frictionless_join_default")
+```
+
+- [ ] **Step 5: Apply migration and check for drift**
+
+Run: `cd server && .venv/bin/alembic upgrade head && .venv/bin/alembic check`
+Expected: upgrade succeeds; `alembic check` prints "No new upgrade operations detected."
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_model.py -q`
+Expected: PASS (2 passed)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/app/models/user.py server/app/models/event.py server/alembic/versions/ server/tests/test_frictionless_model.py
+git commit -m "feat(join): add frictionless_join model columns + migration (#369)"
+```
+
+---
+
+## Task 2: Auto-name generator service
+
+**Files:**
+- Modify: `server/pyproject.toml` (dependencies array)
+- Create: `server/app/services/guest_names.py`
+- Test: `server/tests/test_guest_names.py`
+
+- [ ] **Step 1: Add the dependency**
+
+In `server/pyproject.toml`, add to the `dependencies` list:
+
+```toml
+    "coolname==5.0.0",
+```
+
+Run: `cd server && .venv/bin/pip install coolname==5.0.0`
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# server/tests/test_guest_names.py
+from app.models.event import Event
+from app.models.guest import Guest
+from app.models.guest_profile import GuestProfile
+from app.services.guest_names import generate_unique_nickname
+
+
+def test_generates_titlecased_no_hyphen(db, test_event: Event):
+    nick = generate_unique_nickname(db, event_id=test_event.id)
+    assert nick
+    assert "-" not in nick
+    assert nick[0].isupper()
+    assert len(nick) <= 30
+
+
+def test_avoids_existing_nickname_in_event(db, test_event: Event, monkeypatch):
+    # Force the 2-word generator to always collide, proving the suffix/retry path.
+    import app.services.guest_names as gn
+
+    guest = Guest(token="g" * 64, fingerprint_hash="fp_x")
+    db.add(guest)
+    db.commit()
+    db.add(GuestProfile(event_id=test_event.id, guest_id=guest.id, nickname="Taken"))
+    db.commit()
+
+    calls = {"n": 0}
+
+    def fake_slug(n):
+        if n == 2:
+            calls["n"] += 1
+            return "taken"  # always collides at 2 words
+        return "unique-three-words"  # 3-word fallback
+
+    monkeypatch.setattr(gn, "generate_slug", fake_slug)
+    nick = generate_unique_nickname(db, event_id=test_event.id, max_attempts=3)
+    # Either a digit-suffixed "Taken##" or the 3-word fallback; never bare "Taken".
+    assert nick.lower() != "taken"
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd server && .venv/bin/pytest tests/test_guest_names.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.services.guest_names'`
+
+- [ ] **Step 4: Write the implementation**
+
+```python
+# server/app/services/guest_names.py
+"""Auto-generated guest nicknames for frictionless-join events.
+
+Server-side so it shares the per-event nickname uniqueness check and never
+ships a wordlist to the client. Vocabulary comes from `coolname` (BSD-2-Clause,
+zero deps).
+"""
+
+import secrets
+
+from coolname import generate_slug
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.guest_profile import GuestProfile
+
+
+def _slug_to_name(slug: str) -> str:
+    """'dancing-panda' -> 'DancingPanda', clamped to the 30-char nickname limit."""
+    name = "".join(part.capitalize() for part in slug.split("-"))
+    return name[:30]
+
+
+def _is_taken(db: Session, *, event_id: int, candidate: str) -> bool:
+    return (
+        db.query(GuestProfile.id)
+        .filter(
+            GuestProfile.event_id == event_id,
+            func.lower(GuestProfile.nickname) == candidate.lower(),
+        )
+        .first()
+        is not None
+    )
+
+
+def generate_unique_nickname(db: Session, *, event_id: int, max_attempts: int = 5) -> str:
+    """Return a nickname unique (case-insensitive) within the event.
+
+    Tries `max_attempts` two-word names, suffixing a 2-digit number after the
+    first collision. Falls back to a collision-proof three-word name if all
+    attempts collide.
+    """
+    for attempt in range(max_attempts):
+        base = _slug_to_name(generate_slug(2))
+        candidate = base if attempt == 0 else f"{base}{secrets.randbelow(90) + 10}"
+        candidate = candidate[:30]
+        if not _is_taken(db, event_id=event_id, candidate=candidate):
+            return candidate
+    return _slug_to_name(generate_slug(3))
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd server && .venv/bin/pytest tests/test_guest_names.py -q`
+Expected: PASS (2 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/pyproject.toml server/app/services/guest_names.py server/tests/test_guest_names.py
+git commit -m "feat(join): add coolname-based guest nickname generator (#369)"
+```
+
+---
+
+## Task 3: EventOut field + EventUpdate + update_event apply
+
+**Files:**
+- Modify: `server/app/schemas/event.py` (`EventOut` ~line 79, `EventUpdate` ~line 31)
+- Modify: `server/app/services/event.py` (`update_event` ~line 151)
+- Modify: `server/app/api/events.py` (`update_event_endpoint` ~line 451 — pass new field)
+- Test: `server/tests/test_frictionless_event_api.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# server/tests/test_frictionless_event_api.py
+from app.models.user import User
+
+
+def test_event_out_exposes_frictionless_join(client, db, test_user: User, auth_headers):
+    r = client.post("/api/events", json={"name": "E1", "expires_hours": 6}, headers=auth_headers)
+    assert r.status_code == 201
+    assert r.json()["frictionless_join"] is False
+
+
+def test_patch_event_sets_frictionless_join(client, db, test_user: User, auth_headers):
+    code = client.post(
+        "/api/events", json={"name": "E2", "expires_hours": 6}, headers=auth_headers
+    ).json()["code"]
+    r = client.patch(f"/api/events/{code}", json={"frictionless_join": True}, headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json()["frictionless_join"] is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_event_api.py -q`
+Expected: FAIL — response JSON has no `frictionless_join` key (KeyError on assert).
+
+- [ ] **Step 3: Add the schema fields**
+
+In `server/app/schemas/event.py`, add to `EventOut` (after `requests_open`):
+
+```python
+    # Frictionless join (guests skip nickname/email)
+    frictionless_join: bool = False
+```
+
+Add to `EventUpdate`:
+
+```python
+    frictionless_join: bool | None = None
+```
+
+- [ ] **Step 4: Apply it in the service + endpoint**
+
+In `server/app/services/event.py`, change `update_event` signature and body:
+
+```python
+def update_event(
+    db: Session,
+    event: Event,
+    name: str | None = None,
+    expires_at: datetime | None = None,
+    frictionless_join: bool | None = None,
+) -> Event:
+    """Update an event's properties."""
+    if name is not None:
+        event.name = name
+    if expires_at is not None:
+        event.expires_at = expires_at
+    if frictionless_join is not None:
+        event.frictionless_join = frictionless_join
+    db.commit()
+    db.refresh(event)
+    return event
+```
+
+In `server/app/api/events.py`, in `update_event_endpoint`, pass the field:
+
+```python
+    updated = update_event(
+        db,
+        event,
+        name=event_data.name,
+        expires_at=event_data.expires_at,
+        frictionless_join=event_data.frictionless_join,
+    )
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_event_api.py -q`
+Expected: PASS (2 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/app/schemas/event.py server/app/services/event.py server/app/api/events.py server/tests/test_frictionless_event_api.py
+git commit -m "feat(join): expose + edit event.frictionless_join via EventOut/PATCH (#369)"
+```
+
+---
+
+## Task 4: Event creation seeds from DJ default
+
+**Files:**
+- Modify: `server/app/services/event.py` (`create_event` ~line 90)
+- Test: `server/tests/test_frictionless_seed.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# server/tests/test_frictionless_seed.py
+from app.models.user import User
+from app.services.event import create_event
+
+
+def test_create_event_seeds_from_dj_default(db, test_user: User):
+    test_user.frictionless_join_default = True
+    db.commit()
+    event = create_event(db, "Seeded", test_user)
+    assert event.frictionless_join is True
+
+
+def test_create_event_default_off_when_dj_default_off(db, test_user: User):
+    event = create_event(db, "NotSeeded", test_user)
+    assert event.frictionless_join is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_seed.py -q`
+Expected: FAIL — `test_create_event_seeds_from_dj_default` asserts True but gets False.
+
+- [ ] **Step 3: Seed the field in create_event**
+
+In `server/app/services/event.py`, in `create_event`, add `frictionless_join` to the `Event(...)` constructor:
+
+```python
+        event = Event(
+            code=code,
+            join_code=join_code,
+            name=name,
+            created_by_user_id=user.id,
+            expires_at=expires_at,
+            frictionless_join=user.frictionless_join_default,
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_seed.py -q`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/services/event.py server/tests/test_frictionless_seed.py
+git commit -m "feat(join): seed event.frictionless_join from DJ default at creation (#369)"
+```
+
+---
+
+## Task 5: ensure-name + join-config endpoints
+
+**Files:**
+- Modify: `server/app/schemas/collect.py` (add request/response models)
+- Modify: `server/app/api/collect.py` (add two endpoints near `set_profile`)
+- Test: `server/tests/test_frictionless_ensure_name.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Mirror the `_default_guest_cookie` helper from `tests/test_collect_public.py` (mints `wrzdj_guest` + `wrzdj_human` cookies).
+
+```python
+# server/tests/test_frictionless_ensure_name.py
+from app.models.event import Event
+from app.models.guest import Guest
+from app.services.human_verification import HUMAN_COOKIE_NAME, issue_human_cookie
+
+
+def _verified_guest_cookie(client, db):
+    from fastapi import Response
+
+    guest = Guest(token="frictionguest" + "0" * 51, fingerprint_hash="fp_fric")
+    db.add(guest)
+    db.commit()
+    db.refresh(guest)
+    helper = Response()
+    issue_human_cookie(helper, guest.id)
+    human_value = helper.headers.get("set-cookie", "").split("=", 1)[1].split(";", 1)[0]
+    client.cookies.clear()
+    client.cookies.set("wrzdj_guest", guest.token)
+    client.cookies.set(HUMAN_COOKIE_NAME, human_value)
+    return guest
+
+
+def test_join_config_reports_flag(client, db, test_event: Event):
+    test_event.frictionless_join = True
+    db.commit()
+    r = client.get(f"/api/public/collect/{test_event.code}/join-config")
+    assert r.status_code == 200
+    assert r.json()["frictionless_join"] is True
+
+
+def test_ensure_name_autogenerates_when_frictionless(client, db, test_event: Event):
+    test_event.frictionless_join = True
+    db.commit()
+    _verified_guest_cookie(client, db)
+    r = client.post(f"/api/public/collect/{test_event.code}/guest/ensure-name", json={})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["auto_generated"] is True
+    assert body["nickname"]
+
+
+def test_ensure_name_idempotent(client, db, test_event: Event):
+    test_event.frictionless_join = True
+    db.commit()
+    _verified_guest_cookie(client, db)
+    first = client.post(f"/api/public/collect/{test_event.code}/guest/ensure-name", json={}).json()
+    second = client.post(f"/api/public/collect/{test_event.code}/guest/ensure-name", json={}).json()
+    assert first["nickname"] == second["nickname"]
+
+
+def test_ensure_name_manual_rename(client, db, test_event: Event):
+    test_event.frictionless_join = True
+    db.commit()
+    _verified_guest_cookie(client, db)
+    client.post(f"/api/public/collect/{test_event.code}/guest/ensure-name", json={})
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/guest/ensure-name",
+        json={"nickname": "MyChosenName"},
+    )
+    assert r.status_code == 200
+    assert r.json()["nickname"] == "MyChosenName"
+    assert r.json()["auto_generated"] is False
+
+
+def test_ensure_name_403_when_not_frictionless(client, db, test_event: Event):
+    # test_event.frictionless_join defaults False
+    _verified_guest_cookie(client, db)
+    r = client.post(f"/api/public/collect/{test_event.code}/guest/ensure-name", json={})
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "frictionless_disabled"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_ensure_name.py -q`
+Expected: FAIL — 404 (endpoints don't exist yet).
+
+- [ ] **Step 3: Add the schemas**
+
+In `server/app/schemas/collect.py`, after `CollectProfileResponse`:
+
+```python
+class JoinConfigResponse(BaseModel):
+    frictionless_join: bool
+
+
+class EnsureNameRequest(BaseModel):
+    nickname: Nickname | None = None
+
+
+class EnsureNameResponse(BaseModel):
+    nickname: str
+    auto_generated: bool
+```
+
+(`Nickname` is the validated, profanity-checked type already defined at the top of this file.)
+
+- [ ] **Step 4: Add the endpoints**
+
+In `server/app/api/collect.py`, import the new pieces near the top:
+
+```python
+from app.schemas.collect import EnsureNameRequest, EnsureNameResponse, JoinConfigResponse
+from app.services.guest_names import generate_unique_nickname
+from app.api.deps import require_verified_human_soft
+```
+
+Then add, just after the `set_profile` endpoint:
+
+```python
+@router.get("/{code}/join-config", response_model=JoinConfigResponse)
+@limiter.limit("60/minute")
+def join_config(code: str, request: Request, db: Session = Depends(get_db)):
+    """Public, unauthenticated: lets the join page decide its gate mode on load."""
+    event = _get_event_or_404(db, code)
+    return JoinConfigResponse(frictionless_join=event.frictionless_join)
+
+
+@router.post("/{code}/guest/ensure-name", response_model=EnsureNameResponse)
+@limiter.limit("10/minute")
+def ensure_name(
+    code: str,
+    payload: EnsureNameRequest,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+    guest_id: int | None = Depends(require_verified_human_soft),
+):
+    """Frictionless-join name management. Auto-generates a nickname when none is
+    set, or applies a manual rename. Gated on event.frictionless_join so it can
+    never bypass email verification on a hardened (non-frictionless) event.
+    """
+    event = _get_event_or_404(db, code)
+    if not event.frictionless_join:
+        raise HTTPException(status_code=403, detail={"code": "frictionless_disabled"})
+    if guest_id is None:
+        raise HTTPException(status_code=403, detail={"code": "human_verification_required"})
+
+    existing = collect_service.get_profile(db, event_id=event.id, guest_id=guest_id)
+    if payload.nickname is not None:
+        chosen, auto = payload.nickname, False
+    elif existing is not None and existing.nickname:
+        return EnsureNameResponse(nickname=existing.nickname, auto_generated=False)
+    else:
+        chosen, auto = generate_unique_nickname(db, event_id=event.id), True
+
+    try:
+        profile = upsert_profile(db, event_id=event.id, guest_id=guest_id, nickname=chosen)
+    except NicknameConflictError as exc:
+        raise HTTPException(
+            status_code=409, detail={"code": "nickname_taken", "claimed": exc.claimed}
+        )
+    return EnsureNameResponse(nickname=profile.nickname, auto_generated=auto)
+```
+
+(`Response` is already imported from fastapi in this file; if not, add it to the existing fastapi import. `collect_service`, `upsert_profile`, `NicknameConflictError`, `_get_event_or_404`, `limiter` are already imported/defined in collect.py.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_ensure_name.py -q`
+Expected: PASS (5 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/app/schemas/collect.py server/app/api/collect.py server/tests/test_frictionless_ensure_name.py
+git commit -m "feat(join): ensure-name + join-config endpoints for frictionless mode (#369)"
+```
+
+---
+
+## Task 6: DJ default — UserOut field + PATCH /me/preferences
+
+**Files:**
+- Modify: `server/app/schemas/user.py` (`UserOut`)
+- Modify: `server/app/services/account.py` (add `update_preferences`)
+- Modify: `server/app/api/auth.py` (add `PATCH /me/preferences`)
+- Test: `server/tests/test_frictionless_preferences.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# server/tests/test_frictionless_preferences.py
+def test_me_exposes_frictionless_default(client, auth_headers):
+    r = client.get("/api/auth/me", headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json()["frictionless_join_default"] is False
+
+
+def test_patch_preferences_updates_default(client, auth_headers):
+    r = client.patch(
+        "/api/auth/me/preferences",
+        json={"frictionless_join_default": True},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["frictionless_join_default"] is True
+    # persisted
+    assert client.get("/api/auth/me", headers=auth_headers).json()["frictionless_join_default"] is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_preferences.py -q`
+Expected: FAIL — `/me` response has no `frictionless_join_default`.
+
+- [ ] **Step 3: Add the UserOut field**
+
+In `server/app/schemas/user.py`, add to `UserOut`:
+
+```python
+    frictionless_join_default: bool = False
+```
+
+- [ ] **Step 4: Add the service function**
+
+In `server/app/services/account.py`:
+
+```python
+def update_preferences(db: Session, user: User, *, frictionless_join_default: bool) -> User:
+    """Update self-service DJ preferences."""
+    user.frictionless_join_default = frictionless_join_default
+    db.commit()
+    db.refresh(user)
+    return user
+```
+
+(Ensure `User` and `Session` are imported in that module — they are used by existing functions.)
+
+- [ ] **Step 5: Add the endpoint + request schema**
+
+In `server/app/api/auth.py`, add a request model near the other auth schemas (or inline in `app/schemas/user.py` and import). Inline at top of `auth.py` imports if a local model is simplest:
+
+```python
+from pydantic import BaseModel
+
+
+class MePreferencesUpdate(BaseModel):
+    frictionless_join_default: bool
+```
+
+Then the endpoint (place after `change_password`):
+
+```python
+@router.patch("/me/preferences", response_model=UserOut)
+@limiter.limit("20/minute")
+def update_me_preferences(
+    body: MePreferencesUpdate,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    updated = account_service.update_preferences(
+        db, current_user, frictionless_join_default=body.frictionless_join_default
+    )
+    return UserOut.model_validate(updated)
+```
+
+(`UserOut`, `account_service`, `get_current_active_user`, `limiter`, `Request` are already imported in auth.py. If `limiter` is not used elsewhere in auth.py, drop the decorator — check existing endpoints; `change_password` shows the established decorator pattern to mirror.)
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_preferences.py -q`
+Expected: PASS (2 passed)
+
+- [ ] **Step 7: Run the full backend suite + lint**
+
+Run: `cd server && .venv/bin/ruff check . && .venv/bin/ruff format . && .venv/bin/pytest --tb=short -q`
+Expected: lint clean; all tests pass; coverage ≥ threshold.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/app/schemas/user.py server/app/services/account.py server/app/api/auth.py server/tests/test_frictionless_preferences.py
+git commit -m "feat(join): per-DJ frictionless_join_default via PATCH /me/preferences (#369)"
+```
+
+---
+
+## Task 7: Regenerate OpenAPI types
+
+**Files:**
+- Modify: `server/openapi.json` (generated)
+- Modify: `dashboard/lib/api-types.generated.ts` (generated)
+
+- [ ] **Step 1: Regenerate**
+
+Run:
+```bash
+cd dashboard && npm run types:export && npm run types:generate
+```
+
+- [ ] **Step 2: Verify the new fields landed**
+
+Run: `cd dashboard && grep -n "frictionless_join" lib/api-types.generated.ts`
+Expected: matches for `frictionless_join` (EventOut), `frictionless_join_default` (UserOut), and the `EnsureNameResponse`/`JoinConfigResponse` schemas.
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd dashboard && npx tsc --noEmit`
+Expected: no errors (the `Event` type alias now carries `frictionless_join`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/openapi.json dashboard/lib/api-types.generated.ts
+git commit -m "chore(types): regenerate OpenAPI types for frictionless join (#369)"
+```
+
+---
+
+## Task 8: API client methods
+
+**Files:**
+- Modify: `dashboard/lib/api.ts` (`getMe` ~line 401; new methods near `getCollectProfile` ~line 1222)
+- Test: `dashboard/lib/__tests__/api.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// add to dashboard/lib/__tests__/api.test.ts
+describe('frictionless join api', () => {
+  it('getJoinConfig hits the public collect endpoint', async () => {
+    const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ frictionless_join: true }), { status: 200 })
+    );
+    const res = await apiClient.getJoinConfig('CODE01');
+    expect(res.frictionless_join).toBe(true);
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('/api/public/collect/CODE01/join-config'),
+      expect.anything()
+    );
+    spy.mockRestore();
+  });
+
+  it('ensureGuestName posts to the ensure-name endpoint', async () => {
+    const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ nickname: 'DancingPanda', auto_generated: true }), { status: 200 })
+    );
+    const res = await apiClient.ensureGuestName('CODE01');
+    expect(res.nickname).toBe('DancingPanda');
+    spy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dashboard && npm test -- --run api.test`
+Expected: FAIL — `apiClient.getJoinConfig is not a function`.
+
+- [ ] **Step 3: Add the methods**
+
+In `dashboard/lib/api.ts`, add `frictionless_join_default: boolean;` to the inline return type of `getMe()`.
+
+Add near `getCollectProfile` (use the generated schema types where available):
+
+```typescript
+  async getJoinConfig(code: string): Promise<{ frictionless_join: boolean }> {
+    return this.publicFetch(`${getApiUrl()}/api/public/collect/${code}/join-config`);
+  }
+
+  async ensureGuestName(
+    code: string,
+    reverify?: () => Promise<void>,
+    nickname?: string,
+  ): Promise<{ nickname: string; auto_generated: boolean }> {
+    const doFetch = () =>
+      fetch(`${getApiUrl()}/api/public/collect/${code}/guest/ensure-name`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(nickname ? { nickname } : {}),
+      });
+    return withHumanRetry(doFetch, reverify);
+  }
+
+  async updateMyPreferences(prefs: { frictionless_join_default: boolean }): Promise<void> {
+    await this.fetch('/api/auth/me/preferences', {
+      method: 'PATCH',
+      body: JSON.stringify(prefs),
+    });
+  }
+```
+
+(`withHumanRetry`, `publicFetch`, `getApiUrl` already exist in this file. `withHumanRetry` parses the JSON body and re-bootstraps on a 403 `human_verification_required`, matching `submitRequest`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dashboard && npm test -- --run api.test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/lib/api.ts dashboard/lib/__tests__/api.test.ts
+git commit -m "feat(join): api client getJoinConfig/ensureGuestName/updateMyPreferences (#369)"
+```
+
+---
+
+## Task 9: Join page — gate-mode decision + auto-name
+
+**Files:**
+- Modify: `dashboard/app/join/[code]/page.tsx` (state ~line 90-123; mount effect; `IdentityBar` usages)
+- Test: `dashboard/app/join/[code]/__tests__/page.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// add to dashboard/app/join/[code]/__tests__/page.test.tsx
+it('skips NicknameGate and auto-names when frictionless_join is on', async () => {
+  mockApi.getJoinConfig.mockResolvedValue({ frictionless_join: true });
+  mockApi.ensureGuestName.mockResolvedValue({ nickname: 'DancingPanda', auto_generated: true });
+  mockApi.getEvent.mockResolvedValue({
+    id: 1, code: 'TEST01', join_code: 'TEST01', name: 'Party', requests_open: true,
+    frictionless_join: true,
+  } as never);
+  mockApi.checkHasRequested.mockResolvedValue({ has_requested: false } as never);
+  render(<JoinPage />);
+  // No "What's your nickname?" gate; the auto-name shows in the identity bar.
+  await waitFor(() => expect(screen.getByText(/DancingPanda/)).toBeInTheDocument());
+  expect(screen.queryByText(/What's your nickname/i)).not.toBeInTheDocument();
+});
+```
+
+Add `getJoinConfig: vi.fn()` and `ensureGuestName: vi.fn()` to the `mockApi` object at the top of the test file, and (in tests that don't set it) default `getJoinConfig` to resolve `{ frictionless_join: false }` in `beforeEach` so existing gate tests still render `NicknameGate`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dashboard && npm test -- --run join`
+Expected: FAIL — gate still renders / `getJoinConfig` undefined.
+
+- [ ] **Step 3: Implement the gate-mode decision**
+
+In `dashboard/app/join/[code]/page.tsx`, add state near the other gate state (after line 111):
+
+```typescript
+  const [autoNamed, setAutoNamed] = useState(false);
+  const { isLoading: identityLoading } = useGuestIdentity();
+```
+
+(Import `useGuestIdentity` from `'@/lib/use-guest-identity'` if not already imported.)
+
+Add a mount effect that decides the gate mode (place before the existing `loadEvent` effect):
+
+```typescript
+  // Decide gate mode on load. Frictionless events skip NicknameGate entirely:
+  // the guest gets an auto-generated name and lands straight on search.
+  useEffect(() => {
+    if (gateComplete || identityLoading) return;
+    let active = true;
+    (async () => {
+      try {
+        const cfg = await api.getJoinConfig(code);
+        if (!active || !cfg.frictionless_join) return; // not frictionless -> NicknameGate renders
+        const res = await api.ensureGuestName(code, reverify);
+        if (!active) return;
+        setNickname(res.nickname);
+        setAutoNamed(res.auto_generated);
+        setGateComplete(true);
+      } catch {
+        // On any failure, fall back to the normal NicknameGate flow.
+      }
+    })();
+    return () => { active = false; };
+  }, [code, gateComplete, identityLoading, reverify]);
+```
+
+Update the three `IdentityBar` usages to pass the rename affordance (add `autoNamed` + `onRename`):
+
+```typescript
+        <IdentityBar
+          nickname={nickname}
+          emailVerified={emailVerified}
+          onVerified={() => setEmailVerified(true)}
+          autoNamed={autoNamed}
+          onRename={async (newName: string) => {
+            await api.ensureGuestName(code, reverify, newName);
+            setNickname(newName);
+            setAutoNamed(false);
+          }}
+          forceDark
+        />
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dashboard && npm test -- --run join`
+Expected: PASS (new test + existing gate tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "dashboard/app/join/[code]/page.tsx" "dashboard/app/join/[code]/__tests__/page.test.tsx"
+git commit -m "feat(join): skip nickname gate + auto-name on frictionless events (#369)"
+```
+
+---
+
+## Task 10: IdentityBar "Add a name" rename affordance
+
+**Files:**
+- Modify: `dashboard/components/IdentityBar.tsx`
+- Test: `dashboard/components/__tests__/IdentityBar.test.tsx` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// dashboard/components/__tests__/IdentityBar.test.tsx
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { IdentityBar } from '../IdentityBar';
+
+describe('IdentityBar rename', () => {
+  it('shows "Add a name" when autoNamed and calls onRename', async () => {
+    const onRename = vi.fn().mockResolvedValue(undefined);
+    render(
+      <IdentityBar nickname="DancingPanda" emailVerified={false} onVerified={() => {}}
+        autoNamed onRename={onRename} />
+    );
+    fireEvent.click(screen.getByText(/Add a name/i));
+    fireEvent.change(screen.getByPlaceholderText(/your name/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByText(/^Save$/));
+    await waitFor(() => expect(onRename).toHaveBeenCalledWith('Alex'));
+  });
+
+  it('does not show "Add a name" when not autoNamed', () => {
+    render(<IdentityBar nickname="Alex" emailVerified={false} onVerified={() => {}} />);
+    expect(screen.queryByText(/Add a name/i)).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dashboard && npm test -- --run IdentityBar`
+Expected: FAIL — `autoNamed`/`onRename` not supported; no "Add a name" control.
+
+- [ ] **Step 3: Extend IdentityBar**
+
+In `dashboard/components/IdentityBar.tsx`, extend `Props`:
+
+```typescript
+interface Props {
+  nickname: string;
+  emailVerified: boolean;
+  onVerified: () => void;
+  picksLabel?: string;
+  forceDark?: boolean;
+  autoNamed?: boolean;
+  onRename?: (newName: string) => Promise<void> | void;
+}
+```
+
+Add local state + a minimal inline rename control. Inside the component, add:
+
+```typescript
+  const [renaming, setRenaming] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [savingName, setSavingName] = useState(false);
+```
+
+(Import `useState` from `'react'` if not already imported.) Render an "Add a name" button next to the name when `autoNamed && onRename` and not already verified, and a tiny inline form when `renaming`:
+
+```tsx
+      {autoNamed && onRename && !renaming && (
+        <button className="identity-bar-action" onClick={() => { setDraft(''); setRenaming(true); }}>
+          Add a name
+        </button>
+      )}
+      {renaming && (
+        <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+          <input
+            className="input"
+            placeholder="Your name"
+            value={draft}
+            maxLength={30}
+            onChange={(e) => setDraft(e.target.value)}
+            autoFocus
+          />
+          <button
+            className="btn btn-primary"
+            disabled={!draft.trim() || savingName}
+            onClick={async () => {
+              setSavingName(true);
+              try { await onRename!(draft.trim()); setRenaming(false); }
+              finally { setSavingName(false); }
+            }}
+          >
+            Save
+          </button>
+        </span>
+      )}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dashboard && npm test -- --run IdentityBar`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/components/IdentityBar.tsx dashboard/components/__tests__/IdentityBar.test.tsx
+git commit -m "feat(join): IdentityBar 'Add a name' rename for auto-named guests (#369)"
+```
+
+---
+
+## Task 11: DJ per-event toggle (event management)
+
+**Files:**
+- Modify: `dashboard/app/(dj)/events/[code]/page.tsx` (add `frictionlessJoin` state + `onToggleFrictionless`, mirroring the existing `requestsOpen`/`onToggleRequests` wiring)
+- Modify: `dashboard/app/(dj)/events/[code]/components/EventManagementTab.tsx` (props pass-through)
+- Modify: `dashboard/app/(dj)/events/[code]/components/KioskControlsCard.tsx` (render the toggle)
+- Test: `dashboard/app/(dj)/events/[code]/components/__tests__/EventManagementTab.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// add to EventManagementTab.test.tsx (mirror existing requests-open toggle test)
+it('renders Frictionless join toggle and fires handler', () => {
+  const onToggleFrictionless = vi.fn();
+  render(
+    <EventManagementTab
+      {...baseProps}
+      frictionlessJoin={false}
+      togglingFrictionless={false}
+      onToggleFrictionless={onToggleFrictionless}
+    />
+  );
+  fireEvent.click(screen.getByText(/Frictionless join/i));
+  expect(onToggleFrictionless).toHaveBeenCalled();
+});
+```
+
+(Use the file's existing `baseProps` helper; if absent, mirror the prop object the other tests in this file construct.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dashboard && npm test -- --run EventManagementTab`
+Expected: FAIL — no "Frictionless join" control.
+
+- [ ] **Step 3: Thread the prop through**
+
+In `KioskControlsCard.tsx`, extend the props interface with:
+
+```typescript
+  frictionlessJoin: boolean;
+  togglingFrictionless: boolean;
+  onToggleFrictionless: () => void;
+```
+
+Destructure them in the function signature, and render a toggle row mirroring the `onToggleRequests` button block:
+
+```tsx
+        <button
+          type="button"
+          className="kiosk-toggle"
+          disabled={togglingFrictionless}
+          onClick={onToggleFrictionless}
+        >
+          Frictionless join: {frictionlessJoin ? 'On' : 'Off'}
+        </button>
+        <p className="kiosk-toggle-help">
+          Guests skip the nickname/email step and get an auto-generated name. Good for weddings & private parties.
+        </p>
+```
+
+In `EventManagementTab.tsx`, add the three props to `EventManagementTabProps` and forward them to `<KioskControlsCard>`:
+
+```tsx
+          frictionlessJoin={props.frictionlessJoin}
+          togglingFrictionless={props.togglingFrictionless}
+          onToggleFrictionless={props.onToggleFrictionless}
+```
+
+In `app/(dj)/events/[code]/page.tsx`, add state + handler mirroring `requestsOpen`/`onToggleRequests`:
+
+```typescript
+  const [frictionlessJoin, setFrictionlessJoin] = useState(event?.frictionless_join ?? false);
+  const [togglingFrictionless, setTogglingFrictionless] = useState(false);
+
+  const onToggleFrictionless = async () => {
+    if (!event) return;
+    setTogglingFrictionless(true);
+    try {
+      const updated = await api.updateEvent(event.code, { frictionless_join: !frictionlessJoin });
+      setFrictionlessJoin(updated.frictionless_join);
+      setEvent(updated);
+    } finally {
+      setTogglingFrictionless(false);
+    }
+  };
+```
+
+Pass `frictionlessJoin`, `togglingFrictionless`, `onToggleFrictionless` into `<EventManagementTab>`. Initialize/sync `frictionlessJoin` from `event.frictionless_join` when the event loads (mirror how `requestsOpen` is synced from `event`).
+
+Extend `updateEvent` in `dashboard/lib/api.ts` to accept the field:
+
+```typescript
+  async updateEvent(
+    code: string,
+    data: { expires_at?: string; name?: string; frictionless_join?: boolean },
+  ): Promise<Event> {
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dashboard && npm test -- --run EventManagementTab`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "dashboard/app/(dj)/events/[code]/page.tsx" "dashboard/app/(dj)/events/[code]/components/EventManagementTab.tsx" "dashboard/app/(dj)/events/[code]/components/KioskControlsCard.tsx" dashboard/lib/api.ts "dashboard/app/(dj)/events/[code]/components/__tests__/EventManagementTab.test.tsx"
+git commit -m "feat(join): DJ per-event frictionless toggle in event management (#369)"
+```
+
+---
+
+## Task 12: DJ default toggle on Account page
+
+**Files:**
+- Modify: `dashboard/app/(dj)/account/page.tsx` (new "Guest Experience" card)
+- Test: `dashboard/app/(dj)/account/__tests__/page.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// add to dashboard/app/(dj)/account/__tests__/page.test.tsx
+it('toggles frictionless_join_default and saves', async () => {
+  mockApi.getMe.mockResolvedValue({
+    id: 1, username: 'dj', role: 'dj', help_pages_seen: [],
+    pending_email: null, email: null, frictionless_join_default: false,
+  } as never);
+  const update = vi.spyOn(mockApi, 'updateMyPreferences').mockResolvedValue(undefined as never);
+  render(<AccountPage />);
+  const toggle = await screen.findByLabelText(/Frictionless join by default/i);
+  fireEvent.click(toggle);
+  await waitFor(() =>
+    expect(update).toHaveBeenCalledWith({ frictionless_join_default: true })
+  );
+});
+```
+
+Add `updateMyPreferences: vi.fn()` to the test file's `mockApi`, and ensure `getMe` is mocked with `frictionless_join_default`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dashboard && npm test -- --run account`
+Expected: FAIL — no "Frictionless join by default" control.
+
+- [ ] **Step 3: Add the card**
+
+In `dashboard/app/(dj)/account/page.tsx`, add state:
+
+```typescript
+  const [frictionlessDefault, setFrictionlessDefault] = useState(false);
+  const [savingPref, setSavingPref] = useState(false);
+```
+
+In the existing `api.getMe()` effect, also read the field:
+
+```typescript
+      api.getMe()
+        .then(user => {
+          if (!isActive) return;
+          setEmailPending(prev => prev ?? (user.pending_email ?? null));
+          setFrictionlessDefault(user.frictionless_join_default);
+        })
+        .catch(() => {});
+```
+
+Add a handler:
+
+```typescript
+  const handleToggleFrictionless = async () => {
+    const next = !frictionlessDefault;
+    setSavingPref(true);
+    try {
+      await api.updateMyPreferences({ frictionless_join_default: next });
+      setFrictionlessDefault(next);
+    } finally {
+      setSavingPref(false);
+    }
+  };
+```
+
+Add a new card after the Change Email card (mirror the existing card styling):
+
+```tsx
+      <div style={{ background: 'var(--card)', borderRadius: '0.75rem', padding: '1.5rem', marginTop: '1.5rem' }}>
+        <h2 style={{ marginTop: 0, marginBottom: '1.25rem', fontSize: '1.1rem' }}>Guest Experience</h2>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <input
+            type="checkbox"
+            checked={frictionlessDefault}
+            disabled={savingPref}
+            onChange={handleToggleFrictionless}
+            aria-label="Frictionless join by default"
+          />
+          <span>
+            Frictionless join by default (new events)
+            <br />
+            <span style={{ color: 'var(--text-secondary)', fontSize: '0.85rem' }}>
+              New events let guests skip the nickname/email step and get an auto-generated name.
+            </span>
+          </span>
+        </label>
+      </div>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dashboard && npm test -- --run account`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "dashboard/app/(dj)/account/page.tsx" "dashboard/app/(dj)/account/__tests__/page.test.tsx"
+git commit -m "feat(join): DJ frictionless-join default toggle on Account page (#369)"
+```
+
+---
+
+## Task 13: Full local CI + final verification
+
+- [ ] **Step 1: Backend CI**
+
+Run:
+```bash
+cd server && .venv/bin/ruff check . && .venv/bin/ruff format --check . && .venv/bin/bandit -r app -c pyproject.toml -q && .venv/bin/alembic upgrade head && .venv/bin/alembic check && .venv/bin/pytest --tb=short -q
+```
+Expected: all green, coverage ≥ threshold, no migration drift.
+
+- [ ] **Step 2: Frontend CI**
+
+Run:
+```bash
+cd dashboard && npm run lint && npx tsc --noEmit && npm test -- --run
+```
+Expected: lint clean, no type errors, all vitest suites pass.
+
+- [ ] **Step 3: Fix `next-env.d.ts` if touched**
+
+Run: `cd dashboard && git checkout next-env.d.ts 2>/dev/null || true`
+
+- [ ] **Step 4: Final commit (if any lint/format fixes were applied)**
+
+```bash
+git add -A && git commit -m "chore(join): lint/format fixes for frictionless join (#369)" || echo "nothing to commit"
+```
+
+---
+
+## Self-review checklist (completed during plan authoring)
+
+- **Spec coverage:** model (T1), auto-name lib (T2), EventOut+PATCH (T3), creation seed (T4), ensure-name+join-config+frictionless guard (T5), DJ default+PATCH /me (T6), types (T7), api client (T8), join page skip-gate+auto-name (T9), IdentityBar rename (T10), DJ per-event toggle (T11), DJ default UI (T12). Anti-abuse preserved: ensure-name keeps `require_verified_human_soft` and is guarded by `event.frictionless_join`. Collect untouched (no edits to collect gates). ✓
+- **Placeholder scan:** no TBD/TODO; every code step has concrete code. ✓
+- **Type consistency:** `ensureGuestName`/`getJoinConfig` return shapes match `EnsureNameResponse`/`JoinConfigResponse`; `frictionless_join` (Event) and `frictionless_join_default` (User) names consistent across backend, generated types, and frontend. ✓
+- **Out of scope:** settings-hub consolidation, tri-state inherit, Turnstile removal — all deferred per spec. ✓

--- a/docs/superpowers/plans/2026-05-29-frictionless-join.md
+++ b/docs/superpowers/plans/2026-05-29-frictionless-join.md
@@ -10,6 +10,10 @@
 
 **Spec:** `docs/superpowers/specs/2026-05-29-frictionless-join-design.md`
 
+## Test execution note (read before running any pytest)
+
+`server/pyproject.toml` sets `addopts = "... --cov-fail-under=85"`, so **every** pytest invocation computes coverage over all of `app` and a single-file run will FAIL the 85% gate even when its tests pass. Therefore **all single-file/targeted pytest commands in this plan append `--no-cov`** (tests still run; coverage gating is skipped). The **full-suite** runs in Task 6 Step 7 and Task 13 keep coverage on — those are the real gate. The backend DB for this worktree is the isolated `wrzdj_fric` database (configured in the worktree `.env`); `alembic` commands target it.
+
 ## Routing resolution note (read before coding)
 
 The `/join/[code]` page currently calls **both** `/api/events/{code}/*` (collection-code lookup) and `/api/public/collect/{code}/*` (collection-code lookup via `NicknameGate`) successfully with one `code` param. This plan therefore anchors all new guest endpoints to the **collect router** (`/api/public/collect`, resolved via `collect.py:_get_event_or_404` → `Event.code == code`), the identical resolution path `NicknameGate` already uses. This guarantees the new endpoints resolve the same event row the existing gate does, independent of the latent collection-vs-join code routing quirk (pre-existing, out of scope for #369).
@@ -77,7 +81,7 @@ def test_event_frictionless_join_defaults_false(db, test_user: User):
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cd server && .venv/bin/pytest tests/test_frictionless_model.py -q`
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_model.py -q --no-cov`
 Expected: FAIL — `AttributeError: 'User' object has no attribute 'frictionless_join_default'`
 
 - [ ] **Step 3: Add the model columns**
@@ -132,7 +136,7 @@ Expected: upgrade succeeds; `alembic check` prints "No new upgrade operations de
 
 - [ ] **Step 6: Run test to verify it passes**
 
-Run: `cd server && .venv/bin/pytest tests/test_frictionless_model.py -q`
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_model.py -q --no-cov`
 Expected: PASS (2 passed)
 
 - [ ] **Step 7: Commit**
@@ -205,7 +209,7 @@ def test_avoids_existing_nickname_in_event(db, test_event: Event, monkeypatch):
 
 - [ ] **Step 3: Run test to verify it fails**
 
-Run: `cd server && .venv/bin/pytest tests/test_guest_names.py -q`
+Run: `cd server && .venv/bin/pytest tests/test_guest_names.py -q --no-cov`
 Expected: FAIL — `ModuleNotFoundError: No module named 'app.services.guest_names'`
 
 - [ ] **Step 4: Write the implementation**
@@ -264,7 +268,7 @@ def generate_unique_nickname(db: Session, *, event_id: int, max_attempts: int = 
 
 - [ ] **Step 5: Run test to verify it passes**
 
-Run: `cd server && .venv/bin/pytest tests/test_guest_names.py -q`
+Run: `cd server && .venv/bin/pytest tests/test_guest_names.py -q --no-cov`
 Expected: PASS (2 passed)
 
 - [ ] **Step 6: Commit**
@@ -308,7 +312,7 @@ def test_patch_event_sets_frictionless_join(client, db, test_user: User, auth_he
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cd server && .venv/bin/pytest tests/test_frictionless_event_api.py -q`
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_event_api.py -q --no-cov`
 Expected: FAIL — response JSON has no `frictionless_join` key (KeyError on assert).
 
 - [ ] **Step 3: Add the schema fields**
@@ -364,7 +368,7 @@ In `server/app/api/events.py`, in `update_event_endpoint`, pass the field:
 
 - [ ] **Step 5: Run test to verify it passes**
 
-Run: `cd server && .venv/bin/pytest tests/test_frictionless_event_api.py -q`
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_event_api.py -q --no-cov`
 Expected: PASS (2 passed)
 
 - [ ] **Step 6: Commit**
@@ -404,7 +408,7 @@ def test_create_event_default_off_when_dj_default_off(db, test_user: User):
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cd server && .venv/bin/pytest tests/test_frictionless_seed.py -q`
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_seed.py -q --no-cov`
 Expected: FAIL — `test_create_event_seeds_from_dj_default` asserts True but gets False.
 
 - [ ] **Step 3: Seed the field in create_event**
@@ -424,7 +428,7 @@ In `server/app/services/event.py`, in `create_event`, add `frictionless_join` to
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `cd server && .venv/bin/pytest tests/test_frictionless_seed.py -q`
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_seed.py -q --no-cov`
 Expected: PASS (2 passed)
 
 - [ ] **Step 5: Commit**
@@ -522,7 +526,7 @@ def test_ensure_name_403_when_not_frictionless(client, db, test_event: Event):
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cd server && .venv/bin/pytest tests/test_frictionless_ensure_name.py -q`
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_ensure_name.py -q --no-cov`
 Expected: FAIL — 404 (endpoints don't exist yet).
 
 - [ ] **Step 3: Add the schemas**
@@ -607,7 +611,7 @@ def ensure_name(
 
 - [ ] **Step 5: Run test to verify it passes**
 
-Run: `cd server && .venv/bin/pytest tests/test_frictionless_ensure_name.py -q`
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_ensure_name.py -q --no-cov`
 Expected: PASS (5 passed)
 
 - [ ] **Step 6: Commit**
@@ -651,7 +655,7 @@ def test_patch_preferences_updates_default(client, auth_headers):
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cd server && .venv/bin/pytest tests/test_frictionless_preferences.py -q`
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_preferences.py -q --no-cov`
 Expected: FAIL — `/me` response has no `frictionless_join_default`.
 
 - [ ] **Step 3: Add the UserOut field**
@@ -710,7 +714,7 @@ def update_me_preferences(
 
 - [ ] **Step 6: Run test to verify it passes**
 
-Run: `cd server && .venv/bin/pytest tests/test_frictionless_preferences.py -q`
+Run: `cd server && .venv/bin/pytest tests/test_frictionless_preferences.py -q --no-cov`
 Expected: PASS (2 passed)
 
 - [ ] **Step 7: Run the full backend suite + lint**

--- a/docs/superpowers/specs/2026-05-29-frictionless-join-design.md
+++ b/docs/superpowers/specs/2026-05-29-frictionless-join-design.md
@@ -1,0 +1,168 @@
+# Frictionless Join — Design Spec
+
+**Issue:** #369 — "Restore 'Scan QR → Request Song' Guest Flow (No Signup/Email Verification)"
+**Date:** 2026-05-29
+**Author:** thewrz
+**Status:** Approved (brainstorm) → pending implementation plan
+
+## Problem
+
+The `/join` (live-event) guest page currently blocks the entire experience behind
+`NicknameGate` (`dashboard/app/join/[code]/page.tsx:389` — `if (!gateComplete) return <NicknameGate />`).
+A first-time guest must pick "New name" → type a nickname (≥2 chars) → Save → Skip email
+(~4 interactions) before they can even see the song search.
+
+For weddings / private parties this friction is unwanted: the QR code is handed out only
+to in-room guests during the event, so heavy bot-hardening is unnecessary there. The
+hardening was added primarily for the long-lived, public-internet `/collect` (pre-event
+voting) page, and its nickname/email requirements leaked into the live `/join` flow.
+
+The fix removes only the **nickname/email** friction on `/join`, while keeping the
+invisible anti-abuse layer (Turnstile human-cookie + guest fingerprint) intact, and never
+touching `/collect`.
+
+## Key facts grounding the design
+
+- Friction is **frontend-only**. Backend join endpoints (`events.py` search/submit/vote)
+  already gate on `require_verified_human_soft` — no nickname, no email server-side.
+- The nickname is **not** the anti-abuse key. Double-vote/dedup runs off the `wrzdj_guest`
+  cookie + ThumbmarkJS fingerprint (`guest_id`). Dropping the nickname does not reopen
+  double-voting.
+- `/collect` hard gates (`require_email_verified`) live on `collect.py` endpoints. A
+  join-only flag never reaches them.
+- `GET /api/events/{code}` (`events.py:359`) is **public, no auth**, returns `EventOut` —
+  this is what the join page reads via `api.getEvent(code)`. Adding the flag here surfaces
+  it to the join page with no new fetch.
+- Per-event booleans are well-precedented on `Event` (`requests_open`, `kiosk_display_only`,
+  `tidal_sync_enabled`, …).
+
+## Decisions (locked during brainstorm)
+
+1. **Scope:** per-event override + per-DJ default, via a **snapshot** model.
+   The DJ's default *pre-fills* a new event's own boolean at creation time; thereafter the
+   event's boolean is the final say. No nullable column, no runtime resolution, no
+   "default changed → old events mutate" surprise.
+2. **Relaxed UX:** when frictionless is on, the guest lands **straight on song search**
+   with an **auto-generated username**; an optional "Add a name" affordance lets them
+   rename / claim later. Never required.
+3. **Username generation:** server-side via `coolname` (BSD-2-Clause, zero deps, actively
+   maintained). Numeric suffix on collision.
+4. **Identity:** keep the existing ThumbmarkJS fingerprint + `wrzdj_guest` cookie. No change.
+5. **Anti-abuse preserved:** Turnstile human-verification (`require_verified_human_soft`,
+   invisible managed mode) stays on `/join`. Only nickname/email friction is removed.
+
+## Data model
+
+- `User.frictionless_join_default: Mapped[bool]` — default `False`. The DJ's personal default.
+- `Event.frictionless_join: Mapped[bool]` — default `False`. **Seeded from the creator's
+  `frictionless_join_default` at event creation**, editable per-event afterward.
+
+Alembic migration adds both columns. Models get matching `Mapped[bool]` definitions; run
+`alembic upgrade head && alembic check` locally (CI enforces no drift).
+
+## Backend
+
+### Auto-name service
+- New dependency: `coolname` in `server/pyproject.toml` (BSD-2-Clause, zero transitive deps,
+  Python 3.10+; backend is 3.11+).
+- New `server/app/services/guest_names.py`:
+  - `generate_unique_nickname(db, event) -> str` → `coolname.generate_slug(2)` →
+    title-cased, hyphen-stripped → `"DancingPanda"`.
+  - On collision (reuse the existing per-event nickname uniqueness check used by the
+    collect claim flow), append 2–3 random digits and retry up to **5 times**; if still
+    colliding, fall back to `coolname.generate_slug(3)` (three words, collision-proof in
+    practice).
+
+### Ensure-name endpoint
+- New public endpoint `POST /api/public/events/{join_code}/guest/ensure-name`:
+  - Gated by `require_verified_human_soft` (same human-cookie layer as other join endpoints).
+  - If the event is frictionless **and** the resolved guest has no nickname: generate +
+    store one.
+  - Returns `{ nickname: str, auto_generated: bool }`. Idempotent — returns the existing
+    nickname (with `auto_generated` reflecting how it was set) if one already exists.
+  - If the event is **not** frictionless, this endpoint is a no-op / not used by the
+    frontend (the normal `NicknameGate` flow runs instead).
+
+### Expose + edit
+- `EventOut` (`server/app/schemas/event.py`) gains `frictionless_join: bool` — read by the
+  public join page.
+- `PATCH /api/events/{code}` accepts `frictionless_join: bool` (DJ per-event toggle; owner-scoped).
+- Per-DJ default `frictionless_join_default`:
+  - **Read** via the existing `GET /api/auth/me` (the user object the account page already
+    fetches via `api.getMe()`); add the field to that response.
+  - **Written** via a new self-service preferences endpoint `PATCH /api/auth/me`
+    (owner = current user; no admin route). Password/email already have dedicated routes;
+    this is the first general user-preferences PATCH.
+  - Event creation reads the creator's `frictionless_join_default` to seed the new event's
+    `frictionless_join`.
+
+## Frontend
+
+### Join page — `dashboard/app/join/[code]/page.tsx`
+- When `event.frictionless_join` is true:
+  - **Skip `<NicknameGate>`** (the `if (!gateComplete)` early return at line 389).
+  - On load, call `api.ensureGuestName(code)`, set `nickname` from the response, mark
+    `gateComplete`. Guest lands straight on search.
+- `IdentityBar`: when the name is auto-generated (`auto_generated: true`), show an
+  **"Add a name" / rename** affordance → small modal reusing the nickname input; the email /
+  cross-device path remains available there but never required.
+- When `event.frictionless_join` is false: today's `NicknameGate` flow, unchanged.
+
+### DJ controls
+- Event management page: a "Frictionless join" checkbox in the event settings card (wires
+  `PATCH /{code}`). Helper text: "Guests skip the nickname/email step and get an
+  auto-generated name. Good for weddings & private parties."
+- DJ default lives on the **existing Account Settings page** (`app/(dj)/account/page.tsx`,
+  reached via the dashboard "Account" button → `/account`). Add a new "Guest Experience"
+  card with a "Frictionless join by default (new events)" toggle; read from `api.getMe()`,
+  save via `api.updateMyPreferences({ frictionless_join_default })` → `PATCH /api/auth/me`.
+
+### API client (`dashboard/lib/api.ts`)
+- Add `ensureGuestName(code): Promise<{ nickname: string; auto_generated: boolean }>`
+  (public, no auth).
+- Add `updateMyPreferences({ frictionless_join_default }): Promise<User>` → `PATCH /api/auth/me`.
+- Extend the `Event` type with `frictionless_join: boolean` and the `User`/`getMe` type with
+  `frictionless_join_default: boolean`.
+
+## Explicitly untouched
+
+- `/collect` page and `collect.py` endpoints — all hard gates (`require_email_verified`)
+  stay. The flag is never read there.
+- Turnstile human-verification on `/join` — stays (invisible managed mode).
+- Dedup / anti-double-vote — still `wrzdj_guest` cookie + ThumbmarkJS fingerprint.
+
+## Testing
+
+### Backend (pytest)
+- Migration upgrade + `alembic check` (no drift).
+- `guest_names.generate_unique_nickname`: happy path + collision → suffix retry.
+- Ensure-name endpoint: frictionless on (generates), frictionless off (no-op), idempotency
+  (second call returns same nickname), human-cookie gate behavior.
+- `EventOut` serializes `frictionless_join`.
+- Event creation seeds `frictionless_join` from the creator's `frictionless_join_default`.
+- `PATCH /{code}` updates `frictionless_join` (owner-scoped; non-owner rejected).
+
+### Frontend (vitest)
+- Join page: skips gate + shows search when `frictionless_join` true; renders `NicknameGate`
+  when false.
+- `IdentityBar`: rename affordance appears for auto-generated names.
+- DJ controls: event checkbox + DJ-default toggle call the right endpoints.
+- Update `Event` / EventOut fixtures with the new field (per CLAUDE.md shared-type pitfall).
+
+## Future consolidation (noted, not in this PR)
+
+The `frictionless_join_default` toggle is added to the existing `/account` page as a first
+step. Eventually the Account page should become a unified DJ settings hub that absorbs:
+- the current Account Settings (password / email),
+- this new Guest Experience default, and
+- the **AI settings** currently at `/settings/ai` (from the `epic/ai-engine` branch).
+
+This PR only adds the new card to `/account`; the broader merge of `/settings/ai` into
+`/account` is tracked separately and must wait until `epic/ai-engine` lands on `main`.
+
+## Out of scope (YAGNI)
+
+- Live "inherit" tri-state on the event column (snapshot model chosen instead).
+- Per-event auto-name vocabulary customization.
+- Removing Turnstile from `/join`.
+- The full settings-hub consolidation above (separate effort, post-`epic/ai-engine`).

--- a/server/alembic/versions/a11334c031bb_add_frictionless_join_flags.py
+++ b/server/alembic/versions/a11334c031bb_add_frictionless_join_flags.py
@@ -1,0 +1,35 @@
+"""add frictionless join flags
+
+Revision ID: a11334c031bb
+Revises: 045
+Create Date: 2026-05-29 20:49:39.964139
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a11334c031bb"
+down_revision: str | None = "045"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("frictionless_join_default", sa.Boolean(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "events",
+        sa.Column("frictionless_join", sa.Boolean(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("events", "frictionless_join")
+    op.drop_column("users", "frictionless_join_default")

--- a/server/app/api/auth.py
+++ b/server/app/api/auth.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordRequestForm
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_active_user, get_current_user, get_db
@@ -36,6 +37,10 @@ from app.services.turnstile import verify_turnstile_token
 
 router = APIRouter()
 settings = get_settings()
+
+
+class MePreferencesUpdate(BaseModel):
+    frictionless_join_default: bool
 
 
 @router.post("/login", response_model=Token)
@@ -128,6 +133,20 @@ def change_password(
     except ValueError:
         raise HTTPException(status_code=400, detail="Current password is incorrect")
     return StatusMessageResponse(status="ok", message="Password updated. Please log in again.")
+
+
+@router.patch("/me/preferences", response_model=UserOut)
+@limiter.limit("20/minute")
+def update_me_preferences(
+    body: MePreferencesUpdate,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    updated = account_service.update_preferences(
+        db, current_user, frictionless_join_default=body.frictionless_join_default
+    )
+    return UserOut.model_validate(updated)
 
 
 @router.post("/me/email/request", response_model=StatusMessageResponse)

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -7,13 +7,18 @@ endpoints. See docs/RECOVERY-IP-IDENTITY.md.
 import logging
 from typing import Literal
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 from sqlalchemy import desc, func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_db, require_email_verified, require_verified_human
+from app.api.deps import (
+    get_db,
+    require_email_verified,
+    require_verified_human,
+    require_verified_human_soft,
+)
 from app.core.rate_limit import limiter
 from app.models.event import Event
 from app.models.guest import Guest
@@ -35,6 +40,9 @@ from app.schemas.collect import (
     EnrichPreviewRequest,
     EnrichPreviewResponse,
     EnrichPreviewResult,
+    EnsureNameRequest,
+    EnsureNameResponse,
+    JoinConfigResponse,
     LiveJoinCodeResponse,
 )
 from app.services import collect as collect_service
@@ -42,6 +50,7 @@ from app.services.activity_log import log_activity
 from app.services.beatport import search_beatport_tracks
 from app.services.collect import NicknameConflictError, upsert_profile
 from app.services.dedup import compute_dedupe_key, find_duplicate
+from app.services.guest_names import generate_unique_nickname
 from app.services.sync.enrichment_pipeline import _find_best_match
 from app.services.sync.orchestrator import enrich_request_metadata
 from app.services.system_settings import get_system_settings
@@ -229,6 +238,51 @@ def set_profile(
         submission_count=profile.submission_count if profile is not None else 0,
         submission_cap=event.submission_cap_per_guest,
     )
+
+
+@router.get("/{code}/join-config", response_model=JoinConfigResponse)
+@limiter.limit("60/minute")
+def join_config(code: str, request: Request, db: Session = Depends(get_db)):
+    """Public, unauthenticated: lets the join page decide its gate mode on load."""
+    event = _get_event_or_404(db, code)
+    return JoinConfigResponse(frictionless_join=event.frictionless_join)
+
+
+@router.post("/{code}/guest/ensure-name", response_model=EnsureNameResponse)
+@limiter.limit("10/minute")
+def ensure_name(
+    code: str,
+    payload: EnsureNameRequest,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+    guest_id: int | None = Depends(require_verified_human_soft),
+):
+    """Frictionless-join name management. Auto-generates a nickname when none is
+    set, or applies a manual rename. Gated on event.frictionless_join so it can
+    never bypass email verification on a hardened (non-frictionless) event.
+    """
+    event = _get_event_or_404(db, code)
+    if not event.frictionless_join:
+        raise HTTPException(status_code=403, detail={"code": "frictionless_disabled"})
+    if guest_id is None:
+        raise HTTPException(status_code=403, detail={"code": "human_verification_required"})
+
+    existing = collect_service.get_profile(db, event_id=event.id, guest_id=guest_id)
+    if payload.nickname is not None:
+        chosen, auto = payload.nickname, False
+    elif existing is not None and existing.nickname:
+        return EnsureNameResponse(nickname=existing.nickname, auto_generated=False)
+    else:
+        chosen, auto = generate_unique_nickname(db, event_id=event.id), True
+
+    try:
+        profile = upsert_profile(db, event_id=event.id, guest_id=guest_id, nickname=chosen)
+    except NicknameConflictError as exc:
+        raise HTTPException(
+            status_code=409, detail={"code": "nickname_taken", "claimed": exc.claimed}
+        )
+    return EnsureNameResponse(nickname=profile.nickname, auto_generated=auto)
 
 
 @router.get("/{code}/profile/me", response_model=CollectMyPicksResponse)

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -282,6 +282,8 @@ def ensure_name(
         raise HTTPException(
             status_code=409, detail={"code": "nickname_taken", "claimed": exc.claimed}
         )
+    if profile is None:  # guest_id is non-None above, so this is defensive only
+        raise HTTPException(status_code=500, detail="Failed to create guest profile")
     return EnsureNameResponse(nickname=profile.nickname, auto_generated=auto)
 
 

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -261,6 +261,11 @@ def ensure_name(
     """Frictionless-join name management. Auto-generates a nickname when none is
     set, or applies a manual rename. Gated on event.frictionless_join so it can
     never bypass email verification on a hardened (non-frictionless) event.
+
+    Not anonymous: requires the `wrzdj_human` HMAC-signed verified-human cookie
+    (set via Turnstile) through `require_verified_human_soft`. Calls without a
+    resolvable verified-human guest are rejected with 403
+    `human_verification_required`.
     """
     event = _get_event_or_404(db, code)
     if not event.frictionless_join:

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -277,6 +277,7 @@ def _event_to_out(
         banner_kiosk_url=banner_kiosk_url,
         banner_colors=banner_colors,
         requests_open=event.requests_open,
+        frictionless_join=event.frictionless_join,
         collection_opens_at=event.collection_opens_at,
         live_starts_at=event.live_starts_at,
         submission_cap_per_guest=event.submission_cap_per_guest,
@@ -455,6 +456,7 @@ def update_event_endpoint(
         event,
         name=event_data.name,
         expires_at=event_data.expires_at,
+        frictionless_join=event_data.frictionless_join,
     )
     return _event_to_out(updated, request)
 

--- a/server/app/models/event.py
+++ b/server/app/models/event.py
@@ -60,6 +60,12 @@ class Event(Base):
         Boolean, default=False, nullable=False, server_default="0"
     )
 
+    # Frictionless join: guests skip nickname/email and get an auto-generated name.
+    # Seeded from the creator's frictionless_join_default at event creation.
+    frictionless_join: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="0"
+    )
+
     # Custom banner image
     banner_filename: Mapped[str | None] = mapped_column(String(255), nullable=True)
     banner_colors: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/server/app/models/user.py
+++ b/server/app/models/user.py
@@ -51,6 +51,11 @@ class User(Base):
     # Help onboarding state (JSON array of page IDs)
     help_pages_seen: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # Frictionless join: DJ default applied to new events (snapshot at creation).
+    frictionless_join_default: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="0"
+    )
+
     events: Mapped[list["Event"]] = relationship("Event", back_populates="created_by")
 
     def get_help_pages_seen(self) -> list[str]:

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -94,6 +94,19 @@ class CollectProfileResponse(BaseModel):
     submission_cap: int
 
 
+class JoinConfigResponse(BaseModel):
+    frictionless_join: bool
+
+
+class EnsureNameRequest(BaseModel):
+    nickname: Nickname | None = None
+
+
+class EnsureNameResponse(BaseModel):
+    nickname: str
+    auto_generated: bool
+
+
 class CollectMyPicksItem(CollectLeaderboardRow):
     interaction: Literal["submitted", "upvoted"]
 

--- a/server/app/schemas/event.py
+++ b/server/app/schemas/event.py
@@ -31,6 +31,7 @@ class EventCreate(BaseModel):
 class EventUpdate(BaseModel):
     expires_at: datetime | None = None
     name: str | None = Field(default=None, min_length=1, max_length=100)
+    frictionless_join: bool | None = None
 
 
 class DisplaySettingsUpdate(BaseModel):
@@ -77,6 +78,8 @@ class EventOut(BaseSchema):
     banner_colors: list[str] | None = None
     # Requests open/closed
     requests_open: bool = True
+    # Frictionless join (guests skip nickname/email)
+    frictionless_join: bool = False
     # Pre-event collection
     collection_opens_at: OptionalIsoDatetime = None
     live_starts_at: OptionalIsoDatetime = None

--- a/server/app/schemas/user.py
+++ b/server/app/schemas/user.py
@@ -17,6 +17,7 @@ class UserOut(BaseSchema):
     created_at: datetime
     help_pages_seen: list[str] = []
     pending_email: str | None = None
+    frictionless_join_default: bool = False
 
     @field_validator("help_pages_seen", mode="before")
     @classmethod

--- a/server/app/services/account.py
+++ b/server/app/services/account.py
@@ -59,6 +59,14 @@ def invalidate_pending_email_changes(db: Session, user_id: int) -> None:
     ).update({"used": True})
 
 
+def update_preferences(db: Session, user: User, *, frictionless_join_default: bool) -> User:
+    """Update self-service DJ preferences."""
+    user.frictionless_join_default = frictionless_join_default
+    db.commit()
+    db.refresh(user)
+    return user
+
+
 def change_password(db: Session, user: User, current_password: str, new_password: str) -> None:
     """Change a user's password after verifying the current password.
 

--- a/server/app/services/event.py
+++ b/server/app/services/event.py
@@ -93,6 +93,7 @@ def create_event(db: Session, name: str, user: User, expires_hours: int = 6) -> 
             name=name,
             created_by_user_id=user.id,
             expires_at=expires_at,
+            frictionless_join=user.frictionless_join_default,
         )
         db.add(event)
         try:

--- a/server/app/services/event.py
+++ b/server/app/services/event.py
@@ -153,12 +153,15 @@ def update_event(
     event: Event,
     name: str | None = None,
     expires_at: datetime | None = None,
+    frictionless_join: bool | None = None,
 ) -> Event:
     """Update an event's properties."""
     if name is not None:
         event.name = name
     if expires_at is not None:
         event.expires_at = expires_at
+    if frictionless_join is not None:
+        event.frictionless_join = frictionless_join
     db.commit()
     db.refresh(event)
     return event

--- a/server/app/services/guest_names.py
+++ b/server/app/services/guest_names.py
@@ -1,0 +1,48 @@
+"""Auto-generated guest nicknames for frictionless-join events.
+
+Server-side so it shares the per-event nickname uniqueness check and never
+ships a wordlist to the client. Vocabulary comes from `coolname` (BSD-2-Clause,
+zero deps).
+"""
+
+import secrets
+
+from coolname import generate_slug
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.guest_profile import GuestProfile
+
+
+def _slug_to_name(slug: str) -> str:
+    """'dancing-panda' -> 'DancingPanda', clamped to the 30-char nickname limit."""
+    name = "".join(part.capitalize() for part in slug.split("-"))
+    return name[:30]
+
+
+def _is_taken(db: Session, *, event_id: int, candidate: str) -> bool:
+    return (
+        db.query(GuestProfile.id)
+        .filter(
+            GuestProfile.event_id == event_id,
+            func.lower(GuestProfile.nickname) == candidate.lower(),
+        )
+        .first()
+        is not None
+    )
+
+
+def generate_unique_nickname(db: Session, *, event_id: int, max_attempts: int = 5) -> str:
+    """Return a nickname unique (case-insensitive) within the event.
+
+    Tries `max_attempts` two-word names, suffixing a 2-digit number after the
+    first collision. Falls back to a collision-proof three-word name if all
+    attempts collide.
+    """
+    for attempt in range(max_attempts):
+        base = _slug_to_name(generate_slug(2))
+        candidate = base if attempt == 0 else f"{base}{secrets.randbelow(90) + 10}"
+        candidate = candidate[:30]
+        if not _is_taken(db, event_id=event_id, candidate=candidate):
+            return candidate
+    return _slug_to_name(generate_slug(3))

--- a/server/app/services/guest_names.py
+++ b/server/app/services/guest_names.py
@@ -36,8 +36,9 @@ def generate_unique_nickname(db: Session, *, event_id: int, max_attempts: int = 
     """Return a nickname unique (case-insensitive) within the event.
 
     Tries `max_attempts` two-word names, suffixing a 2-digit number after the
-    first collision. Falls back to a collision-proof three-word name if all
-    attempts collide.
+    first collision. Falls back to a three-word name, then to an opaque
+    guaranteed-unique suffix — so an auto-generated name never collides and
+    surfaces a 409 to the guest.
     """
     for attempt in range(max_attempts):
         base = _slug_to_name(generate_slug(2))
@@ -45,4 +46,9 @@ def generate_unique_nickname(db: Session, *, event_id: int, max_attempts: int = 
         candidate = candidate[:30]
         if not _is_taken(db, event_id=event_id, candidate=candidate):
             return candidate
-    return _slug_to_name(generate_slug(3))
+
+    fallback = _slug_to_name(generate_slug(3))
+    if not _is_taken(db, event_id=event_id, candidate=fallback):
+        return fallback
+    # Last resort: opaque, effectively-unique suffix (e.g. "Guest1a2b3c4d").
+    return f"Guest{secrets.token_hex(4)}"

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -9308,7 +9308,7 @@
     },
     "/api/public/collect/{code}/guest/ensure-name": {
       "post": {
-        "description": "Frictionless-join name management. Auto-generates a nickname when none is\nset, or applies a manual rename. Gated on event.frictionless_join so it can\nnever bypass email verification on a hardened (non-frictionless) event.",
+        "description": "Frictionless-join name management. Auto-generates a nickname when none is\nset, or applies a manual rename. Gated on event.frictionless_join so it can\nnever bypass email verification on a hardened (non-frictionless) event.\n\nNot anonymous: requires the `wrzdj_human` HMAC-signed verified-human cookie\n(set via Turnstile) through `require_verified_human_soft`. Calls without a\nresolvable verified-human guest are rejected with 403\n`human_verification_required`.",
         "operationId": "ensure_name_api_public_collect__code__guest_ensure_name_post",
         "parameters": [
           {

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -653,7 +653,7 @@
       "Body_upload_banner_api_events__code__banner_post": {
         "properties": {
           "file": {
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File",
             "type": "string"
           }
@@ -1897,6 +1897,44 @@
         "title": "EnrichPreviewResult",
         "type": "object"
       },
+      "EnsureNameRequest": {
+        "properties": {
+          "nickname": {
+            "anyOf": [
+              {
+                "maxLength": 30,
+                "minLength": 2,
+                "pattern": "^[a-zA-Z0-9 _.-]+$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nickname"
+          }
+        },
+        "title": "EnsureNameRequest",
+        "type": "object"
+      },
+      "EnsureNameResponse": {
+        "properties": {
+          "auto_generated": {
+            "title": "Auto Generated",
+            "type": "boolean"
+          },
+          "nickname": {
+            "title": "Nickname",
+            "type": "string"
+          }
+        },
+        "required": [
+          "auto_generated",
+          "nickname"
+        ],
+        "title": "EnsureNameResponse",
+        "type": "object"
+      },
       "EventCreate": {
         "properties": {
           "expires_hours": {
@@ -2103,6 +2141,11 @@
             "title": "Expires At",
             "type": "string"
           },
+          "frictionless_join": {
+            "default": false,
+            "title": "Frictionless Join",
+            "type": "boolean"
+          },
           "id": {
             "title": "Id",
             "type": "integer"
@@ -2202,6 +2245,7 @@
           "collection_phase_override",
           "created_at",
           "expires_at",
+          "frictionless_join",
           "id",
           "is_active",
           "join_code",
@@ -2241,6 +2285,17 @@
               }
             ],
             "title": "Expires At"
+          },
+          "frictionless_join": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Frictionless Join"
           },
           "name": {
             "anyOf": [
@@ -2660,6 +2715,19 @@
         "title": "IntegrationToggleResponse",
         "type": "object"
       },
+      "JoinConfigResponse": {
+        "properties": {
+          "frictionless_join": {
+            "title": "Frictionless Join",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "frictionless_join"
+        ],
+        "title": "JoinConfigResponse",
+        "type": "object"
+      },
       "KioskAssignRequest": {
         "description": "Body for reassigning a kiosk to a different event.",
         "properties": {
@@ -3072,6 +3140,19 @@
           "join_code"
         ],
         "title": "LiveJoinCodeResponse",
+        "type": "object"
+      },
+      "MePreferencesUpdate": {
+        "properties": {
+          "frictionless_join_default": {
+            "title": "Frictionless Join Default",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "frictionless_join_default"
+        ],
+        "title": "MePreferencesUpdate",
         "type": "object"
       },
       "MyRequestInfo": {
@@ -5187,6 +5268,11 @@
             ],
             "title": "Email"
           },
+          "frictionless_join_default": {
+            "default": false,
+            "title": "Frictionless Join Default",
+            "type": "boolean"
+          },
           "help_pages_seen": {
             "default": [],
             "items": {
@@ -5226,6 +5312,7 @@
         "required": [
           "created_at",
           "email",
+          "frictionless_join_default",
           "help_pages_seen",
           "id",
           "is_active",
@@ -6471,6 +6558,52 @@
           }
         ],
         "summary": "Change Password",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/me/preferences": {
+      "patch": {
+        "operationId": "update_me_preferences_api_auth_me_preferences_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MePreferencesUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Me Preferences",
         "tags": [
           "auth"
         ]
@@ -9173,6 +9306,102 @@
         ]
       }
     },
+    "/api/public/collect/{code}/guest/ensure-name": {
+      "post": {
+        "description": "Frictionless-join name management. Auto-generates a nickname when none is\nset, or applies a manual rename. Gated on event.frictionless_join so it can\nnever bypass email verification on a hardened (non-frictionless) event.",
+        "operationId": "ensure_name_api_public_collect__code__guest_ensure_name_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnsureNameRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnsureNameResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Ensure Name",
+        "tags": [
+          "collect"
+        ]
+      }
+    },
+    "/api/public/collect/{code}/join-config": {
+      "get": {
+        "description": "Public, unauthenticated: lets the join page decide its gate mode on load.",
+        "operationId": "join_config_api_public_collect__code__join_config_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JoinConfigResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Join Config",
+        "tags": [
+          "collect"
+        ]
+      }
+    },
     "/api/public/collect/{code}/leaderboard": {
       "get": {
         "operationId": "leaderboard_api_public_collect__code__leaderboard_get",
@@ -9559,7 +9788,7 @@
     },
     "/api/public/e/{code}/bridge-status": {
       "get": {
-        "description": "Get bridge connection status for public display.\n\nIndependent of track data \u2014 returns bridge connectivity even when\nno track is currently playing.",
+        "description": "Get bridge connection status for public display.\n\nIndependent of track data \u2014 returns bridge connectivity even when\nno track is currently playing. Resolves by join_code: serves guest-facing\nkiosk display + overlay pages.",
         "operationId": "get_public_bridge_status_api_public_e__code__bridge_status_get",
         "parameters": [
           {
@@ -9602,7 +9831,7 @@
     },
     "/api/public/e/{code}/history": {
       "get": {
-        "description": "Get play history for public display.\n\nReturns the list of tracks played during the event, newest first.",
+        "description": "Get play history for public display.\n\nReturns the list of tracks played during the event, newest first.\nResolves by join_code: serves guest-facing kiosk display.",
         "operationId": "get_public_history_api_public_e__code__history_get",
         "parameters": [
           {
@@ -9668,7 +9897,7 @@
     },
     "/api/public/e/{code}/nowplaying": {
       "get": {
-        "description": "Get current now-playing track for public display.\n\nReturns the track currently playing from StageLinQ, or None if nothing playing.",
+        "description": "Get current now-playing track for public display.\n\nReturns the track currently playing from StageLinQ, or None if nothing playing.\n\nResolves by join_code: this endpoint serves the kiosk display + OBS overlay\npages, which route by join_code per the post-PR-#324 public/guest URL contract.",
         "operationId": "get_public_now_playing_api_public_e__code__nowplaying_get",
         "parameters": [
           {

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "better-profanity>=0.7.0",
     "sse-starlette>=2.0.0",
     "python-json-logger>=3.0",
+    "coolname==5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/server/tests/test_api_contracts.py
+++ b/server/tests/test_api_contracts.py
@@ -63,6 +63,7 @@ USER_OUT_KEYS = {
     "created_at",
     "help_pages_seen",
     "pending_email",
+    "frictionless_join_default",
 }
 
 EVENT_OUT_KEYS = {
@@ -90,6 +91,7 @@ EVENT_OUT_KEYS = {
     "live_starts_at",
     "submission_cap_per_guest",
     "collection_phase_override",
+    "frictionless_join",
 }
 
 REQUEST_OUT_KEYS = {

--- a/server/tests/test_frictionless_ensure_name.py
+++ b/server/tests/test_frictionless_ensure_name.py
@@ -1,0 +1,70 @@
+from app.models.event import Event
+from app.models.guest import Guest
+from app.services.human_verification import COOKIE_NAME as HUMAN_COOKIE_NAME
+from app.services.human_verification import issue_human_cookie
+
+
+def _verified_guest_cookie(client, db):
+    from fastapi import Response
+
+    guest = Guest(token="frictionguest" + "0" * 51, fingerprint_hash="fp_fric")
+    db.add(guest)
+    db.commit()
+    db.refresh(guest)
+    helper = Response()
+    issue_human_cookie(helper, guest.id)
+    human_value = helper.headers.get("set-cookie", "").split("=", 1)[1].split(";", 1)[0]
+    client.cookies.clear()
+    client.cookies.set("wrzdj_guest", guest.token)
+    client.cookies.set(HUMAN_COOKIE_NAME, human_value)
+    return guest
+
+
+def test_join_config_reports_flag(client, db, test_event: Event):
+    test_event.frictionless_join = True
+    db.commit()
+    r = client.get(f"/api/public/collect/{test_event.code}/join-config")
+    assert r.status_code == 200
+    assert r.json()["frictionless_join"] is True
+
+
+def test_ensure_name_autogenerates_when_frictionless(client, db, test_event: Event):
+    test_event.frictionless_join = True
+    db.commit()
+    _verified_guest_cookie(client, db)
+    r = client.post(f"/api/public/collect/{test_event.code}/guest/ensure-name", json={})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["auto_generated"] is True
+    assert body["nickname"]
+
+
+def test_ensure_name_idempotent(client, db, test_event: Event):
+    test_event.frictionless_join = True
+    db.commit()
+    _verified_guest_cookie(client, db)
+    first = client.post(f"/api/public/collect/{test_event.code}/guest/ensure-name", json={}).json()
+    second = client.post(f"/api/public/collect/{test_event.code}/guest/ensure-name", json={}).json()
+    assert first["nickname"] == second["nickname"]
+
+
+def test_ensure_name_manual_rename(client, db, test_event: Event):
+    test_event.frictionless_join = True
+    db.commit()
+    _verified_guest_cookie(client, db)
+    client.post(f"/api/public/collect/{test_event.code}/guest/ensure-name", json={})
+    r = client.post(
+        f"/api/public/collect/{test_event.code}/guest/ensure-name",
+        json={"nickname": "MyChosenName"},
+    )
+    assert r.status_code == 200
+    assert r.json()["nickname"] == "MyChosenName"
+    assert r.json()["auto_generated"] is False
+
+
+def test_ensure_name_403_when_not_frictionless(client, db, test_event: Event):
+    # test_event.frictionless_join defaults False
+    _verified_guest_cookie(client, db)
+    r = client.post(f"/api/public/collect/{test_event.code}/guest/ensure-name", json={})
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "frictionless_disabled"

--- a/server/tests/test_frictionless_ensure_name.py
+++ b/server/tests/test_frictionless_ensure_name.py
@@ -68,3 +68,18 @@ def test_ensure_name_403_when_not_frictionless(client, db, test_event: Event):
     r = client.post(f"/api/public/collect/{test_event.code}/guest/ensure-name", json={})
     assert r.status_code == 403
     assert r.json()["detail"]["code"] == "frictionless_disabled"
+
+
+def test_ensure_name_403_no_cookie_soft_mode(client, db, test_event: Event):
+    """Frictionless + no wrzdj_guest cookie + soft mode -> 403 human_verification_required.
+
+    Pins the guest_id-None guard: get_guest_id returns None without the cookie, so
+    require_verified_human_soft passes None through and the endpoint must refuse
+    gracefully (not 500). Regression for review finding (#369).
+    """
+    test_event.frictionless_join = True
+    db.commit()
+    client.cookies.clear()
+    r = client.post(f"/api/public/collect/{test_event.code}/guest/ensure-name", json={})
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "human_verification_required"

--- a/server/tests/test_frictionless_event_api.py
+++ b/server/tests/test_frictionless_event_api.py
@@ -1,0 +1,17 @@
+# server/tests/test_frictionless_event_api.py
+from app.models.user import User
+
+
+def test_event_out_exposes_frictionless_join(client, db, test_user: User, auth_headers):
+    r = client.post("/api/events", json={"name": "E1", "expires_hours": 6}, headers=auth_headers)
+    assert r.status_code == 201
+    assert r.json()["frictionless_join"] is False
+
+
+def test_patch_event_sets_frictionless_join(client, db, test_user: User, auth_headers):
+    code = client.post(
+        "/api/events", json={"name": "E2", "expires_hours": 6}, headers=auth_headers
+    ).json()["code"]
+    r = client.patch(f"/api/events/{code}", json={"frictionless_join": True}, headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json()["frictionless_join"] is True

--- a/server/tests/test_frictionless_model.py
+++ b/server/tests/test_frictionless_model.py
@@ -1,0 +1,16 @@
+from app.models.user import User
+
+
+def test_user_frictionless_default_defaults_false(db):
+    user = User(username="dj_fric", password_hash="x", role="dj")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    assert user.frictionless_join_default is False
+
+
+def test_event_frictionless_join_defaults_false(db, test_user: User):
+    from app.services.event import create_event
+
+    event = create_event(db, "Frictionless Test", test_user)
+    assert event.frictionless_join is False

--- a/server/tests/test_frictionless_preferences.py
+++ b/server/tests/test_frictionless_preferences.py
@@ -1,0 +1,19 @@
+# server/tests/test_frictionless_preferences.py
+def test_me_exposes_frictionless_default(client, auth_headers):
+    r = client.get("/api/auth/me", headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json()["frictionless_join_default"] is False
+
+
+def test_patch_preferences_updates_default(client, auth_headers):
+    r = client.patch(
+        "/api/auth/me/preferences",
+        json={"frictionless_join_default": True},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["frictionless_join_default"] is True
+    # persisted
+    assert (
+        client.get("/api/auth/me", headers=auth_headers).json()["frictionless_join_default"] is True
+    )

--- a/server/tests/test_frictionless_seed.py
+++ b/server/tests/test_frictionless_seed.py
@@ -1,0 +1,14 @@
+from app.models.user import User
+from app.services.event import create_event
+
+
+def test_create_event_seeds_from_dj_default(db, test_user: User):
+    test_user.frictionless_join_default = True
+    db.commit()
+    event = create_event(db, "Seeded", test_user)
+    assert event.frictionless_join is True
+
+
+def test_create_event_default_off_when_dj_default_off(db, test_user: User):
+    event = create_event(db, "NotSeeded", test_user)
+    assert event.frictionless_join is False

--- a/server/tests/test_guest_names.py
+++ b/server/tests/test_guest_names.py
@@ -1,0 +1,36 @@
+from app.models.event import Event
+from app.models.guest import Guest
+from app.models.guest_profile import GuestProfile
+from app.services.guest_names import generate_unique_nickname
+
+
+def test_generates_titlecased_no_hyphen(db, test_event: Event):
+    nick = generate_unique_nickname(db, event_id=test_event.id)
+    assert nick
+    assert "-" not in nick
+    assert nick[0].isupper()
+    assert len(nick) <= 30
+
+
+def test_avoids_existing_nickname_in_event(db, test_event: Event, monkeypatch):
+    # Force the 2-word generator to always collide, proving the suffix/retry path.
+    import app.services.guest_names as gn
+
+    guest = Guest(token="g" * 64, fingerprint_hash="fp_x")
+    db.add(guest)
+    db.commit()
+    db.add(GuestProfile(event_id=test_event.id, guest_id=guest.id, nickname="Taken"))
+    db.commit()
+
+    calls = {"n": 0}
+
+    def fake_slug(n):
+        if n == 2:
+            calls["n"] += 1
+            return "taken"  # always collides at 2 words
+        return "unique-three-words"  # 3-word fallback
+
+    monkeypatch.setattr(gn, "generate_slug", fake_slug)
+    nick = generate_unique_nickname(db, event_id=test_event.id, max_attempts=3)
+    # Either a digit-suffixed "Taken##" or the 3-word fallback; never bare "Taken".
+    assert nick.lower() != "taken"

--- a/server/tests/test_guest_names.py
+++ b/server/tests/test_guest_names.py
@@ -34,3 +34,32 @@ def test_avoids_existing_nickname_in_event(db, test_event: Event, monkeypatch):
     nick = generate_unique_nickname(db, event_id=test_event.id, max_attempts=3)
     # Either a digit-suffixed "Taken##" or the 3-word fallback; never bare "Taken".
     assert nick.lower() != "taken"
+
+
+def test_last_resort_when_two_and_three_word_both_collide(db, test_event: Event, monkeypatch):
+    """When every slug (2- and 3-word) collides, fall back to a guaranteed-unique
+    opaque name rather than returning a taken one (which would 409 the guest)."""
+    import app.services.guest_names as gn
+
+    guest = Guest(token="h" * 64, fingerprint_hash="fp_y")
+    db.add(guest)
+    db.commit()
+    # Pre-take both the 2-word ("collide-collide" -> "CollideCollide") and 3-word
+    # ("collide-collide-collide" -> "CollideCollideCollide") TitleCased names.
+    # max_attempts=1 means only the bare 2-word name is tried before the fallback,
+    # so no random digit-suffix attempt can escape ahead of the last-resort path.
+    db.add(GuestProfile(event_id=test_event.id, guest_id=guest.id, nickname="CollideCollide"))
+    g2 = Guest(token="i" * 64, fingerprint_hash="fp_z")
+    db.add(g2)
+    db.commit()
+    db.add(GuestProfile(event_id=test_event.id, guest_id=g2.id, nickname="CollideCollideCollide"))
+    db.commit()
+
+    def fake_slug(n):
+        return "-".join(["collide"] * n)  # collides at both 2 and 3 words
+
+    monkeypatch.setattr(gn, "generate_slug", fake_slug)
+    nick = generate_unique_nickname(db, event_id=test_event.id, max_attempts=1)
+    assert nick.startswith("Guest")
+    assert not nick.startswith("CollideCollide")
+    assert len(nick) <= 30


### PR DESCRIPTION
## Summary

Restores a low-friction "scan QR → request a song" guest flow for **live events**, addressing #369. A DJ can mark an event **Frictionless join**; guests then land straight on song search with an **auto-generated username** (no nickname/email step) and can optionally rename themselves. The hardened `/collect` (pre-event voting) page is left completely untouched.

The friction being removed was purely the frontend `NicknameGate` on `/join` — backend join endpoints already gated only on the soft human-cookie. Anti-abuse is preserved: the invisible Turnstile human-verification cookie and the ThumbmarkJS guest fingerprint (which is the real dedup key, **not** the nickname) both still apply.

## Scope model

- `User.frictionless_join_default` — a per-DJ default toggled on `/account` (new "Guest Experience" card).
- `Event.frictionless_join` — a per-event flag, **snapshot-seeded** from the creator's default at event creation, then editable per event (final say). No runtime "inherit" resolution, no "default changed → old events mutate" surprises.

## Backend

- **Model + migration** (`a11334c031bb`, `down_revision=045`): two boolean columns, `server_default="0"`.
- **`services/guest_names.py`** — `coolname`-based (BSD-2-Clause, zero deps) unique-per-event nickname generator: 2-word slug → digit-suffix retry → 3-word fallback → opaque `Guest<hex>` last resort, all uniqueness-checked so an auto-name can never collide into a 409.
- **Endpoints** (`api/collect.py`):
  - `GET /api/public/collect/{code}/join-config` — unauthenticated; lets the join page decide its gate mode on load.
  - `POST /api/public/collect/{code}/guest/ensure-name` — auto-generates or renames a nickname, gated by `require_verified_human_soft` **and** `event.frictionless_join`.
- **`EventOut.frictionless_join`** + `EventUpdate` + `PATCH /api/events/{code}`; `create_event` seeds from the DJ default.
- **`UserOut.frictionless_join_default`** + `PATCH /api/auth/me/preferences`.
- Regenerated OpenAPI types.

### Security invariant (load-bearing)

`ensure-name` checks `event.frictionless_join` **before** anything else and returns `403 frictionless_disabled` when it is false. This makes it impossible to use the email-free name-write path to bypass the `require_email_verified` gate on the shared `GuestProfile` system — the relaxation only ever applies to events a DJ explicitly opted in.

## Frontend

- **Join page** (`/join/[code]`): fetches `join-config` on mount (ungated, before deciding the gate). When frictionless, it skips `NicknameGate`, calls `ensureGuestName`, and lands the guest on search. When not frictionless, `NicknameGate` renders exactly as before (regression-guarded). A `gateDecided` flag prevents the gate from flashing before the async auto-name resolves.
- **`IdentityBar`**: optional `autoNamed` / `onRename` props add an "Add a name" rename affordance for auto-named guests (existing usages unchanged).
- **DJ event management**: a "Frictionless join" toggle threaded through the event page → `EventManagementTab` → `KioskControlsCard`.
- **Account page**: a "Guest Experience" card with the per-DJ default, with save-error display.

## Test plan

- [x] Backend: `2044 passed`, coverage `88.12%` (≥85% gate)
- [x] Backend: `alembic upgrade head` + `alembic check` clean (no model/migration drift)
- [x] Backend: ruff check, ruff format, bandit all clean
- [x] Frontend: `943 passed` (66 files), `tsc --noEmit` clean, eslint clean
- [x] New backend tests: model defaults, name-gen collision + last-resort, ensure-name (auto / rename / idempotent / **403 when not frictionless** / **403 no-cookie soft mode**), join-config, EventOut field, creation seed, PATCH flag, `/me/preferences`
- [x] New frontend tests: api client methods, IdentityBar rename, join page skips gate when on / renders gate when off, DJ toggle, account default toggle
- [ ] Manual: scan QR on a frictionless event → straight to search with an auto-name; verify `/collect` still requires email; verify a non-frictionless event still shows the nickname gate

Two adversarial review passes (one per phase) were run during development; all findings were fixed (auto-name 409 hardening, ensure-name None-guard, soft-mode regression test; account error display, rename `aria-label`, removed a stray `console.error`).

Design + plan: `docs/superpowers/specs/2026-05-29-frictionless-join-design.md`, `docs/superpowers/plans/2026-05-29-frictionless-join.md`.

Closes #369.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frictionless join: DJs can enable guests to join without nickname/email friction (per-event toggle + DJ default in account settings).
  * Guests get auto-generated names when frictionless join is active; guests can rename themselves during the join flow via an "Add a name" option.
  * Join flow prevents nickname-gate flashing while deciding gate mode.

* **Documentation**
  * Added design and implementation plan for frictionless join.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->