### PR TITLE
fix(setbuilder): theme-correct buttons, toggle overlap, dashboard nav link

### DIFF
--- a/dashboard/app/(dj)/__tests__/layout.test.tsx
+++ b/dashboard/app/(dj)/__tests__/layout.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import DJLayout from '../layout';
+
+let mockPathname = '/dashboard';
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+vi.mock('@/components/ThemeToggle', () => ({
+  ThemeToggle: () => <button data-testid="theme-toggle-mock">Theme</button>,
+}));
+
+describe('DJLayout', () => {
+  it('renders the floating theme toggle on regular DJ pages', () => {
+    mockPathname = '/dashboard';
+    render(
+      <DJLayout>
+        <div>content</div>
+      </DJLayout>,
+    );
+    expect(screen.getByTestId('theme-toggle-mock')).toBeInTheDocument();
+  });
+
+  it('suppresses the floating toggle on /setbuilder routes (rendered inline there instead)', () => {
+    mockPathname = '/setbuilder/42';
+    render(
+      <DJLayout>
+        <div>content</div>
+      </DJLayout>,
+    );
+    expect(screen.queryByTestId('theme-toggle-mock')).not.toBeInTheDocument();
+  });
+
+  it('renders children regardless of route', () => {
+    mockPathname = '/setbuilder';
+    render(
+      <DJLayout>
+        <div data-testid="child">content</div>
+      </DJLayout>,
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+});

--- a/dashboard/app/(dj)/dashboard/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/dashboard/__tests__/page.test.tsx
@@ -120,6 +120,12 @@ describe('DashboardPage', () => {
     expect(screen.getByRole('link', { name: 'Account' })).toHaveAttribute('href', '/account');
   });
 
+  it('renders Set Builder link to /setbuilder', async () => {
+    vi.mocked(api.getEvents).mockResolvedValue([]);
+    render(<DashboardPage />);
+    expect(screen.getByRole('link', { name: 'Set Builder' })).toHaveAttribute('href', '/setbuilder');
+  });
+
   it('renders activity log panel', async () => {
     vi.mocked(api.getEvents).mockResolvedValue([]);
     render(<DashboardPage />);

--- a/dashboard/app/(dj)/dashboard/page.tsx
+++ b/dashboard/app/(dj)/dashboard/page.tsx
@@ -221,6 +221,13 @@ export default function DashboardPage() {
                 Create Event
               </button>
             </HelpSpot>
+            <Link
+              href="/setbuilder"
+              className="btn"
+              style={{ background: 'var(--surface-raised)', textDecoration: 'none', color: 'var(--text)' }}
+            >
+              Set Builder
+            </Link>
             <a
               href="https://github.com/thewrz/WrzDJ/releases/latest"
               target="_blank"

--- a/dashboard/app/(dj)/layout.tsx
+++ b/dashboard/app/(dj)/layout.tsx
@@ -1,19 +1,27 @@
 'use client';
 
 import { type ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
 import { ThemeToggle } from '@/components/ThemeToggle';
 
 export default function DJLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  // Setbuilder pages place real actions in the top-right corner, so the
+  // floating toggle would overlap them — those pages render it inline instead.
+  const floatingToggle = !pathname?.startsWith('/setbuilder');
+
   return (
     <>
-      <div style={{
-        position: 'fixed',
-        top: '1rem',
-        right: '4.5rem',
-        zIndex: 1050,
-      }}>
-        <ThemeToggle />
-      </div>
+      {floatingToggle && (
+        <div style={{
+          position: 'fixed',
+          top: '1rem',
+          right: '4.5rem',
+          zIndex: 1050,
+        }}>
+          <ThemeToggle />
+        </div>
+      )}
       {children}
     </>
   );

--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { SetDetail } from '@/lib/api-types';
+import { ThemeToggle } from '@/components/ThemeToggle';
 import BuilderWorkspace from '../components/BuilderWorkspace';
 import PoolPanel from '../components/PoolPanel';
 import SetActionsMenu from '../SetActionsMenu';
@@ -71,16 +72,17 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
           ← Sets
         </Link>
         <span className={styles.topbarTitle}>{set?.name ?? 'Loading…'}</span>
-        {set ? (
-          <SetActionsMenu
-            set={set}
-            onShareChanged={(token) =>
-              setSet((prev) => (prev ? { ...prev, share_token: token } : prev))
-            }
-          />
-        ) : (
-          <span style={{ width: 60 }} />
-        )}
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}>
+          {set && (
+            <SetActionsMenu
+              set={set}
+              onShareChanged={(token) =>
+                setSet((prev) => (prev ? { ...prev, share_token: token } : prev))
+              }
+            />
+          )}
+          <ThemeToggle />
+        </span>
       </div>
 
       <div className={styles.workspace}>

--- a/dashboard/app/(dj)/setbuilder/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/page.test.tsx
@@ -31,6 +31,12 @@ vi.mock('@/lib/auth', () => ({
   useAuth: () => ({ isAuthenticated: true, isLoading: false, role: 'dj' }),
 }));
 
+// ThemeToggle renders inline here (the (dj) layout's floating toggle is
+// suppressed on /setbuilder routes to avoid overlapping the topbar actions).
+vi.mock('@/components/ThemeToggle', () => ({
+  ThemeToggle: () => <button data-testid="theme-toggle-mock">Theme</button>,
+}));
+
 describe('SetbuilderPage', () => {
   beforeEach(() => {
     mockListSets.mockReset();
@@ -43,6 +49,14 @@ describe('SetbuilderPage', () => {
     render(<SetbuilderPage />);
     await waitFor(() => {
       expect(screen.getByText(/no sets yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders the theme toggle inline in the header', async () => {
+    mockListSets.mockResolvedValue([]);
+    render(<SetbuilderPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('theme-toggle-mock')).toBeInTheDocument();
     });
   });
 

--- a/dashboard/app/(dj)/setbuilder/components/curve.module.css
+++ b/dashboard/app/(dj)/setbuilder/components/curve.module.css
@@ -67,6 +67,7 @@
 
 .viewSwitch {
   display: inline-flex;
+  background: var(--surface-raised);
   border: 1px solid var(--border);
   border-radius: 6px;
   overflow: hidden;
@@ -83,12 +84,12 @@
 }
 
 .viewBtnActive {
-  background: var(--surface-raised);
-  color: #00f5d4;
+  background: var(--card);
+  color: var(--color-curve-accent);
 }
 
 .toolbarBtn {
-  background: transparent;
+  background: var(--surface-raised);
   border: 1px solid var(--border);
   border-radius: 6px;
   color: var(--text-secondary);

--- a/dashboard/app/(dj)/setbuilder/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { SetSummary } from '@/lib/api-types';
+import { ThemeToggle } from '@/components/ThemeToggle';
 import ShareDialog from './ShareDialog';
 
 export default function SetbuilderPage() {
@@ -146,6 +147,7 @@ export default function SetbuilderPage() {
           <button className="btn btn-primary" onClick={() => setShowCreate(true)}>
             New Set
           </button>
+          <ThemeToggle />
         </div>
       </div>
 

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -48,6 +48,7 @@
   --color-accent-checkbox: #3b82f6;
   --color-live-badge: #ef4444;
   --color-status-accepted: #8b5cf6;
+  --color-curve-accent: #00f5d4;
 }
 
 html,
@@ -77,6 +78,9 @@ a {
   overflow: hidden;
 }
 
+/* Default background matters: without it, bare `.btn` buttons fall back to the
+   browser's light ButtonFace background under near-white --text — effectively
+   invisible in dark themes (same failure mode documented on .btn-secondary). */
 .btn {
   display: inline-block;
   padding: 0.75rem 1.5rem;
@@ -85,8 +89,14 @@ a {
   cursor: pointer;
   font-size: 1rem;
   font-weight: 500;
+  background: var(--surface-raised);
   color: var(--text);
   transition: background 0.2s;
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .btn-primary {

--- a/dashboard/lib/__tests__/theme-vars.test.ts
+++ b/dashboard/lib/__tests__/theme-vars.test.ts
@@ -22,6 +22,7 @@ const EXPECTED_TOKENS = [
   '--color-log-warning-bg', '--color-log-warning-text',
   '--color-log-error-bg', '--color-log-error-text',
   '--color-accent-checkbox', '--color-live-badge', '--color-status-accepted',
+  '--color-curve-accent',
 ] as const;
 
 describe('getThemeVars', () => {
@@ -67,7 +68,7 @@ describe('getThemeVars', () => {
       expect(darkKeys).toEqual(dayKeys);
     });
 
-    it('every theme includes all 37 expected tokens', () => {
+    it('every theme includes all 38 expected tokens', () => {
       for (const theme of THEMES) {
         const vars = getThemeVars(theme);
         for (const key of EXPECTED_TOKENS) {
@@ -77,9 +78,9 @@ describe('getThemeVars', () => {
       }
     });
 
-    it('has exactly 37 tokens — no extras, no missing', () => {
+    it('has exactly 38 tokens — no extras, no missing', () => {
       const darkKeys = Object.keys(getThemeVars('dark'));
-      expect(darkKeys).toHaveLength(37);
+      expect(darkKeys).toHaveLength(38);
     });
   });
 

--- a/dashboard/lib/theme-vars.ts
+++ b/dashboard/lib/theme-vars.ts
@@ -3,7 +3,7 @@
  *
  * Tier 1 — surfaces & structure (9 vars)
  * Tier 2 — semantic action colors (14 vars)
- * Tier 3 — named UI roles (14 vars)
+ * Tier 3 — named UI roles (15 vars)
  *
  * dark:          Default. Pure dark, standard contrast.
  * high-contrast: Boosted contrast for accessibility / bright environments.
@@ -58,6 +58,7 @@ const THEME_VARS: Record<Theme, Record<string, string>> = {
     '--color-accent-checkbox':  '#3b82f6',
     '--color-live-badge':       '#ef4444',
     '--color-status-accepted':  '#8b5cf6',
+    '--color-curve-accent':     '#00f5d4',
   },
 
   'high-contrast': {
@@ -103,6 +104,7 @@ const THEME_VARS: Record<Theme, Record<string, string>> = {
     '--color-accent-checkbox':  '#60a5fa',
     '--color-live-badge':       '#f87171',
     '--color-status-accepted':  '#a78bfa',
+    '--color-curve-accent':     '#00f5d4',
   },
 
   daylight: {
@@ -148,6 +150,7 @@ const THEME_VARS: Record<Theme, Record<string, string>> = {
     '--color-accent-checkbox':  '#2563eb',
     '--color-live-badge':       '#dc2626',
     '--color-status-accepted':  '#7c3aed',
+    '--color-curve-accent':     '#0f766e',
   },
 };
 


### PR DESCRIPTION
## Summary

Fixes three issues found during local testing of the setbuilder:

1. **Invisible buttons in dark themes** — the bare `.btn` class defined no background, so any `btn`/`btn btn-sm` button without an inline background override fell back to the browser's light `ButtonFace` default with near-white `--text` on top (~1:1 contrast). This hit the setbuilder pool panel ("+ Add", "Clear", "Remove"), ReplacePopover, ImportModal — and ~25 other bare-btn instances across admin/events pages. `.btn` now defaults to `background: var(--surface-raised)` (the same convention used inline everywhere else), plus a new `.btn:disabled` state.
2. **Curve toolbar contrast + magic number** — ghost-style toolbar buttons got raised surfaces, and the hardcoded `#00f5d4` active accent now routes through a new `--color-curve-accent` theme token (neon teal in dark/high-contrast, teal-700 in daylight) so it respects the global theme system.
3. **Theme toggle overlapping setbuilder topbar** — the (dj) layout's fixed-position ThemeToggle sat on top of the topbar's Duplicate/Share actions. It is now suppressed on `/setbuilder` routes and rendered inline in the setbuilder headers instead.
4. **No nav path to Set Builder** — the dashboard header now links to `/setbuilder` (previously only reachable by typing the URL).

## Test plan

- [x] New: dashboard renders Set Builder link → `/setbuilder`
- [x] New: DJLayout suppresses floating toggle on `/setbuilder` routes, renders it elsewhere
- [x] New: setbuilder sets page renders inline theme toggle
- [x] Updated: theme-vars fixture (37 → 38 tokens, `--color-curve-accent` in all three themes)
- [x] Full frontend CI locally: ESLint ✓, tsc --noEmit ✓, vitest 1095/1095 ✓
- [x] Manual: verify pool-panel buttons readable in all three themes on the running testing instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Set Builder" link to dashboard navigation
  * Integrated Theme Toggle into setbuilder interface
  * Theme toggle conditionally displayed based on current page route

* **Style**
  * Improved button styling for enhanced dark theme appearance
  * Updated toolbar button colors and visual consistency
  * Added new accent color token for design consistency

* **Tests**
  * Added layout and component test coverage
  * Added page integration tests
  * Added UI rendering verification tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->