### PR TITLE
feat(setbuilder): read-only share links + duplicate set (#398)

### DIFF
--- a/dashboard/app/(dj)/setbuilder/SetActionsMenu.tsx
+++ b/dashboard/app/(dj)/setbuilder/SetActionsMenu.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { api } from '@/lib/api';
+import type { SetDetail } from '@/lib/api-types';
+import ShareDialog from './ShareDialog';
+
+interface SetActionsMenuProps {
+  set: SetDetail;
+  /** Lets the builder page keep its copy of the set in sync after share changes. */
+  onShareChanged: (token: string | null) => void;
+}
+
+/** Duplicate + Share actions for the builder topbar (brand-menu equivalent). */
+export default function SetActionsMenu({ set, onShareChanged }: SetActionsMenuProps) {
+  const router = useRouter();
+  const [shareOpen, setShareOpen] = useState(false);
+  const [duplicating, setDuplicating] = useState(false);
+  const [error, setError] = useState(false);
+
+  const duplicate = async () => {
+    setDuplicating(true);
+    setError(false);
+    try {
+      const dup = await api.duplicateSet(set.id);
+      router.push(`/setbuilder/${dup.id}`);
+    } catch {
+      setError(true);
+      setDuplicating(false);
+    }
+  };
+
+  return (
+    <span style={{ display: 'inline-flex', gap: '0.5rem', alignItems: 'center' }}>
+      {error && (
+        <span style={{ color: 'var(--color-danger)', fontSize: '0.75rem' }}>Duplicate failed</span>
+      )}
+      <button
+        type="button"
+        className="btn btn-sm"
+        style={{ background: 'var(--surface-raised)' }}
+        disabled={duplicating}
+        onClick={duplicate}
+      >
+        {duplicating ? 'Duplicating…' : 'Duplicate'}
+      </button>
+      <button
+        type="button"
+        className="btn btn-sm"
+        style={{ background: 'var(--surface-raised)' }}
+        onClick={() => setShareOpen(true)}
+      >
+        {set.share_token ? 'Shared' : 'Share'}
+      </button>
+      {shareOpen && (
+        <ShareDialog set={set} onClose={() => setShareOpen(false)} onChanged={onShareChanged} />
+      )}
+    </span>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/ShareDialog.tsx
+++ b/dashboard/app/(dj)/setbuilder/ShareDialog.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useState } from 'react';
+import { api } from '@/lib/api';
+import type { SetSummary } from '@/lib/api-types';
+
+interface ShareDialogProps {
+  set: SetSummary;
+  onClose: () => void;
+  /** Called with the new token (or null after revoke) so callers can update state. */
+  onChanged: (token: string | null) => void;
+}
+
+function shareUrl(token: string): string {
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  return `${origin}/shared/${token}`;
+}
+
+/** Read-only share-link management for a set: create, regenerate, revoke. */
+export default function ShareDialog({ set, onClose, onChanged }: ShareDialogProps) {
+  const [token, setToken] = useState<string | null>(set.share_token);
+  const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const generate = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await api.shareSet(set.id);
+      setToken(result.share_token);
+      setCopied(false);
+      onChanged(result.share_token);
+    } catch {
+      setError('Failed to update share link');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const revoke = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await api.revokeSetShare(set.id);
+      setToken(null);
+      setCopied(false);
+      onChanged(null);
+    } catch {
+      setError('Failed to revoke share link');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const copy = async () => {
+    if (!token) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl(token));
+      setCopied(true);
+    } catch {
+      setError('Copy failed — copy the URL manually');
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label={`Share ${set.name}`}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0, 0, 0, 0.6)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 100,
+      }}
+      onClick={onClose}
+    >
+      <div
+        className="card"
+        style={{ maxWidth: 480, width: '90%' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 style={{ marginBottom: '0.5rem' }}>Share &ldquo;{set.name}&rdquo;</h2>
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '1rem' }}>
+          Anyone with the link can view this set. They cannot edit, export, or see your account.
+        </p>
+
+        {error && (
+          <p style={{ color: 'var(--color-danger)', fontSize: '0.875rem', marginBottom: '0.75rem' }}>
+            {error}
+          </p>
+        )}
+
+        {token ? (
+          <>
+            <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+              <input
+                type="text"
+                className="input"
+                readOnly
+                value={shareUrl(token)}
+                aria-label="Share URL"
+                onFocus={(e) => e.target.select()}
+              />
+              <button type="button" className="btn btn-sm btn-primary" onClick={copy}>
+                {copied ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <button
+                type="button"
+                className="btn btn-sm"
+                style={{ background: 'var(--surface-raised)' }}
+                disabled={busy}
+                onClick={generate}
+              >
+                Regenerate
+              </button>
+              <button type="button" className="btn btn-sm btn-danger" disabled={busy} onClick={revoke}>
+                Revoke
+              </button>
+              <span style={{ flex: 1 }} />
+              <button
+                type="button"
+                className="btn btn-sm"
+                style={{ background: 'var(--surface-raised)' }}
+                onClick={onClose}
+              >
+                Close
+              </button>
+            </div>
+          </>
+        ) : (
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
+            <button type="button" className="btn btn-primary" disabled={busy} onClick={generate}>
+              {busy ? 'Creating…' : 'Create share link'}
+            </button>
+            <button
+              type="button"
+              className="btn"
+              style={{ background: 'var(--surface-raised)' }}
+              onClick={onClose}
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { SetDetail } from '@/lib/api-types';
+import SetActionsMenu from '../SetActionsMenu';
 import styles from '../setbuilder.module.css';
 
 export default function BuilderPage({ params }: { params: Promise<{ setId: string }> }) {
@@ -68,7 +69,16 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
           ← Sets
         </Link>
         <span className={styles.topbarTitle}>{set?.name ?? 'Loading…'}</span>
-        <span style={{ width: 60 }} />
+        {set ? (
+          <SetActionsMenu
+            set={set}
+            onShareChanged={(token) =>
+              setSet((prev) => (prev ? { ...prev, share_token: token } : prev))
+            }
+          />
+        ) : (
+          <span style={{ width: 60 }} />
+        )}
       </div>
 
       <div className={styles.workspace}>

--- a/dashboard/app/(dj)/setbuilder/__tests__/ShareDialog.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/ShareDialog.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ShareDialog from '../ShareDialog';
+import type { SetSummary } from '@/lib/api-types';
+
+const mockShareSet = vi.fn();
+const mockRevokeSetShare = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    shareSet: (id: number) => mockShareSet(id),
+    revokeSetShare: (id: number) => mockRevokeSetShare(id),
+  },
+}));
+
+function makeSet(overrides: Partial<SetSummary> = {}): SetSummary {
+  return {
+    id: 7,
+    name: 'Friday Wedding',
+    event_id: null,
+    status: 'draft',
+    sharing_mode: 'private',
+    share_token: null,
+    created_at: '2026-06-07T00:00:00Z',
+    updated_at: '2026-06-07T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('ShareDialog', () => {
+  beforeEach(() => {
+    mockShareSet.mockReset();
+    mockRevokeSetShare.mockReset();
+  });
+
+  it('offers to create a share link when not shared', () => {
+    render(<ShareDialog set={makeSet()} onClose={vi.fn()} onChanged={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /create share link/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /revoke/i })).not.toBeInTheDocument();
+  });
+
+  it('creates a link and surfaces the share URL', async () => {
+    mockShareSet.mockResolvedValue({ share_token: 'tok_abc' });
+    const onChanged = vi.fn();
+    render(<ShareDialog set={makeSet()} onClose={vi.fn()} onChanged={onChanged} />);
+    fireEvent.click(screen.getByRole('button', { name: /create share link/i }));
+    await waitFor(() => {
+      expect(screen.getByDisplayValue(/\/shared\/tok_abc$/)).toBeInTheDocument();
+    });
+    expect(mockShareSet).toHaveBeenCalledWith(7);
+    expect(onChanged).toHaveBeenCalledWith('tok_abc');
+  });
+
+  it('shows the existing URL with regenerate and revoke when already shared', () => {
+    render(
+      <ShareDialog
+        set={makeSet({ share_token: 'tok_live' })}
+        onClose={vi.fn()}
+        onChanged={vi.fn()}
+      />
+    );
+    expect(screen.getByDisplayValue(/\/shared\/tok_live$/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /regenerate/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /revoke/i })).toBeInTheDocument();
+  });
+
+  it('revokes the link', async () => {
+    mockRevokeSetShare.mockResolvedValue(undefined);
+    const onChanged = vi.fn();
+    render(
+      <ShareDialog
+        set={makeSet({ share_token: 'tok_live' })}
+        onClose={vi.fn()}
+        onChanged={onChanged}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /revoke/i }));
+    await waitFor(() => {
+      expect(mockRevokeSetShare).toHaveBeenCalledWith(7);
+    });
+    expect(onChanged).toHaveBeenCalledWith(null);
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/page.test.tsx
@@ -14,12 +14,16 @@ vi.mock('next/link', () => ({
 
 const mockListSets = vi.fn();
 const mockRenameSet = vi.fn();
+const mockDuplicateSet = vi.fn();
 vi.mock('@/lib/api', () => ({
   api: {
     listSets: () => mockListSets(),
     createSet: vi.fn(),
     deleteSet: vi.fn(),
     renameSet: (id: number, name: string) => mockRenameSet(id, name),
+    duplicateSet: (id: number) => mockDuplicateSet(id),
+    shareSet: vi.fn(),
+    revokeSetShare: vi.fn(),
   },
 }));
 
@@ -31,6 +35,7 @@ describe('SetbuilderPage', () => {
   beforeEach(() => {
     mockListSets.mockReset();
     mockRenameSet.mockReset();
+    mockDuplicateSet.mockReset();
   });
 
   it('renders the empty state when there are no sets', async () => {
@@ -95,6 +100,59 @@ describe('SetbuilderPage', () => {
     await waitFor(() => {
       expect(mockRenameSet).toHaveBeenCalledWith(1, 'Saturday Gala');
       expect(screen.getByText('Saturday Gala')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a Shared badge when a set has a share token', async () => {
+    mockListSets.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Friday Wedding',
+        event_id: null,
+        status: 'draft',
+        sharing_mode: 'private',
+        share_token: 'tok_live',
+        created_at: '2026-06-07T00:00:00Z',
+        updated_at: '2026-06-07T00:00:00Z',
+      },
+    ]);
+    render(<SetbuilderPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Shared')).toBeInTheDocument();
+    });
+  });
+
+  it('duplicates a set and prepends the copy to the list', async () => {
+    mockListSets.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Friday Wedding',
+        event_id: null,
+        status: 'draft',
+        sharing_mode: 'private',
+        share_token: null,
+        created_at: '2026-06-07T00:00:00Z',
+        updated_at: '2026-06-07T00:00:00Z',
+      },
+    ]);
+    mockDuplicateSet.mockResolvedValue({
+      id: 2,
+      name: 'Friday Wedding (copy)',
+      event_id: null,
+      status: 'draft',
+      sharing_mode: 'private',
+      share_token: null,
+      created_at: '2026-06-08T00:00:00Z',
+      updated_at: '2026-06-08T00:00:00Z',
+    });
+    render(<SetbuilderPage />);
+    await waitFor(() => expect(screen.getByText('Friday Wedding')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /duplicate/i }));
+
+    await waitFor(() => {
+      expect(mockDuplicateSet).toHaveBeenCalledWith(1);
+      expect(screen.getByText('Friday Wedding (copy)')).toBeInTheDocument();
     });
   });
 });

