### PR TITLE
docs: refresh README + CONTRIB for features landed on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ A real-time song request system for DJs. Guests scan a QR code to submit request
 
 **Security & identity**
 - Fernet-encrypted OAuth tokens at rest (MultiFernet for key rotation)
-- Supply-chain hardening: pinned base-image SHAs, all GitHub Actions pinned to commit SHAs, committed `uv.lock` at CVE-floor versions
+- Supply-chain hardening: all GitHub Actions pinned to commit SHAs, committed lockfiles (`uv.lock` at CVE-floor versions, `package-lock.json`), CI security scans (bandit, pip-audit, npm audit), and a SHA-digest-pinned base image in the bridge build
 - Separate public codes for pre-event collection (`/collect`) and live join (`/join`); guest-facing endpoints never expose internal event IDs
 - IP-free guest identity (cookie + ThumbmarkJS reconciliation, no IP storage or logging)
 - HMAC-signed `wrzdj_human` cookie with 60-min sliding window after Turnstile pass

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A real-time song request system for DJs. Guests scan a QR code to submit request
 - Search songs via Spotify, submit requests with notes, upvote others
 - Live request queue and kiosk display showing what's playing now
 - Cloudflare Turnstile human verification (invisible managed challenge) on `/join` and `/collect`
-- Mandatory nickname gate with profanity filter and letter-padding bypass protection
+- Nickname gate (profanity filter + letter-padding bypass protection) on standard events, or **frictionless join** — when the DJ enables it, guests skip the nickname/email step and get an auto-generated name they can rename later (great for weddings and private parties)
 - Email verification with one-time codes (Resend API) and cross-device guest profile merge
 - Pre-event song collection (`/collect`) — guests vote on suggestions before the night, DJs bulk-review
 - Inline song preview in the collect detail sheet (Spotify/Tidal embed)
@@ -54,6 +54,7 @@ A real-time song request system for DJs. Guests scan a QR code to submit request
 - Event banners, play history with source badges, CSV export
 - "Enrich All" advanced action to backfill BPM/key/genre on existing requests in batches
 - Pre-event collection toggle per event (enable guest voting before doors open)
+- Frictionless-join toggle per event (skip the guest nickname/email gate, auto-name guests), with a per-DJ account default applied to new events
 - Collection suggestions sync to a dedicated pre-event Tidal playlist; bidirectional option auto-rejects requests removed from the playlist
 - Self-service account management: DJs can update their own password and email address
 - Bridge connection status, activity log, contextual help system
@@ -73,7 +74,8 @@ A real-time song request system for DJs. Guests scan a QR code to submit request
 
 **Security & identity**
 - Fernet-encrypted OAuth tokens at rest (MultiFernet for key rotation)
-- Pinned base image SHAs in production Dockerfiles (supply-chain hardening)
+- Supply-chain hardening: pinned base-image SHAs, all GitHub Actions pinned to commit SHAs, committed `uv.lock` at CVE-floor versions
+- Separate public codes for pre-event collection (`/collect`) and live join (`/join`); guest-facing endpoints never expose internal event IDs
 - IP-free guest identity (cookie + ThumbmarkJS reconciliation, no IP storage or logging)
 - HMAC-signed `wrzdj_human` cookie with 60-min sliding window after Turnstile pass
 - IP-bound nonce flow for kiosk-pair (no Turnstile on input-less Pi devices)
@@ -227,6 +229,23 @@ Production uses a subdomain model: `app.your-domain.example` (frontend) and `api
 docker compose up --build
 ```
 
