### PR TITLE
fix(join): route email-required name claim into email flow, not a dead-end

### DIFF
--- a/dashboard/components/NicknameGate.tsx
+++ b/dashboard/components/NicknameGate.tsx
@@ -2,7 +2,13 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { z } from 'zod';
-import { apiClient, ApiError, CollectProfileResponse, NicknameConflictError } from '../lib/api';
+import {
+  apiClient,
+  ApiError,
+  CollectProfileResponse,
+  EmailVerificationRequiredError,
+  NicknameConflictError,
+} from '../lib/api';
 import { useGuestIdentity } from '../lib/use-guest-identity';
 import { getTurnstileSiteKey, loadTurnstileScript } from '../lib/turnstile';
 import { ModalOverlay } from './ModalOverlay';
@@ -54,6 +60,9 @@ export function NicknameGate({ code, onComplete, reverify }: Props) {
   const [inputError, setInputError] = useState<string | null>(null);
   const [savedFlash, setSavedFlash] = useState(false);
   const [profileCache, setProfileCache] = useState<CollectProfileResponse | null>(null);
+  // A name the guest chose that requires email verification before it can be
+  // claimed. Stashed when the save is blocked, then auto-applied after verify.
+  const [pendingNickname, setPendingNickname] = useState<string | null>(null);
   const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [otpTurnstileToken, setOtpTurnstileToken] = useState<string>('');
   const otpWidgetRef = useRef<HTMLDivElement | null>(null);
@@ -162,6 +171,13 @@ export function NicknameGate({ code, onComplete, reverify }: Props) {
       if (err instanceof NicknameConflictError) {
         setCollisionNickname(parsed.data);
         setGateState(err.claimed ? 'collision_claimed' : 'collision_unclaimed');
+      } else if (err instanceof EmailVerificationRequiredError) {
+        // Claiming a name requires a verified email (collect hardening, #324).
+        // Stash the chosen name and route into the email flow rather than
+        // showing a dead-end error; the name is claimed after verification.
+        setPendingNickname(parsed.data);
+        setSavedNickname(parsed.data);
+        setGateState('email_login');
       } else {
         setInputError(err instanceof ApiError ? err.message : "Couldn't save — please try again");
       }
@@ -207,11 +223,32 @@ export function NicknameGate({ code, onComplete, reverify }: Props) {
           submissionCount: p.submission_count,
           submissionCap: p.submission_cap,
         });
+      } else if (pendingNickname) {
+        // Email is now verified — claim the name the guest chose before the gate.
+        const claimed = await apiClient.setCollectProfile(
+          code,
+          { nickname: pendingNickname },
+          reverify,
+        );
+        setPendingNickname(null);
+        onComplete({
+          nickname: claimed.nickname ?? pendingNickname,
+          emailVerified: true,
+          submissionCount: claimed.submission_count,
+          submissionCap: claimed.submission_cap,
+        });
       } else {
         setGateState('nickname_input');
       }
     } catch (err) {
-      setInputError(err instanceof ApiError ? err.message : 'Invalid or expired code.');
+      if (err instanceof NicknameConflictError) {
+        // The stashed name was claimed by someone else during verification.
+        setCollisionNickname(pendingNickname ?? '');
+        setPendingNickname(null);
+        setGateState(err.claimed ? 'collision_claimed' : 'collision_unclaimed');
+      } else {
+        setInputError(err instanceof ApiError ? err.message : 'Invalid or expired code.');
+      }
     } finally {
       setVerifyingCode(false);
     }

