### PR TITLE
feat(setbuilder): pool import — 4 sources with source tagging + dedupe (#388)

### DIFF
--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { SetDetail } from '@/lib/api-types';
+import PoolPanel from '../components/PoolPanel';
 import styles from '../setbuilder.module.css';
 
 export default function BuilderPage({ params }: { params: Promise<{ setId: string }> }) {
@@ -73,8 +74,7 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
 
       <div className={styles.workspace}>
         <section className={`${styles.panel} ${styles.panelPool}`} aria-label="Pool">
-          <div className={styles.panelHeader}>Pool</div>
-          <div className={styles.panelBody}>Candidate tracks will appear here.</div>
+          <PoolPanel setId={Number(setId)} />
         </section>
 
         <section className={`${styles.panel} ${styles.panelCurve}`} aria-label="Curve">

--- a/dashboard/app/(dj)/setbuilder/components/ImportModal.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/ImportModal.tsx
@@ -1,0 +1,469 @@
+'use client';
+
+/**
+ * Pool import modal (issue #388) — five flows:
+ * event picker / Tidal playlist / Beatport playlist / public URL / manual search.
+ */
+
+import { useEffect, useState } from 'react';
+import { api } from '@/lib/api';
+import type {
+  BuilderPlaylists,
+  Event,
+  PoolImportResult,
+  PoolUrlPreview,
+  SearchResult,
+} from '@/lib/api-types';
+import styles from '../setbuilder.module.css';
+import { SourceIcon, sourceColor } from './PoolBadges';
+
+export type ImportKind = 'event' | 'tidal' | 'beatport' | 'public_url' | 'manual';
+
+interface ImportModalProps {
+  kind: ImportKind;
+  setId: number;
+  /** `${kind}:${external_ref}` keys already in the sources accordion */
+  existingRefs: Set<string>;
+  onClose: () => void;
+  onImported: (result: PoolImportResult) => void;
+  onError: (message: string) => void;
+}
+
+export default function ImportModal(props: ImportModalProps) {
+  return (
+    <div className={styles.modalWrap} role="dialog" aria-modal="true">
+      <div className={styles.modalBackdrop} onClick={props.onClose} />
+      <div className={styles.importModal}>
+        {props.kind === 'event' && <ImportEvent {...props} />}
+        {(props.kind === 'tidal' || props.kind === 'beatport') && <ImportPlaylist {...props} />}
+        {props.kind === 'public_url' && <ImportPublicUrl {...props} />}
+        {props.kind === 'manual' && <ImportManual {...props} />}
+      </div>
+    </div>
+  );
+}
+
+function ModalHeader({
+  kind,
+  title,
+  subtitle,
+  onClose,
+}: {
+  kind: string;
+  title: string;
+  subtitle: string;
+  onClose: () => void;
+}) {
+  return (
+    <div className={styles.imHeader}>
+      <span className={styles.imHeaderIcon} style={{ color: sourceColor(kind) }}>
+        <SourceIcon kind={kind} size={20} />
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div className={styles.imTitle}>{title}</div>
+        <div className={styles.imSubtitle}>{subtitle}</div>
+      </div>
+      <button className={styles.iconBtn} onClick={onClose} aria-label="Close">
+        ✕
+      </button>
+    </div>
+  );
+}
+
+function errMessage(e: unknown): string {
+  if (e instanceof Error && e.message) return e.message;
+  return 'Import failed — try again';
+}
+
+function ImportEvent({ setId, existingRefs, onClose, onImported, onError }: ImportModalProps) {
+  const [events, setEvents] = useState<Event[] | null>(null);
+  const [picked, setPicked] = useState<number | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    api
+      .getEvents()
+      .then(setEvents)
+      .catch(() => setEvents([]));
+  }, []);
+
+  const doImport = async () => {
+    if (picked == null) return;
+    setBusy(true);
+    try {
+      onImported(await api.importPoolEvent(setId, picked));
+    } catch (e) {
+      onError(errMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <ModalHeader
+        kind="event"
+        title="Import event requests"
+        subtitle="Tracks that guests requested via WrzDJ."
+        onClose={onClose}
+      />
+      <div className={styles.imBody}>
+        {events === null && <div className={styles.imEmpty}>Loading events…</div>}
+        {events !== null && events.length === 0 && (
+          <div className={styles.imEmpty}>No events yet.</div>
+        )}
+        <div className={styles.imList}>
+          {(events ?? []).map((e) => {
+            const already = existingRefs.has(`event:${e.id}`);
+            return (
+              <button
+                key={e.id}
+                className={`${styles.imListItem} ${picked === e.id ? styles.imPicked : ''}`}
+                onClick={() => setPicked(e.id)}
+                disabled={busy}
+              >
+                <span style={{ color: sourceColor('event') }}>
+                  <SourceIcon kind="event" size={16} />
+                </span>
+                <span className={styles.imListInfo}>
+                  <span className={styles.imListTitle}>
+                    {e.name}
+                    {already && <span className={styles.imImported}> · already imported</span>}
+                  </span>
+                  <span className={styles.imListSub}>{e.code}</span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        <div className={styles.imFootnote}>
+          Imported tracks are de-duped automatically — tracks already in the pool keep their
+          original source tag. Re-importing refreshes new requests only.
+        </div>
+      </div>
+      <div className={styles.imFooter}>
+        <button className="btn btn-sm" onClick={onClose}>
+          Cancel
+        </button>
+        <span style={{ flex: 1 }} />
+        <button
+          className="btn btn-primary btn-sm"
+          disabled={picked == null || busy}
+          onClick={doImport}
+        >
+          {busy ? 'Importing…' : 'Import requests'}
+        </button>
+      </div>
+    </>
+  );
+}
+
+function ImportPlaylist({ kind, setId, existingRefs, onClose, onImported, onError }: ImportModalProps) {
+  const service = kind as 'tidal' | 'beatport';
+  const [playlists, setPlaylists] = useState<BuilderPlaylists | null>(null);
+  const [picked, setPicked] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const label = service === 'tidal' ? 'Tidal' : 'Beatport';
+
+  useEffect(() => {
+    api
+      .getBuilderPlaylists()
+      .then(setPlaylists)
+      .catch(() => setPlaylists(null));
+  }, []);
+
+  const connected = playlists
+    ? service === 'tidal'
+      ? playlists.tidal_connected
+      : playlists.beatport_connected
+    : true;
+  const list = playlists ? (service === 'tidal' ? playlists.tidal : playlists.beatport) : [];
+
+  const doImport = async () => {
+    if (!picked) return;
+    const name = list.find((p) => p.id === picked)?.name;
+    setBusy(true);
+    try {
+      const call = service === 'tidal' ? api.importPoolTidal : api.importPoolBeatport;
+      onImported(await call.call(api, setId, picked, name));
+    } catch (e) {
+      onError(errMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <ModalHeader
+        kind={service}
+        title={`Import ${label} playlist`}
+        subtitle={`Pulled live via your connected ${label} account.`}
+        onClose={onClose}
+      />
+      <div className={styles.imBody}>
+        {playlists === null && <div className={styles.imEmpty}>Loading playlists…</div>}
+        {playlists !== null && !connected && (
+          <div className={styles.imEmpty}>
+            {label} isn&apos;t connected. Link it from your account settings first.
+          </div>
+        )}
+        <div className={styles.imList}>
+          {list.map((p) => {
+            const already = existingRefs.has(`${service}:${p.id}`);
+            return (
+              <button
+                key={p.id}
+                className={`${styles.imListItem} ${picked === p.id ? styles.imPicked : ''}`}
+                onClick={() => setPicked(p.id)}
+                disabled={busy}
+              >
+                <span style={{ color: sourceColor(service) }}>
+                  <SourceIcon kind={service} size={16} />
+                </span>
+                <span className={styles.imListInfo}>
+                  <span className={styles.imListTitle}>
+                    {p.name}
+                    {already && <span className={styles.imImported}> · already imported</span>}
+                  </span>
+                  <span className={styles.imListSub}>{p.num_tracks} tracks</span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        <div className={styles.imFootnote}>
+          De-duped automatically — tracks already in the pool from another source keep their
+          original source tag.
+        </div>
+      </div>
+      <div className={styles.imFooter}>
+        <button className="btn btn-sm" onClick={onClose}>
+          Cancel
+        </button>
+        <span style={{ flex: 1 }} />
+        <button className="btn btn-primary btn-sm" disabled={!picked || busy} onClick={doImport}>
+          {busy ? 'Importing…' : 'Import playlist'}
+        </button>
+      </div>
+    </>
+  );
+}
+
+function ImportPublicUrl({ setId, onClose, onImported, onError }: ImportModalProps) {
+  const [url, setUrl] = useState('');
+  const [preview, setPreview] = useState<PoolUrlPreview | null>(null);
+  const [validating, setValidating] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const validate = async () => {
+    setValidating(true);
+    setValidationError(null);
+    setPreview(null);
+    try {
+      setPreview(await api.previewPoolUrl(setId, url.trim()));
+    } catch (e) {
+      setValidationError(errMessage(e));
+    } finally {
+      setValidating(false);
+    }
+  };
+
+  const doImport = async () => {
+    setBusy(true);
+    try {
+      onImported(await api.importPoolUrl(setId, url.trim()));
+    } catch (e) {
+      onError(errMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <ModalHeader
+        kind="public_url"
+        title="Import public playlist"
+        subtitle="Paste a public playlist URL from Spotify or Tidal."
+        onClose={onClose}
+      />
+      <div className={styles.imBody}>
+        <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+          <input
+            className={styles.imInput}
+            placeholder="https://open.spotify.com/playlist/…"
+            value={url}
+            onChange={(e) => {
+              setUrl(e.target.value);
+              setPreview(null);
+              setValidationError(null);
+            }}
+            autoFocus
+          />
+          <button
+            className="btn btn-primary btn-sm"
+            disabled={!/^https:\/\/.+/.test(url.trim()) || validating}
+            onClick={validate}
+          >
+            {validating ? 'Checking…' : 'Validate'}
+          </button>
+        </div>
+
+        {validationError && <div className={styles.imError}>{validationError}</div>}
+
+        {preview && !preview.supported && (
+          <div className={styles.imError}>{preview.message ?? 'Provider not supported yet.'}</div>
+        )}
+
+        {preview && preview.supported && (
+          <div className={styles.imPreviewCard}>
+            <div className={styles.imPreviewRow}>
+              <span className={styles.imPreviewLabel}>Detected</span>
+              <span>{preview.provider === 'spotify' ? 'Spotify' : 'Tidal'} · public playlist</span>
+            </div>
+            <div className={styles.imPreviewRow}>
+              <span className={styles.imPreviewLabel}>Name</span>
+              <span>{preview.name ?? '—'}</span>
+            </div>
+            <div className={styles.imPreviewRow}>
+              <span className={styles.imPreviewLabel}>Tracks</span>
+              <span>{preview.track_count ?? '—'} found · de-duped on import</span>
+            </div>
+            {preview.owner && (
+              <div className={styles.imPreviewRow}>
+                <span className={styles.imPreviewLabel}>Owner</span>
+                <span>{preview.owner}</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className={styles.imFootnote}>
+          We never fetch the URL itself — the playlist ID is extracted and pulled via the official
+          API. Apple Music / YouTube / SoundCloud support is planned.
+        </div>
+      </div>
+      <div className={styles.imFooter}>
+        <button className="btn btn-sm" onClick={onClose}>
+          Cancel
+        </button>
+        <span style={{ flex: 1 }} />
+        <button
+          className="btn btn-primary btn-sm"
+          disabled={!preview?.supported || busy}
+          onClick={doImport}
+        >
+          {busy ? 'Importing…' : 'Import playlist'}
+        </button>
+      </div>
+    </>
+  );
+}
+
+function ImportManual({ setId, onClose, onImported, onError }: ImportModalProps) {
+  const [q, setQ] = useState('');
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    const term = q.trim();
+    if (term.length < 2) {
+      setResults([]);
+      return;
+    }
+    const handle = setTimeout(() => {
+      setSearching(true);
+      api
+        .search(term)
+        .then(setResults)
+        .catch(() => setResults([]))
+        .finally(() => setSearching(false));
+    }, 350);
+    return () => clearTimeout(handle);
+  }, [q]);
+
+  const pick = async (r: SearchResult) => {
+    setBusy(true);
+    try {
+      const service =
+        r.source === 'spotify' || r.source === 'beatport' || r.source === 'tidal'
+          ? r.source
+          : 'manual';
+      onImported(
+        await api.importPoolManual(setId, {
+          title: r.title,
+          artist: r.artist,
+          album: r.album ?? null,
+          genre: r.genre ?? null,
+          bpm: r.bpm ?? null,
+          key: r.key ?? null,
+          isrc: r.isrc ?? null,
+          artwork_url: r.album_art?.startsWith('https://') ? r.album_art : null,
+          source_service: service,
+          source_track_id: service === 'spotify' ? (r.spotify_id ?? null) : null,
+        })
+      );
+    } catch (e) {
+      onError(errMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <ModalHeader
+        kind="manual"
+        title="Add a single track"
+        subtitle="Search across your connected services."
+        onClose={onClose}
+      />
+      <div className={styles.imBody}>
+        <input
+          className={styles.imInput}
+          placeholder="Search title or artist…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          autoFocus
+          style={{ marginBottom: 10, width: '100%' }}
+        />
+        <div className={styles.imList}>
+          {results.map((r, i) => (
+            <button
+              key={`${r.source}-${r.spotify_id ?? r.url ?? i}`}
+              className={styles.imListItem}
+              onClick={() => pick(r)}
+              disabled={busy}
+            >
+              <span style={{ color: sourceColor('manual') }}>
+                <SourceIcon kind="manual" size={16} />
+              </span>
+              <span className={styles.imListInfo}>
+                <span className={styles.imListTitle}>{r.title}</span>
+                <span className={styles.imListSub}>
+                  {r.artist}
+                  {r.bpm ? ` · ${r.bpm} BPM` : ''}
+                  {r.key ? ` · ${r.key}` : ''} · {r.source}
+                </span>
+              </span>
+            </button>
+          ))}
+          {q.trim().length < 2 && (
+            <div className={styles.imEmpty}>Type to search Spotify, Beatport, Tidal…</div>
+          )}
+          {q.trim().length >= 2 && !searching && results.length === 0 && (
+            <div className={styles.imEmpty}>No matches.</div>
+          )}
+        </div>
+      </div>
+      <div className={styles.imFooter}>
+        <button className="btn btn-sm" onClick={onClose}>
+          Done
+        </button>
+      </div>
+    </>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/PoolBadges.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/PoolBadges.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+/**
+ * Pool row badges + source iconography (issue #388).
+ * Translated from the design prototype (pool-panel.jsx) — Camelot key,
+ * BPM and energy mini-badges plus per-source-kind SVG icons and colors.
+ */
+
+import { getCamelotColor } from '@/lib/camelot-colors';
+
+export type SourceKind = 'event' | 'tidal' | 'beatport' | 'public_url' | 'manual';
+
+export const SOURCE_COLORS: Record<SourceKind, string> = {
+  event: '#b78bff',
+  tidal: '#00ffff',
+  beatport: '#88e837',
+  public_url: '#ff70b4',
+  manual: '#9ca3af',
+};
+
+export function sourceColor(kind: string | undefined): string {
+  return SOURCE_COLORS[(kind ?? 'manual') as SourceKind] ?? '#9ca3af';
+}
+
+export function SourceIcon({ kind, size = 14 }: { kind: string; size?: number }) {
+  const common = {
+    width: size,
+    height: size,
+    viewBox: '0 0 24 24',
+    fill: 'none',
+    stroke: 'currentColor',
+    strokeWidth: 1.8,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+  };
+  if (kind === 'event')
+    return (
+      <svg {...common} aria-hidden>
+        <rect x="3" y="4" width="18" height="18" rx="2" />
+        <path d="M16 2v4M8 2v4M3 10h18" />
+      </svg>
+    );
+  if (kind === 'tidal')
+    return (
+      <svg {...common} aria-hidden>
+        <path d="m12 4 4 4-4 4-4-4 4-4Z M4 12l4 4 4-4-4-4-4 4Z M20 12l-4 4-4-4 4-4 4 4Z M12 20l-4-4 4-4 4 4-4 4Z" />
+      </svg>
+    );
+  if (kind === 'beatport')
+    return (
+      <svg {...common} aria-hidden>
+        <circle cx="12" cy="12" r="9" />
+        <circle cx="12" cy="12" r="4" />
+      </svg>
+    );
+  if (kind === 'public_url')
+    return (
+      <svg {...common} aria-hidden>
+        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+        <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+      </svg>
+    );
+  // manual
+  return (
+    <svg {...common} aria-hidden>
+      <path d="M12 5v14M5 12h14" />
+    </svg>
+  );
+}
+
+export function CamelotBadge({ camelot }: { camelot: string | null }) {
+  if (!camelot) return null;
+  const c = getCamelotColor(camelot);
+  return (
+    <span
+      style={{
+        background: c.bg,
+        color: c.text,
+        fontSize: 10,
+        fontWeight: 700,
+        padding: '1px 5px',
+        borderRadius: 4,
+        lineHeight: '14px',
+      }}
+      title={`Camelot ${camelot}`}
+    >
+      {camelot}
+    </span>
+  );
+}
+
+export function BpmBadge({ bpm }: { bpm: number | null }) {
+  if (bpm == null) return null;
+  return (
+    <span
+      style={{
+        background: 'var(--surface-raised, #23262d)',
+        color: 'var(--text-secondary)',
+        fontSize: 10,
+        fontWeight: 600,
+        padding: '1px 5px',
+        borderRadius: 4,
+        lineHeight: '14px',
+      }}
+      title={`${Math.round(bpm)} BPM`}
+    >
+      {Math.round(bpm)}
+    </span>
+  );
+}
+
+export function EnergyMini({ value }: { value: number | null }) {
+  const v = value ?? 0;
+  return (
+    <span
+      style={{ display: 'inline-flex', alignItems: 'flex-end', gap: 1.5, height: 12 }}
+      title={value == null ? 'Energy not analyzed yet' : `Energy ${value}/10`}
+      aria-label={value == null ? 'Energy unknown' : `Energy ${value} of 10`}
+    >
+      {[0, 1, 2, 3, 4].map((i) => {
+        const on = v / 2 > i;
+        return (
+          <span
+            key={i}
+            style={{
+              width: 3,
+              borderRadius: 1,
+              height: on ? `${30 + i * 17}%` : '12%',
+              background: on ? 'var(--color-primary, #8b5cf6)' : 'var(--border, #3a3a3a)',
+            }}
+          />
+        );
+      })}
+    </span>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
@@ -1,0 +1,465 @@
+'use client';
+
+/**
+ * Pool panel (issue #388) — candidate-track surface for set building.
+ * Sources accordion (filter + remove-by-source), type tabs, search,
+ * multi-select removal, per-track context menu, import toast.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { api } from '@/lib/api';
+import type { PoolImportResult, PoolSource, PoolState } from '@/lib/api-types';
+import styles from '../setbuilder.module.css';
+import ImportModal, { type ImportKind } from './ImportModal';
+import { BpmBadge, CamelotBadge, EnergyMini, SourceIcon, sourceColor } from './PoolBadges';
+
+const TYPE_TABS: { id: string; label: string }[] = [
+  { id: 'all', label: 'All' },
+  { id: 'event', label: 'Requests' },
+  { id: 'tidal', label: 'Tidal' },
+  { id: 'beatport', label: 'Beatport' },
+  { id: 'public_url', label: 'URL' },
+  { id: 'manual', label: 'Manual' },
+];
+
+const IMPORT_MENU: { kind: ImportKind; title: string; sub: string }[] = [
+  { kind: 'event', title: 'WrzDJ Event Requests', sub: 'Pick from your events' },
+  { kind: 'tidal', title: 'Tidal Playlist', sub: 'Via your connected account' },
+  { kind: 'beatport', title: 'Beatport Playlist', sub: 'Via your connected account' },
+  { kind: 'public_url', title: 'Public Playlist URL', sub: 'Spotify, Tidal' },
+  { kind: 'manual', title: 'Add single track', sub: 'Search a service' },
+];
+
+interface ContextMenuState {
+  x: number;
+  y: number;
+  trackId: number;
+  sourceId: number;
+}
+
+export default function PoolPanel({ setId }: { setId: number }) {
+  const [pool, setPool] = useState<PoolState>({ sources: [], tracks: [] });
+  const [loaded, setLoaded] = useState(false);
+  const [tab, setTab] = useState('all');
+  const [q, setQ] = useState('');
+  const [sourcesExpanded, setSourcesExpanded] = useState(true);
+  const [activeSourceId, setActiveSourceId] = useState<number | null>(null);
+  const [selectMode, setSelectMode] = useState(false);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [addMenuOpen, setAddMenuOpen] = useState(false);
+  const [importKind, setImportKind] = useState<ImportKind | null>(null);
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .getPool(setId)
+      .then(setPool)
+      .catch(() => setToast('Failed to load pool'))
+      .finally(() => setLoaded(true));
+  }, [setId]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const handle = setTimeout(() => setToast(null), 3500);
+    return () => clearTimeout(handle);
+  }, [toast]);
+
+  // Close popovers on outside click
+  useEffect(() => {
+    const onDoc = () => {
+      setAddMenuOpen(false);
+      setContextMenu(null);
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, []);
+
+  const sourceById = useMemo(() => {
+    const m = new Map<number, PoolSource>();
+    for (const s of pool.sources) m.set(s.id, s);
+    return m;
+  }, [pool.sources]);
+
+  const tabCounts = useMemo(() => {
+    const c: Record<string, number> = { all: pool.tracks.length };
+    for (const t of pool.tracks) {
+      const kind = sourceById.get(t.source_id)?.kind ?? 'manual';
+      c[kind] = (c[kind] ?? 0) + 1;
+    }
+    return c;
+  }, [pool.tracks, sourceById]);
+
+  const sourceCounts = useMemo(() => {
+    const c = new Map<number, number>();
+    for (const t of pool.tracks) c.set(t.source_id, (c.get(t.source_id) ?? 0) + 1);
+    return c;
+  }, [pool.tracks]);
+
+  const filtered = useMemo(() => {
+    const term = q.trim().toLowerCase();
+    return pool.tracks.filter((t) => {
+      const kind = sourceById.get(t.source_id)?.kind ?? 'manual';
+      if (tab !== 'all' && kind !== tab) return false;
+      if (activeSourceId != null && t.source_id !== activeSourceId) return false;
+      if (!term) return true;
+      return `${t.title} ${t.artist} ${t.genre ?? ''}`.toLowerCase().includes(term);
+    });
+  }, [pool.tracks, sourceById, tab, q, activeSourceId]);
+
+  const existingRefs = useMemo(() => {
+    const refs = new Set<string>();
+    for (const s of pool.sources) if (s.external_ref) refs.add(`${s.kind}:${s.external_ref}`);
+    return refs;
+  }, [pool.sources]);
+
+  const onImported = useCallback((result: PoolImportResult) => {
+    setPool(result.pool);
+    setImportKind(null);
+    setToast(`${result.added} new · ${result.deduped} de-duped`);
+  }, []);
+
+  const removeTracks = useCallback(
+    async (ids: number[]) => {
+      try {
+        const result = await api.removePoolTracks(setId, ids);
+        setPool(result.pool);
+        setSelected(new Set());
+        setSelectMode(false);
+        setToast(`Removed ${result.removed} track${result.removed === 1 ? '' : 's'}`);
+      } catch {
+        setToast('Remove failed');
+      }
+    },
+    [setId]
+  );
+
+  const removeSource = useCallback(
+    async (sourceId: number) => {
+      try {
+        const result = await api.removePoolSource(setId, sourceId);
+        setPool(result.pool);
+        if (activeSourceId === sourceId) setActiveSourceId(null);
+        setToast(`Removed source · ${result.removed} tracks`);
+      } catch {
+        setToast('Remove failed');
+      }
+    },
+    [setId, activeSourceId]
+  );
+
+  const toggleSelect = (id: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <div className={styles.poolPanel}>
+      {/* Header: count + Add menu */}
+      <div className={styles.poolHeader}>
+        <span className={styles.poolTitle}>
+          Pool <span className={styles.poolCount}>{pool.tracks.length}</span>
+        </span>
+        <span style={{ flex: 1 }} />
+        <span style={{ position: 'relative' }} onMouseDown={(e) => e.stopPropagation()}>
+          <button
+            className="btn btn-sm"
+            onClick={() => setAddMenuOpen((o) => !o)}
+            aria-expanded={addMenuOpen}
+          >
+            + Add
+          </button>
+          {addMenuOpen && (
+            <div className={styles.popoverMenu}>
+              <div className={styles.popoverLabel}>Import from</div>
+              {IMPORT_MENU.map((m) => (
+                <button
+                  key={m.kind}
+                  className={styles.popoverItem}
+                  onClick={() => {
+                    setAddMenuOpen(false);
+                    setImportKind(m.kind);
+                  }}
+                >
+                  <span style={{ color: sourceColor(m.kind) }}>
+                    <SourceIcon kind={m.kind} />
+                  </span>
+                  <span>
+                    <span className={styles.popoverItemTitle}>{m.title}</span>
+                    <span className={styles.popoverItemSub}>{m.sub}</span>
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </span>
+      </div>
+
+      {/* Sources accordion */}
+      <div className={styles.poolSources}>
+        <button className={styles.sourcesToggle} onClick={() => setSourcesExpanded((e) => !e)}>
+          <span className={styles.sourcesCaret}>{sourcesExpanded ? '▾' : '▸'}</span>
+          <span>Sources</span>
+          <span className={styles.poolCount}>{pool.sources.length}</span>
+          <span style={{ flex: 1 }} />
+          {activeSourceId != null && (
+            <span
+              role="button"
+              tabIndex={0}
+              className={styles.sourcesClearFilter}
+              onClick={(e) => {
+                e.stopPropagation();
+                setActiveSourceId(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') setActiveSourceId(null);
+              }}
+            >
+              filtered · clear
+            </span>
+          )}
+        </button>
+        {sourcesExpanded && (
+          <div>
+            {pool.sources.map((s) => {
+              const count = sourceCounts.get(s.id) ?? 0;
+              const isActive = activeSourceId === s.id;
+              return (
+                <div key={s.id} className={`${styles.sourceRow} ${isActive ? styles.sourceRowActive : ''}`}>
+                  <button
+                    className={styles.sourceRowMain}
+                    onClick={() => setActiveSourceId(isActive ? null : s.id)}
+                    title="Click to filter pool by this source"
+                  >
+                    <span style={{ color: sourceColor(s.kind) }}>
+                      <SourceIcon kind={s.kind} size={13} />
+                    </span>
+                    <span className={styles.sourceInfo}>
+                      <span className={styles.sourceLabel}>{s.label}</span>
+                      {s.meta && <span className={styles.sourceMeta}>{s.meta}</span>}
+                    </span>
+                    <span className={styles.sourceCount}>{count}</span>
+                  </button>
+                  {s.kind !== 'manual' && (
+                    <button
+                      className={styles.sourceRemove}
+                      onClick={() => removeSource(s.id)}
+                      title={`Remove all ${count} tracks imported via "${s.label}"`}
+                      aria-label={`Remove source ${s.label}`}
+                    >
+                      ✕
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+            {loaded && pool.sources.length === 0 && (
+              <div className={styles.sourcesEmpty}>
+                No sources yet. Tap <strong>+ Add</strong> to import.
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Type tabs */}
+      <div className={styles.poolTabs}>
+        {TYPE_TABS.map((t) => (
+          <button
+            key={t.id}
+            className={`${styles.poolTab} ${tab === t.id ? styles.poolTabActive : ''}`}
+            onClick={() => setTab(t.id)}
+          >
+            {t.label} <span className={styles.poolCount}>{tabCounts[t.id] ?? 0}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Search + multi-select toggle */}
+      <div className={styles.poolSearch}>
+        <input
+          className={styles.imInput}
+          placeholder="Search pool…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          style={{ flex: 1 }}
+        />
+        <button
+          className="btn btn-sm"
+          onClick={() => {
+            setSelectMode((m) => !m);
+            setSelected(new Set());
+          }}
+          title={selectMode ? 'Exit multi-select' : 'Multi-select tracks'}
+          aria-pressed={selectMode}
+        >
+          ☑
+        </button>
+      </div>
+
+      {/* Track list */}
+      <div className={styles.poolList}>
+        {filtered.map((t) => {
+          const source = sourceById.get(t.source_id);
+          const isSelected = selected.has(t.id);
+          return (
+            <div
+              key={t.id}
+              className={`${styles.poolTrack} ${isSelected ? styles.poolTrackSelected : ''}`}
+              onClick={() => selectMode && toggleSelect(t.id)}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                setContextMenu({ x: e.clientX, y: e.clientY, trackId: t.id, sourceId: t.source_id });
+              }}
+            >
+              {selectMode && (
+                <input
+                  type="checkbox"
+                  checked={isSelected}
+                  onChange={() => toggleSelect(t.id)}
+                  onClick={(e) => e.stopPropagation()}
+                  aria-label={`Select ${t.title}`}
+                />
+              )}
+              <div className={styles.trackInfo}>
+                <div className={styles.trackTitle}>{t.title}</div>
+                <div className={styles.trackArtist}>{t.artist}</div>
+                <div className={styles.trackMetaRow}>
+                  <BpmBadge bpm={t.bpm} />
+                  <CamelotBadge camelot={t.camelot} />
+                  <EnergyMini value={t.energy} />
+                  {source && (
+                    <span
+                      className={styles.srcChip}
+                      style={{ color: sourceColor(source.kind) }}
+                      title={`Imported via ${source.label}`}
+                    >
+                      <SourceIcon kind={source.kind} size={10} />
+                      <span className={styles.srcChipLabel}>
+                        {source.label.length > 18 ? `${source.label.slice(0, 16)}…` : source.label}
+                      </span>
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div
+                className={styles.poolTrackStripe}
+                style={{ background: sourceColor(source?.kind) }}
+              />
+            </div>
+          );
+        })}
+        {loaded && filtered.length === 0 && (
+          <div className={styles.imEmpty}>
+            {pool.tracks.length === 0 ? 'Pool is empty — import some tracks.' : 'No matches.'}
+          </div>
+        )}
+      </div>
+
+      {/* Multi-select footer */}
+      {selectMode && (
+        <div className={styles.selectFooter}>
+          <button
+            className="btn btn-sm"
+            onClick={() => setSelected(new Set(filtered.map((t) => t.id)))}
+          >
+            Select all visible
+          </button>
+          <button className="btn btn-sm" onClick={() => setSelected(new Set())} disabled={!selected.size}>
+            Clear
+          </button>
+          <span style={{ flex: 1 }} />
+          <button
+            className={`btn btn-sm ${styles.dangerBtn}`}
+            disabled={!selected.size}
+            onClick={() => removeTracks([...selected])}
+          >
+            Remove {selected.size || ''}
+          </button>
+          <button
+            className="btn btn-sm"
+            onClick={() => {
+              setSelectMode(false);
+              setSelected(new Set());
+            }}
+          >
+            Done
+          </button>
+        </div>
+      )}
+
+      {/* Context menu */}
+      {contextMenu && (
+        <div
+          className={styles.popoverMenu}
+          style={{ position: 'fixed', left: contextMenu.x, top: contextMenu.y, right: 'auto' }}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <button
+            className={styles.popoverItem}
+            onClick={() => {
+              removeTracks([contextMenu.trackId]);
+              setContextMenu(null);
+            }}
+          >
+            <span className={styles.popoverItemTitle}>Remove this track</span>
+          </button>
+          {(() => {
+            const source = sourceById.get(contextMenu.sourceId);
+            if (!source || source.kind === 'manual') return null;
+            const count = sourceCounts.get(source.id) ?? 0;
+            return (
+              <button
+                className={styles.popoverItem}
+                onClick={() => {
+                  removeSource(source.id);
+                  setContextMenu(null);
+                }}
+              >
+                <span>
+                  <span className={styles.popoverItemTitle}>
+                    Remove all from “{source.label}”
+                  </span>
+                  <span className={styles.popoverItemSub}>{count} tracks</span>
+                </span>
+              </button>
+            );
+          })()}
+          <button
+            className={styles.popoverItem}
+            onClick={() => {
+              setSelectMode(true);
+              setSelected(new Set([contextMenu.trackId]));
+              setContextMenu(null);
+            }}
+          >
+            <span className={styles.popoverItemTitle}>Multi-select…</span>
+          </button>
+        </div>
+      )}
+
+      {/* Import modal */}
+      {importKind && (
+        <ImportModal
+          kind={importKind}
+          setId={setId}
+          existingRefs={existingRefs}
+          onClose={() => setImportKind(null)}
+          onImported={onImported}
+          onError={(msg) => setToast(msg)}
+        />
+      )}
+
+      {/* Toast */}
+      {toast && (
+        <div className={styles.poolToast} role="status">
+          {toast}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/ImportModal.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/ImportModal.test.tsx
@@ -1,0 +1,432 @@
+/**
+ * ImportModal component tests (issue #388) — covers all five import flows:
+ * event picker, Tidal/Beatport playlist, public URL validate+import, manual search.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import type { BuilderPlaylists, PoolImportResult, SearchResult } from '@/lib/api-types';
+import ImportModal from '../ImportModal';
+
+const mockApi = vi.hoisted(() => ({
+  getEvents: vi.fn(),
+  getBuilderPlaylists: vi.fn(),
+  importPoolEvent: vi.fn(),
+  importPoolTidal: vi.fn(),
+  importPoolBeatport: vi.fn(),
+  previewPoolUrl: vi.fn(),
+  importPoolUrl: vi.fn(),
+  importPoolManual: vi.fn(),
+  search: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({ api: mockApi }));
+
+const IMPORT_RESULT: PoolImportResult = {
+  added: 2,
+  deduped: 1,
+  source: {
+    id: 1,
+    kind: 'event',
+    external_ref: '7',
+    label: 'Prom Night',
+    meta: null,
+    created_at: '2026-06-09T00:00:00Z',
+  },
+  pool: { sources: [], tracks: [] },
+} as unknown as PoolImportResult;
+
+const PLAYLISTS: BuilderPlaylists = {
+  tidal_connected: true,
+  beatport_connected: false,
+  tidal: [
+    {
+      id: 'pl-1',
+      name: 'Friday Warmup',
+      num_tracks: 12,
+      source: 'tidal',
+      cover_url: null,
+      description: null,
+    },
+  ],
+  beatport: [],
+};
+
+function makeSearchResult(over: Partial<SearchResult>): SearchResult {
+  return {
+    title: 'Track',
+    artist: 'Artist',
+    album: null,
+    album_art: null,
+    bpm: null,
+    genre: null,
+    isrc: null,
+    key: null,
+    popularity: 0,
+    preview_url: null,
+    source: 'spotify',
+    spotify_id: null,
+    url: null,
+    ...over,
+  };
+}
+
+const baseProps = {
+  setId: 1,
+  existingRefs: new Set<string>(),
+  onClose: vi.fn(),
+  onImported: vi.fn(),
+  onError: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ImportModal — event flow', () => {
+  it('shows loading then empty state when no events exist', async () => {
+    mockApi.getEvents.mockResolvedValue([]);
+    render(<ImportModal kind="event" {...baseProps} />);
+    expect(screen.getByText('Loading events…')).toBeTruthy();
+    expect(await screen.findByText('No events yet.')).toBeTruthy();
+  });
+
+  it('treats getEvents failure as an empty list', async () => {
+    mockApi.getEvents.mockRejectedValue(new Error('boom'));
+    render(<ImportModal kind="event" {...baseProps} />);
+    expect(await screen.findByText('No events yet.')).toBeTruthy();
+  });
+
+  it('marks already-imported events and imports the picked event', async () => {
+    mockApi.getEvents.mockResolvedValue([
+      { id: 7, code: 'ABC123', name: 'Prom Night' },
+      { id: 8, code: 'DEF456', name: 'Warehouse' },
+    ]);
+    mockApi.importPoolEvent.mockResolvedValue(IMPORT_RESULT);
+    const onImported = vi.fn();
+    render(
+      <ImportModal
+        kind="event"
+        {...baseProps}
+        onImported={onImported}
+        existingRefs={new Set(['event:7'])}
+      />
+    );
+    await screen.findByText('Prom Night');
+    expect(screen.getByText('· already imported')).toBeTruthy();
+    // import button disabled until a pick
+    const importBtn = screen.getByText('Import requests') as HTMLButtonElement;
+    expect(importBtn.disabled).toBe(true);
+    fireEvent.click(screen.getByText('Warehouse'));
+    expect(importBtn.disabled).toBe(false);
+    fireEvent.click(importBtn);
+    await waitFor(() => expect(mockApi.importPoolEvent).toHaveBeenCalledWith(1, 8));
+    expect(onImported).toHaveBeenCalledWith(IMPORT_RESULT);
+  });
+
+  it('surfaces import errors via onError with the Error message', async () => {
+    mockApi.getEvents.mockResolvedValue([{ id: 7, code: 'ABC123', name: 'Prom Night' }]);
+    mockApi.importPoolEvent.mockRejectedValue(new Error('Event not found'));
+    const onError = vi.fn();
+    render(<ImportModal kind="event" {...baseProps} onError={onError} />);
+    fireEvent.click(await screen.findByText('Prom Night'));
+    fireEvent.click(screen.getByText('Import requests'));
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('Event not found'));
+  });
+
+  it('closes via the Cancel button and the backdrop', async () => {
+    mockApi.getEvents.mockResolvedValue([]);
+    const onClose = vi.fn();
+    const { container } = render(<ImportModal kind="event" {...baseProps} onClose={onClose} />);
+    await screen.findByText('No events yet.');
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    fireEvent.click(container.querySelector('[class*="modalBackdrop"]')!);
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('ImportModal — playlist flows', () => {
+  it('lists Tidal playlists, marks imported ones, and imports the pick', async () => {
+    mockApi.getBuilderPlaylists.mockResolvedValue(PLAYLISTS);
+    mockApi.importPoolTidal.mockResolvedValue(IMPORT_RESULT);
+    const onImported = vi.fn();
+    render(
+      <ImportModal
+        kind="tidal"
+        {...baseProps}
+        onImported={onImported}
+        existingRefs={new Set(['tidal:pl-1'])}
+      />
+    );
+    expect(screen.getByText('Loading playlists…')).toBeTruthy();
+    expect(await screen.findByText('Import Tidal playlist')).toBeTruthy();
+    expect(screen.getByText('· already imported')).toBeTruthy();
+    expect(screen.getByText('12 tracks')).toBeTruthy();
+    fireEvent.click(screen.getByText('Friday Warmup'));
+    fireEvent.click(screen.getByText('Import playlist'));
+    await waitFor(() =>
+      expect(mockApi.importPoolTidal).toHaveBeenCalledWith(1, 'pl-1', 'Friday Warmup')
+    );
+    expect(onImported).toHaveBeenCalledWith(IMPORT_RESULT);
+  });
+
+  it('shows the not-connected notice for Beatport', async () => {
+    mockApi.getBuilderPlaylists.mockResolvedValue(PLAYLISTS);
+    render(<ImportModal kind="beatport" {...baseProps} />);
+    expect(await screen.findByText(/Beatport isn't connected/)).toBeTruthy();
+  });
+
+  it('routes Beatport picks through importPoolBeatport and reports generic errors', async () => {
+    mockApi.getBuilderPlaylists.mockResolvedValue({
+      ...PLAYLISTS,
+      beatport_connected: true,
+      beatport: [
+        {
+          id: 'bp-9',
+          name: 'Peak Time',
+          num_tracks: 30,
+          source: 'beatport',
+          cover_url: null,
+          description: null,
+        },
+      ],
+    });
+    mockApi.importPoolBeatport.mockRejectedValue('not-an-error');
+    const onError = vi.fn();
+    render(<ImportModal kind="beatport" {...baseProps} onError={onError} />);
+    fireEvent.click(await screen.findByText('Peak Time'));
+    fireEvent.click(screen.getByText('Import playlist'));
+    await waitFor(() =>
+      expect(mockApi.importPoolBeatport).toHaveBeenCalledWith(1, 'bp-9', 'Peak Time')
+    );
+    expect(onError).toHaveBeenCalledWith('Import failed — try again');
+  });
+});
+
+describe('ImportModal — public URL flow', () => {
+  it('enables Validate only for https URLs and imports a supported preview', async () => {
+    mockApi.previewPoolUrl.mockResolvedValue({
+      supported: true,
+      provider: 'spotify',
+      name: 'Summer Mix',
+      track_count: 42,
+      owner: 'DJ Wrz',
+      message: null,
+    });
+    mockApi.importPoolUrl.mockResolvedValue(IMPORT_RESULT);
+    const onImported = vi.fn();
+    render(<ImportModal kind="public_url" {...baseProps} onImported={onImported} />);
+    const input = screen.getByPlaceholderText('https://open.spotify.com/playlist/…');
+    const validateBtn = screen.getByText('Validate') as HTMLButtonElement;
+    expect(validateBtn.disabled).toBe(true);
+    fireEvent.change(input, { target: { value: 'http://not-secure.com/x' } });
+    expect(validateBtn.disabled).toBe(true);
+    fireEvent.change(input, { target: { value: ' https://open.spotify.com/playlist/abc ' } });
+    expect(validateBtn.disabled).toBe(false);
+    fireEvent.click(validateBtn);
+    await waitFor(() =>
+      expect(mockApi.previewPoolUrl).toHaveBeenCalledWith(1, 'https://open.spotify.com/playlist/abc')
+    );
+    expect(await screen.findByText('Spotify · public playlist')).toBeTruthy();
+    expect(screen.getByText('Summer Mix')).toBeTruthy();
+    expect(screen.getByText('42 found · de-duped on import')).toBeTruthy();
+    expect(screen.getByText('DJ Wrz')).toBeTruthy();
+    fireEvent.click(screen.getByText('Import playlist'));
+    await waitFor(() =>
+      expect(mockApi.importPoolUrl).toHaveBeenCalledWith(1, 'https://open.spotify.com/playlist/abc')
+    );
+    expect(onImported).toHaveBeenCalledWith(IMPORT_RESULT);
+  });
+
+  it('renders Tidal previews with em-dash fallbacks for missing fields', async () => {
+    mockApi.previewPoolUrl.mockResolvedValue({
+      supported: true,
+      provider: 'tidal',
+      name: null,
+      track_count: null,
+      owner: null,
+      message: null,
+    });
+    render(<ImportModal kind="public_url" {...baseProps} />);
+    fireEvent.change(screen.getByPlaceholderText('https://open.spotify.com/playlist/…'), {
+      target: { value: 'https://tidal.com/playlist/xyz' },
+    });
+    fireEvent.click(screen.getByText('Validate'));
+    expect(await screen.findByText('Tidal · public playlist')).toBeTruthy();
+    expect(screen.getByText('—')).toBeTruthy();
+    expect(screen.getByText('— found · de-duped on import')).toBeTruthy();
+    // owner row hidden when owner is null
+    expect(screen.queryByText('Owner')).toBeNull();
+  });
+
+  it('shows unsupported-provider message (and a fallback when message is null)', async () => {
+    mockApi.previewPoolUrl.mockResolvedValueOnce({
+      supported: false,
+      provider: 'unknown',
+      name: null,
+      track_count: null,
+      owner: null,
+      message: 'Apple Music is not supported yet',
+    });
+    render(<ImportModal kind="public_url" {...baseProps} />);
+    const input = screen.getByPlaceholderText('https://open.spotify.com/playlist/…');
+    fireEvent.change(input, { target: { value: 'https://music.apple.com/playlist/1' } });
+    fireEvent.click(screen.getByText('Validate'));
+    expect(await screen.findByText('Apple Music is not supported yet')).toBeTruthy();
+    const importBtn = screen.getByText('Import playlist') as HTMLButtonElement;
+    expect(importBtn.disabled).toBe(true);
+
+    mockApi.previewPoolUrl.mockResolvedValueOnce({
+      supported: false,
+      provider: 'unknown',
+      name: null,
+      track_count: null,
+      owner: null,
+      message: null,
+    });
+    fireEvent.change(input, { target: { value: 'https://example.com/other' } });
+    fireEvent.click(screen.getByText('Validate'));
+    expect(await screen.findByText('Provider not supported yet.')).toBeTruthy();
+  });
+
+  it('shows validation errors and clears them when the URL changes', async () => {
+    mockApi.previewPoolUrl.mockRejectedValue(new Error('URL host not allowed'));
+    render(<ImportModal kind="public_url" {...baseProps} />);
+    const input = screen.getByPlaceholderText('https://open.spotify.com/playlist/…');
+    fireEvent.change(input, { target: { value: 'https://evil.example/playlist' } });
+    fireEvent.click(screen.getByText('Validate'));
+    expect(await screen.findByText('URL host not allowed')).toBeTruthy();
+    fireEvent.change(input, { target: { value: 'https://evil.example/playlist2' } });
+    expect(screen.queryByText('URL host not allowed')).toBeNull();
+  });
+
+  it('reports import failures via onError', async () => {
+    mockApi.previewPoolUrl.mockResolvedValue({
+      supported: true,
+      provider: 'spotify',
+      name: 'Mix',
+      track_count: 1,
+      owner: null,
+      message: null,
+    });
+    mockApi.importPoolUrl.mockRejectedValue(new Error('Playlist gone'));
+    const onError = vi.fn();
+    render(<ImportModal kind="public_url" {...baseProps} onError={onError} />);
+    fireEvent.change(screen.getByPlaceholderText('https://open.spotify.com/playlist/…'), {
+      target: { value: 'https://open.spotify.com/playlist/abc' },
+    });
+    fireEvent.click(screen.getByText('Validate'));
+    await screen.findByText('Spotify · public playlist');
+    fireEvent.click(screen.getByText('Import playlist'));
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('Playlist gone'));
+  });
+});
+
+describe('ImportModal — manual search flow', () => {
+  it('prompts to type, then searches after debounce and renders BPM/key metadata', async () => {
+    mockApi.search.mockResolvedValue([
+      makeSearchResult({
+        title: 'With Meta',
+        artist: 'A1',
+        bpm: 128,
+        key: '8A',
+        source: 'beatport',
+        url: 'https://beatport.com/track/1',
+      }),
+      makeSearchResult({ title: 'Bare', artist: 'A2', source: 'tidal', url: 'https://t/2' }),
+    ]);
+    render(<ImportModal kind="manual" {...baseProps} />);
+    expect(screen.getByText('Type to search Spotify, Beatport, Tidal…')).toBeTruthy();
+    fireEvent.change(screen.getByPlaceholderText('Search title or artist…'), {
+      target: { value: 'meta' },
+    });
+    await waitFor(() => expect(mockApi.search).toHaveBeenCalledWith('meta'));
+    expect(await screen.findByText('With Meta')).toBeTruthy();
+    expect(screen.getByText(/A1 · 128 BPM · 8A · beatport/)).toBeTruthy();
+    expect(screen.getByText(/A2 · tidal/)).toBeTruthy();
+  });
+
+  it('imports a Spotify pick with its spotify_id and https artwork', async () => {
+    mockApi.search.mockResolvedValue([
+      makeSearchResult({
+        title: 'Sp Track',
+        artist: 'Sp Artist',
+        album: 'Sp Album',
+        genre: 'House',
+        bpm: 124,
+        key: 'Am',
+        isrc: 'US123',
+        album_art: 'https://img.example/a.jpg',
+        source: 'spotify',
+        spotify_id: 'sp-1',
+      }),
+    ]);
+    mockApi.importPoolManual.mockResolvedValue(IMPORT_RESULT);
+    const onImported = vi.fn();
+    render(<ImportModal kind="manual" {...baseProps} onImported={onImported} />);
+    fireEvent.change(screen.getByPlaceholderText('Search title or artist…'), {
+      target: { value: 'sp' },
+    });
+    fireEvent.click(await screen.findByText('Sp Track'));
+    await waitFor(() =>
+      expect(mockApi.importPoolManual).toHaveBeenCalledWith(1, {
+        title: 'Sp Track',
+        artist: 'Sp Artist',
+        album: 'Sp Album',
+        genre: 'House',
+        bpm: 124,
+        key: 'Am',
+        isrc: 'US123',
+        artwork_url: 'https://img.example/a.jpg',
+        source_service: 'spotify',
+        source_track_id: 'sp-1',
+      })
+    );
+    expect(onImported).toHaveBeenCalledWith(IMPORT_RESULT);
+  });
+
+  it('falls back to manual source and drops non-https artwork for unknown sources', async () => {
+    mockApi.search.mockResolvedValue([
+      makeSearchResult({
+        title: 'Odd Track',
+        artist: 'Odd Artist',
+        album_art: 'http://insecure.example/a.jpg',
+        source: 'soundcloud',
+      }),
+    ]);
+    mockApi.importPoolManual.mockRejectedValue(new Error('Pool is full'));
+    const onError = vi.fn();
+    render(<ImportModal kind="manual" {...baseProps} onError={onError} />);
+    fireEvent.change(screen.getByPlaceholderText('Search title or artist…'), {
+      target: { value: 'odd' },
+    });
+    fireEvent.click(await screen.findByText('Odd Track'));
+    await waitFor(() =>
+      expect(mockApi.importPoolManual).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          artwork_url: null,
+          source_service: 'manual',
+          source_track_id: null,
+        })
+      )
+    );
+    expect(onError).toHaveBeenCalledWith('Pool is full');
+  });
+
+  it('shows "No matches." when a search returns nothing (or fails)', async () => {
+    mockApi.search.mockRejectedValue(new Error('rate limited'));
+    render(<ImportModal kind="manual" {...baseProps} />);
+    fireEvent.change(screen.getByPlaceholderText('Search title or artist…'), {
+      target: { value: 'zz' },
+    });
+    await waitFor(() => expect(mockApi.search).toHaveBeenCalled());
+    expect(await screen.findByText('No matches.')).toBeTruthy();
+    // clearing back below 2 chars returns to the type-to-search prompt
+    fireEvent.change(screen.getByPlaceholderText('Search title or artist…'), {
+      target: { value: 'z' },
+    });
+    expect(screen.getByText('Type to search Spotify, Beatport, Tidal…')).toBeTruthy();
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * PoolPanel component tests (issue #388) — source tagging visibility,
+ * source filter + remove-by-source, multi-select removal, dedupe toast.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import type { PoolState } from '@/lib/api-types';
+import PoolPanel from '../PoolPanel';
+
+const mockApi = vi.hoisted(() => ({
+  getPool: vi.fn(),
+  getBuilderPlaylists: vi.fn(),
+  importPoolEvent: vi.fn(),
+  importPoolManual: vi.fn(),
+  removePoolTracks: vi.fn(),
+  removePoolSource: vi.fn(),
+  getEvents: vi.fn(),
+  search: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({ api: mockApi }));
+
+const SOURCES = [
+  {
+    id: 1,
+    kind: 'event' as const,
+    external_ref: '7',
+    label: 'Prom Night',
+    meta: 'WrzDJ event requests',
+    created_at: '2026-06-09T00:00:00Z',
+  },
+  {
+    id: 2,
+    kind: 'tidal' as const,
+    external_ref: 'pl-1',
+    label: 'Friday Warmup',
+    meta: 'Tidal playlist',
+    created_at: '2026-06-09T00:00:00Z',
+  },
+];
+
+const TRACKS = [
+  {
+    id: 11,
+    source_id: 1,
+    track_id: 'request:1',
+    title: 'Event Song',
+    artist: 'Event Artist',
+    album: null,
+    genre: 'House',
+    bpm: 126,
+    key: 'Am',
+    camelot: '8A',
+    energy: 7,
+    isrc: null,
+    duration_sec: null,
+    artwork_url: null,
+    created_at: '2026-06-09T00:00:00Z',
+  },
+  {
+    id: 12,
+    source_id: 2,
+    track_id: 'tidal:9',
+    title: 'Tidal Song',
+    artist: 'Tidal Artist',
+    album: null,
+    genre: null,
+    bpm: null,
+    key: null,
+    camelot: null,
+    energy: null,
+    isrc: null,
+    duration_sec: null,
+    artwork_url: null,
+    created_at: '2026-06-09T00:00:00Z',
+  },
+];
+
+const POOL: PoolState = { sources: SOURCES, tracks: TRACKS };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockApi.getPool.mockResolvedValue(POOL);
+});
+
+describe('PoolPanel', () => {
+  it('renders tracks with source chips and badges', async () => {
+    render(<PoolPanel setId={1} />);
+    expect(await screen.findByText('Event Song')).toBeTruthy();
+    expect(screen.getByText('Tidal Song')).toBeTruthy();
+    // source chip labels visible on rows (chip + accordion row)
+    expect(screen.getAllByText('Prom Night').length).toBeGreaterThanOrEqual(2);
+    // camelot + bpm badges
+    expect(screen.getByText('8A')).toBeTruthy();
+    expect(screen.getByText('126')).toBeTruthy();
+  });
+
+  it('filters the list when a source row is clicked', async () => {
+    render(<PoolPanel setId={1} />);
+    await screen.findByText('Event Song');
+    fireEvent.click(screen.getAllByTitle('Click to filter pool by this source')[0]);
+    // first source row main button is Prom Night — Tidal Song should disappear
+    expect(screen.queryByText('Tidal Song')).toBeNull();
+    expect(screen.getByText('Event Song')).toBeTruthy();
+    expect(screen.getByText('filtered · clear')).toBeTruthy();
+  });
+
+  it('removes a source via the hover × and updates state from response', async () => {
+    mockApi.removePoolSource.mockResolvedValue({
+      removed: 1,
+      pool: { sources: [SOURCES[1]], tracks: [TRACKS[1]] },
+    });
+    render(<PoolPanel setId={1} />);
+    await screen.findByText('Event Song');
+    fireEvent.click(screen.getByLabelText('Remove source Prom Night'));
+    await waitFor(() => expect(mockApi.removePoolSource).toHaveBeenCalledWith(1, 1));
+    await waitFor(() => expect(screen.queryByText('Event Song')).toBeNull());
+    expect(screen.getByText('Tidal Song')).toBeTruthy();
+    expect(screen.getByText('Removed source · 1 tracks')).toBeTruthy();
+  });
+
+  it('multi-select: select-all-visible then remove calls removePoolTracks', async () => {
+    mockApi.removePoolTracks.mockResolvedValue({
+      removed: 2,
+      pool: { sources: SOURCES, tracks: [] },
+    });
+    render(<PoolPanel setId={1} />);
+    await screen.findByText('Event Song');
+    fireEvent.click(screen.getByTitle('Multi-select tracks'));
+    fireEvent.click(screen.getByText('Select all visible'));
+    fireEvent.click(screen.getByText('Remove 2'));
+    await waitFor(() =>
+      expect(mockApi.removePoolTracks).toHaveBeenCalledWith(1, expect.arrayContaining([11, 12]))
+    );
+    await waitFor(() => expect(screen.queryByText('Event Song')).toBeNull());
+  });
+
+  it('type tabs show live counts and filter by source kind', async () => {
+    render(<PoolPanel setId={1} />);
+    await screen.findByText('Event Song');
+    const tidalTab = screen.getByRole('button', { name: /Tidal 1/ });
+    fireEvent.click(tidalTab);
+    expect(screen.queryByText('Event Song')).toBeNull();
+    expect(screen.getByText('Tidal Song')).toBeTruthy();
+  });
+
+  it('import flow surfaces the dedupe toast "N new · M de-duped"', async () => {
+    mockApi.getEvents.mockResolvedValue([
+      { id: 7, code: 'ABC123', name: 'Prom Night' },
+    ]);
+    mockApi.importPoolEvent.mockResolvedValue({
+      added: 3,
+      deduped: 2,
+      source: SOURCES[0],
+      pool: POOL,
+    });
+    render(<PoolPanel setId={1} />);
+    await screen.findByText('Event Song');
+    fireEvent.click(screen.getByText('+ Add'));
+    fireEvent.click(screen.getByText('WrzDJ Event Requests'));
+    // event picker modal: pick the event then import
+    fireEvent.click(await screen.findByText('ABC123'));
+    fireEvent.click(screen.getByText('Import requests'));
+    await waitFor(() => expect(mockApi.importPoolEvent).toHaveBeenCalledWith(1, 7));
+    expect(await screen.findByText('3 new · 2 de-duped')).toBeTruthy();
+  });
+
+  it('context menu offers per-track and per-source removal', async () => {
+    mockApi.removePoolTracks.mockResolvedValue({
+      removed: 1,
+      pool: { sources: SOURCES, tracks: [TRACKS[1]] },
+    });
+    render(<PoolPanel setId={1} />);
+    const row = await screen.findByText('Event Song');
+    fireEvent.contextMenu(row);
+    expect(screen.getByText(/Remove all from “Prom Night”/)).toBeTruthy();
+    fireEvent.click(screen.getByText('Remove this track'));
+    await waitFor(() => expect(mockApi.removePoolTracks).toHaveBeenCalledWith(1, [11]));
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/setbuilder.module.css
+++ b/dashboard/app/(dj)/setbuilder/setbuilder.module.css
@@ -68,3 +68,538 @@
   font-size: 0.875rem;
   text-align: center;
 }
+
+/* ------------------------------------------------------------------ */
+/* Pool panel (issue #388)                                            */
+
+.poolPanel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  position: relative;
+  font-size: 0.8125rem;
+}
+
+.poolHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.poolTitle {
+  font-family: var(--font-display), sans-serif;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.poolCount {
+  display: inline-block;
+  min-width: 1.2em;
+  padding: 0 0.35em;
+  border-radius: 8px;
+  background: var(--surface-raised, rgba(255, 255, 255, 0.06));
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+  text-align: center;
+}
+
+.popoverMenu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  z-index: 40;
+  min-width: 230px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.35rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+
+.popoverLabel {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.6563rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.popoverItem {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.45rem 0.5rem;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.popoverItem:hover {
+  background: var(--surface-raised, rgba(255, 255, 255, 0.06));
+}
+
+.popoverItemTitle {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.popoverItemSub {
+  display: block;
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+}
+
+.poolSources {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.sourcesToggle {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  width: 100%;
+  padding: 0.45rem 0.75rem;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+}
+
+.sourcesCaret {
+  font-size: 0.625rem;
+}
+
+.sourcesClearFilter {
+  font-size: 0.6563rem;
+  color: var(--color-primary, #8b5cf6);
+  text-transform: none;
+  letter-spacing: 0;
+  cursor: pointer;
+}
+
+.sourceRow {
+  display: flex;
+  align-items: center;
+  padding-right: 0.5rem;
+}
+
+.sourceRow:hover {
+  background: var(--surface-raised, rgba(255, 255, 255, 0.04));
+}
+
+.sourceRowActive {
+  background: var(--surface-raised, rgba(255, 255, 255, 0.07));
+}
+
+.sourceRowMain {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex: 1;
+  min-width: 0;
+  padding: 0.4rem 0.75rem;
+  background: none;
+  border: none;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.sourceInfo {
+  flex: 1;
+  min-width: 0;
+}
+
+.sourceLabel {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sourceMeta {
+  display: block;
+  font-size: 0.6563rem;
+  color: var(--text-secondary);
+}
+
+.sourceCount {
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.sourceRemove {
+  visibility: hidden;
+  background: none;
+  border: none;
+  color: var(--color-danger, #ef4444);
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+}
+
+.sourceRow:hover .sourceRemove {
+  visibility: visible;
+}
+
+.sourcesEmpty {
+  padding: 0.6rem 0.75rem;
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+}
+
+.poolTabs {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--border-subtle);
+  overflow-x: auto;
+}
+
+.poolTab {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.poolTabActive {
+  border-color: var(--border);
+  background: var(--surface-raised, rgba(255, 255, 255, 0.06));
+  color: var(--text);
+}
+
+.poolSearch {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.6rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.poolList {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.poolTrack {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.9rem 0.45rem 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+  cursor: default;
+}
+
+.poolTrack:hover {
+  background: var(--surface-raised, rgba(255, 255, 255, 0.04));
+}
+
+.poolTrackSelected {
+  background: var(--surface-raised, rgba(139, 92, 246, 0.12));
+}
+
+.trackInfo {
+  flex: 1;
+  min-width: 0;
+}
+
+.trackTitle {
+  font-size: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.trackArtist {
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.trackMetaRow {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 0.2rem;
+}
+
+.srcChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.625rem;
+  max-width: 9rem;
+  overflow: hidden;
+}
+
+.srcChipLabel {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.poolTrackStripe {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+}
+
+.selectFooter {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.6rem;
+  border-top: 1px solid var(--border);
+  background: var(--card);
+}
+
+.dangerBtn {
+  background: rgba(239, 68, 68, 0.15) !important;
+  border-color: rgba(239, 68, 68, 0.4) !important;
+  color: #f87171 !important;
+}
+
+.poolToast {
+  position: absolute;
+  left: 50%;
+  bottom: 0.75rem;
+  transform: translateX(-50%);
+  z-index: 50;
+  padding: 0.45rem 0.9rem;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 0.75rem;
+  color: var(--text);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+  white-space: nowrap;
+}
+
+/* Import modal */
+
+.modalWrap {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modalBackdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.importModal {
+  position: relative;
+  width: min(480px, calc(100vw - 2rem));
+  max-height: min(620px, calc(100vh - 4rem));
+  display: flex;
+  flex-direction: column;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.imHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.imHeaderIcon {
+  display: inline-flex;
+}
+
+.imTitle {
+  font-family: var(--font-display), sans-serif;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.imSubtitle {
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+}
+
+.iconBtn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  padding: 0.25rem;
+}
+
+.imBody {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.85rem 1rem;
+}
+
+.imList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.imListItem {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.5rem 0.6rem;
+  background: none;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.imListItem:hover:not(:disabled) {
+  background: var(--surface-raised, rgba(255, 255, 255, 0.05));
+}
+
+.imListItem:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.imPicked {
+  border-color: var(--color-primary, #8b5cf6);
+  background: var(--surface-raised, rgba(139, 92, 246, 0.1));
+}
+
+.imListInfo {
+  flex: 1;
+  min-width: 0;
+}
+
+.imListTitle {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.imListSub {
+  display: block;
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+}
+
+.imImported {
+  font-weight: 400;
+  font-size: 0.6563rem;
+  color: var(--text-secondary);
+}
+
+.imInput {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.4rem 0.6rem;
+  color: var(--text);
+  font-size: 0.75rem;
+}
+
+.imInput:focus {
+  outline: none;
+  border-color: var(--color-primary, #8b5cf6);
+}
+
+.imFootnote {
+  margin-top: 0.75rem;
+  font-size: 0.6563rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.imFooter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.7rem 1rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.imEmpty {
+  padding: 1.25rem 0.25rem;
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.imError {
+  margin-bottom: 0.6rem;
+  padding: 0.5rem 0.7rem;
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  border-radius: 8px;
+  background: rgba(239, 68, 68, 0.1);
+  color: #f87171;
+  font-size: 0.6875rem;
+}
+
+.imPreviewCard {
+  margin-bottom: 0.6rem;
+  padding: 0.6rem 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.imPreviewRow {
+  display: flex;
+  gap: 0.6rem;
+  font-size: 0.6875rem;
+}
+
+.imPreviewLabel {
+  width: 4.5rem;
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  font-size: 0.625rem;
+  letter-spacing: 0.05em;
+  line-height: 1.6;
+}

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -2412,6 +2412,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/setbuilder/playlists": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Builder Playlists
+         * @description Connected-service playlists for the import modal pickers.
+         */
+        get: operations["list_builder_playlists_api_setbuilder_playlists_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/setbuilder/sets": {
         parameters: {
             query?: never;
@@ -2462,6 +2482,186 @@ export interface paths {
          * @description Rename one of the current DJ's sets, or 404.
          */
         patch: operations["rename_set_api_setbuilder_sets__set_id__patch"];
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/pool": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Pool State
+         * @description Full pool snapshot (sources + tracks) for one of the DJ's sets.
+         */
+        get: operations["get_pool_state_api_setbuilder_sets__set_id__pool_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/pool/import/beatport": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Import Pool Beatport
+         * @description Import a connected-account Beatport playlist into the pool.
+         */
+        post: operations["import_pool_beatport_api_setbuilder_sets__set_id__pool_import_beatport_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/pool/import/event": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Import Pool Event
+         * @description Import a DJ-owned event's non-rejected requests into the pool.
+         */
+        post: operations["import_pool_event_api_setbuilder_sets__set_id__pool_import_event_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/pool/import/manual": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Import Pool Manual
+         * @description Add a single manually-searched track to the pool.
+         */
+        post: operations["import_pool_manual_api_setbuilder_sets__set_id__pool_import_manual_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/pool/import/tidal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Import Pool Tidal
+         * @description Import a connected-account Tidal playlist into the pool.
+         */
+        post: operations["import_pool_tidal_api_setbuilder_sets__set_id__pool_import_tidal_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/pool/import/url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Import Pool Url
+         * @description Import a validated public playlist URL into the pool.
+         */
+        post: operations["import_pool_url_api_setbuilder_sets__set_id__pool_import_url_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/pool/sources/{source_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Remove Pool Source
+         * @description Remove an import source and exactly its tracks.
+         */
+        delete: operations["remove_pool_source_api_setbuilder_sets__set_id__pool_sources__source_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/pool/tracks/remove": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Remove Pool Tracks
+         * @description Remove pool tracks by id (per-track context menu + multi-select).
+         */
+        post: operations["remove_pool_tracks_api_setbuilder_sets__set_id__pool_tracks_remove_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/pool/url-preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Preview Pool Url
+         * @description Validate a public playlist URL and return the preview card payload.
+         */
+        post: operations["preview_pool_url_api_setbuilder_sets__set_id__pool_url_preview_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/api/tidal/auth/cancel": {
@@ -3069,10 +3269,7 @@ export interface components {
         };
         /** Body_upload_banner_api_events__code__banner_post */
         Body_upload_banner_api_events__code__banner_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** BridgeApiKeyResponse */
@@ -3165,6 +3362,20 @@ export interface components {
             plugin_id: string | null;
             /** Uptime Seconds */
             uptime_seconds: number | null;
+        };
+        /**
+         * BuilderPlaylistsOut
+         * @description Connected-service playlist pickers for the import modal.
+         */
+        BuilderPlaylistsOut: {
+            /** Beatport */
+            beatport: components["schemas"]["PlaylistInfo"][];
+            /** Beatport Connected */
+            beatport_connected: boolean;
+            /** Tidal */
+            tidal: components["schemas"]["PlaylistInfo"][];
+            /** Tidal Connected */
+            tidal_connected: boolean;
         };
         /** BulkActionResponse */
         BulkActionResponse: {
@@ -4279,6 +4490,199 @@ export interface components {
             items: components["schemas"]["PlayHistoryEntry"][];
             /** Total */
             total: number;
+        };
+        /** PlaylistInfo */
+        PlaylistInfo: {
+            /** Cover Url */
+            cover_url: string | null;
+            /** Description */
+            description: string | null;
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Num Tracks */
+            num_tracks: number;
+            /** Source */
+            source: string;
+        };
+        /**
+         * PoolImportEventIn
+         * @description Body for importing a WrzDJ event's requests.
+         */
+        PoolImportEventIn: {
+            /** Event Id */
+            event_id: number;
+        };
+        /**
+         * PoolImportManualIn
+         * @description Body for adding a single track picked from manual search.
+         */
+        PoolImportManualIn: {
+            /** Album */
+            album?: string | null;
+            /** Artist */
+            artist: string;
+            /** Artwork Url */
+            artwork_url?: string | null;
+            /** Bpm */
+            bpm?: number | null;
+            /** Duration Sec */
+            duration_sec?: number | null;
+            /** Genre */
+            genre?: string | null;
+            /** Isrc */
+            isrc?: string | null;
+            /** Key */
+            key?: string | null;
+            /**
+             * Source Service
+             * @default manual
+             * @enum {string}
+             */
+            source_service: "spotify" | "beatport" | "tidal" | "manual";
+            /** Source Track Id */
+            source_track_id?: string | null;
+            /** Title */
+            title: string;
+        };
+        /**
+         * PoolImportPlaylistIn
+         * @description Body for importing a connected-account (Tidal/Beatport) playlist.
+         */
+        PoolImportPlaylistIn: {
+            /** Label */
+            label?: string | null;
+            /** Playlist Id */
+            playlist_id: string;
+        };
+        /**
+         * PoolImportResult
+         * @description Result of any import flow — toast reads 'added new · deduped de-duped'.
+         */
+        PoolImportResult: {
+            /** Added */
+            added: number;
+            /** Deduped */
+            deduped: number;
+            pool: components["schemas"]["PoolState"];
+            source: components["schemas"]["PoolSourceOut"];
+        };
+        /**
+         * PoolImportUrlIn
+         * @description Body for public playlist URL preview/import.
+         */
+        PoolImportUrlIn: {
+            /** Url */
+            url: string;
+        };
+        /**
+         * PoolMutationResult
+         * @description Result of a removal flow.
+         */
+        PoolMutationResult: {
+            pool: components["schemas"]["PoolState"];
+            /** Removed */
+            removed: number;
+        };
+        /**
+         * PoolRemoveTracksIn
+         * @description Body for per-track / multi-select removal.
+         */
+        PoolRemoveTracksIn: {
+            /** Track Ids */
+            track_ids: number[];
+        };
+        /**
+         * PoolSourceOut
+         * @description An import source row for the sources accordion.
+         */
+        PoolSourceOut: {
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** External Ref */
+            external_ref: string | null;
+            /** Id */
+            id: number;
+            /**
+             * Kind
+             * @enum {string}
+             */
+            kind: "event" | "tidal" | "beatport" | "public_url" | "manual";
+            /** Label */
+            label: string;
+            /** Meta */
+            meta: string | null;
+        };
+        /**
+         * PoolState
+         * @description Full pool snapshot: sources + tracks.
+         */
+        PoolState: {
+            /** Sources */
+            sources: components["schemas"]["PoolSourceOut"][];
+            /** Tracks */
+            tracks: components["schemas"]["PoolTrackOut"][];
+        };
+        /**
+         * PoolTrackOut
+         * @description A pool track row (badges: camelot, bpm, energy; chip: source_id).
+         */
+        PoolTrackOut: {
+            /** Album */
+            album: string | null;
+            /** Artist */
+            artist: string;
+            /** Artwork Url */
+            artwork_url: string | null;
+            /** Bpm */
+            bpm: number | null;
+            /** Camelot */
+            camelot: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Duration Sec */
+            duration_sec: number | null;
+            /** Energy */
+            energy: number | null;
+            /** Genre */
+            genre: string | null;
+            /** Id */
+            id: number;
+            /** Isrc */
+            isrc: string | null;
+            /** Key */
+            key: string | null;
+            /** Source Id */
+            source_id: number;
+            /** Title */
+            title: string;
+            /** Track Id */
+            track_id: string | null;
+        };
+        /**
+         * PoolUrlPreview
+         * @description Validate → preview card payload for a public playlist URL.
+         */
+        PoolUrlPreview: {
+            /** Message */
+            message: string | null;
+            /** Name */
+            name: string | null;
+            /** Owner */
+            owner: string | null;
+            /** Provider */
+            provider: string;
+            /** Supported */
+            supported: boolean;
+            /** Track Count */
+            track_count: number | null;
         };
         /** PublicEventInfo */
         PublicEventInfo: {
@@ -9229,6 +9633,26 @@ export interface operations {
             };
         };
     };
+    list_builder_playlists_api_setbuilder_playlists_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BuilderPlaylistsOut"];
+                };
+            };
+        };
+    };
     list_sets_api_setbuilder_sets_get: {
         parameters: {
             query?: never;
@@ -9364,6 +9788,314 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SetDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_pool_state_api_setbuilder_sets__set_id__pool_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PoolState"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    import_pool_beatport_api_setbuilder_sets__set_id__pool_import_beatport_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PoolImportPlaylistIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PoolImportResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    import_pool_event_api_setbuilder_sets__set_id__pool_import_event_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PoolImportEventIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PoolImportResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    import_pool_manual_api_setbuilder_sets__set_id__pool_import_manual_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PoolImportManualIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PoolImportResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    import_pool_tidal_api_setbuilder_sets__set_id__pool_import_tidal_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PoolImportPlaylistIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PoolImportResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    import_pool_url_api_setbuilder_sets__set_id__pool_import_url_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PoolImportUrlIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PoolImportResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    remove_pool_source_api_setbuilder_sets__set_id__pool_sources__source_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+                source_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PoolMutationResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    remove_pool_tracks_api_setbuilder_sets__set_id__pool_tracks_remove_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PoolRemoveTracksIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PoolMutationResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    preview_pool_url_api_setbuilder_sets__set_id__pool_url_preview_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PoolImportUrlIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PoolUrlPreview"];
                 };
             };
             /** @description Validation Error */

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -191,6 +191,16 @@ export interface SetDetail extends SetSummary {
   exported_at: string | null;
 }
 
+// WrzDJSet pool (issue #388)
+export type PoolSource = Schemas['PoolSourceOut'];
+export type PoolTrack = Schemas['PoolTrackOut'];
+export type PoolState = Schemas['PoolState'];
+export type PoolImportResult = Schemas['PoolImportResult'];
+export type PoolMutationResult = Schemas['PoolMutationResult'];
+export type PoolUrlPreview = Schemas['PoolUrlPreview'];
+export type PoolImportManualIn = Schemas['PoolImportManualIn'];
+export type BuilderPlaylists = Schemas['BuilderPlaylistsOut'];
+
 /** OpenAPI expresses PaginatedResponse with `items: any[]`; keep this
  *  hand-crafted generic wrapper for type-safe consumer sites. */
 export interface PaginatedResponse<T> {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -24,6 +24,7 @@ import type {
   BeatportSearchResult,
   BeatportStatus,
   BridgeCommandResponse,
+  BuilderPlaylists,
   DisplaySettingsResponse,
   PublicBridgeStatus,
   Event,
@@ -43,6 +44,11 @@ import type {
   PaginatedResponse,
   PlayHistoryResponse,
   PlaylistListResponse,
+  PoolImportManualIn,
+  PoolImportResult,
+  PoolMutationResult,
+  PoolState,
+  PoolUrlPreview,
   PublicEvent,
   RecommendationResponse,
   SearchResult,
@@ -642,6 +648,69 @@ class ApiClient {
   }
   async deleteSet(setId: number): Promise<void> {
     await this.rawFetch(`/api/setbuilder/sets/${setId}`, { method: 'DELETE' });
+  }
+
+  // WrzDJSet pool (issue #388)
+  async getPool(setId: number): Promise<PoolState> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pool`);
+  }
+  async getBuilderPlaylists(): Promise<BuilderPlaylists> {
+    return this.fetch('/api/setbuilder/playlists');
+  }
+  async importPoolEvent(setId: number, eventId: number): Promise<PoolImportResult> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pool/import/event`, {
+      method: 'POST',
+      body: JSON.stringify({ event_id: eventId }),
+    });
+  }
+  async importPoolTidal(
+    setId: number,
+    playlistId: string,
+    label?: string
+  ): Promise<PoolImportResult> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pool/import/tidal`, {
+      method: 'POST',
+      body: JSON.stringify({ playlist_id: playlistId, label: label ?? null }),
+    });
+  }
+  async importPoolBeatport(
+    setId: number,
+    playlistId: string,
+    label?: string
+  ): Promise<PoolImportResult> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pool/import/beatport`, {
+      method: 'POST',
+      body: JSON.stringify({ playlist_id: playlistId, label: label ?? null }),
+    });
+  }
+  async previewPoolUrl(setId: number, url: string): Promise<PoolUrlPreview> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pool/url-preview`, {
+      method: 'POST',
+      body: JSON.stringify({ url }),
+    });
+  }
+  async importPoolUrl(setId: number, url: string): Promise<PoolImportResult> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pool/import/url`, {
+      method: 'POST',
+      body: JSON.stringify({ url }),
+    });
+  }
+  async importPoolManual(setId: number, track: PoolImportManualIn): Promise<PoolImportResult> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pool/import/manual`, {
+      method: 'POST',
+      body: JSON.stringify(track),
+    });
+  }
+  async removePoolTracks(setId: number, trackIds: number[]): Promise<PoolMutationResult> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pool/tracks/remove`, {
+      method: 'POST',
+      body: JSON.stringify({ track_ids: trackIds }),
+    });
+  }
+  async removePoolSource(setId: number, sourceId: number): Promise<PoolMutationResult> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pool/sources/${sourceId}`, {
+      method: 'DELETE',
+    });
   }
 
   async bulkDeleteEvents(codes: string[]): Promise<{ status: string; count: number }> {

--- a/docs/superpowers/plans/2026-06-09-setbuilder-pool-import.md
+++ b/docs/superpowers/plans/2026-06-09-setbuilder-pool-import.md
@@ -1,0 +1,111 @@
+# WrzDJSet Pool Import (issue #388) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pool candidate-track surface for the set builder: import tracks from 4 source types (event requests, Tidal playlist, Beatport playlist, public playlist URL) plus manual single-track search, with per-source tagging, ISRC/fuzzy dedupe, and per-track / multi-select / per-source removal flows.
+
+**Architecture:** Two new tables (`set_pool_sources`, `set_pool_tracks`) cascade under `sets`. All pool logic lives in NEW file `server/app/services/setbuilder/pool.py`; routes/schemas are strictly ADDITIVE in the shared `api/setbuilder.py` / `schemas/setbuilder.py`. Public-URL import never fetches the user URL — it parses a playlist ID with strict per-host regexes and calls official APIs (spotipy client-credentials for Spotify, the DJ's connected Tidal session for Tidal), which is the SSRF defense. Frontend: new `PoolPanel` + `ImportModal` components under `dashboard/app/(dj)/setbuilder/components/`, mounted in the existing builder page (additive), styled via additions to `setbuilder.module.css` using `var(--*)` tokens.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2.0 + Alembic (slot 053, down_revision "052"), pytest (SQLite in-memory), Next.js 16 / React 19 + vitest, vanilla CSS modules.
+
+**Key design decisions (document in PR):**
+- Public URL import supports **Spotify** (client-credentials, no user auth needed) and **Tidal** (requires DJ's connected Tidal session) end-to-end. Apple Music / YouTube / SoundCloud URL shapes are *recognized* by the validator but return `supported: false` with a clear message (no public-API credentials exist in this codebase for them). Beatport playlist URLs route DJs to the OAuth picker.
+- Re-importing the same external source (same playlist / event) reuses the existing source row and imports only new tracks — dedupe stats report it; no duplicate source rows ever.
+- Dedupe: exact ISRC match against pool first, then `sha256(normalize_artist + ":" + normalize_track_title)[:32]` signature (reuses `services/track_normalizer.py`). First import wins; original source tag preserved (per design footnote).
+- `energy` is nullable — TrackVibe enrichment is issue #391; the badge renders empty bars until then.
+- `track_id` is the namespaced free-form string convention from TrackVibe (`tidal:123`, `beatport:456`, `spotify:abc`, `request:789`), NOT an FK.
+- Per-source removal is allowed for every kind incl. manual (prototype hides × for manual/recs buckets; our manual bucket is per-set and removable via track flows; the × is hidden for `manual` to match the prototype).
+
+---
+
+### Task 1: Models + migration 053
+
+**Files:**
+- Create: `server/app/models/set_pool.py`
+- Modify: `server/app/models/__init__.py` (export), `server/app/models/set.py` (add `pool_sources`/`pool_tracks` relationships — additive)
+- Create: `server/alembic/versions/053_add_setbuilder_pool_tables.py`
+
+- [x] **Step 1: Write models**
+
+`set_pool_sources`: id PK; set_id FK sets.id CASCADE idx; kind String(20) ("event"|"tidal"|"beatport"|"public_url"|"manual"); external_ref String(500) nullable; label String(200); meta String(200) nullable; created_at.
+`set_pool_tracks`: id PK; set_id FK CASCADE idx; source_id FK set_pool_sources.id CASCADE idx; track_id String(255) nullable; title/artist String(255); album String(255) nullable; genre String(100) nullable; bpm Float nullable; key String(20) nullable; camelot String(3) nullable; energy Integer nullable; isrc String(15) nullable; duration_sec Integer nullable; artwork_url String(500) nullable; dedupe_sig String(64) idx; created_at; UniqueConstraint(set_id, dedupe_sig).
+
+- [x] **Step 2: Migration 053** — revision "053", down_revision "052"; mirror model exactly (indexes ↔ index=True).
+- [x] **Step 3: Verify** — `cd server && .venv/bin/alembic upgrade head && .venv/bin/alembic check` → "No new upgrade operations detected".
+- [x] **Step 4: Commit** `feat(setbuilder): pool source/track models + migration 053`
+
+### Task 2: Pool service core (dedupe, import, removal) — TDD
+
+**Files:**
+- Create: `server/app/services/setbuilder/pool.py`
+- Test: `server/tests/test_setbuilder_pool_service.py`
+
+- [x] **Step 1: Failing tests** — dedupe_signature equality for "Song (Original Mix)" vs "Song", feat. canonicalization; `import_candidates` returns (added, deduped) with ISRC-match dedupe across different titles; re-import same candidates → 0 added; `get_or_create_source` reuses row on same (set, kind, external_ref); `remove_tracks` scoped to set; `remove_source` deletes exactly its tracks and the source row.
+- [x] **Step 2: Implement** — `PoolCandidate` dataclass (track_id, title, artist, album, genre, bpm, key, energy, isrc, duration_sec, artwork_url); `dedupe_signature(artist, title)` via `normalize_track()` + sha256[:32]; `camelot_code(key)` via `recommendation.camelot.parse_key`; `get_pool`, `get_or_create_source`, `import_candidates` (builds existing sig-set + isrc-set, skips blanks, single commit), `remove_tracks`, `remove_source`.
+- [x] **Step 3: Run** `.venv/bin/pytest tests/test_setbuilder_pool_service.py -v` → PASS.
+- [x] **Step 4: Commit** `feat(setbuilder): pool service — source tagging, ISRC+fuzzy dedupe, removal`
+
+### Task 3: Candidate builders (event / tidal / beatport / manual / public URL)
+
+**Files:**
+- Modify: `server/app/services/setbuilder/pool.py` (builders)
+- Create: `server/app/services/setbuilder/playlist_url.py` (URL validator/parser)
+- Test: `server/tests/test_setbuilder_pool_service.py` (+ URL parser tests)
+
+- [x] **Step 1: Failing tests** — URL parser: accepts `https://open.spotify.com/playlist/<22 base62>`, `https://tidal.com/browse/playlist/<uuid>`, `https://listen.tidal.com/playlist/<uuid>`; recognizes-but-unsupported apple/youtube/soundcloud; rejects http://, non-allowlisted hosts, `javascript:`, userinfo tricks (`https://open.spotify.com@evil.com/...`), path traversal. Event candidates: maps Request rows (excludes REJECTED), tags `request:{id}`; ownership enforced at API layer.
+- [x] **Step 2: Implement**
+  - `playlist_url.py`: `ParsedPlaylistUrl(provider, playlist_id, supported, message)`; strict full-match regexes per host via `urllib.parse.urlsplit` (scheme must be https, netloc exact-match allowlist, no port/userinfo), ID charset constrained (`[A-Za-z0-9]{16,40}` spotify, uuid for tidal).
+  - Builders in `pool.py`: `candidates_from_event(db, user, event_id)` (owner check → None if unowned), `candidates_from_tidal(db, user, playlist_id)` (uses `tidal.get_playlist_tracks` + `tidal._track_to_result`), `candidates_from_beatport(db, user, playlist_id)` (`beatport.get_playlist_tracks` → BeatportSearchResult), `candidate_from_manual(payload)`, `preview_public_playlist(db, user, parsed)` + `candidates_from_public_url(db, user, parsed)` (spotify: spotipy `playlist()` / `playlist_items()` paginated w/ external_ids.isrc; tidal: DJ session).
+- [x] **Step 3: Run tests** → PASS.
+- [x] **Step 4: Commit** `feat(setbuilder): pool import candidate builders + public-URL validator`
+
+### Task 4: Schemas + API routes (additive) — TDD at API boundary
+
+**Files:**
+- Modify (ADDITIVE): `server/app/schemas/setbuilder.py`, `server/app/api/setbuilder.py`
+- Test: `server/tests/test_setbuilder_pool_api.py`
+
+Routes (all `get_current_active_user`, owner-or-404, rate-limited):
+- `GET /api/setbuilder/sets/{id}/pool` → `PoolState{sources, tracks}` (60/min)
+- `GET /api/setbuilder/playlists` → `{tidal_connected, beatport_connected, tidal[], beatport[]}` (20/min)
+- `POST .../pool/import/event {event_id}` (10/min)
+- `POST .../pool/import/tidal {playlist_id}` / `POST .../pool/import/beatport {playlist_id}` (10/min)
+- `POST .../pool/url-preview {url}` → `UrlPreview{provider, supported, name?, owner?, track_count?, message?}` (10/min)
+- `POST .../pool/import/url {url}` (10/min)
+- `POST .../pool/import/manual {ManualTrackIn}` (30/min)
+- `POST .../pool/tracks/remove {track_ids: list[int] (1..500)}` → `PoolMutationResult{removed, pool}` (30/min)
+- `DELETE .../pool/sources/{source_id}` → `PoolMutationResult` (30/min)
+
+Import endpoints return `ImportResult{added, deduped, source, pool}` (toast = "N new · M de-duped"). Pydantic constraints on every input field.
+
+- [x] Steps: failing tests (ownership 404s incl. cross-user; event import end-to-end from `test_event` + requests; tidal/beatport mocked imports; dedupe counts across sources; url-preview unsupported + invalid 422; manual import; remove flows count-consistency) → implement → `pytest -q` full suite green → commit `feat(setbuilder): pool import/removal API`.
+
+### Task 5: OpenAPI types + frontend API client
+
+**Files:**
+- Run: `cd dashboard && npm run types:export && npm run types:generate`
+- Modify (ADDITIVE): `dashboard/lib/api-types.ts` (re-export new schemas), `dashboard/lib/api.ts` (pool methods)
+
+- [x] Add `getPool, getBuilderPlaylists, importPoolEvent, importPoolTidal, importPoolBeatport, previewPoolUrl, importPoolUrl, importPoolManual, removePoolTracks, removePoolSource`. `npx tsc --noEmit` green. Commit `feat(setbuilder): pool API client + generated types`.
+
+### Task 6: Frontend Pool panel + Import modal
+
+**Files:**
+- Create: `dashboard/app/(dj)/setbuilder/components/PoolBadges.tsx` (SourceIcon, CamelotBadge via `lib/camelot-colors`, BpmBadge, EnergyMini)
+- Create: `dashboard/app/(dj)/setbuilder/components/ImportModal.tsx` (event picker / tidal / beatport playlist pickers / public URL validate→preview→import / manual search via `api.search`)
+- Create: `dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx` (header + Add menu, sources accordion w/ filter + hover-×, type tabs w/ counts, search + multi-select toggle, track rows w/ badges + source chip, selection footer, right-click context menu, toast)
+- Modify (ADDITIVE): `dashboard/app/(dj)/setbuilder/[setId]/page.tsx` (mount `<PoolPanel setId>` in pool section), `dashboard/app/(dj)/setbuilder/setbuilder.module.css` (append pool classes)
+
+- [x] Implement per design prototype (`~/wrzdjset-design/project/pool-panel.jsx`, `import-modal.jsx`) translated to TS + module CSS + theme tokens; counts always derived from fetched pool state. Commit `feat(setbuilder): pool panel UI — sources accordion, import modal, removal flows`.
+
+### Task 7: Frontend tests
+
+**Files:**
+- Create: `dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx`
+
+- [x] Mock `lib/api`; assert: pool renders tracks w/ source chip + badges; source row click filters; source × calls removePoolSource and updates counts; multi-select select-all/remove calls removePoolTracks; import toast shows "N new · M de-duped". `npm test -- --run` green. Commit `test(setbuilder): pool panel component tests`.
+
+### Task 8: Full CI + finish
+
+- [x] Backend: ruff check/format, bandit, pytest (≥80% cov), alembic upgrade+check. Frontend: lint, tsc, vitest. `git checkout next-env.d.ts` if dirty.
+- [x] superpowers:finishing-a-development-branch → option 2: push + PR (`Closes #388`, Design decisions section, migration-slot note).

--- a/server/alembic/versions/053_add_setbuilder_pool_tables.py
+++ b/server/alembic/versions/053_add_setbuilder_pool_tables.py
@@ -1,0 +1,82 @@
+"""Add WrzDJSet pool tables (set_pool_sources, set_pool_tracks) — issue #388
+
+Revision ID: 053
+Revises: 052
+Create Date: 2026-06-09 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "053"
+down_revision: str | None = "052"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "set_pool_sources",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "set_id",
+            sa.Integer(),
+            sa.ForeignKey("sets.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("kind", sa.String(20), nullable=False),
+        sa.Column("external_ref", sa.String(500), nullable=True),
+        sa.Column("label", sa.String(200), nullable=False),
+        sa.Column("meta", sa.String(200), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index("ix_set_pool_sources_set_id", "set_pool_sources", ["set_id"])
+
+    op.create_table(
+        "set_pool_tracks",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "set_id",
+            sa.Integer(),
+            sa.ForeignKey("sets.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "source_id",
+            sa.Integer(),
+            sa.ForeignKey("set_pool_sources.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("track_id", sa.String(255), nullable=True),
+        sa.Column("title", sa.String(255), nullable=False),
+        sa.Column("artist", sa.String(255), nullable=False),
+        sa.Column("album", sa.String(255), nullable=True),
+        sa.Column("genre", sa.String(100), nullable=True),
+        sa.Column("bpm", sa.Float(), nullable=True),
+        sa.Column("key", sa.String(20), nullable=True),
+        sa.Column("camelot", sa.String(3), nullable=True),
+        sa.Column("energy", sa.Integer(), nullable=True),
+        sa.Column("isrc", sa.String(15), nullable=True),
+        sa.Column("duration_sec", sa.Integer(), nullable=True),
+        sa.Column("artwork_url", sa.String(500), nullable=True),
+        sa.Column("dedupe_sig", sa.String(64), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("set_id", "dedupe_sig", name="uq_set_pool_track_sig"),
+    )
+    op.create_index("ix_set_pool_tracks_set_id", "set_pool_tracks", ["set_id"])
+    op.create_index("ix_set_pool_tracks_source_id", "set_pool_tracks", ["source_id"])
+    op.create_index("ix_set_pool_tracks_dedupe_sig", "set_pool_tracks", ["dedupe_sig"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_set_pool_tracks_dedupe_sig", table_name="set_pool_tracks")
+    op.drop_index("ix_set_pool_tracks_source_id", table_name="set_pool_tracks")
+    op.drop_index("ix_set_pool_tracks_set_id", table_name="set_pool_tracks")
+    op.drop_table("set_pool_tracks")
+    op.drop_index("ix_set_pool_sources_set_id", table_name="set_pool_sources")
+    op.drop_table("set_pool_sources")

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -12,8 +12,26 @@ from app.api.deps import get_current_active_user, get_db
 from app.core.rate_limit import limiter
 from app.models.set import Set
 from app.models.user import User
-from app.schemas.setbuilder import SetCreate, SetDetail, SetRename, SetSummary
-from app.services.setbuilder import set_service
+from app.schemas.setbuilder import (
+    BuilderPlaylistsOut,
+    PoolImportEventIn,
+    PoolImportManualIn,
+    PoolImportPlaylistIn,
+    PoolImportResult,
+    PoolImportUrlIn,
+    PoolMutationResult,
+    PoolRemoveTracksIn,
+    PoolSourceOut,
+    PoolState,
+    PoolTrackOut,
+    PoolUrlPreview,
+    SetCreate,
+    SetDetail,
+    SetRename,
+    SetSummary,
+)
+from app.services.setbuilder import pool, set_service
+from app.services.setbuilder.playlist_url import InvalidPlaylistUrl, parse_public_playlist_url
 
 router = APIRouter()
 
@@ -88,3 +106,274 @@ def delete_set(
     """Delete one of the current DJ's sets, or 404."""
     set_obj = _get_owned_or_404(db, set_id, current_user)
     set_service.delete_set(db, set_obj)
+
+
+# ---------------------------------------------------------------------------
+# Pool (issue #388) — candidate-track surface with per-source import/removal.
+# All endpoints are owner-scoped via _get_owned_or_404.
+
+
+def _pool_state(db: Session, set_id: int) -> PoolState:
+    sources, tracks = pool.get_pool(db, set_id)
+    return PoolState(
+        sources=[PoolSourceOut.model_validate(s) for s in sources],
+        tracks=[PoolTrackOut.model_validate(t) for t in tracks],
+    )
+
+
+def _import_result(db: Session, set_id: int, source, added: int, deduped: int) -> PoolImportResult:
+    return PoolImportResult(
+        added=added,
+        deduped=deduped,
+        source=PoolSourceOut.model_validate(source),
+        pool=_pool_state(db, set_id),
+    )
+
+
+@router.get("/sets/{set_id}/pool", response_model=PoolState)
+@limiter.limit("60/minute")
+def get_pool_state(
+    set_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PoolState:
+    """Full pool snapshot (sources + tracks) for one of the DJ's sets."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    return _pool_state(db, set_obj.id)
+
+
+@router.get("/playlists", response_model=BuilderPlaylistsOut)
+@limiter.limit("20/minute")
+def list_builder_playlists(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> BuilderPlaylistsOut:
+    """Connected-service playlists for the import modal pickers."""
+    from app.schemas.recommendation import PlaylistInfo
+
+    tidal_connected = bool(current_user.tidal_access_token)
+    beatport_connected = bool(current_user.beatport_access_token)
+    tidal_playlists: list[PlaylistInfo] = []
+    beatport_playlists: list[PlaylistInfo] = []
+
+    if tidal_connected:
+        from app.services.tidal import list_user_playlists as tidal_list
+
+        tidal_playlists = [PlaylistInfo(**vars(p)) for p in tidal_list(db, current_user)]
+    if beatport_connected:
+        from app.services.beatport import list_user_playlists as bp_list
+
+        beatport_playlists = [PlaylistInfo(**vars(p)) for p in bp_list(db, current_user)]
+
+    return BuilderPlaylistsOut(
+        tidal_connected=tidal_connected,
+        beatport_connected=beatport_connected,
+        tidal=tidal_playlists,
+        beatport=beatport_playlists,
+    )
+
+
+@router.post("/sets/{set_id}/pool/import/event", response_model=PoolImportResult)
+@limiter.limit("10/minute")
+def import_pool_event(
+    set_id: int,
+    payload: PoolImportEventIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PoolImportResult:
+    """Import a DJ-owned event's non-rejected requests into the pool."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    result = pool.candidates_from_event(db, current_user, payload.event_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+    event, candidates = result
+    source = pool.get_or_create_source(
+        db,
+        set_obj,
+        kind="event",
+        external_ref=str(event.id),
+        label=event.name,
+        meta="WrzDJ event requests",
+    )
+    added, deduped = pool.import_candidates(db, set_obj, source, candidates)
+    return _import_result(db, set_obj.id, source, added, deduped)
+
+
+@router.post("/sets/{set_id}/pool/import/tidal", response_model=PoolImportResult)
+@limiter.limit("10/minute")
+def import_pool_tidal(
+    set_id: int,
+    payload: PoolImportPlaylistIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PoolImportResult:
+    """Import a connected-account Tidal playlist into the pool."""
+    from app.services.tidal import TidalFetchError
+
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    try:
+        candidates = pool.candidates_from_tidal(db, current_user, payload.playlist_id)
+    except TidalFetchError:
+        raise HTTPException(status_code=502, detail="Couldn't fetch that Tidal playlist") from None
+    source = pool.get_or_create_source(
+        db,
+        set_obj,
+        kind="tidal",
+        external_ref=payload.playlist_id,
+        label=payload.label or "Tidal playlist",
+        meta="Tidal playlist",
+    )
+    added, deduped = pool.import_candidates(db, set_obj, source, candidates)
+    return _import_result(db, set_obj.id, source, added, deduped)
+
+
+@router.post("/sets/{set_id}/pool/import/beatport", response_model=PoolImportResult)
+@limiter.limit("10/minute")
+def import_pool_beatport(
+    set_id: int,
+    payload: PoolImportPlaylistIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PoolImportResult:
+    """Import a connected-account Beatport playlist into the pool."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    # beatport.get_playlist_tracks returns [] on fetch failure (existing semantics)
+    candidates = pool.candidates_from_beatport(db, current_user, payload.playlist_id)
+    source = pool.get_or_create_source(
+        db,
+        set_obj,
+        kind="beatport",
+        external_ref=payload.playlist_id,
+        label=payload.label or "Beatport playlist",
+        meta="Beatport playlist",
+    )
+    added, deduped = pool.import_candidates(db, set_obj, source, candidates)
+    return _import_result(db, set_obj.id, source, added, deduped)
+
+
+@router.post("/sets/{set_id}/pool/url-preview", response_model=PoolUrlPreview)
+@limiter.limit("10/minute")
+def preview_pool_url(
+    set_id: int,
+    payload: PoolImportUrlIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PoolUrlPreview:
+    """Validate a public playlist URL and return the preview card payload."""
+    _get_owned_or_404(db, set_id, current_user)
+    try:
+        parsed = parse_public_playlist_url(payload.url)
+    except InvalidPlaylistUrl as e:
+        raise HTTPException(status_code=422, detail=str(e)) from None
+    if not parsed.supported:
+        return PoolUrlPreview(provider=parsed.provider, supported=False, message=parsed.message)
+    try:
+        meta = pool.preview_public_playlist(db, current_user, parsed.provider, parsed.playlist_id)
+    except pool.PoolImportError as e:
+        raise HTTPException(status_code=502, detail=str(e)) from None
+    return PoolUrlPreview(provider=parsed.provider, supported=True, **meta)
+
+
+@router.post("/sets/{set_id}/pool/import/url", response_model=PoolImportResult)
+@limiter.limit("10/minute")
+def import_pool_url(
+    set_id: int,
+    payload: PoolImportUrlIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PoolImportResult:
+    """Import a validated public playlist URL into the pool."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    try:
+        parsed = parse_public_playlist_url(payload.url)
+    except InvalidPlaylistUrl as e:
+        raise HTTPException(status_code=422, detail=str(e)) from None
+    if not parsed.supported:
+        raise HTTPException(status_code=422, detail=parsed.message)
+    try:
+        name, candidates = pool.candidates_from_public_url(
+            db, current_user, parsed.provider, parsed.playlist_id
+        )
+    except pool.PoolImportError as e:
+        raise HTTPException(status_code=502, detail=str(e)) from None
+    source = pool.get_or_create_source(
+        db,
+        set_obj,
+        kind="public_url",
+        external_ref=f"{parsed.provider}:{parsed.playlist_id}",
+        label=name,
+        meta=f"Public {parsed.provider} playlist",
+    )
+    added, deduped = pool.import_candidates(db, set_obj, source, candidates)
+    return _import_result(db, set_obj.id, source, added, deduped)
+
+
+@router.post("/sets/{set_id}/pool/import/manual", response_model=PoolImportResult)
+@limiter.limit("30/minute")
+def import_pool_manual(
+    set_id: int,
+    payload: PoolImportManualIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PoolImportResult:
+    """Add a single manually-searched track to the pool."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    candidate = pool.candidate_from_manual(
+        title=payload.title,
+        artist=payload.artist,
+        album=payload.album,
+        genre=payload.genre,
+        bpm=payload.bpm,
+        key=payload.key,
+        isrc=payload.isrc,
+        duration_sec=payload.duration_sec,
+        artwork_url=payload.artwork_url,
+        source_service=payload.source_service,
+        source_track_id=payload.source_track_id,
+    )
+    source = pool.get_or_create_source(
+        db, set_obj, kind="manual", external_ref=None, label="Manual", meta="Single-track search"
+    )
+    added, deduped = pool.import_candidates(db, set_obj, source, [candidate])
+    return _import_result(db, set_obj.id, source, added, deduped)
+
+
+@router.post("/sets/{set_id}/pool/tracks/remove", response_model=PoolMutationResult)
+@limiter.limit("30/minute")
+def remove_pool_tracks(
+    set_id: int,
+    payload: PoolRemoveTracksIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PoolMutationResult:
+    """Remove pool tracks by id (per-track context menu + multi-select)."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    removed = pool.remove_tracks(db, set_obj, payload.track_ids)
+    return PoolMutationResult(removed=removed, pool=_pool_state(db, set_obj.id))
+
+
+@router.delete("/sets/{set_id}/pool/sources/{source_id}", response_model=PoolMutationResult)
+@limiter.limit("30/minute")
+def remove_pool_source(
+    set_id: int,
+    source_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PoolMutationResult:
+    """Remove an import source and exactly its tracks."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    source = pool.get_owned_source(db, set_obj, source_id)
+    if source is None:
+        raise HTTPException(status_code=404, detail="Source not found")
+    removed = pool.remove_source(db, set_obj, source)
+    return PoolMutationResult(removed=removed, pool=_pool_state(db, set_obj.id))

--- a/server/app/models/__init__.py
+++ b/server/app/models/__init__.py
@@ -15,6 +15,7 @@ from app.models.request import Request
 from app.models.request_vote import RequestVote
 from app.models.search_cache import SearchCache
 from app.models.set import Set, SetCollaborator, SetCurvePoint, SetSlot
+from app.models.set_pool import SetPoolSource, SetPoolTrack
 from app.models.system_settings import SystemSettings
 from app.models.track_vibe import TrackVibe, TrackVibeOverride
 from app.models.user import User
@@ -41,6 +42,8 @@ __all__ = [
     "Set",
     "SetCollaborator",
     "SetCurvePoint",
+    "SetPoolSource",
+    "SetPoolTrack",
     "SetSlot",
     "SystemSettings",
     "TrackVibe",

--- a/server/app/models/set.py
+++ b/server/app/models/set.py
@@ -77,6 +77,16 @@ class Set(Base):
         back_populates="set",
         cascade="all, delete-orphan",
     )
+    pool_sources: Mapped[list["SetPoolSource"]] = relationship(
+        "SetPoolSource",
+        back_populates="set",
+        cascade="all, delete-orphan",
+    )
+    pool_tracks: Mapped[list["SetPoolTrack"]] = relationship(
+        "SetPoolTrack",
+        back_populates="set",
+        cascade="all, delete-orphan",
+    )
 
 
 class SetSlot(Base):

--- a/server/app/models/set_pool.py
+++ b/server/app/models/set_pool.py
@@ -1,0 +1,83 @@
+"""WrzDJSet pool models (issue #388).
+
+The pool is a set's candidate-track surface. Every track is tagged with the
+SetPoolSource it was imported through ("importedVia") so removal flows can
+operate per-source. Both tables cascade-delete with their parent Set; tracks
+also cascade with their source row (remove-by-source).
+
+`track_id` is the namespaced free-form string convention shared with
+TrackVibe (e.g. "tidal:12345", "beatport:678", "spotify:abc", "request:9") —
+deliberately NOT an FK because no unified track table exists.
+
+`dedupe_sig` is the normalized artist+title hash (see services/setbuilder/
+pool.dedupe_signature) and is unique per set: dedupe-on-import is the
+feature, and the constraint keeps it honest under concurrent imports.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.time import utcnow
+from app.models.base import Base
+
+
+class SetPoolSource(Base):
+    __tablename__ = "set_pool_sources"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    set_id: Mapped[int] = mapped_column(
+        ForeignKey("sets.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # "event" | "tidal" | "beatport" | "public_url" | "manual"
+    kind: Mapped[str] = mapped_column(String(20), nullable=False)
+    # event id / playlist id / sanitized playlist URL; NULL for the manual bucket
+    external_ref: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    label: Mapped[str] = mapped_column(String(200), nullable=False)
+    meta: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow)
+
+    set: Mapped["Set"] = relationship("Set", back_populates="pool_sources")
+    tracks: Mapped[list["SetPoolTrack"]] = relationship(
+        "SetPoolTrack",
+        back_populates="source",
+        cascade="all, delete-orphan",
+    )
+
+
+class SetPoolTrack(Base):
+    __tablename__ = "set_pool_tracks"
+    __table_args__ = (UniqueConstraint("set_id", "dedupe_sig", name="uq_set_pool_track_sig"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    set_id: Mapped[int] = mapped_column(
+        ForeignKey("sets.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    source_id: Mapped[int] = mapped_column(
+        ForeignKey("set_pool_sources.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    track_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    artist: Mapped[str] = mapped_column(String(255), nullable=False)
+    album: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    genre: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    bpm: Mapped[float | None] = mapped_column(Float, nullable=True)
+    key: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    camelot: Mapped[str | None] = mapped_column(String(3), nullable=True)
+    energy: Mapped[int | None] = mapped_column(Integer, nullable=True)  # 0-10 (#391 fills)
+    isrc: Mapped[str | None] = mapped_column(String(15), nullable=True)
+    duration_sec: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    artwork_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    dedupe_sig: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow)
+
+    set: Mapped["Set"] = relationship("Set", back_populates="pool_tracks")
+    source: Mapped["SetPoolSource"] = relationship("SetPoolSource", back_populates="tracks")

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -5,6 +5,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.schemas.recommendation import PlaylistInfo
+
 
 class SetCreate(BaseModel):
     """Body for creating a new (empty) set."""
@@ -43,3 +45,126 @@ class SetDetail(SetSummary):
     key_strictness: float
     tidal_playlist_id: str | None
     exported_at: datetime | None
+
+
+# ---------------------------------------------------------------------------
+# Pool (issue #388)
+
+
+class PoolSourceOut(BaseModel):
+    """An import source row for the sources accordion."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    kind: Literal["event", "tidal", "beatport", "public_url", "manual"]
+    external_ref: str | None
+    label: str
+    meta: str | None
+    created_at: datetime
+
+
+class PoolTrackOut(BaseModel):
+    """A pool track row (badges: camelot, bpm, energy; chip: source_id)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    source_id: int
+    track_id: str | None
+    title: str
+    artist: str
+    album: str | None
+    genre: str | None
+    bpm: float | None
+    key: str | None
+    camelot: str | None
+    energy: int | None
+    isrc: str | None
+    duration_sec: int | None
+    artwork_url: str | None
+    created_at: datetime
+
+
+class PoolState(BaseModel):
+    """Full pool snapshot: sources + tracks."""
+
+    sources: list[PoolSourceOut]
+    tracks: list[PoolTrackOut]
+
+
+class PoolImportResult(BaseModel):
+    """Result of any import flow — toast reads 'added new · deduped de-duped'."""
+
+    added: int
+    deduped: int
+    source: PoolSourceOut
+    pool: PoolState
+
+
+class PoolMutationResult(BaseModel):
+    """Result of a removal flow."""
+
+    removed: int
+    pool: PoolState
+
+
+class PoolImportEventIn(BaseModel):
+    """Body for importing a WrzDJ event's requests."""
+
+    event_id: int = Field(..., ge=1)
+
+
+class PoolImportPlaylistIn(BaseModel):
+    """Body for importing a connected-account (Tidal/Beatport) playlist."""
+
+    playlist_id: str = Field(..., min_length=1, max_length=100, pattern=r"^[A-Za-z0-9_-]+$")
+    label: str | None = Field(None, max_length=200)
+
+
+class PoolImportUrlIn(BaseModel):
+    """Body for public playlist URL preview/import."""
+
+    url: str = Field(..., min_length=12, max_length=500)
+
+
+class PoolUrlPreview(BaseModel):
+    """Validate → preview card payload for a public playlist URL."""
+
+    provider: str
+    supported: bool
+    name: str | None = None
+    owner: str | None = None
+    track_count: int | None = None
+    message: str | None = None
+
+
+class PoolImportManualIn(BaseModel):
+    """Body for adding a single track picked from manual search."""
+
+    title: str = Field(..., min_length=1, max_length=255)
+    artist: str = Field(..., min_length=1, max_length=255)
+    album: str | None = Field(None, max_length=255)
+    genre: str | None = Field(None, max_length=100)
+    bpm: float | None = Field(None, ge=0, le=400)
+    key: str | None = Field(None, max_length=20)
+    isrc: str | None = Field(None, max_length=15)
+    duration_sec: int | None = Field(None, ge=0, le=36000)
+    artwork_url: str | None = Field(None, max_length=500, pattern=r"^https://")
+    source_service: Literal["spotify", "beatport", "tidal", "manual"] = "manual"
+    source_track_id: str | None = Field(None, max_length=100)
+
+
+class PoolRemoveTracksIn(BaseModel):
+    """Body for per-track / multi-select removal."""
+
+    track_ids: list[int] = Field(..., min_length=1, max_length=500)
+
+
+class BuilderPlaylistsOut(BaseModel):
+    """Connected-service playlist pickers for the import modal."""
+
+    tidal_connected: bool
+    beatport_connected: bool
+    tidal: list[PlaylistInfo]
+    beatport: list[PlaylistInfo]

--- a/server/app/services/setbuilder/playlist_url.py
+++ b/server/app/services/setbuilder/playlist_url.py
@@ -1,0 +1,114 @@
+"""Public playlist URL validation for WrzDJSet pool import (issue #388).
+
+Security posture (SSRF defense): we NEVER fetch the user-supplied URL.
+This module only *parses* it — https scheme enforced, exact-match host
+allowlist, no userinfo/port tricks, playlist IDs constrained to strict
+charsets — and importers then call official APIs (spotipy / tidalapi)
+with the extracted ID.
+
+Recognized-but-unsupported providers (Apple Music, YouTube, SoundCloud,
+Beatport) parse successfully with ``supported=False`` so the UI can show
+a precise message instead of a generic "invalid URL" error.
+"""
+
+import re
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+_SPOTIFY_PLAYLIST_RE = re.compile(r"^/playlist/([A-Za-z0-9]{16,40})/?$")
+_TIDAL_UUID = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+_TIDAL_PLAYLIST_RE = re.compile(rf"^/(?:browse/)?playlist/({_TIDAL_UUID})/?$")
+
+_UNSUPPORTED_HOSTS: dict[str, tuple[str, str]] = {
+    "music.apple.com": (
+        "apple_music",
+        "Apple Music playlists aren't supported yet — no public API access is configured.",
+    ),
+    "www.youtube.com": (
+        "youtube",
+        "YouTube playlists aren't supported yet — no public API access is configured.",
+    ),
+    "youtube.com": (
+        "youtube",
+        "YouTube playlists aren't supported yet — no public API access is configured.",
+    ),
+    "music.youtube.com": (
+        "youtube",
+        "YouTube playlists aren't supported yet — no public API access is configured.",
+    ),
+    "soundcloud.com": (
+        "soundcloud",
+        "SoundCloud playlists aren't supported yet — no public API access is configured.",
+    ),
+    "www.beatport.com": (
+        "beatport",
+        "Use the Beatport import option instead — it pulls playlists via your connected account.",
+    ),
+    "beatport.com": (
+        "beatport",
+        "Use the Beatport import option instead — it pulls playlists via your connected account.",
+    ),
+}
+
+
+class InvalidPlaylistUrl(ValueError):
+    """Raised when a URL is not a recognizable https playlist URL."""
+
+
+@dataclass(frozen=True)
+class ParsedPlaylistUrl:
+    provider: str  # "spotify" | "tidal" | "apple_music" | "youtube" | "soundcloud" | "beatport"
+    playlist_id: str | None
+    supported: bool
+    message: str | None = None
+
+
+def parse_public_playlist_url(url: str) -> ParsedPlaylistUrl:
+    """Parse and validate a public playlist URL against the host allowlist.
+
+    Raises InvalidPlaylistUrl for anything that is not an https URL on a
+    known playlist host with a well-formed playlist path.
+    """
+    if not url or len(url) > 500:
+        raise InvalidPlaylistUrl("URL is empty or too long")
+
+    try:
+        split = urlsplit(url.strip())
+    except ValueError as e:
+        raise InvalidPlaylistUrl("URL could not be parsed") from e
+
+    if split.scheme != "https":
+        raise InvalidPlaylistUrl("Only https playlist URLs are accepted")
+    if split.username or split.password:
+        raise InvalidPlaylistUrl("URLs with credentials are not accepted")
+    try:
+        if split.port is not None:
+            raise InvalidPlaylistUrl("URLs with explicit ports are not accepted")
+    except ValueError as e:  # non-numeric port
+        raise InvalidPlaylistUrl("URL could not be parsed") from e
+
+    host = (split.hostname or "").lower()
+    path = split.path or ""
+
+    if host == "open.spotify.com":
+        m = _SPOTIFY_PLAYLIST_RE.match(path)
+        if not m:
+            raise InvalidPlaylistUrl("Not a Spotify playlist URL (expected /playlist/<id>)")
+        return ParsedPlaylistUrl(provider="spotify", playlist_id=m.group(1), supported=True)
+
+    if host in ("tidal.com", "listen.tidal.com", "www.tidal.com"):
+        m = _TIDAL_PLAYLIST_RE.match(path)
+        if not m:
+            raise InvalidPlaylistUrl("Not a Tidal playlist URL (expected /playlist/<uuid>)")
+        return ParsedPlaylistUrl(provider="tidal", playlist_id=m.group(1).lower(), supported=True)
+
+    if host in _UNSUPPORTED_HOSTS:
+        provider, message = _UNSUPPORTED_HOSTS[host]
+        return ParsedPlaylistUrl(
+            provider=provider, playlist_id=None, supported=False, message=message
+        )
+
+    raise InvalidPlaylistUrl(
+        "Unrecognized playlist host — supported: Spotify, Tidal "
+        "(Apple Music / YouTube / SoundCloud coming later)"
+    )

--- a/server/app/services/setbuilder/pool.py
+++ b/server/app/services/setbuilder/pool.py
@@ -1,0 +1,489 @@
+"""WrzDJSet pool service (issue #388).
+
+The pool is a set's candidate-track surface. Tracks flow in from five
+import flows (event requests, Tidal playlist, Beatport playlist, public
+playlist URL, manual single-track search); every track is tagged with the
+SetPoolSource it came through so removal flows can operate per-source.
+
+Dedupe on import: exact ISRC match against the pool first, then a
+normalized artist+title signature (via services/track_normalizer). The
+first import wins — the original source tag is preserved.
+"""
+
+import hashlib
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from app.models.event import Event
+from app.models.request import Request, RequestStatus
+from app.models.set import Set
+from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.models.user import User
+from app.services.recommendation.camelot import parse_key
+from app.services.track_normalizer import normalize_track
+
+logger = logging.getLogger(__name__)
+
+
+class PoolImportError(Exception):
+    """Import failed for a user-presentable reason (message is safe to surface)."""
+
+
+@dataclass(frozen=True)
+class PoolCandidate:
+    """A track candidate produced by an import flow, pre-insert."""
+
+    title: str
+    artist: str
+    track_id: str | None = None
+    album: str | None = None
+    genre: str | None = None
+    bpm: float | None = None
+    key: str | None = None
+    energy: int | None = None
+    isrc: str | None = None
+    duration_sec: int | None = None
+    artwork_url: str | None = None
+
+
+def dedupe_signature(artist: str, title: str) -> str:
+    """Normalized artist+title hash — the fuzzy fallback dedupe key."""
+    n = normalize_track(title, artist)
+    normalized = f"{n.artist.lower().strip()}:{n.title.lower().strip()}"
+    return hashlib.sha256(normalized.encode()).hexdigest()[:32]
+
+
+def camelot_code(key: str | None) -> str | None:
+    """Convert any common key notation to a Camelot code ('8B'), or None."""
+    pos = parse_key(key)
+    return str(pos) if pos else None
+
+
+def _normalize_isrc(isrc: str | None) -> str | None:
+    if not isrc:
+        return None
+    cleaned = isrc.strip().upper().replace("-", "")
+    return cleaned or None
+
+
+# ---------------------------------------------------------------------------
+# Pool reads
+
+
+def get_pool(db: Session, set_id: int) -> tuple[list[SetPoolSource], list[SetPoolTrack]]:
+    """All sources + tracks for a set, in stable insertion order."""
+    sources = (
+        db.query(SetPoolSource)
+        .filter(SetPoolSource.set_id == set_id)
+        .order_by(SetPoolSource.id)
+        .all()
+    )
+    tracks = (
+        db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_id).order_by(SetPoolTrack.id).all()
+    )
+    return sources, tracks
+
+
+def get_owned_source(db: Session, set_obj: Set, source_id: int) -> SetPoolSource | None:
+    """Fetch a source scoped to the set. None if missing or from another set."""
+    return (
+        db.query(SetPoolSource)
+        .filter(SetPoolSource.id == source_id, SetPoolSource.set_id == set_obj.id)
+        .one_or_none()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sources + import
+
+
+def get_or_create_source(
+    db: Session,
+    set_obj: Set,
+    *,
+    kind: str,
+    external_ref: str | None,
+    label: str,
+    meta: str | None = None,
+) -> SetPoolSource:
+    """Find-or-create the source row for (set, kind, external_ref).
+
+    Re-importing the same playlist/event reuses the existing row (label and
+    meta are refreshed) so counts stay consistent and no duplicate source
+    rows ever appear in the accordion.
+    """
+    existing = (
+        db.query(SetPoolSource)
+        .filter(
+            SetPoolSource.set_id == set_obj.id,
+            SetPoolSource.kind == kind,
+            SetPoolSource.external_ref == external_ref,
+        )
+        .first()
+    )
+    if existing is not None:
+        existing.label = label
+        if meta is not None:
+            existing.meta = meta
+        db.flush()
+        return existing
+    source = SetPoolSource(
+        set_id=set_obj.id, kind=kind, external_ref=external_ref, label=label, meta=meta
+    )
+    db.add(source)
+    db.flush()
+    return source
+
+
+def import_candidates(
+    db: Session,
+    set_obj: Set,
+    source: SetPoolSource,
+    candidates: Iterable[PoolCandidate],
+) -> tuple[int, int]:
+    """Insert candidates into the pool, deduping against existing tracks.
+
+    Returns (added, deduped). Dedupe order: ISRC exact match, then
+    normalized artist+title signature. First import wins — existing rows
+    keep their original source tag.
+    """
+    existing = db.query(SetPoolTrack.dedupe_sig, SetPoolTrack.isrc).filter(
+        SetPoolTrack.set_id == set_obj.id
+    )
+    seen_sigs: set[str] = set()
+    seen_isrcs: set[str] = set()
+    for sig, isrc in existing:
+        seen_sigs.add(sig)
+        norm = _normalize_isrc(isrc)
+        if norm:
+            seen_isrcs.add(norm)
+
+    added = 0
+    deduped = 0
+    for c in candidates:
+        title = (c.title or "").strip()
+        artist = (c.artist or "").strip()
+        if not title or not artist:
+            continue
+        sig = dedupe_signature(artist, title)
+        isrc = _normalize_isrc(c.isrc)
+        if sig in seen_sigs or (isrc and isrc in seen_isrcs):
+            deduped += 1
+            continue
+        db.add(
+            SetPoolTrack(
+                set_id=set_obj.id,
+                source_id=source.id,
+                track_id=c.track_id,
+                title=title[:255],
+                artist=artist[:255],
+                album=c.album,
+                genre=c.genre,
+                bpm=c.bpm,
+                key=c.key,
+                camelot=camelot_code(c.key),
+                energy=c.energy,
+                isrc=isrc,
+                duration_sec=c.duration_sec,
+                artwork_url=c.artwork_url,
+                dedupe_sig=sig,
+            )
+        )
+        seen_sigs.add(sig)
+        if isrc:
+            seen_isrcs.add(isrc)
+        added += 1
+
+    db.commit()
+    return added, deduped
+
+
+# ---------------------------------------------------------------------------
+# Removal flows
+
+
+def remove_tracks(db: Session, set_obj: Set, track_ids: list[int]) -> int:
+    """Delete pool tracks by id, scoped to the set. Returns rows removed."""
+    if not track_ids:
+        return 0
+    removed = (
+        db.query(SetPoolTrack)
+        .filter(SetPoolTrack.set_id == set_obj.id, SetPoolTrack.id.in_(track_ids))
+        .delete(synchronize_session=False)
+    )
+    db.commit()
+    return removed
+
+
+def remove_source(db: Session, set_obj: Set, source: SetPoolSource) -> int:
+    """Delete a source and exactly its tracks (cascade). Returns track count removed."""
+    count = db.query(SetPoolTrack).filter(SetPoolTrack.source_id == source.id).count()
+    db.delete(source)
+    db.commit()
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Candidate builders (one per import flow)
+
+
+def candidates_from_event(
+    db: Session, user: User, event_id: int
+) -> tuple[Event, list[PoolCandidate]] | None:
+    """Map a DJ's own event's non-rejected requests to candidates.
+
+    Returns None if the event is missing or not owned by the user (the API
+    layer surfaces a 404 to avoid leaking existence).
+    """
+    event = (
+        db.query(Event)
+        .filter(Event.id == event_id, Event.created_by_user_id == user.id)
+        .one_or_none()
+    )
+    if event is None:
+        return None
+    requests = (
+        db.query(Request)
+        .filter(
+            Request.event_id == event.id,
+            Request.status != RequestStatus.REJECTED.value,
+        )
+        .order_by(Request.id)
+        .all()
+    )
+    candidates = [
+        PoolCandidate(
+            track_id=f"request:{r.id}",
+            title=r.song_title,
+            artist=r.artist,
+            genre=r.genre,
+            bpm=r.bpm,
+            key=r.musical_key,
+        )
+        for r in requests
+    ]
+    return event, candidates
+
+
+def candidates_from_tidal(db: Session, user: User, playlist_id: str) -> list[PoolCandidate]:
+    """Fetch a connected-account Tidal playlist's tracks as candidates.
+
+    Raises tidal.TidalFetchError on fetch failure (caller maps to 502).
+    """
+    from app.services import tidal
+
+    raw_tracks = tidal.get_playlist_tracks(db, user, playlist_id)
+    candidates: list[PoolCandidate] = []
+    for raw in raw_tracks:
+        r = tidal._track_to_result(raw)
+        candidates.append(
+            PoolCandidate(
+                track_id=f"tidal:{r.track_id}",
+                title=f"{r.title} ({r.version})" if r.version else r.title,
+                artist=r.artist,
+                album=r.album,
+                bpm=r.bpm,
+                key=r.key,
+                isrc=r.isrc,
+                duration_sec=r.duration_seconds,
+                artwork_url=r.cover_url,
+            )
+        )
+    return candidates
+
+
+def candidates_from_beatport(db: Session, user: User, playlist_id: str) -> list[PoolCandidate]:
+    """Fetch a connected-account Beatport playlist's tracks as candidates."""
+    from app.services import beatport
+
+    results = beatport.get_playlist_tracks(db, user, playlist_id)
+    candidates: list[PoolCandidate] = []
+    for r in results:
+        title = r.title
+        if r.mix_name and r.mix_name.strip().lower() not in ("original mix", "original"):
+            title = f"{r.title} ({r.mix_name})"
+        candidates.append(
+            PoolCandidate(
+                track_id=f"beatport:{r.track_id}",
+                title=title,
+                artist=r.artist,
+                genre=r.genre,
+                bpm=float(r.bpm) if r.bpm is not None else None,
+                key=r.key,
+                duration_sec=r.duration_seconds,
+                artwork_url=r.cover_url,
+            )
+        )
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Public playlist URL (Spotify via client credentials, Tidal via DJ session)
+
+_SPOTIFY_PAGE_SIZE = 100
+
+
+def preview_public_playlist(db: Session, user: User, provider: str, playlist_id: str) -> dict:
+    """Lightweight metadata for the validate→preview card. Never fetches the raw URL."""
+    if provider == "spotify":
+        return _spotify_playlist_preview(playlist_id)
+    if provider == "tidal":
+        return _tidal_playlist_preview(db, user, playlist_id)
+    raise PoolImportError("This provider isn't supported for public playlist import yet")
+
+
+def candidates_from_public_url(
+    db: Session, user: User, provider: str, playlist_id: str
+) -> tuple[str, list[PoolCandidate]]:
+    """Fetch all tracks of a public playlist. Returns (playlist_name, candidates)."""
+    if provider == "spotify":
+        return _spotify_playlist_candidates(playlist_id)
+    if provider == "tidal":
+        return _tidal_playlist_candidates(db, user, playlist_id)
+    raise PoolImportError("This provider isn't supported for public playlist import yet")
+
+
+def _spotify_client():
+    from app.services.spotify import _get_spotify_client
+
+    try:
+        return _get_spotify_client()
+    except ValueError as e:
+        raise PoolImportError("Spotify is not configured on this server") from e
+
+
+def _spotify_playlist_preview(playlist_id: str) -> dict:
+    sp = _spotify_client()
+    try:
+        data = sp.playlist(playlist_id, fields="name,owner.display_name,tracks.total")
+    except Exception as e:
+        logger.warning("Spotify playlist preview failed: %s", type(e).__name__)
+        raise PoolImportError("Couldn't fetch that Spotify playlist — is it public?") from e
+    return {
+        "name": data.get("name"),
+        "owner": (data.get("owner") or {}).get("display_name"),
+        "track_count": (data.get("tracks") or {}).get("total"),
+    }
+
+
+def _spotify_playlist_candidates(playlist_id: str) -> tuple[str, list[PoolCandidate]]:
+    sp = _spotify_client()
+    preview = _spotify_playlist_preview(playlist_id)
+    candidates: list[PoolCandidate] = []
+    offset = 0
+    try:
+        while True:
+            page = sp.playlist_items(
+                playlist_id,
+                limit=_SPOTIFY_PAGE_SIZE,
+                offset=offset,
+                fields=(
+                    "items(track(id,name,duration_ms,external_ids.isrc,"
+                    "artists.name,album(name,images))),next"
+                ),
+                additional_types=("track",),
+            )
+
+            items = page.get("items") or []
+            for item in items:
+                track = item.get("track") or {}
+                name = track.get("name")
+                artists = ", ".join(
+                    a.get("name", "") for a in (track.get("artists") or []) if a.get("name")
+                )
+                if not name or not artists:
+                    continue
+                album = track.get("album") or {}
+                images = album.get("images") or []
+                duration_ms = track.get("duration_ms")
+                candidates.append(
+                    PoolCandidate(
+                        track_id=f"spotify:{track.get('id')}" if track.get("id") else None,
+                        title=name,
+                        artist=artists,
+                        album=album.get("name"),
+                        isrc=(track.get("external_ids") or {}).get("isrc"),
+                        duration_sec=int(duration_ms / 1000) if duration_ms else None,
+                        artwork_url=images[0].get("url") if images else None,
+                    )
+                )
+            if not page.get("next") or not items:
+                break
+            offset += _SPOTIFY_PAGE_SIZE
+    except PoolImportError:
+        raise
+    except Exception as e:
+        logger.warning("Spotify playlist fetch failed: %s", type(e).__name__)
+        raise PoolImportError("Couldn't fetch that Spotify playlist — is it public?") from e
+    return preview.get("name") or "Spotify playlist", candidates
+
+
+def _tidal_session_or_error(db: Session, user: User):
+    from app.services import tidal
+
+    session = tidal.get_tidal_session(db, user)
+    if session is None:
+        raise PoolImportError("Connect your Tidal account to import Tidal playlist URLs")
+    return session
+
+
+def _tidal_playlist_preview(db: Session, user: User, playlist_id: str) -> dict:
+    session = _tidal_session_or_error(db, user)
+    try:
+        playlist = session.playlist(playlist_id)
+        return {
+            "name": playlist.name,
+            "owner": None,
+            "track_count": getattr(playlist, "num_tracks", None),
+        }
+    except Exception as e:
+        logger.warning("Tidal playlist preview failed: %s", type(e).__name__)
+        raise PoolImportError("Couldn't fetch that Tidal playlist — is it public?") from e
+
+
+def _tidal_playlist_candidates(
+    db: Session, user: User, playlist_id: str
+) -> tuple[str, list[PoolCandidate]]:
+    from app.services import tidal
+
+    preview = _tidal_playlist_preview(db, user, playlist_id)
+    try:
+        candidates = candidates_from_tidal(db, user, playlist_id)
+    except tidal.TidalFetchError as e:
+        raise PoolImportError("Couldn't fetch that Tidal playlist — is it public?") from e
+    return preview.get("name") or "Tidal playlist", candidates
+
+
+def candidate_from_manual(
+    *,
+    title: str,
+    artist: str,
+    album: str | None = None,
+    genre: str | None = None,
+    bpm: float | None = None,
+    key: str | None = None,
+    isrc: str | None = None,
+    duration_sec: int | None = None,
+    artwork_url: str | None = None,
+    source_service: str = "manual",
+    source_track_id: str | None = None,
+) -> PoolCandidate:
+    """Build a candidate from a manual search pick (validated at the API layer)."""
+    track_id = None
+    if source_track_id and source_service != "manual":
+        track_id = f"{source_service}:{source_track_id}"
+    return PoolCandidate(
+        track_id=track_id,
+        title=title,
+        artist=artist,
+        album=album,
+        genre=genre,
+        bpm=bpm,
+        key=key,
+        isrc=isrc,
+        duration_sec=duration_sec,
+        artwork_url=artwork_url,
+    )

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1064,7 +1064,7 @@
       "Body_upload_banner_api_events__code__banner_post": {
         "properties": {
           "file": {
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File",
             "type": "string"
           }
@@ -1338,6 +1338,41 @@
           "uptime_seconds"
         ],
         "title": "BridgeStatusResponse",
+        "type": "object"
+      },
+      "BuilderPlaylistsOut": {
+        "description": "Connected-service playlist pickers for the import modal.",
+        "properties": {
+          "beatport": {
+            "items": {
+              "$ref": "#/components/schemas/PlaylistInfo"
+            },
+            "title": "Beatport",
+            "type": "array"
+          },
+          "beatport_connected": {
+            "title": "Beatport Connected",
+            "type": "boolean"
+          },
+          "tidal": {
+            "items": {
+              "$ref": "#/components/schemas/PlaylistInfo"
+            },
+            "title": "Tidal",
+            "type": "array"
+          },
+          "tidal_connected": {
+            "title": "Tidal Connected",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "beatport",
+          "beatport_connected",
+          "tidal",
+          "tidal_connected"
+        ],
+        "title": "BuilderPlaylistsOut",
         "type": "object"
       },
       "BulkActionResponse": {
@@ -4680,6 +4715,623 @@
           "total"
         ],
         "title": "PlayHistoryResponse",
+        "type": "object"
+      },
+      "PlaylistInfo": {
+        "properties": {
+          "cover_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Url"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "num_tracks": {
+            "title": "Num Tracks",
+            "type": "integer"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "cover_url",
+          "description",
+          "id",
+          "name",
+          "num_tracks",
+          "source"
+        ],
+        "title": "PlaylistInfo",
+        "type": "object"
+      },
+      "PoolImportEventIn": {
+        "description": "Body for importing a WrzDJ event's requests.",
+        "properties": {
+          "event_id": {
+            "minimum": 1.0,
+            "title": "Event Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "event_id"
+        ],
+        "title": "PoolImportEventIn",
+        "type": "object"
+      },
+      "PoolImportManualIn": {
+        "description": "Body for adding a single track picked from manual search.",
+        "properties": {
+          "album": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Album"
+          },
+          "artist": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Artist",
+            "type": "string"
+          },
+          "artwork_url": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "pattern": "^https://",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Artwork Url"
+          },
+          "bpm": {
+            "anyOf": [
+              {
+                "maximum": 400.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "duration_sec": {
+            "anyOf": [
+              {
+                "maximum": 36000.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Sec"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "maxLength": 100,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "isrc": {
+            "anyOf": [
+              {
+                "maxLength": 15,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Isrc"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "maxLength": 20,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "source_service": {
+            "default": "manual",
+            "enum": [
+              "spotify",
+              "beatport",
+              "tidal",
+              "manual"
+            ],
+            "title": "Source Service",
+            "type": "string"
+          },
+          "source_track_id": {
+            "anyOf": [
+              {
+                "maxLength": 100,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Track Id"
+          },
+          "title": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "artist"
+        ],
+        "title": "PoolImportManualIn",
+        "type": "object"
+      },
+      "PoolImportPlaylistIn": {
+        "description": "Body for importing a connected-account (Tidal/Beatport) playlist.",
+        "properties": {
+          "label": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "playlist_id": {
+            "maxLength": 100,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9_-]+$",
+            "title": "Playlist Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "playlist_id"
+        ],
+        "title": "PoolImportPlaylistIn",
+        "type": "object"
+      },
+      "PoolImportResult": {
+        "description": "Result of any import flow \u2014 toast reads 'added new \u00b7 deduped de-duped'.",
+        "properties": {
+          "added": {
+            "title": "Added",
+            "type": "integer"
+          },
+          "deduped": {
+            "title": "Deduped",
+            "type": "integer"
+          },
+          "pool": {
+            "$ref": "#/components/schemas/PoolState"
+          },
+          "source": {
+            "$ref": "#/components/schemas/PoolSourceOut"
+          }
+        },
+        "required": [
+          "added",
+          "deduped",
+          "pool",
+          "source"
+        ],
+        "title": "PoolImportResult",
+        "type": "object"
+      },
+      "PoolImportUrlIn": {
+        "description": "Body for public playlist URL preview/import.",
+        "properties": {
+          "url": {
+            "maxLength": 500,
+            "minLength": 12,
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "title": "PoolImportUrlIn",
+        "type": "object"
+      },
+      "PoolMutationResult": {
+        "description": "Result of a removal flow.",
+        "properties": {
+          "pool": {
+            "$ref": "#/components/schemas/PoolState"
+          },
+          "removed": {
+            "title": "Removed",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "pool",
+          "removed"
+        ],
+        "title": "PoolMutationResult",
+        "type": "object"
+      },
+      "PoolRemoveTracksIn": {
+        "description": "Body for per-track / multi-select removal.",
+        "properties": {
+          "track_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "maxItems": 500,
+            "minItems": 1,
+            "title": "Track Ids",
+            "type": "array"
+          }
+        },
+        "required": [
+          "track_ids"
+        ],
+        "title": "PoolRemoveTracksIn",
+        "type": "object"
+      },
+      "PoolSourceOut": {
+        "description": "An import source row for the sources accordion.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "external_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "External Ref"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "kind": {
+            "enum": [
+              "event",
+              "tidal",
+              "beatport",
+              "public_url",
+              "manual"
+            ],
+            "title": "Kind",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "required": [
+          "created_at",
+          "external_ref",
+          "id",
+          "kind",
+          "label",
+          "meta"
+        ],
+        "title": "PoolSourceOut",
+        "type": "object"
+      },
+      "PoolState": {
+        "description": "Full pool snapshot: sources + tracks.",
+        "properties": {
+          "sources": {
+            "items": {
+              "$ref": "#/components/schemas/PoolSourceOut"
+            },
+            "title": "Sources",
+            "type": "array"
+          },
+          "tracks": {
+            "items": {
+              "$ref": "#/components/schemas/PoolTrackOut"
+            },
+            "title": "Tracks",
+            "type": "array"
+          }
+        },
+        "required": [
+          "sources",
+          "tracks"
+        ],
+        "title": "PoolState",
+        "type": "object"
+      },
+      "PoolTrackOut": {
+        "description": "A pool track row (badges: camelot, bpm, energy; chip: source_id).",
+        "properties": {
+          "album": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Album"
+          },
+          "artist": {
+            "title": "Artist",
+            "type": "string"
+          },
+          "artwork_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Artwork Url"
+          },
+          "bpm": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "camelot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Camelot"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "duration_sec": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Sec"
+          },
+          "energy": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Energy"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "isrc": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Isrc"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "source_id": {
+            "title": "Source Id",
+            "type": "integer"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "track_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Track Id"
+          }
+        },
+        "required": [
+          "album",
+          "artist",
+          "artwork_url",
+          "bpm",
+          "camelot",
+          "created_at",
+          "duration_sec",
+          "energy",
+          "genre",
+          "id",
+          "isrc",
+          "key",
+          "source_id",
+          "title",
+          "track_id"
+        ],
+        "title": "PoolTrackOut",
+        "type": "object"
+      },
+      "PoolUrlPreview": {
+        "description": "Validate \u2192 preview card payload for a public playlist URL.",
+        "properties": {
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "owner": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string"
+          },
+          "supported": {
+            "title": "Supported",
+            "type": "boolean"
+          },
+          "track_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Track Count"
+          }
+        },
+        "required": [
+          "message",
+          "name",
+          "owner",
+          "provider",
+          "supported",
+          "track_count"
+        ],
+        "title": "PoolUrlPreview",
         "type": "object"
       },
       "PublicEventInfo": {
@@ -13397,6 +14049,33 @@
         ]
       }
     },
+    "/api/setbuilder/playlists": {
+      "get": {
+        "description": "Connected-service playlists for the import modal pickers.",
+        "operationId": "list_builder_playlists_api_setbuilder_playlists_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BuilderPlaylistsOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Builder Playlists",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
     "/api/setbuilder/sets": {
       "get": {
         "description": "List the current DJ's sets, newest first.",
@@ -13611,6 +14290,517 @@
           }
         ],
         "summary": "Rename Set",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/pool": {
+      "get": {
+        "description": "Full pool snapshot (sources + tracks) for one of the DJ's sets.",
+        "operationId": "get_pool_state_api_setbuilder_sets__set_id__pool_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PoolState"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Pool State",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/pool/import/beatport": {
+      "post": {
+        "description": "Import a connected-account Beatport playlist into the pool.",
+        "operationId": "import_pool_beatport_api_setbuilder_sets__set_id__pool_import_beatport_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PoolImportPlaylistIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PoolImportResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Import Pool Beatport",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/pool/import/event": {
+      "post": {
+        "description": "Import a DJ-owned event's non-rejected requests into the pool.",
+        "operationId": "import_pool_event_api_setbuilder_sets__set_id__pool_import_event_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PoolImportEventIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PoolImportResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Import Pool Event",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/pool/import/manual": {
+      "post": {
+        "description": "Add a single manually-searched track to the pool.",
+        "operationId": "import_pool_manual_api_setbuilder_sets__set_id__pool_import_manual_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PoolImportManualIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PoolImportResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Import Pool Manual",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/pool/import/tidal": {
+      "post": {
+        "description": "Import a connected-account Tidal playlist into the pool.",
+        "operationId": "import_pool_tidal_api_setbuilder_sets__set_id__pool_import_tidal_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PoolImportPlaylistIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PoolImportResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Import Pool Tidal",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/pool/import/url": {
+      "post": {
+        "description": "Import a validated public playlist URL into the pool.",
+        "operationId": "import_pool_url_api_setbuilder_sets__set_id__pool_import_url_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PoolImportUrlIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PoolImportResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Import Pool Url",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/pool/sources/{source_id}": {
+      "delete": {
+        "description": "Remove an import source and exactly its tracks.",
+        "operationId": "remove_pool_source_api_setbuilder_sets__set_id__pool_sources__source_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "source_id",
+            "required": true,
+            "schema": {
+              "title": "Source Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PoolMutationResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Remove Pool Source",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/pool/tracks/remove": {
+      "post": {
+        "description": "Remove pool tracks by id (per-track context menu + multi-select).",
+        "operationId": "remove_pool_tracks_api_setbuilder_sets__set_id__pool_tracks_remove_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PoolRemoveTracksIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PoolMutationResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Remove Pool Tracks",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/pool/url-preview": {
+      "post": {
+        "description": "Validate a public playlist URL and return the preview card payload.",
+        "operationId": "preview_pool_url_api_setbuilder_sets__set_id__pool_url_preview_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PoolImportUrlIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PoolUrlPreview"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Preview Pool Url",
         "tags": [
           "setbuilder"
         ]

--- a/server/tests/test_setbuilder_pool_api.py
+++ b/server/tests/test_setbuilder_pool_api.py
@@ -1,0 +1,431 @@
+"""API-boundary tests for WrzDJSet pool endpoints (issue #388)."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.event import Event
+from app.models.request import Request as SongRequest
+from app.models.request import RequestStatus
+from app.models.user import User
+
+
+@pytest.fixture
+def set_id(client: TestClient, auth_headers: dict) -> int:
+    resp = client.post("/api/setbuilder/sets", json={"name": "Pool Set"}, headers=auth_headers)
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+@pytest.fixture
+def other_dj_headers(client: TestClient, db: Session) -> dict:
+    from app.services.auth import get_password_hash
+
+    user = User(username="otherdj", password_hash=get_password_hash("otherpassword1"), role="dj")
+    db.add(user)
+    db.commit()
+    resp = client.post(
+        "/api/auth/login", data={"username": "otherdj", "password": "otherpassword1"}
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _seed_requests(db: Session, event: Event) -> None:
+    db.add_all(
+        [
+            SongRequest(
+                event_id=event.id,
+                song_title="Pool Track A",
+                artist="Artist A",
+                dedupe_key="pk1",
+                genre="House",
+                bpm=126.0,
+                musical_key="Am",
+            ),
+            SongRequest(
+                event_id=event.id,
+                song_title="Pool Track B",
+                artist="Artist B",
+                dedupe_key="pk2",
+            ),
+            SongRequest(
+                event_id=event.id,
+                song_title="Rejected Track",
+                artist="Artist C",
+                dedupe_key="pk3",
+                status=RequestStatus.REJECTED.value,
+            ),
+        ]
+    )
+    db.commit()
+
+
+class TestPoolOwnership:
+    def test_pool_404_for_other_users_set(self, client, set_id, other_dj_headers):
+        assert (
+            client.get(f"/api/setbuilder/sets/{set_id}/pool", headers=other_dj_headers).status_code
+            == 404
+        )
+        assert (
+            client.post(
+                f"/api/setbuilder/sets/{set_id}/pool/import/event",
+                json={"event_id": 1},
+                headers=other_dj_headers,
+            ).status_code
+            == 404
+        )
+        assert (
+            client.post(
+                f"/api/setbuilder/sets/{set_id}/pool/tracks/remove",
+                json={"track_ids": [1]},
+                headers=other_dj_headers,
+            ).status_code
+            == 404
+        )
+
+    def test_pool_requires_auth(self, client, set_id):
+        assert client.get(f"/api/setbuilder/sets/{set_id}/pool").status_code == 401
+
+
+class TestEventImport:
+    def test_import_event_end_to_end(self, client, db, auth_headers, set_id, test_event):
+        _seed_requests(db, test_event)
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/event",
+            json={"event_id": test_event.id},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["added"] == 2  # rejected excluded
+        assert body["deduped"] == 0
+        assert body["source"]["kind"] == "event"
+        assert body["source"]["label"] == test_event.name
+        tracks = body["pool"]["tracks"]
+        assert len(tracks) == 2
+        assert all(t["source_id"] == body["source"]["id"] for t in tracks)
+        by_title = {t["title"]: t for t in tracks}
+        assert by_title["Pool Track A"]["camelot"] == "8A"
+        assert by_title["Pool Track A"]["bpm"] == 126.0
+
+    def test_import_unowned_event_404(
+        self, client, db, set_id, auth_headers, other_dj_headers, test_event
+    ):
+        # other DJ creates a set, then tries to import OUR event
+        resp = client.post(
+            "/api/setbuilder/sets", json={"name": "Other Set"}, headers=other_dj_headers
+        )
+        other_set = resp.json()["id"]
+        resp = client.post(
+            f"/api/setbuilder/sets/{other_set}/pool/import/event",
+            json={"event_id": test_event.id},
+            headers=other_dj_headers,
+        )
+        assert resp.status_code == 404
+
+    def test_reimport_event_dedupes_and_reuses_source(
+        self, client, db, auth_headers, set_id, test_event
+    ):
+        _seed_requests(db, test_event)
+        first = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/event",
+            json={"event_id": test_event.id},
+            headers=auth_headers,
+        ).json()
+        second = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/event",
+            json={"event_id": test_event.id},
+            headers=auth_headers,
+        ).json()
+        assert second["added"] == 0
+        assert second["deduped"] == 2
+        assert second["source"]["id"] == first["source"]["id"]
+        assert len(second["pool"]["sources"]) == 1
+
+
+class TestPlaylistImports:
+    def test_import_tidal_playlist(self, client, auth_headers, set_id, monkeypatch):
+        from app.services.setbuilder.pool import PoolCandidate
+
+        monkeypatch.setattr(
+            "app.services.setbuilder.pool.candidates_from_tidal",
+            lambda db, user, pid: [
+                PoolCandidate(
+                    track_id="tidal:1",
+                    title="Tidal Song",
+                    artist="Tidal Artist",
+                    bpm=128.0,
+                    key="8A",
+                    isrc="QZABC1234567",
+                )
+            ],
+        )
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/tidal",
+            json={"playlist_id": "abc-123", "label": "Friday Warmup"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert (body["added"], body["deduped"]) == (1, 0)
+        assert body["source"]["kind"] == "tidal"
+        assert body["source"]["label"] == "Friday Warmup"
+
+    def test_import_tidal_fetch_failure_502(self, client, auth_headers, set_id, monkeypatch):
+        from app.services.tidal import TidalFetchError
+
+        def boom(db, user, pid):
+            raise TidalFetchError("nope")
+
+        monkeypatch.setattr("app.services.setbuilder.pool.candidates_from_tidal", boom)
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/tidal",
+            json={"playlist_id": "abc-123"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 502
+
+    def test_import_beatport_playlist(self, client, auth_headers, set_id, monkeypatch):
+        from app.services.setbuilder.pool import PoolCandidate
+
+        monkeypatch.setattr(
+            "app.services.setbuilder.pool.candidates_from_beatport",
+            lambda db, user, pid: [
+                PoolCandidate(track_id="beatport:9", title="Beat Song", artist="Beat Artist")
+            ],
+        )
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/beatport",
+            json={"playlist_id": "9"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["source"]["kind"] == "beatport"
+
+    def test_playlist_id_charset_rejected(self, client, auth_headers, set_id):
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/tidal",
+            json={"playlist_id": "../../etc"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
+
+
+class TestUrlImport:
+    def test_preview_invalid_url_422(self, client, auth_headers, set_id):
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/url-preview",
+            json={"url": "https://evil.com/playlist/37i9dQZF1DXcBWIGoYBM5M"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
+
+    def test_preview_unsupported_provider(self, client, auth_headers, set_id):
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/url-preview",
+            json={"url": "https://music.apple.com/us/playlist/hits/pl.abc123"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["supported"] is False
+        assert body["provider"] == "apple_music"
+        assert body["message"]
+
+    def test_preview_spotify(self, client, auth_headers, set_id, monkeypatch):
+        monkeypatch.setattr(
+            "app.services.setbuilder.pool.preview_public_playlist",
+            lambda db, user, provider, pid: {
+                "name": "Wedding Bangers 2026",
+                "owner": "djwedding",
+                "track_count": 87,
+            },
+        )
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/url-preview",
+            json={"url": "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["supported"] is True
+        assert body["name"] == "Wedding Bangers 2026"
+        assert body["track_count"] == 87
+
+    def test_import_url_end_to_end(self, client, auth_headers, set_id, monkeypatch):
+        from app.services.setbuilder.pool import PoolCandidate
+
+        monkeypatch.setattr(
+            "app.services.setbuilder.pool.candidates_from_public_url",
+            lambda db, user, provider, pid: (
+                "Wedding Bangers 2026",
+                [
+                    PoolCandidate(track_id="spotify:a", title="URL Song", artist="URL Artist"),
+                    PoolCandidate(track_id="spotify:b", title="URL Song 2", artist="URL Artist"),
+                ],
+            ),
+        )
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/url",
+            json={"url": "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["added"] == 2
+        assert body["source"]["kind"] == "public_url"
+        assert body["source"]["label"] == "Wedding Bangers 2026"
+
+    def test_import_url_provider_failure_502(self, client, auth_headers, set_id, monkeypatch):
+        from app.services.setbuilder.pool import PoolImportError
+
+        def boom(db, user, provider, pid):
+            raise PoolImportError("Couldn't fetch that Spotify playlist — is it public?")
+
+        monkeypatch.setattr("app.services.setbuilder.pool.candidates_from_public_url", boom)
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/url",
+            json={"url": "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 502
+
+
+class TestManualImport:
+    def test_manual_import(self, client, auth_headers, set_id):
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/manual",
+            json={
+                "title": "Bad Romance",
+                "artist": "Lady Gaga",
+                "bpm": 119,
+                "key": "Am",
+                "source_service": "tidal",
+                "source_track_id": "555",
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["added"] == 1
+        assert body["source"]["kind"] == "manual"
+        track = body["pool"]["tracks"][0]
+        assert track["track_id"] == "tidal:555"
+        assert track["camelot"] == "8A"
+
+    def test_manual_dedupe_toast_counts(self, client, auth_headers, set_id):
+        payload = {"title": "Bad Romance", "artist": "Lady Gaga"}
+        client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/manual",
+            json=payload,
+            headers=auth_headers,
+        )
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/manual",
+            json=payload,
+            headers=auth_headers,
+        )
+        assert (resp.json()["added"], resp.json()["deduped"]) == (0, 1)
+
+    def test_manual_validation(self, client, auth_headers, set_id):
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/manual",
+            json={"title": "", "artist": "A", "bpm": 9999},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
+
+    def test_manual_artwork_must_be_https(self, client, auth_headers, set_id):
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/manual",
+            json={"title": "T", "artist": "A", "artwork_url": "http://evil.com/x.jpg"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
+
+
+class TestRemovalFlows:
+    def _import_two(self, client, auth_headers, set_id):
+        for title in ("Song One", "Song Two"):
+            client.post(
+                f"/api/setbuilder/sets/{set_id}/pool/import/manual",
+                json={"title": title, "artist": "Artist"},
+                headers=auth_headers,
+            )
+        pool_state = client.get(f"/api/setbuilder/sets/{set_id}/pool", headers=auth_headers).json()
+        return pool_state
+
+    def test_remove_tracks(self, client, auth_headers, set_id):
+        state = self._import_two(client, auth_headers, set_id)
+        ids = [t["id"] for t in state["tracks"]]
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/tracks/remove",
+            json={"track_ids": ids[:1]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["removed"] == 1
+        assert len(body["pool"]["tracks"]) == 1
+
+    def test_remove_source_counts_consistent(
+        self, client, db, auth_headers, set_id, test_event, monkeypatch
+    ):
+        from app.services.setbuilder.pool import PoolCandidate
+
+        _seed_requests(db, test_event)
+        client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/event",
+            json={"event_id": test_event.id},
+            headers=auth_headers,
+        )
+        monkeypatch.setattr(
+            "app.services.setbuilder.pool.candidates_from_tidal",
+            lambda db_, user, pid: [
+                PoolCandidate(track_id="tidal:1", title="Unique Tidal", artist="T")
+            ],
+        )
+        imp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/tidal",
+            json={"playlist_id": "p1"},
+            headers=auth_headers,
+        ).json()
+        tidal_source_id = imp["source"]["id"]
+        resp = client.delete(
+            f"/api/setbuilder/sets/{set_id}/pool/sources/{tidal_source_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["removed"] == 1
+        # event tracks untouched, tidal source gone
+        assert len(body["pool"]["tracks"]) == 2
+        assert all(s["id"] != tidal_source_id for s in body["pool"]["sources"])
+
+    def test_remove_source_404_for_other_set(self, client, auth_headers, other_dj_headers, set_id):
+        state = self._import_two(client, auth_headers, set_id)
+        source_id = state["sources"][0]["id"]
+        # other DJ's set with same source id namespace
+        other_set = client.post(
+            "/api/setbuilder/sets", json={"name": "Other"}, headers=other_dj_headers
+        ).json()["id"]
+        resp = client.delete(
+            f"/api/setbuilder/sets/{other_set}/pool/sources/{source_id}",
+            headers=other_dj_headers,
+        )
+        assert resp.status_code == 404
+
+
+class TestBuilderPlaylists:
+    def test_playlists_disconnected(self, client, auth_headers):
+        resp = client.get("/api/setbuilder/playlists", headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["tidal_connected"] is False
+        assert body["beatport_connected"] is False
+        assert body["tidal"] == []
+        assert body["beatport"] == []
+
+    def test_playlists_requires_active_user(self, client, pending_headers):
+        resp = client.get("/api/setbuilder/playlists", headers=pending_headers)
+        assert resp.status_code == 403

--- a/server/tests/test_setbuilder_pool_service.py
+++ b/server/tests/test_setbuilder_pool_service.py
@@ -1,0 +1,353 @@
+"""Unit tests for the WrzDJSet pool service + public-URL validator (issue #388)."""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.request import Request, RequestStatus
+from app.models.set import Set
+from app.models.user import User
+from app.services.setbuilder import pool
+from app.services.setbuilder.playlist_url import (
+    InvalidPlaylistUrl,
+    parse_public_playlist_url,
+)
+
+
+@pytest.fixture
+def test_set(db: Session, test_user: User) -> Set:
+    s = Set(owner_id=test_user.id, name="Pool Test Set")
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    return s
+
+
+def _candidate(title: str, artist: str, **kwargs) -> pool.PoolCandidate:
+    return pool.PoolCandidate(title=title, artist=artist, **kwargs)
+
+
+class TestDedupeSignature:
+    def test_strips_generic_mix_suffix(self):
+        assert pool.dedupe_signature("Artist", "Song (Original Mix)") == pool.dedupe_signature(
+            "Artist", "Song"
+        )
+
+    def test_canonicalizes_feat(self):
+        assert pool.dedupe_signature("A feat. B", "Song") == pool.dedupe_signature(
+            "A featuring B", "Song"
+        )
+
+    def test_case_insensitive(self):
+        assert pool.dedupe_signature("ARTIST", "SONG") == pool.dedupe_signature("artist", "song")
+
+    def test_distinct_tracks_differ(self):
+        assert pool.dedupe_signature("Artist", "Song A") != pool.dedupe_signature(
+            "Artist", "Song B"
+        )
+
+
+class TestCamelotCode:
+    def test_major_key(self):
+        assert pool.camelot_code("C major") == "8B"
+
+    def test_camelot_passthrough(self):
+        assert pool.camelot_code("8A") == "8A"
+
+    def test_none(self):
+        assert pool.camelot_code(None) is None
+
+    def test_unparseable(self):
+        assert pool.camelot_code("not a key") is None
+
+
+class TestSources:
+    def test_get_or_create_source_creates(self, db, test_set):
+        src = pool.get_or_create_source(
+            db, test_set, kind="tidal", external_ref="pl-1", label="My Playlist"
+        )
+        assert src.id is not None
+        assert src.kind == "tidal"
+
+    def test_get_or_create_source_reuses_row(self, db, test_set):
+        a = pool.get_or_create_source(
+            db, test_set, kind="tidal", external_ref="pl-1", label="My Playlist"
+        )
+        b = pool.get_or_create_source(
+            db, test_set, kind="tidal", external_ref="pl-1", label="My Playlist (renamed)"
+        )
+        assert a.id == b.id
+        assert b.label == "My Playlist (renamed)"
+
+    def test_manual_bucket_is_singleton_per_set(self, db, test_set):
+        a = pool.get_or_create_source(
+            db, test_set, kind="manual", external_ref=None, label="Manual"
+        )
+        b = pool.get_or_create_source(
+            db, test_set, kind="manual", external_ref=None, label="Manual"
+        )
+        assert a.id == b.id
+
+
+class TestImportCandidates:
+    def test_imports_and_counts(self, db, test_set):
+        src = pool.get_or_create_source(
+            db, test_set, kind="manual", external_ref=None, label="Manual"
+        )
+        added, deduped = pool.import_candidates(
+            db,
+            test_set,
+            src,
+            [
+                _candidate("Song A", "Artist 1", key="C major", bpm=124.0),
+                _candidate("Song B", "Artist 2"),
+            ],
+        )
+        assert (added, deduped) == (2, 0)
+        _, tracks = pool.get_pool(db, test_set.id)
+        assert len(tracks) == 2
+        assert tracks[0].camelot == "8B"
+        assert tracks[0].source_id == src.id
+
+    def test_fuzzy_dedupe_preserves_first_source_tag(self, db, test_set):
+        src1 = pool.get_or_create_source(
+            db, test_set, kind="event", external_ref="1", label="Event"
+        )
+        src2 = pool.get_or_create_source(
+            db, test_set, kind="manual", external_ref=None, label="Manual"
+        )
+        pool.import_candidates(db, test_set, src1, [_candidate("Song A", "Artist")])
+        added, deduped = pool.import_candidates(
+            db, test_set, src2, [_candidate("Song A (Original Mix)", "Artist")]
+        )
+        assert (added, deduped) == (0, 1)
+        _, tracks = pool.get_pool(db, test_set.id)
+        assert len(tracks) == 1
+        assert tracks[0].source_id == src1.id
+
+    def test_isrc_dedupe_with_different_titles(self, db, test_set):
+        src = pool.get_or_create_source(
+            db, test_set, kind="manual", external_ref=None, label="Manual"
+        )
+        pool.import_candidates(
+            db, test_set, src, [_candidate("Song A", "Artist", isrc="USUM71703861")]
+        )
+        added, deduped = pool.import_candidates(
+            db, test_set, src, [_candidate("Totally Different Name", "Artist", isrc="usum71703861")]
+        )
+        assert (added, deduped) == (0, 1)
+
+    def test_reimport_same_source_zero_added(self, db, test_set):
+        src = pool.get_or_create_source(db, test_set, kind="tidal", external_ref="p", label="P")
+        cands = [_candidate("Song A", "Artist"), _candidate("Song B", "Artist")]
+        pool.import_candidates(db, test_set, src, cands)
+        added, deduped = pool.import_candidates(db, test_set, src, cands)
+        assert (added, deduped) == (0, 2)
+
+    def test_blank_candidates_skipped(self, db, test_set):
+        src = pool.get_or_create_source(
+            db, test_set, kind="manual", external_ref=None, label="Manual"
+        )
+        added, deduped = pool.import_candidates(
+            db, test_set, src, [_candidate("", " "), _candidate("Real", "Artist")]
+        )
+        assert (added, deduped) == (1, 0)
+
+    def test_intra_batch_dedupe(self, db, test_set):
+        src = pool.get_or_create_source(
+            db, test_set, kind="manual", external_ref=None, label="Manual"
+        )
+        added, deduped = pool.import_candidates(
+            db, test_set, src, [_candidate("Song A", "Artist"), _candidate("Song A", "Artist")]
+        )
+        assert (added, deduped) == (1, 1)
+
+
+class TestRemoval:
+    def test_remove_tracks_scoped_to_set(self, db, test_user, test_set):
+        other_set = Set(owner_id=test_user.id, name="Other")
+        db.add(other_set)
+        db.commit()
+        src_a = pool.get_or_create_source(db, test_set, kind="manual", external_ref=None, label="M")
+        src_b = pool.get_or_create_source(
+            db, other_set, kind="manual", external_ref=None, label="M"
+        )
+        pool.import_candidates(db, test_set, src_a, [_candidate("Song A", "Artist")])
+        pool.import_candidates(db, other_set, src_b, [_candidate("Song B", "Artist")])
+        _, other_tracks = pool.get_pool(db, other_set.id)
+        removed = pool.remove_tracks(db, test_set, [t.id for t in other_tracks])
+        assert removed == 0
+        _, still_there = pool.get_pool(db, other_set.id)
+        assert len(still_there) == 1
+
+    def test_remove_source_removes_exactly_its_tracks(self, db, test_set):
+        src1 = pool.get_or_create_source(db, test_set, kind="tidal", external_ref="p1", label="P1")
+        src2 = pool.get_or_create_source(
+            db, test_set, kind="beatport", external_ref="p2", label="P2"
+        )
+        pool.import_candidates(
+            db, test_set, src1, [_candidate("Song A", "Artist"), _candidate("Song B", "Artist")]
+        )
+        pool.import_candidates(db, test_set, src2, [_candidate("Song C", "Artist")])
+        removed = pool.remove_source(db, test_set, src1)
+        assert removed == 2
+        sources, tracks = pool.get_pool(db, test_set.id)
+        assert [s.id for s in sources] == [src2.id]
+        assert len(tracks) == 1
+        assert tracks[0].title == "Song C"
+
+
+class TestEventCandidates:
+    def test_maps_requests_excluding_rejected(self, db, test_user, test_event):
+        db.add_all(
+            [
+                Request(
+                    event_id=test_event.id,
+                    song_title="Keep Me",
+                    artist="Artist",
+                    dedupe_key="k1",
+                    genre="House",
+                    bpm=126.0,
+                    musical_key="8A",
+                ),
+                Request(
+                    event_id=test_event.id,
+                    song_title="Rejected",
+                    artist="Artist",
+                    dedupe_key="k2",
+                    status=RequestStatus.REJECTED.value,
+                ),
+            ]
+        )
+        db.commit()
+        result = pool.candidates_from_event(db, test_user, test_event.id)
+        assert result is not None
+        event, cands = result
+        assert event.id == test_event.id
+        assert [c.title for c in cands] == ["Keep Me"]
+        assert cands[0].track_id.startswith("request:")
+        assert cands[0].genre == "House"
+
+    def test_unowned_event_returns_none(self, db, test_user, test_event):
+        from app.services.auth import get_password_hash
+
+        other = User(username="other", password_hash=get_password_hash("x" * 12), role="dj")
+        db.add(other)
+        db.commit()
+        assert pool.candidates_from_event(db, other, test_event.id) is None
+
+
+class TestUrlParser:
+    def test_spotify_playlist(self):
+        p = parse_public_playlist_url("https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M")
+        assert (p.provider, p.supported) == ("spotify", True)
+        assert p.playlist_id == "37i9dQZF1DXcBWIGoYBM5M"
+
+    def test_spotify_with_query(self):
+        p = parse_public_playlist_url(
+            "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M?si=abc123"
+        )
+        assert p.playlist_id == "37i9dQZF1DXcBWIGoYBM5M"
+
+    def test_tidal_browse_playlist(self):
+        p = parse_public_playlist_url(
+            "https://tidal.com/browse/playlist/12345678-90ab-cdef-1234-567890abcdef"
+        )
+        assert (p.provider, p.supported) == ("tidal", True)
+        assert p.playlist_id == "12345678-90ab-cdef-1234-567890abcdef"
+
+    def test_listen_tidal_playlist(self):
+        p = parse_public_playlist_url(
+            "https://listen.tidal.com/playlist/12345678-90ab-cdef-1234-567890abcdef"
+        )
+        assert (p.provider, p.supported) == ("tidal", True)
+
+    def test_apple_music_recognized_unsupported(self):
+        p = parse_public_playlist_url("https://music.apple.com/us/playlist/top-hits/pl.abc123DEF")
+        assert (p.provider, p.supported) == ("apple_music", False)
+        assert p.message
+
+    def test_youtube_recognized_unsupported(self):
+        p = parse_public_playlist_url("https://www.youtube.com/playlist?list=PLabc_123-xyz")
+        assert (p.provider, p.supported) == ("youtube", False)
+
+    def test_soundcloud_recognized_unsupported(self):
+        p = parse_public_playlist_url("https://soundcloud.com/some-dj/sets/some-playlist")
+        assert (p.provider, p.supported) == ("soundcloud", False)
+
+    def test_beatport_recognized_unsupported(self):
+        p = parse_public_playlist_url("https://www.beatport.com/playlists/123456")
+        assert (p.provider, p.supported) == ("beatport", False)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M",  # not https
+            "https://evil.com/playlist/37i9dQZF1DXcBWIGoYBM5M",  # bad host
+            "https://open.spotify.com@evil.com/playlist/37i9dQZF1DXcBWIGoYBM5M",  # userinfo
+            "https://open.spotify.com:8443/playlist/37i9dQZF1DXcBWIGoYBM5M",  # port
+            "https://open.spotify.com/playlist/../../etc/passwd",  # bad id charset
+            "https://open.spotify.com/track/37i9dQZF1DXcBWIGoYBM5M",  # not a playlist
+            "javascript:alert(1)",
+            "ftp://tidal.com/browse/playlist/12345678-90ab-cdef-1234-567890abcdef",
+            "not a url at all",
+            "https://tidal.com/browse/playlist/not-a-uuid",
+        ],
+    )
+    def test_rejected_urls(self, url):
+        with pytest.raises(InvalidPlaylistUrl):
+            parse_public_playlist_url(url)
+
+
+class TestPlaylistCandidates:
+    def test_tidal_candidates_mapped(self, db, test_user, monkeypatch):
+        from app.schemas.tidal import TidalSearchResult
+
+        class FakeTrack:
+            pass
+
+        def fake_get_playlist_tracks(db_, user, playlist_id):
+            return [FakeTrack()]
+
+        def fake_track_to_result(t):
+            return TidalSearchResult(
+                track_id="999",
+                title="Tidal Song",
+                artist="Tidal Artist",
+                album="Album",
+                bpm=128.0,
+                key="Am",
+                duration_seconds=200,
+                cover_url="https://resources.tidal.com/x.jpg",
+                isrc="QZABC1234567",
+            )
+
+        monkeypatch.setattr("app.services.tidal.get_playlist_tracks", fake_get_playlist_tracks)
+        monkeypatch.setattr("app.services.tidal._track_to_result", fake_track_to_result)
+        cands = pool.candidates_from_tidal(db, test_user, "pl-1")
+        assert len(cands) == 1
+        assert cands[0].track_id == "tidal:999"
+        assert cands[0].isrc == "QZABC1234567"
+
+    def test_beatport_candidates_mapped(self, db, test_user, monkeypatch):
+        from app.schemas.beatport import BeatportSearchResult
+
+        def fake_get_playlist_tracks(db_, user, playlist_id):
+            return [
+                BeatportSearchResult(
+                    track_id="42",
+                    title="Beat Song",
+                    artist="Beat Artist",
+                    mix_name="Club Mix",
+                    genre="Tech House",
+                    bpm=127,
+                    key="5A",
+                    duration_seconds=300,
+                )
+            ]
+
+        monkeypatch.setattr("app.services.beatport.get_playlist_tracks", fake_get_playlist_tracks)
+        cands = pool.candidates_from_beatport(db, test_user, "42")
+        assert len(cands) == 1
+        assert cands[0].track_id == "beatport:42"
+        assert cands[0].title == "Beat Song (Club Mix)"
+        assert cands[0].genre == "Tech House"


### PR DESCRIPTION
Closes #388

## Summary
- **Pool tables** (`set_pool_sources`, `set_pool_tracks`) — migration **053**, cascade under `sets`; every track tagged with its import source (`importedVia` chip), `track_id` follows the TrackVibe namespaced-string convention (`tidal:123`, `request:7`, …)
- **Pool service** (`server/app/services/setbuilder/pool.py`): dedupe-on-import (exact ISRC first, then normalized artist+title signature via `track_normalizer`; first import wins, original source tag preserved), per-set source reuse, removal flows (by ids / by source), candidate builders for all five flows
- **Public-URL validator** (`playlist_url.py`): https-only, exact-host allowlist, strict ID charsets, no userinfo/port tricks — **the user URL is never fetched** (SSRF defense); IDs are extracted and pulled via official APIs (spotipy client-credentials for Spotify, DJ's connected Tidal session for Tidal)
- **API** (additive on `/api/setbuilder`): `GET …/pool`, `GET /playlists` (picker), `POST …/pool/import/{event,tidal,beatport,url,manual}`, `POST …/pool/url-preview`, `POST …/pool/tracks/remove`, `DELETE …/pool/sources/{id}` — all `get_current_active_user`, owner-or-404, rate-limited, Pydantic-constrained inputs
- **Frontend** (`dashboard/app/(dj)/setbuilder/components/`): `PoolPanel` (sources accordion w/ click-to-filter + hover-× remove, type tabs w/ live counts, search, multi-select footer, right-click context menu, toast "N new · M de-duped"), `ImportModal` (event picker / Tidal / Beatport / public-URL validate→preview→import / manual debounced search), `PoolBadges` (Camelot via `lib/camelot-colors`, BPM, energy bars, source icons)
- Tests: 41 service-level + 23 API-boundary (pytest) + 7 component tests (vitest)

## Design decisions
- **Public URL providers**: end-to-end support for **Spotify** (client credentials — no user auth needed) and **Tidal** (requires the DJ's connected session). Apple Music / YouTube / SoundCloud URL shapes are *recognized* but return `supported: false` with a clear message — no public-API credentials exist in this codebase for them. Beatport URLs route DJs to the OAuth picker instead.
- **Re-import = refresh**: importing the same playlist/event again reuses the existing source row (no duplicate accordion rows) and imports only new tracks; the dedupe toast reports it.
- **Dedupe constraint in DB**: `UNIQUE(set_id, dedupe_sig)` keeps dedupe honest under concurrent imports; ISRC matching is handled at the service layer (normalized, dash-stripped, uppercased).
- **Event imports exclude REJECTED requests** (DJ explicitly declined those).
- **`energy` is nullable** — TrackVibe enrichment is #391; the badge renders empty bars until then.
- **Manual bucket** is a per-set singleton source with no hover-× (matches the design prototype); manual tracks are removable via track/multi-select flows.
- **`artwork_url` must be https** (Pydantic pattern) — defensive against scheme tricks in stored/rendered image URLs.
- **Remix titles**: Beatport mix names other than "Original Mix" are folded into the title (`"Song (Club Mix)"`) so named remixes don't fuzzy-collide with originals (the normalizer preserves named remixes).

## Migration note
Migration **053** anchored on **052**; sibling PR for #398 uses slot **054** — second to merge re-anchors.

## Test plan
- [x] Backend: ruff check/format, bandit, pytest (2625 passed, 87.6% cov), `alembic upgrade head && alembic check` clean on a fresh DB
- [x] Frontend: eslint, tsc --noEmit, vitest (1012 passed)
- [ ] Manual: import each source type on a live set, verify chips/counts/toast, remove-by-source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pool panel in Set Builder with full import flows (events, Tidal/Beatport, public URL preview/import, manual), source badges (BPM/Camelot/energy), search/filters, multi-select, bulk removal, context menu, and dedupe-toasts.
* **Documentation**
  * Added rollout/implementation plan for pool import.
* **Tests**
  * Comprehensive frontend and backend tests covering imports, filtering, dedupe, URL parsing, previews, and removals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->