### PR TITLE
fix(guest): paginate collect leaderboard + join list (drop 200/50 hard caps)

### DIFF
--- a/dashboard/app/collect/[code]/page.test.tsx
+++ b/dashboard/app/collect/[code]/page.test.tsx
@@ -53,6 +53,7 @@ const mockEnrichPreview = vi.fn();
 const mockGetLiveJoinCode = vi.fn().mockResolvedValue({ join_code: "ABC" });
 
 vi.mock("../../../lib/api", () => ({
+  PUBLIC_PAGE_MAX: 500,
   ApiError: class ApiError extends Error {
     status: number;
     constructor(message: string, status: number) {

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -25,6 +25,10 @@ import MyPicksPanel from './components/MyPicksPanel';
 import SubmitBar from './components/SubmitBar';
 
 const POLL_MS = 5000;
+/* Leaderboard is a growing window: "Load more" grows displayLimit and every
+   poll re-fetches [0, displayLimit) from offset 0. This keeps live vote
+   updates correct without client-side dedup or offset-drift bugs. */
+const PAGE_SIZE = 100;
 
 export default function CollectPage() {
   const router = useRouter();
@@ -44,6 +48,7 @@ export default function CollectPage() {
     ...(myPicks?.submitted ?? []).map((s) => s.id),
   ]);
   const [tab, setTab] = useState<'trending' | 'all'>('all');
+  const [displayLimit, setDisplayLimit] = useState(PAGE_SIZE);
   const [error, setError] = useState<string | null>(null);
   const [emailVerified, setEmailVerified] = useState(false);
   const [nickname, setNickname] = useState<string | null>(null);
@@ -132,7 +137,7 @@ export default function CollectPage() {
 
       const [p, lb] = await Promise.all([
         apiClient.getCollectProfile(code),
-        apiClient.getCollectLeaderboard(code, tab),
+        apiClient.getCollectLeaderboard(code, tab, displayLimit),
       ]);
       setProfile({ submission_count: p.submission_count, submission_cap: p.submission_cap });
       setLeaderboard(lb);
@@ -226,7 +231,7 @@ export default function CollectPage() {
         } else if (ev.phase === 'collection') {
           // Leaderboard is ungated; my-picks requires email verification, so skip
           // it until the guest verifies to avoid surfacing a sticky 403 error.
-          const lb = await apiClient.getCollectLeaderboard(code, tab);
+          const lb = await apiClient.getCollectLeaderboard(code, tab, displayLimit);
           if (!cancelled) setLeaderboard(lb);
           if (emailVerified) {
             const picks = await apiClient.getCollectMyPicks(code);
@@ -252,7 +257,7 @@ export default function CollectPage() {
       if (timer) clearTimeout(timer);
       document.removeEventListener('visibilitychange', onVisibility);
     };
-  }, [code, tab, gateComplete, emailVerified, humanState, router]);
+  }, [code, tab, displayLimit, gateComplete, emailVerified, humanState, router]);
 
   const leaderboardAvgBpm = useMemo(() => {
     const withBpm = (leaderboard?.requests ?? []).filter((r) => r.bpm != null);
@@ -401,7 +406,7 @@ export default function CollectPage() {
             </div>
             <div style={{ padding: '5px 10px', borderRadius: 7, border: `1px solid ${border}`, flexShrink: 0 }}>
               <span style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 15.7, fontWeight: 800, color: '#fff' }}>
-                {(leaderboard?.requests ?? []).length}
+                {leaderboard?.total ?? 0}
               </span>
               <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 9, color: subFg, letterSpacing: 1.2, marginTop: 2 }}>
                 SONGS
@@ -420,11 +425,25 @@ export default function CollectPage() {
           <LeaderboardTabs
             rows={leaderboard?.requests ?? []}
             tab={tab}
-            onTabChange={setTab}
+            onTabChange={(t) => { setTab(t); setDisplayLimit(PAGE_SIZE); }}
             onVote={(id) => apiClient.voteCollectRequest(code, id, reverify)}
             votedIds={votedIds}
             onRowClick={setDetailRow}
           />
+          {(leaderboard?.requests.length ?? 0) < (leaderboard?.total ?? 0) && (
+            <button
+              type="button"
+              onClick={() => setDisplayLimit((d) => d + PAGE_SIZE)}
+              style={{
+                width: '100%', marginTop: 10, padding: '13px 16px', borderRadius: 12,
+                background: surface, border: `1px solid ${border}`, color: '#fff',
+                fontFamily: 'var(--font-mono, monospace)', fontSize: 12.5, fontWeight: 700,
+                letterSpacing: 1.2, cursor: 'pointer',
+              }}
+            >
+              LOAD MORE · {(leaderboard?.total ?? 0) - (leaderboard?.requests.length ?? 0)} MORE
+            </button>
+          )}
         </section>
 
         {myPicks && <MyPicksPanel picks={myPicks} />}
@@ -456,7 +475,7 @@ export default function CollectPage() {
           row={detailRow}
           code={code}
           rank={(leaderboard?.requests ?? []).findIndex((r) => r.id === detailRow.id) + 1 || 1}
-          totalCount={leaderboard?.requests.length ?? 0}
+          totalCount={leaderboard?.total ?? 0}
           voted={detailVoted || votedIds.has(detailRow.id)}
           onVote={async () => {
             if (!detailVoted && !votedIds.has(detailRow.id)) {

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -9,6 +9,7 @@ import {
   CollectLeaderboardResponse,
   CollectLeaderboardRow,
   CollectMyPicksResponse,
+  PUBLIC_PAGE_MAX,
   SearchResult,
 } from '../../../lib/api';
 import { useGuestIdentity } from '../../../lib/use-guest-identity';
@@ -430,10 +431,10 @@ export default function CollectPage() {
             votedIds={votedIds}
             onRowClick={setDetailRow}
           />
-          {(leaderboard?.requests.length ?? 0) < (leaderboard?.total ?? 0) && (
+          {(leaderboard?.requests.length ?? 0) < Math.min(leaderboard?.total ?? 0, PUBLIC_PAGE_MAX) && (
             <button
               type="button"
-              onClick={() => setDisplayLimit((d) => d + PAGE_SIZE)}
+              onClick={() => setDisplayLimit((d) => Math.min(d + PAGE_SIZE, PUBLIC_PAGE_MAX))}
               style={{
                 width: '100%', marginTop: 10, padding: '13px 16px', borderRadius: 12,
                 background: surface, border: `1px solid ${border}`, color: '#fff',
@@ -441,7 +442,7 @@ export default function CollectPage() {
                 letterSpacing: 1.2, cursor: 'pointer',
               }}
             >
-              LOAD MORE · {(leaderboard?.total ?? 0) - (leaderboard?.requests.length ?? 0)} MORE
+              LOAD MORE · {Math.max(Math.min(leaderboard?.total ?? 0, PUBLIC_PAGE_MAX) - (leaderboard?.requests.length ?? 0), 0)} MORE
             </button>
           )}
         </section>

--- a/dashboard/app/join/[code]/__tests__/page.test.tsx
+++ b/dashboard/app/join/[code]/__tests__/page.test.tsx
@@ -73,6 +73,7 @@ vi.mock('@/components/IdentityBar', () => ({
 vi.mock('@/lib/api', () => ({
   api: mockApi,
   ApiError: MockApiError,
+  PUBLIC_PAGE_MAX: 500,
 }));
 
 vi.mock('@/lib/useHumanVerification', () => ({

--- a/dashboard/app/join/[code]/page.tsx
+++ b/dashboard/app/join/[code]/page.tsx
@@ -19,6 +19,10 @@ import SongDetailSheet from './components/SongDetailSheet';
 
 const POLL_INTERVAL_MS = 10000;
 const BACKOFF_INTERVAL_MS = 60000;
+/* Request list is a growing window: "Load more" grows displayLimit and every
+   poll/SSE refresh re-fetches [0, displayLimit) so live vote/status updates
+   stay correct without client-side dedup. */
+const PAGE_SIZE = 100;
 
 const ACCENT = '#00f0ff';
 const ACCENT2 = '#ff2bd6';
@@ -63,6 +67,8 @@ export default function JoinEventPage() {
   const [error, setError] = useState<{ message: string; status: number } | null>(null);
 
   const [guestRequests, setGuestRequests] = useState<GuestRequestInfo[]>([]);
+  const [total, setTotal] = useState(0);
+  const [displayLimit, setDisplayLimit] = useState(PAGE_SIZE);
   const [pollInterval, setPollInterval] = useState(POLL_INTERVAL_MS);
   const [nowPlaying, setNowPlaying] = useState<GuestNowPlaying | null>(null);
 
@@ -205,16 +211,17 @@ export default function JoinEventPage() {
   /* Poll guest requests — start as soon as event is loaded */
   const loadRequests = useCallback(async () => {
     try {
-      const data = await api.getPublicRequests(code);
+      const data = await api.getPublicRequests(code, displayLimit);
       setGuestRequests(data.requests);
       setNowPlaying(data.now_playing);
+      setTotal(data.total ?? data.requests.length);
       setPollInterval(POLL_INTERVAL_MS);
     } catch (err) {
       if (err instanceof ApiError && err.status === 429) {
         setPollInterval(BACKOFF_INTERVAL_MS);
       }
     }
-  }, [code]);
+  }, [code, displayLimit]);
 
   useEffect(() => {
     if (!event) return;
@@ -566,7 +573,7 @@ export default function JoinEventPage() {
             </div>
           </div>
           <div style={{ display: 'flex', gap: 5 }}>
-            <StatPill label="QUEUE" value={String(guestRequests.length)} accent="#fff" sub={subFg} border={border} />
+            <StatPill label="QUEUE" value={String(total || guestRequests.length)} accent="#fff" sub={subFg} border={border} />
           </div>
         </div>
 
@@ -777,11 +784,24 @@ export default function JoinEventPage() {
             })
           )}
 
-          {tabRows.length > 0 && (
+          {activeTab !== 'mine' && guestRequests.length < total ? (
+            <button
+              type="button"
+              onClick={() => setDisplayLimit((d) => d + PAGE_SIZE)}
+              style={{
+                width: '100%', marginTop: 10, padding: '13px 16px', borderRadius: 10,
+                background: surface, border: `1px solid ${border}`, color: '#fff',
+                fontFamily: 'var(--font-mono, monospace)', fontSize: 11.5, fontWeight: 700,
+                letterSpacing: 1.4, cursor: 'pointer',
+              }}
+            >
+              LOAD MORE · {total - guestRequests.length} MORE
+            </button>
+          ) : tabRows.length > 0 ? (
             <div style={{ textAlign: 'center', padding: '10px 0 0', fontFamily: 'var(--font-mono, monospace)', fontSize: 10.9, color: subFg2, letterSpacing: 1.5 }}>
               ◇ END OF QUEUE ◇
             </div>
-          )}
+          ) : null}
         </div>
       </div>
 

--- a/dashboard/app/join/[code]/page.tsx
+++ b/dashboard/app/join/[code]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { useParams } from 'next/navigation';
-import { api, ApiError, PublicEvent, GuestNowPlaying, GuestRequestInfo, SearchResult } from '@/lib/api';
+import { api, ApiError, PublicEvent, GuestNowPlaying, GuestRequestInfo, PUBLIC_PAGE_MAX, SearchResult } from '@/lib/api';
 import { useEventStream } from '@/lib/use-event-stream';
 import { useGuestIdentity } from '@/lib/use-guest-identity';
 import { useHumanVerification } from '@/lib/useHumanVerification';
@@ -784,10 +784,10 @@ export default function JoinEventPage() {
             })
           )}
 
-          {activeTab !== 'mine' && guestRequests.length < total ? (
+          {activeTab !== 'mine' && guestRequests.length < Math.min(total, PUBLIC_PAGE_MAX) ? (
             <button
               type="button"
-              onClick={() => setDisplayLimit((d) => d + PAGE_SIZE)}
+              onClick={() => setDisplayLimit((d) => Math.min(d + PAGE_SIZE, PUBLIC_PAGE_MAX))}
               style={{
                 width: '100%', marginTop: 10, padding: '13px 16px', borderRadius: 10,
                 background: surface, border: `1px solid ${border}`, color: '#fff',
@@ -795,7 +795,7 @@ export default function JoinEventPage() {
                 letterSpacing: 1.4, cursor: 'pointer',
               }}
             >
-              LOAD MORE · {total - guestRequests.length} MORE
+              LOAD MORE · {Math.max(Math.min(total, PUBLIC_PAGE_MAX) - guestRequests.length, 0)} MORE
             </button>
           ) : tabRows.length > 0 ? (
             <div style={{ textAlign: 'center', padding: '10px 0 0', fontFamily: 'var(--font-mono, monospace)', fontSize: 10.9, color: subFg2, letterSpacing: 1.5 }}>

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -1318,6 +1318,47 @@ describe('ApiClient', () => {
       const [url] = mockFetch.mock.calls[0];
       expect(url).toContain('/api/public/events/ABC123/requests');
     });
+
+    it('appends limit and offset when provided', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ requests: [], now_playing: null, total: 0 }),
+      });
+
+      await api.getPublicRequests('ABC123', 100, 200);
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('limit=100');
+      expect(url).toContain('offset=200');
+    });
+
+    it('omits the query string when no paging args are given', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ requests: [], now_playing: null, total: 0 }),
+      });
+
+      await api.getPublicRequests('ABC123');
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).not.toContain('?');
+    });
+  });
+
+  describe('getCollectLeaderboard', () => {
+    it('includes tab and paging params in the URL', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ requests: [], total: 0 }),
+      });
+
+      await api.getCollectLeaderboard('ABC123', 'all', 100, 50);
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('tab=all');
+      expect(url).toContain('limit=100');
+      expect(url).toContain('offset=50');
+    });
   });
 
   describe('getKioskDisplay', () => {

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -2474,7 +2474,10 @@ export interface components {
         };
         /** Body_upload_banner_api_events__code__banner_post */
         Body_upload_banner_api_events__code__banner_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** BridgeApiKeyResponse */
@@ -3060,6 +3063,11 @@ export interface components {
             now_playing: components["schemas"]["GuestNowPlaying"] | null;
             /** Requests */
             requests: components["schemas"]["GuestRequestInfo"][];
+            /**
+             * Total
+             * @default 0
+             */
+            total: number;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -6612,6 +6620,8 @@ export interface operations {
         parameters: {
             query?: {
                 tab?: "trending" | "all";
+                limit?: number;
+                offset?: number;
             };
             header?: never;
             path: {
@@ -7093,7 +7103,10 @@ export interface operations {
     };
     get_public_requests_api_public_events__code__requests_get: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+                offset?: number;
+            };
             header?: never;
             path: {
                 code: string;

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -742,8 +742,16 @@ class ApiClient {
     return res.json();
   }
 
-  async getPublicRequests(code: string): Promise<GuestRequestListResponse> {
-    return this.publicFetch(`${getApiUrl()}/api/public/events/${code}/requests`);
+  async getPublicRequests(
+    code: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<GuestRequestListResponse> {
+    const qs = new URLSearchParams();
+    if (limit != null) qs.set('limit', String(limit));
+    if (offset != null) qs.set('offset', String(offset));
+    const suffix = qs.toString() ? `?${qs}` : '';
+    return this.publicFetch(`${getApiUrl()}/api/public/events/${code}/requests${suffix}`);
   }
 
   async getPublicEvent(code: string): Promise<PublicEvent> {
@@ -1220,9 +1228,14 @@ class ApiClient {
   async getCollectLeaderboard(
     code: string,
     tab: 'trending' | 'all' = 'trending',
+    limit?: number,
+    offset?: number,
   ): Promise<CollectLeaderboardResponse> {
+    const qs = new URLSearchParams({ tab });
+    if (limit != null) qs.set('limit', String(limit));
+    if (offset != null) qs.set('offset', String(offset));
     const res = await fetch(
-      `${getApiUrl()}/api/public/collect/${code}/leaderboard?tab=${tab}`,
+      `${getApiUrl()}/api/public/collect/${code}/leaderboard?${qs}`,
       { method: 'GET', headers: { 'Content-Type': 'application/json' } },
     );
     if (!res.ok) throw new ApiError(`getCollectLeaderboard failed: ${res.status}`, res.status);

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -115,6 +115,11 @@ export interface CollectEventPreview {
   expires_at: string;
 }
 
+/** Max `limit` the public list endpoints accept in a single request.
+ *  MUST match server/app/core/pagination.py MAX_PAGE_SIZE. Sending a larger
+ *  `limit` returns HTTP 422, so growing-window UIs clamp to this value. */
+export const PUBLIC_PAGE_MAX = 500;
+
 export interface CollectLeaderboardRow {
   id: number;
   title: string;

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -7,7 +7,7 @@ endpoints. See docs/RECOVERY-IP-IDENTITY.md.
 import logging
 from typing import Literal
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse
 from sqlalchemy import desc, func
 from sqlalchemy.exc import IntegrityError
@@ -19,6 +19,7 @@ from app.api.deps import (
     require_verified_human,
     require_verified_human_soft,
 )
+from app.core.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from app.core.rate_limit import limiter
 from app.models.event import Event
 from app.models.guest import Guest
@@ -125,6 +126,8 @@ def leaderboard(
     code: str,
     request: Request,
     tab: Literal["trending", "all"] = "trending",
+    limit: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    offset: int = Query(default=0, ge=0),
     db: Session = Depends(get_db),
 ):
     event = _get_event_or_404(db, code)
@@ -144,7 +147,11 @@ def leaderboard(
         # and upvote existing submissions rather than recency bias.
         q = q.order_by(func.lower(SongRequest.song_title).asc())
 
-    rows = q.limit(200).all()
+    # True count of the full result set, computed before pagination so the
+    # client knows how many rows exist beyond this page. order_by(None) drops
+    # the ORDER BY from the COUNT subquery (it can't change the count).
+    total = q.order_by(None).count()
+    rows = q.offset(offset).limit(limit).all()
     return CollectLeaderboardResponse(
         requests=[
             CollectLeaderboardRow(
@@ -163,7 +170,7 @@ def leaderboard(
             )
             for r, email_verified_at in rows
         ],
-        total=len(rows),
+        total=total,
     )
 
 

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -138,14 +138,18 @@ def leaderboard(
         .filter(SongRequest.event_id == event.id)
         .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
     )
+    # id.desc() is a unique final tiebreaker so offset pages stay stable
+    # (no dup/skip) when rows tie on the primary sort key.
     if tab == "trending":
         q = q.filter(SongRequest.vote_count >= 1).order_by(
-            SongRequest.vote_count.desc(), SongRequest.created_at.desc()
+            SongRequest.vote_count.desc(),
+            SongRequest.created_at.desc(),
+            SongRequest.id.desc(),
         )
     else:
         # "All" is the discovery view — alphabetical makes it easy to scan
         # and upvote existing submissions rather than recency bias.
-        q = q.order_by(func.lower(SongRequest.song_title).asc())
+        q = q.order_by(func.lower(SongRequest.song_title).asc(), SongRequest.id.desc())
 
     # True count of the full result set, computed before pagination so the
     # client knows how many rows exist beyond this page. order_by(None) drops

--- a/server/app/api/public.py
+++ b/server/app/api/public.py
@@ -4,12 +4,13 @@ import json
 from datetime import datetime
 from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
 from app.core.config import get_settings
+from app.core.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from app.core.rate_limit import get_guest_id, limiter
 from app.core.time import utcnow
 from app.models.event import Event
@@ -82,6 +83,10 @@ class GuestRequestListResponse(BaseModel):
     event: PublicEventInfo
     requests: list[GuestRequestInfo]
     now_playing: GuestNowPlaying | None = None
+    # Full count of NEW/ACCEPTED requests for the event, independent of the
+    # page returned in `requests`. Lets the client offer "load more" / show a
+    # truthful song count instead of inferring from the (capped) page length.
+    total: int = 0
 
 
 class MyRequestInfo(BaseModel):
@@ -251,6 +256,8 @@ def get_public_event(
 def get_public_requests(
     code: str,
     request: Request,
+    limit: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    offset: int = Query(default=0, ge=0),
     db: Session = Depends(get_db),
 ) -> GuestRequestListResponse:
     """Get publicly visible requests for an event (NEW and ACCEPTED only)."""
@@ -265,15 +272,20 @@ def get_public_requests(
     if lookup_result == EventLookupResult.ARCHIVED:
         raise HTTPException(status_code=410, detail="Event has been archived")
 
-    requests_with_verified = (
+    base_q = (
         db.query(SongRequest, Guest.email_verified_at)
         .outerjoin(Guest, SongRequest.guest_id == Guest.id)
         .filter(
             SongRequest.event_id == event.id,
             SongRequest.status.in_([RequestStatus.NEW.value, RequestStatus.ACCEPTED.value]),
         )
-        .order_by(SongRequest.vote_count.desc(), SongRequest.created_at.desc())
-        .limit(50)
+    )
+    # Count before ordering/pagination so the client gets the true total.
+    total = base_q.count()
+    requests_with_verified = (
+        base_q.order_by(SongRequest.vote_count.desc(), SongRequest.created_at.desc())
+        .offset(offset)
+        .limit(limit)
         .all()
     )
 
@@ -310,6 +322,7 @@ def get_public_requests(
             for r, email_verified_at in requests_with_verified
         ],
         now_playing=guest_now_playing,
+        total=total,
     )
 
 

--- a/server/app/api/public.py
+++ b/server/app/api/public.py
@@ -283,7 +283,13 @@ def get_public_requests(
     # Count before ordering/pagination so the client gets the true total.
     total = base_q.count()
     requests_with_verified = (
-        base_q.order_by(SongRequest.vote_count.desc(), SongRequest.created_at.desc())
+        # id.desc() is a unique final tiebreaker so offset pages stay stable
+        # (no dup/skip) when rows tie on vote_count + created_at.
+        base_q.order_by(
+            SongRequest.vote_count.desc(),
+            SongRequest.created_at.desc(),
+            SongRequest.id.desc(),
+        )
         .offset(offset)
         .limit(limit)
         .all()

--- a/server/app/core/pagination.py
+++ b/server/app/core/pagination.py
@@ -1,0 +1,21 @@
+"""Shared pagination bounds for public guest-facing list endpoints.
+
+These bound the *payload size of a single request* — a denial-of-service /
+response-size guard, not a product-level ceiling. Clients page through larger
+result sets with ``offset``; the endpoints always report the true ``total`` so
+callers know how many rows exist beyond the current page.
+
+History: the collect leaderboard and join request list previously hard-capped
+at ``.limit(200)`` / ``.limit(50)`` with ``total=len(rows)``. That silently hid
+every row past the cap and reported a frozen, wrong count. The cap below is a
+real upper bound a client cannot exceed in one call, but it no longer doubles
+as a hidden display ceiling.
+"""
+
+# Default page size when a client omits ``limit``.
+DEFAULT_PAGE_SIZE = 100
+
+# Hard upper bound on a single page. ~500 rows keeps JSON payloads small enough
+# for mobile guests on /join and /collect while sitting far above any realistic
+# single-event request count. Raise only alongside multi-page client fetching.
+MAX_PAGE_SIZE = 500

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -653,7 +653,7 @@
       "Body_upload_banner_api_events__code__banner_post": {
         "properties": {
           "file": {
-            "contentMediaType": "application/octet-stream",
+            "format": "binary",
             "title": "File",
             "type": "string"
           }
@@ -2474,12 +2474,18 @@
             },
             "title": "Requests",
             "type": "array"
+          },
+          "total": {
+            "default": 0,
+            "title": "Total",
+            "type": "integer"
           }
         },
         "required": [
           "event",
           "now_playing",
-          "requests"
+          "requests",
+          "total"
         ],
         "title": "GuestRequestListResponse",
         "type": "object"
@@ -9505,6 +9511,29 @@
               "title": "Tab",
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -10207,6 +10236,29 @@
             "schema": {
               "title": "Code",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
             }
           }
         ],

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -108,6 +108,77 @@ def test_collect_leaderboard_all_tab_includes_zero_votes(
     assert 0 in votes
 
 
+def _make_collection_requests(db, event: Event, count: int) -> None:
+    """Create `count` collection-phase NEW requests titled 'Song NNN', 0 votes.
+
+    Titled with zero-padded indices so the "all" tab's alphabetical sort is
+    deterministic for offset/limit assertions.
+    """
+    from app.models.request import Request, RequestStatus
+
+    now = utcnow()
+    for i in range(count):
+        db.add(
+            Request(
+                event_id=event.id,
+                song_title=f"Song {i:03d}",
+                artist=f"Artist {i:03d}",
+                source="spotify",
+                status=RequestStatus.NEW.value,
+                vote_count=0,
+                dedupe_key=f"pg_dk_{i}",
+                submitted_during_collection=True,
+                created_at=now,
+            )
+        )
+    db.commit()
+
+
+def test_collect_leaderboard_paginates_with_limit_and_offset(client, db, test_event):
+    _enable_collection(db, test_event)
+    _make_collection_requests(db, test_event, 5)
+
+    # "all" tab sorts alphabetically → deterministic ordering across pages.
+    r1 = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all&limit=2&offset=0")
+    assert r1.status_code == 200
+    b1 = r1.json()
+    assert [row["title"] for row in b1["requests"]] == ["Song 000", "Song 001"]
+    assert b1["total"] == 5
+
+    r2 = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all&limit=2&offset=2")
+    b2 = r2.json()
+    assert [row["title"] for row in b2["requests"]] == ["Song 002", "Song 003"]
+    assert b2["total"] == 5
+
+    # Final partial page: one row left, total still reports the full set.
+    r3 = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all&limit=2&offset=4")
+    b3 = r3.json()
+    assert [row["title"] for row in b3["requests"]] == ["Song 004"]
+    assert b3["total"] == 5
+
+
+def test_collect_leaderboard_total_reflects_full_count_beyond_page(client, db, test_event):
+    """Regression: total is the full DB count, not the size of the returned page.
+
+    The endpoint previously hard-capped at `.limit(200).all()` and returned
+    `total=len(rows)`, so any submission past the cap was invisible AND the
+    reported total silently froze at the cap. Pin the fixed behavior.
+    """
+    _enable_collection(db, test_event)
+    _make_collection_requests(db, test_event, 7)
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all&limit=3")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["requests"]) == 3
+    assert body["total"] == 7
+
+
+def test_collect_leaderboard_rejects_oversized_limit(client, db, test_event):
+    _enable_collection(db, test_event)
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?limit=99999")
+    assert r.status_code == 422
+
+
 def test_collect_profile_set_nickname(client, db, test_event):
     _enable_collection(db, test_event)
     r = client.post(

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -179,6 +179,37 @@ def test_collect_leaderboard_rejects_oversized_limit(client, db, test_event):
     assert r.status_code == 422
 
 
+def test_collect_leaderboard_tiebreaker_orders_by_id_desc(client, db, test_event):
+    """Equal-title rows on the 'all' tab order by id desc so offset pages stay
+    stable (no dup/skip). Pins the CodeRabbit pagination finding."""
+    from app.models.request import Request, RequestStatus
+
+    _enable_collection(db, test_event)
+    same_time = utcnow()
+    ids = []
+    for i in range(3):
+        r = Request(
+            event_id=test_event.id,
+            song_title="Same Title",
+            artist=f"Artist {i}",
+            source="spotify",
+            status=RequestStatus.NEW.value,
+            vote_count=0,
+            dedupe_key=f"tie_dk_{i}",
+            submitted_during_collection=True,
+            created_at=same_time,
+        )
+        db.add(r)
+        db.flush()
+        ids.append(r.id)
+    db.commit()
+
+    r = client.get(f"/api/public/collect/{test_event.code}/leaderboard?tab=all")
+    assert r.status_code == 200
+    returned = [row["id"] for row in r.json()["requests"]]
+    assert returned == sorted(ids, reverse=True)
+
+
 def test_collect_profile_set_nickname(client, db, test_event):
     _enable_collection(db, test_event)
     r = client.post(

--- a/server/tests/test_public.py
+++ b/server/tests/test_public.py
@@ -365,6 +365,32 @@ class TestGuestRequestList:
         r = client.get(f"/api/public/events/{test_event.join_code}/requests?limit=99999")
         assert r.status_code == 422
 
+    def test_tiebreaker_orders_by_id_desc(self, client: TestClient, test_event: Event, db: Session):
+        """Rows tied on (vote_count, created_at) order by id desc so offset pages
+        stay stable (no dup/skip). Pins the CodeRabbit pagination finding."""
+        same_time = utcnow()
+        ids = []
+        for i in range(3):
+            r = Request(
+                event_id=test_event.id,
+                song_title=f"Tie {i}",
+                artist="Artist",
+                source="spotify",
+                status=RequestStatus.NEW.value,
+                dedupe_key=f"tie_{i}",
+                vote_count=0,
+                created_at=same_time,
+            )
+            db.add(r)
+            db.flush()
+            ids.append(r.id)
+        db.commit()
+
+        r = client.get(f"/api/public/events/{test_event.join_code}/requests")
+        assert r.status_code == 200
+        returned = [x["id"] for x in r.json()["requests"]]
+        assert returned == sorted(ids, reverse=True)
+
 
 class TestPublicRequestsEnrichmentFields:
     """bpm/musical_key/genre are exposed in /events/{code}/requests response."""

--- a/server/tests/test_public.py
+++ b/server/tests/test_public.py
@@ -309,6 +309,62 @@ class TestGuestRequestList:
         data = response.json()
         assert data["requests"][0]["nickname"] is None
 
+    def test_paginates_and_reports_total(self, client: TestClient, test_event: Event, db: Session):
+        """limit/offset slice the list; total reports the full count."""
+        for i in range(5):
+            db.add(
+                Request(
+                    event_id=test_event.id,
+                    song_title=f"Track {i:03d}",
+                    artist="Artist",
+                    source="spotify",
+                    status=RequestStatus.NEW.value,
+                    dedupe_key=f"pub_pg_{i}",
+                    vote_count=i,  # distinct → deterministic vote_count desc order
+                )
+            )
+        db.commit()
+
+        # Order is vote_count desc → Track 004 (4), 003 (3), 002 (2), 001 (1), 000 (0)
+        r1 = client.get(f"/api/public/events/{test_event.join_code}/requests?limit=2&offset=0")
+        assert r1.status_code == 200
+        b1 = r1.json()
+        assert [x["title"] for x in b1["requests"]] == ["Track 004", "Track 003"]
+        assert b1["total"] == 5
+
+        r2 = client.get(f"/api/public/events/{test_event.join_code}/requests?limit=2&offset=2")
+        b2 = r2.json()
+        assert [x["title"] for x in b2["requests"]] == ["Track 002", "Track 001"]
+        assert b2["total"] == 5
+
+    def test_total_reflects_full_count_beyond_page(
+        self, client: TestClient, test_event: Event, db: Session
+    ):
+        """Regression: the list was hard-capped at .limit(50); total must be honest."""
+        for i in range(6):
+            db.add(
+                Request(
+                    event_id=test_event.id,
+                    song_title=f"S{i}",
+                    artist="Artist",
+                    source="spotify",
+                    status=RequestStatus.NEW.value,
+                    dedupe_key=f"pub_tot_{i}",
+                    vote_count=0,
+                )
+            )
+        db.commit()
+
+        r = client.get(f"/api/public/events/{test_event.join_code}/requests?limit=2")
+        assert r.status_code == 200
+        body = r.json()
+        assert len(body["requests"]) == 2
+        assert body["total"] == 6
+
+    def test_rejects_oversized_limit(self, client: TestClient, test_event: Event):
+        r = client.get(f"/api/public/events/{test_event.join_code}/requests?limit=99999")
+        assert r.status_code == 422
+
 
 class TestPublicRequestsEnrichmentFields:
     """bpm/musical_key/genre are exposed in /events/{code}/requests response."""


### PR DESCRIPTION
## Problem

Production event **ELZ2G2** only showed **200 songs** on the collect page, with more clearly submitted. Investigation found it was a **backend hard cap**, not a display bug — and there were two:

| Surface | Endpoint | Cap |
|---------|----------|-----|
| Collect leaderboard | `GET /api/public/collect/{code}/leaderboard` | `q.limit(200).all()` |
| Join request list | `GET /api/public/events/{code}/requests` | `.limit(50)` |

Both returned `total=len(rows)`, so beyond the cap the list was **silently truncated** *and* the displayed song count **froze at the cap** (the count badge literally couldn't exceed 200). Neither endpoint accepted any paging params, so the client had no way to reach later rows.

## Fix — proper offset/limit pagination

**Backend**
- `limit` (default 100, max 500) + `offset` query params on both endpoints
- True `total` via `COUNT(*)` computed **before** pagination (not `len(rows)`)
- `total` added to `GuestRequestListResponse` (the collect response already had it)
- New `server/app/core/pagination.py` documents the bounds as a **payload guard, not a display ceiling**
- OpenAPI schema + TS types regenerated

**Frontend** — growing-window model
- `displayLimit` state grows on **"Load more"**; the fetch always reads from `offset=0`
- This is intentional: both pages already re-fetch and *replace* their whole list on a timer (collect 5s, join 10s + SSE). A growing window keeps live vote/status updates correct with **no client-side dedup and no offset-drift** when vote counts reorder rows. The backend still exposes true `offset` paging for any future non-polling consumer.
- **Count badges now show the real `total`** instead of the capped page length

## Trade-off

`MAX_PAGE_SIZE=500` bounds a single request's payload. The product ceiling is gone (count is honest; `offset` can reach any row), but the frontend's growing window tops out at 500 displayed rows — far above any realistic single event. If an event is ever expected to exceed 500 distinct requests, the frontend would need multi-page fetching (backend already supports it).

## Tests

- **Backend (6):** offset/limit slicing across pages, `total` honest beyond the returned page (regression refs the old `.limit(200)`/`total=len(rows)`), oversized-`limit` → 422 — for both endpoints
- **Frontend (4):** `getPublicRequests` / `getCollectLeaderboard` append `limit`/`offset` correctly and omit the query string when unset

## Verification (local CI, all green)

- Backend: `2065 passed`, coverage **88.07%** (≥85% gate), ruff + format + bandit clean
- Frontend: `952 passed`, `tsc` clean, ESLint clean

## Manual test plan

- [ ] On an event with >100 collection submissions, open `/collect/{code}` — count badge shows the **true** total; list shows 100 with a **Load more · N more** button that loads the rest
- [ ] On a live event with >100 NEW/ACCEPTED requests, open `/join/{code}` — QUEUE pill shows true total; Load more works on LEADERBOARD/RECENT
- [ ] Confirm ELZ2G2 now shows all songs, not 200
- [ ] Verify live vote updates still reorder correctly while a window is expanded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Leaderboards and request queues support incremental pagination with a visible "LOAD MORE" button and capped page size
  * Headers, counters and queue pills show accurate total counts for all items
  * Changing tabs resets the view to the initial paginated window

* **Tests**
  * Added coverage for pagination slicing, total-count accuracy, ordering stability and oversized-limit validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->