### PR TITLE
fix(routing): dual-code routing for frictionless /join + close get_event leak (#382)

### DIFF
--- a/dashboard/app/join/[code]/__tests__/page.test.tsx
+++ b/dashboard/app/join/[code]/__tests__/page.test.tsx
@@ -13,6 +13,7 @@ const { mockApi, MockApiError } = vi.hoisted(() => {
 
   const mockApi = {
     getEvent: vi.fn(),
+    getPublicEvent: vi.fn(),
     checkHasRequested: vi.fn(),
     getCollectEvent: vi.fn(),
     getCollectProfile: vi.fn(),
@@ -94,6 +95,16 @@ function setupDefaultMocks() {
     requests_open: true,
     banner_url: null,
   });
+  mockApi.getPublicEvent.mockResolvedValue({
+    name: 'Test Event',
+    collection_code: 'TEST01',
+    requests_open: true,
+    frictionless_join: false,
+    phase: 'live',
+    submission_cap_per_guest: 5,
+    banner_url: null,
+    banner_colors: null,
+  });
   mockApi.checkHasRequested.mockResolvedValue({ has_requested: false });
   mockApi.getCollectEvent.mockResolvedValue({
     phase: 'live',
@@ -142,6 +153,13 @@ describe('JoinEventPage — NicknameGate wiring', () => {
       expect(bar).toHaveTextContent('TestUser');
     });
   });
+
+  it('loads the event via getPublicEvent and never calls the id-leaking getEvent', async () => {
+    setupDefaultMocks();
+    render(<JoinEventPage />);
+    await waitFor(() => expect(mockApi.getPublicEvent).toHaveBeenCalledWith('TEST01'));
+    expect(mockApi.getEvent).not.toHaveBeenCalled();
+  });
 });
 
 describe('JoinEventPage — error states', () => {
@@ -151,7 +169,7 @@ describe('JoinEventPage — error states', () => {
   });
 
   it('shows Event Expired when API returns 410', async () => {
-    mockApi.getEvent.mockRejectedValue(new MockApiError('Gone', 410));
+    mockApi.getPublicEvent.mockRejectedValue(new MockApiError('Gone', 410));
     render(<JoinEventPage />);
     await waitFor(() => {
       expect(screen.getByText('Event Expired')).toBeInTheDocument();
@@ -159,7 +177,7 @@ describe('JoinEventPage — error states', () => {
   });
 
   it('shows Event Not Found when API returns 404', async () => {
-    mockApi.getEvent.mockRejectedValue(new MockApiError('Not found', 404));
+    mockApi.getPublicEvent.mockRejectedValue(new MockApiError('Not found', 404));
     render(<JoinEventPage />);
     await waitFor(() => {
       expect(screen.getByText('Event Not Found')).toBeInTheDocument();
@@ -167,7 +185,7 @@ describe('JoinEventPage — error states', () => {
   });
 
   it('shows generic error message when API fails with non-HTTP error', async () => {
-    mockApi.getEvent.mockRejectedValue(new Error('Network error'));
+    mockApi.getPublicEvent.mockRejectedValue(new Error('Network error'));
     render(<JoinEventPage />);
     await waitFor(() => {
       expect(screen.getByText('Oops!')).toBeInTheDocument();
@@ -176,7 +194,7 @@ describe('JoinEventPage — error states', () => {
   });
 
   it('shows error from ApiError message when status is generic', async () => {
-    mockApi.getEvent.mockRejectedValue(new MockApiError('Something went wrong', 500));
+    mockApi.getPublicEvent.mockRejectedValue(new MockApiError('Something went wrong', 500));
     render(<JoinEventPage />);
     await waitFor(() => {
       expect(screen.getByText('Something went wrong')).toBeInTheDocument();
@@ -194,6 +212,16 @@ describe('JoinEventPage — requests closed state', () => {
       name: 'Closed Event',
       requests_open: false,
       banner_url: null,
+    });
+    mockApi.getPublicEvent.mockResolvedValue({
+      name: 'Closed Event',
+      collection_code: 'TEST01',
+      requests_open: false,
+      frictionless_join: false,
+      phase: 'live',
+      submission_cap_per_guest: 5,
+      banner_url: null,
+      banner_colors: null,
     });
   });
 
@@ -274,6 +302,16 @@ describe('JoinEventPage — request list view', () => {
       requests_open: false,
       banner_url: null,
     });
+    mockApi.getPublicEvent.mockResolvedValue({
+      name: 'Test Event',
+      collection_code: 'TEST01',
+      requests_open: false,
+      frictionless_join: false,
+      phase: 'live',
+      submission_cap_per_guest: 5,
+      banner_url: null,
+      banner_colors: null,
+    });
     mockApi.getPublicRequests.mockResolvedValue({ requests: [], now_playing: null });
     render(<JoinEventPage />);
     await waitFor(() => {
@@ -328,18 +366,15 @@ describe('JoinEventPage — request list view', () => {
   });
 
   it('shows pre-event banner when collectPhase is collection', async () => {
-    mockApi.getCollectEvent.mockResolvedValue({
-      phase: 'collection',
-      code: 'TEST01',
+    mockApi.getPublicEvent.mockResolvedValue({
       name: 'Test Event',
-      banner_filename: null,
+      collection_code: 'TEST01',
+      requests_open: true,
+      frictionless_join: false,
+      phase: 'collection',
+      submission_cap_per_guest: 5,
       banner_url: null,
       banner_colors: null,
-      submission_cap_per_guest: 5,
-      registration_enabled: false,
-      collection_opens_at: null,
-      live_starts_at: null,
-      expires_at: new Date(Date.now() + 86400000).toISOString(),
     });
     mockApi.getPublicRequests.mockResolvedValue({ requests: [], now_playing: null });
     render(<JoinEventPage />);
@@ -349,18 +384,15 @@ describe('JoinEventPage — request list view', () => {
   });
 
   it('shows pre-event banner when collectPhase is pre_announce', async () => {
-    mockApi.getCollectEvent.mockResolvedValue({
-      phase: 'pre_announce',
-      code: 'TEST01',
+    mockApi.getPublicEvent.mockResolvedValue({
       name: 'Test Event',
-      banner_filename: null,
+      collection_code: 'TEST01',
+      requests_open: true,
+      frictionless_join: false,
+      phase: 'pre_announce',
+      submission_cap_per_guest: 5,
       banner_url: null,
       banner_colors: null,
-      submission_cap_per_guest: 5,
-      registration_enabled: false,
-      collection_opens_at: null,
-      live_starts_at: null,
-      expires_at: new Date(Date.now() + 86400000).toISOString(),
     });
     mockApi.getPublicRequests.mockResolvedValue({ requests: [], now_playing: null });
     render(<JoinEventPage />);
@@ -705,6 +737,16 @@ describe('JoinEventPage — frictionless join', () => {
       id: 1, code: 'TEST01', join_code: 'TEST01', name: 'Party', requests_open: true,
       frictionless_join: true,
     } as never);
+    mockApi.getPublicEvent.mockResolvedValue({
+      name: 'Party',
+      collection_code: 'TEST01',
+      requests_open: true,
+      frictionless_join: true,
+      phase: 'live',
+      submission_cap_per_guest: 5,
+      banner_url: null,
+      banner_colors: null,
+    });
     mockApi.checkHasRequested.mockResolvedValue({ has_requested: false } as never);
     render(<JoinEventPage />);
     // No "What's your nickname?" gate; the auto-name shows in the identity bar.

--- a/dashboard/app/join/[code]/page.tsx
+++ b/dashboard/app/join/[code]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { useParams } from 'next/navigation';
-import { api, ApiError, Event, GuestNowPlaying, GuestRequestInfo, SearchResult } from '@/lib/api';
+import { api, ApiError, PublicEvent, GuestNowPlaying, GuestRequestInfo, SearchResult } from '@/lib/api';
 import { useEventStream } from '@/lib/use-event-stream';
 import { useGuestIdentity } from '@/lib/use-guest-identity';
 import { useHumanVerification } from '@/lib/useHumanVerification';
@@ -58,7 +58,7 @@ export default function JoinEventPage() {
   const { state: humanState, reverify, widgetContainerRef } = useHumanVerification();
   const [recoveryOpen, setRecoveryOpen] = useState(false);
 
-  const [event, setEvent] = useState<Event | null>(null);
+  const [event, setEvent] = useState<PublicEvent | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<{ message: string; status: number } | null>(null);
 
@@ -164,8 +164,9 @@ export default function JoinEventPage() {
   /* Load event */
   const loadEvent = useCallback(async () => {
     try {
-      const data = await api.getEvent(code);
+      const data = await api.getPublicEvent(code);
       setEvent(data);
+      setCollectPhase(data.phase);
       setError(null);
       try {
         const { has_requested } = await api.checkHasRequested(code);
@@ -193,14 +194,11 @@ export default function JoinEventPage() {
   useEffect(() => {
     if (!gateComplete || !code) return;
     let cancelled = false;
-    Promise.allSettled([
-      api.getCollectEvent(code),
-      api.getCollectProfile(code),
-    ]).then(([evResult, profileResult]) => {
-      if (cancelled) return;
-      if (evResult.status === 'fulfilled') setCollectPhase(evResult.value.phase);
-      if (profileResult.status === 'fulfilled') setEmailVerified(profileResult.value.email_verified);
-    });
+    api.getCollectProfile(code)
+      .then((profile) => {
+        if (!cancelled) setEmailVerified(profile.email_verified);
+      })
+      .catch(() => { /* email-verified is best-effort on the live page */ });
     return () => { cancelled = true; };
   }, [code, gateComplete]);
 
@@ -504,7 +502,7 @@ export default function JoinEventPage() {
     collectPhase === 'pre_announce' || collectPhase === 'collection' ? (
       <div className="join-pre-event-banner">
         🎟️ Pre-event voting is open —{' '}
-        <a href={`/collect/${code}`}>go to the pre-event page →</a>
+        <a href={`/collect/${event.collection_code}`}>go to the pre-event page →</a>
       </div>
     ) : null;
 

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -1583,6 +1583,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/public/events/{code}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Public Event
+         * @description Guest-safe event info for the live /join page. Resolves by EITHER public
+         *     code; never emits event.id. Replaces the join page's use of the DJ EventOut
+         *     endpoint (which leaks the private id) and folds in phase + frictionless_join.
+         */
+        get: operations["get_public_event_api_public_events__code__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/public/events/{code}/display": {
         parameters: {
             query?: never;
@@ -3453,6 +3475,32 @@ export interface components {
             code: string;
             /** Name */
             name: string;
+        };
+        /**
+         * PublicEventResponse
+         * @description Guest-safe live-event projection. Deliberately omits event.id and any
+         *     DJ-only fields (see #382 serializer hygiene).
+         */
+        PublicEventResponse: {
+            /** Banner Colors */
+            banner_colors: string[] | null;
+            /** Banner Url */
+            banner_url: string | null;
+            /** Collection Code */
+            collection_code: string;
+            /** Frictionless Join */
+            frictionless_join: boolean;
+            /** Name */
+            name: string;
+            /**
+             * Phase
+             * @enum {string}
+             */
+            phase: "pre_announce" | "collection" | "live" | "closed";
+            /** Requests Open */
+            requests_open: boolean;
+            /** Submission Cap Per Guest */
+            submission_cap_per_guest: number;
         };
         /** PublicRequestInfo */
         PublicRequestInfo: {
@@ -6906,6 +6954,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["NowPlayingResponse"] | null;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_public_event_api_public_events__code__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                code: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublicEventResponse"];
                 };
             };
             /** @description Validation Error */

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -21,6 +21,7 @@ type Schemas = components['schemas'];
 // ---------------------------------------------------------------------------
 
 export type Event = Schemas['EventOut'];
+export type PublicEvent = Schemas['PublicEventResponse'];
 export type SongRequest = Schemas['RequestOut'];
 export type PublicRequestInfo = Schemas['PublicRequestInfo'] & { requester_verified?: boolean };
 export type GuestRequestInfo = Schemas['GuestRequestInfo'] & { requester_verified?: boolean };

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -29,6 +29,7 @@ import type {
   PaginatedResponse,
   PlayHistoryResponse,
   PlaylistListResponse,
+  PublicEvent,
   RecommendationResponse,
   SearchResult,
   SongRequest,
@@ -81,6 +82,7 @@ export type {
   PlayHistoryItem,
   PlayHistoryResponse,
   PublicBridgeStatus,
+  PublicEvent,
   PublicRequestInfo,
   RecommendationResponse,
   RecommendedTrack,
@@ -742,6 +744,10 @@ class ApiClient {
 
   async getPublicRequests(code: string): Promise<GuestRequestListResponse> {
     return this.publicFetch(`${getApiUrl()}/api/public/events/${code}/requests`);
+  }
+
+  async getPublicEvent(code: string): Promise<PublicEvent> {
+    return this.publicFetch(`${getApiUrl()}/api/public/events/${code}`);
   }
 
   async getKioskDisplay(code: string): Promise<KioskDisplay> {

--- a/docs/superpowers/plans/2026-05-30-dual-code-routing.md
+++ b/docs/superpowers/plans/2026-05-30-dual-code-routing.md
@@ -1,0 +1,758 @@
+# Dual-Code Routing Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the live `/join` page work end-to-end via the real `join_code` share link by resolving every guest-facing endpoint through one canonical lookup that accepts either of an event's two public codes, and stop leaking the private `event.id` to guests.
+
+**Architecture:** One new resolver `get_event_by_public_code_with_status` = `or_(Event.code, Event.join_code)` replaces the per-router lookups on the guest surface (collect router, events search/submit, public reads, SSE stream). A new guest-safe `GET /api/public/events/{code}` returns a projection with no `event.id`. The behavioral boundary (frictionless vs collect-auth) stays enforced by flags/auth deps, never by code identity. SSE submit publishes the resolved `event.code` so a join_code submit reaches the stream. Frontend swaps the id-leaking `getEvent` for `getPublicEvent`; `NicknameGate` is untouched. No DB migration.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2.0 (backend), pytest; Next.js 16 / React 19 + TypeScript (frontend), vitest; OpenAPI-typescript codegen.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-dual-code-routing-design.md`
+
+---
+
+## File Structure
+
+**Backend (create):**
+- `server/tests/test_dual_code_routing.py` — resolver unit tests, events submit-by-join_code, get_event-stays-collection-only, SSE channel-match, new endpoint (no-id-leak + fields).
+
+**Backend (modify):**
+- `server/app/services/event.py` — add `get_event_by_public_code_with_status`.
+- `server/app/api/collect.py` — `_get_event_or_404` → canonical resolver.
+- `server/app/api/events.py` — `event_search` + `submit_request` → canonical; `submit_request` publishes `event.code`.
+- `server/app/api/public.py` — `get_public_requests` / `check_has_requested` / `get_my_requests` → canonical; add `PublicEventResponse` schema + `GET /events/{code}` endpoint.
+- `server/app/api/sse.py` — `event_stream` → canonical (still subscribes `event.code`).
+- `server/tests/test_collect_public.py` — add join_code-resolution + frictionless-flag-boundary tests (reuses its autouse human-cookie fixture).
+
+**Frontend (modify):**
+- `server/openapi.json` + `dashboard/lib/api-types.generated.ts` — regenerated.
+- `dashboard/lib/api-types.ts` — add `PublicEvent` alias.
+- `dashboard/lib/api.ts` — add `getPublicEvent`; export `PublicEvent`.
+- `dashboard/app/join/[code]/page.tsx` — `getEvent`→`getPublicEvent`; drop `getCollectEvent`; phase-banner link uses `collection_code`; `event` state typed `PublicEvent`.
+- `dashboard/app/join/[code]/__tests__/page.test.tsx` — update mocks.
+
+---
+
+## Task 0: Worktree environment + clean baseline
+
+**Files:** none (setup only)
+
+- [ ] **Step 1: Create the backend venv and install deps**
+
+```bash
+cd server
+python3 -m venv .venv
+.venv/bin/pip install -U pip wheel
+.venv/bin/pip install -e ".[dev]" || .venv/bin/pip install -r requirements.txt -r requirements-dev.txt
+```
+(Use whichever install path the repo provides — check `server/pyproject.toml` for the `[project.optional-dependencies] dev` group first.)
+
+- [ ] **Step 2: Install frontend deps**
+
+```bash
+cd ../dashboard && npm install
+```
+
+- [ ] **Step 3: Verify clean backend baseline**
+
+Run: `cd ../server && .venv/bin/pytest -q`
+Expected: PASS (note the count; this is the green baseline).
+
+- [ ] **Step 4: Verify clean frontend baseline**
+
+Run: `cd ../dashboard && npm test -- --run`
+Expected: PASS.
+
+**If either baseline fails:** stop and report — do not start implementing on a red baseline.
+
+---
+
+## Task 1: Canonical guest resolver
+
+**Files:**
+- Modify: `server/app/services/event.py` (after `get_event_by_join_code_with_status`, ~line 130)
+- Test: `server/tests/test_dual_code_routing.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# server/tests/test_dual_code_routing.py
+"""Issue #382 — guest endpoints resolve by EITHER public code (collection or join)."""
+
+from app.models.event import Event
+from app.services.event import (
+    EventLookupResult,
+    get_event_by_public_code_with_status,
+)
+
+
+def test_public_code_resolver_accepts_both_codes(db, test_event: Event):
+    by_collection, s1 = get_event_by_public_code_with_status(db, test_event.code)
+    by_join, s2 = get_event_by_public_code_with_status(db, test_event.join_code)
+    assert by_collection is not None and by_join is not None
+    assert by_collection.id == test_event.id == by_join.id
+    assert s1 == EventLookupResult.FOUND
+    assert s2 == EventLookupResult.FOUND
+
+
+def test_public_code_resolver_is_case_insensitive(db, test_event: Event):
+    ev, _ = get_event_by_public_code_with_status(db, test_event.join_code.lower())
+    assert ev is not None and ev.id == test_event.id
+
+
+def test_public_code_resolver_not_found(db):
+    ev, status = get_event_by_public_code_with_status(db, "ZZZZZZ")
+    assert ev is None
+    assert status == EventLookupResult.NOT_FOUND
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_dual_code_routing.py -q`
+Expected: FAIL — `ImportError: cannot import name 'get_event_by_public_code_with_status'`.
+
+- [ ] **Step 3: Implement the resolver**
+
+```python
+# server/app/services/event.py — add after get_event_by_join_code_with_status (~line 130)
+
+def get_event_by_public_code_with_status(
+    db: Session, code: str
+) -> tuple[Event | None, EventLookupResult]:
+    """Resolve a guest-facing public code that may be EITHER the collection
+    `code` or the live `join_code` (one event, two public handles). Behavioral
+    gating (frictionless vs collect-auth) is enforced by each endpoint's
+    flags/auth dependencies, never by which code resolved the event. Codes are
+    globally unique across both columns (`generate_unique_event_code`), so this
+    is collision-free.
+    """
+    event = (
+        db.query(Event)
+        .filter(or_(Event.code == code.upper(), Event.join_code == code.upper()))
+        .first()
+    )
+    return _event_with_status(event)
+```
+(`or_` is already imported in this module.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_dual_code_routing.py -q`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/services/event.py server/tests/test_dual_code_routing.py
+git commit -m "feat(routing): canonical guest resolver accepting either public code (#382)"
+```
+
+---
+
+## Task 2: Collect router resolves by either code + flag-boundary holds
+
+**Files:**
+- Modify: `server/app/api/collect.py:65-69` (`_get_event_or_404`)
+- Test: `server/tests/test_collect_public.py` (append; reuses its autouse `_default_guest_cookie` fixture)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# server/tests/test_collect_public.py — append at end of file
+
+def test_collect_preview_resolves_by_join_code(client, db, test_event: Event):
+    """#382: the join page hits collect endpoints with join_code — must resolve."""
+    _enable_collection(db, test_event)
+    r = client.get(f"/api/public/collect/{test_event.join_code}")
+    assert r.status_code == 200
+    # The canonical collection code is echoed back, regardless of which code resolved it.
+    assert r.json()["code"] == test_event.code
+
+
+def test_join_config_resolves_by_join_code(client, db, test_event: Event):
+    r = client.get(f"/api/public/collect/{test_event.join_code}/join-config")
+    assert r.status_code == 200
+    assert r.json() == {"frictionless_join": False}
+
+
+def test_ensure_name_resolves_by_join_code_when_frictionless(client, db, test_event: Event):
+    test_event.frictionless_join = True
+    db.commit()
+    r = client.post(
+        f"/api/public/collect/{test_event.join_code}/guest/ensure-name", json={}
+    )
+    assert r.status_code == 200
+    assert r.json()["auto_generated"] is True
+
+
+def test_ensure_name_boundary_is_flag_not_code(client, db, test_event: Event):
+    """The frictionless boundary is the flag, never the code: a non-frictionless
+    event reached by join_code still refuses auto-naming."""
+    # test_event.frictionless_join defaults to False
+    r = client.post(
+        f"/api/public/collect/{test_event.join_code}/guest/ensure-name", json={}
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "frictionless_disabled"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/pytest tests/test_collect_public.py -q -k "join_code or boundary"`
+Expected: FAIL — preview/join-config/ensure-name return 404 for `join_code` (collection-only resolver).
+
+- [ ] **Step 3: Implement — switch `_get_event_or_404` to the canonical resolver**
+
+```python
+# server/app/api/collect.py — replace _get_event_or_404 (lines 65-69)
+
+def _get_event_or_404(db: Session, code: str) -> Event:
+    # Resolve by EITHER public code (collection or join). Collect's gates
+    # (require_verified_human / require_email_verified) still enforce auth, so
+    # accepting a join_code here changes resolution, not authorization. Preserve
+    # collect's existing "inactive -> 404" semantics.
+    event, _ = get_event_by_public_code_with_status(db, code)
+    if event is None or not event.is_active:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return event
+```
+Add the import at the top of `collect.py` (extend the existing `from app.services... import` for event helpers, or add):
+```python
+from app.services.event import get_event_by_public_code_with_status
+```
+
+- [ ] **Step 4: Run to verify pass (and no collect regressions)**
+
+Run: `.venv/bin/pytest tests/test_collect_public.py tests/test_collect_service.py -q`
+Expected: PASS (new tests pass; all pre-existing collect tests still green — collection code still resolves identically).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/api/collect.py server/tests/test_collect_public.py
+git commit -m "fix(routing): collect router resolves by either public code (#382)"
+```
+
+---
+
+## Task 3: events.py search + submit resolve by either code; SSE submit publishes event.code
+
+**Files:**
+- Modify: `server/app/api/events.py` — `event_search` (~line 398), `submit_request` (~line 623 + `publish_event` at ~660)
+- Test: `server/tests/test_dual_code_routing.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# server/tests/test_dual_code_routing.py — append
+
+from app.services.event_bus import get_event_bus
+
+
+def test_submit_request_resolves_by_join_code(client, db, test_event: Event):
+    r = client.post(
+        f"/api/events/{test_event.join_code}/requests",
+        json={"artist": "Daft Punk", "title": "One More Time"},
+    )
+    assert r.status_code == 200
+
+
+def test_get_event_stays_collection_only(client, db, test_event: Event):
+    """The DJ/general GET /api/events/{code} is NOT made canonical — it stays
+    collection-only and keeps leaking EventOut.id to the authed DJ. A guest
+    join_code must NOT resolve here (guests use GET /api/public/events/{code})."""
+    assert client.get(f"/api/events/{test_event.code}").status_code == 200
+    assert client.get(f"/api/events/{test_event.join_code}").status_code == 404
+
+
+def test_submit_via_join_code_publishes_on_event_code_channel(client, db, test_event: Event):
+    """SSE channels are keyed by event.code; the stream subscribes by event.code
+    after resolving join_code. So a join_code submit must publish on event.code,
+    else the guest's own submit never reaches the guest's own stream."""
+    bus = get_event_bus()
+    queue = bus.subscribe(test_event.code)  # mirrors sse.py: subscribes event.code
+    try:
+        r = client.post(
+            f"/api/events/{test_event.join_code}/requests",
+            json={"artist": "Stardust", "title": "Music Sounds Better"},
+        )
+        assert r.status_code == 200
+        msg = queue.get_nowait()  # raises if nothing published to event.code
+        assert msg["event"] == "request_created"
+    finally:
+        bus.unsubscribe(test_event.code, queue)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/pytest tests/test_dual_code_routing.py -q -k "submit or get_event_stays"`
+Expected: FAIL — `submit_request` 404s on `join_code`; the SSE test's `get_nowait()` raises `QueueEmpty` (publishes on the URL join_code channel, not event.code).
+
+- [ ] **Step 3: Implement**
+
+In `event_search` (~line 398) replace:
+```python
+    event_obj, lookup_result = get_event_by_code_with_status(db, code)
+```
+with:
+```python
+    event_obj, lookup_result = get_event_by_public_code_with_status(db, code)
+```
+
+In `submit_request` (~line 623) replace:
+```python
+    event, lookup_result = get_event_by_code_with_status(db, code)
+```
+with:
+```python
+    event, lookup_result = get_event_by_public_code_with_status(db, code)
+```
+
+In `submit_request`'s SSE publish (~line 660) replace `code` with `event.code`:
+```python
+    if not is_duplicate:
+        publish_event(
+            event.code,  # canonical SSE channel key (matches the stream subscriber)
+            "request_created",
+            {
+                "request_id": song_request.id,
+                "title": song_request.song_title,
+                "artist": song_request.artist,
+            },
+        )
+```
+
+Add to the events.py import of event services:
+```python
+from app.services.event import get_event_by_public_code_with_status
+```
+(keep `get_event_by_code_with_status` imported — `get_event` still uses it.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/pytest tests/test_dual_code_routing.py tests/test_events.py -q`
+Expected: PASS (new tests pass; existing events tests still green — collection code still resolves for submit/search).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/api/events.py server/tests/test_dual_code_routing.py
+git commit -m "fix(routing): events search/submit resolve by either code; SSE publishes event.code (#382)"
+```
+
+---
+
+## Task 4: public.py guest reads + SSE stream resolve by either code
+
+**Files:**
+- Modify: `server/app/api/public.py` — `get_public_requests` (~191), `check_has_requested` (~258), `get_my_requests` (~291); import line 18.
+- Modify: `server/app/api/sse.py` — `event_stream` (~80).
+- Test: `server/tests/test_dual_code_routing.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# server/tests/test_dual_code_routing.py — append
+
+def test_public_requests_resolve_by_either_code(client, db, test_event: Event):
+    # Already worked by join_code; now also resolves by collection code (one resolver).
+    assert client.get(f"/api/public/events/{test_event.join_code}/requests").status_code == 200
+    assert client.get(f"/api/public/events/{test_event.code}/requests").status_code == 200
+    assert client.get(f"/api/public/events/{test_event.join_code}/has-requested").status_code == 200
+    assert client.get(f"/api/public/events/{test_event.code}/has-requested").status_code == 200
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/pytest tests/test_dual_code_routing.py -q -k "either_code"`
+Expected: FAIL — the `code` (collection) variants 404 (public reads are join_code-only today).
+
+- [ ] **Step 3: Implement**
+
+In `public.py` line 18 change the import:
+```python
+from app.services.event import (
+    EventLookupResult,
+    get_event_by_join_code_with_status,        # still used by get_kiosk_display
+    get_event_by_public_code_with_status,
+)
+```
+In `get_public_requests`, `check_has_requested`, `get_my_requests`, replace each:
+```python
+    event, lookup_result = get_event_by_join_code_with_status(db, code)
+```
+with:
+```python
+    event, lookup_result = get_event_by_public_code_with_status(db, code)
+```
+(Leave `get_kiosk_display` on `get_event_by_join_code_with_status` — kiosk is a separate surface, out of scope.)
+
+In `sse.py` `event_stream` (~80) replace:
+```python
+    event, result = get_event_by_join_code_with_status(db, code)
+```
+with:
+```python
+    event, result = get_event_by_public_code_with_status(db, code)
+```
+and update the `sse.py` import line accordingly (add `get_event_by_public_code_with_status`). The generator still subscribes `event.code` — unchanged.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/pytest tests/test_dual_code_routing.py tests/test_public.py tests/test_sse_security.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/api/public.py server/app/api/sse.py server/tests/test_dual_code_routing.py
+git commit -m "fix(routing): public guest reads + SSE stream resolve by either code (#382)"
+```
+
+---
+
+## Task 5: New guest-safe `GET /api/public/events/{code}` (no event.id)
+
+**Files:**
+- Modify: `server/app/api/public.py` — add `PublicEventResponse` schema (near the other schemas, ~line 75) + endpoint (after `get_kiosk_display`).
+- Test: `server/tests/test_dual_code_routing.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# server/tests/test_dual_code_routing.py — append
+
+def test_public_event_endpoint_resolves_both_and_omits_id(client, db, test_event: Event):
+    for code in (test_event.join_code, test_event.code):
+        r = client.get(f"/api/public/events/{code}")
+        assert r.status_code == 200, code
+        body = r.json()
+        # Serializer hygiene: the private surrogate key must never be emitted.
+        assert "id" not in body
+        assert test_event.id not in body.values()
+        assert body["name"] == test_event.name
+        assert body["collection_code"] == test_event.code
+        assert body["frictionless_join"] is False
+        assert body["requests_open"] is True
+        assert body["phase"] in {"pre_announce", "collection", "live", "closed"}
+
+
+def test_public_event_endpoint_404_and_410(client, db, test_event: Event):
+    assert client.get("/api/public/events/ZZZZZZ").status_code == 404
+    test_event.is_active = False
+    db.commit()
+    assert client.get(f"/api/public/events/{test_event.join_code}").status_code == 410
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/pytest tests/test_dual_code_routing.py -q -k "public_event_endpoint"`
+Expected: FAIL — 404 (endpoint does not exist yet).
+
+- [ ] **Step 3: Implement the schema + endpoint**
+
+```python
+# server/app/api/public.py — add near the schema block (after HasRequestedResponse, ~line 77)
+
+class PublicEventResponse(BaseModel):
+    """Guest-safe live-event projection. Deliberately omits event.id and any
+    DJ-only fields (see #382 serializer hygiene)."""
+
+    name: str
+    collection_code: str
+    requests_open: bool
+    frictionless_join: bool
+    phase: Literal["pre_announce", "collection", "live", "closed"]
+    submission_cap_per_guest: int
+    banner_url: str | None = None
+    banner_colors: list[str] | None = None
+```
+
+```python
+# server/app/api/public.py — add after get_kiosk_display
+
+@router.get("/events/{code}", response_model=PublicEventResponse)
+@limiter.limit("120/minute")
+def get_public_event(
+    code: str,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> PublicEventResponse:
+    """Guest-safe event info for the live /join page. Resolves by EITHER public
+    code; never emits event.id. Replaces the join page's use of the DJ
+    EventOut endpoint (which leaks the private id) and folds in phase +
+    frictionless_join."""
+    event, lookup_result = get_event_by_public_code_with_status(db, code)
+    if lookup_result == EventLookupResult.NOT_FOUND:
+        raise HTTPException(status_code=404, detail="Event not found")
+    if lookup_result == EventLookupResult.EXPIRED:
+        raise HTTPException(status_code=410, detail="Event has expired")
+    if lookup_result == EventLookupResult.ARCHIVED:
+        raise HTTPException(status_code=410, detail="Event has been archived")
+
+    banner_url = None
+    banner_colors = None
+    if event.banner_filename:
+        api_base = str(request.base_url).rstrip("/")
+        if request.headers.get("x-forwarded-proto") == "https" and api_base.startswith("http://"):
+            api_base = "https://" + api_base[len("http://") :]
+        banner_url = f"{api_base}/uploads/{event.banner_filename}"
+        if event.banner_colors:
+            banner_colors = json.loads(event.banner_colors)
+
+    return PublicEventResponse(
+        name=event.name,
+        collection_code=event.code,
+        requests_open=event.requests_open,
+        frictionless_join=event.frictionless_join,
+        phase=event.phase,
+        submission_cap_per_guest=event.submission_cap_per_guest,
+        banner_url=banner_url,
+        banner_colors=banner_colors,
+    )
+```
+(`json` and `Literal` are already imported in `public.py`.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/pytest tests/test_dual_code_routing.py -q`
+Expected: PASS (all dual-code tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/api/public.py server/tests/test_dual_code_routing.py
+git commit -m "feat(routing): guest-safe GET /api/public/events/{code} (no id leak) (#382)"
+```
+
+---
+
+## Task 6: Regenerate OpenAPI types + frontend API client
+
+**Files:**
+- Regenerate: `server/openapi.json`, `dashboard/lib/api-types.generated.ts`
+- Modify: `dashboard/lib/api-types.ts`, `dashboard/lib/api.ts`
+
+- [ ] **Step 1: Regenerate the OpenAPI spec + TS types**
+
+```bash
+cd dashboard
+npm run types:export     # server/.venv python writes server/openapi.json
+npm run types:generate   # openapi-typescript -> lib/api-types.generated.ts
+```
+Expected: `PublicEventResponse` now present in `lib/api-types.generated.ts` (grep to confirm: `grep PublicEventResponse lib/api-types.generated.ts`).
+
+- [ ] **Step 2: Add the `PublicEvent` alias**
+
+```typescript
+// dashboard/lib/api-types.ts — add near `export type Event = Schemas['EventOut'];`
+export type PublicEvent = Schemas['PublicEventResponse'];
+```
+
+- [ ] **Step 3: Export `PublicEvent` + add the client method**
+
+In `dashboard/lib/api.ts`, add `PublicEvent` to BOTH the `import type { … } from './api-types'` block (line 1) and the `export type { … } from './api-types'` block (line 44).
+
+Add the method next to `getPublicRequests` (~line 743):
+```typescript
+  async getPublicEvent(code: string): Promise<PublicEvent> {
+    return this.publicFetch(`${getApiUrl()}/api/public/events/${code}`);
+  }
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd dashboard && npx tsc --noEmit`
+Expected: PASS (no type errors; `PublicEvent` resolves).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/openapi.json dashboard/lib/api-types.generated.ts dashboard/lib/api-types.ts dashboard/lib/api.ts
+git commit -m "feat(api): getPublicEvent client + regenerated OpenAPI types (#382)"
+```
+
+---
+
+## Task 7: Rewire the live `/join` page onto the guest-safe surface
+
+**Files:**
+- Modify: `dashboard/app/join/[code]/page.tsx`
+- Test: `dashboard/app/join/[code]/__tests__/page.test.tsx`
+
+> **Scope note (low-risk minimal change):** keep `getJoinConfig` for the pre-gate frictionless decision (it now resolves via the canonical resolver, so it works on `join_code`); swap only the id-leaking `getEvent` → `getPublicEvent` and drop `getCollectEvent` (phase now comes from `getPublicEvent`). Folding `getJoinConfig` into `getPublicEvent` is a deferred optional optimization — not done here to avoid disturbing the delicate gate choreography.
+
+- [ ] **Step 1: Update the test mocks (failing first)**
+
+In `dashboard/app/join/[code]/__tests__/page.test.tsx`:
+- Add `getPublicEvent: vi.fn()` to the `mockApi` object (in the `vi.hoisted` block).
+- In `setupDefaultMocks()`, add:
+```typescript
+  mockApi.getPublicEvent.mockResolvedValue({
+    name: 'Test Event',
+    collection_code: 'TEST01',
+    requests_open: true,
+    frictionless_join: false,
+    phase: 'live',
+    submission_cap_per_guest: 5,
+    banner_url: null,
+    banner_colors: null,
+  });
+```
+- Add an assertion test:
+```typescript
+  it('loads the event via getPublicEvent and never calls the id-leaking getEvent', async () => {
+    setupDefaultMocks();
+    render(<JoinEventPage />);
+    await waitFor(() => expect(mockApi.getPublicEvent).toHaveBeenCalledWith('TEST01'));
+    expect(mockApi.getEvent).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd dashboard && npm test -- --run app/join`
+Expected: FAIL — page still calls `getEvent`; `getPublicEvent` never called.
+
+- [ ] **Step 3: Implement the page changes**
+
+In `dashboard/app/join/[code]/page.tsx`:
+
+(a) Change the `event` state type import + declaration — replace `Event` with `PublicEvent`:
+```typescript
+import { api, ApiError, PublicEvent, GuestNowPlaying, GuestRequestInfo, SearchResult } from '@/lib/api';
+```
+```typescript
+  const [event, setEvent] = useState<PublicEvent | null>(null);
+```
+
+(b) In `loadEvent` (~165), swap the loader and set phase here:
+```typescript
+  const loadEvent = useCallback(async () => {
+    try {
+      const data = await api.getPublicEvent(code);
+      setEvent(data);
+      setCollectPhase(data.phase);
+      setError(null);
+      try {
+        const { has_requested } = await api.checkHasRequested(code);
+        if (!has_requested) setShowRequestSheet(true);
+      } catch {
+        setShowRequestSheet(true);
+      }
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError({ message: err.message, status: err.status });
+      } else {
+        setError({ message: 'Event not found or has expired.', status: 0 });
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [code]);
+```
+
+(c) In the collect-phase effect (~193), drop `getCollectEvent` (phase now set in `loadEvent`); keep only the profile read for `email_verified`:
+```typescript
+  useEffect(() => {
+    if (!gateComplete || !code) return;
+    let cancelled = false;
+    api.getCollectProfile(code)
+      .then((profile) => {
+        if (!cancelled) setEmailVerified(profile.email_verified);
+      })
+      .catch(() => { /* email-verified is best-effort on the live page */ });
+    return () => { cancelled = true; };
+  }, [code, gateComplete]);
+```
+
+(d) Phase-banner link (~507) — use the collection code from the resolved event, not the URL `join_code`:
+```typescript
+        🎟️ Pre-event voting is open —{' '}
+        <a href={`/collect/${event.collection_code}`}>go to the pre-event page →</a>
+```
+(`event` is in scope here — this block renders after the `error || !event` guard.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd dashboard && npm test -- --run app/join && npx tsc --noEmit`
+Expected: PASS (join tests green, including the new assertion; typecheck clean).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/app/join
+git commit -m "fix(join): live page uses guest-safe getPublicEvent; collect link uses collection_code (#382)"
+```
+
+---
+
+## Task 8: Full local CI gate
+
+**Files:** none (validation; commit any fixes)
+
+- [ ] **Step 1: Backend CI**
+
+```bash
+cd server
+.venv/bin/ruff check .
+.venv/bin/ruff format --check .
+.venv/bin/bandit -r app -c pyproject.toml -q
+.venv/bin/pytest --tb=short -q
+```
+Expected: all pass; coverage ≥ threshold. Fix lint/format with `.venv/bin/ruff check --fix . && .venv/bin/ruff format .` and re-run.
+
+- [ ] **Step 2: Alembic drift check (no migration expected)**
+
+```bash
+.venv/bin/alembic upgrade head && .venv/bin/alembic check
+```
+Expected: "No new upgrade operations detected." (no model change in this fix).
+
+- [ ] **Step 3: Frontend CI**
+
+```bash
+cd ../dashboard
+npm run lint
+npx tsc --noEmit
+npm test -- --run
+git checkout next-env.d.ts 2>/dev/null || true   # auto-modified by builds; never commit
+```
+Expected: all pass.
+
+- [ ] **Step 4: Commit any fixes**
+
+```bash
+git add -A && git commit -m "chore: satisfy local CI for dual-code routing fix (#382)" || echo "nothing to fix"
+```
+
+- [ ] **Step 5: Push + open PR**
+
+```bash
+git push -u origin fix/dual-code-routing-382
+gh pr create --base main --title "fix(routing): dual-code routing for frictionless /join (#382)" \
+  --body "Closes #382. Canonical guest resolver (either public code) + guest-safe /api/public/events/{code} (no id leak) + SSE event.code publish. No migration. See docs/superpowers/specs/2026-05-30-dual-code-routing-design.md."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Canonical resolver → Task 1. ✓
+- Collect router canonical → Task 2. ✓
+- events search/submit canonical + SSE publish event.code → Task 3. ✓
+- public reads + SSE stream canonical → Task 4. ✓
+- New guest-safe endpoint (no id) → Task 5. ✓
+- OpenAPI regen + client → Task 6. ✓
+- Frontend rewire (getPublicEvent, drop getCollectEvent, collection_code link) → Task 7. ✓
+- Drift guards: resolver-accepts-both (Task 1), serializer-hygiene no-id (Task 5), frictionless-flag-boundary (Task 2), SSE channel-match (Task 3). ✓
+- `get_event` stays collection-only / DJ id-leak out of scope → pinned by `test_get_event_stays_collection_only` (Task 3). ✓
+- No migration; CI gate → Task 8. ✓
+
+**Placeholder scan:** none — every step has runnable code/commands.
+
+**Type consistency:** backend `get_event_by_public_code_with_status` (Tasks 1–5) used identically everywhere; `PublicEventResponse` (backend) ↔ `Schemas['PublicEventResponse']` ↔ `PublicEvent` (frontend) ↔ `getPublicEvent` return — consistent across Tasks 5–7. `event.collection_code` used in both the schema (Task 5) and the page link (Task 7).
+
+**Known follow-ups (documented, not gaps):** folding `getJoinConfig` into `getPublicEvent`; dropping the redundant response `status` field (already omitted — endpoint signals expiry via HTTP 410); token-enumeration hardening (orthogonal, tracked separately in the spec).

--- a/docs/superpowers/specs/2026-05-30-dual-code-routing-design.md
+++ b/docs/superpowers/specs/2026-05-30-dual-code-routing-design.md
@@ -57,7 +57,7 @@ Every endpoint the `/join/[code]` page calls today, with how the backend resolve
 - **Hard capability-scoping** (collect endpoints rejecting `join_code` and vice versa). Explicitly decided against: both codes are public and map to one event, the private key is `event.id`, and behavioral gating lives in flags/auth — so cross-code resolution carries no security weight. The cost (endpoint twins + parametrizing the shared `NicknameGate`) is exactly the redundancy/drift we want to avoid.
 - A third/encrypted code. `event.id` already is the private canonical key; encrypting a value never transmitted is negative ROI.
 - Changing collect-page auth (email + human) — unchanged.
-- Changing DJ `get_event`/`EventOut` (still exposes `id` to the **authenticated** DJ) — out of scope; we only stop guests from hitting it.
+- ~~Changing DJ `get_event`/`EventOut`~~ — **scope expanded during final review** (see [Addendum](#addendum-get_event-hardening-scope-expansion)). The original assumption that `get_event` is "DJ-authenticated" was **factually wrong**: it had no auth dependency and was publicly readable, leaking `event.id` **and** `join_code` (via `join_url`) to any holder of the collection code. It is now gated to owner-or-admin.
 - Bridge (`event.code`), kiosk display/`kiosk-link` (`join_code`/`code` as today), DJ management resolution — unchanged.
 - Token-enumeration hardening (code length / rate limits) — orthogonal; tracked separately.
 
@@ -94,7 +94,7 @@ Reuses the existing `_event_with_status` (NOT_FOUND / ARCHIVED / EXPIRED / FOUND
 | events.py `submit_request` | `get_event_by_code_with_status` | canonical |
 | public.py `get_public_requests`, `check_has_requested`, `get_my_requests` | join_code | canonical (behavior-preserving for existing join_code callers) |
 | sse.py `event_stream` | join_code | canonical (still subscribes by `event.code`) |
-| events.py `get_event` (DJ + kiosk-link) | collection | **unchanged** (DJ/authed; guest use is removed — see §3) |
+| events.py `get_event` (DJ event page) | collection | **owner/admin gated** — was public, now `Depends(get_current_active_user)` + owner-or-admin (Addendum); guest use removed (§3) |
 | public.py `get_kiosk_display`, bridge, DJ management | as today | **unchanged** |
 
 After this, there is exactly **one** resolver for the guest-join surface. `NicknameGate` works on both pages with **zero component change** (its profile reads/writes now resolve either code).
@@ -151,7 +151,7 @@ Required frontend delta is small and mostly deletion. Everything else works once
 | `test_public_event_endpoint_no_id_leak` | `GET /api/public/events/{join_code}` body contains no key equal to `event.id`; schema declares no `id` field |
 | `test_public_event_endpoint_fields` | Response carries `frictionless_join`, `phase`, `requests_open`, `collection_code == event.code` |
 | `test_sse_submit_via_join_code_publishes_event_code` | `submit_request` reached by `join_code` calls `publish_event(event.code, ...)` so a `/stream/{join_code}` subscriber receives it |
-| `test_dj_get_event_unchanged` | `GET /api/events/{collection_code}` (DJ) still returns `EventOut` with `id` (authed) — no regression |
+| `test_get_event_requires_auth_no_id_leak` / `test_get_event_owner_and_admin_ok_nonowner_404` | `GET /api/events/{code}` → 401 unauth, 404 authed non-owner, 200 owner/admin (Addendum hardening) |
 | `test_collect_page_endpoints_unchanged_by_collection_code` | All collect endpoints still resolve normally via collection code |
 
 ### Frontend (vitest — extend `app/join/[code]/__tests__/page.test.tsx`)
@@ -188,8 +188,22 @@ Required frontend delta is small and mostly deletion. Everything else works once
 | Exposing `collection_code` to live guests via `getPublicEvent` | Acceptable — collection code is the *more* public, long-lived share code; the collect page stays auth-gated. |
 | New endpoint duplicates some `EventOut` fields | Intentional guest-safe projection (id hygiene); narrow, read-only, low maintenance. |
 | Missed a `publish_event` site still keying URL code | Test asserts the submit path; grep-audit all call sites during implementation. |
-| `get_event` still leaks `id` to DJ | Out of scope — DJ is authenticated and trusted; guest path no longer touches it. |
+| `get_event` was **public**, leaking `id` + `join_code` to any collection-code holder | **Fixed** (Addendum): owner-or-admin gate. The spec originally mis-scoped this as "DJ-authed"; final review caught that it had no auth dependency. |
 | Future endpoint wires the wrong resolver | `test_public_code_resolver_accepts_both` + serializer-hygiene test are the drift guards. |
+
+## Addendum: get_event hardening (scope expansion)
+
+Surfaced by the final whole-branch review: this spec assumed `GET /api/events/{code}` was DJ-authenticated and therefore out of scope. **That was wrong.** The endpoint had **no auth dependency** — it was publicly readable and returned `EventOut` (`id`, both codes, `join_url`, `collect_url`). So beyond the join page (which the main fix moved onto `getPublicEvent`), *anyone holding the public collection code* could `curl /api/events/{collection_code}` to read the private `event.id` **and derive the `join_code`** from `join_url` — partially defeating #324's intent that the join_code is revealed in-venue (it even bypassed the human-gated `live-join-code` endpoint).
+
+The user approved expanding this PR to close it.
+
+**Fix.** `get_event` now requires `Depends(get_current_active_user)` and is restricted to the **owning DJ or an admin**; non-owners get **404** (not 403) to avoid leaking event existence. Resolution and the existing 404/410 (NOT_FOUND / EXPIRED / ARCHIVED) semantics are unchanged. Branch order: NOT_FOUND→404, then owner/admin→404, then EXPIRED/ARCHIVED→410 — so a non-owner can never distinguish event state. `EventOut`'s shape is unchanged (no frontend ripple; the DJ event page already sends a Bearer token). The endpoint's OpenAPI `security` stanza was regenerated.
+
+**Status matrix:** unauthenticated → 401; authed non-owner non-admin → 404; owner → 200; admin → 200; owner on expired/archived → 410.
+
+**Tests:** `test_get_event_requires_auth_no_id_leak` (401 unauth pins the closed leak) + `test_get_event_owner_and_admin_ok_nonowner_404`. Eight pre-existing tests that called `get_event` unauthenticated were updated to send owner/admin headers (assertions unchanged).
+
+**Not done here (possible future follow-up):** the `live-join-code` reveal-gating story is now consistent for `get_event`, but a broader audit of every endpoint that emits `join_url`/`join_code` is out of scope for this PR.
 
 ## Sources
 

--- a/docs/superpowers/specs/2026-05-30-dual-code-routing-design.md
+++ b/docs/superpowers/specs/2026-05-30-dual-code-routing-design.md
@@ -1,0 +1,197 @@
+# Dual-Code Routing Fix — Design
+
+**Status:** Draft for approval
+**Author:** thewrz
+**Date:** 2026-05-30
+**Issue:** [#382](https://github.com/thewrz/WrzDJ/issues/382) — Dual-code routing breaks frictionless `/join`
+**Related:** #324 (collection-vs-live code split — `2026-05-20-collection-vs-live-event-codes-design.md`), #380 (frictionless join — `2026-05-29-frictionless-join-design.md`), #381 (nickname email-gate fix)
+
+## Background
+
+The #324 split gave each event two public codes on one row: `event.code` (collection — long-lived, social-media, gated) and `event.join_code` (live — day-of, in-venue, frictionless). That spec's routing audit told implementers to "route every `Event.code ==` filter through the appropriate helper" but the audit was **incomplete**: the live `/join` page also calls the general `/api/events/{code}` family (`get_event`, `event_search`, `submit_request`), which were never migrated and still resolve by **collection code**.
+
+Then #380 (frictionless) added two new collection-router endpoints (`join-config`, `ensure-name`) and three cross-page reads (`getCollectEvent` for phase, `getCollectProfile` for email-verified) **onto the live `/join` page** — all resolving by collection code, all called with `join_code`. This re-introduced and widened the mismatch.
+
+**Net effect:** no single `{code}` value makes the `/join` page work. The real DJ share link carries `join_code` (`events.py` builds `join_url = /join/{event.join_code}`), so the canonical link hits the collection-resolving main loader and 404s into the error screen. Using the collection code instead loads the shell but every live endpoint (queue, votes, SSE) 404s, leaving a permanently empty queue.
+
+This is a **resolution-layer** defect only. De-dupe, votes, OTP, and guest identity are keyed by `event_id + guest_id`, never by the code string — so once a call resolves to the right `Event`, every downstream path is already correct. The blast radius is "which lookup each guest endpoint uses."
+
+## Root cause — corrected routing matrix
+
+Every endpoint the `/join/[code]` page calls today, with how the backend resolves the URL `{code}`:
+
+| Frontend call | Endpoint | Router | Resolves by | Broken on `join_code`? |
+|---|---|---|---|---|
+| `getEvent` (main loader) | `GET /api/events/{code}` | events.py | **collection** | ✗ 404 → error screen |
+| `eventSearch` | `GET /api/events/{code}/search` | events.py | **collection** | ✗ |
+| `submitRequest` | `POST /api/events/{code}/requests` | events.py | **collection** | ✗ |
+| `getJoinConfig` | `GET /api/public/collect/{code}/join-config` | collect.py | **collection** | ✗ |
+| `ensureGuestName` | `POST /api/public/collect/{code}/guest/ensure-name` | collect.py | **collection** | ✗ |
+| `getCollectEvent` (phase) | `GET /api/public/collect/{code}` | collect.py | **collection** | ✗ |
+| `getCollectProfile` (email-verified) | `GET /api/public/collect/{code}/profile` | collect.py | **collection** | ✗ |
+| `getCollectProfile`/`setCollectProfile` **via `NicknameGate`** | `GET`/`POST /api/public/collect/{code}/profile` | collect.py | **collection** | ✗ (non-frictionless path) |
+| `checkHasRequested` | `GET /api/public/events/{code}/has-requested` | public.py | join_code | ✓ works |
+| `getPublicRequests` | `GET /api/public/events/{code}/requests` | public.py | join_code | ✓ works |
+| `MyRequestsTracker` | `GET /api/public/events/{code}/my-requests` | public.py | join_code | ✓ works |
+| `useEventStream` | `GET /api/public/events/{code}/stream` | sse.py | join_code | ✓ works |
+
+`NicknameGate` is a **shared component** mounted by both the collect page (collection code) and the non-frictionless `/join` path (`join_code`), so its profile reads/writes are part of the broken surface.
+
+### Two latent bugs surfaced during analysis
+
+1. **Private id leak.** `GET /api/events/{code}` returns `EventOut`, which serializes `id: int` (= `event.id`) plus **both** codes and `join_url`/`collect_url`. The `/join` page calls this — so the canonical private key the product wants kept blind is exposed to guests whenever that call succeeds. `event.id` is already the de-facto private identifier (every guest handler operates on it server-side and never serializes it elsewhere); the fix is to keep it that way on the live surface.
+2. **SSE channel keying.** `event_bus` channels are keyed by a single code string. The stream endpoint resolves `join_code → event` then subscribes by **`event.code`** (canonical). Publishers must therefore publish on `event.code`, not the URL code. `submit_request` currently publishes the **URL** `code`; today that equals `event.code` (DJ uses collection code), but once a `join_code` can reach submit, publishing the URL code would post to the wrong channel and the guest's own submit would never reach the guest's own stream.
+
+## Goals
+
+- Every **guest-facing** endpoint resolves to the same `Event` regardless of which of the event's two public codes the client holds. Codes are globally unique across both columns (`generate_unique_event_code`), so this is collision-free.
+- The live `/join` page works end-to-end via the real `join_code` share link: load, frictionless auto-name **or** nickname gate, queue, votes, search, submit, SSE, email verification, lost-cookie → re-login → guest-merge.
+- Behavioral boundaries (frictionless vs collect) stay enforced by **flags and auth dependencies** (`event.frictionless_join`, `require_email_verified`, `require_verified_human`), never by code identity.
+- Close the `event.id` leak on the live guest surface.
+- Drift-resistant: one canonical guest resolver + guard tests that fail if a future feature wires the wrong lookup or leaks the private id.
+- No regression to collect page, DJ dashboard, kiosk, or bridge.
+
+## Non-goals
+
+- Changing the two-code product model (#324 stays). Collect remains long-lived/gated; join remains day-of/frictionless.
+- **Hard capability-scoping** (collect endpoints rejecting `join_code` and vice versa). Explicitly decided against: both codes are public and map to one event, the private key is `event.id`, and behavioral gating lives in flags/auth — so cross-code resolution carries no security weight. The cost (endpoint twins + parametrizing the shared `NicknameGate`) is exactly the redundancy/drift we want to avoid.
+- A third/encrypted code. `event.id` already is the private canonical key; encrypting a value never transmitted is negative ROI.
+- Changing collect-page auth (email + human) — unchanged.
+- Changing DJ `get_event`/`EventOut` (still exposes `id` to the **authenticated** DJ) — out of scope; we only stop guests from hitting it.
+- Bridge (`event.code`), kiosk display/`kiosk-link` (`join_code`/`code` as today), DJ management resolution — unchanged.
+- Token-enumeration hardening (code length / rate limits) — orthogonal; tracked separately.
+
+## Design
+
+### 1. Canonical guest resolver (single source of truth)
+
+```python
+# server/app/services/event.py  (or_ already imported)
+
+def get_event_by_public_code_with_status(
+    db: Session, code: str
+) -> tuple[Event | None, EventLookupResult]:
+    """Resolve a guest-facing public code that may be EITHER the collection
+    `code` or the live `join_code` (one event, two public handles). Behavioral
+    gating is enforced by the endpoint's flags/auth deps, never by which code
+    resolved the event."""
+    event = (
+        db.query(Event)
+        .filter(or_(Event.code == code.upper(), Event.join_code == code.upper()))
+        .first()
+    )
+    return _event_with_status(event)
+```
+
+Reuses the existing `_event_with_status` (NOT_FOUND / ARCHIVED / EXPIRED / FOUND), so every consumer keeps identical 404/410 semantics.
+
+### 2. Resolution swaps (the whole change is "use the canonical resolver on the guest surface")
+
+| Location | Today | After |
+|---|---|---|
+| collect.py `_get_event_or_404` | `Event.code == code` | canonical — covers preview, leaderboard, profile GET/POST, join-config, ensure-name, profile/me, requests, vote, enrich-preview, live-join-code in one swap |
+| events.py `event_search` | `get_event_by_code_with_status` | canonical |
+| events.py `submit_request` | `get_event_by_code_with_status` | canonical |
+| public.py `get_public_requests`, `check_has_requested`, `get_my_requests` | join_code | canonical (behavior-preserving for existing join_code callers) |
+| sse.py `event_stream` | join_code | canonical (still subscribes by `event.code`) |
+| events.py `get_event` (DJ + kiosk-link) | collection | **unchanged** (DJ/authed; guest use is removed — see §3) |
+| public.py `get_kiosk_display`, bridge, DJ management | as today | **unchanged** |
+
+After this, there is exactly **one** resolver for the guest-join surface. `NicknameGate` works on both pages with **zero component change** (its profile reads/writes now resolve either code).
+
+### 3. New guest-safe live event endpoint (closes the id leak + collapses 3 calls → 1)
+
+```
+GET /api/public/events/{code}   (canonical resolver, no auth)  → PublicEventResponse
+```
+
+New `PublicEventResponse` schema (`server/app/schemas/public.py`) — guest-safe projection, **no `event.id`**:
+
+| Field | Source | Why |
+|---|---|---|
+| `name` | `event.name` | header |
+| `collection_code` | `event.code` | the pre-event `/collect/{code}` cross-link (the public long-term code) |
+| `requests_open` | `event.requests_open` | CTA + closed state |
+| `status` | `compute_event_status` | active/expired/archived (drives 410 UX) |
+| `banner_url`, `banner_colors` | banner helpers | theming |
+| `phase` | `event.phase` | pre-event banner (replaces `getCollectEvent`) |
+| `frictionless_join` | `event.frictionless_join` | gate decision (replaces `getJoinConfig`) |
+| `submission_cap_per_guest` | `event.submission_cap_per_guest` | cap display |
+
+This single call replaces the join page's `getEvent` (EventOut, leaked id) **+** `getJoinConfig` **+** `getCollectEvent`. `email_verified`/`nickname` stay guest-scoped via the existing `getCollectProfile` (now canonical), so this endpoint needs no guest cookie.
+
+### 4. SSE publisher fix
+
+Audit every `publish_event(...)` call site and key on the resolved **`event.code`**, not the URL `code`:
+- `submit_request` (events.py) — **required**: a `join_code` submit must publish to the `event.code` channel the stream subscribes to.
+- accept-all / reject-all / now-playing (events.py), status-change (requests.py), bridge (bridge.py) — change to `event.code` for explicitness; no-op today (DJ/bridge already pass collection code = `event.code`).
+
+### 5. Frontend changes (live `/join` page only)
+
+| File | Change |
+|---|---|
+| `dashboard/lib/api.ts` | Add `getPublicEvent(code) → PublicEventResponse` (`publicFetch /api/public/events/{code}`). No change to `ensureGuestName`/`eventSearch`/`submitRequest`/`getCollectProfile` — their paths now resolve canonically. |
+| `dashboard/app/join/[code]/page.tsx` | Main loader: `getEvent` → `getPublicEvent`. Drop the separate `getJoinConfig` + `getCollectEvent` calls (folded into `getPublicEvent`: `frictionless_join`, `phase`). Phase-banner link uses `collection_code` from the response (not the URL `join_code`). Keep `getCollectProfile` for `email_verified`. |
+| `dashboard/components/NicknameGate.tsx` | **No change.** |
+
+Required frontend delta is small and mostly deletion. Everything else works once the backend resolvers go canonical.
+
+## Testing
+
+### Backend (pytest)
+
+| Test | Asserts |
+|---|---|
+| `test_public_code_resolver_accepts_both` | `get_event_by_public_code_with_status` returns the same event for `code` and `join_code`; NOT_FOUND for a bogus code |
+| `test_join_config_resolves_by_join_code` | `GET /collect/{join_code}/join-config` → 200 (was 404) |
+| `test_ensure_name_resolves_by_join_code` | `POST /collect/{join_code}/guest/ensure-name` auto-names on a frictionless event reached by join_code |
+| `test_frictionless_flag_gates_not_code` | `ensure-name` on a **non-frictionless** event returns 403 `frictionless_disabled` whether reached by `code` or `join_code` — boundary is the flag, not the code |
+| `test_collect_submit_still_email_gated_via_join_code` | `POST /collect/{join_code}/requests` without verified email → 403 `email_verification_required` (no vote-pump regression) |
+| `test_events_search_submit_resolve_by_join_code` | `GET /api/events/{join_code}/search` + `POST /api/events/{join_code}/requests` → 200 |
+| `test_public_event_endpoint_no_id_leak` | `GET /api/public/events/{join_code}` body contains no key equal to `event.id`; schema declares no `id` field |
+| `test_public_event_endpoint_fields` | Response carries `frictionless_join`, `phase`, `requests_open`, `collection_code == event.code` |
+| `test_sse_submit_via_join_code_publishes_event_code` | `submit_request` reached by `join_code` calls `publish_event(event.code, ...)` so a `/stream/{join_code}` subscriber receives it |
+| `test_dj_get_event_unchanged` | `GET /api/events/{collection_code}` (DJ) still returns `EventOut` with `id` (authed) — no regression |
+| `test_collect_page_endpoints_unchanged_by_collection_code` | All collect endpoints still resolve normally via collection code |
+
+### Frontend (vitest — extend `app/join/[code]/__tests__/page.test.tsx`)
+
+| Test | Asserts |
+|---|---|
+| `join loads via getPublicEvent` | Page mounts with mocked `getPublicEvent`, renders queue/CTA |
+| `frictionless path skips gate` | `frictionless_join: true` → `ensureGuestName` called, no `NicknameGate` |
+| `non-frictionless renders gate` | `frictionless_join: false` → `NicknameGate` renders |
+| `phase banner links to collection_code` | Pre-event banner href is `/collect/{collection_code}`, not the join_code |
+| `no getEvent/EventOut on join page` | Join page no longer calls the id-leaking `getEvent` |
+
+## Rollout
+
+- **No migration** — no schema change (resolver + one read endpoint + frontend). `alembic check` stays green (no model drift).
+- Local CI (mirrors `ci.yml`): backend ruff check / ruff format --check / bandit / pip-audit / pytest ≥85%; frontend lint / `tsc --noEmit` / vitest; bridge + bridge-app `tsc --noEmit` / vitest.
+- Branch `fix/dual-code-routing-382` → PR into `main` → remote CI green → squash-merge.
+- Deploy: `./deploy/deploy.sh` (no nginx change, no migration).
+- Optional "eat the dogfood" for a live LAN test before production.
+
+### Smoke (the real share link)
+
+1. Open `/join/{join_code}` (the DJ's actual link) in an incognito tab on a phone.
+2. Frictionless ON → lands on search with an auto-name; OFF → `NicknameGate` renders.
+3. Queue populates; cast a vote; submit a song; confirm SSE updates the queue live.
+4. Verify email from the identity bar; clear cookies; reopen the link; re-verify → guest-merge restores requests/votes.
+5. Confirm DevTools network has **no** response body containing the integer `event.id`.
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Canonical resolver lets a `join_code` hit collect endpoints | Collect gates (`require_email_verified`, `require_verified_human`) are unchanged — resolution ≠ authorization. `test_collect_submit_still_email_gated_via_join_code` pins it. |
+| Exposing `collection_code` to live guests via `getPublicEvent` | Acceptable — collection code is the *more* public, long-lived share code; the collect page stays auth-gated. |
+| New endpoint duplicates some `EventOut` fields | Intentional guest-safe projection (id hygiene); narrow, read-only, low maintenance. |
+| Missed a `publish_event` site still keying URL code | Test asserts the submit path; grep-audit all call sites during implementation. |
+| `get_event` still leaks `id` to DJ | Out of scope — DJ is authenticated and trusted; guest path no longer touches it. |
+| Future endpoint wires the wrong resolver | `test_public_code_resolver_accepts_both` + serializer-hygiene test are the drift guards. |
+
+## Sources
+
+- #324 design (`docs/superpowers/specs/2026-05-20-collection-vs-live-event-codes-design.md`) — established the two-code model and the (incomplete) routing audit this fix completes.
+- [OWASP — Insecure Direct Object Reference prevention](https://cheatsheetseries.owasp.org/cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.html) — keep internal surrogate keys (`event.id`) off public serializers.

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -50,6 +50,7 @@ from app.services.activity_log import log_activity
 from app.services.beatport import search_beatport_tracks
 from app.services.collect import NicknameConflictError, upsert_profile
 from app.services.dedup import compute_dedupe_key, find_duplicate
+from app.services.event import get_event_by_public_code_with_status
 from app.services.guest_names import generate_unique_nickname
 from app.services.sync.enrichment_pipeline import _find_best_match
 from app.services.sync.orchestrator import enrich_request_metadata
@@ -63,7 +64,11 @@ router = APIRouter()
 
 
 def _get_event_or_404(db: Session, code: str) -> Event:
-    event = db.query(Event).filter(Event.code == code).one_or_none()
+    # Resolve by EITHER public code (collection or join). Collect's gates
+    # (require_verified_human / require_email_verified) still enforce auth, so
+    # accepting a join_code here changes resolution, not authorization. Preserve
+    # collect's existing "inactive -> 404" semantics.
+    event, _ = get_event_by_public_code_with_status(db, code)
     if event is None or not event.is_active:
         raise HTTPException(status_code=404, detail="Event not found")
     return event

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -70,6 +70,7 @@ from app.services.event import (
     delete_event,
     get_archived_events_for_user,
     get_event_by_code_with_status,
+    get_event_by_public_code_with_status,
     get_events_for_user,
     get_expired_events_for_user,
     unarchive_event,
@@ -395,7 +396,7 @@ def event_search(
     from app.services.system_settings import get_system_settings
     from app.services.tidal import search_tidal_tracks
 
-    event_obj, lookup_result = get_event_by_code_with_status(db, code)
+    event_obj, lookup_result = get_event_by_public_code_with_status(db, code)
 
     if lookup_result == EventLookupResult.NOT_FOUND:
         raise HTTPException(status_code=404, detail="Event not found")
@@ -620,7 +621,7 @@ def submit_request(
     db: Session = Depends(get_db),
     _human: int | None = Depends(require_verified_human_soft),
 ) -> RequestOut:
-    event, lookup_result = get_event_by_code_with_status(db, code)
+    event, lookup_result = get_event_by_public_code_with_status(db, code)
 
     if lookup_result == EventLookupResult.NOT_FOUND:
         raise HTTPException(status_code=404, detail="Event not found")
@@ -658,7 +659,7 @@ def submit_request(
 
     if not is_duplicate:
         publish_event(
-            code,
+            event.code,  # canonical SSE channel key (matches the stream subscriber)
             "request_created",
             {
                 "request_id": song_request.id,

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -28,7 +28,7 @@ from app.core.config import get_settings
 from app.core.rate_limit import get_guest_id, limiter
 from app.models.event import Event
 from app.models.request import RequestStatus
-from app.models.user import User
+from app.models.user import User, UserRole
 from app.schemas.activity_log import ActivityLogEntry
 from app.schemas.collect import (
     BulkReviewRequest,
@@ -360,10 +360,23 @@ def get_activity_log(
 
 @router.get("/{code}", response_model=EventOut)
 @limiter.limit("60/minute")
-def get_event(code: str, request: Request, db: Session = Depends(get_db)) -> EventOut:
+def get_event(
+    code: str,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> EventOut:
     event, lookup_result = get_event_by_code_with_status(db, code)
 
     if lookup_result == EventLookupResult.NOT_FOUND:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    # EventOut exposes event.id + both codes + share URLs, so this endpoint is
+    # restricted to the owning DJ or an admin. Non-owners get 404 (not 403) to
+    # avoid leaking event existence. (Was public before #382 hardening.)
+    is_owner = event.created_by_user_id == current_user.id
+    is_admin = current_user.role == UserRole.ADMIN.value
+    if not (is_owner or is_admin):
         raise HTTPException(status_code=404, detail="Event not found")
 
     if lookup_result == EventLookupResult.EXPIRED:

--- a/server/app/api/public.py
+++ b/server/app/api/public.py
@@ -12,6 +12,7 @@ from app.api.deps import get_db
 from app.core.config import get_settings
 from app.core.rate_limit import get_guest_id, limiter
 from app.core.time import utcnow
+from app.models.event import Event
 from app.models.guest import Guest
 from app.models.request import Request as SongRequest
 from app.models.request import RequestStatus
@@ -25,6 +26,27 @@ from app.services.request import get_requests_by_guest
 
 router = APIRouter()
 settings = get_settings()
+
+
+def _build_public_banner(request: Request, event: Event) -> tuple[str | None, list[str] | None]:
+    """Build (banner_url, banner_colors) from an event for guest/kiosk responses.
+    api_base is the API server's own base URL (http->https when proxied). Colors
+    parse is defensive: malformed JSON yields None, never a 500."""
+    if not event.banner_filename:
+        return None, None
+    api_base = str(request.base_url).rstrip("/")
+    if request.headers.get("x-forwarded-proto") == "https" and api_base.startswith("http://"):
+        api_base = "https://" + api_base[len("http://") :]
+    banner_url = f"{api_base}/uploads/{event.banner_filename}"
+    banner_colors = None
+    if event.banner_colors:
+        try:
+            parsed = json.loads(event.banner_colors)
+            if isinstance(parsed, list) and all(isinstance(c, str) for c in parsed):
+                banner_colors = parsed
+        except (json.JSONDecodeError, TypeError):
+            banner_colors = None
+    return banner_url, banner_colors
 
 
 class PublicEventInfo(BaseModel):
@@ -170,18 +192,12 @@ def get_kiosk_display(
     )
 
     # Build banner URLs using the API server's own base URL (not PUBLIC_URL, which is the frontend)
-    banner_url = None
+    banner_url, banner_colors = _build_public_banner(request, event)
     banner_kiosk_url = None
-    banner_colors = None
-    if event.banner_filename:
-        api_base = str(request.base_url).rstrip("/")
-        if request.headers.get("x-forwarded-proto") == "https" and api_base.startswith("http://"):
-            api_base = "https://" + api_base[len("http://") :]
-        banner_url = f"{api_base}/uploads/{event.banner_filename}"
+    if banner_url is not None:
         stem = event.banner_filename.rsplit(".", 1)[0]
+        api_base = banner_url.rsplit("/uploads/", 1)[0]
         banner_kiosk_url = f"{api_base}/uploads/{stem}_kiosk.webp"
-        if event.banner_colors:
-            banner_colors = json.loads(event.banner_colors)
 
     return KioskDisplayResponse(
         event=PublicEventInfo(code=event.join_code, name=event.name),
@@ -216,15 +232,7 @@ def get_public_event(
     if lookup_result == EventLookupResult.ARCHIVED:
         raise HTTPException(status_code=410, detail="Event has been archived")
 
-    banner_url = None
-    banner_colors = None
-    if event.banner_filename:
-        api_base = str(request.base_url).rstrip("/")
-        if request.headers.get("x-forwarded-proto") == "https" and api_base.startswith("http://"):
-            api_base = "https://" + api_base[len("http://") :]
-        banner_url = f"{api_base}/uploads/{event.banner_filename}"
-        if event.banner_colors:
-            banner_colors = json.loads(event.banner_colors)
+    banner_url, banner_colors = _build_public_banner(request, event)
 
     return PublicEventResponse(
         name=event.name,

--- a/server/app/api/public.py
+++ b/server/app/api/public.py
@@ -15,7 +15,11 @@ from app.core.time import utcnow
 from app.models.guest import Guest
 from app.models.request import Request as SongRequest
 from app.models.request import RequestStatus
-from app.services.event import EventLookupResult, get_event_by_join_code_with_status
+from app.services.event import (
+    EventLookupResult,
+    get_event_by_join_code_with_status,
+    get_event_by_public_code_with_status,
+)
 from app.services.now_playing import get_now_playing, is_now_playing_hidden
 from app.services.request import get_requests_by_guest
 
@@ -188,7 +192,7 @@ def get_public_requests(
     db: Session = Depends(get_db),
 ) -> GuestRequestListResponse:
     """Get publicly visible requests for an event (NEW and ACCEPTED only)."""
-    event, lookup_result = get_event_by_join_code_with_status(db, code)
+    event, lookup_result = get_event_by_public_code_with_status(db, code)
 
     if lookup_result == EventLookupResult.NOT_FOUND:
         raise HTTPException(status_code=404, detail="Event not found")
@@ -255,7 +259,7 @@ def check_has_requested(
     db: Session = Depends(get_db),
 ) -> HasRequestedResponse:
     """Check if the current client has submitted any requests for this event."""
-    event, lookup_result = get_event_by_join_code_with_status(db, code)
+    event, lookup_result = get_event_by_public_code_with_status(db, code)
 
     if lookup_result == EventLookupResult.NOT_FOUND:
         raise HTTPException(status_code=404, detail="Event not found")
@@ -288,7 +292,7 @@ def get_my_requests(
     db: Session = Depends(get_db),
 ) -> MyRequestsResponse:
     """Get all requests submitted by the current client for this event."""
-    event, lookup_result = get_event_by_join_code_with_status(db, code)
+    event, lookup_result = get_event_by_public_code_with_status(db, code)
 
     if lookup_result == EventLookupResult.NOT_FOUND:
         raise HTTPException(status_code=404, detail="Event not found")

--- a/server/app/api/public.py
+++ b/server/app/api/public.py
@@ -80,6 +80,20 @@ class HasRequestedResponse(BaseModel):
     has_requested: bool
 
 
+class PublicEventResponse(BaseModel):
+    """Guest-safe live-event projection. Deliberately omits event.id and any
+    DJ-only fields (see #382 serializer hygiene)."""
+
+    name: str
+    collection_code: str
+    requests_open: bool
+    frictionless_join: bool
+    phase: Literal["pre_announce", "collection", "live", "closed"]
+    submission_cap_per_guest: int
+    banner_url: str | None = None
+    banner_colors: list[str] | None = None
+
+
 class KioskDisplayResponse(BaseModel):
     event: PublicEventInfo
     qr_join_url: str
@@ -180,6 +194,46 @@ def get_kiosk_display(
         updated_at=utcnow(),
         banner_url=banner_url,
         banner_kiosk_url=banner_kiosk_url,
+        banner_colors=banner_colors,
+    )
+
+
+@router.get("/events/{code}", response_model=PublicEventResponse)
+@limiter.limit("120/minute")
+def get_public_event(
+    code: str,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> PublicEventResponse:
+    """Guest-safe event info for the live /join page. Resolves by EITHER public
+    code; never emits event.id. Replaces the join page's use of the DJ EventOut
+    endpoint (which leaks the private id) and folds in phase + frictionless_join."""
+    event, lookup_result = get_event_by_public_code_with_status(db, code)
+    if lookup_result == EventLookupResult.NOT_FOUND:
+        raise HTTPException(status_code=404, detail="Event not found")
+    if lookup_result == EventLookupResult.EXPIRED:
+        raise HTTPException(status_code=410, detail="Event has expired")
+    if lookup_result == EventLookupResult.ARCHIVED:
+        raise HTTPException(status_code=410, detail="Event has been archived")
+
+    banner_url = None
+    banner_colors = None
+    if event.banner_filename:
+        api_base = str(request.base_url).rstrip("/")
+        if request.headers.get("x-forwarded-proto") == "https" and api_base.startswith("http://"):
+            api_base = "https://" + api_base[len("http://") :]
+        banner_url = f"{api_base}/uploads/{event.banner_filename}"
+        if event.banner_colors:
+            banner_colors = json.loads(event.banner_colors)
+
+    return PublicEventResponse(
+        name=event.name,
+        collection_code=event.code,
+        requests_open=event.requests_open,
+        frictionless_join=event.frictionless_join,
+        phase=event.phase,
+        submission_cap_per_guest=event.submission_cap_per_guest,
+        banner_url=banner_url,
         banner_colors=banner_colors,
     )
 

--- a/server/app/api/sse.py
+++ b/server/app/api/sse.py
@@ -11,7 +11,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from app.api.deps import get_db
 from app.core.rate_limit import limiter
-from app.services.event import EventLookupResult, get_event_by_join_code_with_status
+from app.services.event import EventLookupResult, get_event_by_public_code_with_status
 from app.services.event_bus import get_event_bus
 
 logger = logging.getLogger(__name__)
@@ -70,7 +70,7 @@ async def event_stream(
     - requests_bulk_update: Batch accept/reject
     - bridge_status_changed: Bridge connect/disconnect
     """
-    event, result = get_event_by_join_code_with_status(db, code)
+    event, result = get_event_by_public_code_with_status(db, code)
     if result == EventLookupResult.NOT_FOUND:
         raise HTTPException(status_code=404, detail="Event not found")
     if result == EventLookupResult.ARCHIVED:

--- a/server/app/services/event.py
+++ b/server/app/services/event.py
@@ -129,6 +129,24 @@ def get_event_by_join_code_with_status(
     return _event_with_status(event)
 
 
+def get_event_by_public_code_with_status(
+    db: Session, code: str
+) -> tuple[Event | None, EventLookupResult]:
+    """Resolve a guest-facing public code that may be EITHER the collection
+    `code` or the live `join_code` (one event, two public handles). Behavioral
+    gating (frictionless vs collect-auth) is enforced by each endpoint's
+    flags/auth dependencies, never by which code resolved the event. Codes are
+    globally unique across both columns (`generate_unique_event_code`), so this
+    is collision-free.
+    """
+    event = (
+        db.query(Event)
+        .filter(or_(Event.code == code.upper(), Event.join_code == code.upper()))
+        .first()
+    )
+    return _event_with_status(event)
+
+
 def _event_with_status(event: Event | None) -> tuple[Event | None, EventLookupResult]:
     if not event:
         return None, EventLookupResult.NOT_FOUND

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -7671,6 +7671,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
         "summary": "Get Event",
         "tags": [
           "events"

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3650,6 +3650,78 @@
         "title": "PublicEventInfo",
         "type": "object"
       },
+      "PublicEventResponse": {
+        "description": "Guest-safe live-event projection. Deliberately omits event.id and any\nDJ-only fields (see #382 serializer hygiene).",
+        "properties": {
+          "banner_colors": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Banner Colors"
+          },
+          "banner_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Banner Url"
+          },
+          "collection_code": {
+            "title": "Collection Code",
+            "type": "string"
+          },
+          "frictionless_join": {
+            "title": "Frictionless Join",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "phase": {
+            "enum": [
+              "pre_announce",
+              "collection",
+              "live",
+              "closed"
+            ],
+            "title": "Phase",
+            "type": "string"
+          },
+          "requests_open": {
+            "title": "Requests Open",
+            "type": "boolean"
+          },
+          "submission_cap_per_guest": {
+            "title": "Submission Cap Per Guest",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "banner_colors",
+          "banner_url",
+          "collection_code",
+          "frictionless_join",
+          "name",
+          "phase",
+          "requests_open",
+          "submission_cap_per_guest"
+        ],
+        "title": "PublicEventResponse",
+        "type": "object"
+      },
       "PublicRequestInfo": {
         "properties": {
           "artist": {
@@ -9943,6 +10015,49 @@
         "summary": "Get Public Now Playing",
         "tags": [
           "bridge"
+        ]
+      }
+    },
+    "/api/public/events/{code}": {
+      "get": {
+        "description": "Guest-safe event info for the live /join page. Resolves by EITHER public\ncode; never emits event.id. Replaces the join page's use of the DJ EventOut\nendpoint (which leaks the private id) and folds in phase + frictionless_join.",
+        "operationId": "get_public_event_api_public_events__code__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicEventResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Public Event",
+        "tags": [
+          "public"
         ]
       }
     },

--- a/server/tests/test_api_contracts.py
+++ b/server/tests/test_api_contracts.py
@@ -246,8 +246,8 @@ class TestEventContracts:
         if data:
             _assert_keys(data[0], EVENT_OUT_KEYS, "GET /api/events[0]")
 
-    def test_get_event_shape(self, client: TestClient, test_event: Event):
-        resp = client.get(f"/api/events/{test_event.code}")
+    def test_get_event_shape(self, client: TestClient, auth_headers: dict, test_event: Event):
+        resp = client.get(f"/api/events/{test_event.code}", headers=auth_headers)
         assert resp.status_code == 200
         _assert_keys(resp.json(), EVENT_OUT_KEYS, "GET /api/events/{code}")
 

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -1138,3 +1138,39 @@ class TestLiveJoinCodeEndpoint:
     def test_404_for_unknown_event(self, client, db, test_event):
         r = client.get("/api/public/collect/ZZZZZZ/live-join-code")
         assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# #382: dual-code routing — collect endpoints must resolve by join_code too
+# ---------------------------------------------------------------------------
+
+
+def test_collect_preview_resolves_by_join_code(client, db, test_event: Event):
+    """#382: the join page hits collect endpoints with join_code — must resolve."""
+    _enable_collection(db, test_event)
+    r = client.get(f"/api/public/collect/{test_event.join_code}")
+    assert r.status_code == 200
+    # The canonical collection code is echoed back, regardless of which code resolved it.
+    assert r.json()["code"] == test_event.code
+
+
+def test_join_config_resolves_by_join_code(client, db, test_event: Event):
+    r = client.get(f"/api/public/collect/{test_event.join_code}/join-config")
+    assert r.status_code == 200
+    assert r.json() == {"frictionless_join": False}
+
+
+def test_ensure_name_resolves_by_join_code_when_frictionless(client, db, test_event: Event):
+    test_event.frictionless_join = True
+    db.commit()
+    r = client.post(f"/api/public/collect/{test_event.join_code}/guest/ensure-name", json={})
+    assert r.status_code == 200
+    assert r.json()["auto_generated"] is True
+
+
+def test_ensure_name_boundary_is_flag_not_code(client, db, test_event: Event):
+    """The frictionless boundary is the flag, never the code: a non-frictionless
+    event reached by join_code still refuses auto-naming."""
+    r = client.post(f"/api/public/collect/{test_event.join_code}/guest/ensure-name", json={})
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "frictionless_disabled"

--- a/server/tests/test_dual_code_routing.py
+++ b/server/tests/test_dual_code_routing.py
@@ -1,0 +1,27 @@
+"""Issue #382 — guest endpoints resolve by EITHER public code (collection or join)."""
+
+from app.models.event import Event
+from app.services.event import (
+    EventLookupResult,
+    get_event_by_public_code_with_status,
+)
+
+
+def test_public_code_resolver_accepts_both_codes(db, test_event: Event):
+    by_collection, s1 = get_event_by_public_code_with_status(db, test_event.code)
+    by_join, s2 = get_event_by_public_code_with_status(db, test_event.join_code)
+    assert by_collection is not None and by_join is not None
+    assert by_collection.id == test_event.id == by_join.id
+    assert s1 == EventLookupResult.FOUND
+    assert s2 == EventLookupResult.FOUND
+
+
+def test_public_code_resolver_is_case_insensitive(db, test_event: Event):
+    ev, _ = get_event_by_public_code_with_status(db, test_event.join_code.lower())
+    assert ev is not None and ev.id == test_event.id
+
+
+def test_public_code_resolver_not_found(db):
+    ev, status = get_event_by_public_code_with_status(db, "ZZZZZZ")
+    assert ev is None
+    assert status == EventLookupResult.NOT_FOUND

--- a/server/tests/test_dual_code_routing.py
+++ b/server/tests/test_dual_code_routing.py
@@ -5,6 +5,7 @@ from app.services.event import (
     EventLookupResult,
     get_event_by_public_code_with_status,
 )
+from app.services.event_bus import get_event_bus
 
 
 def test_public_code_resolver_accepts_both_codes(db, test_event: Event):
@@ -25,3 +26,35 @@ def test_public_code_resolver_not_found(db):
     ev, status = get_event_by_public_code_with_status(db, "ZZZZZZ")
     assert ev is None
     assert status == EventLookupResult.NOT_FOUND
+
+
+def test_submit_request_resolves_by_join_code(client, db, test_event: Event):
+    r = client.post(
+        f"/api/events/{test_event.join_code}/requests",
+        json={"artist": "Daft Punk", "title": "One More Time"},
+    )
+    assert r.status_code == 200
+
+
+def test_get_event_stays_collection_only(client, db, test_event: Event):
+    """GET /api/events/{code} is the DJ endpoint (leaks EventOut.id) — it must
+    NOT be made canonical. A guest join_code must NOT resolve here."""
+    assert client.get(f"/api/events/{test_event.code}").status_code == 200
+    assert client.get(f"/api/events/{test_event.join_code}").status_code == 404
+
+
+def test_submit_via_join_code_publishes_on_event_code_channel(client, db, test_event: Event):
+    """SSE channels are keyed by event.code; the stream subscribes by event.code
+    after resolving join_code. So a join_code submit must publish on event.code."""
+    bus = get_event_bus()
+    queue = bus.subscribe(test_event.code)
+    try:
+        r = client.post(
+            f"/api/events/{test_event.join_code}/requests",
+            json={"artist": "Stardust", "title": "Music Sounds Better"},
+        )
+        assert r.status_code == 200
+        msg = queue.get_nowait()  # raises QueueEmpty if nothing published to event.code
+        assert msg["event"] == "request_created"
+    finally:
+        bus.unsubscribe(test_event.code, queue)

--- a/server/tests/test_dual_code_routing.py
+++ b/server/tests/test_dual_code_routing.py
@@ -58,3 +58,11 @@ def test_submit_via_join_code_publishes_on_event_code_channel(client, db, test_e
         assert msg["event"] == "request_created"
     finally:
         bus.unsubscribe(test_event.code, queue)
+
+
+def test_public_requests_resolve_by_either_code(client, db, test_event: Event):
+    # Already worked by join_code; now also resolves by collection code (one resolver).
+    assert client.get(f"/api/public/events/{test_event.join_code}/requests").status_code == 200
+    assert client.get(f"/api/public/events/{test_event.code}/requests").status_code == 200
+    assert client.get(f"/api/public/events/{test_event.join_code}/has-requested").status_code == 200
+    assert client.get(f"/api/public/events/{test_event.code}/has-requested").status_code == 200

--- a/server/tests/test_dual_code_routing.py
+++ b/server/tests/test_dual_code_routing.py
@@ -36,11 +36,13 @@ def test_submit_request_resolves_by_join_code(client, db, test_event: Event):
     assert r.status_code == 200
 
 
-def test_get_event_stays_collection_only(client, db, test_event: Event):
+def test_get_event_stays_collection_only(client, db, test_event: Event, auth_headers):
     """GET /api/events/{code} is the DJ endpoint (leaks EventOut.id) — it must
     NOT be made canonical. A guest join_code must NOT resolve here."""
-    assert client.get(f"/api/events/{test_event.code}").status_code == 200
-    assert client.get(f"/api/events/{test_event.join_code}").status_code == 404
+    assert client.get(f"/api/events/{test_event.code}", headers=auth_headers).status_code == 200
+    # join_code must not resolve on the DJ-only get_event endpoint
+    r = client.get(f"/api/events/{test_event.join_code}", headers=auth_headers)
+    assert r.status_code == 404
 
 
 def test_submit_via_join_code_publishes_on_event_code_channel(client, db, test_event: Event):
@@ -90,3 +92,31 @@ def test_public_event_endpoint_404_and_410(client, db, test_event: Event):
     test_event.is_active = False
     db.commit()
     assert client.get(f"/api/public/events/{test_event.join_code}").status_code == 410
+
+
+def test_get_event_requires_auth_no_id_leak(client, db, test_event: Event):
+    """#382 hardening: GET /api/events/{code} must NOT serve EventOut (id +
+    join_url) to unauthenticated callers holding only the collection code."""
+    r = client.get(f"/api/events/{test_event.code}")
+    assert r.status_code == 401
+
+
+def test_get_event_owner_and_admin_ok_nonowner_404(
+    client, db, test_event: Event, auth_headers, admin_headers
+):
+    # Owner (auth_headers == test_user, who owns test_event) → 200
+    assert client.get(f"/api/events/{test_event.code}", headers=auth_headers).status_code == 200
+    # Admin → 200 (can view any event)
+    assert client.get(f"/api/events/{test_event.code}", headers=admin_headers).status_code == 200
+    # Authenticated NON-owner, non-admin → 404 (no existence leak)
+    from app.models.user import User
+    from app.services.auth import create_access_token, get_password_hash
+
+    other = User(username="otherdj", password_hash=get_password_hash("pw"), role="dj")
+    db.add(other)
+    db.commit()
+    db.refresh(other)
+    # Mint token directly (mirrors conftest auth_headers pattern)
+    other_token = create_access_token(data={"sub": other.username, "tv": other.token_version})
+    other_headers = {"Authorization": f"Bearer {other_token}"}
+    assert client.get(f"/api/events/{test_event.code}", headers=other_headers).status_code == 404

--- a/server/tests/test_dual_code_routing.py
+++ b/server/tests/test_dual_code_routing.py
@@ -66,3 +66,27 @@ def test_public_requests_resolve_by_either_code(client, db, test_event: Event):
     assert client.get(f"/api/public/events/{test_event.code}/requests").status_code == 200
     assert client.get(f"/api/public/events/{test_event.join_code}/has-requested").status_code == 200
     assert client.get(f"/api/public/events/{test_event.code}/has-requested").status_code == 200
+
+
+def test_public_event_endpoint_resolves_both_and_omits_id(client, db, test_event: Event):
+    for code in (test_event.join_code, test_event.code):
+        r = client.get(f"/api/public/events/{code}")
+        assert r.status_code == 200, code
+        body = r.json()
+        # Serializer hygiene: the private surrogate key must never be emitted.
+        assert "id" not in body
+        # Exclude bools: True == 1 in Python, so avoid false positives when id=1.
+        non_bool_values = [v for v in body.values() if not isinstance(v, bool)]
+        assert test_event.id not in non_bool_values
+        assert body["name"] == test_event.name
+        assert body["collection_code"] == test_event.code
+        assert body["frictionless_join"] is False
+        assert body["requests_open"] is True
+        assert body["phase"] in {"pre_announce", "collection", "live", "closed"}
+
+
+def test_public_event_endpoint_404_and_410(client, db, test_event: Event):
+    assert client.get("/api/public/events/ZZZZZZ").status_code == 404
+    test_event.is_active = False
+    db.commit()
+    assert client.get(f"/api/public/events/{test_event.join_code}").status_code == 410

--- a/server/tests/test_events.py
+++ b/server/tests/test_events.py
@@ -82,17 +82,17 @@ class TestListEvents:
 class TestGetEvent:
     """Tests for GET /api/events/{code} endpoint."""
 
-    def test_get_event_success(self, client: TestClient, test_event: Event):
+    def test_get_event_success(self, client: TestClient, test_event: Event, auth_headers: dict):
         """Test getting an event by code."""
-        response = client.get(f"/api/events/{test_event.code}")
+        response = client.get(f"/api/events/{test_event.code}", headers=auth_headers)
         assert response.status_code == 200
         data = response.json()
         assert data["code"] == test_event.code
         assert data["name"] == test_event.name
 
-    def test_get_event_not_found(self, client: TestClient):
+    def test_get_event_not_found(self, client: TestClient, auth_headers: dict):
         """Test getting a nonexistent event returns 404."""
-        response = client.get("/api/events/NOTFND")
+        response = client.get("/api/events/NOTFND", headers=auth_headers)
         assert response.status_code == 404
         assert response.json()["detail"]
 
@@ -252,7 +252,9 @@ class TestDeleteEvent:
 class TestExpiredEvents:
     """Tests for expired event handling with 410 Gone status."""
 
-    def test_get_expired_event_returns_410(self, client: TestClient, db: Session, test_user: User):
+    def test_get_expired_event_returns_410(
+        self, client: TestClient, db: Session, test_user: User, auth_headers: dict
+    ):
         """Test that getting an expired event returns 410 Gone."""
         # Create an expired event
         expired_event = Event(
@@ -265,7 +267,7 @@ class TestExpiredEvents:
         db.add(expired_event)
         db.commit()
 
-        response = client.get(f"/api/events/{expired_event.code}")
+        response = client.get(f"/api/events/{expired_event.code}", headers=auth_headers)
         assert response.status_code == 410
         assert response.json()["detail"]
 
@@ -328,10 +330,12 @@ class TestExpiredEvents:
         assert response.status_code == 410
         assert response.json()["detail"]
 
-    def test_404_vs_410_distinction(self, client: TestClient, db: Session, test_user: User):
+    def test_404_vs_410_distinction(
+        self, client: TestClient, db: Session, test_user: User, auth_headers: dict
+    ):
         """Test that 404 is for not found and 410 is for expired."""
         # Non-existent event should be 404
-        response = client.get("/api/events/NOEXST")
+        response = client.get("/api/events/NOEXST", headers=auth_headers)
         assert response.status_code == 404
         assert response.json()["detail"]
 
@@ -346,7 +350,7 @@ class TestExpiredEvents:
         db.add(expired_event)
         db.commit()
 
-        response = client.get(f"/api/events/{expired_event.code}")
+        response = client.get(f"/api/events/{expired_event.code}", headers=auth_headers)
         assert response.status_code == 410
         assert response.json()["detail"]
 
@@ -412,13 +416,13 @@ class TestArchiveEvents:
         assert response.json()["detail"]
 
     def test_get_archived_event_returns_410(
-        self, client: TestClient, test_event: Event, db: Session
+        self, client: TestClient, test_event: Event, db: Session, auth_headers: dict
     ):
         """Test that getting an archived event returns 410."""
         test_event.archived_at = utcnow()
         db.commit()
 
-        response = client.get(f"/api/events/{test_event.code}")
+        response = client.get(f"/api/events/{test_event.code}", headers=auth_headers)
         assert response.status_code == 410
         assert response.json()["detail"]
 
@@ -1107,7 +1111,7 @@ class TestRequestsOpen:
         assert response.json()["requests_open"] is True
 
         # Also check via EventOut
-        response = client.get(f"/api/events/{test_event.code}")
+        response = client.get(f"/api/events/{test_event.code}", headers=auth_headers)
         assert response.status_code == 200
         assert response.json()["requests_open"] is True
 


### PR DESCRIPTION
Closes #382.

## Problem
WrzDJ events carry two public codes on one row: `event.code` (collection — long-lived, social) and `event.join_code` (live — day-of, frictionless). The live `/join` page's URL carries `join_code`, but ~7 of the endpoints it calls resolved only by collection `code` (the #324 routing audit missed the `/api/events/{code}` family; #380's frictionless additions widened it). Result: the real DJ share link 404'd into the error screen; the alternate code left the live queue permanently empty. Two latent bugs surfaced alongside: the join page loaded the DJ `EventOut` endpoint which **leaks `event.id`**, and SSE channel keying could mismatch on a `join_code` submit.

## Fix
- **One canonical guest resolver** `get_event_by_public_code_with_status` = `or_(Event.code, Event.join_code)` (collision-free — codes are globally unique across both columns), wired into the whole guest surface: collect router (`_get_event_or_404`), events `search`/`submit`, public reads (`requests`/`has-requested`/`my-requests`), SSE stream. `NicknameGate` untouched.
- **New guest-safe `GET /api/public/events/{code}`** → `PublicEventResponse` with **no `event.id`**; folds the join page's `getEvent` + `getJoinConfig` + `getCollectEvent` into one call. The page now loads from it (`getPublicEvent`); the pre-event cross-link uses `collection_code`.
- **SSE submit publishes the resolved `event.code`** so a `join_code` submit reaches the `event.code`-keyed stream subscriber.
- **Behavioral boundary stays flag/auth-enforced, not code-enforced** — frictionless gated by `event.frictionless_join`; collect mutations still require email + human cookie regardless of which code resolved.
- **No DB migration.**

## Security hardening (scope expansion)
`GET /api/events/{code}` was **public** (no auth dependency) and returned `EventOut` (`id` + both codes + `join_url`/`collect_url`) — so any holder of the public collection code could read the private `event.id` and derive the `join_code`. Now restricted to **owner-or-admin** (`Depends(get_current_active_user)` + owner/admin check; non-owner → 404 to hide existence; 404/410 semantics preserved). `EventOut` shape unchanged → no frontend change (the DJ event page already authenticates). OpenAPI security regenerated.

| | unauth | authed non-owner | owner | admin | owner+expired/archived |
|---|---|---|---|---|---|
| `GET /api/events/{code}` | 401 | 404 | 200 | 200 | 410 |

## Test plan
- [x] Backend `pytest`: **2059 passed**, coverage **87.57%** (≥85). New `tests/test_dual_code_routing.py` (13 tests): resolver-accepts-both, frictionless-flag-is-the-boundary, SSE channel match, **serializer hygiene (no `event.id` in guest body)**, `get_event` 401/404 leak-pin.
- [x] Frontend `vitest`: **949 passed**; `tsc --noEmit` + ESLint clean. Join page test pins "loads via `getPublicEvent`, never calls id-leaking `getEvent`".
- [x] `ruff check`/`ruff format`/`bandit` clean.
- [ ] **Remote CI** is authoritative for `alembic check` (couldn't run locally — shared dev DB stamped at a divergent-branch revision; no model/migration changes here, so no drift by construction) and bridge/bridge-app (untouched).

## Design
Full spec + addendum: `docs/superpowers/specs/2026-05-30-dual-code-routing-design.md`. Implementation plan: `docs/superpowers/plans/2026-05-30-dual-code-routing.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public API endpoint for secure guest event information retrieval without exposing internal identifiers
  * Guest access now supports both collection codes and join codes for event lookups

* **Security Improvements**
  * Enhanced authentication requirements on event endpoints
  * Prevented internal event ID exposure in guest-facing API responses
  * Hardened access control to restrict DJ/admin endpoints to authorized users only

* **Tests**
  * Added comprehensive test coverage for dual-code routing behavior and access control enforcement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->