### PR TITLE
feat(setbuilder): Energy curve editor — templates, slot-coupled targets, friction views

### DIFF
--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { SetDetail } from '@/lib/api-types';
+import BuilderWorkspace from '../components/BuilderWorkspace';
 import styles from '../setbuilder.module.css';
 
 export default function BuilderPage({ params }: { params: Promise<{ setId: string }> }) {
@@ -77,15 +78,7 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
           <div className={styles.panelBody}>Candidate tracks will appear here.</div>
         </section>
 
-        <section className={`${styles.panel} ${styles.panelCurve}`} aria-label="Curve">
-          <div className={styles.panelHeader}>Curve</div>
-          <div className={styles.panelBody}>Energy curve editor coming soon.</div>
-        </section>
-
-        <section className={`${styles.panel} ${styles.panelTimeline}`} aria-label="Timeline">
-          <div className={styles.panelHeader}>Timeline</div>
-          <div className={styles.panelBody}>Ordered set timeline coming soon.</div>
-        </section>
+        <BuilderWorkspace setId={Number(setId)} />
 
         <section className={`${styles.panel} ${styles.panelChat}`} aria-label="Chat">
           <div className={styles.panelHeader}>Chat</div>

--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -1,0 +1,195 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import BuilderWorkspace from '../components/BuilderWorkspace';
+import type { SetSlotOut } from '@/lib/api-types';
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  Element.prototype.scrollIntoView = vi.fn();
+  // In-memory localStorage (node 22 jsdom env lacks one without a flag)
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+    },
+    writable: true,
+    configurable: true,
+  });
+});
+
+const mockGetSetSlots = vi.fn();
+const mockGetCurveTemplates = vi.fn();
+const mockGetVibeWindows = vi.fn();
+const mockUpdateSlotTarget = vi.fn();
+const mockApplyCurveTemplate = vi.fn();
+const mockPutVibeWindows = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getSetSlots: (setId: number) => mockGetSetSlots(setId),
+    getCurveTemplates: () => mockGetCurveTemplates(),
+    getVibeWindows: (setId: number) => mockGetVibeWindows(setId),
+    updateSlotTarget: (setId: number, slotId: number, t: number | null) =>
+      mockUpdateSlotTarget(setId, slotId, t),
+    applyCurveTemplate: (setId: number, source: object, mids?: number[]) =>
+      mockApplyCurveTemplate(setId, source, mids),
+    putVibeWindows: (setId: number, windows: object[]) => mockPutVibeWindows(setId, windows),
+    createCurveTemplate: vi.fn(),
+    updateCurveTemplate: vi.fn(),
+    deleteCurveTemplate: vi.fn(),
+  },
+}));
+
+const SLOTS: SetSlotOut[] = [
+  { id: 1, position: 0, track_id: 'a', locked: false, target_energy: null, notes: null },
+  { id: 2, position: 1, track_id: 'b', locked: false, target_energy: 7, notes: null },
+  { id: 3, position: 2, track_id: 'c', locked: false, target_energy: null, notes: null },
+];
+
+const TEMPLATES = {
+  builtin: [
+    {
+      name: 'Club Peak',
+      points: [
+        { t: 0, e: 7, label: 'Warm', slow_start: false, slow_end: false },
+        { t: 1, e: 8, label: 'Cool', slow_start: false, slow_end: false },
+      ],
+    },
+  ],
+  user: [],
+};
+
+describe('BuilderWorkspace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSetSlots.mockResolvedValue(SLOTS);
+    mockGetCurveTemplates.mockResolvedValue(TEMPLATES);
+    mockGetVibeWindows.mockResolvedValue({ windows: [] });
+    mockUpdateSlotTarget.mockResolvedValue({ slot_id: 1, target_energy: 9 });
+    mockPutVibeWindows.mockResolvedValue({ windows: [] });
+  });
+
+  it('fetches slots and renders curve blocks + timeline rows', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('slot-block-0')).toBeInTheDocument();
+      expect(screen.getByTestId('timeline-row-2')).toBeInTheDocument();
+    });
+    expect(mockGetSetSlots).toHaveBeenCalledWith(5);
+  });
+
+  it('hover on a curve block highlights the timeline row (and back)', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('slot-block-1')).toBeInTheDocument());
+
+    fireEvent.mouseEnter(screen.getByTestId('slot-block-1'));
+    expect(screen.getByTestId('timeline-row-1').className).toContain('timelineRowHover');
+
+    fireEvent.mouseLeave(screen.getByTestId('slot-block-1'));
+    fireEvent.mouseEnter(screen.getByTestId('timeline-row-0'));
+    // timeline hover feeds back into the shared state (row 0 highlighted)
+    expect(screen.getByTestId('timeline-row-0').className).toContain('timelineRowHover');
+  });
+
+  it('drag-release PATCHes the slot target', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('target-handle-0')).toBeInTheDocument());
+
+    fireEvent.pointerDown(screen.getByTestId('target-handle-0'), { clientY: 50 });
+    fireEvent.pointerMove(window, { clientY: 10 });
+    fireEvent.pointerUp(window);
+
+    await waitFor(() => expect(mockUpdateSlotTarget).toHaveBeenCalledTimes(1));
+    const [setId, slotId, energy] = mockUpdateSlotTarget.mock.calls[0];
+    expect(setId).toBe(5);
+    expect(slotId).toBe(1);
+    expect(typeof energy).toBe('number');
+  });
+
+  it('drag-release with big mismatch opens the replacement popover (gated)', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('target-handle-0')).toBeInTheDocument());
+
+    // jsdom rects are 0-size → eOfY ends at energy 10, far from track energy 5
+    fireEvent.pointerDown(screen.getByTestId('target-handle-0'), { clientY: 50 });
+    fireEvent.pointerMove(window, { clientY: -100 });
+    fireEvent.pointerUp(window);
+
+    await waitFor(() => expect(screen.getByTestId('replace-popover')).toBeInTheDocument());
+    // empty pool → empty state, gate toggle visible
+    expect(screen.getByTestId('replace-empty')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('replace-keep'));
+    expect(screen.queryByTestId('replace-popover')).not.toBeInTheDocument();
+  });
+
+  it('toggle off suppresses the replacement popover', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('target-handle-0')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('suggest-replacements-toggle'));
+    fireEvent.pointerDown(screen.getByTestId('target-handle-0'), { clientY: 50 });
+    fireEvent.pointerMove(window, { clientY: -100 });
+    fireEvent.pointerUp(window);
+
+    await waitFor(() => expect(mockUpdateSlotTarget).toHaveBeenCalled());
+    expect(screen.queryByTestId('replace-popover')).not.toBeInTheDocument();
+    window.localStorage.removeItem('wrzdj.curve.suggestReplacements');
+  });
+
+  it('applying a built-in template re-targets slots from the server response', async () => {
+    mockApplyCurveTemplate.mockResolvedValue({
+      targets: [
+        { slot_id: 1, target_energy: 7.2 },
+        { slot_id: 2, target_energy: 7.5 },
+        { slot_id: 3, target_energy: 7.8 },
+      ],
+      windows: [],
+    });
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('curve-toolbar')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('template-dropdown-trigger'));
+    await waitFor(() => expect(screen.getByTestId('apply-builtin-Club Peak')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('apply-builtin-Club Peak'));
+
+    await waitFor(() => expect(mockApplyCurveTemplate).toHaveBeenCalledTimes(1));
+    const [setId, source, mids] = mockApplyCurveTemplate.mock.calls[0];
+    expect(setId).toBe(5);
+    expect(source).toEqual({ builtin: 'Club Peak' });
+    expect(mids).toHaveLength(3);
+    // Timeline target chips reflect the applied targets
+    await waitFor(() => {
+      expect(screen.getByTestId('timeline-row-0')).toHaveTextContent('7.2');
+    });
+  });
+
+  it('click on a curve block requests a timeline scroll', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('slot-block-2')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('slot-block-2'));
+    // scrollIntoView only fires when out of view; with jsdom 0-rects rows are
+    // "in view", so just assert no crash and the row exists.
+    expect(screen.getByTestId('timeline-row-2')).toBeInTheDocument();
+  });
+
+  it('adding a vibe preset window persists via PUT', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('slot-block-0')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('vibe-dropdown-trigger'));
+    fireEvent.click(screen.getByTestId('vibe-preset-first-dance'));
+
+    await waitFor(() => expect(mockPutVibeWindows).toHaveBeenCalledTimes(1));
+    const [, windows] = mockPutVibeWindows.mock.calls[0];
+    expect(windows).toHaveLength(1);
+    expect(windows[0].label).toBe('First Dance');
+    expect(screen.getByText('FIRST DANCE')).toBeInTheDocument();
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import CurveEditor from '../components/CurveEditor';
+import type { SlotView, VibeWindowView } from '../components/types';
+
+beforeAll(() => {
+  // jsdom has no ResizeObserver
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+function mkSlot(
+  idx: number,
+  over: Partial<SlotView['track']> = {},
+  target: number | null = null,
+): SlotView {
+  return {
+    id: idx + 1,
+    position: idx,
+    locked: false,
+    targetEnergy: target,
+    track: {
+      id: `t${idx}`,
+      title: `Track ${idx}`,
+      artist: 'Artist',
+      durationSec: 200,
+      energy: 5,
+      bpm: 120,
+      key: '8A',
+      ...over,
+    },
+  };
+}
+
+const noWindows: VibeWindowView[] = [];
+
+function renderEditor(overrides: Partial<React.ComponentProps<typeof CurveEditor>> = {}) {
+  const props: React.ComponentProps<typeof CurveEditor> = {
+    slots: [mkSlot(0), mkSlot(1), mkSlot(2)],
+    view: 'normal',
+    windows: noWindows,
+    hoveredIdx: null,
+    onHover: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<CurveEditor {...props} />), props };
+}
+
+describe('CurveEditor', () => {
+  it('shows the empty state without slots', () => {
+    renderEditor({ slots: [] });
+    expect(screen.getByTestId('curve-empty')).toBeInTheDocument();
+  });
+
+  it('renders one block per slot and the derived curve line', () => {
+    renderEditor();
+    expect(screen.getByTestId('slot-block-0')).toBeInTheDocument();
+    expect(screen.getByTestId('slot-block-2')).toBeInTheDocument();
+    expect(screen.getByTestId('curve-line')).toBeInTheDocument();
+  });
+
+  it('renders amber hatch when target > energy and dashed line when target < energy', () => {
+    renderEditor({
+      slots: [
+        mkSlot(0, { energy: 4 }, 8), // target above
+        mkSlot(1, { energy: 8 }, 4), // target below
+        mkSlot(2, { energy: 5 }, null), // on-load target = track energy → no mismatch
+      ],
+    });
+    expect(screen.getByTestId('mismatch-above-0')).toBeInTheDocument();
+    expect(screen.getByTestId('mismatch-below-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('mismatch-above-2')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mismatch-below-2')).not.toBeInTheDocument();
+  });
+
+  it('renders no seams in normal view, tier-colored seams in bpm view', () => {
+    const slots = [
+      mkSlot(0, { bpm: 100 }),
+      mkSlot(1, { bpm: 101 }), // 1% → match (green)
+      mkSlot(2, { bpm: 120 }), // 15.8% → clash (red)
+    ];
+    const { rerender, props } = renderEditor({ slots });
+    expect(screen.queryByTestId('seam-band-0')).not.toBeInTheDocument();
+
+    rerender(<CurveEditor {...props} view="bpm" />);
+    expect(screen.getByTestId('seam-band-0').dataset.stroke).toBe('#22c55e');
+    expect(screen.getByTestId('seam-band-1').dataset.stroke).toBe('#ef4444');
+  });
+
+  it('renders key-view seams from camelot tiers', () => {
+    const slots = [
+      mkSlot(0, { key: '8A' }),
+      mkSlot(1, { key: '9A' }), // adjacent → perfect (green)
+      mkSlot(2, { key: '3A' }), // far → clash (red)
+    ];
+    renderEditor({ slots, view: 'key' });
+    expect(screen.getByTestId('seam-band-0').dataset.stroke).toBe('#22c55e');
+    expect(screen.getByTestId('seam-band-1').dataset.stroke).toBe('#ef4444');
+  });
+
+  it('shows the exact-metric chip on hovered seam (bpm %)', () => {
+    const slots = [mkSlot(0, { bpm: 100 }), mkSlot(1, { bpm: 104 })];
+    renderEditor({ slots, view: 'bpm', hoveredIdx: 0 });
+    expect(screen.getByTestId('seam-chip-0')).toHaveTextContent('3.8%');
+  });
+
+  it('emits hover + click for timeline sync', () => {
+    const onHover = vi.fn();
+    const onBlockClick = vi.fn();
+    renderEditor({ onHover, onBlockClick });
+    fireEvent.mouseEnter(screen.getByTestId('slot-block-1'));
+    expect(onHover).toHaveBeenCalledWith(1);
+    fireEvent.click(screen.getByTestId('slot-block-1'));
+    expect(onBlockClick).toHaveBeenCalledWith(1);
+    fireEvent.mouseLeave(screen.getByTestId('slot-block-1'));
+    expect(onHover).toHaveBeenCalledWith(null);
+  });
+
+  it('drag on a handle shows the live chip and fires onTargetDragEnd on release', () => {
+    const onTargetDragEnd = vi.fn();
+    renderEditor({ onTargetDragEnd });
+    const handle = screen.getByTestId('target-handle-1');
+    fireEvent.pointerDown(handle, { clientY: 100 });
+    expect(screen.getByTestId('drag-chip')).toBeInTheDocument();
+    fireEvent.pointerMove(window, { clientY: 0 });
+    fireEvent.pointerUp(window);
+    expect(onTargetDragEnd).toHaveBeenCalledTimes(1);
+    const [idx, energy] = onTargetDragEnd.mock.calls[0];
+    expect(idx).toBe(1);
+    expect(typeof energy).toBe('number');
+  });
+
+  it('renders vibe windows with label and supports right-click delete', () => {
+    const onWindowDelete = vi.fn();
+    renderEditor({
+      windows: [{ id: 'w1', t0: 0.2, t1: 0.4, label: 'First Dance' }],
+      onWindowDelete,
+      onWindowChange: vi.fn(),
+    });
+    expect(screen.getByTestId('vibe-window-w1')).toHaveTextContent('FIRST DANCE');
+    fireEvent.contextMenu(screen.getByTestId('vibe-window-header-w1'));
+    expect(onWindowDelete).toHaveBeenCalledWith('w1');
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/__tests__/CurveTemplateEditor.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/CurveTemplateEditor.test.tsx
@@ -86,7 +86,7 @@ describe('CurveTemplateEditorOverlay', () => {
 
   it('deletes a user template after confirm', () => {
     const onDelete = vi.fn();
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     renderOverlay({
       mode: 'edit',
       initial: { id: 4, name: 'Old', points: POINTS },
@@ -94,6 +94,7 @@ describe('CurveTemplateEditorOverlay', () => {
     });
     fireEvent.click(screen.getByTestId('template-delete'));
     expect(onDelete).toHaveBeenCalledWith(4);
+    confirmSpy.mockRestore();
   });
 
   it('escape closes the overlay', () => {

--- a/dashboard/app/(dj)/setbuilder/__tests__/CurveTemplateEditor.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/CurveTemplateEditor.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import CurveTemplateEditorOverlay from '../components/CurveTemplateEditorOverlay';
+import type { CurvePoint } from '@/lib/api-types';
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+const POINTS: CurvePoint[] = [
+  { t: 0, e: 3, label: 'Start', slow_start: false, slow_end: false },
+  { t: 0.5, e: 8, label: 'Peak', slow_start: false, slow_end: false },
+  { t: 1, e: 5, label: 'End', slow_start: false, slow_end: false },
+];
+
+function renderOverlay(over: Partial<React.ComponentProps<typeof CurveTemplateEditorOverlay>> = {}) {
+  const props: React.ComponentProps<typeof CurveTemplateEditorOverlay> = {
+    open: true,
+    mode: 'create',
+    initial: null,
+    isBuiltIn: false,
+    onSaveNew: vi.fn(),
+    onSaveCurrent: vi.fn(),
+    onDelete: vi.fn(),
+    onClose: vi.fn(),
+    ...over,
+  };
+  return { ...render(<CurveTemplateEditorOverlay {...props} />), props };
+}
+
+describe('CurveTemplateEditorOverlay', () => {
+  it('renders nothing when closed', () => {
+    renderOverlay({ open: false });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('starts blank in create mode with 3 default points', () => {
+    renderOverlay();
+    expect(screen.getByTestId('point-count')).toHaveTextContent('3');
+    expect(screen.getByLabelText('Template name')).toHaveValue('Untitled curve');
+  });
+
+  it('loads an existing template for editing and saves changes', () => {
+    const onSaveCurrent = vi.fn();
+    renderOverlay({
+      mode: 'edit',
+      initial: { id: 9, name: 'My Curve', points: POINTS },
+      onSaveCurrent,
+    });
+    fireEvent.change(screen.getByLabelText('Template name'), { target: { value: 'Renamed' } });
+    fireEvent.click(screen.getByTestId('template-save'));
+    expect(onSaveCurrent).toHaveBeenCalledTimes(1);
+    expect(onSaveCurrent.mock.calls[0][0]).toMatchObject({ id: 9, name: 'Renamed' });
+  });
+
+  it('built-in templates offer save-as-copy only, with read-only badge', () => {
+    const onSaveNew = vi.fn();
+    renderOverlay({
+      mode: 'edit',
+      isBuiltIn: true,
+      initial: { name: 'Wedding', points: POINTS },
+      onSaveNew,
+    });
+    expect(screen.getByText('read-only original')).toBeInTheDocument();
+    expect(screen.queryByTestId('template-save')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('template-delete')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Template name')).toHaveValue('Wedding (copy)');
+    fireEvent.click(screen.getByTestId('template-save-as'));
+    expect(onSaveNew).toHaveBeenCalledTimes(1);
+    expect(onSaveNew.mock.calls[0][0].name).toBe('Wedding (copy)');
+  });
+
+  it('removes interior points but never endpoints', () => {
+    renderOverlay({ mode: 'edit', initial: { id: 1, name: 'X', points: POINTS } });
+    expect(screen.getByTestId('point-count')).toHaveTextContent('3');
+    // endpoints have no delete button
+    expect(screen.queryByTestId('point-del-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('point-del-2')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('point-del-1'));
+    expect(screen.getByTestId('point-count')).toHaveTextContent('2');
+  });
+
+  it('deletes a user template after confirm', () => {
+    const onDelete = vi.fn();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    renderOverlay({
+      mode: 'edit',
+      initial: { id: 4, name: 'Old', points: POINTS },
+      onDelete,
+    });
+    fireEvent.click(screen.getByTestId('template-delete'));
+    expect(onDelete).toHaveBeenCalledWith(4);
+  });
+
+  it('escape closes the overlay', () => {
+    const onClose = vi.fn();
+    renderOverlay({ onClose });
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/__tests__/ReplacePopover.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/ReplacePopover.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ReplacePopover from '../components/ReplacePopover';
+import { rankReplacementCandidates } from '../components/curveMath';
+import type { SlotView, TrackView } from '../components/types';
+
+function mkTrack(over: Partial<TrackView> = {}): TrackView {
+  return {
+    id: 'cur',
+    title: 'Current Song',
+    artist: 'Artist',
+    durationSec: 200,
+    energy: 5,
+    bpm: 120,
+    key: '8A',
+    ...over,
+  };
+}
+
+const slot: SlotView = {
+  id: 11,
+  position: 0,
+  locked: false,
+  targetEnergy: 8,
+  track: mkTrack(),
+};
+
+const prompt = { slotIdx: 0, targetEnergy: 8, anchorX: 100, anchorY: 100 };
+
+describe('ReplacePopover', () => {
+  it('renders ranked candidates and fires onReplace with slot + track ids', () => {
+    const pool = [
+      mkTrack({ id: 'a', title: 'Fit A', energy: 8, bpm: 121, key: '8A' }),
+      mkTrack({ id: 'b', title: 'Fit B', energy: 7.6, bpm: 122, key: '9A' }),
+    ];
+    const candidates = rankReplacementCandidates(8, null, pool, new Set());
+    const onReplace = vi.fn();
+    render(
+      <ReplacePopover
+        prompt={prompt}
+        slot={slot}
+        candidates={candidates}
+        onReplace={onReplace}
+        onKeep={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('replace-popover')).toBeInTheDocument();
+    expect(screen.getByText('Fit A')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('replace-candidate-a'));
+    expect(onReplace).toHaveBeenCalledWith(11, 'a');
+  });
+
+  it('shows the empty state when no candidates fit', () => {
+    render(
+      <ReplacePopover
+        prompt={prompt}
+        slot={slot}
+        candidates={[]}
+        onReplace={vi.fn()}
+        onKeep={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('replace-empty')).toBeInTheDocument();
+  });
+
+  it('keep + dismiss callbacks', () => {
+    const onKeep = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <ReplacePopover
+        prompt={prompt}
+        slot={slot}
+        candidates={[]}
+        onReplace={vi.fn()}
+        onKeep={onKeep}
+        onDismiss={onDismiss}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('replace-keep'));
+    expect(onKeep).toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId('replace-backdrop'));
+    expect(onDismiss).toHaveBeenCalled();
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/__tests__/curveMath.test.ts
+++ b/dashboard/app/(dj)/setbuilder/__tests__/curveMath.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from 'vitest';
+import {
+  interpolateEnergy,
+  slotMidpoints,
+  bpmPercentDelta,
+  camelotMixTier,
+  bpmCompat,
+  camelotCompat,
+  parseCamelot,
+  rankReplacementCandidates,
+  slotBlocksFromSlots,
+  fmtTime,
+  VIBE_PRESETS,
+  REPLACE_PROMPT_THRESHOLD,
+} from '../components/curveMath';
+import type { SlotView, TrackView } from '../components/types';
+import { slotViewFromApi, effectiveTarget } from '../components/types';
+
+function mkTrack(over: Partial<TrackView> = {}): TrackView {
+  return {
+    id: 't1',
+    title: 'Song',
+    artist: 'Artist',
+    durationSec: 200,
+    energy: 5,
+    bpm: 120,
+    key: '8A',
+    ...over,
+  };
+}
+
+function mkSlot(idx: number, over: Partial<TrackView> = {}, target: number | null = null): SlotView {
+  return {
+    id: idx + 1,
+    position: idx,
+    locked: false,
+    targetEnergy: target,
+    track: mkTrack({ id: `t${idx}`, ...over }),
+  };
+}
+
+describe('interpolateEnergy', () => {
+  const linear = [
+    { t: 0, e: 0, label: null, slow_start: false, slow_end: false },
+    { t: 1, e: 10, label: null, slow_start: false, slow_end: false },
+  ];
+
+  it('interpolates linearly', () => {
+    expect(interpolateEnergy(linear, 0.5)).toBeCloseTo(5);
+    expect(interpolateEnergy(linear, 0.25)).toBeCloseTo(2.5);
+  });
+
+  it('clamps t outside [0,1]', () => {
+    expect(interpolateEnergy(linear, -1)).toBe(0);
+    expect(interpolateEnergy(linear, 2)).toBe(10);
+  });
+
+  it('handles multi-segment curves', () => {
+    const pts = [
+      { t: 0, e: 2, label: null, slow_start: false, slow_end: false },
+      { t: 0.5, e: 8, label: null, slow_start: false, slow_end: false },
+      { t: 1, e: 4, label: null, slow_start: false, slow_end: false },
+    ];
+    expect(interpolateEnergy(pts, 0.25)).toBeCloseTo(5);
+    expect(interpolateEnergy(pts, 0.75)).toBeCloseTo(6);
+  });
+});
+
+describe('slotMidpoints', () => {
+  it('uses duration-weighted midpoints', () => {
+    const slots = [mkSlot(0, { durationSec: 100 }), mkSlot(1, { durationSec: 300 })];
+    expect(slotMidpoints(slots)).toEqual([0.125, 0.625]);
+  });
+});
+
+describe('bpmPercentDelta (percentage thresholds — acceptance)', () => {
+  it('≤2% is match', () => {
+    // 100 → 102 = 1.96% of destination 102
+    expect(bpmPercentDelta(100, 102).tier).toBe('match');
+  });
+  it('2-5% is good', () => {
+    expect(bpmPercentDelta(100, 104).tier).toBe('good'); // 3.85%
+  });
+  it('5-8% is stretch', () => {
+    expect(bpmPercentDelta(100, 107).tier).toBe('stretch'); // 6.54%
+  });
+  it('>8% is clash', () => {
+    expect(bpmPercentDelta(100, 120).tier).toBe('clash'); // 16.7%
+  });
+  it('detects half/double time: 80 vs 160 is a match, not a clash', () => {
+    const d = bpmPercentDelta(80, 160);
+    expect(d.tier).toBe('match');
+    expect(d.halfDouble).toBe(true);
+    expect(d.pct).toBeCloseTo(0);
+  });
+  it('same large absolute delta can be different tiers at different tempos (percentage, not absolute)', () => {
+    // +8 BPM at 178 destination = 4.5% (good); +8 at 88 destination = 9.1% (clash)
+    expect(bpmPercentDelta(170, 178).tier).toBe('good');
+    expect(bpmPercentDelta(80, 88).tier).toBe('clash');
+  });
+  it('unknown when missing', () => {
+    expect(bpmPercentDelta(null, 120).tier).toBe('unknown');
+  });
+});
+
+describe('parseCamelot / camelotMixTier', () => {
+  it('parses camelot codes', () => {
+    expect(parseCamelot('8A')).toEqual({ num: 8, letter: 'A' });
+    expect(parseCamelot('12b')).toEqual({ num: 12, letter: 'B' });
+    expect(parseCamelot('13A')).toEqual({ num: null, letter: null });
+    expect(parseCamelot(null)).toEqual({ num: null, letter: null });
+  });
+  it('same key and relative maj/min are perfect', () => {
+    expect(camelotMixTier('8A', '8A').tier).toBe('perfect');
+    expect(camelotMixTier('8A', '8B').tier).toBe('perfect');
+  });
+  it('adjacent same-ring is perfect, cross-ring ±1 is good', () => {
+    expect(camelotMixTier('8A', '9A').tier).toBe('perfect');
+    expect(camelotMixTier('8A', '9B').tier).toBe('good');
+  });
+  it('wraps the wheel: 12A ↔ 1A is adjacent', () => {
+    expect(camelotMixTier('12A', '1A').tier).toBe('perfect');
+  });
+  it('far keys clash', () => {
+    expect(camelotMixTier('8A', '2A').tier).toBe('clash');
+  });
+  it('unknown keys are unknown', () => {
+    expect(camelotMixTier(null, '8A').tier).toBe('unknown');
+  });
+});
+
+describe('compat scores', () => {
+  it('bpmCompat honors half-time', () => {
+    expect(bpmCompat(80, 160)).toBe(1.0);
+    expect(bpmCompat(120, 121)).toBe(1.0);
+    expect(bpmCompat(100, 150)).toBe(0.15);
+  });
+  it('camelotCompat tiers', () => {
+    expect(camelotCompat('8A', '8A')).toBe(1.0);
+    expect(camelotCompat('8A', '8B')).toBe(0.9);
+    expect(camelotCompat('8A', '9A')).toBe(0.85);
+    expect(camelotCompat(null, '8A')).toBe(0.5);
+  });
+});
+
+describe('rankReplacementCandidates', () => {
+  const pool: TrackView[] = [
+    mkTrack({ id: 'a', energy: 8, bpm: 122, key: '8A' }),
+    mkTrack({ id: 'b', energy: 7.5, bpm: 150, key: '2B' }),
+    mkTrack({ id: 'c', energy: 3, bpm: 120, key: '8A' }), // too far from target 8
+    mkTrack({ id: 'd', energy: 8, bpm: 121, key: '9A' }),
+    mkTrack({ id: 'e', energy: 8.2, bpm: 123, key: '8B' }),
+    mkTrack({ id: 'f', energy: 7.8, bpm: 119, key: '8A' }),
+    mkTrack({ id: 'g', energy: 8.1, bpm: 124, key: '7A' }),
+    mkTrack({ id: 'in-set', energy: 8, bpm: 122, key: '8A' }),
+  ];
+  const prev = mkTrack({ id: 'prev', bpm: 120, key: '8A' });
+
+  it('excludes in-set tracks, filters ±2.5 energy, caps at top 5', () => {
+    const ranked = rankReplacementCandidates(8, prev, pool, new Set(['in-set']));
+    expect(ranked.length).toBe(5);
+    expect(ranked.map((c) => c.track.id)).not.toContain('in-set');
+    expect(ranked.map((c) => c.track.id)).not.toContain('c');
+  });
+
+  it('ranks energy+bpm+key fit highest first', () => {
+    const ranked = rankReplacementCandidates(8, prev, pool, new Set());
+    expect(ranked[0].score).toBeGreaterThanOrEqual(ranked[ranked.length - 1].score);
+    // 'a' (exact energy, close bpm, same key) makes the cut; 'b' (bpm jump +
+    // key clash) scores worst of the 7 eligible and is cut from the top 5.
+    const ids = ranked.map((c) => c.track.id);
+    expect(ids).toContain('a');
+    expect(ids).not.toContain('b');
+  });
+
+  it('threshold constant matches the spec', () => {
+    expect(REPLACE_PROMPT_THRESHOLD).toBe(0.8);
+  });
+});
+
+describe('slotBlocksFromSlots / effectiveTarget', () => {
+  it('sizes blocks by duration and applies target fallback to track energy', () => {
+    const slots = [
+      mkSlot(0, { durationSec: 100, energy: 4 }),
+      mkSlot(1, { durationSec: 300, energy: 6 }, 9),
+    ];
+    const blocks = slotBlocksFromSlots(slots, 400);
+    expect(blocks[0].width).toBeCloseTo(100);
+    expect(blocks[1].width).toBeCloseTo(300);
+    expect(blocks[0].target).toBe(4); // null target → track energy
+    expect(blocks[1].target).toBe(9);
+    expect(effectiveTarget(slots[0])).toBe(4);
+  });
+});
+
+describe('slotViewFromApi', () => {
+  it('fills safe defaults for missing track metadata', () => {
+    const v = slotViewFromApi({
+      id: 7,
+      position: 2,
+      track_id: null,
+      locked: false,
+      target_energy: null,
+      notes: null,
+    });
+    expect(v.track.durationSec).toBe(210);
+    expect(v.track.energy).toBe(5);
+    expect(v.targetEnergy).toBeNull();
+  });
+});
+
+describe('misc', () => {
+  it('fmtTime', () => {
+    expect(fmtTime(75)).toBe('1:15');
+    expect(fmtTime(3660)).toBe('1:01h');
+  });
+  it('15 vibe presets with the spec anchors', () => {
+    expect(VIBE_PRESETS.length).toBe(15);
+    const labels = VIBE_PRESETS.map((p) => p.label);
+    expect(labels).toContain('First Dance');
+    expect(labels).toContain('Cocktail Hour');
+    expect(labels).toContain('Peak Build');
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+/**
+ * Builder workspace (#389) — owns the slot data + curve↔timeline shared
+ * hover state and renders the Curve and Timeline grid panels. Mounted by
+ * the builder page in place of the Phase 0 placeholders.
+ */
+
+import { useEffect, useState } from 'react';
+import { api } from '@/lib/api';
+import CurvePanel from './CurvePanel';
+import TimelinePanel, { type ScrollRequest } from './TimelinePanel';
+import type { SlotView } from './types';
+import { slotViewFromApi } from './types';
+import sbStyles from '../setbuilder.module.css';
+
+export default function BuilderWorkspace({ setId }: { setId: number }) {
+  const [slots, setSlots] = useState<SlotView[]>([]);
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const [scrollRequest, setScrollRequest] = useState<ScrollRequest | null>(null);
+
+  useEffect(() => {
+    api
+      .getSetSlots(setId)
+      .then((rows) => setSlots(rows.map(slotViewFromApi)))
+      .catch(() => setSlots([]));
+  }, [setId]);
+
+  return (
+    <>
+      <section className={`${sbStyles.panel} ${sbStyles.panelCurve}`} aria-label="Curve">
+        <div className={sbStyles.panelHeader}>Curve</div>
+        <CurvePanel
+          setId={setId}
+          slots={slots}
+          onSlotsChange={(updater) => setSlots(updater)}
+          hoveredIdx={hoveredIdx}
+          onHover={setHoveredIdx}
+          onBlockClick={(idx) => setScrollRequest((prev) => ({ idx, n: (prev?.n ?? 0) + 1 }))}
+        />
+      </section>
+
+      <section className={`${sbStyles.panel} ${sbStyles.panelTimeline}`} aria-label="Timeline">
+        <div className={sbStyles.panelHeader}>Timeline</div>
+        <TimelinePanel
+          slots={slots}
+          hoveredIdx={hoveredIdx}
+          onHover={setHoveredIdx}
+          scrollRequest={scrollRequest}
+        />
+      </section>
+    </>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
@@ -20,10 +20,18 @@ export default function BuilderWorkspace({ setId }: { setId: number }) {
   const [scrollRequest, setScrollRequest] = useState<ScrollRequest | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
     api
       .getSetSlots(setId)
-      .then((rows) => setSlots(rows.map(slotViewFromApi)))
-      .catch(() => setSlots([]));
+      .then((rows) => {
+        if (!cancelled) setSlots(rows.map(slotViewFromApi));
+      })
+      .catch(() => {
+        if (!cancelled) setSlots([]);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [setId]);
 
   return (

--- a/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
@@ -1,0 +1,530 @@
+'use client';
+
+/**
+ * Slot-coupled energy curve editor (#389).
+ *
+ * The curve is DERIVED: a polyline through each slot's target energy at the
+ * slot's midpoint. Blocks are sized by track duration (x) and intrinsic
+ * energy (y). Per-slot vertical drag handles retarget; mismatch renders as
+ * an amber hatch (target above energy) or dashed line (target below).
+ * BPM/Key view modes render tier-colored friction bands at block seams.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  BPM_TIER_COLORS,
+  KEY_TIER_COLORS,
+  bpmPercentDelta,
+  camelotMixTier,
+  fmtTime,
+  slotBlocksFromSlots,
+} from './curveMath';
+import type { SlotView, VibeWindowView } from './types';
+import styles from './curve.module.css';
+
+export type CurveViewMode = 'normal' | 'bpm' | 'key';
+
+const NEON = '#00f5d4';
+const NEON_PURPLE = '#b78bff';
+const WARNING = '#f59e0b';
+
+interface WindowDrag {
+  id: string;
+  mode: 'move' | 'left' | 'right';
+  startMouseT: number;
+  startT0: number;
+  startT1: number;
+}
+
+export interface CurveEditorProps {
+  slots: SlotView[];
+  view: CurveViewMode;
+  windows: VibeWindowView[];
+  hoveredIdx: number | null;
+  onHover: (idx: number | null) => void;
+  onBlockClick?: (idx: number) => void;
+  onTargetDragEnd?: (idx: number, energy: number, anchor: { x: number; y: number }) => void;
+  onWindowChange?: (id: string, patch: Partial<VibeWindowView>) => void;
+  onWindowCommit?: (id: string) => void;
+  onWindowDelete?: (id: string) => void;
+}
+
+export default function CurveEditor({
+  slots,
+  view,
+  windows,
+  hoveredIdx,
+  onHover,
+  onBlockClick,
+  onTargetDragEnd,
+  onWindowChange,
+  onWindowCommit,
+  onWindowDelete,
+}: CurveEditorProps) {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [w, setW] = useState(800);
+  const [h, setH] = useState(220);
+  const [dragIdx, setDragIdx] = useState<number | null>(null);
+  const [dragEnergy, setDragEnergy] = useState<number | null>(null);
+  const [winDrag, setWinDrag] = useState<WindowDrag | null>(null);
+
+  useEffect(() => {
+    if (!wrapRef.current) return;
+    const ro = new ResizeObserver((entries) => {
+      for (const e of entries) {
+        setW(Math.max(300, e.contentRect.width));
+        setH(Math.max(140, e.contentRect.height));
+      }
+    });
+    ro.observe(wrapRef.current);
+    return () => ro.disconnect();
+  }, []);
+
+  const yOf = (e: number) => h - (e / 10) * h;
+  const eOfY = (y: number) => Math.max(0, Math.min(10, (1 - y / h) * 10));
+
+  const totalSec = slots.reduce((acc, s) => acc + s.track.durationSec, 0);
+  const baseBlocks = slotBlocksFromSlots(slots, w);
+  const blocks = baseBlocks.map((b) =>
+    dragIdx === b.idx && dragEnergy != null ? { ...b, target: dragEnergy } : b,
+  );
+
+  // Per-slot handle drag (vertical only)
+  useEffect(() => {
+    if (dragIdx == null) return;
+    const onMove = (ev: PointerEvent) => {
+      if (!svgRef.current) return;
+      const rect = svgRef.current.getBoundingClientRect();
+      const scaleY = rect.height > 0 ? h / rect.height : 1;
+      const y = (ev.clientY - rect.top) * scaleY;
+      setDragEnergy(Math.round(eOfY(y) * 10) / 10);
+    };
+    const onUp = () => {
+      if (dragEnergy != null && onTargetDragEnd) {
+        const b = blocks[dragIdx];
+        onTargetDragEnd(
+          dragIdx,
+          dragEnergy,
+          b ? { x: b.xMid, y: yOf(dragEnergy) } : { x: 0, y: 0 },
+        );
+      }
+      setDragIdx(null);
+      setDragEnergy(null);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dragIdx, dragEnergy, h]);
+
+  // Vibe-window move/resize drag
+  useEffect(() => {
+    if (!winDrag) return;
+    const onMove = (ev: PointerEvent) => {
+      if (!svgRef.current || !onWindowChange) return;
+      const rect = svgRef.current.getBoundingClientRect();
+      const mouseT = Math.max(0, Math.min(1, (ev.clientX - rect.left) / Math.max(1, rect.width)));
+      const dt = mouseT - winDrag.startMouseT;
+      if (winDrag.mode === 'move') {
+        const span = winDrag.startT1 - winDrag.startT0;
+        const t0 = Math.max(0, Math.min(1 - span, winDrag.startT0 + dt));
+        onWindowChange(winDrag.id, { t0, t1: t0 + span });
+      } else if (winDrag.mode === 'left') {
+        const t0 = Math.max(0, Math.min(winDrag.startT1 - 0.02, winDrag.startT0 + dt));
+        onWindowChange(winDrag.id, { t0 });
+      } else {
+        const t1 = Math.max(winDrag.startT0 + 0.02, Math.min(1, winDrag.startT1 + dt));
+        onWindowChange(winDrag.id, { t1 });
+      }
+    };
+    const onUp = () => {
+      if (onWindowCommit) onWindowCommit(winDrag.id);
+      setWinDrag(null);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+  }, [winDrag, onWindowChange, onWindowCommit]);
+
+  const startWindowDrag =
+    (id: string, mode: WindowDrag['mode'], t0: number, t1: number) =>
+    (ev: React.PointerEvent) => {
+      if (!svgRef.current || !onWindowChange) return;
+      ev.preventDefault();
+      ev.stopPropagation();
+      const rect = svgRef.current.getBoundingClientRect();
+      const mouseT = (ev.clientX - rect.left) / Math.max(1, rect.width);
+      setWinDrag({ id, mode, startMouseT: mouseT, startT0: t0, startT1: t1 });
+    };
+
+  const linePath = blocks
+    .map((b, i) => `${i === 0 ? 'M' : 'L'} ${b.xMid.toFixed(2)} ${yOf(b.target).toFixed(2)}`)
+    .join(' ');
+
+  if (slots.length === 0) {
+    return (
+      <div className={styles.emptyState} data-testid="curve-empty">
+        Add tracks to the timeline to shape the energy curve.
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.canvasWrap} ref={wrapRef} data-testid="curve-canvas">
+      <div className={styles.yaxis}>
+        <div>10·peak</div>
+        <div>7</div>
+        <div>5</div>
+        <div>2</div>
+        <div>0</div>
+      </div>
+      <div className={styles.xaxis}>
+        {[0, 0.25, 0.5, 0.75, 1].map((t) => (
+          <div key={t}>{fmtTime(t * totalSec)}</div>
+        ))}
+      </div>
+      <svg
+        ref={svgRef}
+        className={styles.svg}
+        viewBox={`0 0 ${w} ${h}`}
+        preserveAspectRatio="none"
+      >
+        <defs>
+          <pattern
+            id="curveGrid"
+            x="0"
+            y="0"
+            width={w / 8}
+            height={h / 5}
+            patternUnits="userSpaceOnUse"
+          >
+            <path
+              d={`M ${w / 8} 0 L 0 0 0 ${h / 5}`}
+              fill="none"
+              stroke="rgba(255,255,255,0.04)"
+              strokeWidth="1"
+            />
+          </pattern>
+          <pattern id="mismatchPattern" patternUnits="userSpaceOnUse" width="6" height="6">
+            <path
+              d="M -1 1 l 2 -2 M 0 6 l 6 -6 M 5 7 l 2 -2"
+              stroke={WARNING}
+              strokeWidth="0.8"
+              strokeOpacity="0.45"
+            />
+          </pattern>
+        </defs>
+
+        <rect width={w} height={h} fill="url(#curveGrid)" />
+
+        {/* Peak floor reference */}
+        <line
+          x1="0"
+          y1={yOf(8)}
+          x2={w}
+          y2={yOf(8)}
+          stroke="rgba(255,157,63,0.18)"
+          strokeDasharray="3 4"
+          strokeWidth="1"
+        />
+
+        {/* Vibe windows */}
+        {windows.map((win) => {
+          const x = win.t0 * w;
+          const width = Math.max(2, (win.t1 - win.t0) * w);
+          const isDragging = winDrag?.id === win.id;
+          const headerH = 22;
+          return (
+            <g key={win.id} data-testid={`vibe-window-${win.id}`}>
+              <rect
+                x={x}
+                y={0}
+                width={width}
+                height={h}
+                fill={isDragging ? 'rgba(183,139,255,0.18)' : 'rgba(183,139,255,0.07)'}
+                stroke="rgba(183,139,255,0.4)"
+                strokeWidth="1"
+                pointerEvents="none"
+              />
+              <line x1={x} x2={x} y1={0} y2={h} stroke="rgba(183,139,255,0.6)" strokeWidth="1.5" pointerEvents="none" />
+              <line x1={x + width} x2={x + width} y1={0} y2={h} stroke="rgba(183,139,255,0.6)" strokeWidth="1.5" pointerEvents="none" />
+              {/* Header bar: move drag + right-click delete */}
+              <rect
+                x={x}
+                y={0}
+                width={width}
+                height={headerH}
+                fill={isDragging ? 'rgba(183,139,255,0.5)' : 'rgba(183,139,255,0.28)'}
+                stroke="rgba(183,139,255,0.5)"
+                strokeWidth="0.5"
+                style={{ cursor: 'move' }}
+                data-testid={`vibe-window-header-${win.id}`}
+                onContextMenu={(ev) => {
+                  ev.preventDefault();
+                  if (onWindowDelete) onWindowDelete(win.id);
+                }}
+                onPointerDown={startWindowDrag(win.id, 'move', win.t0, win.t1)}
+              />
+              <text
+                x={x + 7}
+                y={headerH / 2 + 3.5}
+                fontSize="9.5"
+                fill="rgb(220,200,255)"
+                fontWeight="700"
+                letterSpacing="0.06em"
+                pointerEvents="none"
+              >
+                {win.label.toUpperCase()}
+              </text>
+              {/* Resize handles */}
+              <rect
+                x={x - 5}
+                y={0}
+                width={10}
+                height={h}
+                fill="transparent"
+                style={{ cursor: 'ew-resize' }}
+                onPointerDown={startWindowDrag(win.id, 'left', win.t0, win.t1)}
+              />
+              <rect
+                x={x + width - 5}
+                y={0}
+                width={10}
+                height={h}
+                fill="transparent"
+                style={{ cursor: 'ew-resize' }}
+                onPointerDown={startWindowDrag(win.id, 'right', win.t0, win.t1)}
+              />
+            </g>
+          );
+        })}
+
+        {/* Slot blocks */}
+        {blocks.map((b) => {
+          const isHover = hoveredIdx === b.idx;
+          const isDragging = dragIdx === b.idx;
+          const gap = view === 'normal' ? 1.5 : 4;
+          const blockH = (b.energy / 10) * h;
+          const targetY = yOf(b.target);
+          const targetAbove = b.target > b.energy + 0.5;
+          const targetBelow = b.energy > b.target + 0.5;
+          return (
+            <g
+              key={`sb-${b.idx}`}
+              data-testid={`slot-block-${b.idx}`}
+              onMouseEnter={() => onHover(b.idx)}
+              onMouseLeave={() => onHover(null)}
+              onClick={(ev) => {
+                if ((ev.target as SVGElement).dataset?.handle) return;
+                if (onBlockClick) onBlockClick(b.idx);
+              }}
+              style={{ cursor: 'pointer' }}
+            >
+              {/* Block (intrinsic energy) */}
+              <rect
+                x={b.x0 + gap / 2}
+                y={h - blockH}
+                width={Math.max(1, b.width - gap)}
+                height={blockH}
+                fill={NEON}
+                fillOpacity={isHover ? 0.55 : 0.13}
+                stroke={isHover || isDragging ? NEON : 'transparent'}
+                strokeWidth={isHover || isDragging ? 1.5 : 1}
+              />
+              {/* Peak cap */}
+              {b.energy >= 8 && (
+                <rect
+                  x={b.x0 + gap / 2}
+                  y={h - blockH}
+                  width={Math.max(1, b.width - gap)}
+                  height={3}
+                  fill="#ff9d3f"
+                  fillOpacity={isHover ? 0.95 : 0.7}
+                />
+              )}
+              {/* Mismatch: target above energy — amber hatch between block top and target */}
+              {targetAbove && (
+                <>
+                  <rect
+                    data-testid={`mismatch-above-${b.idx}`}
+                    x={b.x0 + gap / 2}
+                    y={targetY}
+                    width={Math.max(1, b.width - gap)}
+                    height={Math.max(0, h - blockH - targetY)}
+                    fill={WARNING}
+                    fillOpacity={isDragging ? 0.28 : 0.16}
+                  />
+                  <rect
+                    x={b.x0 + gap / 2}
+                    y={targetY}
+                    width={Math.max(1, b.width - gap)}
+                    height={Math.max(0, h - blockH - targetY)}
+                    fill="url(#mismatchPattern)"
+                  />
+                </>
+              )}
+              {/* Mismatch: target below energy — dashed line inside the block */}
+              {targetBelow && (
+                <line
+                  data-testid={`mismatch-below-${b.idx}`}
+                  x1={b.x0 + gap / 2}
+                  x2={b.x1 - gap / 2}
+                  y1={targetY}
+                  y2={targetY}
+                  stroke={WARNING}
+                  strokeWidth="1.5"
+                  strokeDasharray="3 2"
+                />
+              )}
+              {/* Invisible hit-target */}
+              <rect x={b.x0} y={0} width={b.width} height={h} fill="transparent" />
+            </g>
+          );
+        })}
+
+        {/* Friction seams (BPM / Key views) */}
+        {view !== 'normal' &&
+          blocks.slice(0, -1).map((b, i) => {
+            const next = blocks[i + 1];
+            const a = slots[i].track;
+            const z = slots[i + 1].track;
+            let color: { stroke: string };
+            let chipText: string;
+            let isClash: boolean;
+            if (view === 'bpm') {
+              const info = bpmPercentDelta(a.bpm, z.bpm);
+              color = BPM_TIER_COLORS[info.tier];
+              chipText =
+                info.pct == null
+                  ? '?'
+                  : `${info.pct < 0.05 ? '0' : info.pct.toFixed(1)}%${info.halfDouble ? ' · 2×' : ''}`;
+              isClash = info.tier === 'clash';
+            } else {
+              const info = camelotMixTier(a.key, z.key);
+              color = KEY_TIER_COLORS[info.tier];
+              chipText = info.label;
+              isClash = info.tier === 'clash';
+            }
+            const seamX = (b.x1 + next.x0) / 2;
+            const seamW = Math.max(3, next.x0 - b.x1 - 0.5);
+            // Band sized to the SHORTER neighbor block
+            const meetTop = h - Math.min((b.energy / 10) * h, (next.energy / 10) * h);
+            const isHovered = hoveredIdx === i || hoveredIdx === i + 1;
+            return (
+              <g key={`seam-${i}`} pointerEvents="none" data-testid={`seam-${view}-${i}`}>
+                <rect
+                  data-testid={`seam-band-${i}`}
+                  data-stroke={color.stroke}
+                  x={seamX - seamW / 2}
+                  y={meetTop}
+                  width={seamW}
+                  height={h - meetTop}
+                  fill={color.stroke}
+                  fillOpacity={isHovered ? 0.95 : isClash ? 0.85 : 0.7}
+                  rx={1}
+                />
+                <circle cx={seamX} cy={h - 1} r={isClash ? 3.5 : 3} fill={color.stroke} />
+                {isHovered && (
+                  <g
+                    transform={`translate(${Math.min(Math.max(seamX, 40), w - 40)}, ${h - 18})`}
+                    data-testid={`seam-chip-${i}`}
+                  >
+                    <rect
+                      x={-Math.max(30, chipText.length * 3.4 + 7)}
+                      y={-9}
+                      width={Math.max(60, chipText.length * 6.8 + 14)}
+                      height={16}
+                      rx={3}
+                      fill="var(--bg)"
+                      stroke={color.stroke}
+                      strokeOpacity={0.85}
+                    />
+                    <text
+                      x={0}
+                      y={2.5}
+                      fontSize="9.5"
+                      fill={color.stroke}
+                      fontWeight="700"
+                      textAnchor="middle"
+                    >
+                      {chipText}
+                    </text>
+                  </g>
+                )}
+              </g>
+            );
+          })}
+
+        {/* Derived target curve line */}
+        {linePath && (
+          <path
+            data-testid="curve-line"
+            d={linePath}
+            fill="none"
+            stroke={NEON}
+            strokeWidth={2}
+            strokeLinejoin="miter"
+            pointerEvents="none"
+          />
+        )}
+
+        {/* Drag handles — one per slot at its target energy */}
+        {blocks.map((b) => {
+          const isHover = hoveredIdx === b.idx;
+          const isDragging = dragIdx === b.idx;
+          const r = isDragging ? 7 : isHover ? 6 : 5;
+          const targetY = yOf(b.target);
+          return (
+            <g key={`h-${b.idx}`} transform={`translate(${b.xMid},${targetY})`}>
+              <circle
+                r={12}
+                fill="transparent"
+                data-handle="1"
+                data-testid={`target-handle-${b.idx}`}
+                onPointerDown={(ev) => {
+                  ev.preventDefault();
+                  ev.stopPropagation();
+                  setDragIdx(b.idx);
+                  setDragEnergy(b.target);
+                }}
+                onMouseEnter={() => onHover(b.idx)}
+                style={{ cursor: dragIdx != null ? 'grabbing' : 'ns-resize' }}
+              />
+              <circle
+                className={`${styles.point} ${isDragging ? styles.pointSelected : ''}`}
+                r={r}
+                pointerEvents="none"
+              />
+              {/* Live value chip while dragging */}
+              {isDragging && (
+                <g transform="translate(0,-22)" pointerEvents="none" data-testid="drag-chip">
+                  <rect x={-26} y={-11} width="52" height="20" rx="3" fill="var(--bg)" stroke={NEON} />
+                  <text
+                    x="0"
+                    y="3"
+                    fontSize="11"
+                    fill={NEON}
+                    fontWeight="700"
+                    textAnchor="middle"
+                  >
+                    {(dragEnergy ?? b.target).toFixed(1)}
+                  </text>
+                </g>
+              )}
+            </g>
+          );
+        })}
+
+        {/* Pairing seam markers land with #392; transport playhead with #393 */}
+        <g data-color-ref={NEON_PURPLE} display="none" />
+      </svg>
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
@@ -118,7 +118,6 @@ export default function CurveEditor({
       window.removeEventListener('pointermove', onMove);
       window.removeEventListener('pointerup', onUp);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dragIdx, dragEnergy, h]);
 
   // Vibe-window move/resize drag

--- a/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
@@ -103,11 +103,17 @@ export default function CurveEditor({
     const onUp = () => {
       if (dragEnergy != null && onTargetDragEnd) {
         const b = blocks[dragIdx];
-        onTargetDragEnd(
-          dragIdx,
-          dragEnergy,
-          b ? { x: b.xMid, y: yOf(dragEnergy) } : { x: 0, y: 0 },
-        );
+        // Convert SVG-local coords to viewport coords — the popover positions
+        // with `position: fixed`.
+        const rect = svgRef.current?.getBoundingClientRect();
+        const anchor =
+          b && rect
+            ? {
+                x: rect.left + (b.xMid / Math.max(1, w)) * rect.width,
+                y: rect.top + (yOf(dragEnergy) / Math.max(1, h)) * rect.height,
+              }
+            : { x: 0, y: 0 };
+        onTargetDragEnd(dragIdx, dragEnergy, anchor);
       }
       setDragIdx(null);
       setDragEnergy(null);

--- a/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
@@ -110,6 +110,8 @@ export default function CurvePanel({
   const windowsLoadedFor = useRef<number | null>(null);
   useEffect(() => {
     if (totalSec <= 0 || windowsLoadedFor.current === setId) return;
+    // Mark eagerly so in-flight fetches dedupe; roll back on failure so a
+    // transient error doesn't block the load for the rest of the session.
     windowsLoadedFor.current = setId;
     api
       .getVibeWindows(setId)
@@ -123,7 +125,10 @@ export default function CurvePanel({
           })),
         );
       })
-      .catch(() => setWindows([]));
+      .catch(() => {
+        if (windowsLoadedFor.current === setId) windowsLoadedFor.current = null;
+        setWindows([]);
+      });
   }, [setId, totalSec]);
 
   const persistWindows = useCallback(
@@ -155,7 +160,7 @@ export default function CurvePanel({
       /* optimistic; refetch on next load */
     });
     if (suggestReplacements && Math.abs(energy - slot.track.energy) >= REPLACE_PROMPT_THRESHOLD) {
-      // Anchor is in SVG viewbox coords; position near the pointer instead.
+      // Anchor arrives in viewport coords (converted in CurveEditor onUp).
       setPrompt({ slotIdx: idx, targetEnergy: energy, anchorX: anchor.x, anchorY: anchor.y });
     } else {
       setPrompt(null);

--- a/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
@@ -1,0 +1,345 @@
+'use client';
+
+/**
+ * Curve panel container (#389) — wires the SVG editor, toolbar, template
+ * overlay, vibe windows, and replacement popover to the setbuilder API.
+ *
+ * Targets persist per slot (PATCH on drag-release); templates apply
+ * server-side (slot midpoints computed from track durations); vibe windows
+ * sync via replace-all PUT. Pool candidates arrive via the `pool` prop
+ * (empty until #388 lands).
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { api } from '@/lib/api';
+import type { CurveTemplatesResponse } from '@/lib/api-types';
+import CurveEditor, { type CurveViewMode } from './CurveEditor';
+import CurveToolbar from './CurveToolbar';
+import CurveTemplateEditorOverlay, { type TemplateDraft } from './CurveTemplateEditorOverlay';
+import ReplacePopover, { type ReplacePrompt } from './ReplacePopover';
+import {
+  REPLACE_PROMPT_THRESHOLD,
+  rankReplacementCandidates,
+  slotMidpoints,
+  type VibePreset,
+} from './curveMath';
+import type { SlotView, TrackView, VibeWindowView } from './types';
+
+const SUGGEST_KEY = 'wrzdj.curve.suggestReplacements';
+
+function readSuggestSetting(): boolean | null {
+  try {
+    const stored = window.localStorage.getItem(SUGGEST_KEY);
+    return stored == null ? null : stored !== 'false';
+  } catch {
+    // localStorage unavailable (SSR, privacy mode)
+    return null;
+  }
+}
+
+function writeSuggestSetting(on: boolean): void {
+  try {
+    window.localStorage.setItem(SUGGEST_KEY, String(on));
+  } catch {
+    // best-effort persistence only
+  }
+}
+
+interface OverlayState {
+  open: boolean;
+  mode: 'create' | 'edit';
+  initial: TemplateDraft | null;
+  isBuiltIn: boolean;
+}
+
+const OVERLAY_CLOSED: OverlayState = { open: false, mode: 'create', initial: null, isBuiltIn: false };
+
+export interface CurvePanelProps {
+  setId: number;
+  slots: SlotView[];
+  onSlotsChange: (updater: (prev: SlotView[]) => SlotView[]) => void;
+  hoveredIdx: number | null;
+  onHover: (idx: number | null) => void;
+  onBlockClick: (idx: number) => void;
+  /** Candidate pool for the replacement popover (#388 feeds this). */
+  pool?: TrackView[];
+}
+
+export default function CurvePanel({
+  setId,
+  slots,
+  onSlotsChange,
+  hoveredIdx,
+  onHover,
+  onBlockClick,
+  pool = [],
+}: CurvePanelProps) {
+  const [view, setView] = useState<CurveViewMode>('normal');
+  const [templates, setTemplates] = useState<CurveTemplatesResponse | null>(null);
+  const [activeTemplateName, setActiveTemplateName] = useState<string | null>(null);
+  const [windows, setWindows] = useState<VibeWindowView[]>([]);
+  const [overlay, setOverlay] = useState<OverlayState>(OVERLAY_CLOSED);
+  const [prompt, setPrompt] = useState<ReplacePrompt | null>(null);
+  const [suggestReplacements, setSuggestReplacements] = useState(true);
+
+  const totalSec = slots.reduce((acc, s) => acc + s.track.durationSec, 0);
+
+  // Settings toggle persists per browser
+  useEffect(() => {
+    const stored = readSuggestSetting();
+    if (stored != null) setSuggestReplacements(stored);
+  }, []);
+  const setSuggest = (on: boolean) => {
+    setSuggestReplacements(on);
+    writeSuggestSetting(on);
+  };
+
+  const refreshTemplates = useCallback(() => {
+    api
+      .getCurveTemplates()
+      .then(setTemplates)
+      .catch(() => setTemplates(null));
+  }, []);
+
+  useEffect(() => {
+    refreshTemplates();
+  }, [refreshTemplates]);
+
+  // Load stored vibe windows once per set, after slots (the time domain)
+  // first arrive — a later refetch must never wipe in-session edits.
+  const windowsLoadedFor = useRef<number | null>(null);
+  useEffect(() => {
+    if (totalSec <= 0 || windowsLoadedFor.current === setId) return;
+    windowsLoadedFor.current = setId;
+    api
+      .getVibeWindows(setId)
+      .then((resp) => {
+        setWindows(
+          resp.windows.map((w, i) => ({
+            id: `w-${i}-${w.t0_sec}`,
+            t0: Math.min(1, w.t0_sec / totalSec),
+            t1: Math.min(1, w.t1_sec / totalSec),
+            label: w.label,
+          })),
+        );
+      })
+      .catch(() => setWindows([]));
+  }, [setId, totalSec]);
+
+  const persistWindows = useCallback(
+    (next: VibeWindowView[]) => {
+      if (totalSec <= 0) return;
+      api
+        .putVibeWindows(
+          setId,
+          next.map((w) => ({
+            t0_sec: Math.round(w.t0 * totalSec),
+            t1_sec: Math.max(Math.round(w.t0 * totalSec) + 1, Math.round(w.t1 * totalSec)),
+            label: w.label,
+          })),
+        )
+        .catch(() => {
+          /* keep optimistic local state; next successful PUT reconciles */
+        });
+    },
+    [setId, totalSec],
+  );
+
+  // --- Target drag ---------------------------------------------------------
+
+  const handleTargetDragEnd = (idx: number, energy: number, anchor: { x: number; y: number }) => {
+    const slot = slots[idx];
+    if (!slot) return;
+    onSlotsChange((prev) => prev.map((s, i) => (i === idx ? { ...s, targetEnergy: energy } : s)));
+    api.updateSlotTarget(setId, slot.id, energy).catch(() => {
+      /* optimistic; refetch on next load */
+    });
+    if (suggestReplacements && Math.abs(energy - slot.track.energy) >= REPLACE_PROMPT_THRESHOLD) {
+      // Anchor is in SVG viewbox coords; position near the pointer instead.
+      setPrompt({ slotIdx: idx, targetEnergy: energy, anchorX: anchor.x, anchorY: anchor.y });
+    } else {
+      setPrompt(null);
+    }
+  };
+
+  // --- Templates -----------------------------------------------------------
+
+  const applyTemplate = (source: { builtin?: string; template_id?: number }, name: string) => {
+    const midpoints = slots.length > 0 ? slotMidpoints(slots) : undefined;
+    api
+      .applyCurveTemplate(setId, source, midpoints)
+      .then((resp) => {
+        const bySlotId = new Map(resp.targets.map((t) => [t.slot_id, t.target_energy]));
+        onSlotsChange((prev) =>
+          prev.map((s) => (bySlotId.has(s.id) ? { ...s, targetEnergy: bySlotId.get(s.id) ?? null } : s)),
+        );
+        // Rebuild vibe windows from the template's slow-window flags
+        const next = resp.windows.map((w, i) => ({
+          id: `tw-${i}-${w.t0}`,
+          t0: w.t0,
+          t1: w.t1,
+          label: 'Slow set',
+        }));
+        setWindows(next);
+        persistWindows(next);
+        setActiveTemplateName(name);
+        setPrompt(null);
+      })
+      .catch(() => {
+        /* surface stays unchanged on failure */
+      });
+  };
+
+  const openTemplateEditor = (name: string, isBuiltIn: boolean) => {
+    if (isBuiltIn) {
+      const tpl = templates?.builtin.find((t) => t.name === name);
+      if (!tpl) return;
+      setOverlay({ open: true, mode: 'edit', isBuiltIn: true, initial: { name: tpl.name, points: tpl.points } });
+    } else {
+      const tpl = templates?.user.find((t) => t.name === name);
+      if (!tpl) return;
+      setOverlay({
+        open: true,
+        mode: 'edit',
+        isBuiltIn: false,
+        initial: { id: tpl.id, name: tpl.name, points: tpl.points },
+      });
+    }
+  };
+
+  const saveTemplateNew = (draft: TemplateDraft) => {
+    api
+      .createCurveTemplate(draft.name, draft.points)
+      .then(refreshTemplates)
+      .catch(() => {});
+  };
+
+  const saveTemplateCurrent = (draft: TemplateDraft) => {
+    if (draft.id == null) return;
+    api
+      .updateCurveTemplate(draft.id, draft.name, draft.points)
+      .then(refreshTemplates)
+      .catch(() => {});
+  };
+
+  const deleteTemplate = (templateId: number) => {
+    api
+      .deleteCurveTemplate(templateId)
+      .then(refreshTemplates)
+      .catch(() => {});
+  };
+
+  // --- Vibe windows ---------------------------------------------------------
+
+  const addVibeWindow = (preset: VibePreset) => {
+    setWindows((prev) => {
+      const span = 0.08;
+      let t0 = 0.42;
+      const sorted = [...prev].sort((a, b) => a.t0 - b.t0);
+      for (const s of sorted) {
+        if (t0 + span < s.t0) break;
+        if (t0 >= s.t0 && t0 < s.t1) t0 = Math.min(1 - span, s.t1 + 0.01);
+      }
+      const next = [
+        ...prev,
+        { id: `w-${Date.now()}`, t0, t1: Math.min(1, t0 + span), label: preset.label },
+      ];
+      persistWindows(next);
+      return next;
+    });
+  };
+
+  const changeWindow = (id: string, patch: Partial<VibeWindowView>) => {
+    setWindows((prev) => prev.map((w) => (w.id === id ? { ...w, ...patch } : w)));
+  };
+
+  const commitWindow = () => {
+    setWindows((prev) => {
+      persistWindows(prev);
+      return prev;
+    });
+  };
+
+  const deleteWindow = (id: string) => {
+    setWindows((prev) => {
+      const next = prev.filter((w) => w.id !== id);
+      persistWindows(next);
+      return next;
+    });
+  };
+
+  // --- Replacement popover --------------------------------------------------
+
+  const promptSlot = prompt ? slots[prompt.slotIdx] : null;
+  const inSetIds = new Set(slots.map((s) => s.track.id));
+  const candidates =
+    prompt && promptSlot
+      ? rankReplacementCandidates(
+          prompt.targetEnergy,
+          prompt.slotIdx > 0 ? slots[prompt.slotIdx - 1].track : null,
+          pool,
+          inSetIds,
+        )
+      : [];
+
+  const handleReplace = (slotId: number, trackId: string) => {
+    // Slot/track mutation wires up when the pool ships (#388); until then the
+    // popover candidates are informational.
+    void slotId;
+    void trackId;
+    setPrompt(null);
+  };
+
+  return (
+    <>
+      <CurveToolbar
+        view={view}
+        onViewChange={setView}
+        templates={templates}
+        activeTemplateName={activeTemplateName}
+        onApplyBuiltin={(name) => applyTemplate({ builtin: name }, name)}
+        onApplyUser={(id) => {
+          const tpl = templates?.user.find((t) => t.id === id);
+          if (tpl) applyTemplate({ template_id: id }, tpl.name);
+        }}
+        onCreateTemplate={() => setOverlay({ open: true, mode: 'create', initial: null, isBuiltIn: false })}
+        onEditTemplate={openTemplateEditor}
+        onAddVibeWindow={addVibeWindow}
+        suggestReplacements={suggestReplacements}
+        onSuggestReplacementsChange={setSuggest}
+      />
+      <CurveEditor
+        slots={slots}
+        view={view}
+        windows={windows}
+        hoveredIdx={hoveredIdx}
+        onHover={onHover}
+        onBlockClick={onBlockClick}
+        onTargetDragEnd={handleTargetDragEnd}
+        onWindowChange={changeWindow}
+        onWindowCommit={commitWindow}
+        onWindowDelete={deleteWindow}
+      />
+      <CurveTemplateEditorOverlay
+        open={overlay.open}
+        mode={overlay.mode}
+        initial={overlay.initial}
+        isBuiltIn={overlay.isBuiltIn}
+        onSaveNew={saveTemplateNew}
+        onSaveCurrent={saveTemplateCurrent}
+        onDelete={deleteTemplate}
+        onClose={() => setOverlay(OVERLAY_CLOSED)}
+      />
+      {prompt && promptSlot && (
+        <ReplacePopover
+          prompt={prompt}
+          slot={promptSlot}
+          candidates={candidates}
+          onReplace={handleReplace}
+          onKeep={() => setPrompt(null)}
+          onDismiss={() => setPrompt(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/CurveTemplateEditorOverlay.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveTemplateEditorOverlay.tsx
@@ -1,0 +1,425 @@
+'use client';
+
+/**
+ * Curve template editor overlay (#389) — full-canvas modal for creating and
+ * editing reusable energy-curve templates. Draggable SVG canvas + point list.
+ * Built-in templates open as a read-only starting point (Save-as-copy only).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { CurvePoint } from '@/lib/api-types';
+import styles from './curve.module.css';
+
+const NEON = '#00f5d4';
+
+const BLANK_POINTS: CurvePoint[] = [
+  { t: 0, e: 3, label: 'Start', slow_start: false, slow_end: false },
+  { t: 0.5, e: 7, label: 'Mid', slow_start: false, slow_end: false },
+  { t: 1, e: 5, label: 'End', slow_start: false, slow_end: false },
+];
+
+export interface TemplateDraft {
+  id?: number;
+  name: string;
+  points: CurvePoint[];
+}
+
+export interface CurveTemplateEditorOverlayProps {
+  open: boolean;
+  mode: 'create' | 'edit';
+  initial: TemplateDraft | null;
+  isBuiltIn: boolean;
+  onSaveNew: (draft: TemplateDraft) => void;
+  onSaveCurrent: (draft: TemplateDraft) => void;
+  onDelete: (templateId: number) => void;
+  onClose: () => void;
+}
+
+export default function CurveTemplateEditorOverlay({
+  open,
+  mode,
+  initial,
+  isBuiltIn,
+  onSaveNew,
+  onSaveCurrent,
+  onDelete,
+  onClose,
+}: CurveTemplateEditorOverlayProps) {
+  const [name, setName] = useState('');
+  const [points, setPoints] = useState<CurvePoint[]>([]);
+  const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
+  const [dragIdx, setDragIdx] = useState<number | null>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [w, setW] = useState(820);
+  const [h, setH] = useState(320);
+
+  // Reset on open
+  useEffect(() => {
+    if (!open) return;
+    if (initial) {
+      setName(isBuiltIn ? `${initial.name} (copy)` : initial.name);
+      setPoints(initial.points.map((p) => ({ ...p })));
+    } else {
+      setName('Untitled curve');
+      setPoints(BLANK_POINTS.map((p) => ({ ...p })));
+    }
+    setSelectedIdx(null);
+  }, [open, initial, isBuiltIn]);
+
+  useEffect(() => {
+    if (!open || !wrapRef.current) return;
+    const ro = new ResizeObserver((entries) => {
+      for (const e of entries) {
+        setW(Math.max(400, e.contentRect.width));
+        setH(Math.max(200, e.contentRect.height));
+      }
+    });
+    ro.observe(wrapRef.current);
+    return () => ro.disconnect();
+  }, [open]);
+
+  // Keyboard: escape closes, delete removes selected interior point
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+      if (
+        (e.key === 'Delete' || e.key === 'Backspace') &&
+        selectedIdx != null &&
+        (e.target as HTMLElement).tagName?.toLowerCase() !== 'input'
+      ) {
+        e.preventDefault();
+        removePoint(selectedIdx);
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, selectedIdx, points]);
+
+  // Point drag
+  useEffect(() => {
+    if (dragIdx == null) return;
+    const onMove = (ev: PointerEvent) => {
+      if (!svgRef.current) return;
+      const rect = svgRef.current.getBoundingClientRect();
+      const scaleX = rect.width > 0 ? w / rect.width : 1;
+      const scaleY = rect.height > 0 ? h / rect.height : 1;
+      const x = (ev.clientX - rect.left) * scaleX;
+      const y = (ev.clientY - rect.top) * scaleY;
+      setPoints((prev) =>
+        prev.map((p, i) => {
+          if (i !== dragIdx) return p;
+          const newT =
+            i === 0
+              ? 0
+              : i === prev.length - 1
+                ? 1
+                : Math.max(prev[i - 1].t + 0.005, Math.min(prev[i + 1].t - 0.005, x / w));
+          const newE = Math.max(0, Math.min(10, (1 - y / h) * 10));
+          return { ...p, t: Math.round(newT * 1000) / 1000, e: Math.round(newE * 10) / 10 };
+        }),
+      );
+    };
+    const onUp = () => setDragIdx(null);
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+  }, [dragIdx, w, h]);
+
+  if (!open) return null;
+
+  const xOf = (t: number) => t * w;
+  const yOf = (e: number) => h - (e / 10) * h;
+
+  const addPointAt = (ev: React.MouseEvent) => {
+    if ((ev.target as SVGElement).dataset?.handle) return;
+    if (!svgRef.current) return;
+    const rect = svgRef.current.getBoundingClientRect();
+    const scaleX = rect.width > 0 ? w / rect.width : 1;
+    const scaleY = rect.height > 0 ? h / rect.height : 1;
+    const t = Math.max(0, Math.min(1, ((ev.clientX - rect.left) * scaleX) / w));
+    const e = Math.max(0, Math.min(10, (1 - ((ev.clientY - rect.top) * scaleY) / h) * 10));
+    setPoints((prev) => {
+      if (prev.length >= 32) return prev;
+      const insertIdx = prev.findIndex((p) => p.t > t);
+      const idx = insertIdx === -1 ? prev.length - 1 : insertIdx;
+      if (idx === 0 || idx >= prev.length) return prev;
+      const next = [...prev];
+      next.splice(idx, 0, {
+        t: Math.round(t * 1000) / 1000,
+        e: Math.round(e * 10) / 10,
+        label: '',
+        slow_start: false,
+        slow_end: false,
+      });
+      setSelectedIdx(idx);
+      return next;
+    });
+  };
+
+  const removePoint = (i: number) => {
+    if (i === 0 || i === points.length - 1) return; // endpoints locked
+    setPoints((prev) => prev.filter((_, j) => j !== i));
+    setSelectedIdx(null);
+  };
+
+  const updatePoint = (i: number, patch: Partial<CurvePoint>) => {
+    setPoints((prev) => prev.map((p, j) => (j === i ? { ...p, ...patch } : p)));
+  };
+
+  const linePath = points
+    .map((p, i) => `${i === 0 ? 'M' : 'L'} ${xOf(p.t).toFixed(2)} ${yOf(p.e).toFixed(2)}`)
+    .join(' ');
+  const fillPath = `${linePath} L ${w} ${h} L 0 ${h} Z`;
+
+  const nameOk = name.trim().length > 0;
+  const canSaveCurrent = !isBuiltIn && initial?.id != null && nameOk;
+
+  return (
+    <div className={styles.overlayWrap} role="dialog" aria-label="Curve template editor">
+      <div className={styles.overlayBackdrop} onClick={onClose} data-testid="overlay-backdrop" />
+      <div className={styles.overlayShell}>
+        <div className={styles.overlayHeader}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div className={styles.overlayEyebrow}>
+              {mode === 'create'
+                ? 'Create curve template'
+                : isBuiltIn
+                  ? `Editing built-in · "${initial?.name}"`
+                  : 'Edit template'}
+            </div>
+            <input
+              className={styles.overlayNameInput}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Template name…"
+              aria-label="Template name"
+            />
+          </div>
+          {isBuiltIn && (
+            <div
+              className={styles.readonlyBadge}
+              title="Built-in templates can't be overwritten — use Save as new copy"
+            >
+              read-only original
+            </div>
+          )}
+          <button className="btn btn-sm" onClick={onClose} title="Close (esc)">
+            ✕
+          </button>
+        </div>
+
+        <div className={styles.overlayBody}>
+          <div className={styles.overlayCanvasCol}>
+            <div className={styles.overlayHelp}>
+              <kbd>double-click</kbd> empty area to add · <kbd>drag</kbd> any point ·{' '}
+              <kbd>delete</kbd> selected (endpoints locked)
+            </div>
+            <div className={styles.overlayCanvas} ref={wrapRef}>
+              <div className={styles.yaxis}>
+                <div>10·peak</div>
+                <div>7</div>
+                <div>5</div>
+                <div>2</div>
+                <div>0</div>
+              </div>
+              <div className={styles.xaxis}>
+                <div>0%</div>
+                <div>25%</div>
+                <div>50%</div>
+                <div>75%</div>
+                <div>100%</div>
+              </div>
+              <svg
+                ref={svgRef}
+                className={styles.svg}
+                viewBox={`0 0 ${w} ${h}`}
+                preserveAspectRatio="none"
+                onDoubleClick={addPointAt}
+                data-testid="template-canvas"
+              >
+                <defs>
+                  <linearGradient id="cteFill" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor={NEON} stopOpacity="0.28" />
+                    <stop offset="60%" stopColor={NEON} stopOpacity="0.06" />
+                    <stop offset="100%" stopColor={NEON} stopOpacity="0" />
+                  </linearGradient>
+                </defs>
+                <line
+                  x1="0"
+                  y1={yOf(8)}
+                  x2={w}
+                  y2={yOf(8)}
+                  stroke="rgba(255,157,63,0.18)"
+                  strokeDasharray="3 4"
+                  strokeWidth="1"
+                />
+                <path d={fillPath} fill="url(#cteFill)" />
+                <path d={linePath} fill="none" stroke={NEON} strokeWidth="2.5" strokeLinejoin="round" />
+                {points.map((p, i) => {
+                  const isSelected = selectedIdx === i;
+                  const isEndpoint = i === 0 || i === points.length - 1;
+                  return (
+                    <g
+                      key={i}
+                      transform={`translate(${xOf(p.t)},${yOf(p.e)})`}
+                      style={{ cursor: 'grab' }}
+                    >
+                      <circle
+                        r={14}
+                        fill="transparent"
+                        data-handle="1"
+                        data-testid={`template-point-${i}`}
+                        onPointerDown={(ev) => {
+                          ev.preventDefault();
+                          ev.stopPropagation();
+                          setDragIdx(i);
+                          setSelectedIdx(i);
+                        }}
+                        onClick={() => setSelectedIdx(i)}
+                        onDoubleClick={(e) => e.stopPropagation()}
+                      />
+                      <circle
+                        r={isSelected ? 8 : 6}
+                        fill={isSelected ? NEON : 'var(--bg)'}
+                        stroke={isSelected ? NEON : isEndpoint ? 'var(--color-warning)' : NEON}
+                        strokeWidth={isSelected ? 2.5 : 2}
+                        pointerEvents="none"
+                      />
+                    </g>
+                  );
+                })}
+              </svg>
+            </div>
+          </div>
+
+          {/* Point list sidebar */}
+          <div className={styles.overlaySide}>
+            <div className={styles.overlaySideHeader}>
+              <span>Points</span>
+              <span data-testid="point-count">{points.length}</span>
+            </div>
+            <div className={styles.pointsList}>
+              {points.map((p, i) => {
+                const isEndpoint = i === 0 || i === points.length - 1;
+                return (
+                  <div
+                    key={i}
+                    className={`${styles.pointRow} ${selectedIdx === i ? styles.pointRowSelected : ''}`}
+                    onClick={() => setSelectedIdx(i)}
+                    data-testid={`point-row-${i}`}
+                  >
+                    <div className={styles.pointNum}>{String(i + 1).padStart(2, '0')}</div>
+                    <input
+                      className={styles.pointLabelInput}
+                      value={p.label ?? ''}
+                      onChange={(e) => updatePoint(i, { label: e.target.value })}
+                      placeholder={isEndpoint ? (i === 0 ? 'start' : 'end') : 'label'}
+                      aria-label={`Point ${i + 1} label`}
+                    />
+                    <div className={styles.pointT}>
+                      <input
+                        type="number"
+                        min={0}
+                        max={100}
+                        step={1}
+                        value={Math.round(p.t * 100)}
+                        disabled={isEndpoint}
+                        onChange={(e) => {
+                          const v = parseInt(e.target.value, 10) || 0;
+                          updatePoint(i, { t: Math.max(0, Math.min(1, v / 100)) });
+                        }}
+                        aria-label={`Point ${i + 1} position`}
+                      />
+                      <span>%</span>
+                    </div>
+                    <div className={styles.pointE}>
+                      <input
+                        type="range"
+                        min={0}
+                        max={10}
+                        step={0.1}
+                        value={p.e}
+                        onChange={(e) => updatePoint(i, { e: parseFloat(e.target.value) })}
+                        aria-label={`Point ${i + 1} energy`}
+                      />
+                      <span>{p.e.toFixed(1)}</span>
+                    </div>
+                    {!isEndpoint && (
+                      <button
+                        className={styles.pointDel}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          removePoint(i);
+                        }}
+                        title="Delete point"
+                        data-testid={`point-del-${i}`}
+                      >
+                        ✕
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+            <div className={styles.overlayFootnote}>
+              Endpoints are locked at 0% and 100%. Built-in templates can only be saved as a new
+              copy.
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.overlayFooter}>
+          {!isBuiltIn && initial?.id != null && (
+            <button
+              className="btn btn-sm"
+              style={{ color: 'var(--color-danger)' }}
+              data-testid="template-delete"
+              onClick={() => {
+                if (window.confirm(`Delete template "${initial.name}"?`)) {
+                  onDelete(initial.id as number);
+                  onClose();
+                }
+              }}
+            >
+              Delete
+            </button>
+          )}
+          <div style={{ flex: 1 }} />
+          <button className="btn btn-sm" onClick={onClose}>
+            Cancel
+          </button>
+          {canSaveCurrent && (
+            <button
+              className="btn btn-sm btn-primary"
+              disabled={!nameOk}
+              data-testid="template-save"
+              onClick={() => {
+                onSaveCurrent({ id: initial?.id, name: name.trim(), points });
+                onClose();
+              }}
+            >
+              Save changes
+            </button>
+          )}
+          <button
+            className="btn btn-sm btn-primary"
+            disabled={!nameOk}
+            data-testid="template-save-as"
+            onClick={() => {
+              onSaveNew({ name: name.trim(), points });
+              onClose();
+            }}
+          >
+            {isBuiltIn ? 'Save as new copy' : 'Save as new'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/CurveTemplateEditorOverlay.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveTemplateEditorOverlay.tsx
@@ -331,7 +331,12 @@ export default function CurveTemplateEditorOverlay({
                         disabled={isEndpoint}
                         onChange={(e) => {
                           const v = parseInt(e.target.value, 10) || 0;
-                          updatePoint(i, { t: Math.max(0, Math.min(1, v / 100)) });
+                          const raw = Math.max(0, Math.min(1, v / 100));
+                          // Clamp to neighbors — manual edits must respect the
+                          // same monotonic ordering the drag logic enforces.
+                          const minT = i > 0 ? points[i - 1].t + 0.005 : 0;
+                          const maxT = i < points.length - 1 ? points[i + 1].t - 0.005 : 1;
+                          updatePoint(i, { t: Math.max(minT, Math.min(maxT, raw)) });
                         }}
                         aria-label={`Point ${i + 1} position`}
                       />

--- a/dashboard/app/(dj)/setbuilder/components/CurveTemplateEditorOverlay.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveTemplateEditorOverlay.tsx
@@ -95,7 +95,6 @@ export default function CurveTemplateEditorOverlay({
     };
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, selectedIdx, points]);
 
   // Point drag

--- a/dashboard/app/(dj)/setbuilder/components/CurveToolbar.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveToolbar.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+/**
+ * Curve toolbar (#389): Normal / BPM friction / Key friction view switch,
+ * template dropdown (built-in + user + create/edit), vibe-window preset
+ * dropdown (15 presets), and the replacement-suggestion toggle.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { CurveTemplatesResponse } from '@/lib/api-types';
+import type { CurveViewMode } from './CurveEditor';
+import { VIBE_PRESETS, type VibePreset } from './curveMath';
+import styles from './curve.module.css';
+
+export interface CurveToolbarProps {
+  view: CurveViewMode;
+  onViewChange: (view: CurveViewMode) => void;
+  templates: CurveTemplatesResponse | null;
+  activeTemplateName: string | null;
+  onApplyBuiltin: (name: string) => void;
+  onApplyUser: (templateId: number) => void;
+  onCreateTemplate: () => void;
+  onEditTemplate: (name: string, isBuiltIn: boolean) => void;
+  onAddVibeWindow: (preset: VibePreset) => void;
+  suggestReplacements: boolean;
+  onSuggestReplacementsChange: (on: boolean) => void;
+}
+
+const VIEW_LABELS: Record<CurveViewMode, string> = {
+  normal: 'Normal',
+  bpm: 'BPM friction',
+  key: 'Key friction',
+};
+
+function useClickOutside(open: boolean, onClose: () => void) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [open, onClose]);
+  return ref;
+}
+
+export default function CurveToolbar({
+  view,
+  onViewChange,
+  templates,
+  activeTemplateName,
+  onApplyBuiltin,
+  onApplyUser,
+  onCreateTemplate,
+  onEditTemplate,
+  onAddVibeWindow,
+  suggestReplacements,
+  onSuggestReplacementsChange,
+}: CurveToolbarProps) {
+  const [tplOpen, setTplOpen] = useState(false);
+  const [vibeOpen, setVibeOpen] = useState(false);
+  const tplRef = useClickOutside(tplOpen, () => setTplOpen(false));
+  const vibeRef = useClickOutside(vibeOpen, () => setVibeOpen(false));
+
+  return (
+    <div className={styles.toolbar} data-testid="curve-toolbar">
+      <div className={styles.viewSwitch} role="tablist" aria-label="Curve view mode">
+        {(Object.keys(VIEW_LABELS) as CurveViewMode[]).map((mode) => (
+          <button
+            key={mode}
+            role="tab"
+            aria-selected={view === mode}
+            className={`${styles.viewBtn} ${view === mode ? styles.viewBtnActive : ''}`}
+            onClick={() => onViewChange(mode)}
+            data-testid={`view-${mode}`}
+          >
+            {VIEW_LABELS[mode]}
+          </button>
+        ))}
+      </div>
+
+      {/* Template dropdown */}
+      <div className={styles.dropdown} ref={tplRef}>
+        <button
+          className={styles.toolbarBtn}
+          onClick={() => setTplOpen((o) => !o)}
+          data-testid="template-dropdown-trigger"
+        >
+          〜 {activeTemplateName ?? 'Pick curve…'} ▾
+        </button>
+        {tplOpen && (
+          <div className={styles.menu} data-testid="template-menu">
+            <button
+              className={styles.menuItem}
+              onClick={() => {
+                setTplOpen(false);
+                onCreateTemplate();
+              }}
+              data-testid="template-create-new"
+            >
+              + Create new curve template…
+            </button>
+            <div className={styles.menuDivider} />
+            <div className={styles.menuSection}>Built-in</div>
+            {(templates?.builtin ?? []).map((t) => (
+              <div key={t.name} className={styles.menuRow}>
+                <button
+                  className={styles.menuItem}
+                  onClick={() => {
+                    setTplOpen(false);
+                    onApplyBuiltin(t.name);
+                  }}
+                  data-testid={`apply-builtin-${t.name}`}
+                >
+                  {activeTemplateName === t.name ? '● ' : ''}
+                  {t.name}
+                </button>
+                <button
+                  className={styles.menuEdit}
+                  title="Open built-in as starting point for a new template"
+                  onClick={() => {
+                    setTplOpen(false);
+                    onEditTemplate(t.name, true);
+                  }}
+                  data-testid={`edit-builtin-${t.name}`}
+                >
+                  ✎
+                </button>
+              </div>
+            ))}
+            {(templates?.user.length ?? 0) > 0 && (
+              <>
+                <div className={styles.menuDivider} />
+                <div className={styles.menuSection}>My templates</div>
+                {templates?.user.map((t) => (
+                  <div key={t.id} className={styles.menuRow}>
+                    <button
+                      className={styles.menuItem}
+                      onClick={() => {
+                        setTplOpen(false);
+                        onApplyUser(t.id);
+                      }}
+                      data-testid={`apply-user-${t.id}`}
+                    >
+                      {activeTemplateName === t.name ? '● ' : ''}
+                      {t.name}
+                    </button>
+                    <button
+                      className={styles.menuEdit}
+                      title="Edit this template"
+                      onClick={() => {
+                        setTplOpen(false);
+                        onEditTemplate(t.name, false);
+                      }}
+                      data-testid={`edit-user-${t.id}`}
+                    >
+                      ✎
+                    </button>
+                  </div>
+                ))}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Vibe window dropdown */}
+      <div className={styles.dropdown} ref={vibeRef}>
+        <button
+          className={styles.toolbarBtn}
+          onClick={() => setVibeOpen((o) => !o)}
+          data-testid="vibe-dropdown-trigger"
+        >
+          + Vibe window ▾
+        </button>
+        {vibeOpen && (
+          <div className={styles.menu} data-testid="vibe-menu">
+            {VIBE_PRESETS.map((p) => (
+              <button
+                key={p.id}
+                className={styles.menuItem}
+                onClick={() => {
+                  setVibeOpen(false);
+                  onAddVibeWindow(p);
+                }}
+                data-testid={`vibe-preset-${p.id}`}
+              >
+                {p.label}
+                <span className={styles.menuItemHint}>{p.hint}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <label className={styles.toggleLabel} title="Offer pool replacements when a drag-release leaves |target − energy| ≥ 0.8">
+        <input
+          type="checkbox"
+          checked={suggestReplacements}
+          onChange={(e) => onSuggestReplacementsChange(e.target.checked)}
+          data-testid="suggest-replacements-toggle"
+        />
+        Suggest replacements
+      </label>
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/ReplacePopover.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/ReplacePopover.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+/**
+ * Replacement popover (#389) — surfaces after a drag-release when a slot's
+ * target energy diverges from the track's intrinsic energy by ≥ 0.8.
+ * Lists the top-5 pool candidates ranked by energy match + BPM continuity +
+ * Camelot adjacency. Candidates come in via props (pool lands with #388).
+ */
+
+import type { ReplacementCandidate } from './curveMath';
+import type { SlotView } from './types';
+import styles from './curve.module.css';
+
+export interface ReplacePrompt {
+  slotIdx: number;
+  targetEnergy: number;
+  anchorX: number;
+  anchorY: number;
+}
+
+export interface ReplacePopoverProps {
+  prompt: ReplacePrompt;
+  slot: SlotView;
+  candidates: ReplacementCandidate[];
+  onReplace: (slotId: number, trackId: string) => void;
+  onKeep: () => void;
+  onDismiss: () => void;
+}
+
+export default function ReplacePopover({
+  prompt,
+  slot,
+  candidates,
+  onReplace,
+  onKeep,
+  onDismiss,
+}: ReplacePopoverProps) {
+  const cur = slot.track;
+  const target = prompt.targetEnergy;
+  const dir = target - cur.energy > 0 ? 'higher' : 'lower';
+
+  return (
+    <>
+      <div className={styles.popoverBackdrop} onClick={onDismiss} data-testid="replace-backdrop" />
+      <div
+        className={styles.popover}
+        role="dialog"
+        aria-label="Find replacement track"
+        data-testid="replace-popover"
+        style={{
+          left: Math.max(12, Math.min(prompt.anchorX, window.innerWidth - 372)),
+          top: Math.max(12, Math.min(prompt.anchorY + 12, window.innerHeight - 320)),
+        }}
+      >
+        <div className={styles.popoverHeader}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div className={styles.popoverEyebrow}>
+              Slot {String(prompt.slotIdx + 1).padStart(2, '0')} · energy retarget
+            </div>
+            <div className={styles.popoverTitle}>
+              <span>{cur.energy.toFixed(0)}</span>
+              <span aria-hidden>→</span>
+              <span className={styles.popoverTarget}>{target.toFixed(1)}</span>
+              <span className={styles.popoverEyebrow}>target</span>
+            </div>
+            <div className={styles.popoverSub}>
+              &ldquo;{cur.title}&rdquo; is energy {cur.energy} — you&rsquo;ve dialed the target{' '}
+              {dir}. Replace with a track that fits?
+            </div>
+          </div>
+          <button className="btn btn-sm" onClick={onDismiss} title="Keep current track">
+            ✕
+          </button>
+        </div>
+
+        {candidates.length === 0 && (
+          <div className={styles.popoverEmpty} data-testid="replace-empty">
+            No pool tracks within ±2.5 of energy {target.toFixed(1)}. Import tracks into the pool
+            or try the agent chat for a creative pick.
+          </div>
+        )}
+
+        <div>
+          {candidates.map((c) => (
+            <button
+              key={c.track.id}
+              className={styles.candidate}
+              onClick={() => onReplace(slot.id, c.track.id)}
+              data-testid={`replace-candidate-${c.track.id}`}
+            >
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div className={styles.candidateTitle}>{c.track.title}</div>
+                <div className={styles.candidateArtist}>{c.track.artist}</div>
+              </div>
+              <span className={styles.candidateMeta}>
+                {c.track.bpm != null ? `${Math.round(c.track.bpm)} BPM` : '— BPM'} ·{' '}
+                {c.track.key ?? '—'} · e{c.track.energy}
+              </span>
+              <span className={styles.candidateScore} title="Composite fit (energy + BPM + Camelot)">
+                {Math.round(c.score * 100)}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <div className={styles.popoverFooter}>
+          <button className="btn btn-sm" onClick={onKeep} data-testid="replace-keep">
+            Keep &ldquo;{cur.title}&rdquo; anyway
+          </button>
+          <button className="btn btn-sm" onClick={onDismiss}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+/**
+ * Minimal timeline list (#389) — ordered slot rows with BPM/key/energy
+ * badges and bidirectional hover sync with the curve. Clicking a curve
+ * block scrolls the matching row into view (only when out of view).
+ * Full drag-reorder timeline lands with #390/#397.
+ */
+
+import { useEffect, useRef } from 'react';
+import { fmtTime } from './curveMath';
+import type { SlotView } from './types';
+import { effectiveTarget } from './types';
+import styles from './curve.module.css';
+
+export interface ScrollRequest {
+  idx: number;
+  /** Monotonic nonce so repeated clicks on the same row re-trigger. */
+  n: number;
+}
+
+export interface TimelinePanelProps {
+  slots: SlotView[];
+  hoveredIdx: number | null;
+  onHover: (idx: number | null) => void;
+  scrollRequest: ScrollRequest | null;
+}
+
+export default function TimelinePanel({
+  slots,
+  hoveredIdx,
+  onHover,
+  scrollRequest,
+}: TimelinePanelProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  useEffect(() => {
+    if (!scrollRequest || !listRef.current) return;
+    const row = rowRefs.current[scrollRequest.idx];
+    if (!row) return;
+    const list = listRef.current.getBoundingClientRect();
+    const r = row.getBoundingClientRect();
+    const outOfView = r.top < list.top || r.bottom > list.bottom;
+    if (outOfView) {
+      row.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }, [scrollRequest]);
+
+  if (slots.length === 0) {
+    return (
+      <div className={styles.emptyState} data-testid="timeline-empty">
+        No tracks in the set yet — fill from the pool to build the timeline.
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.timelineList} ref={listRef} data-testid="timeline-list">
+      {slots.map((s, i) => (
+        <div
+          key={s.id}
+          ref={(el) => {
+            rowRefs.current[i] = el;
+          }}
+          className={`${styles.timelineRow} ${hoveredIdx === i ? styles.timelineRowHover : ''}`}
+          onMouseEnter={() => onHover(i)}
+          onMouseLeave={() => onHover(null)}
+          data-testid={`timeline-row-${i}`}
+        >
+          <span className={styles.timelinePos}>{String(i + 1).padStart(2, '0')}</span>
+          <span className={styles.timelineTitle}>
+            {s.track.title}
+            {s.track.artist ? (
+              <span className={styles.timelineArtist}> — {s.track.artist}</span>
+            ) : null}
+          </span>
+          <span className={styles.timelineBadge}>{fmtTime(s.track.durationSec)}</span>
+          <span className={styles.timelineBadge}>
+            {s.track.bpm != null ? `${Math.round(s.track.bpm)} BPM` : '— BPM'}
+          </span>
+          <span className={styles.timelineBadge}>{s.track.key ?? '—'}</span>
+          <span className={styles.timelineBadge}>e{s.track.energy}</span>
+          <span className={styles.timelineTarget} title="Target energy">
+            ◎ {effectiveTarget(s).toFixed(1)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/curve.module.css
+++ b/dashboard/app/(dj)/setbuilder/components/curve.module.css
@@ -1,0 +1,590 @@
+/* Energy curve editor styles (#389) */
+
+.canvasWrap {
+  position: relative;
+  flex: 1;
+  min-height: 160px;
+  margin: 0 8px 18px 36px;
+}
+
+.svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  overflow: visible;
+}
+
+.yaxis {
+  position: absolute;
+  left: -32px;
+  top: 0;
+  bottom: 0;
+  width: 28px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-end;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.5625rem;
+  color: var(--text-tertiary);
+  pointer-events: none;
+}
+
+.xaxis {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -16px;
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.5625rem;
+  color: var(--text-tertiary);
+  pointer-events: none;
+}
+
+.point {
+  fill: var(--bg);
+  stroke: #00f5d4;
+  stroke-width: 2;
+}
+
+.pointSelected {
+  fill: #00f5d4;
+}
+
+/* Toolbar */
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+  flex-wrap: wrap;
+}
+
+.viewSwitch {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.viewBtn {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+  letter-spacing: 0.03em;
+}
+
+.viewBtnActive {
+  background: var(--surface-raised);
+  color: #00f5d4;
+}
+
+.toolbarBtn {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.toolbarBtn:hover {
+  color: var(--text);
+  border-color: var(--text-tertiary);
+}
+
+.toggleLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  margin-left: auto;
+}
+
+/* Dropdown menus (template picker, vibe presets) */
+.dropdown {
+  position: relative;
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 30;
+  min-width: 230px;
+  max-height: 320px;
+  overflow-y: auto;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.25rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+}
+
+.menuSection {
+  font-size: 0.5625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+  padding: 0.4rem 0.6rem 0.2rem;
+}
+
+.menuRow {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.menuItem {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-size: 0.75rem;
+  text-align: left;
+  padding: 0.4rem 0.6rem;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.menuItem:hover {
+  background: var(--surface-raised);
+}
+
+.menuItemHint {
+  font-size: 0.625rem;
+  color: var(--text-tertiary);
+  margin-left: auto;
+  padding-left: 0.5rem;
+}
+
+.menuEdit {
+  background: transparent;
+  border: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  padding: 0.3rem 0.45rem;
+  border-radius: 5px;
+}
+
+.menuEdit:hover {
+  color: var(--text);
+  background: var(--surface-raised);
+}
+
+.menuDivider {
+  height: 1px;
+  background: var(--border-subtle);
+  margin: 0.25rem 0;
+}
+
+/* Replacement popover */
+.popoverBackdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+}
+
+.popover {
+  position: fixed;
+  z-index: 41;
+  width: 360px;
+  max-width: calc(100vw - 24px);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.55);
+  padding: 0.75rem;
+}
+
+.popoverHeader {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.popoverEyebrow {
+  font-size: 0.5625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+}
+
+.popoverTitle {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-family: var(--font-mono, monospace);
+  font-size: 1rem;
+  color: var(--text);
+}
+
+.popoverTarget {
+  color: #00f5d4;
+  font-weight: 700;
+}
+
+.popoverSub {
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+  margin-top: 0.2rem;
+}
+
+.candidate {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  padding: 0.4rem 0.5rem;
+  cursor: pointer;
+  text-align: left;
+}
+
+.candidate:hover {
+  background: var(--surface-raised);
+}
+
+.candidateTitle {
+  font-size: 0.75rem;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.candidateArtist {
+  font-size: 0.625rem;
+  color: var(--text-secondary);
+}
+
+.candidateMeta {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.625rem;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+.candidateScore {
+  font-family: var(--font-mono, monospace);
+  font-weight: 700;
+  font-size: 0.8125rem;
+  color: #00f5d4;
+}
+
+.popoverEmpty {
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+  padding: 0.6rem 0.4rem;
+}
+
+.popoverFooter {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  justify-content: flex-end;
+}
+
+/* Template editor overlay */
+.overlayWrap {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.overlayBackdrop {
+  position: absolute;
+  inset: 0;
+  background: var(--color-overlay);
+}
+
+.overlayShell {
+  position: relative;
+  z-index: 1;
+  width: min(940px, calc(100vw - 32px));
+  height: min(620px, calc(100vh - 48px));
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.overlayHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.overlayEyebrow {
+  font-size: 0.5625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+}
+
+.overlayNameInput {
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-bottom: 1px dashed var(--border);
+  color: var(--text);
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.15rem 0;
+  outline: none;
+}
+
+.overlayBody {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.overlayCanvasCol {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 0.75rem 1rem 1.5rem 1rem;
+  min-width: 0;
+}
+
+.overlayHelp {
+  font-size: 0.625rem;
+  color: var(--text-tertiary);
+  margin-bottom: 0.5rem;
+}
+
+.overlayCanvas {
+  position: relative;
+  flex: 1;
+  margin-left: 32px;
+  margin-bottom: 16px;
+}
+
+.overlaySide {
+  width: 280px;
+  border-left: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.overlaySideHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.pointsList {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.4rem;
+}
+
+.pointRow {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.4rem;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.pointRowSelected {
+  border-color: #00f5d4;
+  background: rgba(0, 245, 212, 0.06);
+}
+
+.pointNum {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.625rem;
+  color: var(--text-tertiary);
+  width: 18px;
+}
+
+.pointLabelInput {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text);
+  font-size: 0.6875rem;
+  padding: 0.1rem 0;
+  outline: none;
+}
+
+.pointT {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.625rem;
+  color: var(--text-secondary);
+}
+
+.pointT input {
+  width: 38px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  color: var(--text);
+  font-size: 0.625rem;
+  padding: 0.1rem 0.2rem;
+}
+
+.pointE {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.625rem;
+  color: var(--text-secondary);
+}
+
+.pointE input[type='range'] {
+  width: 56px;
+}
+
+.pointDel {
+  background: transparent;
+  border: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  padding: 0.15rem;
+}
+
+.pointDel:hover {
+  color: var(--color-danger);
+}
+
+.overlayFootnote {
+  font-size: 0.5625rem;
+  color: var(--text-tertiary);
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.overlayFooter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.readonlyBadge {
+  font-size: 0.5625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-warning);
+  border: 1px solid var(--color-warning);
+  border-radius: 4px;
+  padding: 0.15rem 0.4rem;
+  white-space: nowrap;
+}
+
+/* Timeline panel */
+.timelineList {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.4rem;
+}
+
+.timelineRow {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.45rem 0.6rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+
+.timelineRowHover {
+  background: var(--surface-raised);
+  border-color: rgba(0, 245, 212, 0.45);
+}
+
+.timelinePos {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.625rem;
+  color: var(--text-tertiary);
+  width: 22px;
+}
+
+.timelineTitle {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.75rem;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.timelineArtist {
+  font-size: 0.625rem;
+  color: var(--text-secondary);
+}
+
+.timelineBadge {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.5625rem;
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  padding: 0.1rem 0.3rem;
+  white-space: nowrap;
+}
+
+.timelineTarget {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.5625rem;
+  color: #00f5d4;
+  white-space: nowrap;
+}
+
+.emptyState {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  text-align: center;
+}

--- a/dashboard/app/(dj)/setbuilder/components/curveMath.ts
+++ b/dashboard/app/(dj)/setbuilder/components/curveMath.ts
@@ -1,0 +1,284 @@
+/**
+ * Pure math + presets for the energy-curve editor (#389).
+ *
+ * Mirrors the design-bundle helpers exactly:
+ * - BPM friction is PERCENTAGE-based (relative to the destination tempo)
+ *   with half/double-time detection — tiers at ≤2% / ≤5% / ≤8% / >8%.
+ * - Camelot friction tiers come from wheel distance + ring crossing.
+ * - Replacement ranking: 0.55 energy match + 0.25 BPM continuity +
+ *   0.20 Camelot adjacency, candidates within ±2.5 energy, top 5.
+ */
+
+import type { CurvePoint } from '@/lib/api-types';
+import type { SlotView, TrackView } from './types';
+import { effectiveTarget } from './types';
+
+// ---------------------------------------------------------------------------
+// Interpolation (piecewise linear — matches server curve.py)
+// ---------------------------------------------------------------------------
+
+export function interpolateEnergy(points: CurvePoint[], t: number): number {
+  if (points.length === 0) return 5;
+  const tt = Math.max(0, Math.min(1, t));
+  if (tt <= points[0].t) return points[0].e;
+  if (tt >= points[points.length - 1].t) return points[points.length - 1].e;
+  for (let i = 0; i < points.length - 1; i++) {
+    const a = points[i];
+    const b = points[i + 1];
+    if (tt >= a.t && tt <= b.t) {
+      const span = b.t - a.t;
+      if (span <= 0) return b.e;
+      return a.e + ((b.e - a.e) * (tt - a.t)) / span;
+    }
+  }
+  return points[points.length - 1].e;
+}
+
+/** Normalized slot midpoints from track durations (uniform when total is 0). */
+export function slotMidpoints(slots: SlotView[]): number[] {
+  const total = slots.reduce((acc, s) => acc + s.track.durationSec, 0);
+  if (total <= 0) return slots.map((_, i) => (i + 0.5) / slots.length);
+  let cur = 0;
+  return slots.map((s) => {
+    const mid = (cur + s.track.durationSec / 2) / total;
+    cur += s.track.durationSec;
+    return mid;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// BPM friction (percentage thresholds + half/double-time)
+// ---------------------------------------------------------------------------
+
+export type BpmTier = 'match' | 'good' | 'stretch' | 'clash' | 'unknown';
+
+export interface BpmDelta {
+  tier: BpmTier;
+  /** Percent of destination tempo (0-100); null when either BPM missing. */
+  pct: number | null;
+  halfDouble: boolean;
+}
+
+export function bpmPercentDelta(b1: number | null, b2: number | null): BpmDelta {
+  if (!b1 || !b2) return { tier: 'unknown', pct: null, halfDouble: false };
+  const candidates = [
+    { delta: Math.abs(b1 - b2), halfDouble: false },
+    { delta: Math.abs(b1 - b2 * 0.5), halfDouble: true },
+    { delta: Math.abs(b1 - b2 * 2.0), halfDouble: true },
+  ];
+  let best = candidates[0];
+  for (const c of candidates) if (c.delta < best.delta) best = c;
+  const pct = (best.delta / b2) * 100;
+  let tier: BpmTier;
+  if (pct <= 2) tier = 'match'; // ≤2% — inaudible drift
+  else if (pct <= 5) tier = 'good'; // 2-5% — well within pitch fader
+  else if (pct <= 8) tier = 'stretch'; // 5-8% — at the pitch-fader edge
+  else tier = 'clash'; // >8% — intentional shift required
+  return { tier, pct, halfDouble: best.halfDouble };
+}
+
+// ---------------------------------------------------------------------------
+// Camelot parsing + friction tiers
+// ---------------------------------------------------------------------------
+
+interface CamelotInfo {
+  num: number | null;
+  letter: 'A' | 'B' | null;
+}
+
+export function parseCamelot(key: string | null): CamelotInfo {
+  if (!key) return { num: null, letter: null };
+  const m = key.trim().toUpperCase().match(/^([1-9]|1[0-2])([AB])$/);
+  if (!m) return { num: null, letter: null };
+  return { num: parseInt(m[1], 10), letter: m[2] as 'A' | 'B' };
+}
+
+export type KeyTier = 'perfect' | 'good' | 'ok' | 'clash' | 'unknown';
+
+export interface KeyMix {
+  tier: KeyTier;
+  dist: number | null;
+  label: string;
+}
+
+export function camelotMixTier(k1: string | null, k2: string | null): KeyMix {
+  const a = parseCamelot(k1);
+  const b = parseCamelot(k2);
+  if (!a.num || !b.num) return { tier: 'unknown', dist: null, label: '?' };
+  if (a.num === b.num && a.letter === b.letter) {
+    return { tier: 'perfect', dist: 0, label: 'Same key' };
+  }
+  if (a.num === b.num) return { tier: 'perfect', dist: 0, label: 'Relative maj/min' };
+  const dist = Math.min(Math.abs(a.num - b.num), 12 - Math.abs(a.num - b.num));
+  if (a.letter === b.letter && dist === 1) return { tier: 'perfect', dist, label: 'Adjacent · ±1' };
+  if (a.letter !== b.letter && dist === 1) {
+    return { tier: 'good', dist, label: 'Energy shift · ±1 cross' };
+  }
+  if (a.letter === b.letter && dist === 2) return { tier: 'good', dist, label: 'Adjacent · ±2' };
+  if (dist === 2) return { tier: 'ok', dist, label: 'Mood shift · ±2 cross' };
+  if (dist === 3) return { tier: 'ok', dist, label: '±3 on wheel' };
+  return { tier: 'clash', dist, label: `±${dist} clash` };
+}
+
+// ---------------------------------------------------------------------------
+// Compatibility scores (0-1) for replacement ranking
+// ---------------------------------------------------------------------------
+
+export function bpmCompat(b1: number | null, b2: number | null): number {
+  if (!b1 || !b2) return 0.5;
+  const diff = Math.min(Math.abs(b1 - b2), Math.abs(b1 - b2 * 0.5), Math.abs(b1 - b2 * 2.0));
+  if (diff <= 3) return 1.0;
+  if (diff <= 6) return 0.85;
+  if (diff <= 12) return 0.6;
+  if (diff <= 20) return 0.35;
+  return 0.15;
+}
+
+export function camelotCompat(k1: string | null, k2: string | null): number {
+  const a = parseCamelot(k1);
+  const b = parseCamelot(k2);
+  if (!a.num || !b.num) return 0.5;
+  if (a.num === b.num && a.letter === b.letter) return 1.0;
+  if (a.num === b.num) return 0.9;
+  const diff = Math.min(Math.abs(a.num - b.num), 12 - Math.abs(a.num - b.num));
+  if (a.letter === b.letter && diff === 1) return 0.85;
+  if (a.letter === b.letter && diff === 2) return 0.55;
+  if (a.letter !== b.letter && diff === 1) return 0.4;
+  return 0.2;
+}
+
+export interface ReplacementCandidate {
+  track: TrackView;
+  energyDist: number;
+  score: number;
+}
+
+/** Threshold at which a drag-release prompts the replacement popover. */
+export const REPLACE_PROMPT_THRESHOLD = 0.8;
+
+export function rankReplacementCandidates(
+  targetEnergy: number,
+  prevTrack: TrackView | null,
+  pool: TrackView[],
+  inSetIds: ReadonlySet<string>,
+): ReplacementCandidate[] {
+  return pool
+    .filter((t) => !inSetIds.has(t.id))
+    .map((t) => {
+      const energyDist = Math.abs(t.energy - targetEnergy);
+      const bpmFit = prevTrack ? bpmCompat(prevTrack.bpm, t.bpm) : 0.8;
+      const keyFit = prevTrack ? camelotCompat(prevTrack.key, t.key) : 0.8;
+      const score = (1 - Math.min(energyDist / 4, 1)) * 0.55 + bpmFit * 0.25 + keyFit * 0.2;
+      return { track: t, energyDist, score };
+    })
+    .filter((c) => c.energyDist <= 2.5)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 5);
+}
+
+// ---------------------------------------------------------------------------
+// Tier color palettes (design bundle)
+// ---------------------------------------------------------------------------
+
+export interface TierColor {
+  stroke: string;
+  fill: string;
+  chip: string;
+  chipBg: string;
+}
+
+export const BPM_TIER_COLORS: Record<BpmTier, TierColor> = {
+  match: { stroke: '#22c55e', fill: 'rgba(34,197,94,0.18)', chip: '#4ade80', chipBg: 'rgba(34,197,94,0.14)' },
+  good: { stroke: '#84cc16', fill: 'rgba(132,204,22,0.18)', chip: '#a3e635', chipBg: 'rgba(132,204,22,0.14)' },
+  stretch: { stroke: '#f59e0b', fill: 'rgba(245,158,11,0.18)', chip: '#fbbf24', chipBg: 'rgba(245,158,11,0.14)' },
+  clash: { stroke: '#ef4444', fill: 'rgba(239,68,68,0.20)', chip: '#f87171', chipBg: 'rgba(239,68,68,0.14)' },
+  unknown: { stroke: '#6b7280', fill: 'rgba(107,114,128,0.15)', chip: '#9ca3af', chipBg: 'rgba(107,114,128,0.14)' },
+};
+
+export const KEY_TIER_COLORS: Record<KeyTier, TierColor> = {
+  perfect: BPM_TIER_COLORS.match,
+  good: BPM_TIER_COLORS.good,
+  ok: BPM_TIER_COLORS.stretch,
+  clash: BPM_TIER_COLORS.clash,
+  unknown: BPM_TIER_COLORS.unknown,
+};
+
+// ---------------------------------------------------------------------------
+// Slot block geometry
+// ---------------------------------------------------------------------------
+
+export interface SlotBlock {
+  idx: number;
+  slot: SlotView;
+  x0: number;
+  x1: number;
+  xMid: number;
+  width: number;
+  /** Intrinsic track energy. */
+  energy: number;
+  /** Effective target (drag override applied by caller). */
+  target: number;
+}
+
+export function slotBlocksFromSlots(slots: SlotView[], width: number): SlotBlock[] {
+  const total = slots.reduce((acc, s) => acc + s.track.durationSec, 0);
+  if (total <= 0) return [];
+  const blocks: SlotBlock[] = [];
+  let cur = 0;
+  for (let i = 0; i < slots.length; i++) {
+    const s = slots[i];
+    const t0 = cur / total;
+    const t1 = (cur + s.track.durationSec) / total;
+    blocks.push({
+      idx: i,
+      slot: s,
+      x0: t0 * width,
+      x1: t1 * width,
+      xMid: ((t0 + t1) / 2) * width,
+      width: Math.max(1, (t1 - t0) * width),
+      energy: s.track.energy,
+      target: effectiveTarget(s),
+    });
+    cur += s.track.durationSec;
+  }
+  return blocks;
+}
+
+export function fmtTime(sec: number): string {
+  const s = Math.max(0, Math.round(sec));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}h`;
+  return `${m}:${String(s % 60).padStart(2, '0')}`;
+}
+
+// ---------------------------------------------------------------------------
+// Vibe-window presets (15 — design bundle)
+// ---------------------------------------------------------------------------
+
+export interface VibePreset {
+  id: string;
+  label: string;
+  energyBias: [number, number];
+  hint: string;
+}
+
+export const VIBE_PRESETS: VibePreset[] = [
+  { id: 'slow-dance', label: 'Slow Dance', energyBias: [3, 5], hint: 'tender · partner sway · 70-90 BPM' },
+  { id: 'first-dance', label: 'First Dance', energyBias: [3, 4], hint: 'intimate · the couple’s song' },
+  { id: 'parent-dance', label: 'Parent Dance', energyBias: [3, 5], hint: 'sentimental · multigenerational' },
+  { id: 'cocktail', label: 'Cocktail Hour', energyBias: [3, 5], hint: 'conversational · jazz/soul/standards' },
+  { id: 'dinner', label: 'Dinner', energyBias: [2, 4], hint: 'background · low BPM · vocals OK' },
+  { id: 'cake-cutting', label: 'Cake Cutting', energyBias: [5, 7], hint: 'feel-good · short build' },
+  { id: 'bouquet-toss', label: 'Bouquet Toss', energyBias: [7, 9], hint: 'singles anthem · empowered · sing-along' },
+  { id: 'garter-toss', label: 'Garter Toss', energyBias: [7, 9], hint: 'cheeky · uptempo' },
+  { id: 'money-dance', label: 'Money Dance', energyBias: [5, 7], hint: 'cultural · uptempo · 3-5 min' },
+  { id: 'peak-build', label: 'Peak Build', energyBias: [7, 10], hint: 'energy lift into the drop' },
+  { id: 'hype-up', label: 'Hype Up', energyBias: [9, 10], hint: 'maximum · anthem stack' },
+  { id: 'sing-along', label: 'Sing-along', energyBias: [6, 8], hint: 'every-line-known · crowd vocals' },
+  { id: 'breather', label: 'Breather', energyBias: [4, 6], hint: 'cool-down between peaks' },
+  { id: 'last-call', label: 'Last Call', energyBias: [5, 7], hint: 'final ramp · 1-2 anthems' },
+  { id: 'send-off', label: 'Send-off', energyBias: [5, 7], hint: 'closer · grand finale tone' },
+];
+
+export const BUILTIN_TEMPLATE_NAMES = ['Open-Format', 'Wedding', 'Prom', 'Club Peak'] as const;

--- a/dashboard/app/(dj)/setbuilder/components/types.ts
+++ b/dashboard/app/(dj)/setbuilder/components/types.ts
@@ -1,0 +1,64 @@
+/**
+ * View-model types for the energy-curve editor (#389).
+ *
+ * Track metadata flows from the pool (#388) / two-pass algorithm (#390);
+ * until those land, `slotViewFromApi` fills safe defaults so the curve is
+ * renderable from the bare Phase 0 slot rows.
+ */
+
+import type { SetSlotOut } from '@/lib/api-types';
+
+export interface TrackView {
+  id: string;
+  title: string;
+  artist: string;
+  durationSec: number;
+  /** Intrinsic track energy 0-10 (vibe-sourced). */
+  energy: number;
+  bpm: number | null;
+  /** Camelot key string, e.g. "8A". */
+  key: string | null;
+}
+
+export interface SlotView {
+  id: number;
+  position: number;
+  locked: boolean;
+  /** Explicit target; null = fall back to track energy. */
+  targetEnergy: number | null;
+  track: TrackView;
+}
+
+/** A vibe window in normalized timeline coordinates (t in [0,1]). */
+export interface VibeWindowView {
+  id: string;
+  t0: number;
+  t1: number;
+  label: string;
+}
+
+export const DEFAULT_TRACK_DURATION_SEC = 210;
+export const DEFAULT_TRACK_ENERGY = 5;
+
+export function slotViewFromApi(slot: SetSlotOut): SlotView {
+  return {
+    id: slot.id,
+    position: slot.position,
+    locked: slot.locked,
+    targetEnergy: slot.target_energy ?? null,
+    track: {
+      id: slot.track_id ?? `slot-${slot.id}`,
+      title: slot.track_id ?? `Slot ${slot.position + 1}`,
+      artist: '',
+      durationSec: DEFAULT_TRACK_DURATION_SEC,
+      energy: DEFAULT_TRACK_ENERGY,
+      bpm: null,
+      key: null,
+    },
+  };
+}
+
+/** Effective target for a slot: explicit target, else the track's energy. */
+export function effectiveTarget(slot: SlotView): number {
+  return slot.targetEnergy ?? slot.track.energy;
+}

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -2412,6 +2412,54 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/setbuilder/curve-templates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Curve Templates
+         * @description Built-in templates plus the current DJ's saved templates.
+         */
+        get: operations["list_curve_templates_api_setbuilder_curve_templates_get"];
+        put?: never;
+        /**
+         * Create Curve Template
+         * @description Save a new per-DJ curve template.
+         */
+        post: operations["create_curve_template_api_setbuilder_curve_templates_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/curve-templates/{template_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update Curve Template
+         * @description Overwrite one of the current DJ's templates, or 404.
+         */
+        put: operations["update_curve_template_api_setbuilder_curve_templates__template_id__put"];
+        post?: never;
+        /**
+         * Delete Curve Template
+         * @description Delete one of the current DJ's templates, or 404.
+         */
+        delete: operations["delete_curve_template_api_setbuilder_curve_templates__template_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/setbuilder/sets": {
         parameters: {
             query?: never;
@@ -2462,6 +2510,90 @@ export interface paths {
          * @description Rename one of the current DJ's sets, or 404.
          */
         patch: operations["rename_set_api_setbuilder_sets__set_id__patch"];
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/curve/apply-template": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Apply Curve Template
+         * @description Re-target every slot from a built-in or saved template shape.
+         */
+        post: operations["apply_curve_template_api_setbuilder_sets__set_id__curve_apply_template_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/slots": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Set Slots
+         * @description Ordered timeline slots for one of the current DJ's sets.
+         */
+        get: operations["list_set_slots_api_setbuilder_sets__set_id__slots_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/slots/{slot_id}/target": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Slot Target
+         * @description Set (or clear with null) a slot's energy target.
+         */
+        patch: operations["update_slot_target_api_setbuilder_sets__set_id__slots__slot_id__target_patch"];
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/vibe-windows": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Vibe Windows
+         * @description The set's stored vibe windows.
+         */
+        get: operations["get_vibe_windows_api_setbuilder_sets__set_id__vibe_windows_get"];
+        /**
+         * Put Vibe Windows
+         * @description Replace-all update of the set's vibe windows.
+         */
+        put: operations["put_vibe_windows_api_setbuilder_sets__set_id__vibe_windows_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/api/tidal/auth/cancel": {
@@ -2930,6 +3062,32 @@ export interface components {
             role?: string | null;
         };
         /**
+         * ApplyTemplateRequest
+         * @description Apply a template's shape onto the set's slots.
+         *
+         *     Exactly one of ``builtin`` / ``template_id``. ``slot_midpoints`` are the
+         *     normalized slot midpoints (client knows track durations); omitted means
+         *     uniform buckets.
+         */
+        ApplyTemplateRequest: {
+            /** Builtin */
+            builtin?: string | null;
+            /** Slot Midpoints */
+            slot_midpoints?: number[] | null;
+            /** Template Id */
+            template_id?: number | null;
+        };
+        /**
+         * ApplyTemplateResponse
+         * @description Per-slot targets persisted by an apply, plus suggested vibe windows.
+         */
+        ApplyTemplateResponse: {
+            /** Targets */
+            targets: components["schemas"]["SlotTargetOut"][];
+            /** Windows */
+            windows: components["schemas"]["TemplateWindowOut"][];
+        };
+        /**
          * AuditEventRow
          * @description A single audit-trail row with joined display labels.
          *
@@ -3069,10 +3227,7 @@ export interface components {
         };
         /** Body_upload_banner_api_events__code__banner_post */
         Body_upload_banner_api_events__code__banner_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** BridgeApiKeyResponse */
@@ -3165,6 +3320,16 @@ export interface components {
             plugin_id: string | null;
             /** Uptime Seconds */
             uptime_seconds: number | null;
+        };
+        /**
+         * BuiltinTemplateOut
+         * @description A built-in (code-defined) template.
+         */
+        BuiltinTemplateOut: {
+            /** Name */
+            name: string;
+            /** Points */
+            points: components["schemas"]["CurvePointModel"][];
         };
         /** BulkActionResponse */
         BulkActionResponse: {
@@ -3549,6 +3714,65 @@ export interface components {
             message: string | null;
             /** Ok */
             ok: boolean;
+        };
+        /**
+         * CurvePointModel
+         * @description One normalized template point: position t in [0,1], energy e in [0,10].
+         */
+        CurvePointModel: {
+            /** E */
+            e: number;
+            /** Label */
+            label: string | null;
+            /**
+             * Slow End
+             * @default false
+             */
+            slow_end: boolean;
+            /**
+             * Slow Start
+             * @default false
+             */
+            slow_start: boolean;
+            /** T */
+            t: number;
+        };
+        /**
+         * CurveTemplateCreate
+         * @description Body for creating (or fully updating) a user curve template.
+         */
+        CurveTemplateCreate: {
+            /** Name */
+            name: string;
+            /** Points */
+            points: components["schemas"]["CurvePointModel"][];
+        };
+        /**
+         * CurveTemplateOut
+         * @description A persisted per-DJ template.
+         */
+        CurveTemplateOut: {
+            /** Id */
+            id: number;
+            /** Name */
+            name: string;
+            /** Points */
+            points: components["schemas"]["CurvePointModel"][];
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
+        /**
+         * CurveTemplatesResponse
+         * @description All templates available to the DJ.
+         */
+        CurveTemplatesResponse: {
+            /** Builtin */
+            builtin: components["schemas"]["BuiltinTemplateOut"][];
+            /** User */
+            user: components["schemas"]["CurveTemplateOut"][];
         };
         /**
          * DisplaySettingsResponse
@@ -4666,6 +4890,42 @@ export interface components {
              */
             updated_at: string;
         };
+        /**
+         * SlotOut
+         * @description Timeline slot (curve-editor surface; track metadata joins with #388).
+         */
+        SlotOut: {
+            /** Id */
+            id: number;
+            /** Locked */
+            locked: boolean;
+            /** Notes */
+            notes: string | null;
+            /** Position */
+            position: number;
+            /** Target Energy */
+            target_energy: number | null;
+            /** Track Id */
+            track_id: string | null;
+        };
+        /**
+         * SlotTargetOut
+         * @description One slot's persisted target after an update/apply.
+         */
+        SlotTargetOut: {
+            /** Slot Id */
+            slot_id: number;
+            /** Target Energy */
+            target_energy: number | null;
+        };
+        /**
+         * SlotTargetUpdate
+         * @description Body for setting/clearing a slot's energy target. None = reset.
+         */
+        SlotTargetUpdate: {
+            /** Target Energy */
+            target_energy?: number | null;
+        };
         /** StatusMessageResponse */
         StatusMessageResponse: {
             /** Message */
@@ -4745,6 +5005,16 @@ export interface components {
             playlist_id: string;
             /** Source */
             source: string;
+        };
+        /**
+         * TemplateWindowOut
+         * @description Suggested vibe window from a template's slow_start/slow_end flags.
+         */
+        TemplateWindowOut: {
+            /** T0 */
+            t0: number;
+            /** T1 */
+            t1: number;
         };
         /** TidalAuthCheckResponse */
         TidalAuthCheckResponse: {
@@ -5019,6 +5289,34 @@ export interface components {
             expires_in: number;
             /** Verified */
             verified: boolean;
+        };
+        /**
+         * VibeWindowModel
+         * @description A named region of the set timeline, in seconds.
+         */
+        VibeWindowModel: {
+            /** Label */
+            label: string;
+            /** T0 Sec */
+            t0_sec: number;
+            /** T1 Sec */
+            t1_sec: number;
+        };
+        /**
+         * VibeWindowsPut
+         * @description Replace-all body for a set's vibe windows.
+         */
+        VibeWindowsPut: {
+            /** Windows */
+            windows: components["schemas"]["VibeWindowModel"][];
+        };
+        /**
+         * VibeWindowsResponse
+         * @description A set's stored vibe windows.
+         */
+        VibeWindowsResponse: {
+            /** Windows */
+            windows: components["schemas"]["VibeWindowModel"][];
         };
         /** VoteResponse */
         VoteResponse: {
@@ -9229,6 +9527,123 @@ export interface operations {
             };
         };
     };
+    list_curve_templates_api_setbuilder_curve_templates_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CurveTemplatesResponse"];
+                };
+            };
+        };
+    };
+    create_curve_template_api_setbuilder_curve_templates_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CurveTemplateCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CurveTemplateOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_curve_template_api_setbuilder_curve_templates__template_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                template_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CurveTemplateCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CurveTemplateOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_curve_template_api_setbuilder_curve_templates__template_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                template_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_sets_api_setbuilder_sets_get: {
         parameters: {
             query?: never;
@@ -9364,6 +9779,174 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SetDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    apply_curve_template_api_setbuilder_sets__set_id__curve_apply_template_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ApplyTemplateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApplyTemplateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_set_slots_api_setbuilder_sets__set_id__slots_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SlotOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_slot_target_api_setbuilder_sets__set_id__slots__slot_id__target_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+                slot_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SlotTargetUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SlotTargetOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_vibe_windows_api_setbuilder_sets__set_id__vibe_windows_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VibeWindowsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    put_vibe_windows_api_setbuilder_sets__set_id__vibe_windows_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["VibeWindowsPut"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VibeWindowsResponse"];
                 };
             };
             /** @description Validation Error */

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -191,6 +191,17 @@ export interface SetDetail extends SetSummary {
   exported_at: string | null;
 }
 
+// WrzDJSet energy curve editor (#389)
+export type CurvePoint = Schemas['CurvePointModel'];
+export type BuiltinCurveTemplate = Schemas['BuiltinTemplateOut'];
+export type CurveTemplate = Schemas['CurveTemplateOut'];
+export type CurveTemplatesResponse = Schemas['CurveTemplatesResponse'];
+export type SetSlotOut = Schemas['SlotOut'];
+export type SlotTargetOut = Schemas['SlotTargetOut'];
+export type ApplyTemplateResponse = Schemas['ApplyTemplateResponse'];
+export type VibeWindow = Schemas['VibeWindowModel'];
+export type VibeWindowsResponse = Schemas['VibeWindowsResponse'];
+
 /** OpenAPI expresses PaginatedResponse with `items: any[]`; keep this
  *  hand-crafted generic wrapper for type-safe consumer sites. */
 export interface PaginatedResponse<T> {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -37,6 +37,10 @@ import type {
   KioskPairResponse,
   KioskPairStatusResponse,
   KioskSessionResponse,
+  ApplyTemplateResponse,
+  CurvePoint,
+  CurveTemplate,
+  CurveTemplatesResponse,
   LLMRecommendationResponse,
   MyRequestsResponse,
   NowPlayingInfo,
@@ -47,7 +51,9 @@ import type {
   RecommendationResponse,
   SearchResult,
   SetDetail,
+  SetSlotOut,
   SetSummary,
+  SlotTargetOut,
   SongRequest,
   SystemSettings,
   SystemStats,
@@ -55,6 +61,8 @@ import type {
   TidalSearchResult,
   TidalSyncResult,
   TidalStatus,
+  VibeWindow,
+  VibeWindowsResponse,
   VoteResponse,
 } from './api-types';
 
@@ -642,6 +650,62 @@ class ApiClient {
   }
   async deleteSet(setId: number): Promise<void> {
     await this.rawFetch(`/api/setbuilder/sets/${setId}`, { method: 'DELETE' });
+  }
+
+  // WrzDJSet energy curve editor (#389)
+  async getCurveTemplates(): Promise<CurveTemplatesResponse> {
+    return this.fetch('/api/setbuilder/curve-templates');
+  }
+  async createCurveTemplate(name: string, points: CurvePoint[]): Promise<CurveTemplate> {
+    return this.fetch('/api/setbuilder/curve-templates', {
+      method: 'POST',
+      body: JSON.stringify({ name, points }),
+    });
+  }
+  async updateCurveTemplate(
+    templateId: number,
+    name: string,
+    points: CurvePoint[],
+  ): Promise<CurveTemplate> {
+    return this.fetch(`/api/setbuilder/curve-templates/${templateId}`, {
+      method: 'PUT',
+      body: JSON.stringify({ name, points }),
+    });
+  }
+  async deleteCurveTemplate(templateId: number): Promise<void> {
+    await this.rawFetch(`/api/setbuilder/curve-templates/${templateId}`, { method: 'DELETE' });
+  }
+  async getSetSlots(setId: number): Promise<SetSlotOut[]> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/slots`);
+  }
+  async updateSlotTarget(
+    setId: number,
+    slotId: number,
+    targetEnergy: number | null,
+  ): Promise<SlotTargetOut> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/slots/${slotId}/target`, {
+      method: 'PATCH',
+      body: JSON.stringify({ target_energy: targetEnergy }),
+    });
+  }
+  async applyCurveTemplate(
+    setId: number,
+    source: { builtin?: string; template_id?: number },
+    slotMidpoints?: number[],
+  ): Promise<ApplyTemplateResponse> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/curve/apply-template`, {
+      method: 'POST',
+      body: JSON.stringify({ ...source, slot_midpoints: slotMidpoints ?? null }),
+    });
+  }
+  async getVibeWindows(setId: number): Promise<VibeWindowsResponse> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/vibe-windows`);
+  }
+  async putVibeWindows(setId: number, windows: VibeWindow[]): Promise<VibeWindowsResponse> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/vibe-windows`, {
+      method: 'PUT',
+      body: JSON.stringify({ windows }),
+    });
   }
 
   async bulkDeleteEvents(codes: string[]): Promise<{ status: string; count: number }> {

--- a/docs/superpowers/plans/2026-06-09-curve-editor.md
+++ b/docs/superpowers/plans/2026-06-09-curve-editor.md
@@ -1,0 +1,143 @@
+# WrzDJSet Energy Curve Editor Implementation Plan (#389)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Slot-coupled energy-curve editor for the WrzDJSet builder: per-slot draggable targets, built-in + per-DJ persisted curve templates with an overlay editor, vibe windows, replacement popover on target mismatch, and BPM/Key seam-friction view modes.
+
+**Architecture:** Backend owns templates + piecewise-linear interpolation (`services/setbuilder/curve.py`), a per-DJ `set_curve_templates` table (migration 055), a nullable `target_energy` column on `set_slots`, and additive `/api/setbuilder` routes. Frontend is a set of NEW components under `dashboard/app/(dj)/setbuilder/components/` (SVG canvas, pure-math lib, popover, overlay editor), mounted into the builder page by swapping only the Curve + Timeline placeholder sections (shared-file courtesy with #388/#398).
+
+**Tech Stack:** FastAPI + SQLAlchemy 2.0 + Alembic + pytest; Next.js 16 / React 19, vanilla CSS modules, SVG, vitest.
+
+---
+
+## Design decisions (ambiguities resolved)
+
+1. **Per-slot target persistence** — `SetSlot.target_energy` (Float, nullable). `NULL` means "no explicit target → fall back to track energy on load" (issue: "on load target = track energy"). Added in migration `055_add_curve_templates` (one migration covers the table + the column; slots 053/054 reserved by siblings).
+2. **Track metadata gap** — pool/track models land with #388; slots only carry `track_id` today. The `GET /sets/{id}/slots` payload is metadata-free; the frontend maps slots to view models with safe defaults (duration 210s, energy 5) so the curve renders pre-#388. Components are fully prop-driven so #388/#390 can feed real metadata without touching the editor.
+3. **Server-side template application** — `POST /sets/{id}/curve/apply-template` accepts optional `slot_midpoints` (client knows durations; server doesn't yet). Missing midpoints → uniform `(i+0.5)/n`. Server interpolates via curve.py and persists `target_energy` per slot (acceptance: "Templates re-target slots").
+4. **Vibe windows persistence** — paired `SetCurvePoint` rows (start: `is_slow_window_start=True` + label; end: `is_slow_window_end=True`), `energy=0` (windows don't contribute to the envelope — the curve is derived from slot targets). Replace-all `PUT` semantics.
+5. **Replacement-prompt gate** — design's `tweaks.energyMismatchPrompt`: stored client-side in `localStorage` (`wrzdj.curve.suggestReplacements`, default ON) as a toolbar toggle; the builder settings modal is out of scope (#394/#395 own builder settings).
+6. **Replace action** — popover ranks pool candidates (props) and emits `onReplace(slotId, trackId)`; actual slot mutation wires up when #388's pool + slot CRUD land. Popover renders the empty-state when the pool is empty.
+7. **Friction math source of truth** — mirrors the design bundle exactly: BPM pct = best of direct/half/double delta relative to destination tempo; tiers ≤2 / ≤5 / ≤8 / >8 %. Camelot tiers from wheel distance.
+8. **Built-in templates** — the four shapes from the design bundle's `CURVE_PRESETS` (Open-Format, Wedding, Prom, Club Peak) with their slow-window flags.
+
+---
+
+### Task 1: Migration 055 + SetCurveTemplate model + SetSlot.target_energy
+
+**Files:**
+- Create: `server/app/models/curve_template.py`
+- Modify: `server/app/models/set.py` (add `target_energy` to SetSlot)
+- Modify: `server/app/models/__init__.py` (register import, additive)
+- Create: `server/alembic/versions/055_add_curve_templates.py` (down_revision="052")
+- Test: `server/tests/test_setbuilder_curve_models.py`
+
+Model: `SetCurveTemplate(id, user_id FK users CASCADE indexed, name String(80) not null, points_json Text not null, created_at, updated_at)`.
+SetSlot gains `target_energy: Mapped[float | None] = mapped_column(Float, nullable=True)`.
+
+- [ ] Step 1: failing model test (create template row; slot target_energy default None)
+- [ ] Step 2: model + migration; `alembic upgrade head && alembic check` clean
+- [ ] Step 3: tests pass; commit `feat(setbuilder): curve template model + slot target_energy (055)`
+
+### Task 2: curve.py service — builtins, interpolation, template CRUD, apply, vibe windows
+
+**Files:**
+- Create: `server/app/services/setbuilder/curve.py`
+- Test: `server/tests/test_setbuilder_curve_service.py`
+
+Contents:
+- `BUILTIN_TEMPLATES: dict[str, list[dict]]` — four design-bundle shapes, points `{t, e, label, slow_start?, slow_end?}`.
+- `interpolate_energy(points, t) -> float` — piecewise linear, clamps t to [0,1], flat extension beyond endpoint t's.
+- `targets_at_midpoints(points, midpoints) -> list[float]` — rounded to 0.1.
+- `uniform_midpoints(n) -> list[float]` — `(i+0.5)/n`.
+- Template CRUD (owner-scoped): `list_templates`, `get_owned_template`, `create_template`, `update_template`, `delete_template` (points stored as JSON string).
+- `apply_points_to_slots(db, set_obj, points, midpoints|None) -> list[tuple[slot_id, target]]` — orders slots by position, validates midpoint count, persists `target_energy`.
+- `set_slot_target(db, slot, value|None)`.
+- `windows_from_points(points) -> list[{t0, t1, label}]` — pairs slow_start/slow_end flags (used by apply response so the client can rebuild windows).
+- `get_vibe_windows(db, set_id)` / `replace_vibe_windows(db, set_obj, windows)` — paired SetCurvePoint rows as per design decision 4.
+
+- [ ] TDD: interpolation endpoints/midpoints/rounding tests; builtin shape sanity (4 names, endpoints at t=0/1); apply with uniform + explicit midpoints; midpoint count mismatch raises ValueError; vibe window round-trip; commit `feat(setbuilder): curve service — templates, interpolation, vibe windows`
+
+### Task 3: Schemas (additive) + API routes (additive)
+
+**Files:**
+- Modify: `server/app/schemas/setbuilder.py` (append new classes only)
+- Modify: `server/app/api/setbuilder.py` (append new routes only)
+- Test: `server/tests/test_setbuilder_curve_api.py`
+
+Schemas: `CurvePointModel{t: 0..1, e: 0..10, label?: <=50, slow_start, slow_end}`, points-list validator (2..32 points, non-decreasing t, first t=0, last t=1); `CurveTemplateCreate{name 1..80, points}`, `CurveTemplateUpdate` (same), `BuiltinTemplateOut{name, points}`, `CurveTemplateOut{id, name, points, updated_at}`, `CurveTemplatesResponse{builtin, user}`, `SlotOut{id, position, track_id, locked, target_energy, notes}`, `SlotTargetUpdate{target_energy: float|None 0..10}`, `SlotTargetOut{slot_id, target_energy}`, `ApplyTemplateRequest{builtin?|template_id? (exactly one), slot_midpoints?: list[0..1] non-decreasing}`, `ApplyTemplateResponse{targets, windows}`, `VibeWindowModel{t0_sec>=0, t1_sec>t0_sec, label 1..50}`, `VibeWindowsPut{windows max 30}`, `VibeWindowsResponse{windows}`.
+
+Routes (all `get_current_active_user`, rate-limited, owner-scoped 404):
+- `GET /curve-templates` (60/min), `POST /curve-templates` (30/min, 201), `PUT /curve-templates/{id}` (30/min), `DELETE /curve-templates/{id}` (30/min, 204)
+- `GET /sets/{set_id}/slots` (60/min)
+- `PATCH /sets/{set_id}/slots/{slot_id}/target` (60/min)
+- `POST /sets/{set_id}/curve/apply-template` (30/min)
+- `GET /sets/{set_id}/vibe-windows` (60/min), `PUT /sets/{set_id}/vibe-windows` (30/min)
+
+- [ ] TDD: auth gating (401/403-pending), owner isolation (404 on foreign set/template), template CRUD happy paths + validation 422s (bad t order, endpoint t, >32 points), apply-template persists targets (uniform + explicit midpoints; builtin + user template; 422 on both/neither id; 400 on midpoint count mismatch), slot target patch + null reset, vibe-windows put/get round-trip + 422 on t1<=t0. Commit `feat(setbuilder): curve template + slot target + vibe window endpoints`
+
+### Task 4: OpenAPI regeneration + frontend API client
+
+**Files:**
+- Regenerate: `server/openapi.json`, `dashboard/lib/api-types.generated.ts` (`npm run types:export && npm run types:generate`)
+- Modify: `dashboard/lib/api-types.ts` (additive exports)
+- Modify: `dashboard/lib/api.ts` (additive methods: `getCurveTemplates`, `createCurveTemplate`, `updateCurveTemplate`, `deleteCurveTemplate`, `getSetSlots`, `updateSlotTarget`, `applyCurveTemplate`, `getVibeWindows`, `putVibeWindows`)
+
+- [ ] Regenerate, export types from generated schemas, add client methods, commit `feat(setbuilder): curve API client + regenerated types`
+
+### Task 5: curveMath.ts — pure frontend math + presets
+
+**Files:**
+- Create: `dashboard/app/(dj)/setbuilder/components/curveMath.ts`
+- Create: `dashboard/app/(dj)/setbuilder/components/types.ts`
+- Test: `dashboard/app/(dj)/setbuilder/__tests__/curveMath.test.ts`
+
+Port from the design bundle: `interpolateEnergy`, `parseCamelot`, `bpmPercentDelta` (% of destination tempo, half/double detection, tiers match/good/stretch/clash at 2/5/8%), `camelotMixTier` (perfect/good/ok/clash + labels), `bpmCompat`, `camelotCompat`, `rankReplacementCandidates(target, prevTrack, pool, inSetIds)` (0.55 energy + 0.25 bpm + 0.20 key, ±2.5 energy filter, top 5), `BPM_TIER_COLORS`, `KEY_TIER_COLORS`, `VIBE_PRESETS` (15), `slotBlocksFromSlots` geometry helper, `fmtTime`.
+
+- [ ] TDD all math (esp. percentage thresholds + half/double-time, acceptance #3); commit `feat(setbuilder): curve math lib + vibe presets`
+
+### Task 6: CurveEditor SVG component
+
+**Files:**
+- Create: `dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx`
+- Create: `dashboard/app/(dj)/setbuilder/components/curve.module.css`
+- Test: `dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx`
+
+Port of design `curve-editor.jsx` minus pairings/playhead/pool-drop (other issues): slot blocks (x=duration share, y=energy), derived target polyline through slot midpoints, per-slot drag handles (pointer events, vertical-only) with live value chip, mismatch visuals (amber hatch `mismatchPattern` above block when target > energy+0.5; dashed amber line when target < energy−0.5), seam friction bands in bpm/key view (band sized to shorter neighbor, hover chip with exact pct/label), vibe windows (header-bar move drag, edge resize, right-click delete, double-click → preset pick callback), hover sync props (`hoveredIdx`, `onHover`, `onBlockClick`).
+
+- [ ] Render tests with fixture slots: block count, mismatch hatch presence, seam tier colors, window labels, drag-end callback firing (pointer events). Commit `feat(setbuilder): slot-coupled SVG curve editor`
+
+### Task 7: CurveTemplateEditorOverlay + ReplacePopover + CurveToolbar
+
+**Files:**
+- Create: `dashboard/app/(dj)/setbuilder/components/CurveTemplateEditorOverlay.tsx`
+- Create: `dashboard/app/(dj)/setbuilder/components/ReplacePopover.tsx`
+- Create: `dashboard/app/(dj)/setbuilder/components/CurveToolbar.tsx`
+- Test: `dashboard/app/(dj)/setbuilder/__tests__/CurveTemplateEditor.test.tsx`, `__tests__/ReplacePopover.test.tsx`
+
+Overlay: draggable SVG canvas (double-click add point, endpoints locked at t=0/1, delete key), point list sidebar (label, t %, energy slider, delete), Save changes (user templates) / Save as new / Delete; built-ins open read-only original → save-as-copy only.
+ReplacePopover: header (current energy → target), top-5 candidate rows (title/artist/bpm/key/energy/fit score), empty state, "Keep anyway" + Cancel.
+Toolbar: Normal/BPM/Key segmented view switch, template dropdown (built-in + My templates + Create new + per-row edit), Add-vibe-window dropdown (15 presets), suggest-replacements toggle (localStorage).
+
+- [ ] Tests: overlay add/remove/save-as flows; popover ranking display + gate. Commit `feat(setbuilder): template overlay editor, replace popover, curve toolbar`
+
+### Task 8: CurvePanel + TimelinePanel + BuilderWorkspace wiring
+
+**Files:**
+- Create: `dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx`
+- Create: `dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx`
+- Create: `dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx`
+- Modify: `dashboard/app/(dj)/setbuilder/[setId]/page.tsx` — replace ONLY the Curve + Timeline placeholder sections with `<BuilderWorkspace setId=…/>`
+- Test: `dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx`
+
+CurvePanel: loads slots + windows + templates, maps to SlotView (defaults for missing metadata), local target state, PATCH on drag-end, mismatch ≥0.8 → ReplacePopover (gated by toggle), apply-template → POST + rebuild windows from response, template save/save-as/delete → API, windows drag/delete → debounced PUT.
+TimelinePanel: ordered slot rows (position, title/artist, BPM/key/energy badges, target chip), hover-sync both directions, `scrollIntoView({block:'nearest'})` on curve-block click only when out of view.
+BuilderWorkspace: owns shared hover state + slot data, renders both panels in their grid areas.
+
+- [ ] Tests: workspace fetch + hover sync + drag-end PATCH (mock api). Commit `feat(setbuilder): mount curve + timeline panels in builder workspace`
+
+### Task 9: Full CI + finish
+
+- [ ] Backend: ruff check/format, bandit, pytest (coverage ≥85), alembic upgrade+check
+- [ ] Frontend: lint, tsc --noEmit, vitest --run
+- [ ] `git checkout next-env.d.ts` if dirty; push; PR with `Closes #389` + Design decisions section

--- a/server/alembic/versions/055_add_curve_templates.py
+++ b/server/alembic/versions/055_add_curve_templates.py
@@ -1,0 +1,54 @@
+"""Curve templates table + per-slot energy target (issue #389).
+
+Revision ID: 055
+Revises: 052
+Create Date: 2026-06-09
+
+Two changes for the WrzDJSet energy-curve editor:
+
+- ``set_curve_templates`` — per-DJ reusable curve templates. ``points_json``
+  is a JSON list of normalized points {t: 0-1, e: 0-10, label}. Built-in
+  templates live in code; only user templates persist here.
+- ``set_slots.target_energy`` (Float, nullable) — the slot's target energy
+  (0-10, 0.1 resolution). NULL means "no explicit target"; the UI falls back
+  to the track's intrinsic energy.
+
+Anchored on 052 (053/054 are reserved by sibling WrzDJSet PRs #388/#398).
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "055"
+down_revision: str | None = "052"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "set_curve_templates",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=80), nullable=False),
+        sa.Column("points_json", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(
+        "ix_set_curve_templates_user_id", "set_curve_templates", ["user_id"], unique=False
+    )
+
+    op.add_column("set_slots", sa.Column("target_energy", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("set_slots", "target_energy")
+    op.drop_index("ix_set_curve_templates_user_id", table_name="set_curve_templates")
+    op.drop_table("set_curve_templates")

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -12,8 +12,27 @@ from app.api.deps import get_current_active_user, get_db
 from app.core.rate_limit import limiter
 from app.models.set import Set
 from app.models.user import User
-from app.schemas.setbuilder import SetCreate, SetDetail, SetRename, SetSummary
-from app.services.setbuilder import set_service
+from app.schemas.setbuilder import (
+    ApplyTemplateRequest,
+    ApplyTemplateResponse,
+    BuiltinTemplateOut,
+    CurvePointModel,
+    CurveTemplateCreate,
+    CurveTemplateOut,
+    CurveTemplatesResponse,
+    SetCreate,
+    SetDetail,
+    SetRename,
+    SetSummary,
+    SlotOut,
+    SlotTargetOut,
+    SlotTargetUpdate,
+    TemplateWindowOut,
+    VibeWindowModel,
+    VibeWindowsPut,
+    VibeWindowsResponse,
+)
+from app.services.setbuilder import curve, set_service
 
 router = APIRouter()
 
@@ -88,3 +107,178 @@ def delete_set(
     """Delete one of the current DJ's sets, or 404."""
     set_obj = _get_owned_or_404(db, set_id, current_user)
     set_service.delete_set(db, set_obj)
+
+
+# ---------------------------------------------------------------------------
+# Energy curve editor (#389) — templates, slot targets, vibe windows
+# ---------------------------------------------------------------------------
+
+
+def _builtin_templates_out() -> list[BuiltinTemplateOut]:
+    return [
+        BuiltinTemplateOut(name=name, points=[CurvePointModel(**p) for p in points])
+        for name, points in curve.BUILTIN_TEMPLATES.items()
+    ]
+
+
+def _template_out(tpl) -> CurveTemplateOut:
+    return CurveTemplateOut(
+        id=tpl.id,
+        name=tpl.name,
+        points=[CurvePointModel(**p) for p in curve.template_points(tpl)],
+        updated_at=tpl.updated_at,
+    )
+
+
+def _get_owned_template_or_404(db: Session, template_id: int, user: User):
+    tpl = curve.get_owned_template(db, template_id, user.id)
+    if tpl is None:
+        raise HTTPException(status_code=404, detail="Template not found")
+    return tpl
+
+
+@router.get("/curve-templates", response_model=CurveTemplatesResponse)
+@limiter.limit("60/minute")
+def list_curve_templates(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> CurveTemplatesResponse:
+    """Built-in templates plus the current DJ's saved templates."""
+    return CurveTemplatesResponse(
+        builtin=_builtin_templates_out(),
+        user=[_template_out(t) for t in curve.list_templates(db, current_user.id)],
+    )
+
+
+@router.post(
+    "/curve-templates", response_model=CurveTemplateOut, status_code=status.HTTP_201_CREATED
+)
+@limiter.limit("30/minute")
+def create_curve_template(
+    payload: CurveTemplateCreate,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> CurveTemplateOut:
+    """Save a new per-DJ curve template."""
+    points = [p.model_dump(exclude_none=True) for p in payload.points]
+    return _template_out(curve.create_template(db, current_user.id, payload.name, points))
+
+
+@router.put("/curve-templates/{template_id}", response_model=CurveTemplateOut)
+@limiter.limit("30/minute")
+def update_curve_template(
+    template_id: int,
+    payload: CurveTemplateCreate,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> CurveTemplateOut:
+    """Overwrite one of the current DJ's templates, or 404."""
+    tpl = _get_owned_template_or_404(db, template_id, current_user)
+    points = [p.model_dump(exclude_none=True) for p in payload.points]
+    return _template_out(curve.update_template(db, tpl, payload.name, points))
+
+
+@router.delete("/curve-templates/{template_id}", status_code=status.HTTP_204_NO_CONTENT)
+@limiter.limit("30/minute")
+def delete_curve_template(
+    template_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> None:
+    """Delete one of the current DJ's templates, or 404."""
+    tpl = _get_owned_template_or_404(db, template_id, current_user)
+    curve.delete_template(db, tpl)
+
+
+@router.get("/sets/{set_id}/slots", response_model=list[SlotOut])
+@limiter.limit("60/minute")
+def list_set_slots(
+    set_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> list[SlotOut]:
+    """Ordered timeline slots for one of the current DJ's sets."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    slots = sorted(set_obj.slots, key=lambda s: s.position)
+    return [SlotOut.model_validate(s) for s in slots]
+
+
+@router.patch("/sets/{set_id}/slots/{slot_id}/target", response_model=SlotTargetOut)
+@limiter.limit("60/minute")
+def update_slot_target(
+    set_id: int,
+    slot_id: int,
+    payload: SlotTargetUpdate,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> SlotTargetOut:
+    """Set (or clear with null) a slot's energy target."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    slot = next((s for s in set_obj.slots if s.id == slot_id), None)
+    if slot is None:
+        raise HTTPException(status_code=404, detail="Slot not found")
+    slot = curve.set_slot_target(db, slot, payload.target_energy)
+    return SlotTargetOut(slot_id=slot.id, target_energy=slot.target_energy)
+
+
+@router.post("/sets/{set_id}/curve/apply-template", response_model=ApplyTemplateResponse)
+@limiter.limit("30/minute")
+def apply_curve_template(
+    set_id: int,
+    payload: ApplyTemplateRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> ApplyTemplateResponse:
+    """Re-target every slot from a built-in or saved template shape."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    if payload.builtin is not None:
+        points = curve.BUILTIN_TEMPLATES.get(payload.builtin)
+        if points is None:
+            raise HTTPException(status_code=404, detail="Template not found")
+    else:
+        tpl = _get_owned_template_or_404(db, payload.template_id, current_user)
+        points = curve.template_points(tpl)
+    try:
+        applied = curve.apply_points_to_slots(db, set_obj, points, payload.slot_midpoints)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return ApplyTemplateResponse(
+        targets=[SlotTargetOut(slot_id=sid, target_energy=t) for sid, t in applied],
+        windows=[TemplateWindowOut(**w) for w in curve.windows_from_points(points)],
+    )
+
+
+@router.get("/sets/{set_id}/vibe-windows", response_model=VibeWindowsResponse)
+@limiter.limit("60/minute")
+def get_vibe_windows(
+    set_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> VibeWindowsResponse:
+    """The set's stored vibe windows."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    windows = curve.get_vibe_windows(db, set_obj.id)
+    return VibeWindowsResponse(windows=[VibeWindowModel(**w) for w in windows])
+
+
+@router.put("/sets/{set_id}/vibe-windows", response_model=VibeWindowsResponse)
+@limiter.limit("30/minute")
+def put_vibe_windows(
+    set_id: int,
+    payload: VibeWindowsPut,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> VibeWindowsResponse:
+    """Replace-all update of the set's vibe windows."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    stored = curve.replace_vibe_windows(db, set_obj, [w.model_dump() for w in payload.windows])
+    return VibeWindowsResponse(windows=[VibeWindowModel(**w) for w in stored])

--- a/server/app/models/__init__.py
+++ b/server/app/models/__init__.py
@@ -1,5 +1,6 @@
 from app.models.activity_log import ActivityLog
 from app.models.base import Base
+from app.models.curve_template import SetCurveTemplate
 from app.models.email_verification_code import EmailVerificationCode
 from app.models.event import Event
 from app.models.guest import Guest
@@ -41,6 +42,7 @@ __all__ = [
     "Set",
     "SetCollaborator",
     "SetCurvePoint",
+    "SetCurveTemplate",
     "SetSlot",
     "SystemSettings",
     "TrackVibe",

--- a/server/app/models/curve_template.py
+++ b/server/app/models/curve_template.py
@@ -1,0 +1,29 @@
+"""Per-DJ reusable energy-curve templates (#389).
+
+A template is a normalized point list (t in [0,1], e in [0,10]) stored as a
+JSON string in ``points_json``. Built-in templates live in code
+(``services/setbuilder/curve.py``); only user-created templates persist here.
+Validation of the point shape happens at the API boundary (Pydantic).
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.time import utcnow
+from app.models.base import Base
+
+
+class SetCurveTemplate(Base):
+    __tablename__ = "set_curve_templates"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(80), nullable=False)
+    points_json: Mapped[str] = mapped_column(Text, nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow, onupdate=utcnow)

--- a/server/app/models/set.py
+++ b/server/app/models/set.py
@@ -92,6 +92,9 @@ class SetSlot(Base):
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     transition_score: Mapped[float | None] = mapped_column(Float, nullable=True)
     transition_warnings: Mapped[str | None] = mapped_column(Text, nullable=True)  # JSON
+    # Per-slot energy target (0-10, 0.1 resolution). NULL = no explicit
+    # target; UI falls back to the track's intrinsic energy. (#389)
+    target_energy: Mapped[float | None] = mapped_column(Float, nullable=True)
 
     set: Mapped["Set"] = relationship("Set", back_populates="slots")
 

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class SetCreate(BaseModel):
@@ -43,3 +43,162 @@ class SetDetail(SetSummary):
     key_strictness: float
     tidal_playlist_id: str | None
     exported_at: datetime | None
+
+
+# ---------------------------------------------------------------------------
+# Energy curve editor (#389)
+# ---------------------------------------------------------------------------
+
+
+class CurvePointModel(BaseModel):
+    """One normalized template point: position t in [0,1], energy e in [0,10]."""
+
+    t: float = Field(..., ge=0.0, le=1.0)
+    e: float = Field(..., ge=0.0, le=10.0)
+    label: str | None = Field(None, max_length=50)
+    slow_start: bool = False
+    slow_end: bool = False
+
+
+def _validate_curve_points(points: list[CurvePointModel]) -> list[CurvePointModel]:
+    """Shared shape rules: 2-32 points, endpoints at t=0/t=1, non-decreasing t."""
+    if not (2 <= len(points) <= 32):
+        raise ValueError("curve needs between 2 and 32 points")
+    if points[0].t != 0.0:
+        raise ValueError("first point must be at t=0")
+    if points[-1].t != 1.0:
+        raise ValueError("last point must be at t=1")
+    ts = [p.t for p in points]
+    if any(b < a for a, b in zip(ts, ts[1:])):
+        raise ValueError("points must be ordered by non-decreasing t")
+    return points
+
+
+class CurveTemplateCreate(BaseModel):
+    """Body for creating (or fully updating) a user curve template."""
+
+    name: str = Field(..., min_length=1, max_length=80)
+    points: list[CurvePointModel]
+
+    _check_points = field_validator("points")(_validate_curve_points)
+
+
+class BuiltinTemplateOut(BaseModel):
+    """A built-in (code-defined) template."""
+
+    name: str
+    points: list[CurvePointModel]
+
+
+class CurveTemplateOut(BaseModel):
+    """A persisted per-DJ template."""
+
+    id: int
+    name: str
+    points: list[CurvePointModel]
+    updated_at: datetime
+
+
+class CurveTemplatesResponse(BaseModel):
+    """All templates available to the DJ."""
+
+    builtin: list[BuiltinTemplateOut]
+    user: list[CurveTemplateOut]
+
+
+class SlotOut(BaseModel):
+    """Timeline slot (curve-editor surface; track metadata joins with #388)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    position: int
+    track_id: str | None
+    locked: bool
+    target_energy: float | None
+    notes: str | None
+
+
+class SlotTargetUpdate(BaseModel):
+    """Body for setting/clearing a slot's energy target. None = reset."""
+
+    target_energy: float | None = Field(None, ge=0.0, le=10.0)
+
+
+class SlotTargetOut(BaseModel):
+    """One slot's persisted target after an update/apply."""
+
+    slot_id: int
+    target_energy: float | None
+
+
+class ApplyTemplateRequest(BaseModel):
+    """Apply a template's shape onto the set's slots.
+
+    Exactly one of ``builtin`` / ``template_id``. ``slot_midpoints`` are the
+    normalized slot midpoints (client knows track durations); omitted means
+    uniform buckets.
+    """
+
+    builtin: str | None = Field(None, max_length=80)
+    template_id: int | None = None
+    slot_midpoints: list[float] | None = None
+
+    @field_validator("slot_midpoints")
+    @classmethod
+    def _check_midpoints(cls, v: list[float] | None) -> list[float] | None:
+        if v is None:
+            return v
+        if len(v) > 500:
+            raise ValueError("too many slot_midpoints")
+        if any(not (0.0 <= m <= 1.0) for m in v):
+            raise ValueError("slot_midpoints must be within [0, 1]")
+        if any(b < a for a, b in zip(v, v[1:])):
+            raise ValueError("slot_midpoints must be non-decreasing")
+        return v
+
+    @model_validator(mode="after")
+    def _exactly_one_source(self) -> "ApplyTemplateRequest":
+        if (self.builtin is None) == (self.template_id is None):
+            raise ValueError("provide exactly one of builtin or template_id")
+        return self
+
+
+class ApplyTemplateResponse(BaseModel):
+    """Per-slot targets persisted by an apply, plus suggested vibe windows."""
+
+    targets: list[SlotTargetOut]
+    windows: list["TemplateWindowOut"]
+
+
+class TemplateWindowOut(BaseModel):
+    """Suggested vibe window from a template's slow_start/slow_end flags."""
+
+    t0: float
+    t1: float
+
+
+class VibeWindowModel(BaseModel):
+    """A named region of the set timeline, in seconds."""
+
+    t0_sec: int = Field(..., ge=0)
+    t1_sec: int = Field(..., ge=0)
+    label: str = Field(..., min_length=1, max_length=50)
+
+    @model_validator(mode="after")
+    def _ordered(self) -> "VibeWindowModel":
+        if self.t1_sec <= self.t0_sec:
+            raise ValueError("t1_sec must be greater than t0_sec")
+        return self
+
+
+class VibeWindowsPut(BaseModel):
+    """Replace-all body for a set's vibe windows."""
+
+    windows: list[VibeWindowModel] = Field(..., max_length=30)
+
+
+class VibeWindowsResponse(BaseModel):
+    """A set's stored vibe windows."""
+
+    windows: list[VibeWindowModel]

--- a/server/app/services/setbuilder/curve.py
+++ b/server/app/services/setbuilder/curve.py
@@ -1,0 +1,284 @@
+"""Energy-curve templates + interpolation for WrzDJSet (#389, exec summary §3).
+
+The curve is *derived*: it connects each slot's ``target_energy`` at the
+slot's midpoint. Templates (built-in or per-DJ persisted) are normalized
+point lists ``{t: 0-1, e: 0-10, label}``; applying a template interpolates
+the template shape at every slot midpoint (piecewise linear, exec summary
+§11 default) and persists the result onto ``SetSlot.target_energy``.
+
+Vibe windows persist as *paired* ``SetCurvePoint`` rows: the start row sets
+``is_slow_window_start`` + carries the label; the end row sets
+``is_slow_window_end``. Window rows use ``energy=0`` — they do not
+contribute to the energy envelope (the envelope comes from slot targets).
+"""
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.curve_template import SetCurveTemplate
+from app.models.set import Set, SetCurvePoint, SetSlot
+
+# Built-in templates (design-bundle CURVE_PRESETS). ``slow_start``/``slow_end``
+# flags mark suggested vibe-window boundaries the client rebuilds on apply.
+BUILTIN_TEMPLATES: dict[str, list[dict]] = {
+    "Open-Format": [
+        {"t": 0, "e": 4, "label": "Arrival"},
+        {"t": 0.10, "e": 5, "label": "Warm-up"},
+        {"t": 0.25, "e": 7, "label": "Lift"},
+        {"t": 0.45, "e": 9, "label": "Peak I"},
+        {"t": 0.55, "e": 7, "label": "Breather", "slow_start": True},
+        {"t": 0.62, "e": 5, "label": "Slow set", "slow_end": True},
+        {"t": 0.72, "e": 8, "label": "Re-energize"},
+        {"t": 0.85, "e": 10, "label": "Peak II"},
+        {"t": 0.95, "e": 6, "label": "Last call"},
+        {"t": 1.0, "e": 3, "label": "Close"},
+    ],
+    "Wedding": [
+        {"t": 0, "e": 3, "label": "Cocktail"},
+        {"t": 0.15, "e": 4, "label": "Dinner"},
+        {"t": 0.3, "e": 6, "label": "First sets"},
+        {"t": 0.5, "e": 9, "label": "Peak"},
+        {"t": 0.7, "e": 5, "label": "Slow songs", "slow_start": True},
+        {"t": 0.78, "e": 4, "label": "Slow end", "slow_end": True},
+        {"t": 0.88, "e": 9, "label": "Closer peak"},
+        {"t": 1.0, "e": 6, "label": "Send-off"},
+    ],
+    "Prom": [
+        {"t": 0, "e": 5, "label": "Arrival"},
+        {"t": 0.2, "e": 8, "label": "Lift"},
+        {"t": 0.4, "e": 10, "label": "Peak I"},
+        {"t": 0.55, "e": 6, "label": "Slow", "slow_start": True},
+        {"t": 0.65, "e": 5, "label": "Slow", "slow_end": True},
+        {"t": 0.85, "e": 10, "label": "Peak II"},
+        {"t": 1.0, "e": 7, "label": "Close"},
+    ],
+    "Club Peak": [
+        {"t": 0, "e": 7, "label": "Warm"},
+        {"t": 0.3, "e": 9, "label": "Build"},
+        {"t": 0.6, "e": 10, "label": "Peak"},
+        {"t": 0.85, "e": 10, "label": "Hold"},
+        {"t": 1.0, "e": 8, "label": "Cool"},
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Interpolation (piecewise linear)
+# ---------------------------------------------------------------------------
+
+
+def interpolate_energy(points: list[dict], t: float) -> float:
+    """Energy of the curve at normalized position ``t`` (clamped to [0, 1]).
+
+    Piecewise-linear between consecutive points; flat extension before the
+    first / after the last point.
+    """
+    if not points:
+        return 5.0
+    t = max(0.0, min(1.0, t))
+    if t <= points[0]["t"]:
+        return float(points[0]["e"])
+    if t >= points[-1]["t"]:
+        return float(points[-1]["e"])
+    for a, b in zip(points, points[1:]):
+        if a["t"] <= t <= b["t"]:
+            span = b["t"] - a["t"]
+            if span <= 0:
+                return float(b["e"])
+            f = (t - a["t"]) / span
+            return float(a["e"]) + (float(b["e"]) - float(a["e"])) * f
+    return float(points[-1]["e"])
+
+
+def targets_at_midpoints(points: list[dict], midpoints: list[float]) -> list[float]:
+    """Interpolated targets (rounded to 0.1) at each slot midpoint."""
+    return [round(interpolate_energy(points, m), 1) for m in midpoints]
+
+
+def uniform_midpoints(n: int) -> list[float]:
+    """Uniform slot midpoints for ``n`` slots: (i + 0.5) / n."""
+    return [(i + 0.5) / n for i in range(n)]
+
+
+def windows_from_points(points: list[dict]) -> list[dict]:
+    """Pair slow_start/slow_end flags into ``{t0, t1}`` windows."""
+    windows: list[dict] = []
+    open_t: float | None = None
+    for p in points:
+        if p.get("slow_start"):
+            open_t = p["t"]
+        if p.get("slow_end") and open_t is not None:
+            windows.append({"t0": open_t, "t1": p["t"]})
+            open_t = None
+    return windows
+
+
+# ---------------------------------------------------------------------------
+# Template CRUD (owner-scoped)
+# ---------------------------------------------------------------------------
+
+
+def template_points(tpl: SetCurveTemplate) -> list[dict]:
+    """Decode a template's stored point list."""
+    return json.loads(tpl.points_json)
+
+
+def list_templates(db: Session, user_id: int) -> list[SetCurveTemplate]:
+    """The DJ's saved templates, newest first."""
+    return (
+        db.query(SetCurveTemplate)
+        .filter(SetCurveTemplate.user_id == user_id)
+        .order_by(SetCurveTemplate.updated_at.desc())
+        .all()
+    )
+
+
+def get_owned_template(db: Session, template_id: int, user_id: int) -> SetCurveTemplate | None:
+    """Fetch a template by id, scoped to the owner. None if missing/unowned."""
+    return (
+        db.query(SetCurveTemplate)
+        .filter(SetCurveTemplate.id == template_id, SetCurveTemplate.user_id == user_id)
+        .one_or_none()
+    )
+
+
+def create_template(db: Session, user_id: int, name: str, points: list[dict]) -> SetCurveTemplate:
+    """Persist a new per-DJ template."""
+    tpl = SetCurveTemplate(user_id=user_id, name=name, points_json=json.dumps(points))
+    db.add(tpl)
+    db.commit()
+    db.refresh(tpl)
+    return tpl
+
+
+def update_template(
+    db: Session, tpl: SetCurveTemplate, name: str, points: list[dict]
+) -> SetCurveTemplate:
+    """Overwrite a template's name + points."""
+    tpl.name = name
+    tpl.points_json = json.dumps(points)
+    db.commit()
+    db.refresh(tpl)
+    return tpl
+
+
+def delete_template(db: Session, tpl: SetCurveTemplate) -> None:
+    """Delete a template."""
+    db.delete(tpl)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Slot targets
+# ---------------------------------------------------------------------------
+
+
+def apply_points_to_slots(
+    db: Session,
+    set_obj: Set,
+    points: list[dict],
+    midpoints: list[float] | None,
+) -> list[tuple[int, float]]:
+    """Re-target every slot from the template shape; persist + return targets.
+
+    ``midpoints`` are normalized slot midpoints supplied by the client (which
+    knows track durations). When None, slots are treated as uniform buckets.
+
+    Raises ValueError when the midpoint count doesn't match the slot count.
+    """
+    slots = (
+        db.query(SetSlot)
+        .filter(SetSlot.set_id == set_obj.id)
+        .order_by(SetSlot.position.asc())
+        .all()
+    )
+    if not slots:
+        return []
+    if midpoints is None:
+        midpoints = uniform_midpoints(len(slots))
+    elif len(midpoints) != len(slots):
+        raise ValueError(f"expected {len(slots)} slot_midpoints, got {len(midpoints)}")
+
+    targets = targets_at_midpoints(points, midpoints)
+    for slot, target in zip(slots, targets):
+        slot.target_energy = target
+    db.commit()
+    return [(slot.id, target) for slot, target in zip(slots, targets)]
+
+
+def set_slot_target(db: Session, slot: SetSlot, value: float | None) -> SetSlot:
+    """Set (or clear, with None) a slot's explicit energy target."""
+    slot.target_energy = value if value is None else round(value, 1)
+    db.commit()
+    db.refresh(slot)
+    return slot
+
+
+# ---------------------------------------------------------------------------
+# Vibe windows (paired SetCurvePoint rows)
+# ---------------------------------------------------------------------------
+
+
+def get_vibe_windows(db: Session, set_id: int) -> list[dict]:
+    """Decode paired window rows into ``{t0_sec, t1_sec, label}`` dicts.
+
+    Rows are read in insertion (id) order — ``replace_vibe_windows`` writes
+    each window as an adjacent start/end pair, which keeps pairing correct
+    even when windows overlap in time.
+    """
+    rows = (
+        db.query(SetCurvePoint)
+        .filter(
+            SetCurvePoint.set_id == set_id,
+            (SetCurvePoint.is_slow_window_start == True)  # noqa: E712
+            | (SetCurvePoint.is_slow_window_end == True),  # noqa: E712
+        )
+        .order_by(SetCurvePoint.id.asc())
+        .all()
+    )
+    windows: list[dict] = []
+    open_row: SetCurvePoint | None = None
+    for row in rows:
+        if row.is_slow_window_start:
+            open_row = row
+        elif row.is_slow_window_end and open_row is not None:
+            windows.append(
+                {
+                    "t0_sec": open_row.position_sec,
+                    "t1_sec": row.position_sec,
+                    "label": open_row.label or "Vibe window",
+                }
+            )
+            open_row = None
+    return windows
+
+
+def replace_vibe_windows(db: Session, set_obj: Set, windows: list[dict]) -> list[dict]:
+    """Replace-all vibe windows for a set; returns the stored windows."""
+    db.query(SetCurvePoint).filter(
+        SetCurvePoint.set_id == set_obj.id,
+        (SetCurvePoint.is_slow_window_start == True)  # noqa: E712
+        | (SetCurvePoint.is_slow_window_end == True),  # noqa: E712
+    ).delete(synchronize_session=False)
+
+    for w in sorted(windows, key=lambda w: w["t0_sec"]):
+        db.add(
+            SetCurvePoint(
+                set_id=set_obj.id,
+                position_sec=w["t0_sec"],
+                energy=0,
+                label=w["label"],
+                is_slow_window_start=True,
+            )
+        )
+        db.add(
+            SetCurvePoint(
+                set_id=set_obj.id,
+                position_sec=w["t1_sec"],
+                energy=0,
+                is_slow_window_end=True,
+            )
+        )
+    db.commit()
+    return get_vibe_windows(db, set_obj.id)

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -681,6 +681,75 @@
         "title": "AdminUserUpdate",
         "type": "object"
       },
+      "ApplyTemplateRequest": {
+        "description": "Apply a template's shape onto the set's slots.\n\nExactly one of ``builtin`` / ``template_id``. ``slot_midpoints`` are the\nnormalized slot midpoints (client knows track durations); omitted means\nuniform buckets.",
+        "properties": {
+          "builtin": {
+            "anyOf": [
+              {
+                "maxLength": 80,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Builtin"
+          },
+          "slot_midpoints": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slot Midpoints"
+          },
+          "template_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Template Id"
+          }
+        },
+        "title": "ApplyTemplateRequest",
+        "type": "object"
+      },
+      "ApplyTemplateResponse": {
+        "description": "Per-slot targets persisted by an apply, plus suggested vibe windows.",
+        "properties": {
+          "targets": {
+            "items": {
+              "$ref": "#/components/schemas/SlotTargetOut"
+            },
+            "title": "Targets",
+            "type": "array"
+          },
+          "windows": {
+            "items": {
+              "$ref": "#/components/schemas/TemplateWindowOut"
+            },
+            "title": "Windows",
+            "type": "array"
+          }
+        },
+        "required": [
+          "targets",
+          "windows"
+        ],
+        "title": "ApplyTemplateResponse",
+        "type": "object"
+      },
       "AuditEventRow": {
         "description": "A single audit-trail row with joined display labels.\n\nNever includes credential material \u2014 only the target connector's\nhuman-readable display name (joined from ``llm_connectors``).",
         "properties": {
@@ -1064,7 +1133,7 @@
       "Body_upload_banner_api_events__code__banner_post": {
         "properties": {
           "file": {
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File",
             "type": "string"
           }
@@ -1338,6 +1407,28 @@
           "uptime_seconds"
         ],
         "title": "BridgeStatusResponse",
+        "type": "object"
+      },
+      "BuiltinTemplateOut": {
+        "description": "A built-in (code-defined) template.",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "points": {
+            "items": {
+              "$ref": "#/components/schemas/CurvePointModel"
+            },
+            "title": "Points",
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "points"
+        ],
+        "title": "BuiltinTemplateOut",
         "type": "object"
       },
       "BulkActionResponse": {
@@ -2620,6 +2711,136 @@
           "ok"
         ],
         "title": "ConnectorTestResult",
+        "type": "object"
+      },
+      "CurvePointModel": {
+        "description": "One normalized template point: position t in [0,1], energy e in [0,10].",
+        "properties": {
+          "e": {
+            "maximum": 10.0,
+            "minimum": 0.0,
+            "title": "E",
+            "type": "number"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "slow_end": {
+            "default": false,
+            "title": "Slow End",
+            "type": "boolean"
+          },
+          "slow_start": {
+            "default": false,
+            "title": "Slow Start",
+            "type": "boolean"
+          },
+          "t": {
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "T",
+            "type": "number"
+          }
+        },
+        "required": [
+          "e",
+          "label",
+          "slow_end",
+          "slow_start",
+          "t"
+        ],
+        "title": "CurvePointModel",
+        "type": "object"
+      },
+      "CurveTemplateCreate": {
+        "description": "Body for creating (or fully updating) a user curve template.",
+        "properties": {
+          "name": {
+            "maxLength": 80,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "points": {
+            "items": {
+              "$ref": "#/components/schemas/CurvePointModel"
+            },
+            "title": "Points",
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "points"
+        ],
+        "title": "CurveTemplateCreate",
+        "type": "object"
+      },
+      "CurveTemplateOut": {
+        "description": "A persisted per-DJ template.",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "points": {
+            "items": {
+              "$ref": "#/components/schemas/CurvePointModel"
+            },
+            "title": "Points",
+            "type": "array"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "points",
+          "updated_at"
+        ],
+        "title": "CurveTemplateOut",
+        "type": "object"
+      },
+      "CurveTemplatesResponse": {
+        "description": "All templates available to the DJ.",
+        "properties": {
+          "builtin": {
+            "items": {
+              "$ref": "#/components/schemas/BuiltinTemplateOut"
+            },
+            "title": "Builtin",
+            "type": "array"
+          },
+          "user": {
+            "items": {
+              "$ref": "#/components/schemas/CurveTemplateOut"
+            },
+            "title": "User",
+            "type": "array"
+          }
+        },
+        "required": [
+          "builtin",
+          "user"
+        ],
+        "title": "CurveTemplatesResponse",
         "type": "object"
       },
       "DisplaySettingsResponse": {
@@ -5862,6 +6083,112 @@
         "title": "SetSummary",
         "type": "object"
       },
+      "SlotOut": {
+        "description": "Timeline slot (curve-editor surface; track metadata joins with #388).",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "locked": {
+            "title": "Locked",
+            "type": "boolean"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "position": {
+            "title": "Position",
+            "type": "integer"
+          },
+          "target_energy": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Energy"
+          },
+          "track_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Track Id"
+          }
+        },
+        "required": [
+          "id",
+          "locked",
+          "notes",
+          "position",
+          "target_energy",
+          "track_id"
+        ],
+        "title": "SlotOut",
+        "type": "object"
+      },
+      "SlotTargetOut": {
+        "description": "One slot's persisted target after an update/apply.",
+        "properties": {
+          "slot_id": {
+            "title": "Slot Id",
+            "type": "integer"
+          },
+          "target_energy": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Energy"
+          }
+        },
+        "required": [
+          "slot_id",
+          "target_energy"
+        ],
+        "title": "SlotTargetOut",
+        "type": "object"
+      },
+      "SlotTargetUpdate": {
+        "description": "Body for setting/clearing a slot's energy target. None = reset.",
+        "properties": {
+          "target_energy": {
+            "anyOf": [
+              {
+                "maximum": 10.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Energy"
+          }
+        },
+        "title": "SlotTargetUpdate",
+        "type": "object"
+      },
       "StatusMessageResponse": {
         "properties": {
           "message": {
@@ -6128,6 +6455,25 @@
           "playlist_id"
         ],
         "title": "TemplatePlaylistRequest",
+        "type": "object"
+      },
+      "TemplateWindowOut": {
+        "description": "Suggested vibe window from a template's slow_start/slow_end flags.",
+        "properties": {
+          "t0": {
+            "title": "T0",
+            "type": "number"
+          },
+          "t1": {
+            "title": "T1",
+            "type": "number"
+          }
+        },
+        "required": [
+          "t0",
+          "t1"
+        ],
+        "title": "TemplateWindowOut",
         "type": "object"
       },
       "TidalAuthCheckResponse": {
@@ -6922,6 +7268,69 @@
           "verified"
         ],
         "title": "VerifyStatusResponse",
+        "type": "object"
+      },
+      "VibeWindowModel": {
+        "description": "A named region of the set timeline, in seconds.",
+        "properties": {
+          "label": {
+            "maxLength": 50,
+            "minLength": 1,
+            "title": "Label",
+            "type": "string"
+          },
+          "t0_sec": {
+            "minimum": 0.0,
+            "title": "T0 Sec",
+            "type": "integer"
+          },
+          "t1_sec": {
+            "minimum": 0.0,
+            "title": "T1 Sec",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "label",
+          "t0_sec",
+          "t1_sec"
+        ],
+        "title": "VibeWindowModel",
+        "type": "object"
+      },
+      "VibeWindowsPut": {
+        "description": "Replace-all body for a set's vibe windows.",
+        "properties": {
+          "windows": {
+            "items": {
+              "$ref": "#/components/schemas/VibeWindowModel"
+            },
+            "maxItems": 30,
+            "title": "Windows",
+            "type": "array"
+          }
+        },
+        "required": [
+          "windows"
+        ],
+        "title": "VibeWindowsPut",
+        "type": "object"
+      },
+      "VibeWindowsResponse": {
+        "description": "A set's stored vibe windows.",
+        "properties": {
+          "windows": {
+            "items": {
+              "$ref": "#/components/schemas/VibeWindowModel"
+            },
+            "title": "Windows",
+            "type": "array"
+          }
+        },
+        "required": [
+          "windows"
+        ],
+        "title": "VibeWindowsResponse",
         "type": "object"
       },
       "VoteResponse": {
@@ -13397,6 +13806,175 @@
         ]
       }
     },
+    "/api/setbuilder/curve-templates": {
+      "get": {
+        "description": "Built-in templates plus the current DJ's saved templates.",
+        "operationId": "list_curve_templates_api_setbuilder_curve_templates_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurveTemplatesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Curve Templates",
+        "tags": [
+          "setbuilder"
+        ]
+      },
+      "post": {
+        "description": "Save a new per-DJ curve template.",
+        "operationId": "create_curve_template_api_setbuilder_curve_templates_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CurveTemplateCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurveTemplateOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Create Curve Template",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/curve-templates/{template_id}": {
+      "delete": {
+        "description": "Delete one of the current DJ's templates, or 404.",
+        "operationId": "delete_curve_template_api_setbuilder_curve_templates__template_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "template_id",
+            "required": true,
+            "schema": {
+              "title": "Template Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Curve Template",
+        "tags": [
+          "setbuilder"
+        ]
+      },
+      "put": {
+        "description": "Overwrite one of the current DJ's templates, or 404.",
+        "operationId": "update_curve_template_api_setbuilder_curve_templates__template_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "template_id",
+            "required": true,
+            "schema": {
+              "title": "Template Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CurveTemplateCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurveTemplateOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Curve Template",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
     "/api/setbuilder/sets": {
       "get": {
         "description": "List the current DJ's sets, newest first.",
@@ -13611,6 +14189,287 @@
           }
         ],
         "summary": "Rename Set",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/curve/apply-template": {
+      "post": {
+        "description": "Re-target every slot from a built-in or saved template shape.",
+        "operationId": "apply_curve_template_api_setbuilder_sets__set_id__curve_apply_template_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApplyTemplateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplyTemplateResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Apply Curve Template",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/slots": {
+      "get": {
+        "description": "Ordered timeline slots for one of the current DJ's sets.",
+        "operationId": "list_set_slots_api_setbuilder_sets__set_id__slots_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/SlotOut"
+                  },
+                  "title": "Response List Set Slots Api Setbuilder Sets  Set Id  Slots Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Set Slots",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/slots/{slot_id}/target": {
+      "patch": {
+        "description": "Set (or clear with null) a slot's energy target.",
+        "operationId": "update_slot_target_api_setbuilder_sets__set_id__slots__slot_id__target_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "slot_id",
+            "required": true,
+            "schema": {
+              "title": "Slot Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SlotTargetUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SlotTargetOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Slot Target",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/vibe-windows": {
+      "get": {
+        "description": "The set's stored vibe windows.",
+        "operationId": "get_vibe_windows_api_setbuilder_sets__set_id__vibe_windows_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VibeWindowsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Vibe Windows",
+        "tags": [
+          "setbuilder"
+        ]
+      },
+      "put": {
+        "description": "Replace-all update of the set's vibe windows.",
+        "operationId": "put_vibe_windows_api_setbuilder_sets__set_id__vibe_windows_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VibeWindowsPut"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VibeWindowsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Put Vibe Windows",
         "tags": [
           "setbuilder"
         ]

--- a/server/tests/test_setbuilder_curve_api.py
+++ b/server/tests/test_setbuilder_curve_api.py
@@ -1,0 +1,371 @@
+"""API tests for the curve-editor endpoints (#389).
+
+Pins auth gating, owner isolation, template CRUD + validation, server-side
+template application (uniform + explicit midpoints), slot target patching,
+and vibe-window replace/get round trips.
+"""
+
+from app.models.set import SetSlot
+from app.services.auth import get_password_hash
+
+VALID_POINTS = [
+    {"t": 0.0, "e": 3.0, "label": "Start"},
+    {"t": 0.5, "e": 8.0, "label": "Peak"},
+    {"t": 1.0, "e": 5.0, "label": "End"},
+]
+
+
+def _make_second_dj(db):
+    from app.models.user import User
+
+    user = User(username="otherdj", password_hash=get_password_hash("x" * 12), role="dj")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _login(client, username, password):
+    resp = client.post("/api/auth/login", data={"username": username, "password": password})
+    assert resp.status_code == 200, resp.json()
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _mk_set(client, auth_headers, name="Set"):
+    return client.post("/api/setbuilder/sets", json={"name": name}, headers=auth_headers).json()
+
+
+def _mk_slots(db, set_id, n):
+    for i in range(n):
+        db.add(SetSlot(set_id=set_id, position=i))
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Template list / create / update / delete
+# ---------------------------------------------------------------------------
+
+
+def test_list_templates_includes_builtins(client, auth_headers):
+    resp = client.get("/api/setbuilder/curve-templates", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    names = [t["name"] for t in body["builtin"]]
+    assert names == ["Open-Format", "Wedding", "Prom", "Club Peak"]
+    assert body["user"] == []
+
+
+def test_templates_require_auth(client):
+    assert client.get("/api/setbuilder/curve-templates").status_code == 401
+
+
+def test_templates_reject_pending(client, pending_headers):
+    resp = client.get("/api/setbuilder/curve-templates", headers=pending_headers)
+    assert resp.status_code == 403
+
+
+def test_create_update_delete_template(client, auth_headers):
+    resp = client.post(
+        "/api/setbuilder/curve-templates",
+        json={"name": "My Wedding Mod", "points": VALID_POINTS},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.json()
+    tpl = resp.json()
+    assert tpl["name"] == "My Wedding Mod"
+    assert [p["t"] for p in tpl["points"]] == [0.0, 0.5, 1.0]
+
+    resp = client.put(
+        f"/api/setbuilder/curve-templates/{tpl['id']}",
+        json={
+            "name": "Renamed",
+            "points": [{"t": 0.0, "e": 1.0}, {"t": 1.0, "e": 9.0}],
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Renamed"
+    assert len(resp.json()["points"]) == 2
+
+    listed = client.get("/api/setbuilder/curve-templates", headers=auth_headers).json()
+    assert [t["name"] for t in listed["user"]] == ["Renamed"]
+
+    resp = client.delete(f"/api/setbuilder/curve-templates/{tpl['id']}", headers=auth_headers)
+    assert resp.status_code == 204
+    listed = client.get("/api/setbuilder/curve-templates", headers=auth_headers).json()
+    assert listed["user"] == []
+
+
+def test_template_owner_isolation(client, auth_headers, db):
+    _make_second_dj(db)
+    other_headers = _login(client, "otherdj", "xxxxxxxxxxxx")
+    tpl = client.post(
+        "/api/setbuilder/curve-templates",
+        json={"name": "Theirs", "points": VALID_POINTS},
+        headers=other_headers,
+    ).json()
+
+    resp = client.put(
+        f"/api/setbuilder/curve-templates/{tpl['id']}",
+        json={"name": "Hijack", "points": VALID_POINTS},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404
+    resp = client.delete(f"/api/setbuilder/curve-templates/{tpl['id']}", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_create_template_validation(client, auth_headers):
+    # First point must be t=0, last t=1
+    bad_endpoint = [{"t": 0.1, "e": 5.0}, {"t": 1.0, "e": 5.0}]
+    resp = client.post(
+        "/api/setbuilder/curve-templates",
+        json={"name": "Bad", "points": bad_endpoint},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+    # Non-monotonic t order
+    bad_order = [
+        {"t": 0.0, "e": 5.0},
+        {"t": 0.8, "e": 5.0},
+        {"t": 0.4, "e": 5.0},
+        {"t": 1.0, "e": 5.0},
+    ]
+    resp = client.post(
+        "/api/setbuilder/curve-templates",
+        json={"name": "Bad", "points": bad_order},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+    # Out-of-range energy
+    bad_energy = [{"t": 0.0, "e": 11.0}, {"t": 1.0, "e": 5.0}]
+    resp = client.post(
+        "/api/setbuilder/curve-templates",
+        json={"name": "Bad", "points": bad_energy},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+    # Too many points
+    many = (
+        [{"t": 0.0, "e": 5.0}]
+        + [{"t": round(0.01 + i * 0.02, 3), "e": 5.0} for i in range(40)]
+        + [{"t": 1.0, "e": 5.0}]
+    )
+    resp = client.post(
+        "/api/setbuilder/curve-templates",
+        json={"name": "Bad", "points": many},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Slots list + target patch
+# ---------------------------------------------------------------------------
+
+
+def test_list_slots(client, auth_headers, db):
+    set_obj = _mk_set(client, auth_headers)
+    _mk_slots(db, set_obj["id"], 3)
+    resp = client.get(f"/api/setbuilder/sets/{set_obj['id']}/slots", headers=auth_headers)
+    assert resp.status_code == 200
+    slots = resp.json()
+    assert [s["position"] for s in slots] == [0, 1, 2]
+    assert all(s["target_energy"] is None for s in slots)
+
+
+def test_list_slots_owner_isolation(client, auth_headers, db):
+    _make_second_dj(db)
+    other_headers = _login(client, "otherdj", "xxxxxxxxxxxx")
+    theirs = _mk_set(client, other_headers, "Theirs")
+    resp = client.get(f"/api/setbuilder/sets/{theirs['id']}/slots", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_patch_slot_target_and_reset(client, auth_headers, db):
+    set_obj = _mk_set(client, auth_headers)
+    _mk_slots(db, set_obj["id"], 1)
+    slot_id = client.get(
+        f"/api/setbuilder/sets/{set_obj['id']}/slots", headers=auth_headers
+    ).json()[0]["id"]
+
+    resp = client.patch(
+        f"/api/setbuilder/sets/{set_obj['id']}/slots/{slot_id}/target",
+        json={"target_energy": 7.25},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["target_energy"] == 7.2  # rounded to 0.1
+
+    resp = client.patch(
+        f"/api/setbuilder/sets/{set_obj['id']}/slots/{slot_id}/target",
+        json={"target_energy": None},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["target_energy"] is None
+
+
+def test_patch_slot_target_validation(client, auth_headers, db):
+    set_obj = _mk_set(client, auth_headers)
+    _mk_slots(db, set_obj["id"], 1)
+    slot_id = client.get(
+        f"/api/setbuilder/sets/{set_obj['id']}/slots", headers=auth_headers
+    ).json()[0]["id"]
+    resp = client.patch(
+        f"/api/setbuilder/sets/{set_obj['id']}/slots/{slot_id}/target",
+        json={"target_energy": 12},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_patch_slot_target_unknown_slot_404(client, auth_headers):
+    set_obj = _mk_set(client, auth_headers)
+    resp = client.patch(
+        f"/api/setbuilder/sets/{set_obj['id']}/slots/99999/target",
+        json={"target_energy": 5},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Apply template
+# ---------------------------------------------------------------------------
+
+
+def test_apply_builtin_template_uniform(client, auth_headers, db):
+    set_obj = _mk_set(client, auth_headers)
+    _mk_slots(db, set_obj["id"], 4)
+    resp = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/curve/apply-template",
+        json={"builtin": "Club Peak"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.json()
+    body = resp.json()
+    assert len(body["targets"]) == 4
+    # Persisted
+    slots = client.get(f"/api/setbuilder/sets/{set_obj['id']}/slots", headers=auth_headers).json()
+    assert [s["target_energy"] for s in slots] == [t["target_energy"] for t in body["targets"]]
+
+
+def test_apply_template_with_midpoints(client, auth_headers, db):
+    set_obj = _mk_set(client, auth_headers)
+    _mk_slots(db, set_obj["id"], 2)
+    tpl = client.post(
+        "/api/setbuilder/curve-templates",
+        json={"name": "Linear", "points": [{"t": 0.0, "e": 0.0}, {"t": 1.0, "e": 10.0}]},
+        headers=auth_headers,
+    ).json()
+    resp = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/curve/apply-template",
+        json={"template_id": tpl["id"], "slot_midpoints": [0.1, 0.9]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert [t["target_energy"] for t in resp.json()["targets"]] == [1.0, 9.0]
+
+
+def test_apply_template_midpoint_count_mismatch_400(client, auth_headers, db):
+    set_obj = _mk_set(client, auth_headers)
+    _mk_slots(db, set_obj["id"], 3)
+    resp = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/curve/apply-template",
+        json={"builtin": "Prom", "slot_midpoints": [0.5]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_apply_template_exactly_one_source(client, auth_headers):
+    set_obj = _mk_set(client, auth_headers)
+    resp = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/curve/apply-template",
+        json={},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+    resp = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/curve/apply-template",
+        json={"builtin": "Prom", "template_id": 1},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_apply_unknown_builtin_404(client, auth_headers):
+    set_obj = _mk_set(client, auth_headers)
+    resp = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/curve/apply-template",
+        json={"builtin": "Nope"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_apply_foreign_user_template_404(client, auth_headers, db):
+    _make_second_dj(db)
+    other_headers = _login(client, "otherdj", "xxxxxxxxxxxx")
+    tpl = client.post(
+        "/api/setbuilder/curve-templates",
+        json={"name": "Theirs", "points": VALID_POINTS},
+        headers=other_headers,
+    ).json()
+    set_obj = _mk_set(client, auth_headers)
+    resp = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/curve/apply-template",
+        json={"template_id": tpl["id"]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Vibe windows
+# ---------------------------------------------------------------------------
+
+
+def test_vibe_windows_put_get(client, auth_headers):
+    set_obj = _mk_set(client, auth_headers)
+    windows = [
+        {"t0_sec": 100, "t1_sec": 300, "label": "First Dance"},
+        {"t0_sec": 900, "t1_sec": 1200, "label": "Peak Build"},
+    ]
+    resp = client.put(
+        f"/api/setbuilder/sets/{set_obj['id']}/vibe-windows",
+        json={"windows": windows},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.json()
+    assert resp.json()["windows"] == windows
+
+    resp = client.get(f"/api/setbuilder/sets/{set_obj['id']}/vibe-windows", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["windows"] == windows
+
+
+def test_vibe_windows_validation(client, auth_headers):
+    set_obj = _mk_set(client, auth_headers)
+    resp = client.put(
+        f"/api/setbuilder/sets/{set_obj['id']}/vibe-windows",
+        json={"windows": [{"t0_sec": 300, "t1_sec": 100, "label": "Backwards"}]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_vibe_windows_owner_isolation(client, auth_headers, db):
+    _make_second_dj(db)
+    other_headers = _login(client, "otherdj", "xxxxxxxxxxxx")
+    theirs = _mk_set(client, other_headers, "Theirs")
+    resp = client.put(
+        f"/api/setbuilder/sets/{theirs['id']}/vibe-windows",
+        json={"windows": []},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404

--- a/server/tests/test_setbuilder_curve_api.py
+++ b/server/tests/test_setbuilder_curve_api.py
@@ -32,7 +32,9 @@ def _login(client, username, password):
 
 
 def _mk_set(client, auth_headers, name="Set"):
-    return client.post("/api/setbuilder/sets", json={"name": name}, headers=auth_headers).json()
+    resp = client.post("/api/setbuilder/sets", json={"name": name}, headers=auth_headers)
+    assert resp.status_code == 201, resp.json()
+    return resp.json()
 
 
 def _mk_slots(db, set_id, n):

--- a/server/tests/test_setbuilder_curve_models.py
+++ b/server/tests/test_setbuilder_curve_models.py
@@ -1,0 +1,36 @@
+"""Model tests for SetCurveTemplate and SetSlot.target_energy (#389)."""
+
+import json
+
+from app.models.curve_template import SetCurveTemplate
+from app.models.set import Set, SetSlot
+
+
+def test_create_curve_template(db, test_user):
+    points = [{"t": 0, "e": 4, "label": "Start"}, {"t": 1.0, "e": 6, "label": "End"}]
+    tpl = SetCurveTemplate(user_id=test_user.id, name="My Curve", points_json=json.dumps(points))
+    db.add(tpl)
+    db.commit()
+    db.refresh(tpl)
+
+    assert tpl.id > 0
+    assert tpl.name == "My Curve"
+    assert json.loads(tpl.points_json) == points
+    assert tpl.created_at is not None
+    assert tpl.updated_at is not None
+
+
+def test_slot_target_energy_defaults_to_none(db, test_user):
+    set_obj = Set(owner_id=test_user.id, name="S")
+    db.add(set_obj)
+    db.commit()
+    slot = SetSlot(set_id=set_obj.id, position=0)
+    db.add(slot)
+    db.commit()
+    db.refresh(slot)
+
+    assert slot.target_energy is None
+    slot.target_energy = 7.5
+    db.commit()
+    db.refresh(slot)
+    assert slot.target_energy == 7.5

--- a/server/tests/test_setbuilder_curve_service.py
+++ b/server/tests/test_setbuilder_curve_service.py
@@ -1,0 +1,175 @@
+"""Service tests for services/setbuilder/curve.py (#389).
+
+Covers piecewise-linear interpolation, built-in template sanity, template
+CRUD owner scoping, apply-to-slots (uniform + explicit midpoints), and
+vibe-window round-trips through paired SetCurvePoint rows.
+"""
+
+import pytest
+
+from app.models.set import Set, SetCurvePoint, SetSlot
+from app.services.setbuilder import curve
+
+
+def _mk_set_with_slots(db, owner_id, n=4):
+    set_obj = Set(owner_id=owner_id, name="S")
+    db.add(set_obj)
+    db.commit()
+    for i in range(n):
+        db.add(SetSlot(set_id=set_obj.id, position=i))
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+# ---------------------------------------------------------------------------
+# Interpolation
+# ---------------------------------------------------------------------------
+
+
+def test_interpolate_linear_midpoint():
+    points = [{"t": 0.0, "e": 0.0}, {"t": 1.0, "e": 10.0}]
+    assert curve.interpolate_energy(points, 0.5) == pytest.approx(5.0)
+    assert curve.interpolate_energy(points, 0.25) == pytest.approx(2.5)
+
+
+def test_interpolate_clamps_t():
+    points = [{"t": 0.0, "e": 3.0}, {"t": 1.0, "e": 7.0}]
+    assert curve.interpolate_energy(points, -0.5) == pytest.approx(3.0)
+    assert curve.interpolate_energy(points, 1.5) == pytest.approx(7.0)
+
+
+def test_interpolate_piecewise_multi_segment():
+    points = [{"t": 0.0, "e": 2.0}, {"t": 0.5, "e": 8.0}, {"t": 1.0, "e": 4.0}]
+    assert curve.interpolate_energy(points, 0.25) == pytest.approx(5.0)
+    assert curve.interpolate_energy(points, 0.75) == pytest.approx(6.0)
+    assert curve.interpolate_energy(points, 0.5) == pytest.approx(8.0)
+
+
+def test_targets_at_midpoints_rounds_to_tenth():
+    points = [{"t": 0.0, "e": 0.0}, {"t": 1.0, "e": 10.0}]
+    targets = curve.targets_at_midpoints(points, [1 / 3])
+    assert targets == [3.3]
+
+
+def test_uniform_midpoints():
+    assert curve.uniform_midpoints(4) == [0.125, 0.375, 0.625, 0.875]
+    assert curve.uniform_midpoints(0) == []
+
+
+# ---------------------------------------------------------------------------
+# Built-in templates
+# ---------------------------------------------------------------------------
+
+
+def test_builtin_templates_present_and_well_formed():
+    assert set(curve.BUILTIN_TEMPLATES) == {"Open-Format", "Wedding", "Prom", "Club Peak"}
+    for points in curve.BUILTIN_TEMPLATES.values():
+        assert points[0]["t"] == 0
+        assert points[-1]["t"] == 1.0
+        assert all(0 <= p["e"] <= 10 for p in points)
+        ts = [p["t"] for p in points]
+        assert ts == sorted(ts)
+
+
+def test_windows_from_points_pairs_flags():
+    points = curve.BUILTIN_TEMPLATES["Wedding"]
+    windows = curve.windows_from_points(points)
+    assert len(windows) == 1
+    assert windows[0]["t0"] == pytest.approx(0.7)
+    assert windows[0]["t1"] == pytest.approx(0.78)
+
+
+# ---------------------------------------------------------------------------
+# Template CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_template_crud_owner_scoped(db, test_user, admin_user):
+    points = [{"t": 0.0, "e": 3.0, "label": "Start"}, {"t": 1.0, "e": 6.0, "label": "End"}]
+    tpl = curve.create_template(db, test_user.id, "Mine", points)
+    assert tpl.id > 0
+
+    assert [t.name for t in curve.list_templates(db, test_user.id)] == ["Mine"]
+    assert curve.list_templates(db, admin_user.id) == []
+    assert curve.get_owned_template(db, tpl.id, admin_user.id) is None
+
+    curve.update_template(db, tpl, "Renamed", [{"t": 0.0, "e": 1.0}, {"t": 1.0, "e": 2.0}])
+    db.refresh(tpl)
+    assert tpl.name == "Renamed"
+    assert curve.template_points(tpl) == [{"t": 0.0, "e": 1.0}, {"t": 1.0, "e": 2.0}]
+
+    curve.delete_template(db, tpl)
+    assert curve.list_templates(db, test_user.id) == []
+
+
+# ---------------------------------------------------------------------------
+# Apply to slots
+# ---------------------------------------------------------------------------
+
+
+def test_apply_points_to_slots_uniform(db, test_user):
+    set_obj = _mk_set_with_slots(db, test_user.id, n=2)
+    points = [{"t": 0.0, "e": 0.0}, {"t": 1.0, "e": 10.0}]
+    result = curve.apply_points_to_slots(db, set_obj, points, None)
+    assert [t for _, t in result] == [2.5, 7.5]
+    slots = db.query(SetSlot).filter_by(set_id=set_obj.id).order_by(SetSlot.position).all()
+    assert [s.target_energy for s in slots] == [2.5, 7.5]
+
+
+def test_apply_points_to_slots_explicit_midpoints(db, test_user):
+    set_obj = _mk_set_with_slots(db, test_user.id, n=2)
+    points = [{"t": 0.0, "e": 0.0}, {"t": 1.0, "e": 10.0}]
+    result = curve.apply_points_to_slots(db, set_obj, points, [0.1, 0.9])
+    assert [t for _, t in result] == [1.0, 9.0]
+
+
+def test_apply_points_midpoint_count_mismatch_raises(db, test_user):
+    set_obj = _mk_set_with_slots(db, test_user.id, n=3)
+    points = [{"t": 0.0, "e": 0.0}, {"t": 1.0, "e": 10.0}]
+    with pytest.raises(ValueError):
+        curve.apply_points_to_slots(db, set_obj, points, [0.5])
+
+
+def test_apply_points_no_slots_returns_empty(db, test_user):
+    set_obj = _mk_set_with_slots(db, test_user.id, n=0)
+    points = [{"t": 0.0, "e": 0.0}, {"t": 1.0, "e": 10.0}]
+    assert curve.apply_points_to_slots(db, set_obj, points, None) == []
+
+
+# ---------------------------------------------------------------------------
+# Vibe windows
+# ---------------------------------------------------------------------------
+
+
+def test_vibe_windows_round_trip(db, test_user):
+    set_obj = _mk_set_with_slots(db, test_user.id, n=1)
+    windows = [
+        {"t0_sec": 100, "t1_sec": 300, "label": "First Dance"},
+        {"t0_sec": 900, "t1_sec": 1200, "label": "Peak Build"},
+    ]
+    curve.replace_vibe_windows(db, set_obj, windows)
+    stored = curve.get_vibe_windows(db, set_obj.id)
+    assert stored == windows
+
+    # Replace-all semantics: a second PUT overwrites the first.
+    curve.replace_vibe_windows(db, set_obj, [{"t0_sec": 0, "t1_sec": 60, "label": "Cocktail Hour"}])
+    stored = curve.get_vibe_windows(db, set_obj.id)
+    assert stored == [{"t0_sec": 0, "t1_sec": 60, "label": "Cocktail Hour"}]
+
+    # Window rows are paired start/end curve points.
+    rows = db.query(SetCurvePoint).filter_by(set_id=set_obj.id).all()
+    assert len(rows) == 2
+    assert sum(1 for r in rows if r.is_slow_window_start) == 1
+    assert sum(1 for r in rows if r.is_slow_window_end) == 1
+
+
+def test_vibe_windows_overlapping_round_trip(db, test_user):
+    """Overlapping windows must pair correctly (insertion-order pairing)."""
+    set_obj = _mk_set_with_slots(db, test_user.id, n=1)
+    windows = [
+        {"t0_sec": 0, "t1_sec": 1000, "label": "Cocktail Hour"},
+        {"t0_sec": 100, "t1_sec": 200, "label": "First Dance"},
+    ]
+    stored = curve.replace_vibe_windows(db, set_obj, windows)
+    assert stored == windows


### PR DESCRIPTION
Closes #389

## Summary

The energy curve is now live in the WrzDJSet builder: a **derived** per-slot target-energy envelope (polyline through each slot's target at its midpoint), with built-in + per-DJ persisted templates, vibe windows, a mismatch-triggered replacement popover, and BPM/Key seam-friction view modes.

### Backend
- **Migration 055** (anchored on 052; 053/054 reserved for #388/#398): new `set_curve_templates` table (per-DJ templates, JSON point lists) + `set_slots.target_energy` (Float, nullable)
- **`services/setbuilder/curve.py`** (exec summary §3): 4 built-in templates (Open-Format, Wedding, Prom, Club Peak), piecewise-linear interpolation (§11 default), owner-scoped template CRUD, server-side template application, vibe-window storage as paired `SetCurvePoint` rows
- **New `/api/setbuilder` routes** (all `get_current_active_user`, rate-limited, owner-scoped 404): curve-template CRUD, `GET sets/{id}/slots`, `PATCH .../slots/{slot_id}/target`, `POST .../curve/apply-template`, `GET/PUT .../vibe-windows`
- 36 new backend tests; suite at 88% coverage

### Frontend (all NEW files under `setbuilder/components/` — shared files touched only additively)
- **CurveEditor.tsx** — SVG canvas: blocks sized by duration×energy, derived curve line, per-block vertical drag handles with live value chip, mismatch visuals (amber hatch when target > energy, dashed line when target < energy), vibe windows (header-bar drag/resize, right-click delete), seam friction bands in BPM/Key views with hover chips
- **curveMath.ts** — percentage-based BPM thresholds (≤2% green / ≤5% lime / ≤8% amber / >8% red) with half/double-time detection, Camelot mix tiers, replacement ranking (0.55 energy + 0.25 BPM + 0.20 Camelot, ±2.5 filter, top 5), 15 vibe presets
- **CurveTemplateEditorOverlay.tsx** — draggable SVG canvas + point list, save/save-as/delete; built-ins are read-only originals (save-as-copy)
- **ReplacePopover.tsx** — opens on drag-release when |target − energy| ≥ 0.8, gated by a persisted toolbar toggle
- **CurveToolbar / CurvePanel / TimelinePanel / BuilderWorkspace** — view modes, template dropdown, vibe-preset dropdown, bidirectional curve↔timeline hover sync + scroll-to-row
- 53 new frontend tests

## Design decisions

1. **Per-slot target persistence** — added `SetSlot.target_energy` (nullable Float) in migration 055 alongside the templates table. `NULL` = "no explicit target", so on load the target falls back to the track's intrinsic energy, exactly matching the issue's "on load target = track energy".
2. **Track metadata gap (pre-#388)** — slots only carry `track_id` today; the pool model lands with #388. The slots payload is metadata-free and the frontend view-model fills safe defaults (210s, energy 5). All editor components are prop-driven, so #388/#390 can feed real metadata with zero editor changes.
3. **Server-side template application with client-supplied midpoints** — the server doesn't know track durations yet, so `apply-template` accepts optional `slot_midpoints` (validated: count match, 0..1, non-decreasing) and falls back to uniform buckets. Interpolation + persistence stay server-side per exec summary §3 ("Templates re-target slots").
4. **Vibe-window storage** — paired `SetCurvePoint` rows (`is_slow_window_start` + label / `is_slow_window_end`), `energy=0` since windows don't contribute to the envelope (the curve derives from slot targets). Replace-all PUT semantics; insertion-order pairing keeps overlapping windows correct.
5. **Replacement-prompt gate** — stored in `localStorage` (`wrzdj.curve.suggestReplacements`, default ON) as a toolbar toggle; the builder settings modal belongs to #394/#395.
6. **Replace action is informational for now** — the popover ranks candidates from a `pool` prop (empty until #388) and the actual slot mutation wires up when pool/slot CRUD land.
7. **Migration slot** — used `055_add_curve_templates` anchored on `052` as instructed; the one migration carries both the new table and the slot column to avoid burning a second slot.

## Test plan
- [x] Backend: ruff check, ruff format, bandit, pytest (2597 passed, 88% ≥ 85%), `alembic upgrade head && alembic check` clean on a scratch DB
- [x] Frontend: ESLint (0 errors), `tsc --noEmit`, vitest (1058 passed, coverage thresholds met), `next build`
- [x] Acceptance: templates re-target slots (server-persisted) · user templates persist per DJ · drag-release ≥0.8 mismatch opens ranked popover (gated) · seam friction uses percentage thresholds with half/double-time detection (pinned by tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive energy-curve editor added to the set builder with timeline sync, smooth scrolling, and view modes (normal / bpm / key).
  * Reusable curve templates (built-in + create/edit/save-as/delete) and “apply to set” that persists per-slot targets.
  * Replacement suggestion popover, vibe-window creation/management, and toolbar controls (templates, presets, suggest-replacements toggle).
* **Tests**
  * Comprehensive unit and integration tests covering editor UI, template flows, replacement logic, slot targeting, and persistence.
* **Documentation**
  * Added implementation plan describing the curve-editor feature and workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->