--- a/dashboard/components/NicknameGate.tsx
+++ b/dashboard/components/NicknameGate.tsx
@@ -211,11 +211,15 @@ export function NicknameGate({ code, onComplete, reverify }: Props) {
   const handleConfirmCode = async () => {
     setVerifyingCode(true);
     setInputError(null);
+    // Tracks whether the OTP itself succeeded, so a later (deferred-claim)
+    // failure is not misreported as a bad code.
+    let verified = false;
     try {
       await apiClient.confirmVerificationCode(emailInput, codeInput);
       const p = await apiClient.getCollectProfile(code);
       setProfileCache(p);
       setEmailVerified(true);
+      verified = true;
       if (p.nickname) {
         onComplete({
           nickname: p.nickname,
@@ -223,29 +227,40 @@ export function NicknameGate({ code, onComplete, reverify }: Props) {
           submissionCount: p.submission_count,
           submissionCap: p.submission_cap,
         });
-      } else if (pendingNickname) {
-        // Email is now verified — claim the name the guest chose before the gate.
-        const claimed = await apiClient.setCollectProfile(
-          code,
-          { nickname: pendingNickname },
-          reverify,
-        );
-        setPendingNickname(null);
-        onComplete({
-          nickname: claimed.nickname ?? pendingNickname,
-          emailVerified: true,
-          submissionCount: claimed.submission_count,
-          submissionCap: claimed.submission_cap,
-        });
-      } else {
-        setGateState('nickname_input');
+        return;
       }
+      if (!pendingNickname) {
+        setGateState('nickname_input');
+        return;
+      }
+      // Email is verified — claim the deferred name as a separate step so a
+      // claim failure can't strand the guest behind an already-consumed code.
+      const claimed = await apiClient.setCollectProfile(
+        code,
+        { nickname: pendingNickname },
+        reverify,
+      );
+      setPendingNickname(null);
+      onComplete({
+        nickname: claimed.nickname ?? pendingNickname,
+        emailVerified: true,
+        submissionCount: claimed.submission_count,
+        submissionCap: claimed.submission_cap,
+      });
     } catch (err) {
       if (err instanceof NicknameConflictError) {
-        // The stashed name was claimed by someone else during verification.
+        // The deferred name was claimed by someone else during verification.
         setCollisionNickname(pendingNickname ?? '');
         setPendingNickname(null);
         setGateState(err.claimed ? 'collision_claimed' : 'collision_unclaimed');
+      } else if (verified) {
+        // OTP succeeded but the deferred claim failed — keep the verified state
+        // and move off the consumed-code screen so the guest can retry the name.
+        setPendingNickname(null);
+        setInputError(
+          err instanceof ApiError ? err.message : "Couldn't save nickname — please try again",
+        );
+        setGateState('nickname_input');
       } else {
         setInputError(err instanceof ApiError ? err.message : 'Invalid or expired code.');
       }
@@ -481,7 +496,13 @@ export function NicknameGate({ code, onComplete, reverify }: Props) {
         <button
           className="btn btn-secondary"
           style={{ width: '100%' }}
-          onClick={() => setGateState('track_select')}
+          onClick={() => {
+            // Abandon any deferred name claim so it isn't auto-applied if the
+            // guest later verifies via the normal email-login path.
+            setPendingNickname(null);
+            setSavedNickname('');
+            setGateState('track_select');
+          }}
         >
           ← Back
         </button>

--- a/dashboard/components/__tests__/NicknameGate.test.tsx
+++ b/dashboard/components/__tests__/NicknameGate.test.tsx
@@ -258,6 +258,80 @@ describe('NicknameGate', () => {
     expect(onComplete).not.toHaveBeenCalled();
   });
 
+  it('clears the deferred name when the email-required flow is abandoned via Back', async () => {
+    const { EmailVerificationRequiredError } = await import('../../lib/api');
+    mockSetProfile.mockRejectedValueOnce(new EmailVerificationRequiredError());
+    mockGetProfile
+      .mockResolvedValueOnce(emptyProfile)
+      .mockResolvedValueOnce({
+        nickname: null,
+        email_verified: true,
+        submission_count: 0,
+        submission_cap: 5,
+      });
+    render(<NicknameGate code="EVT01" onComplete={onComplete} reverify={vi.fn()} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    // Blocked → routed to the email step; the user backs out…
+    await waitFor(() => screen.getByPlaceholderText(/you@example\.com/i));
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+    // …then chooses the normal email-login path instead.
+    await waitFor(() => screen.getByRole('button', { name: /have email/i }));
+    fireEvent.click(screen.getByRole('button', { name: /have email/i }));
+    fireEvent.change(screen.getByPlaceholderText(/you@example\.com/i), {
+      target: { value: 'someone@example.com' },
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /send code/i })).not.toBeDisabled(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /send code/i }));
+    await waitFor(() => screen.getByPlaceholderText(/6.digit/i));
+    fireEvent.change(screen.getByPlaceholderText(/6.digit/i), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /^verify$/i }));
+    // The abandoned 'Alex' must NOT be auto-claimed; lands on a fresh name prompt.
+    await waitFor(() => expect(screen.getByPlaceholderText(/dancingqueen/i)).toBeInTheDocument());
+    expect(mockSetProfile).toHaveBeenCalledTimes(1);
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('keeps the verified state and unblocks if the deferred claim fails after OTP', async () => {
+    const { EmailVerificationRequiredError, ApiError } = await import('../../lib/api');
+    mockSetProfile
+      .mockRejectedValueOnce(new EmailVerificationRequiredError())
+      .mockRejectedValueOnce(new ApiError('server error', 500));
+    mockGetProfile
+      .mockResolvedValueOnce(emptyProfile)
+      .mockResolvedValueOnce({
+        nickname: null,
+        email_verified: true,
+        submission_count: 0,
+        submission_cap: 5,
+      });
+    render(<NicknameGate code="EVT01" onComplete={onComplete} reverify={vi.fn()} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => screen.getByPlaceholderText(/you@example\.com/i));
+    fireEvent.change(screen.getByPlaceholderText(/you@example\.com/i), {
+      target: { value: 'alex@example.com' },
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /send code/i })).not.toBeDisabled(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /send code/i }));
+    await waitFor(() => screen.getByPlaceholderText(/6.digit/i));
+    fireEvent.change(screen.getByPlaceholderText(/6.digit/i), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /^verify$/i }));
+    // OTP consumed + email verified, but the claim failed: move OFF the code
+    // screen to the name prompt rather than stranding the user behind a used code.
+    await waitFor(() => expect(screen.getByPlaceholderText(/dancingqueen/i)).toBeInTheDocument());
+    expect(screen.queryByPlaceholderText(/6.digit/i)).not.toBeInTheDocument();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
   it('transitions to complete when email verified and profile has nickname', async () => {
     mockGetProfile
       .mockResolvedValueOnce(emptyProfile)

--- a/dashboard/components/__tests__/NicknameGate.test.tsx
+++ b/dashboard/components/__tests__/NicknameGate.test.tsx
@@ -19,6 +19,12 @@ vi.mock('../../lib/api', () => {
       this.claimed = claimed;
     }
   }
+  class EmailVerificationRequiredError extends Error {
+    constructor() {
+      super('email_verification_required');
+      this.name = 'EmailVerificationRequiredError';
+    }
+  }
   return {
     apiClient: {
       getCollectProfile: vi.fn(),
@@ -28,6 +34,7 @@ vi.mock('../../lib/api', () => {
     },
     ApiError,
     NicknameConflictError,
+    EmailVerificationRequiredError,
   };
 });
 
@@ -151,6 +158,104 @@ describe('NicknameGate', () => {
     await waitFor(() => screen.getByRole('button', { name: /log in with email/i }));
     fireEvent.click(screen.getByRole('button', { name: /try a different/i }));
     expect(screen.getByPlaceholderText(/dancingqueen/i)).toBeInTheDocument();
+  });
+
+  // Regression: a brand-new guest in a private tab is not email-verified, so
+  // claiming a name (POST /collect/{code}/profile -> require_email_verified)
+  // returns 403 email_verification_required. Previously this fell through to a
+  // generic "Couldn't save" dead-end; now it must route into the email flow.
+  it('routes to email verification (not a dead-end) when a name claim requires email', async () => {
+    const { EmailVerificationRequiredError } = await import('../../lib/api');
+    mockSetProfile.mockRejectedValueOnce(new EmailVerificationRequiredError());
+    render(<NicknameGate code="EVT01" onComplete={onComplete} reverify={vi.fn()} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    // Lands on the email-login step…
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/you@example\.com/i)).toBeInTheDocument(),
+    );
+    // …and NOT the old generic dead-end error.
+    expect(screen.queryByText(/couldn.t save/i)).not.toBeInTheDocument();
+  });
+
+  it('auto-claims the chosen name after email verification', async () => {
+    const { EmailVerificationRequiredError } = await import('../../lib/api');
+    // 1st save is blocked by the email gate; 2nd save (post-verify) succeeds.
+    mockSetProfile
+      .mockRejectedValueOnce(new EmailVerificationRequiredError())
+      .mockResolvedValueOnce({
+        nickname: 'Alex',
+        email_verified: true,
+        submission_count: 0,
+        submission_cap: 5,
+      });
+    // Profile after code-confirm still has no nickname (the blocked save never persisted).
+    mockGetProfile
+      .mockResolvedValueOnce(emptyProfile)
+      .mockResolvedValueOnce({
+        nickname: null,
+        email_verified: true,
+        submission_count: 0,
+        submission_cap: 5,
+      });
+    render(<NicknameGate code="EVT01" onComplete={onComplete} reverify={vi.fn()} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => screen.getByPlaceholderText(/you@example\.com/i));
+    fireEvent.change(screen.getByPlaceholderText(/you@example\.com/i), {
+      target: { value: 'alex@example.com' },
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /send code/i })).not.toBeDisabled(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /send code/i }));
+    await waitFor(() => screen.getByPlaceholderText(/6.digit/i));
+    fireEvent.change(screen.getByPlaceholderText(/6.digit/i), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /^verify$/i }));
+    await waitFor(() =>
+      expect(onComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ nickname: 'Alex', emailVerified: true }),
+      ),
+    );
+    // The name was claimed in a second profile write, after email was verified.
+    expect(mockSetProfile).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows the collision state if the chosen name is taken during email verification', async () => {
+    const { EmailVerificationRequiredError, NicknameConflictError } = await import('../../lib/api');
+    mockSetProfile
+      .mockRejectedValueOnce(new EmailVerificationRequiredError())
+      .mockRejectedValueOnce(new NicknameConflictError(false));
+    mockGetProfile
+      .mockResolvedValueOnce(emptyProfile)
+      .mockResolvedValueOnce({
+        nickname: null,
+        email_verified: true,
+        submission_count: 0,
+        submission_cap: 5,
+      });
+    render(<NicknameGate code="EVT01" onComplete={onComplete} reverify={vi.fn()} />);
+    await waitFor(() => screen.getByRole('button', { name: /new name/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new name/i }));
+    fireEvent.change(screen.getByPlaceholderText(/dancingqueen/i), { target: { value: 'Alex' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => screen.getByPlaceholderText(/you@example\.com/i));
+    fireEvent.change(screen.getByPlaceholderText(/you@example\.com/i), {
+      target: { value: 'alex@example.com' },
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /send code/i })).not.toBeDisabled(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /send code/i }));
+    await waitFor(() => screen.getByPlaceholderText(/6.digit/i));
+    fireEvent.change(screen.getByPlaceholderText(/6.digit/i), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /^verify$/i }));
+    await waitFor(() => expect(screen.getByText(/already taken/i)).toBeInTheDocument());
+    expect(onComplete).not.toHaveBeenCalled();
   });
 
   it('transitions to complete when email verified and profile has nickname', async () => {


### PR DESCRIPTION
## Problem

Diagnosed from **production** logs. A brand-new guest in a private/incognito tab could not create a username:

```
POST /guest/identify          → guest_id=147  reason=no_match   (fresh guest)
POST /guest/verify-human      → 200            (Turnstile OK, human cookie)
GET  /collect/ELZ2G2/profile  → 200            (require_verified_human — passes)
POST /collect/ELZ2G2/profile  → 403 ×4         (require_email_verified — blocks)
```

`POST /collect/{code}/profile` requires a **verified email** (collect hardening, #324). But `NicknameGate` saved the name *first* and only *then* prompted for email. The blocked save returned `403 email_verification_required`, which `withHumanRetry` surfaces as `EmailVerificationRequiredError`. `NicknameGate`'s catch handled only `NicknameConflictError`/`ApiError`, so it fell through to a generic **"Couldn't save — please try again"** dead-end with no path to verify email. The guest retried → the repeated 403s.

Only reproduces for guests with no verified email — i.e. a private tab (fresh guest). Returning guests already carry a verified-email cookie, so they never hit it.

## Fix (frontend-only — preserves the email-to-claim hardening)

`dashboard/components/NicknameGate.tsx`:
- Handle `EmailVerificationRequiredError`: stash the chosen name and route into the **existing** email-login flow instead of the dead-end.
- Auto-claim the stashed name once the email is verified (`handleConfirmCode`).
- Route a `NicknameConflictError` from the post-verify re-claim (name taken during verification) to the collision state, not a misleading "invalid code" error.

No backend change. The `require_email_verified` gate is unchanged.

## Test plan

- [x] `tsc --noEmit` clean
- [x] ESLint clean on changed files
- [x] `NicknameGate.test.tsx`: 22 pass (3 new — route-to-email, auto-claim, collision race)
- [x] Full frontend vitest: **937/937 pass**
- [ ] Manual: private tab → `/collect/<code>` → "New name" → enter name → now prompted for email → verify → name claimed

## Notes

- Diagnosis traced via the `systematic-debugging` + TDD workflow (failing test reproduces the exact dead-end string, then minimal fix).
- Separate from the in-flight frictionless-join work (#369), which removes this friction on `/join` for opted-in events via a different soft-gated endpoint; this PR fixes the **existing** `/collect` claim path on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Defers nickname claiming when email verification is required, auto-completes the claim after successful verification, preserves verified state if claim fails, and surfaces nickname-collision handling without completing the flow. Back from email login now clears any deferred nickname and resets the name entry.

* **Tests**
  * Added tests covering deferred nickname claims during email verification, auto-claiming on success, collision scenarios, aborting via Back, and verified-state preservation when claims fail.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wrzonance/WrzDJ/pull/381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->