+### Deploy from Pre-Built Images (GHCR)
+
+Self-hosters can run pre-built multi-arch images from GitHub Container Registry instead of building from source:
+
+- `ghcr.io/wrzonance/wrzdj-api` — FastAPI backend
+- `ghcr.io/wrzonance/wrzdj-web` — Next.js frontend (the API URL is patched in at container start, so one image works for any domain)
+
+Tags: `latest` (main), `vX.Y.Z` / `X.Y` (release tags), `sha-<short>` (every commit).
+
+```bash
+cd /opt && git clone https://github.com/thewrz/WrzDJ.git && cd WrzDJ
+cp deploy/.env.example deploy/.env   # set WRZDJ_VERSION (default: latest) and secrets
+./deploy/deploy-ghcr.sh              # pulls images, restarts the stack, polls /health
+```
+
+`deploy/docker-compose.ghcr.yml` runs db + api + web straight from the registry (no `--build`); `deploy/deploy-ghcr.sh [VERSION]` is the one-command pull-and-restart helper.
+
 ### PaaS (Render / Railway)
 
 **Render** auto-detects `render.yaml`. Push to GitHub, connect to [Render](https://render.com), set credentials in the Environment tab.
@@ -268,6 +287,7 @@ HUMAN_COOKIE_SECRET=<openssl rand -base64 32>  # signs wrzdj_human cookie
 RESEND_API_KEY  # email verification provider
 EMAIL_FROM_ADDRESS=noreply@send.yourdomain.com
 SOUNDCHARTS_APP_ID / SOUNDCHARTS_API_KEY  # discovery API
+LISTENBRAINZ_USER_TOKEN  # optional, ListenBrainz artist discovery for recommendations
 CORS_ORIGINS=https://app.yourdomain.com
 PUBLIC_URL=https://app.yourdomain.com
 ```

--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -31,7 +31,7 @@ Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`
 
 - Docker + Docker Compose (for PostgreSQL 16)
 - Python 3.11+ with venv
-- Node.js 20+ with npm
+- Node.js 22+ with npm
 
 ### 1. Start the database
 
@@ -84,9 +84,16 @@ All config lives in `.env` at the repo root. Key variables:
 | `CORS_ORIGINS` | Allowed origins (`*` for dev) |
 | `PUBLIC_URL` | Base URL for QR codes (frontend) |
 | `NEXT_PUBLIC_API_URL` | Backend URL for frontend fetch calls |
-| `BRIDGE_API_KEY` | StageLinQ bridge authentication |
+| `BRIDGE_API_KEY` | Bridge service authentication (all DJ-equipment plugins) |
 | `BOOTSTRAP_ADMIN_USERNAME` | Auto-create admin on first startup |
 | `BOOTSTRAP_ADMIN_PASSWORD` | Auto-create admin on first startup |
+| `TOKEN_ENCRYPTION_KEY` | Fernet key encrypting OAuth tokens at rest (prod-fatal if unset) |
+| `HUMAN_COOKIE_SECRET` | Signs the `wrzdj_human` verification cookie (prod-fatal if unset) |
+| `TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY` | Cloudflare Turnstile (human verification + DJ self-reg) |
+| `BEATPORT_CLIENT_ID` / `BEATPORT_CLIENT_SECRET` | Beatport OAuth credentials (search + playlist sync) |
+| `ANTHROPIC_API_KEY` | Optional — enables AI Assist song recommendations |
+| `RESEND_API_KEY` / `EMAIL_FROM_ADDRESS` | Email verification provider (one-time codes) |
+| `SOUNDCHARTS_APP_ID` / `SOUNDCHARTS_API_KEY` | Soundcharts discovery API (BPM/key/genre) |
 
 ## Available Scripts
 
@@ -99,7 +106,7 @@ All config lives in `.env` at the repo root. Key variables:
 | `.venv/bin/ruff format .` | Auto-format |
 | `.venv/bin/ruff format --check .` | Format check (CI) |
 | `.venv/bin/bandit -r app -c pyproject.toml -q` | Security scan |
-| `.venv/bin/pytest --tb=short -q` | Run tests (70% coverage min) |
+| `.venv/bin/pytest --tb=short -q` | Run tests (85% coverage min) |
 | `.venv/bin/pytest tests/test_requests.py -v` | Run single test file |
 | `alembic upgrade head` | Apply migrations |
 | `alembic revision --autogenerate -m "desc"` | Generate migration |
@@ -159,9 +166,9 @@ npm test -- --run         # Vitest
 
 - Config: `server/pyproject.toml` `[tool.pytest.ini_options]`
 - Test DB: SQLite in-memory (not PostgreSQL)
-- Fixtures: `server/tests/conftest.py` — `db`, `client`, `test_user`, `auth_headers`, `test_event`, `test_request`
+- Fixtures: `server/tests/conftest.py` — `db`, `client`, `test_user`, `auth_headers`, `admin_user`, `admin_headers`, `pending_user`, `pending_headers`, `test_event`, `test_request`
 - TestClient default host: `"testclient"` — use for `client_fingerprint` in fixtures
-- Coverage minimum: 70%
+- Coverage minimum: 85%
 
 ### Frontend (vitest)
 
@@ -193,3 +200,4 @@ npm test -- --run         # Vitest
 - When adding fields to shared interfaces, grep for test fixtures that construct those types
 - TestClient fingerprint is `"testclient"`, not an IP address
 - Backend tests use SQLite, not PostgreSQL — some SQL features may behave differently
+- Events carry two public codes: the collection `code` routes `/collect` (gated pre-event flow), while `join_code` routes `/join`, `/e/{code}/display`, kiosk, OBS overlay, and bridge now-playing — resolve guest requests via the dual-code public resolver and never return the internal `event.id` on public endpoints


### PR DESCRIPTION
## Summary

Refresh `README.md` and `docs/CONTRIB.md` to reflect features that **landed on `main`** since the last README content update (#304, 2026-05-11). Every claim was verified against code on `main` (HEAD `b4938e3`).

### README.md
- **Frictionless join** (#369/#380): nickname gate reworded as conditional; new guest bullet (auto-named guests, rename affordance) + DJ bullet (per-event toggle, per-DJ account default).
- **Pre-built GHCR images** (#318): new "Deploy from Pre-Built Images (GHCR)" subsection — `ghcr.io/wrzonance/wrzdj-api` / `wrzdj-web`, tag scheme, `deploy/docker-compose.ghcr.yml`, `deploy/deploy-ghcr.sh`.
- **Split collection/live codes + id-leak close** (#324/#382): Security bullet — separate `/collect` vs `/join` codes; public endpoints never expose internal event IDs.
- **Supply-chain note** broadened (#322/#323): Actions pinned to commit SHAs, `uv.lock` at CVE-floor.
- Added `LISTENBRAINZ_USER_TOKEN` to the env block.

### docs/CONTRIB.md
- Node `20+` → `22+` (bridge enforces `>=22`).
- Coverage `70%` → `85%` (two spots; matches `--cov-fail-under=85`).
- Env-var table: +10 live vars (`TOKEN_ENCRYPTION_KEY`, `HUMAN_COOKIE_SECRET`, Turnstile, Beatport, `ANTHROPIC_API_KEY`, Resend/email, Soundcharts).
- Completed conftest fixture list (`admin_*`, `pending_*`); fixed `BRIDGE_API_KEY` description; added a dual-code-resolver pitfall.

### Deliberately excluded
The provider-agnostic **LLM gateway epic** (#348–379: Azure/xAI/Gemini/OpenRouter/Bedrock adapters, admin connector governance, token caps, audit trail) merged into **`epic/ai-engine`, not `main`** — `server/app/services/llm/` does not exist on `main`, and the admin AI page still reads "Set ANTHROPIC_API_KEY". Documenting it here would describe unreleased software. README's existing "AI Assist via Claude" + `ANTHROPIC_API_KEY` are correct for `main` and were left unchanged. Those docs should be written on the epic branch / when it merges.

## Test plan
- [x] Docs-only change; every cited file/var/image confirmed present on `main`.
- [ ] Skim rendered Markdown on GitHub for formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user-facing docs for a new "frictionless join" option allowing guests to skip nickname/email with auto-generated names and per-event/per-host defaults.
  * Expanded deployment guide with GHCR/pre-built-image instructions and a one-command deploy example.
  * Enhanced security and contributor docs: supply-chain hardening, public code isolation guidance, Node.js requirement bump, higher test coverage, and updated environment variable list (including an optional token).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->