--- a/dashboard/app/(dj)/setbuilder/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/page.test.tsx
@@ -49,6 +49,7 @@ describe('SetbuilderPage', () => {
         event_id: null,
         status: 'draft',
         sharing_mode: 'private',
+        share_token: null,
         created_at: '2026-06-07T00:00:00Z',
         updated_at: '2026-06-07T00:00:00Z',
       },
@@ -67,6 +68,7 @@ describe('SetbuilderPage', () => {
         event_id: null,
         status: 'draft',
         sharing_mode: 'private',
+        share_token: null,
         created_at: '2026-06-07T00:00:00Z',
         updated_at: '2026-06-07T00:00:00Z',
       },
@@ -77,6 +79,7 @@ describe('SetbuilderPage', () => {
       event_id: null,
       status: 'draft',
       sharing_mode: 'private',
+      share_token: null,
       created_at: '2026-06-07T00:00:00Z',
       updated_at: '2026-06-07T01:00:00Z',
     });

--- a/dashboard/app/(dj)/setbuilder/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { SetSummary } from '@/lib/api-types';
+import ShareDialog from './ShareDialog';
 
 export default function SetbuilderPage() {
   const { isAuthenticated, isLoading, role } = useAuth();
@@ -18,6 +19,7 @@ export default function SetbuilderPage() {
   const [renamingId, setRenamingId] = useState<number | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const [savingRename, setSavingRename] = useState(false);
+  const [shareTarget, setShareTarget] = useState<SetSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -62,6 +64,20 @@ export default function SetbuilderPage() {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete set');
     }
+  };
+
+  const handleDuplicate = async (id: number) => {
+    try {
+      const dup = await api.duplicateSet(id);
+      setSets((prev) => [dup, ...prev]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to duplicate set');
+    }
+  };
+
+  const handleShareChanged = (id: number, token: string | null) => {
+    setSets((prev) => prev.map((s) => (s.id === id ? { ...s, share_token: token } : s)));
+    setShareTarget((prev) => (prev && prev.id === id ? { ...prev, share_token: token } : prev));
   };
 
   const startRename = (s: SetSummary) => {
@@ -209,18 +225,43 @@ export default function SetbuilderPage() {
               ) : (
                 <>
                   <Link href={`/setbuilder/${s.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-                    <h3>{s.name}</h3>
+                    <h3>
+                      {s.name}
+                      {s.share_token && (
+                        <span
+                          className="badge"
+                          style={{ marginLeft: '0.5rem', verticalAlign: 'middle' }}
+                          title="A public read-only link exists for this set"
+                        >
+                          Shared
+                        </span>
+                      )}
+                    </h3>
                     <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
                       Updated: {new Date(s.updated_at).toLocaleString()}
                     </p>
                   </Link>
-                  <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.75rem' }}>
+                  <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.75rem', flexWrap: 'wrap' }}>
                     <button
                       className="btn btn-sm"
                       style={{ background: 'var(--surface-raised)' }}
                       onClick={() => startRename(s)}
                     >
                       Rename
+                    </button>
+                    <button
+                      className="btn btn-sm"
+                      style={{ background: 'var(--surface-raised)' }}
+                      onClick={() => handleDuplicate(s.id)}
+                    >
+                      Duplicate
+                    </button>
+                    <button
+                      className="btn btn-sm"
+                      style={{ background: 'var(--surface-raised)' }}
+                      onClick={() => setShareTarget(s)}
+                    >
+                      Share
                     </button>
                     <button className="btn btn-sm btn-danger" onClick={() => handleDelete(s.id)}>
                       Delete
@@ -231,6 +272,14 @@ export default function SetbuilderPage() {
             </div>
           ))}
         </div>
+      )}
+
+      {shareTarget && (
+        <ShareDialog
+          set={shareTarget}
+          onClose={() => setShareTarget(null)}
+          onChanged={(token) => handleShareChanged(shareTarget.id, token)}
+        />
       )}
     </div>
   );

--- a/dashboard/app/shared/[token]/__tests__/page.test.tsx
+++ b/dashboard/app/shared/[token]/__tests__/page.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import SharedSetPage from '../page';
+import type { SharedSetView } from '@/lib/api-types';
+
+const mockGetSharedSet = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    getSharedSet: (token: string) => mockGetSharedSet(token),
+  },
+}));
+
+let mockToken = 'tok_live';
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ token: mockToken }),
+}));
+
+function makeView(overrides: Partial<SharedSetView> = {}): SharedSetView {
+  return {
+    name: 'Warehouse Closer',
+    status: 'draft',
+    vibe_theme: 'dark-techno',
+    target_duration_sec: 3600,
+    bpm_floor: 124,
+    bpm_ceiling: 132,
+    key_strictness: 0.7,
+    slots: [
+      {
+        position: 1,
+        track_id: 'tidal:111',
+        locked: true,
+        notes: 'opener',
+        transition_score: 0.9,
+      },
+      {
+        position: 2,
+        track_id: 'tidal:222',
+        locked: false,
+        notes: null,
+        transition_score: null,
+      },
+    ],
+    curve_points: [
+      {
+        position_sec: 0,
+        energy: 4,
+        label: 'warmup',
+        is_slow_window_start: true,
+        is_slow_window_end: false,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderPage(token = 'tok_live') {
+  mockToken = token;
+  return render(<SharedSetPage />);
+}
+
+describe('SharedSetPage', () => {
+  beforeEach(() => {
+    mockGetSharedSet.mockReset();
+    mockToken = 'tok_live';
+  });
+
+  it('renders the view-only set with slots and curve', async () => {
+    mockGetSharedSet.mockResolvedValue(makeView());
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Warehouse Closer')).toBeInTheDocument();
+    });
+    expect(mockGetSharedSet).toHaveBeenCalledWith('tok_live');
+    expect(screen.getByText(/view only/i)).toBeInTheDocument();
+    expect(screen.getByText('tidal:111')).toBeInTheDocument();
+    expect(screen.getByText('opener')).toBeInTheDocument();
+    expect(screen.getByText('warmup')).toBeInTheDocument();
+    expect(screen.getByText(/124–132 BPM/)).toBeInTheDocument();
+    // no mutation/agent/export affordances
+    expect(screen.queryByRole('button', { name: /share|duplicate|export|save|delete/i })).toBeNull();
+  });
+
+  it('shows an invalid-link message when the token 404s', async () => {
+    mockGetSharedSet.mockRejectedValue(new Error('Not found'));
+    renderPage('bad');
+    await waitFor(() => {
+      expect(screen.getByText(/invalid or has been revoked/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/dashboard/app/shared/[token]/page.tsx
+++ b/dashboard/app/shared/[token]/page.tsx
@@ -7,8 +7,9 @@ import type { SharedSetView } from '@/lib/api-types';
 
 /** Format seconds as "1h 05m" / "45m". */
 function formatDuration(totalSec: number): string {
-  const hours = Math.floor(totalSec / 3600);
-  const minutes = Math.round((totalSec % 3600) / 60);
+  const totalMinutes = Math.round(totalSec / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
   if (hours === 0) return `${minutes}m`;
   return `${hours}h ${String(minutes).padStart(2, '0')}m`;
 }
@@ -34,10 +35,20 @@ export default function SharedSetPage() {
 
   useEffect(() => {
     if (!token) return;
+    let cancelled = false;
+    setError(false);
+    setView(null);
     api
       .getSharedSet(token)
-      .then(setView)
-      .catch(() => setError(true));
+      .then((data) => {
+        if (!cancelled) setView(data);
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [token]);
 
   if (error) {

--- a/dashboard/app/shared/[token]/page.tsx
+++ b/dashboard/app/shared/[token]/page.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { api } from '@/lib/api';
+import type { SharedSetView } from '@/lib/api-types';
+
+/** Format seconds as "1h 05m" / "45m". */
+function formatDuration(totalSec: number): string {
+  const hours = Math.floor(totalSec / 3600);
+  const minutes = Math.round((totalSec % 3600) / 60);
+  if (hours === 0) return `${minutes}m`;
+  return `${hours}h ${String(minutes).padStart(2, '0')}m`;
+}
+
+function formatCurvePosition(sec: number): string {
+  const minutes = Math.floor(sec / 60);
+  const seconds = sec % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+/**
+ * Public, view-only rendering of a shared set (issue #398).
+ *
+ * No auth, no mutation calls, no agent/export controls — the share token
+ * only grants the single public read endpoint on the server, and this page
+ * intentionally renders nothing interactive beyond scrolling.
+ */
+export default function SharedSetPage() {
+  const params = useParams();
+  const token = params.token as string;
+  const [view, setView] = useState<SharedSetView | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!token) return;
+    api
+      .getSharedSet(token)
+      .then(setView)
+      .catch(() => setError(true));
+  }, [token]);
+
+  if (error) {
+    return (
+      <div className="container" style={{ maxWidth: 720, paddingTop: '4rem' }}>
+        <div className="card" style={{ textAlign: 'center' }}>
+          <h1 style={{ marginBottom: '0.5rem' }}>Set unavailable</h1>
+          <p style={{ color: 'var(--text-secondary)' }}>
+            This link is invalid or has been revoked.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!view) {
+    return (
+      <div className="container" style={{ maxWidth: 720 }}>
+        <div className="loading">Loading…</div>
+      </div>
+    );
+  }
+
+  const chips: string[] = [];
+  if (view.target_duration_sec != null) chips.push(formatDuration(view.target_duration_sec));
+  if (view.bpm_floor != null && view.bpm_ceiling != null) {
+    chips.push(`${view.bpm_floor}–${view.bpm_ceiling} BPM`);
+  }
+  if (view.vibe_theme) chips.push(view.vibe_theme);
+
+  return (
+    <div className="container" style={{ maxWidth: 720, paddingBottom: '3rem' }}>
+      <header style={{ margin: '2rem 0 1.5rem' }}>
+        <span
+          className="badge"
+          style={{ display: 'inline-block', marginBottom: '0.75rem' }}
+          title="Shared read-only view"
+        >
+          View only
+        </span>
+        <h1 style={{ marginBottom: '0.5rem' }}>{view.name}</h1>
+        {chips.length > 0 && (
+          <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
+            {chips.join(' · ')}
+          </p>
+        )}
+      </header>
+
+      <section className="card" style={{ marginBottom: '1.5rem' }} aria-label="Timeline">
+        <h2 style={{ marginBottom: '1rem' }}>Timeline</h2>
+        {view.slots.length === 0 ? (
+          <p style={{ color: 'var(--text-secondary)' }}>No tracks yet.</p>
+        ) : (
+          <ol style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            {view.slots.map((slot) => (
+              <li
+                key={slot.position}
+                style={{
+                  display: 'flex',
+                  gap: '0.75rem',
+                  alignItems: 'baseline',
+                  padding: '0.5rem 0',
+                  borderBottom: '1px solid var(--surface-raised)',
+                }}
+              >
+                <span style={{ color: 'var(--text-secondary)', minWidth: '1.5rem' }}>
+                  {slot.position}
+                </span>
+                <span style={{ flex: 1 }}>
+                  {slot.track_id ?? <em style={{ color: 'var(--text-secondary)' }}>empty slot</em>}
+                  {slot.locked && (
+                    <span style={{ marginLeft: '0.5rem' }} title="Locked" aria-label="Locked">
+                      🔒
+                    </span>
+                  )}
+                  {slot.notes && (
+                    <span
+                      style={{
+                        display: 'block',
+                        color: 'var(--text-secondary)',
+                        fontSize: '0.8125rem',
+                      }}
+                    >
+                      {slot.notes}
+                    </span>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      <section className="card" aria-label="Energy curve">
+        <h2 style={{ marginBottom: '1rem' }}>Energy curve</h2>
+        {view.curve_points.length === 0 ? (
+          <p style={{ color: 'var(--text-secondary)' }}>No curve defined.</p>
+        ) : (
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            {view.curve_points.map((point) => (
+              <li
+                key={point.position_sec}
+                style={{
+                  display: 'flex',
+                  gap: '0.75rem',
+                  alignItems: 'baseline',
+                  padding: '0.375rem 0',
+                }}
+              >
+                <span style={{ color: 'var(--text-secondary)', minWidth: '3.5rem' }}>
+                  {formatCurvePosition(point.position_sec)}
+                </span>
+                <span style={{ minWidth: '6rem' }}>Energy {point.energy}/10</span>
+                {point.label && <span>{point.label}</span>}
+                {(point.is_slow_window_start || point.is_slow_window_end) && (
+                  <span style={{ color: 'var(--text-secondary)', fontSize: '0.8125rem' }}>
+                    {point.is_slow_window_start ? 'slow window starts' : 'slow window ends'}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -9178,6 +9178,13 @@ export interface operations {
                     "application/json": components["schemas"]["SharedSetView"];
                 };
             };
+            /** @description Shared set not found (unknown, revoked, or malformed token). */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -2303,6 +2303,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/public/setbuilder/shared/{token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * View Shared Set
+         * @description Public read-only projection of a shared set (no auth required).
+         *
+         *     Unknown, revoked, and malformed tokens all return the same 404.
+         */
+        get: operations["view_shared_set_api_public_setbuilder_shared__token__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/requests/{request_id}": {
         parameters: {
             query?: never;
@@ -2462,6 +2484,50 @@ export interface paths {
          * @description Rename one of the current DJ's sets, or 404.
          */
         patch: operations["rename_set_api_setbuilder_sets__set_id__patch"];
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/duplicate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Duplicate Set
+         * @description Duplicate an owned set (slots, curve, targets); copy is a private draft.
+         */
+        post: operations["duplicate_set_api_setbuilder_sets__set_id__duplicate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/share": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Or Rotate Share Token
+         * @description Create (or rotate) the read-only share token for an owned set.
+         */
+        post: operations["create_or_rotate_share_token_api_setbuilder_sets__set_id__share_post"];
+        /**
+         * Revoke Share Token
+         * @description Revoke the share token for an owned set; existing links 404.
+         */
+        delete: operations["revoke_share_token_api_setbuilder_sets__set_id__share_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/api/tidal/auth/cancel": {
@@ -3069,10 +3135,7 @@ export interface components {
         };
         /** Body_upload_banner_api_events__code__banner_post */
         Body_upload_banner_api_events__code__banner_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** BridgeApiKeyResponse */
@@ -4604,6 +4667,8 @@ export interface components {
             key_strictness: number;
             /** Name */
             name: string;
+            /** Share Token */
+            share_token: string | null;
             /**
              * Sharing Mode
              * @enum {string}
@@ -4650,6 +4715,8 @@ export interface components {
             id: number;
             /** Name */
             name: string;
+            /** Share Token */
+            share_token: string | null;
             /**
              * Sharing Mode
              * @enum {string}
@@ -4665,6 +4732,76 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
+        };
+        /**
+         * ShareTokenOut
+         * @description Owner response after creating/rotating a share token (issue #398).
+         */
+        ShareTokenOut: {
+            /** Share Token */
+            share_token: string;
+        };
+        /**
+         * SharedCurvePointView
+         * @description View-only curve-point projection for public share links.
+         */
+        SharedCurvePointView: {
+            /** Energy */
+            energy: number;
+            /** Is Slow Window End */
+            is_slow_window_end: boolean;
+            /** Is Slow Window Start */
+            is_slow_window_start: boolean;
+            /** Label */
+            label: string | null;
+            /** Position Sec */
+            position_sec: number;
+        };
+        /**
+         * SharedSetView
+         * @description Public read-only projection of a shared set (issue #398).
+         *
+         *     Never include owner identity, internal ids, event linkage,
+         *     collaborator info, or the token itself.
+         */
+        SharedSetView: {
+            /** Bpm Ceiling */
+            bpm_ceiling: number | null;
+            /** Bpm Floor */
+            bpm_floor: number | null;
+            /** Curve Points */
+            curve_points: components["schemas"]["SharedCurvePointView"][];
+            /** Key Strictness */
+            key_strictness: number;
+            /** Name */
+            name: string;
+            /** Slots */
+            slots: components["schemas"]["SharedSlotView"][];
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "draft" | "locked" | "exported";
+            /** Target Duration Sec */
+            target_duration_sec: number | null;
+            /** Vibe Theme */
+            vibe_theme: string | null;
+        };
+        /**
+         * SharedSlotView
+         * @description View-only slot projection for public share links (no DB ids).
+         */
+        SharedSlotView: {
+            /** Locked */
+            locked: boolean;
+            /** Notes */
+            notes: string | null;
+            /** Position */
+            position: number;
+            /** Track Id */
+            track_id: string | null;
+            /** Transition Score */
+            transition_score: number | null;
         };
         /** StatusMessageResponse */
         StatusMessageResponse: {
@@ -9021,6 +9158,37 @@ export interface operations {
             };
         };
     };
+    view_shared_set_api_public_setbuilder_shared__token__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SharedSetView"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     delete_request_endpoint_api_requests__request_id__delete: {
         parameters: {
             query?: never;
@@ -9365,6 +9533,97 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SetDetail"];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    duplicate_set_api_setbuilder_sets__set_id__duplicate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_or_rotate_share_token_api_setbuilder_sets__set_id__share_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShareTokenOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    revoke_share_token_api_setbuilder_sets__set_id__share_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -177,6 +177,8 @@ export interface SetSummary {
   event_id: number | null;
   status: 'draft' | 'locked' | 'exported';
   sharing_mode: 'private' | 'invite_only';
+  /** Owner-only; non-null means a public read-only share link exists. */
+  share_token: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -189,6 +191,39 @@ export interface SetDetail extends SetSummary {
   key_strictness: number;
   tidal_playlist_id: string | null;
   exported_at: string | null;
+}
+
+export interface ShareTokenOut {
+  share_token: string;
+}
+
+export interface SharedSlotView {
+  position: number;
+  track_id: string | null;
+  locked: boolean;
+  notes: string | null;
+  transition_score: number | null;
+}
+
+export interface SharedCurvePointView {
+  position_sec: number;
+  energy: number;
+  label: string | null;
+  is_slow_window_start: boolean;
+  is_slow_window_end: boolean;
+}
+
+/** Public read-only projection of a shared set (no ids, no owner info). */
+export interface SharedSetView {
+  name: string;
+  status: 'draft' | 'locked' | 'exported';
+  vibe_theme: string | null;
+  target_duration_sec: number | null;
+  bpm_floor: number | null;
+  bpm_ceiling: number | null;
+  key_strictness: number;
+  slots: SharedSlotView[];
+  curve_points: SharedCurvePointView[];
 }
 
 /** OpenAPI expresses PaginatedResponse with `items: any[]`; keep this

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -48,6 +48,8 @@ import type {
   SearchResult,
   SetDetail,
   SetSummary,
+  SharedSetView,
+  ShareTokenOut,
   SongRequest,
   SystemSettings,
   SystemStats,
@@ -125,6 +127,10 @@ export type {
   ServiceCapabilities,
   SetDetail,
   SetSummary,
+  SharedCurvePointView,
+  SharedSetView,
+  SharedSlotView,
+  ShareTokenOut,
   SongRequest,
   SyncResultEntry,
   SystemSettings,
@@ -642,6 +648,23 @@ class ApiClient {
   }
   async deleteSet(setId: number): Promise<void> {
     await this.rawFetch(`/api/setbuilder/sets/${setId}`, { method: 'DELETE' });
+  }
+
+  // WrzDJSet sharing + duplication (issue #398)
+  async duplicateSet(setId: number): Promise<SetDetail> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/duplicate`, { method: 'POST' });
+  }
+  async shareSet(setId: number): Promise<ShareTokenOut> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/share`, { method: 'POST' });
+  }
+  async revokeSetShare(setId: number): Promise<void> {
+    await this.rawFetch(`/api/setbuilder/sets/${setId}/share`, { method: 'DELETE' });
+  }
+  /** Public, unauthenticated read-only view of a shared set. */
+  async getSharedSet(token: string): Promise<SharedSetView> {
+    return this.publicFetch(
+      `${getApiUrl()}/api/public/setbuilder/shared/${encodeURIComponent(token)}`
+    );
   }
 
   async bulkDeleteEvents(codes: string[]): Promise<{ status: string; count: number }> {

--- a/docs/superpowers/plans/2026-06-09-set-share-duplicate.md
+++ b/docs/superpowers/plans/2026-06-09-set-share-duplicate.md
@@ -1,0 +1,396 @@
+# WrzDJSet Share Links + Duplicate Set (Issue #398) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** DJs can duplicate a set (slots, curve, targets, vibe windows; status reset to draft) and share a read-only tokenized link (revoke/regenerate; no auth required to view; view-only on server and client).
+
+**Architecture:** New nullable `share_token` column on `sets` (CSPRNG, unique, indexed). New router file `server/app/api/setbuilder_share.py` holds owner-scoped share/duplicate routes (`/api/setbuilder/...`) and a public read-only route (`/api/public/setbuilder/shared/{token}`) returning a sanitized projection (no ids, no owner identity). Service logic in new `server/app/services/setbuilder/share_service.py`. Frontend: additive API client methods, share dialog + duplicate action on the set list, actions menu in the builder topbar, and a new public page `/shared/[token]` rendering the view-only projection.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2.0 + Alembic + slowapi; Next.js 16 / React 19, vanilla CSS; pytest + vitest.
+
+**Shared-file courtesy:** changes to `server/app/api/setbuilder.py` (none needed), `server/app/schemas/setbuilder.py`, `dashboard/app/(dj)/setbuilder/page.tsx`, `dashboard/app/(dj)/setbuilder/[setId]/page.tsx` are strictly ADDITIVE. Bulk of logic lives in new files.
+
+**Design decisions (document in PR):**
+- `share_token` lives on `Set` (nullable String(64), unique+indexed). NULL = not shared. Regenerate = overwrite, revoke = NULL. Generated via `secrets.token_urlsafe(32)` (43 chars).
+- Public token lookup validates format (`[A-Za-z0-9_-]{20,64}`) before querying; bad format → 404 (same as unknown token; no oracle).
+- Public projection (`SharedSetView`) exposes: set name, status, vibe/targets/key-strictness, slots (position, track_id, locked, notes, transition_score) and curve points (position_sec, energy, label, slow-window flags). It does NOT expose: any DB ids, owner identity, event link, collaborators, tidal playlist id, share token echo.
+- Duplicate copies: name + " (copy)" (truncated to 120), event_id, vibe_theme, targets, bpm floor/ceiling, key_strictness, all slots, all curve points (incl. slow-window flags = "vibe windows"). Resets: status="draft", sharing_mode="private", share_token=None, tidal_playlist_id=None, exported_at=None.
+- "Brand menu" from the design mock doesn't exist in the Phase 0 shell — Duplicate/Share land in a new `SetActionsMenu` component mounted in the builder topbar (replaces the spacer span), plus row actions on the set list.
+- Frontend public page route: `/shared/[token]` (outside the `(dj)` group; no auth hooks).
+- `SetSummary` schema (backend + TS) gains `share_token` — owner-only endpoints, so returning the token there is safe and lets the list page surface share state + build the URL without extra calls.
+
+---
+
+### Task 1: Model column + Alembic migration 054
+
+**Files:**
+- Modify: `server/app/models/set.py` (add `share_token` column after `sharing_mode`)
+- Create: `server/alembic/versions/054_add_set_share_token.py`
+
+- [ ] **Step 1: Add column to model**
+
+```python
+    # CSPRNG read-only share token; NULL = not shared (issue #398)
+    share_token: Mapped[str | None] = mapped_column(
+        String(64), nullable=True, unique=True, index=True
+    )
+```
+
+- [ ] **Step 2: Write migration** (down_revision = "052"; sibling PR #388 holds slot 053 — second to merge re-anchors)
+
+```python
+"""Add share_token to sets (issue #398).
+
+Revision ID: 054
+Revises: 052
+Create Date: 2026-06-09
+
+Nullable CSPRNG token enabling read-only public sharing of a set.
+NULL means not shared; revoke nulls it, regenerate overwrites it.
+Unique index gives O(log n) constant-pattern lookup on the public route.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "054"
+down_revision: str | None = "052"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("sets", sa.Column("share_token", sa.String(length=64), nullable=True))
+    op.create_index("ix_sets_share_token", "sets", ["share_token"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sets_share_token", table_name="sets")
+    op.drop_column("sets", "share_token")
+```
+
+- [ ] **Step 3: Verify migration + drift**
+
+Run: `docker compose up -d db && cd server && .venv/bin/alembic upgrade head && .venv/bin/alembic check`
+Expected: upgrade applies 054, `alembic check` reports no new upgrade operations.
+
+- [ ] **Step 4: Commit** — `feat(setbuilder): add share_token column to sets (migration 054)`
+
+### Task 2: Share + duplicate service (`share_service.py`) with API-boundary TDD
+
+**Files:**
+- Create: `server/app/services/setbuilder/share_service.py`
+- Create: `server/app/schemas/` additions + `server/app/api/setbuilder_share.py` (Task 3 wires routes; service first with unit-ish tests via db fixture)
+- Test: `server/tests/test_setbuilder_share.py`
+
+- [ ] **Step 1: Write failing service tests** (db fixture; seed a Set with slots + curve points directly)
+
+Tests: `test_duplicate_copies_children_and_resets_state`, `test_duplicate_truncates_long_name`, `test_regenerate_changes_token`, `test_revoke_nulls_token`, `test_get_by_token_rejects_bad_format`.
+
+- [ ] **Step 2: Run, verify FAIL** — `cd server && .venv/bin/pytest tests/test_setbuilder_share.py -v` → import error.
+
+- [ ] **Step 3: Implement service**
+
+```python
+"""Share-token + duplicate logic for WrzDJSet sets (issue #398)."""
+
+import re
+import secrets
+
+from sqlalchemy.orm import Session
+
+from app.models.set import Set, SetCurvePoint, SetSlot
+
+_MAX_NAME = 120
+_COPY_SUFFIX = " (copy)"
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{20,64}$")
+
+
+def regenerate_share_token(db: Session, set_obj: Set) -> Set:
+    """Create or rotate the read-only share token (CSPRNG)."""
+    set_obj.share_token = secrets.token_urlsafe(32)
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def revoke_share_token(db: Session, set_obj: Set) -> Set:
+    """Revoke sharing: NULL the token so old links 404."""
+    set_obj.share_token = None
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def get_set_by_share_token(db: Session, token: str) -> Set | None:
+    """Indexed lookup; malformed tokens short-circuit to None (no oracle)."""
+    if not _TOKEN_RE.fullmatch(token):
+        return None
+    return db.query(Set).filter(Set.share_token == token).one_or_none()
+
+
+def duplicate_set(db: Session, src: Set) -> Set:
+    """Copy a set (slots, curve, targets, vibe windows); reset lifecycle state."""
+    name = src.name + _COPY_SUFFIX
+    if len(name) > _MAX_NAME:
+        name = src.name[: _MAX_NAME - len(_COPY_SUFFIX)] + _COPY_SUFFIX
+    dup = Set(
+        owner_id=src.owner_id,
+        event_id=src.event_id,
+        name=name,
+        vibe_theme=src.vibe_theme,
+        target_duration_sec=src.target_duration_sec,
+        bpm_floor=src.bpm_floor,
+        bpm_ceiling=src.bpm_ceiling,
+        key_strictness=src.key_strictness,
+        status="draft",
+        sharing_mode="private",
+    )
+    db.add(dup)
+    db.flush()
+    for slot in sorted(src.slots, key=lambda s: s.position):
+        db.add(
+            SetSlot(
+                set_id=dup.id,
+                position=slot.position,
+                track_id=slot.track_id,
+                locked=slot.locked,
+                notes=slot.notes,
+                transition_score=slot.transition_score,
+                transition_warnings=slot.transition_warnings,
+            )
+        )
+    for cp in src.curve_points:
+        db.add(
+            SetCurvePoint(
+                set_id=dup.id,
+                position_sec=cp.position_sec,
+                energy=cp.energy,
+                label=cp.label,
+                is_slow_window_start=cp.is_slow_window_start,
+                is_slow_window_end=cp.is_slow_window_end,
+            )
+        )
+    db.commit()
+    db.refresh(dup)
+    return dup
+```
+
+- [ ] **Step 4: Run, verify PASS.**
+- [ ] **Step 5: Commit** — `feat(setbuilder): share-token + duplicate service`
+
+### Task 3: Schemas (additive) + owner routes + public route
+
+**Files:**
+- Modify (ADDITIVE): `server/app/schemas/setbuilder.py` — add `share_token: str | None = None` to `SetSummary`; append `SharedSlotView`, `SharedCurvePointView`, `SharedSetView`
+- Create: `server/app/api/setbuilder_share.py` (router + public_router)
+- Modify (ADDITIVE): `server/app/api/__init__.py` — register both routers
+- Test: extend `server/tests/test_setbuilder_share.py`
+
+- [ ] **Step 1: Failing API tests**
+
+Owner routes: POST `/api/setbuilder/sets/{id}/share` 200 returns token; POST again rotates (old token then 404 publicly); DELETE `/api/setbuilder/sets/{id}/share` 204 then public 404; POST `/api/setbuilder/sets/{id}/duplicate` 201 returns new SetDetail with `" (copy)"` name + draft status; all four 401 unauth, 403 pending, 404 on another DJ's set.
+Public route: GET `/api/public/setbuilder/shared/{token}` 200 with projection; assert response contains NO `owner_id`/`id`/`event_id`/`tidal_playlist_id`/`share_token` keys; 404 unknown token; 404 malformed token; works with NO auth header.
+List surfacing: GET `/api/setbuilder/sets` items include `share_token`.
+
+- [ ] **Step 2: Run, verify FAIL.**
+
+- [ ] **Step 3: Schemas (append to `schemas/setbuilder.py`; plus one field on SetSummary)**
+
+```python
+class SharedSlotView(BaseModel):
+    """View-only slot projection for public share links (no DB ids)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    position: int
+    track_id: str | None
+    locked: bool
+    notes: str | None
+    transition_score: float | None
+
+
+class SharedCurvePointView(BaseModel):
+    """View-only curve-point projection for public share links."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    position_sec: int
+    energy: int
+    label: str | None
+    is_slow_window_start: bool
+    is_slow_window_end: bool
+
+
+class SharedSetView(BaseModel):
+    """Public read-only projection of a shared set.
+
+    Never include owner identity, internal ids, event linkage, collaborator
+    info, or the token itself (issue #398 security requirements).
+    """
+
+    name: str
+    status: Literal["draft", "locked", "exported"]
+    vibe_theme: str | None
+    target_duration_sec: int | None
+    bpm_floor: int | None
+    bpm_ceiling: int | None
+    key_strictness: float
+    slots: list[SharedSlotView]
+    curve_points: list[SharedCurvePointView]
+
+
+class ShareTokenOut(BaseModel):
+    """Owner response after creating/rotating a share token."""
+
+    share_token: str
+```
+
+- [ ] **Step 4: Router file `server/app/api/setbuilder_share.py`**
+
+```python
+"""Share-link + duplicate routes for WrzDJSet (issue #398).
+
+`router` mounts under /api/setbuilder (owner-scoped, active DJ only).
+`public_router` mounts under /api/public/setbuilder (no auth; read-only
+projection; token is the sole capability — mutations all live on the
+authenticated router, so a leaked link can never modify anything).
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_active_user, get_db
+from app.core.rate_limit import limiter
+from app.models.set import Set
+from app.models.user import User
+from app.schemas.setbuilder import SetDetail, SharedCurvePointView, SharedSetView, SharedSlotView, ShareTokenOut
+from app.services.setbuilder import set_service, share_service
+
+router = APIRouter()
+public_router = APIRouter()
+
+
+def _get_owned_or_404(db: Session, set_id: int, user: User) -> Set:
+    set_obj = set_service.get_owned_set(db, set_id, user.id)
+    if set_obj is None:
+        raise HTTPException(status_code=404, detail="Set not found")
+    return set_obj
+
+
+@router.post("/sets/{set_id}/share", response_model=ShareTokenOut)
+@limiter.limit("10/minute")
+def create_or_rotate_share_token(...): ...
+
+
+@router.delete("/sets/{set_id}/share", status_code=status.HTTP_204_NO_CONTENT)
+@limiter.limit("10/minute")
+def revoke_share_token(...): ...
+
+
+@router.post("/sets/{set_id}/duplicate", response_model=SetDetail, status_code=201)
+@limiter.limit("10/minute")
+def duplicate_set(...): ...
+
+
+@public_router.get("/shared/{token}", response_model=SharedSetView)
+@limiter.limit("30/minute")
+def view_shared_set(token: str, request: Request, db: Session = Depends(get_db)) -> SharedSetView:
+    set_obj = share_service.get_set_by_share_token(db, token)
+    if set_obj is None:
+        raise HTTPException(status_code=404, detail="Not found")
+    return SharedSetView(
+        name=set_obj.name,
+        status=set_obj.status,
+        vibe_theme=set_obj.vibe_theme,
+        target_duration_sec=set_obj.target_duration_sec,
+        bpm_floor=set_obj.bpm_floor,
+        bpm_ceiling=set_obj.bpm_ceiling,
+        key_strictness=set_obj.key_strictness,
+        slots=[SharedSlotView.model_validate(s) for s in sorted(set_obj.slots, key=lambda s: s.position)],
+        curve_points=[
+            SharedCurvePointView.model_validate(c)
+            for c in sorted(set_obj.curve_points, key=lambda c: c.position_sec)
+        ],
+    )
+```
+
+Registration in `api/__init__.py` (additive, after existing setbuilder line):
+
+```python
+api_router.include_router(setbuilder_share.router, prefix="/setbuilder", tags=["setbuilder"])
+api_router.include_router(
+    setbuilder_share.public_router, prefix="/public/setbuilder", tags=["setbuilder-public"]
+)
+```
+
+- [ ] **Step 5: Run tests, verify PASS; run full backend CI** (ruff check, ruff format --check, bandit, pytest).
+- [ ] **Step 6: Commit** — `feat(setbuilder): share/revoke/duplicate routes + public view-only endpoint`
+
+### Task 4: Frontend API client + types (+ fixture updates)
+
+**Files:**
+- Modify (ADDITIVE): `dashboard/lib/api-types.ts` — add `share_token: string | null` to `SetSummary`; add `SharedSlotView`, `SharedCurvePointView`, `SharedSetView`, `ShareTokenOut` interfaces
+- Modify (ADDITIVE): `dashboard/lib/api.ts` — `duplicateSet`, `shareSet`, `revokeSetShare`, `getSharedSet` (publicFetch)
+- Modify: `dashboard/app/(dj)/setbuilder/__tests__/page.test.tsx` fixtures gain `share_token: null`
+
+- [ ] Steps: add types → add methods → `npx tsc --noEmit` + `npm test -- --run` → commit `feat(setbuilder): frontend api client for share + duplicate`.
+
+```typescript
+  async duplicateSet(setId: number): Promise<SetDetail> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/duplicate`, { method: 'POST' });
+  }
+  async shareSet(setId: number): Promise<ShareTokenOut> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/share`, { method: 'POST' });
+  }
+  async revokeSetShare(setId: number): Promise<void> {
+    await this.rawFetch(`/api/setbuilder/sets/${setId}/share`, { method: 'DELETE' });
+  }
+  async getSharedSet(token: string): Promise<SharedSetView> {
+    return this.publicFetch(`${getApiUrl()}/api/public/setbuilder/shared/${encodeURIComponent(token)}`);
+  }
+```
+
+### Task 5: ShareDialog component + set-list integration
+
+**Files:**
+- Create: `dashboard/app/(dj)/setbuilder/ShareDialog.tsx`
+- Create: `dashboard/app/(dj)/setbuilder/__tests__/ShareDialog.test.tsx`
+- Modify (ADDITIVE): `dashboard/app/(dj)/setbuilder/page.tsx` — "Shared" badge when `share_token` set; row buttons "Duplicate" and "Share"; mount `<ShareDialog>`
+
+ShareDialog: props `{ set: SetSummary; onClose; onChanged(token: string | null) }`. Shows share URL (`${window.location.origin}/shared/${token}`) with Copy button when shared; buttons Create link / Regenerate / Revoke calling api. Tests: renders create state, calls shareSet and surfaces URL, revoke calls revokeSetShare.
+
+Page integration (additive): `const [shareTarget, setShareTarget] = useState<SetSummary | null>(null);` + Duplicate handler `const dup = await api.duplicateSet(id); setSets(prev => [dup, ...prev]);` + badge `{s.share_token && <span className="badge">Shared</span>}`.
+
+- [ ] TDD steps + run vitest + commit `feat(setbuilder): share dialog + duplicate/share actions on set list`.
+
+### Task 6: Builder topbar actions (brand-menu equivalent)
+
+**Files:**
+- Create: `dashboard/app/(dj)/setbuilder/SetActionsMenu.tsx` (Duplicate → router.push to new set; Share → opens ShareDialog)
+- Modify (ADDITIVE): `dashboard/app/(dj)/setbuilder/[setId]/page.tsx` — replace spacer `<span style={{ width: 60 }} />` with `<SetActionsMenu set={set} onShareChanged={...} />`
+
+- [ ] Implement + tsc + commit `feat(setbuilder): duplicate/share actions in builder topbar`.
+
+### Task 7: Public view-only page `/shared/[token]`
+
+**Files:**
+- Create: `dashboard/app/shared/[token]/page.tsx` (+ colocated `shared.module.css` if needed)
+- Create: `dashboard/app/shared/[token]/__tests__/page.test.tsx`
+
+Client page: `use(params)` for token, fetch `api.getSharedSet(token)`, render "View only" badge, set name, meta chips (target duration, BPM range, key strictness, vibe), ordered slot list, curve point list. Error state: "This link is invalid or has been revoked." No auth hooks, no mutation calls, no agent/export UI.
+
+- [ ] TDD steps (loading, success render, 404 error message) + commit `feat(setbuilder): public read-only shared set page`.
+
+### Task 8: Full CI + finish
+
+- [ ] Backend: `cd server && .venv/bin/ruff check . && .venv/bin/ruff format --check . && .venv/bin/bandit -r app -c pyproject.toml -q && .venv/bin/pytest --tb=short -q`
+- [ ] Migration: `.venv/bin/alembic upgrade head && .venv/bin/alembic check`
+- [ ] Frontend: `cd dashboard && npm run lint && npx tsc --noEmit && npm test -- --run`
+- [ ] `git checkout next-env.d.ts` if dirty; push branch; open PR (Closes #398, Design decisions section, migration-slot note).
+
+## Self-review notes
+- Spec coverage: duplicate (Task 2/3/5/6), tokenized read-only link (1/2/3/7), revoke/regenerate (2/3/5), share state on list (3/4/5). ✓
+- Server-side view-only enforcement: public router has exactly one GET; token grants nothing else. ✓
+- Security: CSPRNG token, indexed unique column, format pre-validation, rate limits, sanitized projection. ✓

--- a/server/alembic/versions/054_add_set_share_token.py
+++ b/server/alembic/versions/054_add_set_share_token.py
@@ -1,0 +1,33 @@
+"""Add share_token to sets (issue #398).
+
+Revision ID: 054
+Revises: 052
+Create Date: 2026-06-09
+
+Nullable CSPRNG token enabling read-only public sharing of a set.
+NULL means not shared; revoke nulls it, regenerate overwrites it.
+The unique index gives constant-pattern indexed lookup on the public
+share route (no table scans, no timing oracle beyond the index probe).
+
+Slot note: anchored on 052; sibling PR #388 holds slot 053 — whichever
+merges second re-anchors its down_revision.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "054"
+down_revision: str | None = "052"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("sets", sa.Column("share_token", sa.String(length=64), nullable=True))
+    op.create_index("ix_sets_share_token", "sets", ["share_token"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sets_share_token", table_name="sets")
+    op.drop_column("sets", "share_token")

--- a/server/app/api/__init__.py
+++ b/server/app/api/__init__.py
@@ -15,6 +15,7 @@ from app.api import (
     requests,
     search,
     setbuilder,
+    setbuilder_share,
     sse,
     tidal,
     verify,
@@ -36,6 +37,10 @@ api_router.include_router(requests.router, prefix="/requests", tags=["requests"]
 api_router.include_router(votes.router, prefix="/requests", tags=["votes"])
 api_router.include_router(search.router, prefix="/search", tags=["search"])
 api_router.include_router(setbuilder.router, prefix="/setbuilder", tags=["setbuilder"])
+api_router.include_router(setbuilder_share.router, prefix="/setbuilder", tags=["setbuilder"])
+api_router.include_router(
+    setbuilder_share.public_router, prefix="/public/setbuilder", tags=["setbuilder-public"]
+)
 api_router.include_router(public.router, prefix="/public", tags=["public"])
 api_router.include_router(guest.router, prefix="/public", tags=["guest"])
 api_router.include_router(verify.router, prefix="/public/guest", tags=["verify"])

--- a/server/app/api/setbuilder_share.py
+++ b/server/app/api/setbuilder_share.py
@@ -78,7 +78,13 @@ def duplicate_set(
     return SetDetail.model_validate(share_service.duplicate_set(db, set_obj))
 
 
-@public_router.get("/shared/{token}", response_model=SharedSetView)
+@public_router.get(
+    "/shared/{token}",
+    response_model=SharedSetView,
+    responses={
+        404: {"description": "Shared set not found (unknown, revoked, or malformed token)."},
+    },
+)
 @limiter.limit("30/minute")
 def view_shared_set(
     token: str,

--- a/server/app/api/setbuilder_share.py
+++ b/server/app/api/setbuilder_share.py
@@ -1,0 +1,111 @@
+"""Share-link + duplicate routes for WrzDJSet (issue #398).
+
+``router`` mounts under /api/setbuilder (owner-scoped, active DJ only).
+``public_router`` mounts under /api/public/setbuilder (no auth). The
+share token is the sole capability for the single public GET and grants
+read access only — every mutating route lives on the authenticated
+router, so a leaked link can never modify anything.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_active_user, get_db
+from app.core.rate_limit import limiter
+from app.models.set import Set
+from app.models.user import User
+from app.schemas.setbuilder import (
+    SetDetail,
+    SharedCurvePointView,
+    SharedSetView,
+    SharedSlotView,
+    ShareTokenOut,
+)
+from app.services.setbuilder import set_service, share_service
+
+router = APIRouter()
+public_router = APIRouter()
+
+
+def _get_owned_or_404(db: Session, set_id: int, user: User) -> Set:
+    set_obj = set_service.get_owned_set(db, set_id, user.id)
+    if set_obj is None:
+        raise HTTPException(status_code=404, detail="Set not found")
+    return set_obj
+
+
+@router.post("/sets/{set_id}/share", response_model=ShareTokenOut)
+@limiter.limit("10/minute")
+def create_or_rotate_share_token(
+    set_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> ShareTokenOut:
+    """Create (or rotate) the read-only share token for an owned set."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    set_obj = share_service.regenerate_share_token(db, set_obj)
+    return ShareTokenOut(share_token=set_obj.share_token)
+
+
+@router.delete("/sets/{set_id}/share", status_code=status.HTTP_204_NO_CONTENT)
+@limiter.limit("10/minute")
+def revoke_share_token(
+    set_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> None:
+    """Revoke the share token for an owned set; existing links 404."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    share_service.revoke_share_token(db, set_obj)
+
+
+@router.post(
+    "/sets/{set_id}/duplicate",
+    response_model=SetDetail,
+    status_code=status.HTTP_201_CREATED,
+)
+@limiter.limit("10/minute")
+def duplicate_set(
+    set_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> SetDetail:
+    """Duplicate an owned set (slots, curve, targets); copy is a private draft."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    return SetDetail.model_validate(share_service.duplicate_set(db, set_obj))
+
+
+@public_router.get("/shared/{token}", response_model=SharedSetView)
+@limiter.limit("30/minute")
+def view_shared_set(
+    token: str,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> SharedSetView:
+    """Public read-only projection of a shared set (no auth required).
+
+    Unknown, revoked, and malformed tokens all return the same 404.
+    """
+    set_obj = share_service.get_set_by_share_token(db, token)
+    if set_obj is None:
+        raise HTTPException(status_code=404, detail="Not found")
+    return SharedSetView(
+        name=set_obj.name,
+        status=set_obj.status,
+        vibe_theme=set_obj.vibe_theme,
+        target_duration_sec=set_obj.target_duration_sec,
+        bpm_floor=set_obj.bpm_floor,
+        bpm_ceiling=set_obj.bpm_ceiling,
+        key_strictness=set_obj.key_strictness,
+        slots=[
+            SharedSlotView.model_validate(s)
+            for s in sorted(set_obj.slots, key=lambda s: s.position)
+        ],
+        curve_points=[
+            SharedCurvePointView.model_validate(c)
+            for c in sorted(set_obj.curve_points, key=lambda c: c.position_sec)
+        ],
+    )

--- a/server/app/models/set.py
+++ b/server/app/models/set.py
@@ -55,6 +55,10 @@ class Set(Base):
     sharing_mode: Mapped[str] = mapped_column(
         String(20), nullable=False, default="private", server_default="private"
     )
+    # CSPRNG read-only share token; NULL = not shared (issue #398)
+    share_token: Mapped[str | None] = mapped_column(
+        String(64), nullable=True, unique=True, index=True
+    )
 
     tidal_playlist_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
     exported_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -29,6 +29,8 @@ class SetSummary(BaseModel):
     event_id: int | None
     status: Literal["draft", "locked", "exported"]
     sharing_mode: Literal["private", "invite_only"]
+    # Owner-only surfaces; non-null means a public read-only link exists.
+    share_token: str | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -43,3 +45,51 @@ class SetDetail(SetSummary):
     key_strictness: float
     tidal_playlist_id: str | None
     exported_at: datetime | None
+
+
+class ShareTokenOut(BaseModel):
+    """Owner response after creating/rotating a share token (issue #398)."""
+
+    share_token: str
+
+
+class SharedSlotView(BaseModel):
+    """View-only slot projection for public share links (no DB ids)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    position: int
+    track_id: str | None
+    locked: bool
+    notes: str | None
+    transition_score: float | None
+
+
+class SharedCurvePointView(BaseModel):
+    """View-only curve-point projection for public share links."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    position_sec: int
+    energy: int
+    label: str | None
+    is_slow_window_start: bool
+    is_slow_window_end: bool
+
+
+class SharedSetView(BaseModel):
+    """Public read-only projection of a shared set (issue #398).
+
+    Never include owner identity, internal ids, event linkage,
+    collaborator info, or the token itself.
+    """
+
+    name: str
+    status: Literal["draft", "locked", "exported"]
+    vibe_theme: str | None
+    target_duration_sec: int | None
+    bpm_floor: int | None
+    bpm_ceiling: int | None
+    key_strictness: float
+    slots: list[SharedSlotView]
+    curve_points: list[SharedCurvePointView]

--- a/server/app/services/setbuilder/share_service.py
+++ b/server/app/services/setbuilder/share_service.py
@@ -1,0 +1,94 @@
+"""Share-token + duplicate logic for WrzDJSet sets (issue #398).
+
+The share token is the sole capability for the public read-only view.
+It is generated with a CSPRNG (secrets.token_urlsafe), stored on the
+unique-indexed ``sets.share_token`` column, and never grants access to
+any mutating route (those all require an authenticated owner).
+"""
+
+import re
+import secrets
+
+from sqlalchemy.orm import Session
+
+from app.models.set import Set, SetCurvePoint, SetSlot
+
+_MAX_NAME = 120
+_COPY_SUFFIX = " (copy)"
+# token_urlsafe(32) yields 43 url-safe chars; accept a small range so a
+# future size bump doesn't break old links. Anything else short-circuits.
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{20,64}$")
+
+
+def regenerate_share_token(db: Session, set_obj: Set) -> Set:
+    """Create or rotate the read-only share token (CSPRNG)."""
+    set_obj.share_token = secrets.token_urlsafe(32)
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def revoke_share_token(db: Session, set_obj: Set) -> Set:
+    """Revoke sharing: NULL the token so existing links 404."""
+    set_obj.share_token = None
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def get_set_by_share_token(db: Session, token: str) -> Set | None:
+    """Indexed lookup; malformed tokens short-circuit to None (no oracle)."""
+    if not _TOKEN_RE.fullmatch(token):
+        return None
+    return db.query(Set).filter(Set.share_token == token).one_or_none()
+
+
+def duplicate_set(db: Session, src: Set) -> Set:
+    """Copy a set (slots, curve, targets, vibe windows); reset lifecycle state.
+
+    The copy is always private ("draft", no share token, no export state)
+    regardless of the source's status, per issue #398.
+    """
+    name = src.name + _COPY_SUFFIX
+    if len(name) > _MAX_NAME:
+        name = src.name[: _MAX_NAME - len(_COPY_SUFFIX)] + _COPY_SUFFIX
+    dup = Set(
+        owner_id=src.owner_id,
+        event_id=src.event_id,
+        name=name,
+        vibe_theme=src.vibe_theme,
+        target_duration_sec=src.target_duration_sec,
+        bpm_floor=src.bpm_floor,
+        bpm_ceiling=src.bpm_ceiling,
+        key_strictness=src.key_strictness,
+        status="draft",
+        sharing_mode="private",
+    )
+    db.add(dup)
+    db.flush()
+    for slot in sorted(src.slots, key=lambda s: s.position):
+        db.add(
+            SetSlot(
+                set_id=dup.id,
+                position=slot.position,
+                track_id=slot.track_id,
+                locked=slot.locked,
+                notes=slot.notes,
+                transition_score=slot.transition_score,
+                transition_warnings=slot.transition_warnings,
+            )
+        )
+    for point in src.curve_points:
+        db.add(
+            SetCurvePoint(
+                set_id=dup.id,
+                position_sec=point.position_sec,
+                energy=point.energy,
+                label=point.label,
+                is_slow_window_start=point.is_slow_window_start,
+                is_slow_window_end=point.is_slow_window_end,
+            )
+        )
+    db.commit()
+    db.refresh(dup)
+    return dup

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1064,7 +1064,7 @@
       "Body_upload_banner_api_events__code__banner_post": {
         "properties": {
           "file": {
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File",
             "type": "string"
           }
@@ -5709,6 +5709,17 @@
             "title": "Name",
             "type": "string"
           },
+          "share_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Share Token"
+          },
           "sharing_mode": {
             "enum": [
               "private",
@@ -5774,6 +5785,7 @@
           "id",
           "key_strictness",
           "name",
+          "share_token",
           "sharing_mode",
           "status",
           "target_duration_sec",
@@ -5827,6 +5839,17 @@
             "title": "Name",
             "type": "string"
           },
+          "share_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Share Token"
+          },
           "sharing_mode": {
             "enum": [
               "private",
@@ -5855,11 +5878,215 @@
           "event_id",
           "id",
           "name",
+          "share_token",
           "sharing_mode",
           "status",
           "updated_at"
         ],
         "title": "SetSummary",
+        "type": "object"
+      },
+      "ShareTokenOut": {
+        "description": "Owner response after creating/rotating a share token (issue #398).",
+        "properties": {
+          "share_token": {
+            "title": "Share Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "share_token"
+        ],
+        "title": "ShareTokenOut",
+        "type": "object"
+      },
+      "SharedCurvePointView": {
+        "description": "View-only curve-point projection for public share links.",
+        "properties": {
+          "energy": {
+            "title": "Energy",
+            "type": "integer"
+          },
+          "is_slow_window_end": {
+            "title": "Is Slow Window End",
+            "type": "boolean"
+          },
+          "is_slow_window_start": {
+            "title": "Is Slow Window Start",
+            "type": "boolean"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "position_sec": {
+            "title": "Position Sec",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "energy",
+          "is_slow_window_end",
+          "is_slow_window_start",
+          "label",
+          "position_sec"
+        ],
+        "title": "SharedCurvePointView",
+        "type": "object"
+      },
+      "SharedSetView": {
+        "description": "Public read-only projection of a shared set (issue #398).\n\nNever include owner identity, internal ids, event linkage,\ncollaborator info, or the token itself.",
+        "properties": {
+          "bpm_ceiling": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm Ceiling"
+          },
+          "bpm_floor": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm Floor"
+          },
+          "curve_points": {
+            "items": {
+              "$ref": "#/components/schemas/SharedCurvePointView"
+            },
+            "title": "Curve Points",
+            "type": "array"
+          },
+          "key_strictness": {
+            "title": "Key Strictness",
+            "type": "number"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "slots": {
+            "items": {
+              "$ref": "#/components/schemas/SharedSlotView"
+            },
+            "title": "Slots",
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "draft",
+              "locked",
+              "exported"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "target_duration_sec": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Duration Sec"
+          },
+          "vibe_theme": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vibe Theme"
+          }
+        },
+        "required": [
+          "bpm_ceiling",
+          "bpm_floor",
+          "curve_points",
+          "key_strictness",
+          "name",
+          "slots",
+          "status",
+          "target_duration_sec",
+          "vibe_theme"
+        ],
+        "title": "SharedSetView",
+        "type": "object"
+      },
+      "SharedSlotView": {
+        "description": "View-only slot projection for public share links (no DB ids).",
+        "properties": {
+          "locked": {
+            "title": "Locked",
+            "type": "boolean"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "position": {
+            "title": "Position",
+            "type": "integer"
+          },
+          "track_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Track Id"
+          },
+          "transition_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Transition Score"
+          }
+        },
+        "required": [
+          "locked",
+          "notes",
+          "position",
+          "track_id",
+          "transition_score"
+        ],
+        "title": "SharedSlotView",
         "type": "object"
       },
       "StatusMessageResponse": {
@@ -13086,6 +13313,49 @@
         ]
       }
     },
+    "/api/public/setbuilder/shared/{token}": {
+      "get": {
+        "description": "Public read-only projection of a shared set (no auth required).\n\nUnknown, revoked, and malformed tokens all return the same 404.",
+        "operationId": "view_shared_set_api_public_setbuilder_shared__token__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "token",
+            "required": true,
+            "schema": {
+              "title": "Token",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SharedSetView"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "View Shared Set",
+        "tags": [
+          "setbuilder-public"
+        ]
+      }
+    },
     "/api/requests/{request_id}": {
       "delete": {
         "description": "Delete a single request. Ownership verified via event.",
@@ -13611,6 +13881,141 @@
           }
         ],
         "summary": "Rename Set",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/duplicate": {
+      "post": {
+        "description": "Duplicate an owned set (slots, curve, targets); copy is a private draft.",
+        "operationId": "duplicate_set_api_setbuilder_sets__set_id__duplicate_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetDetail"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Duplicate Set",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/share": {
+      "delete": {
+        "description": "Revoke the share token for an owned set; existing links 404.",
+        "operationId": "revoke_share_token_api_setbuilder_sets__set_id__share_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Revoke Share Token",
+        "tags": [
+          "setbuilder"
+        ]
+      },
+      "post": {
+        "description": "Create (or rotate) the read-only share token for an owned set.",
+        "operationId": "create_or_rotate_share_token_api_setbuilder_sets__set_id__share_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShareTokenOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Create Or Rotate Share Token",
         "tags": [
           "setbuilder"
         ]

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -13339,6 +13339,9 @@
             },
             "description": "Successful Response"
           },
+          "404": {
+            "description": "Shared set not found (unknown, revoked, or malformed token)."
+          },
           "422": {
             "content": {
               "application/json": {

--- a/server/tests/test_setbuilder_share.py
+++ b/server/tests/test_setbuilder_share.py
@@ -161,3 +161,131 @@ def test_get_by_token_rejects_bad_format(db, test_user):
     assert share_service.get_set_by_share_token(db, "short") is None
     assert share_service.get_set_by_share_token(db, "x" * 200) is None
     assert share_service.get_set_by_share_token(db, "bad token!@#" + "a" * 20) is None
+
+
+# ---------------------------------------------------------------------------
+# API: owner share routes
+# ---------------------------------------------------------------------------
+
+
+def test_share_create_and_rotate(client, auth_headers, db, test_user):
+    src = _seed_set(db, test_user.id)
+    resp = client.post(f"/api/setbuilder/sets/{src.id}/share", headers=auth_headers)
+    assert resp.status_code == 200, resp.json()
+    first = resp.json()["share_token"]
+    assert len(first) >= 32
+
+    # rotating invalidates the old link
+    resp = client.post(f"/api/setbuilder/sets/{src.id}/share", headers=auth_headers)
+    second = resp.json()["share_token"]
+    assert second != first
+    assert client.get(f"/api/public/setbuilder/shared/{first}").status_code == 404
+    assert client.get(f"/api/public/setbuilder/shared/{second}").status_code == 200
+
+
+def test_share_revoke(client, auth_headers, db, test_user):
+    src = _seed_set(db, test_user.id)
+    token = client.post(f"/api/setbuilder/sets/{src.id}/share", headers=auth_headers).json()[
+        "share_token"
+    ]
+    resp = client.delete(f"/api/setbuilder/sets/{src.id}/share", headers=auth_headers)
+    assert resp.status_code == 204
+    assert client.get(f"/api/public/setbuilder/shared/{token}").status_code == 404
+
+
+def test_share_routes_owner_scoped(client, auth_headers, db, test_user):
+    other = _make_second_dj(db)
+    theirs = _seed_set(db, other.id)
+    assert (
+        client.post(f"/api/setbuilder/sets/{theirs.id}/share", headers=auth_headers).status_code
+        == 404
+    )
+    assert (
+        client.delete(f"/api/setbuilder/sets/{theirs.id}/share", headers=auth_headers).status_code
+        == 404
+    )
+    assert (
+        client.post(f"/api/setbuilder/sets/{theirs.id}/duplicate", headers=auth_headers).status_code
+        == 404
+    )
+
+
+def test_share_routes_require_auth(client, db, test_user, pending_headers):
+    src = _seed_set(db, test_user.id)
+    assert client.post(f"/api/setbuilder/sets/{src.id}/share").status_code == 401
+    assert client.delete(f"/api/setbuilder/sets/{src.id}/share").status_code == 401
+    assert client.post(f"/api/setbuilder/sets/{src.id}/duplicate").status_code == 401
+    assert (
+        client.post(f"/api/setbuilder/sets/{src.id}/share", headers=pending_headers).status_code
+        == 403
+    )
+    assert (
+        client.post(f"/api/setbuilder/sets/{src.id}/duplicate", headers=pending_headers).status_code
+        == 403
+    )
+
+
+def test_set_list_surfaces_share_state(client, auth_headers, db, test_user):
+    src = _seed_set(db, test_user.id)
+    sets = client.get("/api/setbuilder/sets", headers=auth_headers).json()
+    assert sets[0]["share_token"] is None
+    token = client.post(f"/api/setbuilder/sets/{src.id}/share", headers=auth_headers).json()[
+        "share_token"
+    ]
+    sets = client.get("/api/setbuilder/sets", headers=auth_headers).json()
+    assert sets[0]["share_token"] == token
+
+
+# ---------------------------------------------------------------------------
+# API: duplicate route
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_endpoint(client, auth_headers, db, test_user):
+    src = _seed_set(db, test_user.id)
+    resp = client.post(f"/api/setbuilder/sets/{src.id}/duplicate", headers=auth_headers)
+    assert resp.status_code == 201, resp.json()
+    body = resp.json()
+    assert body["name"] == "Warehouse Closer (copy)"
+    assert body["status"] == "draft"
+    assert body["sharing_mode"] == "private"
+    assert body["share_token"] is None
+    assert body["id"] != src.id
+
+
+# ---------------------------------------------------------------------------
+# API: public view-only projection
+# ---------------------------------------------------------------------------
+
+
+def test_public_shared_view_projection(client, auth_headers, db, test_user):
+    src = _seed_set(db, test_user.id)
+    token = client.post(f"/api/setbuilder/sets/{src.id}/share", headers=auth_headers).json()[
+        "share_token"
+    ]
+
+    # no auth header at all
+    resp = client.get(f"/api/public/setbuilder/shared/{token}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "Warehouse Closer"
+    assert body["vibe_theme"] == "dark-techno"
+    assert body["bpm_floor"] == 124
+    assert [s["position"] for s in body["slots"]] == [1, 2]
+    assert body["slots"][0]["notes"] == "opener"
+    assert [c["energy"] for c in body["curve_points"]] == [4, 9]
+    assert body["curve_points"][0]["is_slow_window_start"] is True
+
+    # never leak owner identity, internal ids, event linkage or the token
+    for forbidden in ("id", "owner_id", "event_id", "tidal_playlist_id", "share_token"):
+        assert forbidden not in body, forbidden
+    for slot in body["slots"]:
+        assert "id" not in slot and "set_id" not in slot
+    for point in body["curve_points"]:
+        assert "id" not in point and "set_id" not in point
+
+
+def test_public_shared_view_unknown_or_malformed_token(client):
+    assert client.get(f"/api/public/setbuilder/shared/{'A' * 43}").status_code == 404
+    assert client.get("/api/public/setbuilder/shared/short").status_code == 404
+    assert client.get("/api/public/setbuilder/shared/bad%20token%21aaaaaaaaaaaa").status_code == 404

--- a/server/tests/test_setbuilder_share.py
+++ b/server/tests/test_setbuilder_share.py
@@ -1,0 +1,163 @@
+"""Tests for WrzDJSet sharing + duplication (issue #398).
+
+Service level: duplicate copies children and resets lifecycle state;
+token regenerate/revoke; malformed-token short circuit.
+API level: owner-scoped share/revoke/duplicate routes, public view-only
+projection (no ids / owner identity leakage), auth gating.
+"""
+
+from app.models.set import Set, SetCurvePoint, SetSlot
+from app.services.auth import get_password_hash
+from app.services.setbuilder import share_service
+
+
+def _seed_set(db, owner_id, **overrides) -> Set:
+    fields = {
+        "owner_id": owner_id,
+        "name": "Warehouse Closer",
+        "vibe_theme": "dark-techno",
+        "target_duration_sec": 3600,
+        "bpm_floor": 124,
+        "bpm_ceiling": 132,
+        "key_strictness": 0.7,
+        "status": "locked",
+        "tidal_playlist_id": "pl-123",
+    }
+    fields.update(overrides)
+    set_obj = Set(**fields)
+    db.add(set_obj)
+    db.flush()
+    db.add(
+        SetSlot(
+            set_id=set_obj.id,
+            position=1,
+            track_id="tidal:111",
+            locked=True,
+            notes="opener",
+            transition_score=0.9,
+            transition_warnings='["bpm jump"]',
+        )
+    )
+    db.add(SetSlot(set_id=set_obj.id, position=2, track_id="tidal:222"))
+    db.add(
+        SetCurvePoint(
+            set_id=set_obj.id,
+            position_sec=0,
+            energy=4,
+            label="warmup",
+            is_slow_window_start=True,
+        )
+    )
+    db.add(
+        SetCurvePoint(
+            set_id=set_obj.id,
+            position_sec=1800,
+            energy=9,
+            label="peak",
+            is_slow_window_end=True,
+        )
+    )
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def _make_second_dj(db):
+    from app.models.user import User
+
+    user = User(username="otherdj", password_hash=get_password_hash("x" * 12), role="dj")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _login(client, username, password):
+    resp = client.post("/api/auth/login", data={"username": username, "password": password})
+    assert resp.status_code == 200, resp.json()
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+# ---------------------------------------------------------------------------
+# Service: duplicate
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_copies_children_and_resets_state(db, test_user):
+    src = _seed_set(db, test_user.id)
+    src.share_token = "A" * 43
+    db.commit()
+
+    dup = share_service.duplicate_set(db, src)
+
+    assert dup.id != src.id
+    assert dup.name == "Warehouse Closer (copy)"
+    assert dup.owner_id == test_user.id
+    # targets + vibe copied
+    assert dup.vibe_theme == "dark-techno"
+    assert dup.target_duration_sec == 3600
+    assert dup.bpm_floor == 124
+    assert dup.bpm_ceiling == 132
+    assert dup.key_strictness == 0.7
+    # lifecycle reset
+    assert dup.status == "draft"
+    assert dup.sharing_mode == "private"
+    assert dup.share_token is None
+    assert dup.tidal_playlist_id is None
+    assert dup.exported_at is None
+    # slots copied with all fields
+    assert [(s.position, s.track_id) for s in dup.slots] == [(1, "tidal:111"), (2, "tidal:222")]
+    first = next(s for s in dup.slots if s.position == 1)
+    assert first.locked is True
+    assert first.notes == "opener"
+    assert first.transition_score == 0.9
+    assert first.transition_warnings == '["bpm jump"]'
+    # curve (incl. slow/vibe windows) copied
+    points = sorted(dup.curve_points, key=lambda c: c.position_sec)
+    assert [(c.position_sec, c.energy, c.label) for c in points] == [
+        (0, 4, "warmup"),
+        (1800, 9, "peak"),
+    ]
+    assert points[0].is_slow_window_start is True
+    assert points[1].is_slow_window_end is True
+    # source untouched
+    db.refresh(src)
+    assert src.status == "locked"
+    assert len(src.slots) == 2
+
+
+def test_duplicate_truncates_long_name(db, test_user):
+    src = _seed_set(db, test_user.id, name="x" * 120)
+    dup = share_service.duplicate_set(db, src)
+    assert len(dup.name) == 120
+    assert dup.name.endswith(" (copy)")
+
+
+# ---------------------------------------------------------------------------
+# Service: token lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_regenerate_changes_token(db, test_user):
+    src = _seed_set(db, test_user.id)
+    share_service.regenerate_share_token(db, src)
+    first = src.share_token
+    assert first is not None and len(first) >= 32
+    share_service.regenerate_share_token(db, src)
+    assert src.share_token != first
+
+
+def test_revoke_nulls_token(db, test_user):
+    src = _seed_set(db, test_user.id)
+    share_service.regenerate_share_token(db, src)
+    share_service.revoke_share_token(db, src)
+    assert src.share_token is None
+
+
+def test_get_by_token_rejects_bad_format(db, test_user):
+    src = _seed_set(db, test_user.id)
+    share_service.regenerate_share_token(db, src)
+    assert share_service.get_set_by_share_token(db, src.share_token) is src
+    assert share_service.get_set_by_share_token(db, "short") is None
+    assert share_service.get_set_by_share_token(db, "x" * 200) is None
+    assert share_service.get_set_by_share_token(db, "bad token!@#" + "a" * 20) is None


### PR DESCRIPTION
Closes #398

## Summary
- **Duplicate set**: `POST /api/setbuilder/sets/{id}/duplicate` copies slots, curve points (incl. slow/vibe windows), targets and vibe theme; resets status to `draft`, sharing to `private`, and clears share token / export state. Surfaced as a set-list row action and in the builder topbar.
- **Read-only share link**: nullable `share_token` on `sets` (migration 054, unique indexed), generated with `secrets.token_urlsafe(32)`. Public `GET /api/public/setbuilder/shared/{token}` (30/min) returns a sanitized view-only projection. New public page `/shared/[token]` renders it with zero mutation/agent/export affordances.
- **Revoke / regenerate**: `POST` (rotate) and `DELETE` (revoke) on `/api/setbuilder/sets/{id}/share` (owner-scoped, 10/min). ShareDialog component handles create/copy/regenerate/revoke.
- **Share state on set list**: `SetSummary` gains owner-only `share_token`; list shows a "Shared" badge.

## Security
- Token is CSPRNG (`secrets.token_urlsafe(32)`), stored on a unique indexed column; lookup is a single indexed equality query with format pre-validation (`[A-Za-z0-9_-]{20,64}`) so malformed input short-circuits.
- Unknown, revoked, and malformed tokens all return an identical 404 (no oracle).
- The public projection contains **no** DB ids, owner identity, event linkage, collaborator info, tidal playlist id, or token echo — pinned by tests that assert forbidden keys are absent.
- View-only is enforced server-side: the token grants exactly one public GET; every mutating route requires `get_current_active_user` + ownership (404 on unowned sets).
- Rate limits: public view 30/min; share rotate/revoke and duplicate 10/min.

## Design decisions
- **Token on the `Set` row** (vs. separate table): one active link per set matches the issue scope; revoke = NULL, regenerate = overwrite. Old links die instantly on rotate.
- **`share_token` exposed in `SetSummary`/`SetDetail`**: these are owner-only endpoints, and returning it lets the list page surface share state and build URLs without extra round-trips.
- **Duplicate copies `event_id`** (the optional event link) since DJs iterate per venue/event; it does NOT copy `tidal_playlist_id`, `exported_at`, `status`, or the share token — a copy is always a private draft. Name gets a `" (copy)"` suffix truncated to the 120-char limit.
- **"Brand menu"**: the Phase 0 builder shell has no brand menu yet, so Duplicate/Share live in a new `SetActionsMenu` mounted in the builder topbar (plus set-list row actions).
- **Public page route `/shared/[token]`**: outside the `(dj)` route group so no auth hooks mount; uses `useParams()` (codebase convention for testable dynamic routes).
- **New router file `setbuilder_share.py`** (+ `share_service.py`, `ShareDialog.tsx`, `SetActionsMenu.tsx`, `/shared/[token]/page.tsx`): keeps changes to shared files (#388/#389 siblings) strictly additive.
- Regenerated `server/openapi.json` + `dashboard/lib/api-types.generated.ts` to keep generated types in sync.

## Migration
Migration 054 anchored on 052; sibling PR for #388 uses slot 053 — second to merge re-anchors. `alembic upgrade head && alembic check` verified locally (no drift).

## Test plan
- [x] Backend: 2574 passed, coverage 87.93% (ruff, ruff format, bandit clean)
- [x] New API tests: owner scoping (404 on unowned), auth gating (401/403), token rotate invalidates old link, revoke 404s, projection leaks no ids/owner fields, malformed tokens 404
- [x] Frontend: 1013 tests passed, lint + strict tsc clean (ShareDialog, set-list duplicate/badge, shared page render + invalid-link states)
- [x] `alembic upgrade head && alembic check` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate sets: create a copy of a set with one click.
  * Set sharing: generate, regenerate, or revoke revocable read-only share links.
  * Shared view: public, read-only page to preview a shared set via its link.
  * UI improvements: “Duplicate” and “Share/Shared” actions in the builder and a Share dialog.
* **Documentation**
  * Added plan describing sharing & duplication rollout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->