### PR TITLE
fix(theme): prevent ThemeToggle hydration mismatch on themed pages

### DIFF
--- a/dashboard/lib/__tests__/theme.test.tsx
+++ b/dashboard/lib/__tests__/theme.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
+import { renderToString } from 'react-dom/server';
 import { ThemeProvider, useTheme } from '../theme';
 import { getThemeVars } from '../theme-vars';
 
@@ -134,5 +135,20 @@ describe('ThemeProvider', () => {
     localStorage.setItem('wrzdj-theme', 'invalid-theme');
     renderWithProvider();
     expect(screen.getByTestId('theme').textContent).toBe('dark');
+  });
+
+  it('server-renders the default theme regardless of saved theme (hydration-safe)', () => {
+    // The server has no localStorage, so its markup must match the client's
+    // FIRST render. If the provider read localStorage during render, the
+    // server (dark) and client (daylight) markup would diverge → React
+    // hydration mismatch. Saved theme is loaded post-mount instead.
+    localStorage.setItem('wrzdj-theme', 'daylight');
+    const html = renderToString(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>
+    );
+    expect(html).toContain('data-testid="theme">dark<');
+    expect(html).not.toContain('data-testid="theme">daylight<');
   });
 });

--- a/dashboard/lib/theme.tsx
+++ b/dashboard/lib/theme.tsx
@@ -55,7 +55,18 @@ function applyTheme(theme: Theme): void {
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>(detectInitialTheme);
+  // Start from a deterministic default so the server-rendered markup matches
+  // the client's first (hydration) render. Reading localStorage during render
+  // would diverge server (no storage → 'dark') from client (saved → e.g.
+  // 'daylight') and trip React's hydration-mismatch warning. The persisted /
+  // auto-detected theme is loaded just below, after mount.
+  const [theme, setThemeState] = useState<Theme>('dark');
+
+  // Resolve the real theme on the client, post-hydration.
+  useEffect(() => {
+    const initial = detectInitialTheme();
+    if (initial !== 'dark') setThemeState(initial);
+  }, []);
 
   const setTheme = useCallback((newTheme: Theme) => {
     setThemeState(newTheme);


### PR DESCRIPTION
## Problem
`ThemeProvider` read `localStorage` inside `useState`'s initializer (`detectInitialTheme`). During SSR there is no `localStorage`, so the server rendered the **default** theme (`dark`); the client's **first** render read the persisted theme (e.g. `daylight`). `ThemeToggle` derives its `title` / `aria-label` / icon class / label text from the active theme, so server and first-client markup diverged → React logged a **hydration-mismatch warning** on every `(dj)` page whenever a non-default theme was saved.

This was surfaced while moving WrzDJSet's setbuilder into the `(dj)` layout group (PR #410), but it is pre-existing and app-wide (fires on `/dashboard`, `/events`, `/account`, …).

## Fix
- Initialize theme state to a deterministic `'dark'` so the **server render and the client's first render are identical** (no mismatch).
- Resolve the persisted / auto-detected theme in a **post-mount `useEffect`**, so the real theme applies immediately after hydration. The toggle's label updates as a normal post-hydration state change (allowed), instead of differing *during* hydration (the illegal case).

No behavior change for users: the saved theme still wins; the `data-theme` attribute and CSS vars were already applied imperatively in an effect (never part of SSR markup), so colors are unchanged.

## Test plan
- [x] New `renderToString` regression test: server markup is independent of `localStorage` (renders `dark` even when `daylight` is saved). Fails before the fix, passes after.
- [x] Existing 8 `ThemeProvider` tests + `ThemeToggle` tests still green (RTL flushes the post-mount effect, so observable behavior is unchanged).
- [x] Frontend CI green locally: `npm run lint` (0 errors), `tsc --noEmit` clean, `vitest` 953 passed.
- [x] Browser-verified: fresh SSR load of `/dashboard` with `wrzdj-theme=daylight` saved and the toggle rendered → **0 console errors** (was a hydration warning before); toggle correctly resolves to "Day", body renders light.

## Notes
- Does **not** address the separate pre-existing FOUC (brief default-theme flash before the post-mount effect applies the saved theme). Eliminating that requires a blocking inline `<head>` script and is out of scope for this warning fix — happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed theme initialization on page load to prevent visual inconsistencies and ensure saved theme preferences display correctly without flickering during server-side rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->