### PR TITLE
feat(llm): org-scoped house connector + AI policy clarity

### DIFF
--- a/dashboard/app/admin/ai/OrgConnectorSection.tsx
+++ b/dashboard/app/admin/ai/OrgConnectorSection.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useState } from 'react';
+import { api } from '@/lib/api';
+import type { LlmConnector, LlmConnectorCreate } from '@/lib/api-types';
+
+export const TYPE_LABELS: Record<string, string> = {
+  openai_apikey: 'OpenAI',
+  anthropic_apikey: 'Anthropic',
+  openrouter_apikey: 'OpenRouter',
+  xai_apikey: 'xAI',
+  gemini_apikey: 'Gemini',
+  openai_compatible: 'OpenAI-compatible',
+  bedrock: 'AWS Bedrock',
+  azure_openai: 'Azure OpenAI',
+};
+
+type OrgConnectorType = LlmConnectorCreate['connector_type'];
+
+// API-key-only subset for the org house-connector form. Compatible / Bedrock /
+// Azure connectors need extra fields (base URL, region, deployment name) that
+// only the DJ-side provider form collects — admins needing those can connect
+// them as a DJ; the org form keeps to simple api-key types.
+const ORG_FORM_TYPES: Array<{ value: OrgConnectorType; label: string }> = [
+  { value: 'openai_apikey', label: TYPE_LABELS.openai_apikey },
+  { value: 'anthropic_apikey', label: TYPE_LABELS.anthropic_apikey },
+  { value: 'openrouter_apikey', label: TYPE_LABELS.openrouter_apikey },
+  { value: 'xai_apikey', label: TYPE_LABELS.xai_apikey },
+  { value: 'gemini_apikey', label: TYPE_LABELS.gemini_apikey },
+];
+
+const STATUS_BADGES: Record<string, { background: string; color: string; label: string }> = {
+  active: {
+    background: 'var(--color-success-subtle)',
+    color: 'var(--color-success)',
+    label: 'Active',
+  },
+  auth_invalid: {
+    background: 'var(--color-danger-subtle)',
+    color: 'var(--color-danger)',
+    label: 'Auth invalid',
+  },
+  disabled: {
+    background: 'var(--color-danger-subtle)',
+    color: 'var(--color-danger)',
+    label: 'Disabled',
+  },
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const style = STATUS_BADGES[status] ?? {
+    background: 'var(--color-warning-subtle, #2a2418)',
+    color: 'var(--text-secondary)',
+    label: status,
+  };
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '0.15rem 0.6rem',
+        borderRadius: '9999px',
+        fontSize: '0.75rem',
+        fontWeight: 600,
+        background: style.background,
+        color: style.color,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {style.label}
+    </span>
+  );
+}
+
+interface OrgConnectorSectionProps {
+  connectors: LlmConnector[];
+  onChanged: () => Promise<void> | void;
+}
+
+export function OrgConnectorSection({ connectors, onChanged }: OrgConnectorSectionProps) {
+  const [connectorType, setConnectorType] = useState<OrgConnectorType>('openai_apikey');
+  const [displayName, setDisplayName] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [modelHint, setModelHint] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  const handleCreate = async () => {
+    setBusy(true);
+    setError('');
+    setMessage('');
+    try {
+      await api.createOrgConnector({
+        connector_type: connectorType,
+        display_name: displayName.trim(),
+        api_key: apiKey,
+        model_hint: modelHint.trim() || null,
+      });
+      setDisplayName('');
+      setApiKey('');
+      setModelHint('');
+      setMessage('Organization connector created');
+      await onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create connector');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleTest = async (id: number) => {
+    setBusy(true);
+    setError('');
+    setMessage('');
+    try {
+      const result = await api.testOrgConnector(id);
+      if (result.ok) {
+        setMessage(result.message ?? 'Connection OK');
+      } else {
+        setError(result.message ?? result.error_code ?? 'Test failed');
+      }
+      await onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Test failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    if (
+      !window.confirm(
+        'Delete this organization connector? Connector-less DJs will lose AI access.',
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    setError('');
+    setMessage('');
+    try {
+      await api.deleteOrgConnector(id);
+      await onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="card" style={{ marginTop: '2rem' }}>
+      <h2 style={{ marginTop: 0 }}>Organization connector</h2>
+      <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginTop: 0 }}>
+        The house credential. DJs without their own connector fall back to it when the toggle
+        allows — usage is billed to the organization.
+      </p>
+
+      {error && <div style={{ color: 'var(--color-danger)', marginBottom: '1rem' }}>{error}</div>}
+      {message && (
+        <div style={{ color: 'var(--color-success)', marginBottom: '1rem' }}>{message}</div>
+      )}
+
+      {connectors.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', marginBottom: '1.5rem' }}>
+          {connectors.map((c) => (
+            <div
+              key={c.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.75rem',
+                flexWrap: 'wrap',
+                padding: '0.75rem',
+                border: '1px solid var(--border-color)',
+                borderRadius: '8px',
+              }}
+            >
+              <div style={{ flex: 1, minWidth: '200px' }}>
+                <div style={{ fontWeight: 500 }}>{c.display_name}</div>
+                <div style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
+                  {TYPE_LABELS[c.connector_type] ?? c.connector_type}
+                  {c.model_hint ? ` · ${c.model_hint}` : ''}
+                </div>
+              </div>
+              <StatusBadge status={c.status} />
+              <button className="btn" onClick={() => handleTest(c.id)} disabled={busy}>
+                Test
+              </button>
+              <button className="btn btn-danger" onClick={() => handleDelete(c.id)} disabled={busy}>
+                Delete
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <h3 style={{ marginBottom: '0.5rem' }}>
+        {connectors.length === 0 ? 'Add the organization connector' : 'Add another connector'}
+      </h3>
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', alignItems: 'flex-end' }}>
+        <div className="form-group" style={{ margin: 0 }}>
+          <label htmlFor="org-connector-type">Provider</label>
+          <select
+            id="org-connector-type"
+            className="input"
+            value={connectorType}
+            onChange={(e) => setConnectorType(e.target.value as OrgConnectorType)}
+          >
+            {ORG_FORM_TYPES.map((t) => (
+              <option key={t.value} value={t.value}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="form-group" style={{ margin: 0 }}>
+          <label htmlFor="org-display-name">Display name</label>
+          <input
+            id="org-display-name"
+            type="text"
+            className="input"
+            placeholder="House OpenAI"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+          />
+        </div>
+        <div className="form-group" style={{ margin: 0 }}>
+          <label htmlFor="org-api-key">API key</label>
+          <input
+            id="org-api-key"
+            type="password"
+            className="input"
+            autoComplete="off"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+          />
+        </div>
+        <div className="form-group" style={{ margin: 0 }}>
+          <label htmlFor="org-model-hint">Model hint (optional)</label>
+          <input
+            id="org-model-hint"
+            type="text"
+            className="input"
+            placeholder="e.g. gpt-5-mini"
+            value={modelHint}
+            onChange={(e) => setModelHint(e.target.value)}
+          />
+        </div>
+        <button
+          className="btn btn-primary"
+          onClick={handleCreate}
+          disabled={busy || !displayName.trim() || !apiKey.trim()}
+        >
+          Add connector
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/admin/ai/OrgConnectorSection.tsx
+++ b/dashboard/app/admin/ai/OrgConnectorSection.tsx
@@ -18,9 +18,9 @@ export const TYPE_LABELS: Record<string, string> = {
 type OrgConnectorType = LlmConnectorCreate['connector_type'];
 
 // API-key-only subset for the org house-connector form. Compatible / Bedrock /
-// Azure connectors need extra fields (base URL, region, deployment name) that
-// only the DJ-side provider form collects — admins needing those can connect
-// them as a DJ; the org form keeps to simple api-key types.
+// Azure connectors need extra fields (base URL, region, deployment name) this
+// form doesn't collect yet — extend it with those fields when an org-scoped
+// compatible/Bedrock/Azure connector is needed.
 const ORG_FORM_TYPES: Array<{ value: OrgConnectorType; label: string }> = [
   { value: 'openai_apikey', label: TYPE_LABELS.openai_apikey },
   { value: 'anthropic_apikey', label: TYPE_LABELS.anthropic_apikey },
@@ -49,7 +49,7 @@ const STATUS_BADGES: Record<string, { background: string; color: string; label: 
 
 function StatusBadge({ status }: { status: string }) {
   const style = STATUS_BADGES[status] ?? {
-    background: 'var(--color-warning-subtle, #2a2418)',
+    background: 'var(--color-warning-subtle)',
     color: 'var(--text-secondary)',
     label: status,
   };
@@ -85,6 +85,13 @@ export function OrgConnectorSection({ connectors, onChanged }: OrgConnectorSecti
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
 
+  // Success messages auto-clear after 3s (same convention as the page's
+  // "Settings saved" flash).
+  const flashMessage = (text: string) => {
+    setMessage(text);
+    setTimeout(() => setMessage(''), 3000);
+  };
+
   const handleCreate = async () => {
     setBusy(true);
     setError('');
@@ -99,7 +106,7 @@ export function OrgConnectorSection({ connectors, onChanged }: OrgConnectorSecti
       setDisplayName('');
       setApiKey('');
       setModelHint('');
-      setMessage('Organization connector created');
+      flashMessage('Organization connector created');
       await onChanged();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create connector');
@@ -115,7 +122,7 @@ export function OrgConnectorSection({ connectors, onChanged }: OrgConnectorSecti
     try {
       const result = await api.testOrgConnector(id);
       if (result.ok) {
-        setMessage(result.message ?? 'Connection OK');
+        flashMessage(result.message ?? 'Connection OK');
       } else {
         setError(result.message ?? result.error_code ?? 'Test failed');
       }
@@ -172,7 +179,7 @@ export function OrgConnectorSection({ connectors, onChanged }: OrgConnectorSecti
                 gap: '0.75rem',
                 flexWrap: 'wrap',
                 padding: '0.75rem',
-                border: '1px solid var(--border-color)',
+                border: '1px solid var(--border)',
                 borderRadius: '8px',
               }}
             >
@@ -184,10 +191,20 @@ export function OrgConnectorSection({ connectors, onChanged }: OrgConnectorSecti
                 </div>
               </div>
               <StatusBadge status={c.status} />
-              <button className="btn" onClick={() => handleTest(c.id)} disabled={busy}>
+              <button
+                className="btn"
+                aria-label={`Test ${c.display_name}`}
+                onClick={() => handleTest(c.id)}
+                disabled={busy}
+              >
                 Test
               </button>
-              <button className="btn btn-danger" onClick={() => handleDelete(c.id)} disabled={busy}>
+              <button
+                className="btn btn-danger"
+                aria-label={`Delete ${c.display_name}`}
+                onClick={() => handleDelete(c.id)}
+                disabled={busy}
+              >
                 Delete
               </button>
             </div>
@@ -231,7 +248,7 @@ export function OrgConnectorSection({ connectors, onChanged }: OrgConnectorSecti
             id="org-api-key"
             type="password"
             className="input"
-            autoComplete="off"
+            autoComplete="new-password"
             value={apiKey}
             onChange={(e) => setApiKey(e.target.value)}
           />

--- a/dashboard/app/admin/ai/__tests__/page.test.tsx
+++ b/dashboard/app/admin/ai/__tests__/page.test.tsx
@@ -1,7 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import AdminAISettingsPage from '../page';
 import { api } from '@/lib/api';
+import type {
+  AISettings,
+  LlmAdminAudit,
+  LlmAdminConnector,
+  LlmAdminPolicy,
+  LlmAdminUsage,
+  LlmConnector,
+  LlmDjStatus,
+} from '@/lib/api-types';
 
 vi.mock('@/lib/auth', () => ({
   useAuth: () => ({
@@ -34,33 +43,111 @@ vi.mock('next/navigation', () => ({
   usePathname: () => '/admin/ai',
 }));
 
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const baseSettings: AISettings = {
+  llm_enabled: true,
+  llm_rate_limit_per_minute: 3,
+};
+
+const basePolicy: LlmAdminPolicy = {
+  llm_apikey_connectors_enabled: true,
+  llm_compatible_connector_enabled: true,
+  llm_default_connector_id: null,
+  llm_call_log_retention_days: 30,
+};
+
+const emptyAudit: LlmAdminAudit = { rows: [], total: 0, limit: 50, offset: 0 };
+const emptyUsage: LlmAdminUsage = { days: 30, rows: [] };
+const emptyDjStatus: LlmDjStatus = { rows: [] };
+
+function adminConnector(overrides: Partial<LlmAdminConnector> = {}): LlmAdminConnector {
+  return {
+    id: 1,
+    user_id: 42,
+    scope: 'user',
+    dj_username: 'someDJ',
+    connector_type: 'openai_apikey',
+    display_name: 'My OpenAI',
+    status: 'active',
+    base_url_plain: null,
+    model_hint: 'gpt-5-mini',
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-01T00:00:00Z',
+    last_used_at: null,
+    last_error: null,
+    is_default: false,
+    last_health_check_at: null,
+    last_health_check_status: null,
+    monthly_token_cap: null,
+    current_month_tokens: 0,
+    ...overrides,
+  };
+}
+
+function orgConnector(overrides: Partial<LlmConnector> = {}): LlmConnector {
+  return {
+    id: 50,
+    user_id: null,
+    scope: 'org',
+    connector_type: 'openai_apikey',
+    display_name: 'House OpenAI',
+    status: 'active',
+    base_url_plain: null,
+    model_hint: 'gpt-5-mini',
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+    last_used_at: null,
+    last_error: null,
+    is_default: false,
+    last_health_check_at: null,
+    last_health_check_status: null,
+    monthly_token_cap: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Mock every API call the page makes on mount with sensible defaults.
+ * Individual tests re-spy specific methods to override.
+ */
+function mockApis(
+  overrides: {
+    settings?: AISettings;
+    policy?: LlmAdminPolicy;
+    connectors?: LlmAdminConnector[];
+    usage?: LlmAdminUsage;
+    orgConnectors?: LlmConnector[];
+    djStatus?: LlmDjStatus;
+    audit?: LlmAdminAudit;
+  } = {},
+) {
+  vi.spyOn(api, 'getAISettings').mockResolvedValue(overrides.settings ?? baseSettings);
+  vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue(overrides.policy ?? basePolicy);
+  vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue(overrides.connectors ?? []);
+  vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue(overrides.usage ?? emptyUsage);
+  vi.spyOn(api, 'listOrgConnectors').mockResolvedValue(overrides.orgConnectors ?? []);
+  vi.spyOn(api, 'getDjLlmStatus').mockResolvedValue(overrides.djStatus ?? emptyDjStatus);
+  vi.spyOn(api, 'getAdminLlmAudit').mockResolvedValue(overrides.audit ?? emptyAudit);
+}
+
 describe('AdminAISettingsPage', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
 
   it('renders loading state initially', () => {
+    mockApis();
     vi.spyOn(api, 'getAISettings').mockImplementation(() => new Promise(() => {}));
-    vi.spyOn(api, 'getAIModels').mockImplementation(() => new Promise(() => {}));
 
     render(<AdminAISettingsPage />);
     expect(screen.getByText('Loading AI settings...')).toBeInTheDocument();
   });
 
-  it('renders settings after load', async () => {
-    vi.spyOn(api, 'getAISettings').mockResolvedValue({
-      llm_enabled: true,
-      llm_model: 'claude-haiku-4-5-20251001',
-      llm_rate_limit_per_minute: 3,
-      api_key_configured: true,
-      api_key_masked: '...abcd',
-    });
-    vi.spyOn(api, 'getAIModels').mockResolvedValue({
-      models: [
-        { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5' },
-        { id: 'claude-sonnet-4-5-20250929', name: 'Claude Sonnet 4.5' },
-      ],
-    });
+  it('renders settings after load without the legacy API Key Status panel', async () => {
+    mockApis();
 
     render(<AdminAISettingsPage />);
 
@@ -68,45 +155,30 @@ describe('AdminAISettingsPage', () => {
       expect(screen.getByText('AI / LLM Settings')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Configured')).toBeInTheDocument();
-    expect(screen.getByText('...abcd')).toBeInTheDocument();
+    // Legacy env-var key panel and model selector are gone.
+    expect(screen.queryByText('API Key Status')).not.toBeInTheDocument();
+    expect(screen.queryByText('Configured')).not.toBeInTheDocument();
+    expect(screen.queryByText('Not Configured')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Model')).not.toBeInTheDocument();
   });
 
-  it('shows not configured badge when no API key', async () => {
-    vi.spyOn(api, 'getAISettings').mockResolvedValue({
-      llm_enabled: false,
-      llm_model: 'claude-haiku-4-5-20251001',
-      llm_rate_limit_per_minute: 3,
-      api_key_configured: false,
-      api_key_masked: 'Not configured',
-    });
-    vi.spyOn(api, 'getAIModels').mockResolvedValue({ models: [] });
+  it('renders the fallback toggle with org-fallback copy', async () => {
+    mockApis();
 
     render(<AdminAISettingsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Not Configured')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /Allow DJs without their own connector to use the organization connector/i,
+        ),
+      ).toBeInTheDocument();
     });
   });
 
   it('calls updateAISettings on save', async () => {
-    vi.spyOn(api, 'getAISettings').mockResolvedValue({
-      llm_enabled: true,
-      llm_model: 'claude-haiku-4-5-20251001',
-      llm_rate_limit_per_minute: 3,
-      api_key_configured: true,
-      api_key_masked: '...abcd',
-    });
-    vi.spyOn(api, 'getAIModels').mockResolvedValue({
-      models: [{ id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5' }],
-    });
-    const updateSpy = vi.spyOn(api, 'updateAISettings').mockResolvedValue({
-      llm_enabled: true,
-      llm_model: 'claude-haiku-4-5-20251001',
-      llm_rate_limit_per_minute: 3,
-      api_key_configured: true,
-      api_key_masked: '...abcd',
-    });
+    mockApis();
+    const updateSpy = vi.spyOn(api, 'updateAISettings').mockResolvedValue(baseSettings);
 
     render(<AdminAISettingsPage />);
 
@@ -117,13 +189,16 @@ describe('AdminAISettingsPage', () => {
     fireEvent.click(screen.getByText('Save Settings'));
 
     await waitFor(() => {
-      expect(updateSpy).toHaveBeenCalled();
+      expect(updateSpy).toHaveBeenCalledWith({
+        llm_enabled: true,
+        llm_rate_limit_per_minute: 3,
+      });
     });
   });
 
   it('shows error on fetch failure', async () => {
+    mockApis();
     vi.spyOn(api, 'getAISettings').mockRejectedValue(new Error('Network error'));
-    vi.spyOn(api, 'getAIModels').mockRejectedValue(new Error('Network error'));
 
     render(<AdminAISettingsPage />);
 
@@ -133,47 +208,7 @@ describe('AdminAISettingsPage', () => {
   });
 
   it('renders connector policy + per-DJ connector cards when gateway data loads', async () => {
-    vi.spyOn(api, 'getAISettings').mockResolvedValue({
-      llm_enabled: true,
-      llm_model: 'claude-haiku-4-5-20251001',
-      llm_rate_limit_per_minute: 3,
-      api_key_configured: true,
-      api_key_masked: '...abcd',
-    });
-    vi.spyOn(api, 'getAIModels').mockResolvedValue({
-      models: [{ id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5' }],
-    });
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
-      llm_call_log_retention_days: 30,
-    });
-    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([
-      {
-        id: 1,
-        user_id: 42,
-        dj_username: 'someDJ',
-        connector_type: 'openai_apikey',
-        display_name: 'My OpenAI',
-        status: 'active',
-        base_url_plain: null,
-        model_hint: 'gpt-5-mini',
-        created_at: '2026-05-01T00:00:00Z',
-        updated_at: '2026-05-01T00:00:00Z',
-        last_used_at: null,
-        last_error: null,
-        is_default: false,
-        last_health_check_at: null,
-        last_health_check_status: null,
-        monthly_token_cap: null,
-        current_month_tokens: 0,
-      },
-    ]);
-    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({
-      days: 30,
-      rows: [],
-    });
+    mockApis({ connectors: [adminConnector()] });
 
     render(<AdminAISettingsPage />);
 
@@ -185,39 +220,135 @@ describe('AdminAISettingsPage', () => {
     expect(screen.getByText(/Usage — last 30 days/)).toBeInTheDocument();
   });
 
+  // -------- org-scoped house connector --------
+
+  it('renders the Organization connector section', async () => {
+    mockApis();
+
+    render(<AdminAISettingsPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Organization connector')).toBeInTheDocument(),
+    );
+  });
+
+  it('shows a create form in the empty state and creates an org connector on submit', async () => {
+    mockApis();
+    const createSpy = vi.spyOn(api, 'createOrgConnector').mockResolvedValue(orgConnector());
+
+    render(<AdminAISettingsPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Organization connector')).toBeInTheDocument(),
+    );
+    // Empty-state explainer
+    expect(screen.getByText(/house credential/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Display name'), {
+      target: { value: 'House key' },
+    });
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk-test-123' },
+    });
+    fireEvent.change(screen.getByLabelText('Model hint (optional)'), {
+      target: { value: 'gpt-5-mini' },
+    });
+    fireEvent.click(screen.getByText('Add connector'));
+
+    await waitFor(() =>
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connector_type: 'openai_apikey',
+          display_name: 'House key',
+          api_key: 'sk-test-123',
+          model_hint: 'gpt-5-mini',
+        }),
+      ),
+    );
+  });
+
+  it('lists an existing org connector with Test and Delete actions', async () => {
+    mockApis({ orgConnectors: [orgConnector()] });
+    const testSpy = vi.spyOn(api, 'testOrgConnector').mockResolvedValue({
+      ok: true,
+      message: 'Connection OK',
+      error_code: null,
+    });
+    const deleteSpy = vi.spyOn(api, 'deleteOrgConnector').mockResolvedValue(undefined);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<AdminAISettingsPage />);
+
+    await waitFor(() => expect(screen.getByText('House OpenAI')).toBeInTheDocument());
+    expect(screen.getByText('Active')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Test'));
+    await waitFor(() => expect(testSpy).toHaveBeenCalledWith(50));
+
+    fireEvent.click(screen.getByText('Delete'));
+    await waitFor(() => expect(deleteSpy).toHaveBeenCalledWith(50));
+  });
+
+  it('renders per-DJ effective-source badges from dj-status', async () => {
+    mockApis({
+      djStatus: {
+        rows: [
+          { user_id: 1, username: 'djtest', effective_source: 'org_fallback' },
+          { user_id: 2, username: 'djown', effective_source: 'own' },
+          { user_id: 3, username: 'djnone', effective_source: 'none' },
+        ],
+      },
+    });
+
+    render(<AdminAISettingsPage />);
+
+    await waitFor(() => expect(screen.getByText('djtest')).toBeInTheDocument());
+    expect(screen.getByText('Org fallback')).toBeInTheDocument();
+    expect(screen.getByText('djown')).toBeInTheDocument();
+    expect(screen.getByText('Own connector')).toBeInTheDocument();
+    expect(screen.getByText('djnone')).toBeInTheDocument();
+    expect(screen.getByText('None — AI unavailable')).toBeInTheDocument();
+  });
+
+  it('offers only org-scoped connectors in the org-default dropdown', async () => {
+    mockApis({
+      connectors: [adminConnector({ display_name: 'My OpenAI' })],
+      orgConnectors: [orgConnector({ display_name: 'House OpenAI' })],
+    });
+
+    render(<AdminAISettingsPage />);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText('Org default connector')).toBeInTheDocument(),
+    );
+    const select = screen.getByLabelText('Org default connector');
+    expect(
+      within(select).getByText('Organization — House OpenAI (OpenAI)'),
+    ).toBeInTheDocument();
+    expect(within(select).queryByText(/My OpenAI/)).not.toBeInTheDocument();
+  });
+
+  // -------- audit trail --------
+
   it('renders the audit trail card with seeded events', async () => {
-    vi.spyOn(api, 'getAISettings').mockResolvedValue({
-      llm_enabled: true,
-      llm_model: 'claude-haiku-4-5-20251001',
-      llm_rate_limit_per_minute: 3,
-      api_key_configured: true,
-      api_key_masked: '...abcd',
-    });
-    vi.spyOn(api, 'getAIModels').mockResolvedValue({ models: [] });
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
-      llm_call_log_retention_days: 30,
-    });
-    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([]);
-    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
-    vi.spyOn(api, 'getAdminLlmAudit').mockResolvedValue({
-      rows: [
-        {
-          id: 1,
-          created_at: '2026-05-20T12:00:00Z',
-          event_type: 'connector_created',
-          actor_user_id: 42,
-          actor_username: 'someDJ',
-          target_connector_id: 7,
-          target_connector_display_name: 'My OpenAI',
-          notes: null,
-        },
-      ],
-      total: 1,
-      limit: 50,
-      offset: 0,
+    mockApis({
+      audit: {
+        rows: [
+          {
+            id: 1,
+            created_at: '2026-05-20T12:00:00Z',
+            event_type: 'connector_created',
+            actor_user_id: 42,
+            actor_username: 'someDJ',
+            target_connector_id: 7,
+            target_connector_display_name: 'My OpenAI',
+            notes: null,
+          },
+        ],
+        total: 1,
+        limit: 50,
+        offset: 0,
+      },
     });
 
     render(<AdminAISettingsPage />);
@@ -235,28 +366,8 @@ describe('AdminAISettingsPage', () => {
   });
 
   it('refetches audit events when the event-type filter changes', async () => {
-    vi.spyOn(api, 'getAISettings').mockResolvedValue({
-      llm_enabled: true,
-      llm_model: 'claude-haiku-4-5-20251001',
-      llm_rate_limit_per_minute: 3,
-      api_key_configured: true,
-      api_key_masked: '...abcd',
-    });
-    vi.spyOn(api, 'getAIModels').mockResolvedValue({ models: [] });
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
-      llm_call_log_retention_days: 30,
-    });
-    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([]);
-    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
-    const auditSpy = vi.spyOn(api, 'getAdminLlmAudit').mockResolvedValue({
-      rows: [],
-      total: 0,
-      limit: 50,
-      offset: 0,
-    });
+    mockApis();
+    const auditSpy = vi.spyOn(api, 'getAdminLlmAudit').mockResolvedValue(emptyAudit);
     const exportSpy = vi
       .spyOn(api, 'downloadAdminLlmAuditCsv')
       .mockResolvedValue(new Blob(['ok'], { type: 'text/csv' }));
@@ -296,61 +407,19 @@ describe('AdminAISettingsPage', () => {
   });
 
   it('force-revokes a connector via the admin table', async () => {
-    vi.spyOn(api, 'getAISettings').mockResolvedValue({
-      llm_enabled: true,
-      llm_model: 'claude-haiku-4-5-20251001',
-      llm_rate_limit_per_minute: 3,
-      api_key_configured: true,
-      api_key_masked: '...abcd',
+    mockApis({
+      connectors: [
+        adminConnector({ id: 9, dj_username: 'badDJ', display_name: 'Compromised' }),
+      ],
     });
-    vi.spyOn(api, 'getAIModels').mockResolvedValue({ models: [] });
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
-      llm_call_log_retention_days: 30,
-    });
-    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([
-      {
+    const revokeSpy = vi.spyOn(api, 'revokeAdminLlmConnector').mockResolvedValue(
+      adminConnector({
         id: 9,
-        user_id: 42,
         dj_username: 'badDJ',
-        connector_type: 'openai_apikey',
         display_name: 'Compromised',
-        status: 'active',
-        base_url_plain: null,
-        model_hint: null,
-        created_at: '2026-05-01T00:00:00Z',
-        updated_at: '2026-05-01T00:00:00Z',
-        last_used_at: null,
-        last_error: null,
-        is_default: false,
-        last_health_check_at: null,
-        last_health_check_status: null,
-        monthly_token_cap: null,
-        current_month_tokens: 0,
-      },
-    ]);
-    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
-    const revokeSpy = vi.spyOn(api, 'revokeAdminLlmConnector').mockResolvedValue({
-      id: 9,
-      user_id: 42,
-      dj_username: 'badDJ',
-      connector_type: 'openai_apikey',
-      display_name: 'Compromised',
-      status: 'disabled',
-      base_url_plain: null,
-      model_hint: null,
-      created_at: '2026-05-01T00:00:00Z',
-      updated_at: '2026-05-01T00:00:00Z',
-      last_used_at: null,
-      last_error: null,
-      is_default: false,
-      last_health_check_at: null,
-      last_health_check_status: null,
-      monthly_token_cap: null,
-      current_month_tokens: 0,
-    });
+        status: 'disabled',
+      }),
+    );
     vi.spyOn(window, 'confirm').mockReturnValue(true);
 
     render(<AdminAISettingsPage />);
@@ -361,26 +430,9 @@ describe('AdminAISettingsPage', () => {
   });
 
   it('persists call-log retention on blur via the policy patch (issue #342)', async () => {
-    vi.spyOn(api, 'getAISettings').mockResolvedValue({
-      llm_enabled: true,
-      llm_model: 'claude-haiku-4-5-20251001',
-      llm_rate_limit_per_minute: 3,
-      api_key_configured: true,
-      api_key_masked: '...abcd',
-    });
-    vi.spyOn(api, 'getAIModels').mockResolvedValue({ models: [] });
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
-      llm_call_log_retention_days: 30,
-    });
-    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([]);
-    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
+    mockApis();
     const patchSpy = vi.spyOn(api, 'updateAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
+      ...basePolicy,
       llm_call_log_retention_days: 90,
     });
 
@@ -402,26 +454,9 @@ describe('AdminAISettingsPage', () => {
   });
 
   it('clamps an out-of-range retention value before patching (issue #342)', async () => {
-    vi.spyOn(api, 'getAISettings').mockResolvedValue({
-      llm_enabled: true,
-      llm_model: 'claude-haiku-4-5-20251001',
-      llm_rate_limit_per_minute: 3,
-      api_key_configured: true,
-      api_key_masked: '...abcd',
-    });
-    vi.spyOn(api, 'getAIModels').mockResolvedValue({ models: [] });
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
-      llm_call_log_retention_days: 30,
-    });
-    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([]);
-    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
+    mockApis();
     const patchSpy = vi.spyOn(api, 'updateAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
+      ...basePolicy,
       llm_call_log_retention_days: 365,
     });
 
@@ -445,26 +480,9 @@ describe('AdminAISettingsPage', () => {
   // coerced back to the current policy before blur ever sees it. 5 is a genuine
   // below-min entry that the blur clamp must lift to 7.
   it('clamps a below-min retention value before patching (issue #342)', async () => {
-    vi.spyOn(api, 'getAISettings').mockResolvedValue({
-      llm_enabled: true,
-      llm_model: 'claude-haiku-4-5-20251001',
-      llm_rate_limit_per_minute: 3,
-      api_key_configured: true,
-      api_key_masked: '...abcd',
-    });
-    vi.spyOn(api, 'getAIModels').mockResolvedValue({ models: [] });
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
-      llm_call_log_retention_days: 30,
-    });
-    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([]);
-    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
+    mockApis();
     const patchSpy = vi.spyOn(api, 'updateAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
+      ...basePolicy,
       llm_call_log_retention_days: 7,
     });
 
@@ -485,80 +503,40 @@ describe('AdminAISettingsPage', () => {
 
   // -------- issue #346: surface health-check columns in connectors table --------
   it('renders last-health-check column with a status badge per connector', async () => {
-    vi.spyOn(api, 'getAISettings').mockResolvedValue({
-      llm_enabled: true,
-      llm_model: 'claude-haiku-4-5-20251001',
-      llm_rate_limit_per_minute: 3,
-      api_key_configured: true,
-      api_key_masked: '...abcd',
+    mockApis({
+      connectors: [
+        adminConnector({
+          id: 1,
+          user_id: 1,
+          dj_username: 'alpha',
+          display_name: 'Alpha key',
+          model_hint: null,
+          last_health_check_at: '2026-05-28T10:00:00Z',
+          last_health_check_status: 'ok',
+        }),
+        adminConnector({
+          id: 2,
+          user_id: 2,
+          dj_username: 'bravo',
+          connector_type: 'anthropic_apikey',
+          display_name: 'Bravo key',
+          status: 'auth_invalid',
+          model_hint: null,
+          last_error: 'auth_invalid',
+          last_health_check_at: '2026-05-28T09:00:00Z',
+          last_health_check_status: 'auth_invalid',
+        }),
+        adminConnector({
+          id: 3,
+          user_id: 3,
+          dj_username: 'charlie',
+          display_name: 'Charlie key',
+          model_hint: null,
+          last_health_check_at: null,
+          last_health_check_status: null,
+        }),
+      ],
     });
-    vi.spyOn(api, 'getAIModels').mockResolvedValue({ models: [] });
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
-      llm_call_log_retention_days: 30,
-    });
-    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([
-      {
-        id: 1,
-        user_id: 1,
-        dj_username: 'alpha',
-        connector_type: 'openai_apikey',
-        display_name: 'Alpha key',
-        status: 'active',
-        base_url_plain: null,
-        model_hint: null,
-        created_at: '2026-05-01T00:00:00Z',
-        updated_at: '2026-05-01T00:00:00Z',
-        last_used_at: null,
-        last_error: null,
-        is_default: false,
-        last_health_check_at: '2026-05-28T10:00:00Z',
-        last_health_check_status: 'ok',
-        monthly_token_cap: null,
-        current_month_tokens: 0,
-      },
-      {
-        id: 2,
-        user_id: 2,
-        dj_username: 'bravo',
-        connector_type: 'anthropic_apikey',
-        display_name: 'Bravo key',
-        status: 'auth_invalid',
-        base_url_plain: null,
-        model_hint: null,
-        created_at: '2026-05-01T00:00:00Z',
-        updated_at: '2026-05-01T00:00:00Z',
-        last_used_at: null,
-        last_error: 'auth_invalid',
-        is_default: false,
-        last_health_check_at: '2026-05-28T09:00:00Z',
-        last_health_check_status: 'auth_invalid',
-        monthly_token_cap: null,
-        current_month_tokens: 0,
-      },
-      {
-        id: 3,
-        user_id: 3,
-        dj_username: 'charlie',
-        connector_type: 'openai_apikey',
-        display_name: 'Charlie key',
-        status: 'active',
-        base_url_plain: null,
-        model_hint: null,
-        created_at: '2026-05-01T00:00:00Z',
-        updated_at: '2026-05-01T00:00:00Z',
-        last_used_at: null,
-        last_error: null,
-        is_default: false,
-        last_health_check_at: null,
-        last_health_check_status: null,
-        monthly_token_cap: null,
-        current_month_tokens: 0,
-      },
-    ]);
-    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
 
     render(<AdminAISettingsPage />);
 
@@ -572,61 +550,28 @@ describe('AdminAISettingsPage', () => {
   });
 
   it('toggles sort direction when clicking the last-health-check header', async () => {
-    vi.spyOn(api, 'getAISettings').mockResolvedValue({
-      llm_enabled: true,
-      llm_model: 'claude-haiku-4-5-20251001',
-      llm_rate_limit_per_minute: 3,
-      api_key_configured: true,
-      api_key_masked: '...abcd',
+    mockApis({
+      connectors: [
+        adminConnector({
+          id: 1,
+          user_id: 1,
+          dj_username: 'older',
+          display_name: 'Older check',
+          model_hint: null,
+          last_health_check_at: '2026-05-01T00:00:00Z',
+          last_health_check_status: 'ok',
+        }),
+        adminConnector({
+          id: 2,
+          user_id: 2,
+          dj_username: 'newer',
+          display_name: 'Newer check',
+          model_hint: null,
+          last_health_check_at: '2026-05-28T00:00:00Z',
+          last_health_check_status: 'ok',
+        }),
+      ],
     });
-    vi.spyOn(api, 'getAIModels').mockResolvedValue({ models: [] });
-    vi.spyOn(api, 'getAdminLlmPolicy').mockResolvedValue({
-      llm_apikey_connectors_enabled: true,
-      llm_compatible_connector_enabled: true,
-      llm_default_connector_id: null,
-      llm_call_log_retention_days: 30,
-    });
-    vi.spyOn(api, 'listAllLlmConnectors').mockResolvedValue([
-      {
-        id: 1,
-        user_id: 1,
-        dj_username: 'older',
-        connector_type: 'openai_apikey',
-        display_name: 'Older check',
-        status: 'active',
-        base_url_plain: null,
-        model_hint: null,
-        created_at: '2026-05-01T00:00:00Z',
-        updated_at: '2026-05-01T00:00:00Z',
-        last_used_at: null,
-        last_error: null,
-        is_default: false,
-        last_health_check_at: '2026-05-01T00:00:00Z',
-        last_health_check_status: 'ok',
-        monthly_token_cap: null,
-        current_month_tokens: 0,
-      },
-      {
-        id: 2,
-        user_id: 2,
-        dj_username: 'newer',
-        connector_type: 'openai_apikey',
-        display_name: 'Newer check',
-        status: 'active',
-        base_url_plain: null,
-        model_hint: null,
-        created_at: '2026-05-01T00:00:00Z',
-        updated_at: '2026-05-01T00:00:00Z',
-        last_used_at: null,
-        last_error: null,
-        is_default: false,
-        last_health_check_at: '2026-05-28T00:00:00Z',
-        last_health_check_status: 'ok',
-        monthly_token_cap: null,
-        current_month_tokens: 0,
-      },
-    ]);
-    vi.spyOn(api, 'getAdminLlmUsage').mockResolvedValue({ days: 30, rows: [] });
 
     render(<AdminAISettingsPage />);
 

--- a/dashboard/app/admin/ai/__tests__/page.test.tsx
+++ b/dashboard/app/admin/ai/__tests__/page.test.tsx
@@ -289,6 +289,39 @@ describe('AdminAISettingsPage', () => {
     await waitFor(() => expect(deleteSpy).toHaveBeenCalledWith(50));
   });
 
+  it('renders the org API key input as a password field', async () => {
+    mockApis();
+
+    render(<AdminAISettingsPage />);
+
+    await waitFor(() => expect(screen.getByLabelText('API key')).toBeInTheDocument());
+    expect(screen.getByLabelText('API key')).toHaveAttribute('type', 'password');
+  });
+
+  it('shows an error and retains the typed key when org connector creation fails', async () => {
+    mockApis();
+    vi.spyOn(api, 'createOrgConnector').mockRejectedValue(new Error('Invalid API key'));
+
+    render(<AdminAISettingsPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Organization connector')).toBeInTheDocument(),
+    );
+
+    fireEvent.change(screen.getByLabelText('Display name'), {
+      target: { value: 'House key' },
+    });
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk-bad' },
+    });
+    fireEvent.click(screen.getByText('Add connector'));
+
+    await waitFor(() => expect(screen.getByText('Invalid API key')).toBeInTheDocument());
+    // Inputs keep their values so the admin can correct and retry.
+    expect((screen.getByLabelText('API key') as HTMLInputElement).value).toBe('sk-bad');
+    expect((screen.getByLabelText('Display name') as HTMLInputElement).value).toBe('House key');
+  });
+
   it('renders per-DJ effective-source badges from dj-status', async () => {
     mockApis({
       djStatus: {

--- a/dashboard/app/admin/ai/page.tsx
+++ b/dashboard/app/admin/ai/page.tsx
@@ -5,28 +5,27 @@ import { api } from '@/lib/api';
 import type { AdminLlmAuditFilters } from '@/lib/api';
 import type {
   AISettings,
-  AIModelInfo,
   LlmAdminAudit,
   LlmAdminConnector,
   LlmAdminPolicy,
   LlmAdminUsage,
+  LlmConnector,
+  LlmDjStatusRow,
 } from '@/lib/api-types';
 import { useAdminPage } from '@/lib/useAdminPage';
 import { HelpSpot } from '@/components/help/HelpSpot';
 import { HelpButton } from '@/components/help/HelpButton';
 import { OnboardingOverlay } from '@/components/help/OnboardingOverlay';
+import { OrgConnectorSection, TYPE_LABELS } from './OrgConnectorSection';
 
 const PAGE_ID = 'admin-ai';
 
-const TYPE_LABELS: Record<string, string> = {
-  openai_apikey: 'OpenAI',
-  anthropic_apikey: 'Anthropic',
-  openrouter_apikey: 'OpenRouter',
-  xai_apikey: 'xAI',
-  gemini_apikey: 'Gemini',
-  openai_compatible: 'OpenAI-compatible',
-  bedrock: 'AWS Bedrock',
-  azure_openai: 'Azure OpenAI',
+// Effective LLM credential source per DJ — computed by the backend with the
+// same rules the gateway resolver applies (see /api/admin/llm/dj-status).
+const SOURCE_LABELS: Record<string, { text: string; color: string }> = {
+  own: { text: 'Own connector', color: 'var(--color-success)' },
+  org_fallback: { text: 'Org fallback', color: 'var(--color-warning)' },
+  none: { text: 'None — AI unavailable', color: 'var(--color-danger)' },
 };
 
 // Audit event types — mirrors AUDIT_* constants in models/llm_connector.py.
@@ -224,7 +223,6 @@ const AUDIT_DAY_OPTIONS: Array<{ value: number; label: string }> = [
 ];
 
 export default function AdminAISettingsPage() {
-  const [models, setModels] = useState<AIModelInfo[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
@@ -232,6 +230,8 @@ export default function AdminAISettingsPage() {
   // LLM gateway state
   const [policy, setPolicy] = useState<LlmAdminPolicy | null>(null);
   const [connectors, setConnectors] = useState<LlmAdminConnector[]>([]);
+  const [orgConnectors, setOrgConnectors] = useState<LlmConnector[]>([]);
+  const [djStatus, setDjStatus] = useState<LlmDjStatusRow[]>([]);
   const [usage, setUsage] = useState<LlmAdminUsage | null>(null);
   const [policyMessage, setPolicyMessage] = useState('');
 
@@ -275,14 +275,7 @@ export default function AdminAISettingsPage() {
 
   const { data: settings, loading, error: loadError, setData: setSettings } = useAdminPage<AISettings>({
     pageId: PAGE_ID,
-    loader: async () => {
-      const [settingsData, modelsData] = await Promise.all([
-        api.getAISettings(),
-        api.getAIModels(),
-      ]);
-      setModels(modelsData.models);
-      return settingsData;
-    },
+    loader: () => api.getAISettings(),
     onError: () => 'Failed to load AI settings',
   });
 
@@ -295,22 +288,30 @@ export default function AdminAISettingsPage() {
       api.getAdminLlmPolicy(),
       api.listAllLlmConnectors(),
       api.getAdminLlmUsage(30),
-    ]).then(([p, c, u]) => {
+      api.listOrgConnectors(),
+      api.getDjLlmStatus(),
+    ]).then(([p, c, u, o, d]) => {
       if (!active) return;
       if (p.status === 'fulfilled') setPolicy(p.value);
       if (c.status === 'fulfilled') setConnectors(c.value);
       if (u.status === 'fulfilled') setUsage(u.value);
-      if (
-        p.status === 'rejected' ||
-        c.status === 'rejected' ||
-        u.status === 'rejected'
-      ) {
+      if (o.status === 'fulfilled') setOrgConnectors(o.value);
+      if (d.status === 'fulfilled') setDjStatus(d.value.rows);
+      if ([p, c, u, o, d].some((r) => r.status === 'rejected')) {
         setPolicyMessage('Some LLM gateway data failed to load');
       }
     });
     return () => {
       active = false;
     };
+  }, []);
+
+  // Reload the org connector list + per-DJ effective sources after any org
+  // connector mutation — both derive from the same scope-aware resolver.
+  const reloadOrgConnectors = useCallback(async () => {
+    const [o, d] = await Promise.allSettled([api.listOrgConnectors(), api.getDjLlmStatus()]);
+    if (o.status === 'fulfilled') setOrgConnectors(o.value);
+    if (d.status === 'fulfilled') setDjStatus(d.value.rows);
   }, []);
 
   // Load audit events whenever filters or the page change.
@@ -371,7 +372,6 @@ export default function AdminAISettingsPage() {
     try {
       const updated = await api.updateAISettings({
         llm_enabled: settings.llm_enabled,
-        llm_model: settings.llm_model,
         llm_rate_limit_per_minute: settings.llm_rate_limit_per_minute,
       });
       setSettings(updated);
@@ -475,39 +475,11 @@ export default function AdminAISettingsPage() {
       )}
 
       <div className="card">
-        {/* API Key Status */}
-        <HelpSpot spotId="admin-ai-key" page={PAGE_ID} order={1} title="API Key Status" description="Whether an Anthropic API key is configured. Required for AI features.">
+        {/* Org-fallback toggle: gates ONLY whether connector-less DJs fall back
+            to the org connector (house-billed). DJs with their own connectors
+            are never blocked by it. */}
+        <HelpSpot spotId="admin-ai-enable" page={PAGE_ID} order={1} title="Organization fallback" description="When off, only DJs who connected their own provider can use AI features. DJs' own connectors are never blocked by this switch.">
           <div className="form-group">
-            <label style={{ fontWeight: 500 }}>API Key Status</label>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginTop: '0.25rem' }}>
-              <span
-                style={{
-                  display: 'inline-block',
-                  padding: '0.25rem 0.75rem',
-                  borderRadius: '9999px',
-                  fontSize: '0.75rem',
-                  fontWeight: 600,
-                  background: settings.api_key_configured ? 'var(--color-success-subtle)' : 'var(--color-danger-subtle)',
-                  color: settings.api_key_configured ? 'var(--color-success)' : 'var(--color-danger)',
-                }}
-              >
-                {settings.api_key_configured ? 'Configured' : 'Not Configured'}
-              </span>
-              <span style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
-                {settings.api_key_masked}
-              </span>
-            </div>
-            {!settings.api_key_configured && (
-              <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginTop: '0.5rem' }}>
-                Set ANTHROPIC_API_KEY in your environment to enable AI features.
-              </p>
-            )}
-          </div>
-        </HelpSpot>
-
-        {/* LLM Enable/Disable */}
-        <HelpSpot spotId="admin-ai-enable" page={PAGE_ID} order={2} title="Enable AI" description="Toggle AI-powered song recommendations for DJs.">
-          <div className="form-group" style={{ marginTop: '1.5rem' }}>
             <label style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', cursor: 'pointer' }}>
               <input
                 type="checkbox"
@@ -516,42 +488,20 @@ export default function AdminAISettingsPage() {
                 style={{ width: '1.25rem', height: '1.25rem' }}
               />
               <div>
-                <div style={{ fontWeight: 500 }}>Enable AI Recommendations</div>
+                <div style={{ fontWeight: 500 }}>
+                  Allow DJs without their own connector to use the organization connector
+                  (house-billed)
+                </div>
                 <div style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
-                  When enabled, DJs can use AI Assist to get intelligent song suggestions.
+                  When off, only DJs who connected their own provider can use AI features.
                 </div>
               </div>
             </label>
           </div>
         </HelpSpot>
 
-        {/* Model Selection */}
-        <HelpSpot spotId="admin-ai-model" page={PAGE_ID} order={3} title="Model Selection" description="Choose which Claude model powers recommendations.">
-          <div className="form-group" style={{ marginTop: '1.5rem' }}>
-            <label htmlFor="ai-model">Model</label>
-            <div style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '0.5rem' }}>
-              Select which Claude model to use for recommendations.
-            </div>
-            <select
-              id="ai-model"
-              className="input"
-              style={{ maxWidth: '400px' }}
-              value={settings.llm_model}
-              onChange={(e) => setSettings({ ...settings, llm_model: e.target.value })}
-            >
-              {models.map((m) => (
-                <option key={m.id} value={m.id}>{m.name}</option>
-              ))}
-              {/* Include current model if not in list */}
-              {!models.some((m) => m.id === settings.llm_model) && (
-                <option value={settings.llm_model}>{settings.llm_model}</option>
-              )}
-            </select>
-          </div>
-        </HelpSpot>
-
         {/* Rate Limit */}
-        <HelpSpot spotId="admin-ai-rate" page={PAGE_ID} order={4} title="Rate Limit" description="Cap AI requests per DJ per minute to control costs.">
+        <HelpSpot spotId="admin-ai-rate" page={PAGE_ID} order={2} title="Rate Limit" description="Cap AI requests per DJ per minute to control costs.">
           <div className="form-group" style={{ marginTop: '1.5rem' }}>
             <label htmlFor="ai-rate-limit">Rate Limit (requests per minute per DJ)</label>
             <div style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '0.5rem' }}>
@@ -585,6 +535,9 @@ export default function AdminAISettingsPage() {
         </button>
       </div>
 
+      {/* ====== Organization (house) connector ====== */}
+      <OrgConnectorSection connectors={orgConnectors} onChanged={reloadOrgConnectors} />
+
       {/* ====== LLM Gateway connector policy ====== */}
       {policy && (
         <div className="card" style={{ marginTop: '2rem' }}>
@@ -612,7 +565,7 @@ export default function AdminAISettingsPage() {
           <div className="form-group" style={{ marginTop: '1.5rem' }}>
             <label htmlFor="default-connector">Org default connector</label>
             <div style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '0.5rem' }}>
-              Used when a system call has no DJ actor (background jobs).
+              Connector-less DJs and background jobs use this connector when fallback is allowed.
             </div>
             <select
               id="default-connector"
@@ -629,11 +582,11 @@ export default function AdminAISettingsPage() {
               style={{ maxWidth: '480px' }}
             >
               <option value="">— None —</option>
-              {connectors
+              {orgConnectors
                 .filter((c) => c.status === 'active')
                 .map((c) => (
                   <option key={c.id} value={c.id}>
-                    {c.dj_username} — {c.display_name} ({TYPE_LABELS[c.connector_type] ?? c.connector_type})
+                    Organization — {c.display_name} ({TYPE_LABELS[c.connector_type] ?? c.connector_type})
                   </option>
                 ))}
             </select>
@@ -670,8 +623,9 @@ export default function AdminAISettingsPage() {
           </div>
 
           <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginTop: '1rem' }}>
-            WrzDJ stores provider credentials encrypted at rest. Calls consume the DJ&apos;s
-            quota or billing directly. Credentials are never shared between DJs.
+            WrzDJ stores provider credentials encrypted at rest. DJ-owned connectors bill the
+            DJ directly and are never shared between DJs; the organization connector bills
+            the organization.
           </p>
         </div>
       )}
@@ -794,6 +748,36 @@ export default function AdminAISettingsPage() {
                 ))}
               </tbody>
             </table>
+          </div>
+        )}
+
+        {/* DJ access: effective credential source per DJ (own / org fallback / none) */}
+        <h3 style={{ marginTop: '1.5rem', marginBottom: '0.25rem' }}>DJ access</h3>
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginTop: 0 }}>
+          Where each DJ&apos;s AI calls are billed — their own connector, the organization
+          fallback, or nowhere (AI unavailable).
+        </p>
+        {djStatus.length === 0 ? (
+          <p style={{ color: 'var(--text-secondary)' }}>No DJs found.</p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+            {djStatus.map((row) => {
+              const label = SOURCE_LABELS[row.effective_source] ?? {
+                text: row.effective_source,
+                color: 'var(--text-secondary)',
+              };
+              return (
+                <div
+                  key={row.user_id}
+                  style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}
+                >
+                  <span style={{ minWidth: '160px' }}>{row.username}</span>
+                  <span style={{ color: label.color, fontSize: '0.875rem', fontWeight: 600 }}>
+                    {label.text}
+                  </span>
+                </div>
+              );
+            })}
           </div>
         )}
       </div>

--- a/dashboard/app/admin/ai/page.tsx
+++ b/dashboard/app/admin/ai/page.tsx
@@ -136,7 +136,7 @@ function capBarColor(percent: number): string {
 function PlainHeader({ label }: { label: string }) {
   return (
     <th
-      style={{ textAlign: 'left', padding: '0.5rem', borderBottom: '1px solid var(--border-color)' }}
+      style={{ textAlign: 'left', padding: '0.5rem', borderBottom: '1px solid var(--border)' }}
     >
       {label}
     </th>
@@ -173,7 +173,7 @@ function SortableHeader({
       style={{
         textAlign: 'left',
         padding: '0.5rem',
-        borderBottom: '1px solid var(--border-color)',
+        borderBottom: '1px solid var(--border)',
         cursor: 'pointer',
         userSelect: 'none',
       }}
@@ -307,11 +307,19 @@ export default function AdminAISettingsPage() {
   }, []);
 
   // Reload the org connector list + per-DJ effective sources after any org
-  // connector mutation — both derive from the same scope-aware resolver.
+  // connector mutation — both derive from the same scope-aware resolver. Also
+  // refresh the policy: deleting the default org connector clears
+  // llm_default_connector_id server-side, and handlePolicyPatch re-sends the
+  // full payload, so a stale id would make every later policy edit 400.
   const reloadOrgConnectors = useCallback(async () => {
-    const [o, d] = await Promise.allSettled([api.listOrgConnectors(), api.getDjLlmStatus()]);
+    const [o, d, p] = await Promise.allSettled([
+      api.listOrgConnectors(),
+      api.getDjLlmStatus(),
+      api.getAdminLlmPolicy(),
+    ]);
     if (o.status === 'fulfilled') setOrgConnectors(o.value);
     if (d.status === 'fulfilled') setDjStatus(d.value.rows);
+    if (p.status === 'fulfilled') setPolicy(p.value);
   }, []);
 
   // Load audit events whenever filters or the page change.
@@ -721,7 +729,7 @@ export default function AdminAISettingsPage() {
                             marginTop: '0.25rem',
                             height: '6px',
                             borderRadius: '9999px',
-                            background: 'var(--border-color)',
+                            background: 'var(--border)',
                             overflow: 'hidden',
                           }}
                         >

--- a/dashboard/components/AiProvidersSection.tsx
+++ b/dashboard/components/AiProvidersSection.tsx
@@ -352,9 +352,14 @@ export default function AiProvidersSection() {
           fallback toggle is on, this DJ's AI calls run on the house connector
           (house-billed) — say so. Otherwise AI features are simply unavailable.
           A failed policy fetch leaves `policy` null, which renders the danger
-          banner — fail-closed messaging, matching `allowedTypes` above.
+          banner — fail-closed messaging, matching `allowedTypes` above. The
+          "connect a provider" instruction is only appended when the admin
+          policy actually allows creating one (otherwise the section below says
+          creation is disabled, and the copy would contradict it). A hard load
+          failure (`error`) suppresses both banners — we don't know whether the
+          DJ has connectors, so we make no availability claims.
         */}
-        {connectors.length === 0 && !loading && (
+        {connectors.length === 0 && !loading && !error && (
           policy?.org_fallback_available ? (
             <div
               style={{
@@ -378,7 +383,9 @@ export default function AiProvidersSection() {
                 fontSize: '0.875rem',
               }}
             >
-              AI features unavailable — connect a provider below to enable them.
+              {allowedTypes.length > 0
+                ? 'AI features unavailable — connect a provider below to enable them.'
+                : 'AI features unavailable.'}
             </div>
           )
         )}

--- a/dashboard/components/AiProvidersSection.tsx
+++ b/dashboard/components/AiProvidersSection.tsx
@@ -347,8 +347,40 @@ export default function AiProvidersSection() {
 
       <section style={{ marginTop: '2rem' }}>
         <h3 style={{ marginTop: 0 }}>Connected providers</h3>
+        {/*
+          Connector-less DJ banners. When an org connector exists AND the admin
+          fallback toggle is on, this DJ's AI calls run on the house connector
+          (house-billed) — say so. Otherwise AI features are simply unavailable.
+          A failed policy fetch leaves `policy` null, which renders the danger
+          banner — fail-closed messaging, matching `allowedTypes` above.
+        */}
         {connectors.length === 0 && !loading && (
-          <p style={{ color: 'var(--text-secondary)' }}>No connectors yet.</p>
+          policy?.org_fallback_available ? (
+            <div
+              style={{
+                background: 'var(--color-warning-subtle)',
+                color: 'var(--color-warning)',
+                padding: '0.75rem 1rem',
+                borderRadius: '0.5rem',
+                fontSize: '0.875rem',
+              }}
+            >
+              You&apos;re using the organization&apos;s connector — usage is billed to the
+              organization. Connect your own provider below to use your own account.
+            </div>
+          ) : (
+            <div
+              style={{
+                background: 'var(--color-danger-subtle)',
+                color: 'var(--color-danger)',
+                padding: '0.75rem 1rem',
+                borderRadius: '0.5rem',
+                fontSize: '0.875rem',
+              }}
+            >
+              AI features unavailable — connect a provider below to enable them.
+            </div>
+          )
         )}
         {connectors.map((c) => {
           const status = STATUS_LABELS[c.status] ?? { text: c.status, color: 'var(--text-secondary)' };

--- a/dashboard/components/__tests__/AiProvidersSection.featurePrefs.test.tsx
+++ b/dashboard/components/__tests__/AiProvidersSection.featurePrefs.test.tsx
@@ -11,6 +11,7 @@ function makeConnector(overrides: Partial<LlmConnector> = {}): LlmConnector {
   return {
     id: 1,
     user_id: 42,
+    scope: 'user',
     connector_type: 'openai_apikey',
     display_name: 'My OpenAI',
     status: 'active',
@@ -36,6 +37,7 @@ describe('AiProvidersSection per-feature defaults', () => {
       llm_apikey_connectors_enabled: true,
       llm_compatible_connector_enabled: true,
       allowed_connector_types: ['openai_apikey'],
+      org_fallback_available: false,
     });
     vi.spyOn(api, 'listLlmFeaturePreferences').mockResolvedValue({
       preferences: [],

--- a/dashboard/components/__tests__/AiProvidersSection.test.tsx
+++ b/dashboard/components/__tests__/AiProvidersSection.test.tsx
@@ -134,6 +134,11 @@ describe('AiProvidersSection', () => {
     );
     expect(screen.queryByText('+ Add provider')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Provider')).not.toBeInTheDocument();
+    // Fail-closed banner: a null policy never claims house billing exists…
+    expect(screen.getByText(/AI features unavailable/i)).toBeInTheDocument();
+    // …and never tells the DJ to "connect a provider" while the same screen
+    // says connector creation is disabled by admin policy.
+    expect(screen.queryByText(/connect a provider below/i)).not.toBeInTheDocument();
   });
 
   it('fails closed: only api-key types when compatible is disabled (no leak of all)', async () => {
@@ -505,6 +510,22 @@ describe('AiProvidersSection', () => {
     expect(
       screen.queryByText(/AI features unavailable — connect a provider/i),
     ).not.toBeInTheDocument();
+  });
+
+  it('shows no availability banner when the connector list fails to load', async () => {
+    // A hard load failure means we don't actually know whether the DJ has
+    // connectors — show only the load error, never a claim about AI
+    // availability or house billing.
+    vi.spyOn(api, 'listLlmConnectors').mockRejectedValue(new Error('boom'));
+    vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(true, true, true));
+
+    render(<AiProvidersSection />);
+
+    await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument());
+    expect(
+      screen.queryByText(/using the organization's connector/i),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/AI features unavailable/i)).not.toBeInTheDocument();
   });
 
   it('deletes after confirmation', async () => {

--- a/dashboard/components/__tests__/AiProvidersSection.test.tsx
+++ b/dashboard/components/__tests__/AiProvidersSection.test.tsx
@@ -20,6 +20,7 @@ const ALL_APIKEY_TYPES: LlmConnectorType[] = [
 function makePolicy(
   apikeyEnabled: boolean,
   compatibleEnabled: boolean,
+  orgFallbackAvailable = false,
 ): LlmDjPolicy {
   const allowed: LlmConnectorType[] = [];
   if (apikeyEnabled) allowed.push(...ALL_APIKEY_TYPES);
@@ -28,6 +29,7 @@ function makePolicy(
     llm_apikey_connectors_enabled: apikeyEnabled,
     llm_compatible_connector_enabled: compatibleEnabled,
     allowed_connector_types: allowed,
+    org_fallback_available: orgFallbackAvailable,
   };
 }
 
@@ -37,6 +39,7 @@ function makeConnector(overrides: Partial<LlmConnector> = {}): LlmConnector {
   return {
     id: 1,
     user_id: 42,
+    scope: 'user',
     connector_type: 'openai_apikey',
     display_name: 'My OpenAI',
     status: 'active',
@@ -454,6 +457,54 @@ describe('AiProvidersSection', () => {
       const card = badge.closest('.card');
       expect(card?.textContent).toContain('B');
     });
+  });
+
+  // ---------- connector-less DJ banners (org fallback) ----------
+
+  it('shows the house-billed banner for a connector-less DJ when fallback is on', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
+    vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(true, true, true));
+
+    render(<AiProvidersSection />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/using the organization's connector/i)).toBeInTheDocument(),
+    );
+    // The danger banner must not show alongside the house-billed one.
+    expect(
+      screen.queryByText(/AI features unavailable — connect a provider/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the connect-a-provider banner when no fallback exists', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([]);
+    vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(true, true, false));
+
+    render(<AiProvidersSection />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/AI features unavailable — connect a provider/i),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByText(/using the organization's connector/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows no banner when the DJ has their own connector', async () => {
+    vi.spyOn(api, 'listLlmConnectors').mockResolvedValue([makeConnector()]);
+    vi.spyOn(api, 'getLlmPolicy').mockResolvedValue(makePolicy(true, true, true));
+
+    render(<AiProvidersSection />);
+
+    await waitFor(() => expect(screen.getByText('My OpenAI')).toBeInTheDocument());
+    expect(
+      screen.queryByText(/using the organization's connector/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/AI features unavailable — connect a provider/i),
+    ).not.toBeInTheDocument();
   });
 
   it('deletes after confirmation', async () => {

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -462,39 +462,18 @@ describe('ApiClient', () => {
       api.setToken('admin-token');
     });
 
-    it('fetches AI models', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          models: [
-            { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5' },
-          ],
-        }),
-      });
-
-      const result = await api.getAIModels();
-      expect(result.models).toHaveLength(1);
-      expect(result.models[0].id).toBe('claude-haiku-4-5-20251001');
-
-      const [url] = mockFetch.mock.calls[0];
-      expect(url).toContain('/api/admin/ai/models');
-    });
-
     it('fetches AI settings', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
           llm_enabled: true,
-          llm_model: 'claude-haiku-4-5-20251001',
           llm_rate_limit_per_minute: 3,
-          api_key_configured: true,
-          api_key_masked: '...test',
         }),
       });
 
       const result = await api.getAISettings();
       expect(result.llm_enabled).toBe(true);
-      expect(result.api_key_configured).toBe(true);
+      expect(result.llm_rate_limit_per_minute).toBe(3);
     });
 
     it('updates AI settings', async () => {
@@ -502,16 +481,13 @@ describe('ApiClient', () => {
         ok: true,
         json: async () => ({
           llm_enabled: false,
-          llm_model: 'claude-sonnet-4-5-20250929',
           llm_rate_limit_per_minute: 5,
-          api_key_configured: true,
-          api_key_masked: '...test',
         }),
       });
 
       const result = await api.updateAISettings({
         llm_enabled: false,
-        llm_model: 'claude-sonnet-4-5-20250929',
+        llm_rate_limit_per_minute: 5,
       });
       expect(result.llm_enabled).toBe(false);
 
@@ -638,6 +614,117 @@ describe('ApiClient', () => {
       await api.setAdminLlmConnectorCap(7, null);
       const [, options] = mockFetch.mock.calls[0];
       expect(JSON.parse(options.body)).toEqual({ monthly_token_cap: null });
+    });
+  });
+
+  describe('Org LLM connectors API', () => {
+    beforeEach(() => {
+      api.setToken('admin-token');
+    });
+
+    it('lists org connectors', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            id: 9,
+            user_id: null,
+            scope: 'org',
+            connector_type: 'anthropic_apikey',
+            display_name: 'House Anthropic',
+            status: 'active',
+            base_url_plain: null,
+            model_hint: null,
+            created_at: '2026-06-01T00:00:00Z',
+            updated_at: '2026-06-01T00:00:00Z',
+            last_used_at: null,
+            last_error: null,
+          },
+        ],
+      });
+
+      const result = await api.listOrgConnectors();
+      expect(result).toHaveLength(1);
+      expect(result[0].scope).toBe('org');
+      expect(result[0].user_id).toBeNull();
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/admin/llm/org-connectors');
+    });
+
+    it('creates an org connector via POST', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 10, scope: 'org', user_id: null }),
+      });
+
+      const result = await api.createOrgConnector({
+        connector_type: 'anthropic_apikey',
+        display_name: 'House Anthropic',
+        base_url: null,
+        bearer: null,
+        api_key: 'sk-ant-test',
+        model_hint: null,
+      });
+      expect(result.id).toBe(10);
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/admin/llm/org-connectors');
+      expect(options.method).toBe('POST');
+    });
+
+    it('tests an org connector via POST to the scoped URL', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, message: 'pong' }),
+      });
+
+      await api.testOrgConnector(9);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/admin/llm/org-connectors/9/test');
+      expect(options.method).toBe('POST');
+    });
+
+    it('rotates org connector credentials via PUT', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 9, scope: 'org', user_id: null }),
+      });
+
+      await api.rotateOrgConnectorCredentials(9, {
+        api_key: 'sk-ant-rotated',
+        bearer: null,
+      });
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/admin/llm/org-connectors/9/credentials');
+      expect(options.method).toBe('PUT');
+    });
+
+    it('deletes an org connector via DELETE', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => null });
+
+      await api.deleteOrgConnector(9);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/admin/llm/org-connectors/9');
+      expect(options.method).toBe('DELETE');
+    });
+
+    it('fetches per-DJ effective LLM status', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          rows: [
+            { user_id: 42, username: 'dj42', effective_source: 'org_fallback' },
+          ],
+        }),
+      });
+
+      const result = await api.getDjLlmStatus();
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].effective_source).toBe('org_fallback');
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/admin/llm/dj-status');
     });
   });
 

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -4,26 +4,6 @@
  */
 
 export interface paths {
-    "/api/admin/ai/models": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Admin Get Ai Models
-         * @description List available AI models.
-         */
-        get: operations["admin_get_ai_models_api_admin_ai_models_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/admin/ai/settings": {
         parameters: {
             query?: never;
@@ -34,11 +14,15 @@ export interface paths {
         /**
          * Admin Get Ai Settings
          * @description Get AI/LLM configuration.
+         *
+         *     ``llm_enabled`` gates only the org-connector fallback — DJs with their own
+         *     connector are never blocked by it. Credential status lives on the connector
+         *     surfaces (``/api/admin/llm/*``).
          */
         get: operations["admin_get_ai_settings_api_admin_ai_settings_get"];
         /**
          * Admin Update Ai Settings
-         * @description Update AI/LLM configuration.
+         * @description Update AI/LLM configuration (org-fallback gate + public rate limit).
          */
         put: operations["admin_update_ai_settings_api_admin_ai_settings_put"];
         post?: never;
@@ -206,8 +190,10 @@ export interface paths {
          *
          *     Honors the same filters as ``GET /audit``. Capped at
          *     ``_AUDIT_CSV_ROW_CAP`` rows to avoid unbounded streaming. Columns:
-         *     timestamp, actor, event_type, target_connector, notes. Never includes
-         *     credential material.
+         *     timestamp, actor, actor_user_id, event_type, target_connector, notes.
+         *     ``actor_user_id`` is empty for system rows, so a DJ literally named
+         *     "system" can never be confused with the NULL-actor system label. Never
+         *     includes credential material.
          */
         get: operations["export_audit_events_csv_api_admin_llm_audit_csv_get"];
         put?: never;
@@ -271,6 +257,112 @@ export interface paths {
         put?: never;
         /** Revoke Connector Admin */
         post: operations["revoke_connector_admin_api_admin_llm_connectors__connector_id__revoke_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/llm/dj-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Dj Llm Status
+         * @description Effective LLM credential source per DJ.
+         *
+         *     Backend-computed from the same rules the gateway resolver applies, so the
+         *     admin UI never duplicates resolution logic.
+         */
+        get: operations["dj_llm_status_api_admin_llm_dj_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/llm/org-connectors": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Org Connectors Admin */
+        get: operations["list_org_connectors_admin_api_admin_llm_org_connectors_get"];
+        put?: never;
+        /**
+         * Create Org Connector
+         * @description Create the organization's house connector (admin-only).
+         *
+         *     Reuses the DJ-connector validation pipeline; the row is org-scoped with no
+         *     owner. Credentials are encrypted at rest via EncryptedText. The DJ-facing
+         *     connector-type policy toggles are not applied — org connectors are an
+         *     admin decision.
+         */
+        post: operations["create_org_connector_api_admin_llm_org_connectors_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/llm/org-connectors/{connector_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Org Connector */
+        delete: operations["delete_org_connector_api_admin_llm_org_connectors__connector_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/llm/org-connectors/{connector_id}/credentials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Rotate Org Connector Credentials */
+        put: operations["rotate_org_connector_credentials_api_admin_llm_org_connectors__connector_id__credentials_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/llm/org-connectors/{connector_id}/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Test Org Connector
+         * @description Run a health check against an org connector and return a sanitised result.
+         *
+         *     Mirrors the DJ-facing ``POST /api/llm/connectors/{id}/test`` — same shared
+         *     helper, same status columns and audit rows, same code → message mapping.
+         */
+        post: operations["test_org_connector_api_admin_llm_org_connectors__connector_id__test_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3089,14 +3181,8 @@ export interface components {
         };
         /** AISettingsOut */
         AISettingsOut: {
-            /** Api Key Configured */
-            api_key_configured: boolean;
-            /** Api Key Masked */
-            api_key_masked: string;
             /** Llm Enabled */
             llm_enabled: boolean;
-            /** Llm Model */
-            llm_model: string;
             /** Llm Rate Limit Per Minute */
             llm_rate_limit_per_minute: number;
         };
@@ -3104,8 +3190,6 @@ export interface components {
         AISettingsUpdate: {
             /** Llm Enabled */
             llm_enabled?: boolean | null;
-            /** Llm Model */
-            llm_model?: string | null;
             /** Llm Rate Limit Per Minute */
             llm_rate_limit_per_minute?: number | null;
         };
@@ -3207,6 +3291,12 @@ export interface components {
             /** Monthly Token Cap */
             monthly_token_cap: number | null;
             /**
+             * Scope
+             * @default user
+             * @enum {string}
+             */
+            scope: "user" | "org";
+            /**
              * Status
              * @enum {string}
              */
@@ -3217,7 +3307,7 @@ export interface components {
              */
             updated_at: string;
             /** User Id */
-            user_id: number;
+            user_id: number | null;
         };
         /** AdminEventOut */
         AdminEventOut: {
@@ -3362,7 +3452,7 @@ export interface components {
          */
         AuditEventRow: {
             /** Actor User Id */
-            actor_user_id: number;
+            actor_user_id: number | null;
             /** Actor Username */
             actor_username: string;
             /**
@@ -3493,7 +3583,10 @@ export interface components {
         };
         /** Body_upload_banner_api_events__code__banner_post */
         Body_upload_banner_api_events__code__banner_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** BridgeApiKeyResponse */
@@ -3964,6 +4057,12 @@ export interface components {
             /** Monthly Token Cap */
             monthly_token_cap: number | null;
             /**
+             * Scope
+             * @default user
+             * @enum {string}
+             */
+            scope: "user" | "org";
+            /**
              * Status
              * @enum {string}
              */
@@ -3974,7 +4073,7 @@ export interface components {
              */
             updated_at: string;
             /** User Id */
-            user_id: number;
+            user_id: number | null;
         };
         /**
          * ConnectorPatch
@@ -4096,6 +4195,23 @@ export interface components {
             /** Requests Open */
             requests_open?: boolean | null;
         };
+        /** DjLlmStatusOut */
+        DjLlmStatusOut: {
+            /** Rows */
+            rows: components["schemas"]["DjLlmStatusRow"][];
+        };
+        /** DjLlmStatusRow */
+        DjLlmStatusRow: {
+            /**
+             * Effective Source
+             * @enum {string}
+             */
+            effective_source: "own" | "org_fallback" | "none";
+            /** User Id */
+            user_id: number;
+            /** Username */
+            username: string;
+        };
         /**
          * DjPolicyOut
          * @description DJ-readable connector policy — the non-sensitive subset of the admin
@@ -4117,6 +4233,11 @@ export interface components {
             llm_apikey_connectors_enabled: boolean;
             /** Llm Compatible Connector Enabled */
             llm_compatible_connector_enabled: boolean;
+            /**
+             * Org Fallback Available
+             * @default false
+             */
+            org_fallback_available: boolean;
         };
         /** EnrichPreviewItem */
         EnrichPreviewItem: {
@@ -5495,8 +5616,6 @@ export interface components {
             human_verification_enforced: boolean;
             /** Llm Enabled */
             llm_enabled: boolean;
-            /** Llm Model */
-            llm_model: string;
             /** Llm Rate Limit Per Minute */
             llm_rate_limit_per_minute: number;
             /** Registration Enabled */
@@ -5518,8 +5637,6 @@ export interface components {
             human_verification_enforced?: boolean | null;
             /** Llm Enabled */
             llm_enabled?: boolean | null;
-            /** Llm Model */
-            llm_model?: string | null;
             /** Llm Rate Limit Per Minute */
             llm_rate_limit_per_minute?: number | null;
             /** Registration Enabled */
@@ -5883,26 +6000,6 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    admin_get_ai_models_api_admin_ai_models_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AIModelsResponse"];
-                };
-            };
-        };
-    };
     admin_get_ai_settings_api_admin_ai_settings_get: {
         parameters: {
             query?: never;
@@ -6314,6 +6411,174 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AdminConnectorOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    dj_llm_status_api_admin_llm_dj_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DjLlmStatusOut"];
+                };
+            };
+        };
+    };
+    list_org_connectors_admin_api_admin_llm_org_connectors_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectorOut"][];
+                };
+            };
+        };
+    };
+    create_org_connector_api_admin_llm_org_connectors_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConnectorCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectorOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_org_connector_api_admin_llm_org_connectors__connector_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                connector_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    rotate_org_connector_credentials_api_admin_llm_org_connectors__connector_id__credentials_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                connector_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConnectorCredentialsRotate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectorOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    test_org_connector_api_admin_llm_org_connectors__connector_id__test_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                connector_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectorTestResult"];
                 };
             };
             /** @description Validation Error */

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -65,6 +65,9 @@ export type LlmAdminPolicyPatch = Schemas['AdminPolicyPatch'];
 // Monthly token cap (issue #339)
 export type LlmAdminConnectorCapPatch = Schemas['AdminConnectorCapPatch'];
 export type LlmDjPolicy = Schemas['DjPolicyOut'];
+// Org-scoped house connector: per-DJ effective credential source rollup
+export type LlmDjStatus = Schemas['DjLlmStatusOut'];
+export type LlmDjStatusRow = Schemas['DjLlmStatusRow'];
 export type LlmAdminUsage = Schemas['AdminUsageOut'];
 export type LlmUsageRow = Schemas['UsageRow'];
 // LLM audit trail (issue #341)

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   LlmConnectorPatch,
   LlmConnectorTestResult,
   LlmDjPolicy,
+  LlmDjStatus,
   LlmFeatureKey,
   LlmFeaturePreferences,
   LlmFeaturePreferenceSet,
@@ -96,6 +97,8 @@ export type {
   LlmConnectorTestResult,
   LlmConnectorType,
   LlmDjPolicy,
+  LlmDjStatus,
+  LlmDjStatusRow,
   LlmFeatureKey,
   LlmFeaturePreference,
   LlmFeaturePreferences,
@@ -1378,10 +1381,6 @@ class ApiClient {
 
   // ========== Admin AI Settings ==========
 
-  async getAIModels(): Promise<AIModelsResponse> {
-    return this.fetch('/api/admin/ai/models');
-  }
-
   async getAISettings(): Promise<AISettings> {
     return this.fetch('/api/admin/ai/settings');
   }
@@ -1592,6 +1591,44 @@ class ApiClient {
       method: 'PATCH',
       body: JSON.stringify({ monthly_token_cap: monthlyTokenCap }),
     });
+  }
+
+  // ========== Admin org-scoped house connector ==========
+
+  async listOrgConnectors(): Promise<LlmConnector[]> {
+    return this.fetch('/api/admin/llm/org-connectors');
+  }
+
+  async createOrgConnector(data: LlmConnectorCreate): Promise<LlmConnector> {
+    return this.fetch('/api/admin/llm/org-connectors', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async testOrgConnector(id: number): Promise<LlmConnectorTestResult> {
+    return this.fetch(`/api/admin/llm/org-connectors/${id}/test`, { method: 'POST' });
+  }
+
+  async rotateOrgConnectorCredentials(
+    id: number,
+    data: LlmConnectorCredentialsRotate,
+  ): Promise<LlmConnector> {
+    return this.fetch(`/api/admin/llm/org-connectors/${id}/credentials`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteOrgConnector(id: number): Promise<void> {
+    await this.fetch(`/api/admin/llm/org-connectors/${id}`, { method: 'DELETE' });
+  }
+
+  // Effective LLM credential source per DJ (own / org_fallback / none) —
+  // backend-computed by the same rules the gateway resolver applies, so the
+  // admin UI never duplicates resolution logic.
+  async getDjLlmStatus(): Promise<LlmDjStatus> {
+    return this.fetch('/api/admin/llm/dj-status');
   }
 
   // ========== Admin LLM audit trail (issue #341) ==========

--- a/docs/superpowers/plans/2026-06-09-org-llm-connector.md
+++ b/docs/superpowers/plans/2026-06-09-org-llm-connector.md
@@ -1,0 +1,1786 @@
+# Org LLM Connector + Admin AI Policy Cleanup — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an org-scoped LLM connector (house-billed fallback), rescope `llm_enabled` to gate only that fallback, and remove the legacy Anthropic env-var admin surface.
+
+**Architecture:** Org connectors live in the existing `llm_connectors` table with a new `scope` column (`'user'`/`'org'`) and nullable `user_id` (CHECK: org ⇔ NULL user). The gateway's per-DJ resolution chain filters to `scope='user'`; the org-default fallback requires `scope='org'` AND `SystemSettings.llm_enabled`. Audit rows allow NULL actor for system-context calls. Admin CRUD for the org connector reuses the existing `connector_storage` + `run_health_check` plumbing.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2.0 + Alembic (backend), Next.js/React + vitest (frontend), pytest (backend tests).
+
+**Spec:** `docs/superpowers/specs/2026-06-09-admin-ai-policy-design.md` (approved). One correction discovered during planning: the DJ-side connector UI is `dashboard/components/AiProvidersSection.tsx` rendered on `/account` — not a `/settings/ai` page. Section 5 of the spec applies to that component.
+
+**Working directory:** `/home/adam/github/WrzDJ-worktrees/org-llm` (branch `feat/org-llm-connector`). The main checkout at `/home/adam/github/WrzDJ` is running the live testing instance — do not run servers or migrations against its database (port 5432).
+
+---
+
+### Task 0: Worktree setup
+
+**Files:** none (environment only)
+
+- [ ] **Step 1: Copy `.env` and link `node_modules`**
+
+```bash
+cd /home/adam/github/WrzDJ-worktrees/org-llm
+cp /home/adam/github/WrzDJ/.env .env
+ln -sfn /home/adam/github/WrzDJ/dashboard/node_modules dashboard/node_modules
+```
+
+(The symlinked `node_modules` is fine for vitest/tsc; do NOT run `next dev` from this worktree — Turbopack breaks on the symlink.)
+
+- [ ] **Step 2: Verify the main venv works from the worktree**
+
+There is no venv in the worktree; use the main checkout's. All backend commands in this plan use:
+
+```bash
+export VENV=/home/adam/github/WrzDJ/server/.venv
+cd /home/adam/github/WrzDJ-worktrees/org-llm/server
+$VENV/bin/pytest tests/test_llm_gateway.py -q
+```
+
+Expected: tests collect and pass (pytest `pythonpath` config resolves `app` from the worktree's cwd).
+
+- [ ] **Step 3: Verify frontend tooling**
+
+```bash
+cd /home/adam/github/WrzDJ-worktrees/org-llm/dashboard
+npx vitest run lib/__tests__/theme-vars.test.ts --reporter=dot
+```
+
+Expected: PASS.
+
+---
+
+### Task 1: Model changes — scope column, nullable user_id, nullable audit actor, drop llm_model
+
+**Files:**
+- Modify: `server/app/models/llm_connector.py`
+- Modify: `server/app/models/system_settings.py`
+- Modify: `server/app/services/system_settings.py`
+- Modify: `server/app/schemas/system_settings.py`
+
+- [ ] **Step 1: Add scope constants + column to `LlmConnector`**
+
+In `server/app/models/llm_connector.py`, after the `STATUS_*` constants block (line ~56), add:
+
+```python
+# Connector scope — 'user' rows belong to a DJ; 'org' rows belong to the
+# organization itself (house-billed fallback). Org rows have user_id NULL,
+# enforced by ck_llm_connectors_org_scope_no_user below.
+SCOPE_USER = "user"
+SCOPE_ORG = "org"
+```
+
+Change the `user_id` column (lines 116-118) to nullable:
+
+```python
+    user_id: Mapped[int | None] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=True
+    )
+```
+
+After `connector_type` (line 119), add the scope column:
+
+```python
+    scope: Mapped[str] = mapped_column(
+        String(10), nullable=False, default=SCOPE_USER, server_default=text("'user'")
+    )
+```
+
+In `__table_args__`, add (alongside the existing cap CheckConstraint):
+
+```python
+        # Org rows must have no owner; user rows must have one.
+        CheckConstraint(
+            "(scope = 'org') = (user_id IS NULL)",
+            name="ck_llm_connectors_org_scope_no_user",
+        ),
+```
+
+- [ ] **Step 2: Make `LlmAuditEvent.actor_user_id` nullable**
+
+In the same file (line 222):
+
+```python
+    # NULL actor = system-context call (no DJ actor); see gateway dispatch.
+    actor_user_id: Mapped[int | None] = mapped_column(
+        ForeignKey("users.id"), index=True, nullable=True
+    )
+```
+
+- [ ] **Step 3: Drop `llm_model` from `SystemSettings`**
+
+In `server/app/models/system_settings.py`, delete the line:
+
+```python
+    llm_model: Mapped[str] = mapped_column(String(100), default="claude-haiku-4-5-20251001")
+```
+
+Update the comment above `llm_enabled` to document the new semantics:
+
+```python
+    # LLM / AI settings.
+    # llm_enabled gates ONLY the org-connector fallback (connector-less DJs and
+    # system-context calls). DJs with their own active connector are never
+    # blocked by this flag. See docs/superpowers/specs/2026-06-09-admin-ai-policy-design.md.
+    llm_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+```
+
+- [ ] **Step 4: Remove `llm_model` from the settings service and schemas**
+
+In `server/app/services/system_settings.py`:
+- delete `llm_model="claude-haiku-4-5-20251001",` from the lazy-create defaults (line 25)
+- delete the `llm_model: str | None = None,` parameter (line 48)
+- delete the `if llm_model is not None: settings.llm_model = llm_model` block (lines 73-74)
+
+In `server/app/schemas/system_settings.py`: remove the `llm_model: str` field (line 15) and `llm_model: str | None = None` (line 28).
+
+- [ ] **Step 5: Find remaining references and fix them**
+
+```bash
+cd /home/adam/github/WrzDJ-worktrees/org-llm/server
+grep -rn "settings.llm_model\|llm_model=" app/ --include="*.py" | grep -v track_vibe | grep -v "llm_model: str"
+```
+
+Expected hits to fix in later tasks (do NOT fix yet, just confirm the list): `app/api/admin.py` (Task 7), `app/api/events.py:1007` (Task 7). `TrackVibe.llm_model` and `schemas/recommendation.py` `llm_model` are response/telemetry fields, NOT the system setting — leave untouched.
+
+- [ ] **Step 6: Run model-touching tests — expect failures only where settings construct llm_model**
+
+```bash
+$VENV/bin/pytest tests/test_admin_api.py tests/test_llm_gateway.py -q 2>&1 | tail -5
+```
+
+Expected: failures referencing `llm_model` (admin AI settings tests) — these are fixed in Task 7. If `test_llm_gateway.py` fails for other reasons, stop and investigate.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/adam/github/WrzDJ-worktrees/org-llm
+git add server/app/models/ server/app/services/system_settings.py server/app/schemas/system_settings.py
+git commit -m "feat(llm): scope column on connectors, nullable audit actor, drop llm_model setting"
+```
+
+(Known-red tests are fixed by Task 7; commit message documents intent. If you prefer green-only commits, squash Tasks 1+7 at the end instead.)
+
+---
+
+### Task 2: Alembic migration 056
+
+**Files:**
+- Create: `server/alembic/versions/056_org_llm_connector.py`
+
+- [ ] **Step 1: Write the migration**
+
+```python
+"""Org-scoped LLM connector + llm_enabled rescope cleanup.
+
+- llm_connectors.scope ('user'|'org'), user_id nullable, CHECK org<->NULL user
+- llm_audit_event.actor_user_id nullable (system-context calls)
+- system_settings.llm_model dropped (display-only legacy)
+- Backfill: if llm_default_connector_id points at the migration-047-seeded
+  env-var connector ("Org Default (migrated from env var)"), convert that row
+  to scope='org' (it was the house key). Any other user-scoped default is
+  cleared — an admin must create a proper org connector.
+
+Revision ID: 056
+Revises: 055
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "056"
+down_revision: str | None = "055"
+branch_labels = None
+depends_on = None
+
+_MIGRATED_DISPLAY_NAME = "Org Default (migrated from env var)"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "llm_connectors",
+        sa.Column("scope", sa.String(10), nullable=False, server_default="user"),
+    )
+    op.alter_column("llm_connectors", "user_id", existing_type=sa.Integer(), nullable=True)
+    op.alter_column("llm_audit_event", "actor_user_id", existing_type=sa.Integer(), nullable=True)
+    op.drop_column("system_settings", "llm_model")
+
+    # Backfill BEFORE adding the CHECK so the converted row satisfies it.
+    conn = op.get_bind()
+    default_id = conn.execute(
+        sa.text("SELECT llm_default_connector_id FROM system_settings LIMIT 1")
+    ).scalar()
+    if default_id is not None:
+        row = conn.execute(
+            sa.text("SELECT id, display_name FROM llm_connectors WHERE id = :cid"),
+            {"cid": default_id},
+        ).first()
+        if row is not None and row[1] == _MIGRATED_DISPLAY_NAME:
+            conn.execute(
+                sa.text(
+                    "UPDATE llm_connectors SET scope = 'org', user_id = NULL WHERE id = :cid"
+                ),
+                {"cid": default_id},
+            )
+        elif row is not None:
+            conn.execute(
+                sa.text("UPDATE system_settings SET llm_default_connector_id = NULL")
+            )
+
+    op.create_check_constraint(
+        "ck_llm_connectors_org_scope_no_user",
+        "llm_connectors",
+        "(scope = 'org') = (user_id IS NULL)",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_llm_connectors_org_scope_no_user", "llm_connectors", type_="check"
+    )
+    # Org rows cannot survive a NOT NULL user_id; clear default + delete them.
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE system_settings SET llm_default_connector_id = NULL "
+            "WHERE llm_default_connector_id IN "
+            "(SELECT id FROM llm_connectors WHERE scope = 'org')"
+        )
+    )
+    conn.execute(sa.text("DELETE FROM llm_connectors WHERE scope = 'org'"))
+    op.add_column(
+        "system_settings",
+        sa.Column(
+            "llm_model",
+            sa.String(100),
+            nullable=False,
+            server_default="claude-haiku-4-5-20251001",
+        ),
+    )
+    op.alter_column("llm_audit_event", "actor_user_id", existing_type=sa.Integer(), nullable=False)
+    op.alter_column("llm_connectors", "user_id", existing_type=sa.Integer(), nullable=False)
+    op.drop_column("llm_connectors", "scope")
+```
+
+- [ ] **Step 2: Verify against a scratch Postgres (NOT the live testing DB on 5432)**
+
+```bash
+docker run --rm -d --name wrzdj-mig-test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=wrzdj -p 5433:5432 postgres:16
+sleep 3
+cd /home/adam/github/WrzDJ-worktrees/org-llm/server
+SCRATCH_URL="postgresql://postgres:test@localhost:5433/wrzdj"
+DATABASE_URL=$SCRATCH_URL $VENV/bin/alembic upgrade head
+DATABASE_URL=$SCRATCH_URL $VENV/bin/alembic check
+docker stop wrzdj-mig-test
+```
+
+Expected: `upgrade head` runs through 056 cleanly; `alembic check` reports no new upgrade operations. (Match the URL scheme — `postgresql://` vs `postgresql+psycopg://` — to whatever the main `.env` `DATABASE_URL` uses; if `alembic check` flags drift, the model and migration disagree — fix before continuing.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/adam/github/WrzDJ-worktrees/org-llm
+git add server/alembic/versions/056_org_llm_connector.py
+git commit -m "feat(llm): migration 056 — org connector scope + audit actor nullability + backfill"
+```
+
+---
+
+### Task 3: connector_storage — scope-aware helpers
+
+**Files:**
+- Modify: `server/app/services/llm/connector_storage.py`
+- Test: `server/tests/test_llm_org_connector.py` (create)
+
+- [ ] **Step 1: Write failing tests for the storage layer**
+
+Create `server/tests/test_llm_org_connector.py`:
+
+```python
+"""Org-scoped connector storage + resolution tests (org-llm-connector spec)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.models.llm_connector import SCOPE_ORG, SCOPE_USER, STATUS_ACTIVE, LlmConnector
+from app.services.llm.connector_storage import (
+    CreateConnectorPayload,
+    create_connector,
+    get_user_label,
+    list_connectors_for_user,
+    list_org_connectors,
+)
+
+
+def _payload(name: str = "Org Key") -> CreateConnectorPayload:
+    return CreateConnectorPayload(
+        connector_type="anthropic_apikey",
+        display_name=name,
+        credentials={"api_key": "sk-ant-test-0000000000000000"},
+        base_url_plain=None,
+        model_hint=None,
+    )
+
+
+def test_create_org_connector_has_null_user_and_org_scope(db):
+    from sqlalchemy import text
+
+    row = create_connector(db, user_id=None, payload=_payload(), scope=SCOPE_ORG)
+    db.commit()
+    assert row.user_id is None
+    assert row.scope == SCOPE_ORG
+    assert row.status == STATUS_ACTIVE
+    # Credentials encrypted at rest: raw column value must not contain the key.
+    raw = db.execute(
+        text("SELECT credentials FROM llm_connectors WHERE id = :i"), {"i": row.id}
+    ).scalar()
+    assert "sk-ant-test" not in (raw or "")
+
+
+def test_create_user_connector_defaults_to_user_scope(db, test_user):
+    row = create_connector(db, user_id=test_user.id, payload=_payload("Mine"))
+    db.commit()
+    assert row.scope == SCOPE_USER
+    assert row.user_id == test_user.id
+
+
+def test_list_org_connectors_excludes_user_rows(db, test_user):
+    create_connector(db, user_id=test_user.id, payload=_payload("Mine"))
+    org = create_connector(db, user_id=None, payload=_payload("House"), scope=SCOPE_ORG)
+    db.commit()
+    rows = list_org_connectors(db)
+    assert [r.id for r in rows] == [org.id]
+
+
+def test_list_connectors_for_user_excludes_org_rows(db, test_user):
+    mine = create_connector(db, user_id=test_user.id, payload=_payload("Mine"))
+    create_connector(db, user_id=None, payload=_payload("House"), scope=SCOPE_ORG)
+    db.commit()
+    rows = list_connectors_for_user(db, test_user.id)
+    assert [r.id for r in rows] == [mine.id]
+
+
+def test_get_user_label_for_org_rows(db):
+    assert get_user_label(db, None) == "Organization"
+```
+
+(Adjust the encryption assertion to match how other tests assert `EncryptedText` — see `server/tests/test_llm_api.py` for the existing pattern and copy it; the intent is "raw DB value does not contain the plaintext key". If no clean pattern exists, drop that assertion — encryption is already covered by existing EncryptedText tests.)
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd /home/adam/github/WrzDJ-worktrees/org-llm/server
+$VENV/bin/pytest tests/test_llm_org_connector.py -q
+```
+
+Expected: FAIL — `ImportError: cannot import name 'list_org_connectors'` / `create_connector() got an unexpected keyword argument 'scope'`.
+
+- [ ] **Step 3: Implement storage changes**
+
+In `server/app/services/llm/connector_storage.py`:
+
+Import the scope constants (extend the existing model import):
+
+```python
+from app.models.llm_connector import (  # noqa: existing imports retained
+    SCOPE_ORG,
+    SCOPE_USER,
+    ...
+)
+```
+
+Add `scope` filter to `list_connectors_for_user` (line 51):
+
+```python
+def list_connectors_for_user(db: Session, user_id: int) -> list[LlmConnector]:
+    return (
+        db.query(LlmConnector)
+        .filter(LlmConnector.user_id == user_id, LlmConnector.scope == SCOPE_USER)
+        .order_by(LlmConnector.created_at.desc())
+        .all()
+    )
+```
+
+Add after `list_all_connectors`:
+
+```python
+def list_org_connectors(db: Session) -> list[LlmConnector]:
+    return (
+        db.query(LlmConnector)
+        .filter(LlmConnector.scope == SCOPE_ORG)
+        .order_by(LlmConnector.created_at.desc())
+        .all()
+    )
+```
+
+Change `create_connector` (line 368):
+
+```python
+def create_connector(
+    db: Session,
+    *,
+    user_id: int | None,
+    payload: CreateConnectorPayload,
+    scope: str = SCOPE_USER,
+) -> LlmConnector:
+    """Persist a new connector. Caller is responsible for audit event + commit.
+
+    Org-scoped rows (scope='org') must pass user_id=None — the DB CHECK
+    enforces it; this assert catches programming errors early.
+    """
+    assert (scope == SCOPE_ORG) == (user_id is None), "org scope requires user_id=None"
+    row = LlmConnector(
+        user_id=user_id,
+        scope=scope,
+        connector_type=payload.connector_type,
+        display_name=payload.display_name,
+        status=STATUS_ACTIVE,
+        credentials=json.dumps(payload.credentials),
+        base_url_plain=payload.base_url_plain,
+        model_hint=payload.model_hint,
+    )
+    db.add(row)
+    db.flush()
+    db.refresh(row)
+    return row
+```
+
+Change `get_user_label` (line 666):
+
+```python
+def get_user_label(db: Session, user_id: int | None) -> str:
+    if user_id is None:
+        return "Organization"
+    user = db.get(User, user_id)
+    return user.username if user else f"user#{user_id}"
+```
+
+Change `audit_event` (line 599) to accept a nullable actor:
+
+```python
+def audit_event(
+    db: Session,
+    *,
+    actor_user_id: int | None,
+    target_connector_id: int | None,
+    event_type: str,
+) -> LlmAuditEvent:
+```
+
+(body unchanged)
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+$VENV/bin/pytest tests/test_llm_org_connector.py tests/test_llm_api.py -q
+```
+
+Expected: new tests PASS; `test_llm_api.py` still PASSES (DJ listing now filters scope, behavior identical for user rows).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/adam/github/WrzDJ-worktrees/org-llm
+git add server/app/services/llm/connector_storage.py server/tests/test_llm_org_connector.py
+git commit -m "feat(llm): scope-aware connector storage + org helpers"
+```
+
+---
+
+### Task 4: Gateway — scoped resolution, gated org fallback, NULL system actor
+
+**Files:**
+- Modify: `server/app/services/llm/gateway.py`
+- Test: `server/tests/test_llm_gateway.py` (extend)
+
+- [ ] **Step 1: Write failing gateway tests**
+
+Append to `server/tests/test_llm_gateway.py` (reuse the file's existing `_make_connector` helper and `_patch_chat` — read its current signature first and pass `scope`/`user_id` accordingly; extend `_make_connector` with `scope: str = "user"` and `user_id: int | None` if needed):
+
+```python
+class TestOrgScopedResolution:
+    @pytest.mark.asyncio
+    async def test_byo_dj_dispatch_works_with_llm_enabled_false(self, db, dj_user, gateway_request):
+        """HEADLINE REGRESSION: a DJ's own connector is never blocked by llm_enabled."""
+        _make_connector(db, user_id=dj_user.id)
+        settings = db.query(SystemSettings).first() or SystemSettings()
+        settings.llm_enabled = False
+        db.add(settings)
+        db.commit()
+
+        with _patch_chat(AsyncMock(return_value=_ok_response())):
+            resp = await Gateway.dispatch(db, dj_user, gateway_request, purpose="recommendation")
+        assert resp is not None
+
+    @pytest.mark.asyncio
+    async def test_connectorless_dj_blocked_when_llm_enabled_false(self, db, dj_user, gateway_request):
+        org = _make_connector(db, user_id=None, scope="org")
+        settings = db.query(SystemSettings).first() or SystemSettings()
+        settings.llm_enabled = False
+        settings.llm_default_connector_id = org.id
+        db.add(settings)
+        db.commit()
+
+        with pytest.raises(NoLlmConfigured):
+            await Gateway.dispatch(db, dj_user, gateway_request, purpose="recommendation")
+
+    @pytest.mark.asyncio
+    async def test_connectorless_dj_uses_org_fallback_when_enabled(self, db, dj_user, gateway_request):
+        org = _make_connector(db, user_id=None, scope="org")
+        settings = db.query(SystemSettings).first() or SystemSettings()
+        settings.llm_enabled = True
+        settings.llm_default_connector_id = org.id
+        db.add(settings)
+        db.commit()
+
+        with _patch_chat(AsyncMock(return_value=_ok_response())):
+            resp = await Gateway.dispatch(db, dj_user, gateway_request, purpose="recommendation")
+        assert resp is not None
+
+    @pytest.mark.asyncio
+    async def test_user_scoped_default_never_resolves_as_org_fallback(self, db, dj_user, gateway_request):
+        """A user-scoped connector configured as default must NOT serve fallback."""
+        other = _make_connector(db, user_id=dj_user.id)  # someone's personal key
+        settings = db.query(SystemSettings).first() or SystemSettings()
+        settings.llm_enabled = True
+        settings.llm_default_connector_id = other.id
+        db.add(settings)
+        db.commit()
+
+        system_actorless = None
+        with pytest.raises(NoLlmConfigured):
+            await Gateway.dispatch(db, system_actorless, gateway_request, purpose="recommendation")
+
+    @pytest.mark.asyncio
+    async def test_system_context_audit_actor_is_null_on_auth_failure(self, db, gateway_request):
+        from app.models.llm_connector import LlmAuditEvent
+
+        org = _make_connector(db, user_id=None, scope="org")
+        settings = db.query(SystemSettings).first() or SystemSettings()
+        settings.llm_enabled = True
+        settings.llm_default_connector_id = org.id
+        db.add(settings)
+        db.commit()
+
+        with _patch_chat(AsyncMock(side_effect=AuthInvalid("nope"))):
+            with pytest.raises(AuthInvalid):
+                await Gateway.dispatch(db, None, gateway_request, purpose="recommendation")
+
+        event = (
+            db.query(LlmAuditEvent)
+            .filter(LlmAuditEvent.target_connector_id == org.id)
+            .order_by(LlmAuditEvent.id.desc())
+            .first()
+        )
+        assert event is not None
+        assert event.actor_user_id is None
+```
+
+Adapt fixture/helper names to the file's actual ones (`_ok_response` may be a local helper or inline `ChatResponse(...)` — copy the construction used by existing passing tests in that file).
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+$VENV/bin/pytest tests/test_llm_gateway.py -q 2>&1 | tail -5
+```
+
+Expected: new tests FAIL (`_make_connector` lacks scope, BYO test fails because `llm_enabled=False`… wait — today the gateway does NOT check llm_enabled, so the BYO test may pass already; the org-gating tests must fail). At least `test_connectorless_dj_blocked_when_llm_enabled_false` and `test_user_scoped_default_never_resolves_as_org_fallback` FAIL.
+
+- [ ] **Step 3: Implement gateway changes**
+
+In `server/app/services/llm/gateway.py`:
+
+Import scope constants (extend existing model import at line 35):
+
+```python
+from app.models.llm_connector import (
+    AUDIT_AUTH_INVALID_OBSERVED,
+    SCOPE_ORG,
+    SCOPE_USER,
+    STATUS_ACTIVE,
+    STATUS_AUTH_INVALID,
+    LlmConnector,
+)
+```
+
+In `_resolve_connector` (line 423), add `LlmConnector.scope == SCOPE_USER` to BOTH per-DJ queries (the `pinned` query and the MRU `row` query), and to the feature-pin validity check:
+
+```python
+            if (
+                pinned_feature is not None
+                and pinned_feature.user_id == actor.id
+                and pinned_feature.scope == SCOPE_USER
+                and pinned_feature.status == STATUS_ACTIVE
+            ):
+```
+
+```python
+        pinned = (
+            db.query(LlmConnector)
+            .filter(
+                LlmConnector.user_id == actor.id,
+                LlmConnector.scope == SCOPE_USER,
+                LlmConnector.status == STATUS_ACTIVE,
+                LlmConnector.is_default == True,  # noqa: E712
+            )
+            .first()
+        )
+```
+
+```python
+        row = (
+            db.query(LlmConnector)
+            .filter(
+                LlmConnector.user_id == actor.id,
+                LlmConnector.scope == SCOPE_USER,
+                LlmConnector.status == STATUS_ACTIVE,
+            )
+            .order_by(nulls_last(desc(LlmConnector.last_used_at)), desc(LlmConnector.id))
+            .first()
+        )
+```
+
+Replace `_resolve_org_default` (line 476):
+
+```python
+def _resolve_org_default(db: Session) -> LlmConnector | None:
+    """Active org-scoped default, gated by the org-fallback policy toggle.
+
+    ``llm_enabled`` governs ONLY this path: DJs with their own connector are
+    resolved earlier and never reach here. Returns ``None`` when the toggle is
+    off, no default is set, or the default is not an active org-scoped row.
+    """
+    settings = db.query(SystemSettings).first()
+    if not settings or not settings.llm_enabled or not settings.llm_default_connector_id:
+        return None
+    default = db.get(LlmConnector, settings.llm_default_connector_id)
+    if default is not None and default.scope == SCOPE_ORG and default.status == STATUS_ACTIVE:
+        return default
+    return None
+```
+
+Delete `_system_actor_id` entirely (lines 485-492). In `Gateway.dispatch` (line 121) and `Gateway.stream` (line 204) replace:
+
+```python
+        actor_id = actor.id if actor else _system_actor_id(db, primary)
+```
+
+with:
+
+```python
+        # NULL actor = system-context call; audit rows record no user rather
+        # than misattributing usage to the connector's owner.
+        actor_id = actor.id if actor else None
+```
+
+Update `_attempt` and `_attempt_stream` signatures: `actor_id: int` → `actor_id: int | None`.
+
+- [ ] **Step 4: Run gateway + related suites**
+
+```bash
+$VENV/bin/pytest tests/test_llm_gateway.py tests/test_llm_gateway_stream.py tests/test_llm_default_connector.py tests/test_llm_feature_preference.py tests/test_llm_quota_cap.py -q
+```
+
+Expected: PASS. `test_llm_default_connector.py` likely seeds a USER-scoped connector as org default and expects fallback — those tests now describe forbidden behavior: update them to seed the default connector with `scope="org", user_id=None` (the legitimate equivalent), keeping their fallback assertions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/services/llm/gateway.py server/tests/test_llm_gateway.py server/tests/test_llm_default_connector.py
+git commit -m "feat(llm): scope-filtered resolution, llm_enabled gates org fallback only, NULL system actor"
+```
+
+---
+
+### Task 5: `is_llm_available` rewrite
+
+**Files:**
+- Modify: `server/app/services/recommendation/llm_hooks.py:67-113`
+- Test: `server/tests/test_llm_hooks.py` (extend/update)
+
+- [ ] **Step 1: Write failing tests**
+
+In `server/tests/test_llm_hooks.py`, add (mirror existing fixture style in the file):
+
+```python
+def test_available_for_byo_dj_even_when_llm_disabled(db, test_user):
+    from app.models.llm_connector import LlmConnector
+    from app.services.recommendation.llm_hooks import is_llm_available
+
+    db.add(
+        LlmConnector(
+            user_id=test_user.id,
+            connector_type="anthropic_apikey",
+            display_name="Mine",
+            status="active",
+            credentials="{}",
+        )
+    )
+    settings = get_system_settings(db)
+    settings.llm_enabled = False
+    db.commit()
+    assert is_llm_available(db, actor=test_user) is True
+
+
+def test_unavailable_for_connectorless_dj_when_llm_disabled(db, test_user):
+    from app.models.llm_connector import LlmConnector
+    from app.services.recommendation.llm_hooks import is_llm_available
+
+    org = LlmConnector(
+        user_id=None,
+        scope="org",
+        connector_type="anthropic_apikey",
+        display_name="House",
+        status="active",
+        credentials="{}",
+    )
+    db.add(org)
+    db.flush()
+    settings = get_system_settings(db)
+    settings.llm_enabled = False
+    settings.llm_default_connector_id = org.id
+    db.commit()
+    assert is_llm_available(db, actor=test_user) is False
+
+
+def test_available_via_org_fallback_when_enabled(db, test_user):
+    from app.models.llm_connector import LlmConnector
+    from app.services.recommendation.llm_hooks import is_llm_available
+
+    org = LlmConnector(
+        user_id=None,
+        scope="org",
+        connector_type="anthropic_apikey",
+        display_name="House",
+        status="active",
+        credentials="{}",
+    )
+    db.add(org)
+    db.flush()
+    settings = get_system_settings(db)
+    settings.llm_enabled = True
+    settings.llm_default_connector_id = org.id
+    db.commit()
+    assert is_llm_available(db, actor=test_user) is True
+```
+
+(Import `get_system_settings` from `app.services.system_settings` at the top if not already imported.)
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+$VENV/bin/pytest tests/test_llm_hooks.py -q
+```
+
+Expected: `test_available_for_byo_dj_even_when_llm_disabled` FAILS (current code returns False on the global flag).
+
+- [ ] **Step 3: Replace `is_llm_available` body**
+
+```python
+def is_llm_available(db=None, actor=None) -> bool:
+    """Check if LLM features are available for this actor.
+
+    Mirrors :func:`app.services.llm.gateway._resolve_connector` semantics:
+
+    - A DJ with an active connector of their own is ALWAYS available —
+      ``llm_enabled`` does not apply to BYO credentials.
+    - Otherwise availability equals the gated org fallback: an active
+      org-scoped default connector AND ``llm_enabled`` true.
+
+    Connector-backed only. Without ``db`` no connector can be resolved, so it
+    returns ``False`` — the legacy Anthropic env-var fallback was removed in #343.
+    """
+    if db is None:
+        return False
+
+    from app.models.llm_connector import SCOPE_USER, STATUS_ACTIVE, LlmConnector
+    from app.services.llm.gateway import _resolve_org_default
+
+    if actor is not None:
+        actor_active = (
+            db.query(LlmConnector.id)
+            .filter(
+                LlmConnector.user_id == actor.id,
+                LlmConnector.scope == SCOPE_USER,
+                LlmConnector.status == STATUS_ACTIVE,
+            )
+            .first()
+        )
+        if actor_active is not None:
+            return True
+
+    return _resolve_org_default(db) is not None
+```
+
+Remove the now-unused `SystemSettings` import inside the old body.
+
+- [ ] **Step 4: Run to verify pass + commit**
+
+```bash
+$VENV/bin/pytest tests/test_llm_hooks.py tests/test_llm_recommendation_via_gateway.py -q
+git add server/app/services/recommendation/llm_hooks.py server/tests/test_llm_hooks.py
+git commit -m "feat(llm): is_llm_available — BYO DJs never blocked by llm_enabled"
+```
+
+---
+
+### Task 6: Policy validation + audit schema nullability
+
+**Files:**
+- Modify: `server/app/api/admin_llm.py` (patch_policy, _audit_query consumers, _connector_to_admin_out, list_connectors_admin, get_usage)
+- Modify: `server/app/schemas/llm.py` (ConnectorOut.user_id, AuditEventRow.actor_user_id, UsageRow.dj_username semantics)
+- Test: `server/tests/test_llm_org_connector.py` (extend), `server/tests/test_llm_admin_audit.py` (update if needed)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `server/tests/test_llm_org_connector.py`:
+
+```python
+def _mk_user_connector(db, user_id):
+    row = LlmConnector(
+        user_id=user_id,
+        connector_type="anthropic_apikey",
+        display_name="Personal",
+        status="active",
+        credentials="{}",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _mk_org_connector(db, name="House"):
+    row = LlmConnector(
+        user_id=None,
+        scope=SCOPE_ORG,
+        connector_type="anthropic_apikey",
+        display_name=name,
+        status="active",
+        credentials="{}",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def test_policy_rejects_user_scoped_default(client, admin_headers, db, test_user):
+    personal = _mk_user_connector(db, test_user.id)
+    resp = client.patch(
+        "/api/admin/llm/policy",
+        json={"llm_default_connector_id": personal.id},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 400
+    assert "org-scoped" in resp.json()["detail"]
+
+
+def test_policy_accepts_org_scoped_default(client, admin_headers, db):
+    org = _mk_org_connector(db)
+    resp = client.patch(
+        "/api/admin/llm/policy",
+        json={"llm_default_connector_id": org.id},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["llm_default_connector_id"] == org.id
+
+
+def test_admin_connector_list_labels_org_rows(client, admin_headers, db):
+    _mk_org_connector(db, name="House Key")
+    resp = client.get("/api/admin/llm/connectors", headers=admin_headers)
+    assert resp.status_code == 200
+    org_rows = [r for r in resp.json() if r["display_name"] == "House Key"]
+    assert org_rows and org_rows[0]["dj_username"] == "Organization"
+    assert org_rows[0]["user_id"] is None
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+$VENV/bin/pytest tests/test_llm_org_connector.py -q
+```
+
+Expected: FAIL — policy accepts user-scoped id (200 vs 400) and admin list crashes/mislabels NULL user rows.
+
+- [ ] **Step 3: Implement**
+
+`server/app/schemas/llm.py`:
+- `ConnectorOut.user_id: int` → `user_id: int | None` (org rows have no owner).
+- Add `scope` to `ConnectorOut`: `scope: Literal["user", "org"] = "user"` (import `Literal` if needed).
+- `AuditEventRow.actor_user_id: int` → `actor_user_id: int | None`.
+
+`server/app/api/admin_llm.py`:
+
+In `patch_policy` (after the `status != "active"` check, line ~164):
+
+```python
+        if target.scope != "org":
+            raise HTTPException(
+                status_code=400,
+                detail="default connector must be org-scoped (create one under Organization connector)",
+            )
+```
+
+In `list_connectors_admin` (line 195): `user_ids = {r.user_id for r in rows if r.user_id is not None}` and the comprehension:
+
+```python
+    return [
+        _connector_to_admin_out(
+            r,
+            "Organization" if r.user_id is None else (usernames.get(r.user_id) or f"user#{r.user_id}"),
+            usage_by_connector.get(r.id, 0),
+        )
+        for r in rows
+    ]
+```
+
+In `get_usage` (line 298): `user_ids = {c.user_id for c in connectors if c.user_id is not None}` and the row construction:
+
+```python
+                    dj_username=(
+                        "Organization"
+                        if c.user_id is None
+                        else usernames.get(c.user_id, f"user#{c.user_id}")
+                    ),
+```
+
+In `list_audit_events` (line 370): `actor_username=actor_username or ("system" if event.actor_user_id is None else f"user#{event.actor_user_id}")` — same fallback in `export_audit_events_csv` (line 429).
+
+- [ ] **Step 4: Run to verify pass**
+
+```bash
+$VENV/bin/pytest tests/test_llm_org_connector.py tests/test_llm_admin_audit.py tests/test_llm_api.py -q
+```
+
+Expected: PASS (fix any audit-test fixtures that asserted non-null actor formats).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/api/admin_llm.py server/app/schemas/llm.py server/tests/
+git commit -m "feat(llm): policy requires org-scoped default; org rows labeled Organization"
+```
+
+---
+
+### Task 7: Org connector CRUD endpoints + legacy admin surface removal
+
+**Files:**
+- Modify: `server/app/api/admin_llm.py` (new org endpoints)
+- Modify: `server/app/api/admin.py:340-432` (slim AI settings, delete models endpoint)
+- Modify: `server/app/schemas/ai_settings.py`
+- Modify: `server/app/api/events.py:1007`
+- Modify: `server/app/core/config.py:138-139`
+- Test: `server/tests/test_llm_org_connector.py` (extend), existing admin tests (update)
+
+- [ ] **Step 1: Write failing tests for org CRUD + legacy removal**
+
+Append to `server/tests/test_llm_org_connector.py`:
+
+```python
+def test_org_crud_requires_admin(client, auth_headers):
+    resp = client.get("/api/admin/llm/org-connectors", headers=auth_headers)
+    assert resp.status_code == 403
+
+
+def test_org_connector_create_list_delete(client, admin_headers):
+    create = client.post(
+        "/api/admin/llm/org-connectors",
+        json={
+            "connector_type": "anthropic_apikey",
+            "display_name": "House Anthropic",
+            "api_key": "sk-ant-api03-" + "a" * 40,
+        },
+        headers=admin_headers,
+    )
+    assert create.status_code == 201, create.text
+    body = create.json()
+    assert body["user_id"] is None
+    assert body["scope"] == "org"
+    cid = body["id"]
+
+    listed = client.get("/api/admin/llm/org-connectors", headers=admin_headers)
+    assert [r["id"] for r in listed.json()] == [cid]
+
+    deleted = client.delete(f"/api/admin/llm/org-connectors/{cid}", headers=admin_headers)
+    assert deleted.status_code == 204
+    assert client.get("/api/admin/llm/org-connectors", headers=admin_headers).json() == []
+
+
+def test_ai_settings_no_longer_exposes_api_key_or_model(client, admin_headers):
+    resp = client.get("/api/admin/ai/settings", headers=admin_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "api_key_configured" not in body
+    assert "api_key_masked" not in body
+    assert "llm_model" not in body
+    assert set(body) == {"llm_enabled", "llm_rate_limit_per_minute"}
+
+
+def test_ai_models_endpoint_removed(client, admin_headers):
+    resp = client.get("/api/admin/ai/models", headers=admin_headers)
+    assert resp.status_code == 404
+```
+
+(Match the `ConnectorCreate` body shape to `server/app/schemas/llm.py:91` — if `api_key` validation rejects the dummy key format, copy a key fixture from `tests/test_llm_api.py`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+$VENV/bin/pytest tests/test_llm_org_connector.py -q
+```
+
+Expected: FAIL — 404 on org-connector routes; AI settings still returns legacy fields.
+
+- [ ] **Step 3: Add org endpoints to `admin_llm.py`**
+
+Imports to extend: `from app.schemas.llm import ConnectorCreate, ConnectorCredentialsRotate, ConnectorOut, ConnectorTestResult` (plus existing), `from app.services.llm.connector_storage import build_create_payload, create_connector, delete_connector, list_org_connectors, rotate_credentials` and `from app.models.llm_connector import AUDIT_CREATED, AUDIT_CREDENTIALS_ROTATED, AUDIT_DELETED`. (Check `rotate_credentials`' exact keyword list at `connector_storage.py:385` and pass only the fields it accepts.)
+
+```python
+# ---------- Organization connector (house-billed fallback) ----------
+
+
+@router.get("/org-connectors", response_model=list[ConnectorOut])
+@limiter.limit("60/minute")
+def list_org_connectors_admin(
+    request: FastAPIRequest,
+    _admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> list[ConnectorOut]:
+    return [ConnectorOut.model_validate(r) for r in list_org_connectors(db)]
+
+
+@router.post("/org-connectors", response_model=ConnectorOut, status_code=201)
+@limiter.limit("10/minute")
+def create_org_connector(
+    request: FastAPIRequest,
+    payload: ConnectorCreate,
+    admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> ConnectorOut:
+    """Create the organization's house connector (admin-only).
+
+    Reuses the DJ-connector validation pipeline; the row is org-scoped with no
+    owner. Credentials are encrypted at rest via EncryptedText.
+    """
+    try:
+        create_payload = build_create_payload(payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    row = create_connector(db, user_id=None, payload=create_payload, scope="org")
+    audit_event(
+        db, actor_user_id=admin.id, target_connector_id=row.id, event_type=AUDIT_CREATED
+    )
+    db.commit()
+    db.refresh(row)
+    return ConnectorOut.model_validate(row)
+
+
+@router.post("/org-connectors/{connector_id}/test", response_model=ConnectorTestResult)
+@limiter.limit("10/minute")
+async def test_org_connector(
+    request: FastAPIRequest,
+    connector_id: int,
+    admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> ConnectorTestResult:
+    from app.services.llm.health_check import run_health_check
+
+    row = get_connector(db, connector_id)
+    if row is None or row.scope != "org":
+        raise HTTPException(status_code=404, detail="Connector not found")
+    outcome = await run_health_check(db, row, actor_user_id=admin.id)
+    db.commit()
+    if outcome.ok:
+        return ConnectorTestResult(ok=True)
+    message = {
+        "auth_invalid": "Authentication failed against the provider",
+        "rate_limited": "Provider rate limited the request",
+        "quota_exceeded": "Provider quota or billing failure",
+        "provider_unavailable": "Provider unreachable or timed out",
+        "error": "Unknown error",
+    }.get(outcome.status, "Unknown error")
+    return ConnectorTestResult(ok=False, error_code=outcome.error_code or outcome.status, message=message)
+
+
+@router.put("/org-connectors/{connector_id}/credentials", response_model=ConnectorOut)
+@limiter.limit("10/minute")
+def rotate_org_connector_credentials(
+    request: FastAPIRequest,
+    connector_id: int,
+    payload: ConnectorCredentialsRotate,
+    admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> ConnectorOut:
+    """Rotate the house connector's credential blob (admin-only)."""
+    row = get_connector(db, connector_id)
+    if row is None or row.scope != "org":
+        raise HTTPException(status_code=404, detail="Connector not found")
+    try:
+        rotate_credentials(
+            db,
+            connector=row,
+            api_key=payload.api_key,
+            base_url=payload.base_url,
+            bearer=payload.bearer,
+            aws_access_key_id=payload.aws_access_key_id,
+            aws_secret_access_key=payload.aws_secret_access_key,
+            aws_region=payload.aws_region,
+            aws_model_id=payload.aws_model_id,
+            azure_resource_name=payload.azure_resource_name,
+            azure_deployment_name=payload.azure_deployment_name,
+            azure_api_version=payload.azure_api_version,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    audit_event(
+        db,
+        actor_user_id=admin.id,
+        target_connector_id=row.id,
+        event_type=AUDIT_CREDENTIALS_ROTATED,
+    )
+    db.commit()
+    db.refresh(row)
+    return ConnectorOut.model_validate(row)
+
+
+@router.delete("/org-connectors/{connector_id}", status_code=204)
+@limiter.limit("10/minute")
+def delete_org_connector(
+    request: FastAPIRequest,
+    connector_id: int,
+    admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> None:
+    row = get_connector(db, connector_id)
+    if row is None or row.scope != "org":
+        raise HTTPException(status_code=404, detail="Connector not found")
+    audit_event(
+        db, actor_user_id=admin.id, target_connector_id=row.id, event_type=AUDIT_DELETED
+    )
+    settings = get_system_settings(db)
+    if settings.llm_default_connector_id == row.id:
+        settings.llm_default_connector_id = None
+    delete_connector(db, row)
+    db.commit()
+```
+
+(`build_create_payload`'s exact signature is at `connector_storage.py:136` — adapt the call if it takes the schema plus flags; mirror how `create_connector_endpoint` in `api/llm.py:219` calls it, including the connector-type policy check `_check_connector_type_allowed` if appropriate for org rows — org connectors are admin-created, so skip the DJ-facing type-policy check.)
+
+- [ ] **Step 4: Slim the legacy admin AI surface**
+
+`server/app/schemas/ai_settings.py` — replace the whole file body with:
+
+```python
+"""Schemas for AI/LLM admin settings."""
+
+from pydantic import BaseModel, Field
+
+
+class AIModelInfo(BaseModel):
+    id: str
+    name: str
+
+
+class AIModelsResponse(BaseModel):
+    models: list[AIModelInfo]
+
+
+class AISettingsOut(BaseModel):
+    llm_enabled: bool
+    llm_rate_limit_per_minute: int
+
+
+class AISettingsUpdate(BaseModel):
+    llm_enabled: bool | None = None
+    llm_rate_limit_per_minute: int | None = Field(None, ge=1, le=30)
+```
+
+(`AIModelInfo`/`AIModelsResponse` stay — `GET /api/llm/openrouter/models` uses them.)
+
+`server/app/api/admin.py`:
+- Delete `_mask_api_key`, `_list_anthropic_models`, the `FALLBACK_MODELS` constant (lines ~56-59), and the `GET /ai/models` endpoint.
+- Remove `AIModelInfo`/`AIModelsResponse` imports if now unused in this file.
+- Rewrite the two settings endpoints:
+
+```python
+@router.get("/ai/settings", response_model=AISettingsOut)
+@limiter.limit("120/minute")
+def admin_get_ai_settings(
+    request: FastAPIRequest,
+    db: Session = Depends(get_db),
+    _admin: User = Depends(get_current_admin),
+) -> AISettingsOut:
+    """Get AI/LLM configuration.
+
+    ``llm_enabled`` gates only the org-connector fallback — DJs with their own
+    connector are never blocked by it. Credential status lives on the
+    connector surfaces (/api/admin/llm/*), not here.
+    """
+    settings = get_system_settings(db)
+    return AISettingsOut(
+        llm_enabled=settings.llm_enabled,
+        llm_rate_limit_per_minute=settings.llm_rate_limit_per_minute,
+    )
+
+
+@router.put("/ai/settings", response_model=AISettingsOut)
+@limiter.limit("30/minute")
+def admin_update_ai_settings(
+    update_data: AISettingsUpdate,
+    request: FastAPIRequest,
+    db: Session = Depends(get_db),
+    _admin: User = Depends(get_current_admin),
+) -> AISettingsOut:
+    """Update AI/LLM configuration."""
+    settings = update_system_settings(
+        db,
+        llm_enabled=update_data.llm_enabled,
+        llm_rate_limit_per_minute=update_data.llm_rate_limit_per_minute,
+    )
+    return AISettingsOut(
+        llm_enabled=settings.llm_enabled,
+        llm_rate_limit_per_minute=settings.llm_rate_limit_per_minute,
+    )
+```
+
+`server/app/api/events.py:1007`:
+
+```python
+        llm_model=result.llm_model or "",
+```
+
+(then remove the `get_settings` import in events.py ONLY if `grep -n "get_settings" server/app/api/events.py` shows no other use).
+
+`server/app/core/config.py`:
+- Delete the `anthropic_api_key: str = ""` field (line 138).
+- Replace the `anthropic_model` line's context with:
+
+```python
+    # Retained ONLY for migration 047_admin_ai_oauth (model_hint on the seeded
+    # connector). No runtime consumer — do not reference in app code.
+    anthropic_model: str = "claude-haiku-4-5-20251001"
+```
+
+- [ ] **Step 5: Sweep for stragglers**
+
+```bash
+cd /home/adam/github/WrzDJ-worktrees/org-llm/server
+grep -rn "anthropic_api_key\|api_key_configured\|api_key_masked\|_list_anthropic_models\|FALLBACK_MODELS" app/ tests/ --include="*.py" | grep -v alembic
+grep -rn "llm_model" app/api/admin.py tests/ --include="*.py" | grep -v track_vibe | grep -v recommendation
+```
+
+Fix every hit (test files asserting the old AI settings shape get updated to the new two-field shape).
+
+- [ ] **Step 6: Run the backend suite**
+
+```bash
+$VENV/bin/pytest --tb=short -q 2>&1 | tail -10
+```
+
+Expected: PASS, coverage ≥ 85%.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/
+git commit -m "feat(llm): org connector CRUD; remove legacy Anthropic env-var admin surface"
+```
+
+---
+
+### Task 8: Per-DJ effective-source endpoint + DJ-visible fallback flag
+
+**Files:**
+- Modify: `server/app/api/admin_llm.py` (dj-status endpoint)
+- Modify: `server/app/api/llm.py` (`get_dj_policy`)
+- Modify: `server/app/schemas/llm.py` (new schemas + DjPolicyOut field)
+- Test: `server/tests/test_llm_org_connector.py` (extend)
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+def test_dj_status_reports_effective_source(client, admin_headers, db, test_user):
+    org = _mk_org_connector(db)
+    settings = get_system_settings(db)
+    settings.llm_enabled = True
+    settings.llm_default_connector_id = org.id
+    db.commit()
+
+    resp = client.get("/api/admin/llm/dj-status", headers=admin_headers)
+    assert resp.status_code == 200
+    by_name = {r["username"]: r["effective_source"] for r in resp.json()["rows"]}
+    assert by_name[test_user.username] == "org_fallback"
+
+    _mk_user_connector(db, test_user.id)
+    resp = client.get("/api/admin/llm/dj-status", headers=admin_headers)
+    by_name = {r["username"]: r["effective_source"] for r in resp.json()["rows"]}
+    assert by_name[test_user.username] == "own"
+
+
+def test_dj_policy_exposes_org_fallback_available(client, auth_headers, db):
+    resp = client.get("/api/llm/policy", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["org_fallback_available"] is False
+
+    org = _mk_org_connector(db)
+    settings = get_system_settings(db)
+    settings.llm_enabled = True
+    settings.llm_default_connector_id = org.id
+    db.commit()
+    resp = client.get("/api/llm/policy", headers=auth_headers)
+    assert resp.json()["org_fallback_available"] is True
+```
+
+(Add `from app.services.system_settings import get_system_settings` to the test file imports. The DJ policy route path is `GET /api/llm/policy` — confirm the actual mounted path from `server/app/api/llm.py:169-178` and `main.py` router prefix; adjust the test URL if it differs.)
+
+- [ ] **Step 2: Run to verify failure, then implement**
+
+Schemas (`server/app/schemas/llm.py`):
+
+```python
+class DjLlmStatusRow(BaseModel):
+    user_id: int
+    username: str
+    effective_source: Literal["own", "org_fallback", "none"]
+
+
+class DjLlmStatusOut(BaseModel):
+    rows: list[DjLlmStatusRow]
+```
+
+Add to `DjPolicyOut`:
+
+```python
+    # True when an active org-scoped default exists AND llm_enabled is on —
+    # i.e. a connector-less DJ will fall back to the house connector.
+    org_fallback_available: bool = False
+```
+
+Endpoint in `admin_llm.py`:
+
+```python
+@router.get("/dj-status", response_model=DjLlmStatusOut)
+@limiter.limit("60/minute")
+def dj_llm_status(
+    request: FastAPIRequest,
+    _admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> DjLlmStatusOut:
+    """Effective LLM credential source per DJ — backend-computed so the admin
+    UI never duplicates gateway resolution rules."""
+    from app.services.llm.gateway import _resolve_org_default
+
+    fallback_on = _resolve_org_default(db) is not None
+    users = (
+        db.query(User)
+        .filter(User.role.in_(["dj", "admin"]))
+        .order_by(User.username.asc())
+        .all()
+    )
+    own_ids = {
+        uid
+        for (uid,) in db.query(LlmConnector.user_id)
+        .filter(LlmConnector.scope == "user", LlmConnector.status == "active")
+        .distinct()
+        .all()
+    }
+    rows = [
+        DjLlmStatusRow(
+            user_id=u.id,
+            username=u.username,
+            effective_source=(
+                "own" if u.id in own_ids else ("org_fallback" if fallback_on else "none")
+            ),
+        )
+        for u in users
+    ]
+    return DjLlmStatusOut(rows=rows)
+```
+
+In `api/llm.py` `get_dj_policy`, compute and include the flag:
+
+```python
+    from app.services.llm.gateway import _resolve_org_default
+
+    ...
+    return DjPolicyOut(
+        ...,
+        org_fallback_available=_resolve_org_default(db) is not None,
+    )
+```
+
+- [ ] **Step 3: Run, then commit**
+
+```bash
+$VENV/bin/pytest tests/test_llm_org_connector.py tests/test_llm_api.py -q
+git add server/
+git commit -m "feat(llm): per-DJ effective-source endpoint + org_fallback_available on DJ policy"
+```
+
+---
+
+### Task 9: OpenAPI + generated types regeneration
+
+**Files:**
+- Regenerate: `server/openapi.json`, `dashboard/lib/api-types.generated.ts`
+
+- [ ] **Step 1: Regenerate**
+
+```bash
+cd /home/adam/github/WrzDJ-worktrees/org-llm/dashboard
+npm run types:export && npm run types:generate
+```
+
+(If `types:export` invokes `.venv/bin/python` relative to `../server`, and the worktree has no venv, run the export with the main venv: `cd ../server && $VENV/bin/python scripts/export_openapi.py`, then `cd ../dashboard && npm run types:generate`.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add server/openapi.json dashboard/lib/api-types.generated.ts
+git commit -m "chore(types): regenerate OpenAPI schema + frontend types for org connector API"
+```
+
+---
+
+### Task 10: Frontend API client + hand-written types
+
+**Files:**
+- Modify: `dashboard/lib/api.ts` (~lines 1381-1400, 1560)
+- Modify: `dashboard/lib/api-types.ts` (hand-written types, if AISettings/LlmConnector/DjPolicy live here — grep first)
+
+- [ ] **Step 1: Locate the hand-written types**
+
+```bash
+cd /home/adam/github/WrzDJ-worktrees/org-llm/dashboard
+grep -rn "api_key_configured\|AISettings\b\|interface LlmConnector\|DjPolicy" lib/*.ts | grep -v generated | grep -v test
+```
+
+- [ ] **Step 2: Apply type changes**
+
+- `AISettings`: remove `api_key_configured`, `api_key_masked`, `llm_model`; keep `llm_enabled`, `llm_rate_limit_per_minute`. Same for `AISettingsUpdate`.
+- `LlmConnector` (or `ConnectorOut`-equivalent): `user_id: number | null`, add `scope: 'user' | 'org'`.
+- `DjPolicy` (DJ policy type): add `org_fallback_available: boolean`.
+- New types:
+
+```typescript
+export interface DjLlmStatusRow {
+  user_id: number;
+  username: string;
+  effective_source: 'own' | 'org_fallback' | 'none';
+}
+
+export interface DjLlmStatusResponse {
+  rows: DjLlmStatusRow[];
+}
+```
+
+- [ ] **Step 3: API client methods**
+
+In `dashboard/lib/api.ts`: delete `getAIModels()` (line 1381). Add next to the admin LLM methods (~line 1560):
+
+```typescript
+  async listOrgConnectors(): Promise<LlmConnector[]> {
+    return this.fetch('/api/admin/llm/org-connectors');
+  }
+
+  async createOrgConnector(data: LlmConnectorCreate): Promise<LlmConnector> {
+    return this.fetch('/api/admin/llm/org-connectors', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async testOrgConnector(id: number): Promise<ConnectorTestResult> {
+    return this.fetch(`/api/admin/llm/org-connectors/${id}/test`, { method: 'POST' });
+  }
+
+  async deleteOrgConnector(id: number): Promise<void> {
+    await this.fetch(`/api/admin/llm/org-connectors/${id}`, { method: 'DELETE' });
+  }
+
+  async getDjLlmStatus(): Promise<DjLlmStatusResponse> {
+    return this.fetch('/api/admin/llm/dj-status');
+  }
+```
+
+(Match the surrounding methods' exact `this.fetch` idiom — some return `this.fetch<T>(...)`; copy the file's convention. `LlmConnectorCreate`/`ConnectorTestResult` type names: reuse whatever the existing `createLlmConnector`/`testLlmConnector` methods use.)
+
+- [ ] **Step 4: Type check + commit**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: errors ONLY in the two pages still referencing removed fields (`admin/ai/page.tsx`, possibly `AiProvidersSection.tsx`) — those are the next tasks. If errors appear elsewhere, fix them now.
+
+```bash
+git add dashboard/lib/
+git commit -m "feat(dashboard): org connector API client; drop legacy AI key/model types"
+```
+
+---
+
+### Task 11: Admin AI page rework
+
+**Files:**
+- Modify: `dashboard/app/admin/ai/page.tsx`
+- Test: `dashboard/app/admin/ai/__tests__/page.test.tsx`
+
+- [ ] **Step 1: Update the page test first**
+
+In `dashboard/app/admin/ai/__tests__/page.test.tsx`:
+- Update the `api` mock: remove `getAIModels`; `getAISettings` resolves `{ llm_enabled: true, llm_rate_limit_per_minute: 3 }`; add `listOrgConnectors: vi.fn().mockResolvedValue([])`, `createOrgConnector`, `testOrgConnector`, `deleteOrgConnector`, `getDjLlmStatus: vi.fn().mockResolvedValue({ rows: [] })`.
+- Delete assertions on "API Key Status" / "Configured" / model select.
+- Add:
+
+```tsx
+it('does not render the legacy API Key Status panel', async () => {
+  render(<AdminAiPage />);
+  await waitFor(() => expect(screen.queryByText('API Key Status')).not.toBeInTheDocument());
+});
+
+it('renders the Organization connector section', async () => {
+  render(<AdminAiPage />);
+  await waitFor(() => expect(screen.getByText('Organization connector')).toBeInTheDocument());
+});
+
+it('renders effective-source badges from dj-status', async () => {
+  vi.mocked(api.getDjLlmStatus).mockResolvedValue({
+    rows: [{ user_id: 1, username: 'djtest', effective_source: 'org_fallback' }],
+  });
+  render(<AdminAiPage />);
+  await waitFor(() => expect(screen.getByText('Org fallback')).toBeInTheDocument());
+});
+```
+
+Run: `npx vitest run app/admin/ai --reporter=dot` → expected FAIL.
+
+- [ ] **Step 2: Rework the page**
+
+In `dashboard/app/admin/ai/page.tsx`:
+
+1. **Delete** the API Key Status card (lines ~478-506, the `HelpSpot spotId="admin-ai-key"` block) and any model-select UI + `getAIModels()` fetch + related state.
+2. **Recopy the enable toggle** (the `admin-ai-enable` HelpSpot): label text becomes `Allow DJs without their own connector to use the organization connector (house-billed)` and the HelpSpot description: `When off, only DJs who connected their own provider can use AI features. DJs' own connectors are never blocked by this switch.`
+3. **Add an "Organization connector" card** above the policy section:
+
+```tsx
+<div className="card">
+  <h2 style={{ marginBottom: '0.5rem' }}>Organization connector</h2>
+  <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '1rem' }}>
+    The house credential. DJs without their own connector fall back to it when the
+    toggle below allows — usage is billed to the organization.
+  </p>
+  {orgConnectors.length === 0 ? (
+    <OrgConnectorForm onCreated={reloadOrgConnectors} />
+  ) : (
+    orgConnectors.map((c) => (
+      <div key={c.id} style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexWrap: 'wrap' }}>
+        <strong>{c.display_name}</strong>
+        <span style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
+          {TYPE_LABELS[c.connector_type] ?? c.connector_type}
+          {c.model_hint ? ` · ${c.model_hint}` : ''}
+        </span>
+        <span
+          style={{
+            padding: '0.25rem 0.75rem', borderRadius: '9999px', fontSize: '0.75rem', fontWeight: 600,
+            background: c.status === 'active' ? 'var(--color-success-subtle)' : 'var(--color-danger-subtle)',
+            color: c.status === 'active' ? 'var(--color-success)' : 'var(--color-danger)',
+          }}
+        >
+          {c.status}
+        </span>
+        <button className="btn btn-sm" onClick={() => handleTestOrg(c.id)}>Test</button>
+        <button className="btn btn-sm btn-danger" onClick={() => handleDeleteOrg(c.id)}>Delete</button>
+      </div>
+    ))
+  )}
+</div>
+```
+
+For `OrgConnectorForm`, reuse the page's existing DJ-connector creation form pattern if one exists on this page; otherwise build a minimal form (type select from `TYPE_LABELS`, display name, api key, model hint) that calls `api.createOrgConnector(...)`. Keep it in the same file unless it pushes the file past ~800 lines — then extract `dashboard/app/admin/ai/OrgConnectorSection.tsx`.
+
+4. **Org-default dropdown** (lines ~612-640): change the helper copy to `Connector-less DJs and background jobs use this connector when fallback is allowed.`, and source options from org connectors only:
+
+```tsx
+{orgConnectors
+  .filter((c) => c.status === 'active')
+  .map((c) => (
+    <option key={c.id} value={c.id}>
+      Organization — {c.display_name} ({TYPE_LABELS[c.connector_type] ?? c.connector_type})
+    </option>
+  ))}
+```
+
+5. **Effective-source badges**: in the per-DJ connectors card, add a small "DJ access" list fed by `api.getDjLlmStatus()`:
+
+```tsx
+const SOURCE_LABELS: Record<string, { text: string; color: string }> = {
+  own: { text: 'Own connector', color: 'var(--color-success)' },
+  org_fallback: { text: 'Org fallback', color: 'var(--color-warning)' },
+  none: { text: 'None — AI unavailable', color: 'var(--color-danger)' },
+};
+```
+
+```tsx
+<div style={{ display: 'flex', flexDirection: 'column', gap: '0.375rem', marginTop: '1rem' }}>
+  {djStatus.map((r) => (
+    <div key={r.user_id} style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+      <span style={{ minWidth: 140 }}>{r.username}</span>
+      <span style={{ color: SOURCE_LABELS[r.effective_source].color, fontSize: '0.8125rem', fontWeight: 600 }}>
+        {SOURCE_LABELS[r.effective_source].text}
+      </span>
+    </div>
+  ))}
+</div>
+```
+
+6. **Usage rollup**: rows where `dj_username === 'Organization'` already render correctly from the backend label — no change needed beyond confirming.
+
+- [ ] **Step 3: Run tests + type check**
+
+```bash
+npx vitest run app/admin/ai --reporter=dot && npx tsc --noEmit
+```
+
+Expected: PASS / clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dashboard/app/admin/ai/
+git commit -m "feat(admin): org connector section + effective-source badges; drop API Key Status panel"
+```
+
+---
+
+### Task 12: DJ-side fallback banner (AiProvidersSection)
+
+**Files:**
+- Modify: `dashboard/components/AiProvidersSection.tsx`
+- Test: existing tests for the component (grep `AiProvidersSection` under `dashboard/components/__tests__/` or `dashboard/app/(dj)/account/__tests__/`); extend where they live
+
+- [ ] **Step 1: Write the failing test**
+
+In the component's existing test file (or `dashboard/components/__tests__/AiProvidersSection.test.tsx` if none), with the existing `api` mock extended so the policy fetch resolves `org_fallback_available`:
+
+```tsx
+it('shows the house-billed banner for a connector-less DJ when fallback is on', async () => {
+  vi.mocked(api.listLlmConnectors).mockResolvedValue([]);
+  mockPolicy({ org_fallback_available: true });
+  render(<AiProvidersSection />);
+  await waitFor(() =>
+    expect(screen.getByText(/using the organization's connector/i)).toBeInTheDocument(),
+  );
+});
+
+it('shows the connect-a-provider banner when no fallback exists', async () => {
+  vi.mocked(api.listLlmConnectors).mockResolvedValue([]);
+  mockPolicy({ org_fallback_available: false });
+  render(<AiProvidersSection />);
+  await waitFor(() =>
+    expect(screen.getByText(/AI features unavailable — connect a provider/i)).toBeInTheDocument(),
+  );
+});
+```
+
+(`mockPolicy` = however the existing tests stub the policy fetch that `fetchPolicySoft()` performs at `AiProvidersSection.tsx:126` — follow the established mock.)
+
+- [ ] **Step 2: Implement the banner**
+
+In `AiProvidersSection.tsx`, replace the bare empty-state (`line ~350: "No connectors yet."`) with:
+
+```tsx
+{connectors.length === 0 && !loading && (
+  policy?.org_fallback_available ? (
+    <div style={{
+      background: 'var(--color-warning-subtle)', color: 'var(--color-warning)',
+      padding: '0.75rem 1rem', borderRadius: '0.5rem', fontSize: '0.875rem',
+    }}>
+      You're using the organization's connector — usage is billed to the organization.
+      Connect your own provider below to use your own account.
+    </div>
+  ) : (
+    <div style={{
+      background: 'var(--color-danger-subtle)', color: 'var(--color-danger)',
+      padding: '0.75rem 1rem', borderRadius: '0.5rem', fontSize: '0.875rem',
+    }}>
+      AI features unavailable — connect a provider below to enable them.
+    </div>
+  )
+)}
+```
+
+(The `policy` state already exists from `fetchPolicySoft()`; extend its type with `org_fallback_available`.)
+
+- [ ] **Step 3: Run tests + type check + commit**
+
+```bash
+npx vitest run --reporter=dot $(grep -rl "AiProvidersSection" dashboard/components/__tests__ dashboard/app 2>/dev/null | grep test | tr '\n' ' ')
+npx tsc --noEmit
+git add dashboard/components/ dashboard/app
+git commit -m "feat(dashboard): DJ banner — house-billed fallback vs connect-a-provider"
+```
+
+---
+
+### Task 13: Full CI + push + PR
+
+- [ ] **Step 1: Backend CI**
+
+```bash
+cd /home/adam/github/WrzDJ-worktrees/org-llm/server
+$VENV/bin/ruff check . && $VENV/bin/ruff format --check . && $VENV/bin/bandit -r app -c pyproject.toml -q && $VENV/bin/pytest --tb=short -q 2>&1 | tail -5
+```
+
+Expected: all clean, coverage ≥ 85%. (Run `$VENV/bin/ruff format .` first if format check fails.)
+
+- [ ] **Step 2: Migration check once more (scratch Postgres, as in Task 2 Step 2)**
+
+- [ ] **Step 3: Frontend CI**
+
+```bash
+cd /home/adam/github/WrzDJ-worktrees/org-llm/dashboard
+npm run lint && npx tsc --noEmit && npm test -- --run 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Push + PR**
+
+```bash
+cd /home/adam/github/WrzDJ-worktrees/org-llm
+git push -u origin feat/org-llm-connector
+gh pr create --title "feat(llm): org-scoped house connector + AI policy clarity" --body "$(cat <<'EOF'
+## Summary
+Implements docs/superpowers/specs/2026-06-09-admin-ai-policy-design.md:
+- Dedicated org-scoped connector (scope column, nullable user_id, CHECK org⇔NULL user)
+- llm_enabled rescoped: gates ONLY the org fallback — BYO-connector DJs are never blocked
+- Legacy Anthropic env-var surface removed (API Key Status panel, /ai/models, llm_model setting)
+- Migration 056 converts the 047-seeded env-var default to org scope; clears personal-connector defaults
+- Admin UI: Organization connector card, recopied fallback toggle, per-DJ effective-source badges
+- DJ UI: house-billed / connect-a-provider banners
+
+## Test plan
+- [ ] Headline regression: BYO DJ dispatch with llm_enabled=False succeeds
+- [ ] Org fallback matrix (enabled/disabled × org connector present/absent)
+- [ ] Policy PATCH rejects user-scoped defaults
+- [ ] alembic upgrade head && alembic check on Postgres
+- [ ] Full backend + frontend CI green locally
+EOF
+)"
+```
+
+---
+
+## Self-review notes (already applied)
+
+- Spec §5 named `/settings/ai`; the real DJ connector UI is `AiProvidersSection.tsx` on `/account` — Task 12 targets the real file.
+- `AIModelInfo`/`AIModelsResponse` schemas survive because `GET /api/llm/openrouter/models` uses them; only the admin Anthropic listing dies.
+- `TrackVibe.llm_model` and `schemas/recommendation.py:llm_model` are telemetry/response fields unrelated to the dropped system setting — explicitly out of scope.
+- Existing `test_llm_default_connector.py` seeds user-scoped org defaults; Task 4 Step 4 converts those fixtures to org-scoped rather than deleting coverage.

--- a/docs/superpowers/specs/2026-06-09-admin-ai-policy-design.md
+++ b/docs/superpowers/specs/2026-06-09-admin-ai-policy-design.md
@@ -1,0 +1,198 @@
+# Admin AI Policy: Org Connector + Legacy Surface Removal
+
+**Date:** 2026-06-09
+**Author:** thewrz (design session with Claude)
+**Branch:** `feat/org-llm-connector`
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+Testing feedback surfaced two intertwined problems on `/admin/ai`:
+
+1. **Legacy Anthropic env-var surface.** The "API Key Status" panel reads
+   `bool(config.anthropic_api_key)` (`server/app/api/admin.py:388-406`) — an
+   env var with **zero runtime role** since #343. The recommendation engine
+   resolves credentials exclusively through LLM connectors. The panel is
+   Anthropic-only, reports the status of a credential nothing uses, and sits
+   next to the connector policy that actually matters. The companion
+   model-listing endpoint (`GET /api/admin/ai/models`,
+   `server/app/api/admin.py:351-385`) is equally Anthropic-only, and
+   `SystemSettings.llm_model` / `ANTHROPIC_MODEL` survive only as display
+   labels (the gateway uses each connector's `model_hint`).
+
+2. **Billing-identity gap in the org default.** `_resolve_connector`
+   (`server/app/services/llm/gateway.py:423-472`) falls back to
+   `SystemSettings.llm_default_connector_id` for **any DJ without an active
+   connector** — and that setting can point at any DJ's *personal* connector.
+   A DJ with no connector silently burns another DJ's API credits, and audit
+   attribution lands on the connector owner (`_system_actor_id`,
+   `gateway.py:485-492`). Separately, the global `llm_enabled` toggle
+   (`SystemSettings.llm_enabled`, enforced in `is_llm_available`,
+   `server/app/services/recommendation/llm_hooks.py:67-113`) blocks LLM
+   recommendations for **all** DJs — including DJs paying with their own
+   tokens.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Who can be the org-wide fallback connector? | **Dedicated org connector** — owned by the organization itself, never a DJ account |
+| Schema shape | **Same table + `scope` column** — `llm_connectors.scope ∈ {'user','org'}`, `user_id` nullable, CHECK `(scope='org') = (user_id IS NULL)` |
+| Fate of global `llm_enabled` | **Rescoped to org fallback only** — gates whether connector-less DJs (and system-context calls) may use the org connector; BYO DJs are never blocked |
+| Legacy env-var surface | **Removed entirely** — panel, models endpoint, `api_key_*` fields, `llm_model` setting, `ANTHROPIC_MODEL` response-label fallback |
+
+## 1. Data model & migration
+
+- `llm_connectors`:
+  - Add `scope: Mapped[str]` — `String(10)`, NOT NULL, server default `'user'`.
+  - `user_id` becomes nullable (`NULL` ⇔ org-scoped row).
+  - CHECK constraint: `(scope = 'org') = (user_id IS NULL)`.
+- `system_settings`:
+  - Drop `llm_model` column (display-only; nothing at runtime consults it).
+  - `llm_enabled` column **keeps its name**; its enforced meaning becomes
+    "org-connector fallback allowed". UI copy carries the semantics.
+  - `llm_default_connector_id` stays, but is only valid pointing at an
+    active `scope='org'` connector (validated at API layer + gateway).
+- `llm_audit_event.actor_user_id` widens to **nullable** (it is
+  `nullable=False` today — `server/app/models/llm_connector.py:222`) so
+  system-context org-connector calls can record a NULL actor.
+- **One Alembic migration** (next after current head `055`):
+  - Schema changes above.
+  - Data backfill, two cases for `llm_default_connector_id`:
+    1. Points at the migration-047-seeded connector (identified by
+       `display_name = "Org Default (migrated from env var)"`): **convert
+       that connector to `scope='org', user_id=NULL`** — it was the house
+       env-var key all along, so org semantics are preserved exactly.
+    2. Points at any other user-scoped connector (a DJ's personal key):
+       **clear to NULL** — the admin creates a proper org connector.
+  - Must pass `alembic upgrade head && alembic check` (model/migration drift
+    gate in CI).
+
+## 2. Gateway resolution
+
+Order unchanged: feature pin → DJ pinned default → DJ MRU → org fallback.
+
+- All per-DJ queries in `_resolve_connector` add an explicit
+  `scope == 'user'` filter (defense-in-depth; `user_id == actor.id` already
+  excludes org rows, but the filter makes intent testable and grep-able).
+- `_resolve_org_default` returns a connector only when it is `scope='org'`,
+  `status='active'`, **and `SystemSettings.llm_enabled` is true**. The
+  `llm_enabled` gate moves out of `is_llm_available`'s global short-circuit
+  and into the fallback path.
+- `is_llm_available(db, actor)` new logic: DJ has an active own connector →
+  `True` (regardless of `llm_enabled`); otherwise `True` iff the gated org
+  fallback resolves; else `False`.
+- System-context calls (`actor=None`) resolve through the same gated org
+  fallback. With no org connector or `llm_enabled=False`, they raise
+  `NoLlmConfigured` as today.
+- Audit attribution: org-connector calls record the **dispatching DJ** as
+  actor when present, `NULL` actor for true system calls. The
+  `_system_actor_id` fallback (attributing to the connector owner) is
+  removed; `llm_audit_event.actor_user_id` becomes nullable (see §1).
+
+## 3. Admin API
+
+**Added** — org connector CRUD, admin-only (`get_current_admin`), under
+`/api/admin/llm/org-connectors`:
+- `GET` (list), `POST` (create), `POST /{id}/test`, `POST /{id}/rotate`,
+  `DELETE /{id}` — thin wrappers over the existing `connector_storage`
+  helpers with `user=None, scope='org'`. Same encryption (`EncryptedText`),
+  same adapters, same call/audit logging. Rate-limited like the DJ
+  endpoints. Credential lifecycle events audit-logged as today.
+
+**Changed**:
+- `PATCH /api/admin/llm/policy` rejects `llm_default_connector_id` that is
+  not an active `scope='org'` connector (400).
+- AI settings response (`AISettingsOut`) loses `api_key_configured`,
+  `api_key_masked`, `llm_model`. `llm_enabled` and
+  `llm_rate_limit_per_minute` remain.
+
+**Removed**:
+- `GET /api/admin/ai/models` and `_list_anthropic_models()` +
+  `FALLBACK_MODELS` (`admin.py`).
+- `ANTHROPIC_MODEL` fallback label at `server/app/api/events.py:1007` — the
+  recommendation response's `llm_model` comes solely from the gateway
+  response (empty string when absent).
+- `anthropic_api_key` is deleted from `server/app/core/config.py` — its
+  only consumers are the panel/endpoint removed above (migration 047 reads
+  `os.environ` directly). `anthropic_model` **stays**: migration
+  `047_admin_ai_oauth.py:223-225` imports `get_settings().anthropic_model`,
+  and applied migrations are never edited — keep the field with a
+  "migration-047 only" comment. Stale `.env` entries remain harmless.
+- Regenerate OpenAPI schema + frontend types (epic-merge lesson: stale
+  generated types break the frontend build).
+
+## 4. Admin UI (`/admin/ai`)
+
+- **Delete** the API Key Status card
+  (`dashboard/app/admin/ai/page.tsx:478-506`) and the models-list usage.
+- **Add** an "Organization connector" section in its place: create / test /
+  delete the house connector (reuse the DJ connector form components),
+  status badge, model hint display.
+- **Policy section**: org-default dropdown lists only org-scoped connectors;
+  the `llm_enabled` toggle is recopied to *"Allow DJs without their own
+  connector to use the organization connector (house-billed)"*.
+- **Per-DJ table**: add an effective-source badge per DJ — `Own connector` /
+  `Org fallback` / `None — AI unavailable`. Computed **backend-side** (the
+  admin per-DJ listing response gains an `effective_source` field) so the
+  frontend never duplicates gateway resolution rules.
+- **Usage rollup**: org-connector usage rows labeled "Organization".
+
+## 5. DJ-side visibility (`/settings/ai`)
+
+- The DJ connectors-list response gains `org_fallback_available: bool`
+  (true iff an active org connector exists and `llm_enabled` is true).
+- A DJ with no connector of their own sees one of two banners:
+  - Fallback available: *"You're using the organization's connector — usage
+    is billed to the organization."*
+  - Otherwise: *"AI features unavailable — connect a provider."*
+- Org connector credentials are never exposed to DJ endpoints.
+
+## 6. Behavior matrix
+
+| DJ state | `llm_enabled` | Org connector | Result |
+|---|---|---|---|
+| Own active connector | any | any | Works — own billing; never blocked |
+| No connector | true | active | Works — org-billed, labeled in UI |
+| No connector | false | any | 503 / "connect a provider" |
+| No connector | true | none/inactive | 503 / "connect a provider" |
+| System context (`actor=None`) | true | active | Works — org-billed, NULL audit actor |
+| System context | false | any | `NoLlmConfigured` |
+
+## 7. Testing
+
+Backend (pytest):
+- **Headline regression**: BYO DJ dispatch succeeds with
+  `llm_enabled=False`.
+- Org fallback honored/blocked per matrix above (each row pinned).
+- `_resolve_connector` never returns an org row for the per-DJ chain, and
+  never returns a user row from `_resolve_org_default`.
+- Policy PATCH rejects user-scoped connector ids (400) and accepts active
+  org-scoped ids.
+- Org CRUD requires admin (403 for DJ), encrypts credentials at rest,
+  audit-logs lifecycle events.
+- Migration: `alembic upgrade head && alembic check`; backfill clears a
+  user-scoped default.
+- Audit rows with NULL actor accepted for system-context org calls.
+
+Frontend (vitest):
+- API Key Status panel gone; Organization connector section renders and
+  drives create/test/delete calls.
+- Per-DJ effective-source badges for all three states.
+- Both DJ banners on `/settings/ai`.
+
+## Rollout
+
+- Single PR on `feat/org-llm-connector`.
+- Deployments whose org default is the 047-seeded env-var connector need no
+  action — the migration converts it to org scope in place.
+- Deployments whose org default was a DJ's personal connector need one admin
+  action after deploy: create a proper org connector on `/admin/ai` (the
+  migration intentionally clears rather than stealing a DJ's key).
+
+## Out of scope
+
+- TrackVibe `llm_provider` gap (#391) — tracked separately.
+- Per-connector model discovery (replacement for the removed Anthropic
+  models endpoint).
+- Per-DJ quotas/budgets on the org connector.

--- a/server/alembic/versions/056_org_llm_connector.py
+++ b/server/alembic/versions/056_org_llm_connector.py
@@ -1,0 +1,85 @@
+"""Org-scoped LLM connector + llm_enabled rescope cleanup.
+
+Revision ID: 056
+Revises: 055
+Create Date: 2026-06-09
+
+- llm_connectors.scope ('user'|'org'), user_id nullable, CHECK org<->NULL user
+- llm_audit_event.actor_user_id nullable (system-context calls)
+- system_settings.llm_model dropped (display-only legacy)
+- Backfill: if llm_default_connector_id points at the migration-047-seeded
+  env-var connector ("Org Default (migrated from env var)"), convert that row
+  to scope='org' (it was the house key). Any other user-scoped default is
+  cleared — an admin must create a proper org connector.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "056"
+down_revision: str | None = "055"
+branch_labels = None
+depends_on = None
+
+_MIGRATED_DISPLAY_NAME = "Org Default (migrated from env var)"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "llm_connectors",
+        sa.Column("scope", sa.String(10), nullable=False, server_default="user"),
+    )
+    op.alter_column("llm_connectors", "user_id", existing_type=sa.Integer(), nullable=True)
+    op.alter_column("llm_audit_event", "actor_user_id", existing_type=sa.Integer(), nullable=True)
+    op.drop_column("system_settings", "llm_model")
+
+    # Backfill BEFORE adding the CHECK so the converted row satisfies it.
+    conn = op.get_bind()
+    default_id = conn.execute(
+        sa.text("SELECT llm_default_connector_id FROM system_settings LIMIT 1")
+    ).scalar()
+    if default_id is not None:
+        row = conn.execute(
+            sa.text("SELECT id, display_name FROM llm_connectors WHERE id = :cid"),
+            {"cid": default_id},
+        ).first()
+        if row is not None and row[1] == _MIGRATED_DISPLAY_NAME:
+            conn.execute(
+                sa.text("UPDATE llm_connectors SET scope = 'org', user_id = NULL WHERE id = :cid"),
+                {"cid": default_id},
+            )
+        elif row is not None:
+            conn.execute(sa.text("UPDATE system_settings SET llm_default_connector_id = NULL"))
+
+    op.create_check_constraint(
+        "ck_llm_connectors_org_scope_no_user",
+        "llm_connectors",
+        "(scope = 'org') = (user_id IS NULL)",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_llm_connectors_org_scope_no_user", "llm_connectors", type_="check")
+    # Org rows cannot survive a NOT NULL user_id; clear default + delete them.
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE system_settings SET llm_default_connector_id = NULL "
+            "WHERE llm_default_connector_id IN "
+            "(SELECT id FROM llm_connectors WHERE scope = 'org')"
+        )
+    )
+    conn.execute(sa.text("DELETE FROM llm_connectors WHERE scope = 'org'"))
+    op.add_column(
+        "system_settings",
+        sa.Column(
+            "llm_model",
+            sa.String(100),
+            nullable=False,
+            server_default="claude-haiku-4-5-20251001",
+        ),
+    )
+    op.alter_column("llm_audit_event", "actor_user_id", existing_type=sa.Integer(), nullable=False)
+    op.alter_column("llm_connectors", "user_id", existing_type=sa.Integer(), nullable=False)
+    op.drop_column("llm_connectors", "scope")

--- a/server/alembic/versions/056_org_llm_connector.py
+++ b/server/alembic/versions/056_org_llm_connector.py
@@ -5,6 +5,7 @@ Revises: 055
 Create Date: 2026-06-09
 
 - llm_connectors.scope ('user'|'org'), user_id nullable, CHECK org<->NULL user
+  + CHECK scope limited to ('user','org')
 - llm_audit_event.actor_user_id nullable (system-context calls)
 - system_settings.llm_model dropped (display-only legacy)
 - Backfill: if llm_default_connector_id points at the migration-047-seeded
@@ -60,6 +61,11 @@ def upgrade() -> None:
             conn.execute(sa.text("UPDATE system_settings SET llm_default_connector_id = NULL"))
 
     op.create_check_constraint(
+        "ck_llm_connectors_scope_valid",
+        "llm_connectors",
+        "scope IN ('user', 'org')",
+    )
+    op.create_check_constraint(
         "ck_llm_connectors_org_scope_no_user",
         "llm_connectors",
         "(scope = 'org') = (user_id IS NULL)",
@@ -68,6 +74,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_constraint("ck_llm_connectors_org_scope_no_user", "llm_connectors", type_="check")
+    op.drop_constraint("ck_llm_connectors_scope_valid", "llm_connectors", type_="check")
     # Org rows cannot survive a NOT NULL user_id. Preserve the credential by
     # reattaching them to the first admin (mirrors the upgrade backfill); only
     # when no admin exists do we clear the default pointer and delete them.

--- a/server/alembic/versions/056_org_llm_connector.py
+++ b/server/alembic/versions/056_org_llm_connector.py
@@ -11,6 +11,9 @@ Create Date: 2026-06-09
   env-var connector ("Org Default (migrated from env var)"), convert that row
   to scope='org' (it was the house key). Any other user-scoped default is
   cleared — an admin must create a proper org connector.
+- Downgrade preserves the org credential by reattaching org rows to the first
+  admin (scope='user'); rows are deleted only when no admin exists. NULL-actor
+  audit rows cannot survive the restored NOT NULL and are purged.
 """
 
 import sqlalchemy as sa
@@ -46,7 +49,11 @@ def upgrade() -> None:
         ).first()
         if row is not None and row[1] == _MIGRATED_DISPLAY_NAME:
             conn.execute(
-                sa.text("UPDATE llm_connectors SET scope = 'org', user_id = NULL WHERE id = :cid"),
+                sa.text(
+                    "UPDATE llm_connectors "
+                    "SET scope = 'org', user_id = NULL, is_default = false "
+                    "WHERE id = :cid"
+                ),
                 {"cid": default_id},
             )
         elif row is not None:
@@ -61,16 +68,27 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_constraint("ck_llm_connectors_org_scope_no_user", "llm_connectors", type_="check")
-    # Org rows cannot survive a NOT NULL user_id; clear default + delete them.
+    # Org rows cannot survive a NOT NULL user_id. Preserve the credential by
+    # reattaching them to the first admin (mirrors the upgrade backfill); only
+    # when no admin exists do we clear the default pointer and delete them.
     conn = op.get_bind()
-    conn.execute(
-        sa.text(
-            "UPDATE system_settings SET llm_default_connector_id = NULL "
-            "WHERE llm_default_connector_id IN "
-            "(SELECT id FROM llm_connectors WHERE scope = 'org')"
+    admin_id = conn.execute(
+        sa.text("SELECT id FROM users WHERE role = 'admin' ORDER BY id ASC LIMIT 1")
+    ).scalar()
+    if admin_id is not None:
+        conn.execute(
+            sa.text("UPDATE llm_connectors SET scope = 'user', user_id = :uid WHERE scope = 'org'"),
+            {"uid": admin_id},
         )
-    )
-    conn.execute(sa.text("DELETE FROM llm_connectors WHERE scope = 'org'"))
+    else:
+        conn.execute(
+            sa.text(
+                "UPDATE system_settings SET llm_default_connector_id = NULL "
+                "WHERE llm_default_connector_id IN "
+                "(SELECT id FROM llm_connectors WHERE scope = 'org')"
+            )
+        )
+        conn.execute(sa.text("DELETE FROM llm_connectors WHERE scope = 'org'"))
     op.add_column(
         "system_settings",
         sa.Column(
@@ -80,6 +98,8 @@ def downgrade() -> None:
             server_default="claude-haiku-4-5-20251001",
         ),
     )
+    # System-context audit rows cannot survive the NOT NULL schema.
+    conn.execute(sa.text("DELETE FROM llm_audit_event WHERE actor_user_id IS NULL"))
     op.alter_column("llm_audit_event", "actor_user_id", existing_type=sa.Integer(), nullable=False)
     op.alter_column("llm_connectors", "user_id", existing_type=sa.Integer(), nullable=False)
     op.drop_column("llm_connectors", "scope")

--- a/server/app/api/admin.py
+++ b/server/app/api/admin.py
@@ -1,7 +1,5 @@
 """Admin API endpoints for user management, event oversight, and system settings."""
 
-import logging
-
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi import Request as FastAPIRequest
 from sqlalchemy import func
@@ -12,7 +10,7 @@ from app.core.rate_limit import limiter
 from app.models.event import Event
 from app.models.request import Request
 from app.models.user import User, UserRole
-from app.schemas.ai_settings import AIModelInfo, AIModelsResponse, AISettingsOut, AISettingsUpdate
+from app.schemas.ai_settings import AISettingsOut, AISettingsUpdate
 from app.schemas.common import BulkActionResponse
 from app.schemas.event import BulkDeleteEventsRequest, EventUpdate
 from app.schemas.integration_health import (
@@ -48,15 +46,6 @@ from app.services.integration_health import (
     get_all_integration_statuses,
 )
 from app.services.system_settings import get_system_settings, update_system_settings
-
-logger = logging.getLogger(__name__)
-
-# Hardcoded fallback model list (used when Anthropic API is unreachable)
-# Last updated: 2026-03-15. Update when new Claude models release.
-FALLBACK_MODELS = [
-    AIModelInfo(id="claude-haiku-4-5-20251001", name="Claude Haiku 4.5"),
-    AIModelInfo(id="claude-sonnet-4-5-20250929", name="Claude Sonnet 4.5"),
-]
 
 router = APIRouter()
 
@@ -282,7 +271,6 @@ def admin_update_settings(
         bridge_enabled=update_data.bridge_enabled,
         human_verification_enforced=update_data.human_verification_enforced,
         llm_enabled=update_data.llm_enabled,
-        llm_model=update_data.llm_model,
         llm_rate_limit_per_minute=update_data.llm_rate_limit_per_minute,
     )
     return SystemSettingsOut.model_validate(settings)
@@ -341,50 +329,6 @@ def admin_check_integration(
 # ========== AI / LLM Settings ==========
 
 
-def _mask_api_key(key: str) -> str:
-    """Mask an API key, showing only last 4 characters."""
-    if not key:
-        return "Not configured"
-    return f"...{key[-4:]}"
-
-
-def _list_anthropic_models() -> list[AIModelInfo]:
-    """Try to list models from Anthropic API, fall back to hardcoded list."""
-    from app.core.config import get_settings
-
-    api_key = get_settings().anthropic_api_key
-    if not api_key:
-        return list(FALLBACK_MODELS)
-
-    try:
-        import anthropic
-
-        client = anthropic.Anthropic(api_key=api_key)
-        response = client.models.list(limit=20)
-        models = []
-        for model in response.data:
-            if "claude" in model.id:
-                display_name = model.display_name if hasattr(model, "display_name") else model.id
-                models.append(AIModelInfo(id=model.id, name=display_name))
-        if models:
-            return models
-    except Exception:
-        logger.warning("Failed to fetch models from Anthropic API, using fallback list")
-
-    return list(FALLBACK_MODELS)
-
-
-@router.get("/ai/models", response_model=AIModelsResponse)
-@limiter.limit("30/minute")
-def admin_get_ai_models(
-    request: FastAPIRequest,
-    _admin: User = Depends(get_current_admin),
-) -> AIModelsResponse:
-    """List available AI models."""
-    models = _list_anthropic_models()
-    return AIModelsResponse(models=models)
-
-
 @router.get("/ai/settings", response_model=AISettingsOut)
 @limiter.limit("120/minute")
 def admin_get_ai_settings(
@@ -392,17 +336,16 @@ def admin_get_ai_settings(
     db: Session = Depends(get_db),
     _admin: User = Depends(get_current_admin),
 ) -> AISettingsOut:
-    """Get AI/LLM configuration."""
-    from app.core.config import get_settings
+    """Get AI/LLM configuration.
 
-    config = get_settings()
+    ``llm_enabled`` gates only the org-connector fallback — DJs with their own
+    connector are never blocked by it. Credential status lives on the connector
+    surfaces (``/api/admin/llm/*``).
+    """
     settings = get_system_settings(db)
     return AISettingsOut(
         llm_enabled=settings.llm_enabled,
-        llm_model=settings.llm_model,
         llm_rate_limit_per_minute=settings.llm_rate_limit_per_minute,
-        api_key_configured=bool(config.anthropic_api_key),
-        api_key_masked=_mask_api_key(config.anthropic_api_key),
     )
 
 
@@ -414,20 +357,13 @@ def admin_update_ai_settings(
     db: Session = Depends(get_db),
     _admin: User = Depends(get_current_admin),
 ) -> AISettingsOut:
-    """Update AI/LLM configuration."""
-    from app.core.config import get_settings
-
-    config = get_settings()
+    """Update AI/LLM configuration (org-fallback gate + public rate limit)."""
     settings = update_system_settings(
         db,
         llm_enabled=update_data.llm_enabled,
-        llm_model=update_data.llm_model,
         llm_rate_limit_per_minute=update_data.llm_rate_limit_per_minute,
     )
     return AISettingsOut(
         llm_enabled=settings.llm_enabled,
-        llm_model=settings.llm_model,
         llm_rate_limit_per_minute=settings.llm_rate_limit_per_minute,
-        api_key_configured=bool(config.anthropic_api_key),
-        api_key_masked=_mask_api_key(config.anthropic_api_key),
     )

--- a/server/app/api/admin_llm.py
+++ b/server/app/api/admin_llm.py
@@ -560,29 +560,13 @@ async def test_org_connector(
     Mirrors the DJ-facing ``POST /api/llm/connectors/{id}/test`` — same shared
     helper, same status columns and audit rows, same code → message mapping.
     """
-    from app.services.llm.health_check import run_health_check
+    from app.services.llm.health_check import outcome_to_test_result, run_health_check
 
     row = _get_org_connector_or_404(db, connector_id)
 
     outcome = await run_health_check(db, row, actor_user_id=admin.id)
     db.commit()
-
-    if outcome.ok:
-        return ConnectorTestResult(ok=True)
-    # Reuse the same code → message mapping the gateway uses for transient
-    # errors. The helper has already sanitised any upstream payload.
-    message = {
-        "auth_invalid": "Authentication failed against the provider",
-        "rate_limited": "Provider rate limited the request",
-        "quota_exceeded": "Provider quota or billing failure",
-        "provider_unavailable": "Provider unreachable or timed out",
-        "error": "Unknown error",
-    }.get(outcome.status, "Unknown error")
-    return ConnectorTestResult(
-        ok=False,
-        error_code=outcome.error_code or outcome.status,
-        message=message,
-    )
+    return outcome_to_test_result(outcome)
 
 
 @router.put("/org-connectors/{connector_id}/credentials", response_model=ConnectorOut)

--- a/server/app/api/admin_llm.py
+++ b/server/app/api/admin_llm.py
@@ -22,7 +22,7 @@ from app.api.deps import get_current_admin, get_db
 from app.core.csv_safe import sanitize_csv_value
 from app.core.rate_limit import limiter
 from app.core.time import utcnow
-from app.models.llm_connector import LlmAuditEvent, LlmConnector
+from app.models.llm_connector import SCOPE_USER, STATUS_ACTIVE, LlmAuditEvent, LlmConnector
 from app.models.user import User
 from app.schemas.llm import (
     AdminAuditOut,
@@ -36,6 +36,8 @@ from app.schemas.llm import (
     ConnectorCredentialsRotate,
     ConnectorOut,
     ConnectorTestResult,
+    DjLlmStatusOut,
+    DjLlmStatusRow,
     UsageRow,
 )
 from app.services.llm.connector_storage import (
@@ -60,6 +62,7 @@ from app.services.llm.connector_storage import (
     rotate_credentials,
     set_monthly_cap,
 )
+from app.services.llm.gateway import _resolve_org_default
 from app.services.system_settings import get_system_settings, update_system_settings
 
 logger = logging.getLogger(__name__)
@@ -227,6 +230,42 @@ def patch_policy(
         llm_default_connector_id=settings.llm_default_connector_id,
         llm_call_log_retention_days=settings.llm_call_log_retention_days,
     )
+
+
+@router.get("/dj-status", response_model=DjLlmStatusOut)
+@limiter.limit("60/minute")
+def dj_llm_status(
+    request: FastAPIRequest,
+    _admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> DjLlmStatusOut:
+    """Effective LLM credential source per DJ.
+
+    Backend-computed from the same rules the gateway resolver applies, so the
+    admin UI never duplicates resolution logic.
+    """
+    fallback_on = _resolve_org_default(db) is not None
+    users = (
+        db.query(User).filter(User.role.in_(["dj", "admin"])).order_by(User.username.asc()).all()
+    )
+    own_ids = {
+        uid
+        for (uid,) in db.query(LlmConnector.user_id)
+        .filter(LlmConnector.scope == SCOPE_USER, LlmConnector.status == STATUS_ACTIVE)
+        .distinct()
+        .all()
+    }
+    rows = [
+        DjLlmStatusRow(
+            user_id=u.id,
+            username=u.username,
+            effective_source=(
+                "own" if u.id in own_ids else ("org_fallback" if fallback_on else "none")
+            ),
+        )
+        for u in users
+    ]
+    return DjLlmStatusOut(rows=rows)
 
 
 @router.get("/connectors", response_model=list[AdminConnectorOut])

--- a/server/app/api/admin_llm.py
+++ b/server/app/api/admin_llm.py
@@ -166,6 +166,13 @@ def patch_policy(
                 status_code=400,
                 detail="default connector must be active",
             )
+        if target.scope != "org":
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "default connector must be org-scoped (create one under Organization connector)"
+                ),
+            )
         update_kwargs["llm_default_connector_id"] = target.id
 
     settings = update_system_settings(db, **update_kwargs)
@@ -192,7 +199,7 @@ def list_connectors_admin(
     db: Session = Depends(get_db),
 ) -> list[AdminConnectorOut]:
     rows = list_all_connectors(db)
-    user_ids = {r.user_id for r in rows}
+    user_ids = {r.user_id for r in rows if r.user_id is not None}
     usernames: dict[int, str] = {}
     if user_ids:
         users = db.query(User).filter(User.id.in_(user_ids)).all()
@@ -204,7 +211,11 @@ def list_connectors_admin(
     return [
         _connector_to_admin_out(
             r,
-            usernames.get(r.user_id) or f"user#{r.user_id}",
+            (
+                "Organization"
+                if r.user_id is None
+                else (usernames.get(r.user_id) or f"user#{r.user_id}")
+            ),
             usage_by_connector.get(r.id, 0),
         )
         for r in rows
@@ -295,7 +306,7 @@ def get_usage(
         connector_ids = [r["connector_id"] for r in rows]
         connectors = db.query(LlmConnector).filter(LlmConnector.id.in_(connector_ids)).all()
         connector_map = {c.id: c for c in connectors}
-        user_ids = {c.user_id for c in connectors}
+        user_ids = {c.user_id for c in connectors if c.user_id is not None}
         users = db.query(User).filter(User.id.in_(user_ids)).all() if user_ids else []
         usernames = {u.id: u.username for u in users}
 
@@ -309,7 +320,11 @@ def get_usage(
             rows_out.append(
                 UsageRow(
                     connector_id=cid,
-                    dj_username=usernames.get(c.user_id, f"user#{c.user_id}"),
+                    dj_username=(
+                        "Organization"
+                        if c.user_id is None
+                        else usernames.get(c.user_id, f"user#{c.user_id}")
+                    ),
                     display_name=c.display_name,
                     connector_type=c.connector_type,  # type: ignore[arg-type]
                     total_calls=total,
@@ -367,7 +382,8 @@ def list_audit_events(
                 created_at=event.created_at,
                 event_type=event.event_type,
                 actor_user_id=event.actor_user_id,
-                actor_username=actor_username or f"user#{event.actor_user_id}",
+                actor_username=actor_username
+                or ("system" if event.actor_user_id is None else f"user#{event.actor_user_id}"),
                 target_connector_id=event.target_connector_id,
                 target_connector_display_name=connector_display_name,
                 notes=None,
@@ -426,7 +442,9 @@ def export_audit_events_csv(
         buffer.truncate(0)
 
         for event, actor_username, connector_display_name in result_rows:
-            actor = actor_username or f"user#{event.actor_user_id}"
+            actor = actor_username or (
+                "system" if event.actor_user_id is None else f"user#{event.actor_user_id}"
+            )
             writer.writerow(
                 [
                     event.created_at.isoformat() if event.created_at else "",

--- a/server/app/api/admin_llm.py
+++ b/server/app/api/admin_llm.py
@@ -23,7 +23,7 @@ from app.core.csv_safe import sanitize_csv_value
 from app.core.rate_limit import limiter
 from app.core.time import utcnow
 from app.models.llm_connector import SCOPE_USER, STATUS_ACTIVE, LlmAuditEvent, LlmConnector
-from app.models.user import User
+from app.models.user import User, UserRole
 from app.schemas.llm import (
     AdminAuditOut,
     AdminConnectorCapPatch,
@@ -246,7 +246,13 @@ def dj_llm_status(
     """
     fallback_on = _resolve_org_default(db) is not None
     users = (
-        db.query(User).filter(User.role.in_(["dj", "admin"])).order_by(User.username.asc()).all()
+        db.query(User)
+        .filter(
+            User.role.in_([UserRole.DJ.value, UserRole.ADMIN.value]),
+            User.is_active == True,  # noqa: E712
+        )
+        .order_by(User.username.asc())
+        .all()
     )
     own_ids = {
         uid

--- a/server/app/api/admin_llm.py
+++ b/server/app/api/admin_llm.py
@@ -32,19 +32,32 @@ from app.schemas.llm import (
     AdminPolicyPatch,
     AdminUsageOut,
     AuditEventRow,
+    ConnectorCreate,
+    ConnectorCredentialsRotate,
+    ConnectorOut,
+    ConnectorTestResult,
     UsageRow,
 )
 from app.services.llm.connector_storage import (
+    AUDIT_CREATED,
+    AUDIT_CREDENTIALS_ROTATED,
+    AUDIT_DELETED,
     AUDIT_POLICY_CHANGED,
     AUDIT_REVOKED_BY_ADMIN,
     audit_event,
+    build_create_payload,
+    create_connector,
     current_month_token_usage,
     current_month_token_usage_bulk,
+    delete_connector,
     get_connector,
     get_usage_stats,
     get_user_label,
     list_all_connectors,
+    list_org_connectors,
+    owner_label,
     revoke_connector,
+    rotate_credentials,
     set_monthly_cap,
 )
 from app.services.system_settings import get_system_settings, update_system_settings
@@ -75,6 +88,31 @@ def _connector_to_admin_out(
             "current_month_tokens": current_month_tokens,
         }
     )
+
+
+def _actor_label(event: LlmAuditEvent, actor_username: str | None) -> str:
+    """Display label for an audit row's actor.
+
+    NULL-actor rows (gateway system calls, org-row health checks) render as
+    "system"; a non-NULL actor whose user row has been deleted falls back to
+    "user#<id>". Shared by the JSON browse endpoint and the CSV export so the
+    two surfaces can never drift.
+    """
+    if actor_username:
+        return actor_username
+    return "system" if event.actor_user_id is None else f"user#{event.actor_user_id}"
+
+
+def _get_org_connector_or_404(db: Session, connector_id: int) -> LlmConnector:
+    """Fetch an org-scoped connector or raise 404.
+
+    User-scoped rows return 404 (not 403) from the org endpoints so a DJ's
+    personal connector IDs are never confirmed through the admin org surface.
+    """
+    row = get_connector(db, connector_id)
+    if row is None or row.scope != "org":
+        raise HTTPException(status_code=404, detail="Connector not found")
+    return row
 
 
 def _audit_query(
@@ -170,7 +208,7 @@ def patch_policy(
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    "default connector must be org-scoped (create one under Organization connector)"
+                    "default connector must be org-scoped — create an Organization connector first"
                 ),
             )
         update_kwargs["llm_default_connector_id"] = target.id
@@ -211,11 +249,7 @@ def list_connectors_admin(
     return [
         _connector_to_admin_out(
             r,
-            (
-                "Organization"
-                if r.user_id is None
-                else (usernames.get(r.user_id) or f"user#{r.user_id}")
-            ),
+            owner_label(r.user_id, usernames),
             usage_by_connector.get(r.id, 0),
         )
         for r in rows
@@ -320,11 +354,7 @@ def get_usage(
             rows_out.append(
                 UsageRow(
                     connector_id=cid,
-                    dj_username=(
-                        "Organization"
-                        if c.user_id is None
-                        else usernames.get(c.user_id, f"user#{c.user_id}")
-                    ),
+                    dj_username=owner_label(c.user_id, usernames),
                     display_name=c.display_name,
                     connector_type=c.connector_type,  # type: ignore[arg-type]
                     total_calls=total,
@@ -382,8 +412,7 @@ def list_audit_events(
                 created_at=event.created_at,
                 event_type=event.event_type,
                 actor_user_id=event.actor_user_id,
-                actor_username=actor_username
-                or ("system" if event.actor_user_id is None else f"user#{event.actor_user_id}"),
+                actor_username=_actor_label(event, actor_username),
                 target_connector_id=event.target_connector_id,
                 target_connector_display_name=connector_display_name,
                 notes=None,
@@ -417,8 +446,10 @@ def export_audit_events_csv(
 
     Honors the same filters as ``GET /audit``. Capped at
     ``_AUDIT_CSV_ROW_CAP`` rows to avoid unbounded streaming. Columns:
-    timestamp, actor, event_type, target_connector, notes. Never includes
-    credential material.
+    timestamp, actor, actor_user_id, event_type, target_connector, notes.
+    ``actor_user_id`` is empty for system rows, so a DJ literally named
+    "system" can never be confused with the NULL-actor system label. Never
+    includes credential material.
     """
     stmt = (
         _audit_query(
@@ -436,19 +467,19 @@ def export_audit_events_csv(
     def _generate() -> Iterator[str]:
         buffer = io.StringIO()
         writer = csv.writer(buffer)
-        writer.writerow(["timestamp", "actor", "event_type", "target_connector", "notes"])
+        writer.writerow(
+            ["timestamp", "actor", "actor_user_id", "event_type", "target_connector", "notes"]
+        )
         yield buffer.getvalue()
         buffer.seek(0)
         buffer.truncate(0)
 
         for event, actor_username, connector_display_name in result_rows:
-            actor = actor_username or (
-                "system" if event.actor_user_id is None else f"user#{event.actor_user_id}"
-            )
             writer.writerow(
                 [
                     event.created_at.isoformat() if event.created_at else "",
-                    sanitize_csv_value(actor),
+                    sanitize_csv_value(_actor_label(event, actor_username)),
+                    "" if event.actor_user_id is None else str(event.actor_user_id),
                     sanitize_csv_value(event.event_type or ""),
                     sanitize_csv_value(connector_display_name or ""),
                     "",
@@ -460,3 +491,154 @@ def export_audit_events_csv(
 
     headers = {"Content-Disposition": 'attachment; filename="llm-audit-events.csv"'}
     return StreamingResponse(_generate(), media_type="text/csv", headers=headers)
+
+
+# ---------- Organization connector (house-billed fallback) ----------
+
+
+@router.get("/org-connectors", response_model=list[ConnectorOut])
+@limiter.limit("60/minute")
+def list_org_connectors_admin(
+    request: FastAPIRequest,
+    _admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> list[ConnectorOut]:
+    return [ConnectorOut.model_validate(r) for r in list_org_connectors(db)]
+
+
+@router.post("/org-connectors", response_model=ConnectorOut, status_code=201)
+@limiter.limit("10/minute")
+def create_org_connector(
+    request: FastAPIRequest,
+    payload: ConnectorCreate,
+    admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> ConnectorOut:
+    """Create the organization's house connector (admin-only).
+
+    Reuses the DJ-connector validation pipeline; the row is org-scoped with no
+    owner. Credentials are encrypted at rest via EncryptedText. The DJ-facing
+    connector-type policy toggles are not applied — org connectors are an
+    admin decision.
+    """
+    try:
+        create_payload = build_create_payload(
+            connector_type=payload.connector_type,
+            display_name=payload.display_name,
+            api_key=payload.api_key,
+            base_url=payload.base_url,
+            bearer=payload.bearer,
+            model_hint=payload.model_hint,
+            aws_access_key_id=payload.aws_access_key_id,
+            aws_secret_access_key=payload.aws_secret_access_key,
+            aws_region=payload.aws_region,
+            aws_model_id=payload.aws_model_id,
+            azure_resource_name=payload.azure_resource_name,
+            azure_deployment_name=payload.azure_deployment_name,
+            azure_api_version=payload.azure_api_version,
+        )
+        row = create_connector(db, user_id=None, payload=create_payload, scope="org")
+    except ValueError as exc:
+        # Field validation failures + the org duplicate-(type, label) guard.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    audit_event(db, actor_user_id=admin.id, target_connector_id=row.id, event_type=AUDIT_CREATED)
+    db.commit()
+    db.refresh(row)
+    return ConnectorOut.model_validate(row)
+
+
+@router.post("/org-connectors/{connector_id}/test", response_model=ConnectorTestResult)
+@limiter.limit("10/minute")
+async def test_org_connector(
+    request: FastAPIRequest,
+    connector_id: int,
+    admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> ConnectorTestResult:
+    """Run a health check against an org connector and return a sanitised result.
+
+    Mirrors the DJ-facing ``POST /api/llm/connectors/{id}/test`` — same shared
+    helper, same status columns and audit rows, same code → message mapping.
+    """
+    from app.services.llm.health_check import run_health_check
+
+    row = _get_org_connector_or_404(db, connector_id)
+
+    outcome = await run_health_check(db, row, actor_user_id=admin.id)
+    db.commit()
+
+    if outcome.ok:
+        return ConnectorTestResult(ok=True)
+    # Reuse the same code → message mapping the gateway uses for transient
+    # errors. The helper has already sanitised any upstream payload.
+    message = {
+        "auth_invalid": "Authentication failed against the provider",
+        "rate_limited": "Provider rate limited the request",
+        "quota_exceeded": "Provider quota or billing failure",
+        "provider_unavailable": "Provider unreachable or timed out",
+        "error": "Unknown error",
+    }.get(outcome.status, "Unknown error")
+    return ConnectorTestResult(
+        ok=False,
+        error_code=outcome.error_code or outcome.status,
+        message=message,
+    )
+
+
+@router.put("/org-connectors/{connector_id}/credentials", response_model=ConnectorOut)
+@limiter.limit("10/minute")
+def rotate_org_connector_credentials(
+    request: FastAPIRequest,
+    connector_id: int,
+    payload: ConnectorCredentialsRotate,
+    admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> ConnectorOut:
+    row = _get_org_connector_or_404(db, connector_id)
+
+    try:
+        rotate_credentials(
+            db,
+            connector=row,
+            api_key=payload.api_key,
+            base_url=payload.base_url,
+            bearer=payload.bearer,
+            aws_access_key_id=payload.aws_access_key_id,
+            aws_secret_access_key=payload.aws_secret_access_key,
+            aws_region=payload.aws_region,
+            aws_model_id=payload.aws_model_id,
+            azure_resource_name=payload.azure_resource_name,
+            azure_deployment_name=payload.azure_deployment_name,
+            azure_api_version=payload.azure_api_version,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    audit_event(
+        db,
+        actor_user_id=admin.id,
+        target_connector_id=row.id,
+        event_type=AUDIT_CREDENTIALS_ROTATED,
+    )
+    db.commit()
+    db.refresh(row)
+    return ConnectorOut.model_validate(row)
+
+
+@router.delete("/org-connectors/{connector_id}", status_code=204)
+@limiter.limit("10/minute")
+def delete_org_connector(
+    request: FastAPIRequest,
+    connector_id: int,
+    admin: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> None:
+    row = _get_org_connector_or_404(db, connector_id)
+    audit_event(db, actor_user_id=admin.id, target_connector_id=row.id, event_type=AUDIT_DELETED)
+    # If this connector is the system default, clear it before deletion (and to
+    # be correct on SQLite, where the FK ON DELETE SET NULL may not fire).
+    settings = get_system_settings(db)
+    if settings.llm_default_connector_id == row.id:
+        settings.llm_default_connector_id = None
+    delete_connector(db, row)
+    db.commit()

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -1004,7 +1004,7 @@ async def get_llm_recommendations(
         services_used=base.services_used,
         total_candidates_searched=base.total_candidates_searched,
         llm_queries=llm_queries,
-        llm_model=result.llm_model or get_settings().anthropic_model,
+        llm_model=result.llm_model or "",
     )
 
 

--- a/server/app/api/llm.py
+++ b/server/app/api/llm.py
@@ -63,7 +63,7 @@ from app.services.llm.connector_storage import (
     update_metadata,
 )
 from app.services.llm.exceptions import LlmError, NoLlmConfigured
-from app.services.llm.gateway import Gateway
+from app.services.llm.gateway import Gateway, _resolve_org_default
 from app.services.llm.openrouter_models import get_openrouter_models
 from app.services.system_settings import get_system_settings
 
@@ -195,6 +195,7 @@ def get_dj_policy(
             apikey_enabled=settings.llm_apikey_connectors_enabled,
             compatible_enabled=settings.llm_compatible_connector_enabled,
         ),  # type: ignore[arg-type]
+        org_fallback_available=_resolve_org_default(db) is not None,
     )
 
 

--- a/server/app/api/llm.py
+++ b/server/app/api/llm.py
@@ -330,29 +330,13 @@ async def test_connector(
     rows are written the same way on every invocation regardless of trigger
     source. See ``services/llm/health_check.py`` for the shared helper.
     """
-    from app.services.llm.health_check import run_health_check
+    from app.services.llm.health_check import outcome_to_test_result, run_health_check
 
     row = _get_owned_connector_or_404(db, connector_id, user.id)
 
     outcome = await run_health_check(db, row, actor_user_id=user.id)
     db.commit()
-
-    if outcome.ok:
-        return ConnectorTestResult(ok=True)
-    # Reuse the same code → message mapping the gateway uses for transient
-    # errors. The helper has already sanitised any upstream payload.
-    message = {
-        "auth_invalid": "Authentication failed against the provider",
-        "rate_limited": "Provider rate limited the request",
-        "quota_exceeded": "Provider quota or billing failure",
-        "provider_unavailable": "Provider unreachable or timed out",
-        "error": "Unknown error",
-    }.get(outcome.status, "Unknown error")
-    return ConnectorTestResult(
-        ok=False,
-        error_code=outcome.error_code or outcome.status,
-        message=message,
-    )
+    return outcome_to_test_result(outcome)
 
 
 # A short, fixed prompt for the streaming health probe. Streams a single

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -128,14 +128,8 @@ class Settings(BaseSettings):
     # ListenBrainz API (artist discovery for recommendations)
     listenbrainz_user_token: str = ""
 
-    # Anthropic API (LLM-powered recommendations).
-    # NOTE: credentials live in the LLM Gateway connector system (the source of
-    # truth since the MVP). These two fields remain only for admin observability
-    # of the legacy key (admin AI-settings/model-listing endpoints) and as the
-    # default model-name label on recommendation responses. The legacy env-var
-    # *fallback* in the recommendation engine was removed in #343, along with the
-    # now-unused ANTHROPIC_MAX_TOKENS / ANTHROPIC_TIMEOUT_SECONDS settings.
-    anthropic_api_key: str = ""
+    # Retained ONLY for migration 047_admin_ai_oauth (model_hint on the seeded
+    # connector). No runtime consumer — do not reference in app code.
     anthropic_model: str = "claude-haiku-4-5-20251001"
 
     # Cache durations (1 hour for Spotify since popularity changes)

--- a/server/app/models/llm_connector.py
+++ b/server/app/models/llm_connector.py
@@ -179,6 +179,12 @@ class LlmConnector(Base):
             "monthly_token_cap IS NULL OR monthly_token_cap >= 0",
             name="ck_llm_connectors_monthly_token_cap_nonnegative",
         ),
+        # Scope is a closed two-value set; an unknown scope (e.g. 'house') would
+        # silently fall outside every scope-filtered resolution path.
+        CheckConstraint(
+            "scope IN ('user', 'org')",
+            name="ck_llm_connectors_scope_valid",
+        ),
         # Org rows must have no owner; user rows must have one.
         CheckConstraint(
             "(scope = 'org') = (user_id IS NULL)",

--- a/server/app/models/llm_connector.py
+++ b/server/app/models/llm_connector.py
@@ -55,6 +55,12 @@ STATUS_ACTIVE = "active"
 STATUS_AUTH_INVALID = "auth_invalid"
 STATUS_DISABLED = "disabled"
 
+# Connector scope — 'user' rows belong to a DJ; 'org' rows belong to the
+# organization itself (house-billed fallback). Org rows have user_id NULL,
+# enforced by ck_llm_connectors_org_scope_no_user below.
+SCOPE_USER = "user"
+SCOPE_ORG = "org"
+
 # Health-check status values written to ``last_health_check_status``. Kept here
 # so the API/background loop/admin UI all use the same vocabulary. These are
 # *outcomes*, not connector statuses — a single connector accumulates many
@@ -113,10 +119,13 @@ class LlmConnector(Base):
     __tablename__ = "llm_connectors"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[int] = mapped_column(
-        ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    user_id: Mapped[int | None] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=True
     )
     connector_type: Mapped[str] = mapped_column(String(40), index=True, nullable=False)
+    scope: Mapped[str] = mapped_column(
+        String(10), nullable=False, default=SCOPE_USER, server_default=text("'user'")
+    )
     display_name: Mapped[str] = mapped_column(String(80), nullable=False)
     status: Mapped[str] = mapped_column(
         String(20), nullable=False, default=STATUS_ACTIVE, server_default=STATUS_ACTIVE
@@ -170,6 +179,11 @@ class LlmConnector(Base):
             "monthly_token_cap IS NULL OR monthly_token_cap >= 0",
             name="ck_llm_connectors_monthly_token_cap_nonnegative",
         ),
+        # Org rows must have no owner; user rows must have one.
+        CheckConstraint(
+            "(scope = 'org') = (user_id IS NULL)",
+            name="ck_llm_connectors_org_scope_no_user",
+        ),
         Index("ix_user_active", "user_id", "status"),
         # Partial unique index — only enforced on Postgres. SQLite ignores
         # the postgresql_where clause but still creates an unfiltered index;
@@ -219,7 +233,10 @@ class LlmAuditEvent(Base):
     __tablename__ = "llm_audit_event"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    actor_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True, nullable=False)
+    # NULL actor = system-context call (no DJ actor); see gateway dispatch.
+    actor_user_id: Mapped[int | None] = mapped_column(
+        ForeignKey("users.id"), index=True, nullable=True
+    )
     target_connector_id: Mapped[int | None] = mapped_column(
         ForeignKey("llm_connectors.id", ondelete="SET NULL"), nullable=True
     )

--- a/server/app/models/llm_connector.py
+++ b/server/app/models/llm_connector.py
@@ -124,7 +124,7 @@ class LlmConnector(Base):
     )
     connector_type: Mapped[str] = mapped_column(String(40), index=True, nullable=False)
     scope: Mapped[str] = mapped_column(
-        String(10), nullable=False, default=SCOPE_USER, server_default=text("'user'")
+        String(10), nullable=False, default=SCOPE_USER, server_default=SCOPE_USER
     )
     display_name: Mapped[str] = mapped_column(String(80), nullable=False)
     status: Mapped[str] = mapped_column(

--- a/server/app/models/system_settings.py
+++ b/server/app/models/system_settings.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, ForeignKey, Integer, String, text
+from sqlalchemy import Boolean, ForeignKey, Integer, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base
@@ -21,9 +21,11 @@ class SystemSettings(Base):
     # Soft-warn-only when False; hard-enforce 403 when True. See docs/HUMAN-VERIFICATION.md.
     human_verification_enforced: Mapped[bool] = mapped_column(Boolean, default=False)
 
-    # LLM / AI settings
+    # LLM / AI settings.
+    # llm_enabled gates ONLY the org-connector fallback (connector-less DJs and
+    # system-context calls). DJs with their own active connector are never
+    # blocked by this flag. See docs/superpowers/specs/2026-06-09-admin-ai-policy-design.md.
     llm_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
-    llm_model: Mapped[str] = mapped_column(String(100), default="claude-haiku-4-5-20251001")
     llm_rate_limit_per_minute: Mapped[int] = mapped_column(Integer, default=3)
 
     # llm_call_log retention (days). Daily cleanup deletes rows older than this.

--- a/server/app/schemas/ai_settings.py
+++ b/server/app/schemas/ai_settings.py
@@ -14,13 +14,9 @@ class AIModelsResponse(BaseModel):
 
 class AISettingsOut(BaseModel):
     llm_enabled: bool
-    llm_model: str
     llm_rate_limit_per_minute: int
-    api_key_configured: bool
-    api_key_masked: str
 
 
 class AISettingsUpdate(BaseModel):
     llm_enabled: bool | None = None
-    llm_model: str | None = None
     llm_rate_limit_per_minute: int | None = Field(None, ge=1, le=30)

--- a/server/app/schemas/llm.py
+++ b/server/app/schemas/llm.py
@@ -57,7 +57,9 @@ class ConnectorOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
-    user_id: int
+    # NULL for org-scoped rows (scope='org') — there is no owning DJ.
+    user_id: int | None
+    scope: Literal["user", "org"] = "user"
     connector_type: ConnectorType
     display_name: str
     status: ConnectorStatus
@@ -317,7 +319,9 @@ class AuditEventRow(BaseModel):
     id: int
     created_at: datetime
     event_type: str
-    actor_user_id: int
+    # NULL for system-context events (gateway system calls, org-row health
+    # checks) — rendered as "system" in actor_username.
+    actor_user_id: int | None
     actor_username: str
     target_connector_id: int | None = None
     target_connector_display_name: str | None = None

--- a/server/app/schemas/llm.py
+++ b/server/app/schemas/llm.py
@@ -256,6 +256,21 @@ class DjPolicyOut(BaseModel):
     llm_apikey_connectors_enabled: bool
     llm_compatible_connector_enabled: bool
     allowed_connector_types: list[ConnectorType]
+    # True when an active org-scoped default exists AND llm_enabled is on —
+    # i.e. a connector-less DJ will fall back to the house connector.
+    org_fallback_available: bool = False
+
+
+class DjLlmStatusRow(BaseModel):
+    user_id: int
+    username: str
+    # "own" = DJ has an active connector; "org_fallback" = will use the org
+    # connector (house-billed); "none" = AI unavailable for this DJ.
+    effective_source: Literal["own", "org_fallback", "none"]
+
+
+class DjLlmStatusOut(BaseModel):
+    rows: list[DjLlmStatusRow]
 
 
 class AdminPolicyPatch(BaseModel):

--- a/server/app/schemas/llm.py
+++ b/server/app/schemas/llm.py
@@ -294,6 +294,7 @@ class AdminConnectorCapPatch(BaseModel):
 
 class UsageRow(BaseModel):
     connector_id: int
+    # "Organization" for org-scoped connectors; otherwise the owning DJ's username.
     dj_username: str
     display_name: str
     connector_type: ConnectorType

--- a/server/app/schemas/system_settings.py
+++ b/server/app/schemas/system_settings.py
@@ -12,7 +12,6 @@ class SystemSettingsOut(BaseSchema):
     bridge_enabled: bool
     human_verification_enforced: bool
     llm_enabled: bool
-    llm_model: str
     llm_rate_limit_per_minute: int
 
 
@@ -25,5 +24,4 @@ class SystemSettingsUpdate(BaseModel):
     bridge_enabled: bool | None = None
     human_verification_enforced: bool | None = None
     llm_enabled: bool | None = None
-    llm_model: str | None = None
     llm_rate_limit_per_minute: int | None = Field(None, ge=1, le=30)

--- a/server/app/services/llm/connector_storage.py
+++ b/server/app/services/llm/connector_storage.py
@@ -30,6 +30,8 @@ from app.models.llm_connector import (
     CONNECTOR_TYPE_OPENAI_COMPATIBLE,
     CONNECTOR_TYPE_OPENROUTER_APIKEY,
     CONNECTOR_TYPE_XAI_APIKEY,
+    SCOPE_ORG,
+    SCOPE_USER,
     STATUS_ACTIVE,
     STATUS_AUTH_INVALID,
     STATUS_DISABLED,
@@ -51,7 +53,7 @@ logger = logging.getLogger(__name__)
 def list_connectors_for_user(db: Session, user_id: int) -> list[LlmConnector]:
     return (
         db.query(LlmConnector)
-        .filter(LlmConnector.user_id == user_id)
+        .filter(LlmConnector.user_id == user_id, LlmConnector.scope == SCOPE_USER)
         .order_by(LlmConnector.created_at.desc())
         .all()
     )
@@ -61,6 +63,15 @@ def list_all_connectors(db: Session) -> list[LlmConnector]:
     return (
         db.query(LlmConnector)
         .order_by(LlmConnector.user_id.asc(), LlmConnector.created_at.desc())
+        .all()
+    )
+
+
+def list_org_connectors(db: Session) -> list[LlmConnector]:
+    return (
+        db.query(LlmConnector)
+        .filter(LlmConnector.scope == SCOPE_ORG)
+        .order_by(LlmConnector.created_at.desc())
         .all()
     )
 
@@ -365,10 +376,36 @@ def _load_existing_blob(connector: LlmConnector) -> dict[str, Any]:
     return blob if isinstance(blob, dict) else {}
 
 
-def create_connector(db: Session, *, user_id: int, payload: CreateConnectorPayload) -> LlmConnector:
-    """Persist a new connector. Caller is responsible for audit event + commit."""
+def create_connector(
+    db: Session,
+    *,
+    user_id: int | None,
+    payload: CreateConnectorPayload,
+    scope: str = SCOPE_USER,
+) -> LlmConnector:
+    """Persist a new connector. Caller is responsible for audit event + commit.
+
+    Org-scoped rows (scope='org') must pass user_id=None — the DB CHECK
+    enforces it; this assert catches programming errors early. Org rows are
+    exempt from the per-user unique label constraint (NULL user_id rows are
+    NULLS-DISTINCT on Postgres), so duplicate org labels are rejected here.
+    """
+    assert (scope == SCOPE_ORG) == (user_id is None), "org scope requires user_id=None"
+    if scope == SCOPE_ORG:
+        duplicate = (
+            db.query(LlmConnector.id)
+            .filter(
+                LlmConnector.scope == SCOPE_ORG,
+                LlmConnector.connector_type == payload.connector_type,
+                LlmConnector.display_name == payload.display_name,
+            )
+            .first()
+        )
+        if duplicate is not None:
+            raise ValueError("An org connector with this label already exists")
     row = LlmConnector(
         user_id=user_id,
+        scope=scope,
         connector_type=payload.connector_type,
         display_name=payload.display_name,
         status=STATUS_ACTIVE,
@@ -599,7 +636,7 @@ def clear_feature_preference(db: Session, *, user_id: int, feature: str) -> bool
 def audit_event(
     db: Session,
     *,
-    actor_user_id: int,
+    actor_user_id: int | None,
     target_connector_id: int | None,
     event_type: str,
 ) -> LlmAuditEvent:
@@ -663,7 +700,9 @@ def purge_call_log_older_than(db: Session, *, retention_days: int) -> int:
     return result.rowcount or 0
 
 
-def get_user_label(db: Session, user_id: int) -> str:
+def get_user_label(db: Session, user_id: int | None) -> str:
+    if user_id is None:
+        return "Organization"
     user = db.get(User, user_id)
     return user.username if user else f"user#{user_id}"
 
@@ -803,6 +842,7 @@ __all__ = [
     "get_user_label",
     "list_all_connectors",
     "list_connectors_for_user",
+    "list_org_connectors",
     "log_call",
     "purge_call_log_older_than",
     "revoke_connector",

--- a/server/app/services/llm/connector_storage.py
+++ b/server/app/services/llm/connector_storage.py
@@ -707,6 +707,13 @@ def get_user_label(db: Session, user_id: int | None) -> str:
     return user.username if user else f"user#{user_id}"
 
 
+def owner_label(user_id: int | None, usernames: dict[int, str]) -> str:
+    """Batch-friendly sibling of get_user_label (no DB hit)."""
+    if user_id is None:
+        return "Organization"
+    return usernames.get(user_id) or f"user#{user_id}"
+
+
 def get_usage_stats(db: Session, *, days: int = 30) -> list[dict]:
     """Aggregate per-connector telemetry for the admin Usage card.
 
@@ -844,6 +851,7 @@ __all__ = [
     "list_connectors_for_user",
     "list_org_connectors",
     "log_call",
+    "owner_label",
     "purge_call_log_older_than",
     "revoke_connector",
     "rotate_credentials",

--- a/server/app/services/llm/gateway.py
+++ b/server/app/services/llm/gateway.py
@@ -3,15 +3,23 @@
 See spec §4.3.
 
 Resolution order:
-1. If ``actor`` is not ``None``:
+1. If ``actor`` is not ``None`` — the per-DJ chain, which only ever returns
+   ``scope='user'`` rows:
    a. The DJ's per-feature pin for ``purpose`` if set and the pinned connector
       is active (``LlmFeaturePreference`` — issue #337). Skipped gracefully when
       the pinned connector was deleted or is no longer active.
    b. Else: the DJ's explicit default active connector if one is pinned
       (``LlmConnector.is_default = True``) — issue #336.
    c. Else: most-recently-used active connector for the DJ.
-2. Else: ``SystemSettings.llm_default_connector_id`` if set and active.
+2. Else (no actor, or no per-DJ match): the org fallback —
+   ``SystemSettings.llm_default_connector_id`` when it points at an ACTIVE
+   ``scope='org'`` row AND ``SystemSettings.llm_enabled`` is True.
+   ``llm_enabled`` gates ONLY this fallback; a DJ's own connector is never
+   blocked by it.
 3. Else: raise :class:`NoLlmConfigured`.
+
+System-context calls (``actor=None``) record a NULL actor on audit rows rather
+than misattributing usage to the connector's owner.
 
 Auto-fallback (issue #338):
 When ``ChatRequest.fallback_policy`` is not ``"none"`` and the resolved
@@ -34,6 +42,8 @@ from sqlalchemy.orm import Session
 from app.core.time import utcnow
 from app.models.llm_connector import (
     AUDIT_AUTH_INVALID_OBSERVED,
+    SCOPE_ORG,
+    SCOPE_USER,
     STATUS_ACTIVE,
     STATUS_AUTH_INVALID,
     LlmConnector,
@@ -118,7 +128,9 @@ class Gateway:
         purpose: str,
     ) -> ChatResponse:
         primary = _resolve_connector(db, actor, purpose=purpose)
-        actor_id = actor.id if actor else _system_actor_id(db, primary)
+        # NULL actor = system-context call; audit rows record no user rather
+        # than misattributing usage to the connector's owner.
+        actor_id = actor.id if actor else None
 
         # Pre-flight: refuse if the resolved connector's monthly cap is reached
         # (issue #339). Raised before any provider call — no tokens spent, and
@@ -201,7 +213,9 @@ class Gateway:
         another connector would corrupt the output. Streaming always fails fast.
         """
         primary = _resolve_connector(db, actor, purpose=purpose)
-        actor_id = actor.id if actor else _system_actor_id(db, primary)
+        # NULL actor = system-context call; audit rows record no user rather
+        # than misattributing usage to the connector's owner.
+        actor_id = actor.id if actor else None
         inner = _attempt_stream(db, primary, request, purpose=purpose, actor_id=actor_id)
         try:
             async for chunk in inner:
@@ -220,7 +234,7 @@ async def _attempt(
     request: ChatRequest,
     *,
     purpose: str,
-    actor_id: int,
+    actor_id: int | None,
 ) -> ChatResponse:
     """Run a single adapter call against ``connector``, logging the outcome.
 
@@ -334,7 +348,7 @@ async def _attempt_stream(
     request: ChatRequest,
     *,
     purpose: str,
-    actor_id: int,
+    actor_id: int | None,
 ) -> AsyncIterator[ChatResponseChunk]:
     """Run a single adapter stream, logging exactly one outcome row.
 
@@ -434,6 +448,7 @@ def _resolve_connector(db: Session, actor: User | None, *, purpose: str) -> LlmC
                 pinned_feature is not None
                 and pinned_feature.user_id == actor.id
                 and pinned_feature.status == STATUS_ACTIVE
+                and pinned_feature.scope == SCOPE_USER
             ):
                 return pinned_feature
 
@@ -445,6 +460,7 @@ def _resolve_connector(db: Session, actor: User | None, *, purpose: str) -> LlmC
             db.query(LlmConnector)
             .filter(
                 LlmConnector.user_id == actor.id,
+                LlmConnector.scope == SCOPE_USER,
                 LlmConnector.status == STATUS_ACTIVE,
                 LlmConnector.is_default == True,  # noqa: E712 (SQLAlchemy comparison)
             )
@@ -457,6 +473,7 @@ def _resolve_connector(db: Session, actor: User | None, *, purpose: str) -> LlmC
             db.query(LlmConnector)
             .filter(
                 LlmConnector.user_id == actor.id,
+                LlmConnector.scope == SCOPE_USER,
                 LlmConnector.status == STATUS_ACTIVE,
             )
             .order_by(nulls_last(desc(LlmConnector.last_used_at)), desc(LlmConnector.id))
@@ -473,20 +490,16 @@ def _resolve_connector(db: Session, actor: User | None, *, purpose: str) -> LlmC
 
 
 def _resolve_org_default(db: Session) -> LlmConnector | None:
-    """Return the active org-default connector, or ``None`` if unset/inactive."""
-    settings = db.query(SystemSettings).first()
-    if settings and settings.llm_default_connector_id:
-        default = db.get(LlmConnector, settings.llm_default_connector_id)
-        if default is not None and default.status == STATUS_ACTIVE:
-            return default
-    return None
+    """Active org-scoped default, gated by the org-fallback policy toggle.
 
-
-def _system_actor_id(db: Session, connector: LlmConnector) -> int:
-    """Best-effort actor id for system-context audit rows.
-
-    When the gateway is called with ``actor=None`` (system context), audit
-    events should still record an actor; fall back to the connector's owner so
-    the trail is traceable.
+    ``llm_enabled`` governs ONLY this path: DJs with their own connector are
+    resolved earlier and never reach here. Returns ``None`` when the toggle is
+    off, no default is set, or the default is not an active org-scoped row.
     """
-    return connector.user_id
+    settings = db.query(SystemSettings).first()
+    if not settings or not settings.llm_enabled or not settings.llm_default_connector_id:
+        return None
+    default = db.get(LlmConnector, settings.llm_default_connector_id)
+    if default is not None and default.scope == SCOPE_ORG and default.status == STATUS_ACTIVE:
+        return default
+    return None

--- a/server/app/services/llm/health_check.py
+++ b/server/app/services/llm/health_check.py
@@ -75,9 +75,13 @@ async def run_health_check(
     db: Session,
     connector: LlmConnector,
     *,
-    actor_user_id: int,
+    actor_user_id: int | None,
 ) -> HealthCheckOutcome:
     """Run ``adapter.health_check()`` against ``connector`` and record the outcome.
+
+    ``actor_user_id`` may be ``None``: the background monitor passes
+    ``connector.user_id``, which is NULL for org-scoped rows — those audit
+    rows are recorded as system events (no attributable user).
 
     Writes (caller commits):
     - ``connector.last_health_check_at`` (always)

--- a/server/app/services/llm/health_check.py
+++ b/server/app/services/llm/health_check.py
@@ -41,6 +41,7 @@ from app.models.llm_connector import (
     STATUS_DISABLED,
     LlmConnector,
 )
+from app.schemas.llm import ConnectorTestResult
 from app.services.llm.connector_storage import audit_event
 from app.services.llm.exceptions import (
     AuthInvalid,
@@ -175,3 +176,31 @@ async def run_health_check(
     if connector.status == STATUS_AUTH_INVALID:
         connector.status = STATUS_ACTIVE
     return HealthCheckOutcome(ok=True, status=HEALTH_CHECK_OK)
+
+
+# Sanitised status → message mapping shared by every connector test endpoint.
+# The health-check helper has already stripped any upstream payload from the
+# outcome, so these fixed strings are all a client ever sees.
+_HEALTH_CHECK_MESSAGES = {
+    HEALTH_CHECK_AUTH_INVALID: "Authentication failed against the provider",
+    HEALTH_CHECK_RATE_LIMITED: "Provider rate limited the request",
+    HEALTH_CHECK_QUOTA_EXCEEDED: "Provider quota or billing failure",
+    HEALTH_CHECK_PROVIDER_UNAVAILABLE: "Provider unreachable or timed out",
+    HEALTH_CHECK_ERROR: "Unknown error",
+}
+
+
+def outcome_to_test_result(outcome: HealthCheckOutcome) -> ConnectorTestResult:
+    """Sanitised DJ/admin-facing test result for a health-check outcome.
+
+    Single source for the status → message mapping so the DJ test endpoint
+    (``POST /api/llm/connectors/{id}/test``) and the admin org-connector test
+    endpoint (``POST /api/admin/llm/org-connectors/{id}/test``) can never drift.
+    """
+    if outcome.ok:
+        return ConnectorTestResult(ok=True)
+    return ConnectorTestResult(
+        ok=False,
+        error_code=outcome.error_code or outcome.status,
+        message=_HEALTH_CHECK_MESSAGES.get(outcome.status, "Unknown error"),
+    )

--- a/server/app/services/llm/health_monitor.py
+++ b/server/app/services/llm/health_monitor.py
@@ -188,9 +188,10 @@ async def _check_one(db: Session, connector: LlmConnector) -> HealthCheckOutcome
     """Run a health check on ``connector``, commit, and notify if it just broke.
 
     The audit row is written with ``actor_user_id = connector.user_id``
-    because the periodic check is *on behalf of* the DJ (vs the manual test
-    button, where the actor is whoever clicked it). This keeps the audit
-    trail attributable.
+    because the periodic check is *on behalf of* the owning DJ (vs the manual
+    test button, where the actor is whoever clicked it). For org-scoped rows
+    ``connector.user_id`` is NULL, so their audit rows carry a NULL actor and
+    surface as "system" events in the admin audit views.
     """
     outcome = await run_health_check(db, connector, actor_user_id=connector.user_id)
     db.commit()

--- a/server/app/services/recommendation/llm_hooks.py
+++ b/server/app/services/recommendation/llm_hooks.py
@@ -65,16 +65,14 @@ async def generate_llm_suggestions(
 
 
 def is_llm_available(db=None, actor=None) -> bool:
-    """Check if LLM recommendations are configured and available.
+    """Check if LLM features are available for this actor.
 
-    Mirrors :func:`app.services.llm.gateway._resolve_connector` semantics so the
-    "feature available" signal aligns with whether dispatch will actually
-    succeed:
+    Mirrors :func:`app.services.llm.gateway._resolve_connector` semantics:
 
-    - If ``actor`` is provided: returns True when the actor owns an active
-      connector (matches the per-DJ MRU lookup).
-    - Otherwise (no actor or no actor-owned active connector): returns True
-      when an active system-default connector is configured.
+    - A DJ with an active connector of their own is ALWAYS available —
+      ``llm_enabled`` does not apply to BYO credentials.
+    - Otherwise availability equals the gated org fallback: an active
+      org-scoped default connector AND ``llm_enabled`` true.
 
     Connector-backed only. Without ``db`` no connector can be resolved, so it
     returns ``False`` — the legacy Anthropic env-var fallback was removed in #343.
@@ -82,20 +80,15 @@ def is_llm_available(db=None, actor=None) -> bool:
     if db is None:
         return False
 
-    from app.models.llm_connector import STATUS_ACTIVE, LlmConnector
-    from app.models.system_settings import SystemSettings
-    from app.services.system_settings import get_system_settings
+    from app.models.llm_connector import SCOPE_USER, STATUS_ACTIVE, LlmConnector
+    from app.services.llm.gateway import _resolve_org_default
 
-    settings = get_system_settings(db)
-    if not settings.llm_enabled:
-        return False
-
-    # Per-DJ active connector — matches gateway resolver step 1.
     if actor is not None:
         actor_active = (
             db.query(LlmConnector.id)
             .filter(
                 LlmConnector.user_id == actor.id,
+                LlmConnector.scope == SCOPE_USER,
                 LlmConnector.status == STATUS_ACTIVE,
             )
             .first()
@@ -103,11 +96,4 @@ def is_llm_available(db=None, actor=None) -> bool:
         if actor_active is not None:
             return True
 
-    # System default fallback — matches gateway resolver step 2.
-    sys_settings = db.query(SystemSettings).first()
-    if sys_settings and sys_settings.llm_default_connector_id:
-        default = db.get(LlmConnector, sys_settings.llm_default_connector_id)
-        if default is not None and default.status == STATUS_ACTIVE:
-            return True
-
-    return False
+    return _resolve_org_default(db) is not None

--- a/server/app/services/system_settings.py
+++ b/server/app/services/system_settings.py
@@ -22,7 +22,6 @@ def get_system_settings(db: Session) -> SystemSettings:
             bridge_enabled=True,
             human_verification_enforced=False,
             llm_enabled=True,
-            llm_model="claude-haiku-4-5-20251001",
             llm_rate_limit_per_minute=3,
             llm_apikey_connectors_enabled=True,
             llm_compatible_connector_enabled=True,
@@ -45,7 +44,6 @@ def update_system_settings(
     bridge_enabled: bool | None = None,
     human_verification_enforced: bool | None = None,
     llm_enabled: bool | None = None,
-    llm_model: str | None = None,
     llm_rate_limit_per_minute: int | None = None,
     llm_apikey_connectors_enabled: bool | None = None,
     llm_compatible_connector_enabled: bool | None = None,
@@ -70,8 +68,6 @@ def update_system_settings(
         settings.human_verification_enforced = human_verification_enforced
     if llm_enabled is not None:
         settings.llm_enabled = llm_enabled
-    if llm_model is not None:
-        settings.llm_model = llm_model
     if llm_rate_limit_per_minute is not None:
         settings.llm_rate_limit_per_minute = llm_rate_limit_per_minute
     if llm_apikey_connectors_enabled is not None:

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -37,21 +37,9 @@
       },
       "AISettingsOut": {
         "properties": {
-          "api_key_configured": {
-            "title": "Api Key Configured",
-            "type": "boolean"
-          },
-          "api_key_masked": {
-            "title": "Api Key Masked",
-            "type": "string"
-          },
           "llm_enabled": {
             "title": "Llm Enabled",
             "type": "boolean"
-          },
-          "llm_model": {
-            "title": "Llm Model",
-            "type": "string"
           },
           "llm_rate_limit_per_minute": {
             "title": "Llm Rate Limit Per Minute",
@@ -59,10 +47,7 @@
           }
         },
         "required": [
-          "api_key_configured",
-          "api_key_masked",
           "llm_enabled",
-          "llm_model",
           "llm_rate_limit_per_minute"
         ],
         "title": "AISettingsOut",
@@ -80,17 +65,6 @@
               }
             ],
             "title": "Llm Enabled"
-          },
-          "llm_model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Llm Model"
           },
           "llm_rate_limit_per_minute": {
             "anyOf": [
@@ -358,6 +332,15 @@
             ],
             "title": "Monthly Token Cap"
           },
+          "scope": {
+            "default": "user",
+            "enum": [
+              "user",
+              "org"
+            ],
+            "title": "Scope",
+            "type": "string"
+          },
           "status": {
             "enum": [
               "active",
@@ -373,8 +356,15 @@
             "type": "string"
           },
           "user_id": {
-            "title": "User Id",
-            "type": "integer"
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
           }
         },
         "required": [
@@ -392,6 +382,7 @@
           "last_used_at",
           "model_hint",
           "monthly_token_cap",
+          "scope",
           "status",
           "updated_at",
           "user_id"
@@ -754,8 +745,15 @@
         "description": "A single audit-trail row with joined display labels.\n\nNever includes credential material \u2014 only the target connector's\nhuman-readable display name (joined from ``llm_connectors``).",
         "properties": {
           "actor_user_id": {
-            "title": "Actor User Id",
-            "type": "integer"
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actor User Id"
           },
           "actor_username": {
             "title": "Actor Username",
@@ -1133,7 +1131,7 @@
       "Body_upload_banner_api_events__code__banner_post": {
         "properties": {
           "file": {
-            "contentMediaType": "application/octet-stream",
+            "format": "binary",
             "title": "File",
             "type": "string"
           }
@@ -2640,6 +2638,15 @@
             ],
             "title": "Monthly Token Cap"
           },
+          "scope": {
+            "default": "user",
+            "enum": [
+              "user",
+              "org"
+            ],
+            "title": "Scope",
+            "type": "string"
+          },
           "status": {
             "enum": [
               "active",
@@ -2655,8 +2662,15 @@
             "type": "string"
           },
           "user_id": {
-            "title": "User Id",
-            "type": "integer"
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
           }
         },
         "required": [
@@ -2672,6 +2686,7 @@
           "last_used_at",
           "model_hint",
           "monthly_token_cap",
+          "scope",
           "status",
           "updated_at",
           "user_id"
@@ -2969,6 +2984,50 @@
         "title": "DisplaySettingsUpdate",
         "type": "object"
       },
+      "DjLlmStatusOut": {
+        "properties": {
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/DjLlmStatusRow"
+            },
+            "title": "Rows",
+            "type": "array"
+          }
+        },
+        "required": [
+          "rows"
+        ],
+        "title": "DjLlmStatusOut",
+        "type": "object"
+      },
+      "DjLlmStatusRow": {
+        "properties": {
+          "effective_source": {
+            "enum": [
+              "own",
+              "org_fallback",
+              "none"
+            ],
+            "title": "Effective Source",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "integer"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "effective_source",
+          "user_id",
+          "username"
+        ],
+        "title": "DjLlmStatusRow",
+        "type": "object"
+      },
       "DjPolicyOut": {
         "description": "DJ-readable connector policy \u2014 the non-sensitive subset of the admin\npolicy surface.\n\nLets the settings/ai page fail *closed*: a normal DJ can learn which\nconnector types the admin has enabled (so disallowed providers are hidden\nin the picker) without exposing admin-only fields such as\n``llm_default_connector_id``.\n\n``allowed_connector_types`` is the pre-computed set of connector types a DJ\nmay create given the two toggles, so the frontend doesn't have to hard-code\nthe api-key-vs-compatible mapping.",
         "properties": {
@@ -2996,12 +3055,18 @@
           "llm_compatible_connector_enabled": {
             "title": "Llm Compatible Connector Enabled",
             "type": "boolean"
+          },
+          "org_fallback_available": {
+            "default": false,
+            "title": "Org Fallback Available",
+            "type": "boolean"
           }
         },
         "required": [
           "allowed_connector_types",
           "llm_apikey_connectors_enabled",
-          "llm_compatible_connector_enabled"
+          "llm_compatible_connector_enabled",
+          "org_fallback_available"
         ],
         "title": "DjPolicyOut",
         "type": "object"
@@ -7117,10 +7182,6 @@
             "title": "Llm Enabled",
             "type": "boolean"
           },
-          "llm_model": {
-            "title": "Llm Model",
-            "type": "string"
-          },
           "llm_rate_limit_per_minute": {
             "title": "Llm Rate Limit Per Minute",
             "type": "integer"
@@ -7147,7 +7208,6 @@
           "bridge_enabled",
           "human_verification_enforced",
           "llm_enabled",
-          "llm_model",
           "llm_rate_limit_per_minute",
           "registration_enabled",
           "search_rate_limit_per_minute",
@@ -7202,17 +7262,6 @@
               }
             ],
             "title": "Llm Enabled"
-          },
-          "llm_model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Llm Model"
           },
           "llm_rate_limit_per_minute": {
             "anyOf": [
@@ -8255,36 +8304,9 @@
   },
   "openapi": "3.1.0",
   "paths": {
-    "/api/admin/ai/models": {
-      "get": {
-        "description": "List available AI models.",
-        "operationId": "admin_get_ai_models_api_admin_ai_models_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIModelsResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "summary": "Admin Get Ai Models",
-        "tags": [
-          "admin"
-        ]
-      }
-    },
     "/api/admin/ai/settings": {
       "get": {
-        "description": "Get AI/LLM configuration.",
+        "description": "Get AI/LLM configuration.\n\n``llm_enabled`` gates only the org-connector fallback \u2014 DJs with their own\nconnector are never blocked by it. Credential status lives on the connector\nsurfaces (``/api/admin/llm/*``).",
         "operationId": "admin_get_ai_settings_api_admin_ai_settings_get",
         "responses": {
           "200": {
@@ -8309,7 +8331,7 @@
         ]
       },
       "put": {
-        "description": "Update AI/LLM configuration.",
+        "description": "Update AI/LLM configuration (org-fallback gate + public rate limit).",
         "operationId": "admin_update_ai_settings_api_admin_ai_settings_put",
         "requestBody": {
           "content": {
@@ -8821,7 +8843,7 @@
     },
     "/api/admin/llm/audit.csv": {
       "get": {
-        "description": "Export the (filtered) audit trail as CSV (admin-only).\n\nHonors the same filters as ``GET /audit``. Capped at\n``_AUDIT_CSV_ROW_CAP`` rows to avoid unbounded streaming. Columns:\ntimestamp, actor, event_type, target_connector, notes. Never includes\ncredential material.",
+        "description": "Export the (filtered) audit trail as CSV (admin-only).\n\nHonors the same filters as ``GET /audit``. Capped at\n``_AUDIT_CSV_ROW_CAP`` rows to avoid unbounded streaming. Columns:\ntimestamp, actor, actor_user_id, event_type, target_connector, notes.\n``actor_user_id`` is empty for system rows, so a DJ literally named\n\"system\" can never be confused with the NULL-actor system label. Never\nincludes credential material.",
         "operationId": "export_audit_events_csv_api_admin_llm_audit_csv_get",
         "parameters": [
           {
@@ -9055,6 +9077,259 @@
           }
         ],
         "summary": "Revoke Connector Admin",
+        "tags": [
+          "admin",
+          "llm"
+        ]
+      }
+    },
+    "/api/admin/llm/dj-status": {
+      "get": {
+        "description": "Effective LLM credential source per DJ.\n\nBackend-computed from the same rules the gateway resolver applies, so the\nadmin UI never duplicates resolution logic.",
+        "operationId": "dj_llm_status_api_admin_llm_dj_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DjLlmStatusOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Dj Llm Status",
+        "tags": [
+          "admin",
+          "llm"
+        ]
+      }
+    },
+    "/api/admin/llm/org-connectors": {
+      "get": {
+        "operationId": "list_org_connectors_admin_api_admin_llm_org_connectors_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ConnectorOut"
+                  },
+                  "title": "Response List Org Connectors Admin Api Admin Llm Org Connectors Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Org Connectors Admin",
+        "tags": [
+          "admin",
+          "llm"
+        ]
+      },
+      "post": {
+        "description": "Create the organization's house connector (admin-only).\n\nReuses the DJ-connector validation pipeline; the row is org-scoped with no\nowner. Credentials are encrypted at rest via EncryptedText. The DJ-facing\nconnector-type policy toggles are not applied \u2014 org connectors are an\nadmin decision.",
+        "operationId": "create_org_connector_api_admin_llm_org_connectors_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Create Org Connector",
+        "tags": [
+          "admin",
+          "llm"
+        ]
+      }
+    },
+    "/api/admin/llm/org-connectors/{connector_id}": {
+      "delete": {
+        "operationId": "delete_org_connector_api_admin_llm_org_connectors__connector_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connector_id",
+            "required": true,
+            "schema": {
+              "title": "Connector Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Org Connector",
+        "tags": [
+          "admin",
+          "llm"
+        ]
+      }
+    },
+    "/api/admin/llm/org-connectors/{connector_id}/credentials": {
+      "put": {
+        "operationId": "rotate_org_connector_credentials_api_admin_llm_org_connectors__connector_id__credentials_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connector_id",
+            "required": true,
+            "schema": {
+              "title": "Connector Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorCredentialsRotate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Rotate Org Connector Credentials",
+        "tags": [
+          "admin",
+          "llm"
+        ]
+      }
+    },
+    "/api/admin/llm/org-connectors/{connector_id}/test": {
+      "post": {
+        "description": "Run a health check against an org connector and return a sanitised result.\n\nMirrors the DJ-facing ``POST /api/llm/connectors/{id}/test`` \u2014 same shared\nhelper, same status columns and audit rows, same code \u2192 message mapping.",
+        "operationId": "test_org_connector_api_admin_llm_org_connectors__connector_id__test_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connector_id",
+            "required": true,
+            "schema": {
+              "title": "Connector Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorTestResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Test Org Connector",
         "tags": [
           "admin",
           "llm"

--- a/server/tests/test_admin.py
+++ b/server/tests/test_admin.py
@@ -313,8 +313,10 @@ class TestAdminLLMSettings:
         assert response.status_code == 200
         data = response.json()
         assert "llm_enabled" in data
-        assert "llm_model" in data
         assert "llm_rate_limit_per_minute" in data
+        # llm_model was removed with the legacy Anthropic env-var surface —
+        # model choice lives on the connector (model_hint) now.
+        assert "llm_model" not in data
 
     def test_update_llm_enabled(self, client: TestClient, admin_headers: dict):
         response = client.patch(
@@ -324,15 +326,6 @@ class TestAdminLLMSettings:
         )
         assert response.status_code == 200
         assert response.json()["llm_enabled"] is False
-
-    def test_update_llm_model(self, client: TestClient, admin_headers: dict):
-        response = client.patch(
-            "/api/admin/settings",
-            headers=admin_headers,
-            json={"llm_model": "claude-sonnet-4-5-20250929"},
-        )
-        assert response.status_code == 200
-        assert response.json()["llm_model"] == "claude-sonnet-4-5-20250929"
 
     def test_update_llm_rate_limit(self, client: TestClient, admin_headers: dict):
         response = client.patch(

--- a/server/tests/test_admin_ai.py
+++ b/server/tests/test_admin_ai.py
@@ -1,32 +1,12 @@
-"""Tests for admin AI settings endpoints."""
+"""Tests for admin AI settings endpoints.
 
-from unittest.mock import patch
+The legacy Anthropic env-var surface (api_key_configured / api_key_masked /
+llm_model and GET /api/admin/ai/models) was removed — credentials live in the
+LLM connector system (/api/admin/llm/*). These endpoints now expose only the
+org-fallback gate and the public rate limit.
+"""
 
 from fastapi.testclient import TestClient
-
-
-class TestAdminAIModels:
-    def test_returns_model_list(self, client: TestClient, admin_headers: dict):
-        response = client.get("/api/admin/ai/models", headers=admin_headers)
-        assert response.status_code == 200
-        data = response.json()
-        assert "models" in data
-        assert len(data["models"]) >= 1
-        assert "id" in data["models"][0]
-        assert "name" in data["models"][0]
-
-    def test_dj_gets_403(self, client: TestClient, auth_headers: dict):
-        response = client.get("/api/admin/ai/models", headers=auth_headers)
-        assert response.status_code == 403
-
-    def test_fallback_when_no_api_key(self, client: TestClient, admin_headers: dict):
-        """Returns fallback models when no API key configured."""
-        with patch("app.core.config.get_settings") as mock:
-            mock.return_value.anthropic_api_key = ""
-            response = client.get("/api/admin/ai/models", headers=admin_headers)
-            assert response.status_code == 200
-            data = response.json()
-            assert len(data["models"]) >= 1
 
 
 class TestAdminAISettings:
@@ -34,40 +14,28 @@ class TestAdminAISettings:
         response = client.get("/api/admin/ai/settings", headers=admin_headers)
         assert response.status_code == 200
         data = response.json()
-        assert "llm_enabled" in data
-        assert "llm_model" in data
-        assert "llm_rate_limit_per_minute" in data
-        assert "api_key_configured" in data
-        assert "api_key_masked" in data
-
-    def test_get_masks_api_key(self, client: TestClient, admin_headers: dict):
-        response = client.get("/api/admin/ai/settings", headers=admin_headers)
-        data = response.json()
-        # Key should be masked or "Not configured"
-        assert "api_key_masked" in data
-        key = data["api_key_masked"]
-        assert key == "Not configured" or key.startswith("...")
+        assert set(data) == {"llm_enabled", "llm_rate_limit_per_minute"}
 
     def test_put_updates_settings(self, client: TestClient, admin_headers: dict):
         response = client.put(
             "/api/admin/ai/settings",
             headers=admin_headers,
-            json={"llm_enabled": False, "llm_model": "claude-sonnet-4-5-20250929"},
+            json={"llm_enabled": False, "llm_rate_limit_per_minute": 10},
         )
         assert response.status_code == 200
         data = response.json()
         assert data["llm_enabled"] is False
-        assert data["llm_model"] == "claude-sonnet-4-5-20250929"
+        assert data["llm_rate_limit_per_minute"] == 10
 
     def test_dj_gets_403(self, client: TestClient, auth_headers: dict):
         response = client.get("/api/admin/ai/settings", headers=auth_headers)
         assert response.status_code == 403
 
-    def test_key_not_exposed_in_full(self, client: TestClient, admin_headers: dict):
-        """Full API key should never appear in the response."""
+    def test_no_credential_fields_exposed(self, client: TestClient, admin_headers: dict):
+        """Credential status lives on the connector surfaces, never here."""
         response = client.get("/api/admin/ai/settings", headers=admin_headers)
         data = response.json()
-        # The masked key should not contain the full key
-        assert "api_key_configured" in data
-        # No field should expose the raw key
         assert "anthropic_api_key" not in data
+        assert "api_key_configured" not in data
+        assert "api_key_masked" not in data
+        assert "llm_model" not in data

--- a/server/tests/test_api_contracts.py
+++ b/server/tests/test_api_contracts.py
@@ -150,7 +150,6 @@ SYSTEM_SETTINGS_KEYS = {
     "bridge_enabled",
     "human_verification_enforced",
     "llm_enabled",
-    "llm_model",
     "llm_rate_limit_per_minute",
 }
 

--- a/server/tests/test_llm_admin_audit.py
+++ b/server/tests/test_llm_admin_audit.py
@@ -247,10 +247,20 @@ class TestAuditCsvExport:
 
         reader = list(csv.reader(io.StringIO(resp.text)))
         header = reader[0]
-        assert header == ["timestamp", "actor", "event_type", "target_connector", "notes"]
+        assert header == [
+            "timestamp",
+            "actor",
+            "actor_user_id",
+            "event_type",
+            "target_connector",
+            "notes",
+        ]
         assert any("connector_created" in r for r in reader[1:])
         assert any("My OpenAI" in r for r in reader[1:])
-        assert any("testuser" in r for r in reader[1:])
+        # actor column carries the username, actor_user_id the numeric id —
+        # so a DJ literally named "system" can't shadow the NULL-actor label.
+        dj_rows = [r for r in reader[1:] if r[1] == "testuser"]
+        assert dj_rows and all(r[2] == str(test_user.id) for r in dj_rows)
 
     def test_csv_honors_event_type_filter(self, client: TestClient, admin_headers, db, test_user):
         conn = _make_connector(db, user_id=test_user.id, display_name="C")

--- a/server/tests/test_llm_api.py
+++ b/server/tests/test_llm_api.py
@@ -766,10 +766,13 @@ class TestAdminLlm:
         assert "testuser" in users
 
     def test_force_revoke_clears_default(self, client: TestClient, admin_headers, db, test_user):
+        # The system default must be org-scoped (user_id=NULL) — the policy
+        # endpoint rejects user-scoped rows.
         row = LlmConnector(
-            user_id=test_user.id,
+            user_id=None,
+            scope="org",
             connector_type="openai_apikey",
-            display_name="Mine",
+            display_name="House",
             status="active",
             credentials=json.dumps({"api_key": "sk-x"}),
         )

--- a/server/tests/test_llm_gateway.py
+++ b/server/tests/test_llm_gateway.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.models.llm_connector import LlmConnector
+from app.models.llm_connector import SCOPE_ORG, LlmConnector
 from app.models.system_settings import SystemSettings
 from app.models.user import User
 from app.services.auth import get_password_hash
@@ -55,20 +55,23 @@ def admin_user_actor(db) -> User:
 
 def _make_connector(
     db,
-    user: User,
+    user: User | None,
     *,
     connector_type: str = "openai_apikey",
     display_name: str = "Test connector",
     status: str = "active",
     model_hint: str = "gpt-5-mini",
+    scope: str = "user",
 ) -> LlmConnector:
+    """Insert a connector. Org-scoped rows (scope='org') take ``user=None``."""
     row = LlmConnector(
-        user_id=user.id,
+        user_id=user.id if user is not None else None,
         connector_type=connector_type,
         display_name=display_name,
         status=status,
         credentials=json.dumps({"api_key": "sk-fake-key"}),
         model_hint=model_hint,
+        scope=scope,
     )
     db.add(row)
     db.commit()
@@ -169,26 +172,12 @@ async def test_disabled_connector_skipped_in_resolution(db, dj_user, gateway_req
 
 
 @pytest.mark.asyncio
-async def test_falls_back_to_system_default(db, admin_user_actor, gateway_request):
-    # admin has no connector of their own — falls back to system default.
-    other_admin = User(
-        username="otheradmin",
-        password_hash=get_password_hash("password123"),
-        role="admin",
+async def test_falls_back_to_system_default(db, gateway_request):
+    # No actor (system context) — falls back to the org-scoped system default.
+    default_connector = _make_connector(
+        db, None, scope=SCOPE_ORG, display_name="default-org-connector"
     )
-    db.add(other_admin)
-    db.commit()
-    db.refresh(other_admin)
-    default_connector = _make_connector(db, other_admin, display_name="default-org-connector")
-
-    # Wire the system default
-    ss = db.query(SystemSettings).first()
-    if ss is None:
-        ss = SystemSettings(id=1, llm_default_connector_id=default_connector.id)
-        db.add(ss)
-    else:
-        ss.llm_default_connector_id = default_connector.id
-    db.commit()
+    _wire_system_default(db, default_connector)
 
     fake_response = ChatResponse(
         text="ok",
@@ -213,17 +202,13 @@ def _wire_system_default(db, connector: LlmConnector) -> None:
     db.commit()
 
 
-def _make_org_default(db, username: str) -> LlmConnector:
-    """Create an admin-owned org connector and wire it as the system default."""
-    owner = User(
-        username=username,
-        password_hash=get_password_hash("password123"),
-        role="admin",
-    )
-    db.add(owner)
-    db.commit()
-    db.refresh(owner)
-    connector = _make_connector(db, owner, display_name="org-default")
+def _make_org_default(db) -> LlmConnector:
+    """Create an org-scoped connector (user_id=NULL) wired as the system default.
+
+    Only ACTIVE scope='org' rows serve as the org fallback now — a user-scoped
+    row wired as the default never resolves (see TestOrgScopedResolution).
+    """
+    connector = _make_connector(db, None, scope=SCOPE_ORG, display_name="org-default")
     _wire_system_default(db, connector)
     return connector
 
@@ -235,7 +220,7 @@ async def test_fallback_org_default_on_rate_limit(db, dj_user):
 
     _make_connector(db, dj_user, display_name="dj-primary")
 
-    org_connector = _make_org_default(db, "orgowner")
+    org_connector = _make_org_default(db)
 
     fallback_response = ChatResponse(
         text="from-fallback",
@@ -274,7 +259,7 @@ async def test_fallback_none_surfaces_original_error(db, dj_user):
 
     _make_connector(db, dj_user, display_name="dj-primary")
 
-    _make_org_default(db, "orgowner2")
+    _make_org_default(db)
 
     chat_mock = AsyncMock(side_effect=RateLimited("slow", retry_after_seconds=5))
     with _patch_chat(chat_mock):
@@ -333,7 +318,7 @@ async def test_retry_then_org_default_retries_same_then_falls_back(db, dj_user):
     """retry_then_org_default: same connector retried once, then org default."""
     _make_connector(db, dj_user, display_name="dj-primary")
 
-    _make_org_default(db, "orgowner3")
+    _make_org_default(db)
 
     ok = ChatResponse(text="recovered", tool_calls=[], stop_reason="end_turn", usage=None)
     # attempt 1 (primary) 429, attempt 2 (primary retry) 429, attempt 3 (org default) ok
@@ -375,7 +360,7 @@ async def test_fallback_not_triggered_for_auth_invalid_when_policy_org_default(d
 
     dj_connector = _make_connector(db, dj_user, display_name="dj-primary")
 
-    org_connector = _make_org_default(db, "orgowner4")
+    org_connector = _make_org_default(db)
 
     ok = ChatResponse(text="recovered", tool_calls=[], stop_reason="end_turn", usage=None)
     chat_mock = AsyncMock(side_effect=[AuthInvalid("expired"), ok])
@@ -405,7 +390,7 @@ async def test_fallback_not_eligible_for_tool_translation_error(db, dj_user):
 
     _make_connector(db, dj_user, display_name="dj-primary")
 
-    _make_org_default(db, "orgowner5")
+    _make_org_default(db)
 
     chat_mock = AsyncMock(side_effect=ToolTranslationError("bad schema"))
     with _patch_chat(chat_mock):
@@ -424,7 +409,7 @@ async def test_fallback_failure_surfaces_fallback_error(db, dj_user):
     """If the fallback connector also fails, the fallback's error surfaces."""
     _make_connector(db, dj_user, display_name="dj-primary")
 
-    _make_org_default(db, "orgowner6")
+    _make_org_default(db)
 
     chat_mock = AsyncMock(
         side_effect=[RateLimited("primary-slow"), ProviderUnavailable("fallback-down")]
@@ -473,3 +458,138 @@ async def test_mru_resolution_picks_recent(db, dj_user, gateway_request):
     assert newer.last_used_at is not None
     # older.last_used_at was never set so should still be None
     assert older.last_used_at is None
+
+
+# ---------- org-scoped resolution + llm_enabled policy ----------
+
+
+def _set_llm_enabled(db, enabled: bool) -> None:
+    ss = db.query(SystemSettings).first()
+    if ss is None:
+        ss = SystemSettings(id=1)
+        db.add(ss)
+    ss.llm_enabled = enabled
+    db.commit()
+
+
+def _ok_response(text: str = "ok") -> ChatResponse:
+    return ChatResponse(text=text, tool_calls=[], stop_reason="end_turn", usage=None)
+
+
+class TestOrgScopedResolution:
+    """Scope-filtered resolution and the ``llm_enabled`` org-fallback policy.
+
+    ``llm_enabled`` now means exactly "org fallback allowed": a DJ's own
+    (user-scoped) connector always dispatches regardless of the toggle, while
+    connector-less DJs and system-context calls reach the org default only when
+    it is an ACTIVE scope='org' row AND the toggle is on.
+    """
+
+    # HEADLINE REGRESSION: a DJ's own connector is never blocked by llm_enabled.
+    @pytest.mark.asyncio
+    async def test_byo_dj_dispatch_works_with_llm_enabled_false(self, db, dj_user, gateway_request):
+        connector = _make_connector(db, dj_user)
+        _set_llm_enabled(db, False)
+
+        with _patch_chat(AsyncMock(return_value=_ok_response())):
+            resp = await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
+
+        assert resp.text == "ok"
+        db.refresh(connector)
+        assert connector.last_used_at is not None
+
+    @pytest.mark.asyncio
+    async def test_connectorless_dj_blocked_when_llm_enabled_false(
+        self, db, dj_user, gateway_request
+    ):
+        """llm_enabled=False blocks the org fallback for connector-less DJs."""
+        org = _make_connector(db, None, scope=SCOPE_ORG, display_name="org-row")
+        _wire_system_default(db, org)
+        _set_llm_enabled(db, False)
+
+        chat_mock = AsyncMock(return_value=_ok_response())
+        with _patch_chat(chat_mock):
+            with pytest.raises(NoLlmConfigured):
+                await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
+
+        chat_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_connectorless_dj_uses_org_fallback_when_enabled(
+        self, db, dj_user, gateway_request
+    ):
+        org = _make_connector(db, None, scope=SCOPE_ORG, display_name="org-row")
+        _wire_system_default(db, org)
+        _set_llm_enabled(db, True)
+
+        with _patch_chat(AsyncMock(return_value=_ok_response("from-org"))):
+            resp = await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
+
+        assert resp.text == "from-org"
+        db.refresh(org)
+        assert org.last_used_at is not None
+
+    @pytest.mark.asyncio
+    async def test_user_scoped_default_never_resolves_as_org_fallback(
+        self, db, dj_user, gateway_request
+    ):
+        """A user-scoped personal key wired as the system default must never
+        serve the org fallback — even with llm_enabled=True."""
+        from app.models.llm_connector import LlmAuditEvent
+
+        personal = _make_connector(db, dj_user, display_name="personal-key")  # scope='user'
+        _wire_system_default(db, personal)
+        _set_llm_enabled(db, True)
+
+        chat_mock = AsyncMock(return_value=_ok_response("leaked"))
+        with _patch_chat(chat_mock):
+            with pytest.raises(NoLlmConfigured):
+                await Gateway.dispatch(db, None, gateway_request, purpose="test")
+
+        chat_mock.assert_not_awaited()
+        # Resolution failed before any call — no audit row may reference the
+        # personal connector (the old code would have misattributed its owner).
+        assert (
+            db.query(LlmAuditEvent).filter(LlmAuditEvent.target_connector_id == personal.id).count()
+            == 0
+        )
+
+    @pytest.mark.asyncio
+    async def test_org_row_never_resolves_in_per_dj_chain(self, db, dj_user, gateway_request):
+        """The per-DJ chain (pin → pinned default → MRU) returns scope='user'
+        rows only: with the fallback blocked by llm_enabled=False, an active
+        org row must not leak in via MRU."""
+        org = _make_connector(db, None, scope=SCOPE_ORG, display_name="only-org")
+        _wire_system_default(db, org)
+        _set_llm_enabled(db, False)
+
+        chat_mock = AsyncMock(return_value=_ok_response())
+        with _patch_chat(chat_mock):
+            with pytest.raises(NoLlmConfigured):
+                await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
+
+        chat_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_system_context_audit_actor_is_null_on_auth_failure(self, db, gateway_request):
+        """System-context calls (actor=None) record a NULL audit actor — never
+        a user id misattributed from the connector's owner."""
+        from app.models.llm_connector import LlmAuditEvent
+
+        org = _make_connector(db, None, scope=SCOPE_ORG, display_name="org-row")
+        _wire_system_default(db, org)
+        _set_llm_enabled(db, True)
+
+        with _patch_chat(AsyncMock(side_effect=AuthInvalid("expired"))):
+            with pytest.raises(AuthInvalid):
+                await Gateway.dispatch(db, None, gateway_request, purpose="test")
+
+        audit = (
+            db.query(LlmAuditEvent)
+            .filter(LlmAuditEvent.target_connector_id == org.id)
+            .order_by(LlmAuditEvent.id.desc())
+            .first()
+        )
+        assert audit is not None
+        assert audit.event_type == "auth_invalid_observed"
+        assert audit.actor_user_id is None

--- a/server/tests/test_llm_gateway.py
+++ b/server/tests/test_llm_gateway.py
@@ -556,12 +556,18 @@ class TestOrgScopedResolution:
 
     @pytest.mark.asyncio
     async def test_org_row_never_resolves_in_per_dj_chain(self, db, dj_user, gateway_request):
-        """The per-DJ chain (pin → pinned default → MRU) returns scope='user'
-        rows only: with the fallback blocked by llm_enabled=False, an active
-        org row must not leak in via MRU."""
+        """A stale per-feature pin pointing at an ORG row must not resolve in
+        the per-DJ chain: the pin-validity branch requires scope='user', so the
+        pinned org connector is skipped, and with the org fallback blocked by
+        llm_enabled=False the dispatch raises NoLlmConfigured."""
+        from app.services.llm.connector_storage import set_feature_preference
+
         org = _make_connector(db, None, scope=SCOPE_ORG, display_name="only-org")
         _wire_system_default(db, org)
         _set_llm_enabled(db, False)
+        # Stale pin: the DJ's "test" feature points straight at the org row.
+        set_feature_preference(db, user_id=dj_user.id, feature="test", connector_id=org.id)
+        db.commit()
 
         chat_mock = AsyncMock(return_value=_ok_response())
         with _patch_chat(chat_mock):

--- a/server/tests/test_llm_hooks.py
+++ b/server/tests/test_llm_hooks.py
@@ -40,6 +40,26 @@ def _add_active_connector(db, user):
     return connector
 
 
+def _add_org_default_connector(db):
+    """Insert an active ORG-scoped connector and point the system default at it."""
+    from app.models.llm_connector import SCOPE_ORG, LlmConnector
+    from app.services.system_settings import update_system_settings
+
+    connector = LlmConnector(
+        user_id=None,
+        scope=SCOPE_ORG,
+        connector_type="anthropic_apikey",
+        display_name="House",
+        status="active",
+        credentials="{}",
+    )
+    db.add(connector)
+    db.commit()
+    db.refresh(connector)
+    update_system_settings(db, llm_default_connector_id=connector.id)
+    return connector
+
+
 class TestIsLLMAvailable:
     """``is_llm_available`` is connector-backed only.
 
@@ -55,15 +75,36 @@ class TestIsLLMAvailable:
 
         assert is_llm_available(actor=MagicMock()) is False
 
-    def test_returns_false_when_llm_disabled_in_settings(self, db: Session, test_user):
-        """When a connector exists but llm_enabled is False in DB, returns False."""
+    def test_available_for_byo_dj_even_when_llm_disabled(self, db: Session, test_user):
+        """HEADLINE REGRESSION (spec §2): a DJ's own connector is never blocked
+        by ``llm_enabled``.
+
+        Replaces the old-semantics test that asserted the inverse — per
+        docs/superpowers/specs/2026-06-09-admin-ai-policy-design.md the
+        ``llm_enabled`` toggle governs ONLY the org-fallback path, never BYO
+        credentials.
+        """
         from app.services.system_settings import update_system_settings
 
         _add_active_connector(db, test_user)
         update_system_settings(db, llm_enabled=False)
+        assert is_llm_available(db, actor=test_user) is True
+
+    def test_unavailable_for_connectorless_dj_when_llm_disabled(self, db: Session, test_user):
+        """Org default exists but llm_enabled=False -> connectorless DJ blocked."""
+        from app.services.system_settings import update_system_settings
+
+        _add_org_default_connector(db)
+        update_system_settings(db, llm_enabled=False)
         assert is_llm_available(db, actor=test_user) is False
-        # Reset
+
+    def test_available_via_org_fallback_when_enabled(self, db: Session, test_user):
+        """Org default exists and llm_enabled=True -> connectorless DJ available."""
+        from app.services.system_settings import update_system_settings
+
+        _add_org_default_connector(db)
         update_system_settings(db, llm_enabled=True)
+        assert is_llm_available(db, actor=test_user) is True
 
     def test_returns_true_when_llm_enabled_and_actor_connector(self, db: Session, test_user):
         """When the actor owns an active connector and llm_enabled is True, returns True."""

--- a/server/tests/test_llm_org_connector.py
+++ b/server/tests/test_llm_org_connector.py
@@ -359,12 +359,28 @@ def test_dj_status_reports_effective_source(client, admin_headers, db, test_user
     by_name = {r["username"]: r["effective_source"] for r in resp.json()["rows"]}
     assert by_name[test_user.username] == "org_fallback"
 
-    _mk_user_connector(db, test_user.id, name="Own S")
+    own = _mk_user_connector(db, test_user.id, name="Own S")
     by_name = {
         r["username"]: r["effective_source"]
         for r in client.get("/api/admin/llm/dj-status", headers=admin_headers).json()["rows"]
     }
     assert by_name[test_user.username] == "own"
+
+    # A non-active connector must not count as "own" — back to the org fallback.
+    own.status = "disabled"
+    db.commit()
+    by_name = {
+        r["username"]: r["effective_source"]
+        for r in client.get("/api/admin/llm/dj-status", headers=admin_headers).json()["rows"]
+    }
+    assert by_name[test_user.username] == "org_fallback"
+
+
+def test_dj_status_excludes_deactivated_users(client, admin_headers, db, test_user):
+    test_user.is_active = False
+    db.commit()
+    rows = client.get("/api/admin/llm/dj-status", headers=admin_headers).json()["rows"]
+    assert test_user.username not in {r["username"] for r in rows}
 
 
 def test_dj_status_none_when_fallback_disabled(client, admin_headers, db, test_user):

--- a/server/tests/test_llm_org_connector.py
+++ b/server/tests/test_llm_org_connector.py
@@ -14,6 +14,7 @@ from app.services.llm.connector_storage import (
     list_connectors_for_user,
     list_org_connectors,
 )
+from app.services.system_settings import get_system_settings
 
 
 def _payload(name: str = "Org Key") -> CreateConnectorPayload:
@@ -341,3 +342,56 @@ def test_ai_settings_no_longer_exposes_api_key_or_model(client, admin_headers):
 
 def test_ai_models_endpoint_removed(client, admin_headers):
     assert client.get("/api/admin/ai/models", headers=admin_headers).status_code == 404
+
+
+# ---------- per-DJ effective-source admin endpoint + DJ-visible fallback flag ----------
+
+
+def test_dj_status_reports_effective_source(client, admin_headers, db, test_user):
+    org = _mk_org_connector(db, name="House S")
+    settings = get_system_settings(db)
+    settings.llm_enabled = True
+    settings.llm_default_connector_id = org.id
+    db.commit()
+
+    resp = client.get("/api/admin/llm/dj-status", headers=admin_headers)
+    assert resp.status_code == 200
+    by_name = {r["username"]: r["effective_source"] for r in resp.json()["rows"]}
+    assert by_name[test_user.username] == "org_fallback"
+
+    _mk_user_connector(db, test_user.id, name="Own S")
+    by_name = {
+        r["username"]: r["effective_source"]
+        for r in client.get("/api/admin/llm/dj-status", headers=admin_headers).json()["rows"]
+    }
+    assert by_name[test_user.username] == "own"
+
+
+def test_dj_status_none_when_fallback_disabled(client, admin_headers, db, test_user):
+    org = _mk_org_connector(db, name="House S2")
+    settings = get_system_settings(db)
+    settings.llm_enabled = False
+    settings.llm_default_connector_id = org.id
+    db.commit()
+    rows = client.get("/api/admin/llm/dj-status", headers=admin_headers).json()["rows"]
+    by_name = {r["username"]: r["effective_source"] for r in rows}
+    assert by_name[test_user.username] == "none"
+
+
+def test_dj_status_requires_admin(client, auth_headers):
+    assert client.get("/api/admin/llm/dj-status", headers=auth_headers).status_code == 403
+
+
+def test_dj_policy_exposes_org_fallback_available(client, auth_headers, db):
+    resp = client.get("/api/llm/policy", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["org_fallback_available"] is False
+
+    org = _mk_org_connector(db, name="House P")
+    settings = get_system_settings(db)
+    settings.llm_enabled = True
+    settings.llm_default_connector_id = org.id
+    db.commit()
+    assert (
+        client.get("/api/llm/policy", headers=auth_headers).json()["org_fallback_available"] is True
+    )

--- a/server/tests/test_llm_org_connector.py
+++ b/server/tests/test_llm_org_connector.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import pytest
 from sqlalchemy import text
 
-from app.models.llm_connector import SCOPE_ORG, SCOPE_USER, STATUS_ACTIVE
+from app.models.llm_connector import SCOPE_ORG, SCOPE_USER, STATUS_ACTIVE, LlmConnector
 from app.services.llm.connector_storage import (
     CreateConnectorPayload,
+    audit_event,
     create_connector,
     get_user_label,
     list_connectors_for_user,
@@ -70,3 +71,108 @@ def test_create_org_connector_rejects_duplicate_label(db):
 
 def test_get_user_label_for_org_rows(db):
     assert get_user_label(db, None) == "Organization"
+
+
+# ---------- admin API surface: org-scope policy + NULL-actor handling ----------
+
+
+def _mk_user_connector(db, user_id, name="Personal"):
+    row = LlmConnector(
+        user_id=user_id,
+        connector_type="anthropic_apikey",
+        display_name=name,
+        status="active",
+        credentials="{}",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _mk_org_connector(db, name="House"):
+    row = LlmConnector(
+        user_id=None,
+        scope=SCOPE_ORG,
+        connector_type="anthropic_apikey",
+        display_name=name,
+        status="active",
+        credentials="{}",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def test_policy_rejects_user_scoped_default(client, admin_headers, db, test_user):
+    personal = _mk_user_connector(db, test_user.id)
+    resp = client.patch(
+        "/api/admin/llm/policy",
+        json={"llm_default_connector_id": personal.id},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 400
+    assert "org-scoped" in resp.json()["detail"]
+
+
+def test_policy_accepts_org_scoped_default(client, admin_headers, db):
+    org = _mk_org_connector(db)
+    resp = client.patch(
+        "/api/admin/llm/policy",
+        json={"llm_default_connector_id": org.id},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["llm_default_connector_id"] == org.id
+
+
+def test_admin_connector_list_labels_org_rows(client, admin_headers, db):
+    _mk_org_connector(db, name="House Key")
+    resp = client.get("/api/admin/llm/connectors", headers=admin_headers)
+    assert resp.status_code == 200
+    org_rows = [r for r in resp.json() if r["display_name"] == "House Key"]
+    assert org_rows and org_rows[0]["dj_username"] == "Organization"
+    assert org_rows[0]["user_id"] is None
+    assert org_rows[0]["scope"] == "org"
+
+
+def test_audit_browse_handles_null_actor(client, admin_headers, db):
+    org = _mk_org_connector(db)
+    audit_event(
+        db, actor_user_id=None, target_connector_id=org.id, event_type="auth_invalid_observed"
+    )
+    db.commit()
+    resp = client.get("/api/admin/llm/audit", headers=admin_headers)
+    assert resp.status_code == 200
+    rows = [r for r in resp.json()["rows"] if r["target_connector_id"] == org.id]
+    assert rows and rows[0]["actor_user_id"] is None
+    assert rows[0]["actor_username"] == "system"
+
+
+def test_audit_csv_handles_null_actor(client, admin_headers, db):
+    org = _mk_org_connector(db)
+    audit_event(
+        db, actor_user_id=None, target_connector_id=org.id, event_type="auth_invalid_observed"
+    )
+    db.commit()
+    resp = client.get("/api/admin/llm/audit.csv", headers=admin_headers)
+    assert resp.status_code == 200
+    assert "system" in resp.text
+    assert "user#None" not in resp.text
+
+
+def test_create_org_connector_allows_same_label_different_type(db):
+    # Carried review item: the duplicate guard must key on (type, label), not label alone.
+    create_connector(db, user_id=None, payload=_payload("House"), scope=SCOPE_ORG)
+    db.commit()
+    payload2 = CreateConnectorPayload(
+        connector_type="openai_apikey",
+        display_name="House",
+        credentials={"api_key": "sk-test-0000000000000000"},
+        base_url_plain=None,
+        model_hint=None,
+    )
+    row = create_connector(db, user_id=None, payload=payload2, scope=SCOPE_ORG)
+    db.commit()
+    assert row.id is not None

--- a/server/tests/test_llm_org_connector.py
+++ b/server/tests/test_llm_org_connector.py
@@ -47,6 +47,26 @@ def test_create_user_connector_defaults_to_user_scope(db, test_user):
     assert row.user_id == test_user.id
 
 
+def test_db_rejects_unknown_scope(db, test_user):
+    # ck_llm_connectors_scope_valid: scope is a closed set — an unknown value
+    # would silently escape every scope-filtered resolution path.
+    from sqlalchemy.exc import IntegrityError
+
+    db.add(
+        LlmConnector(
+            user_id=test_user.id,
+            scope="house",
+            connector_type="anthropic_apikey",
+            display_name="Bad Scope",
+            status="active",
+            credentials="{}",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db.commit()
+    db.rollback()
+
+
 def test_list_org_connectors_excludes_user_rows(db, test_user):
     create_connector(db, user_id=test_user.id, payload=_payload("Mine"))
     org = create_connector(db, user_id=None, payload=_payload("House"), scope=SCOPE_ORG)

--- a/server/tests/test_llm_org_connector.py
+++ b/server/tests/test_llm_org_connector.py
@@ -151,6 +151,9 @@ def test_audit_browse_handles_null_actor(client, admin_headers, db):
 
 
 def test_audit_csv_handles_null_actor(client, admin_headers, db):
+    import csv
+    import io
+
     org = _mk_org_connector(db)
     audit_event(
         db, actor_user_id=None, target_connector_id=org.id, event_type="auth_invalid_observed"
@@ -158,7 +161,20 @@ def test_audit_csv_handles_null_actor(client, admin_headers, db):
     db.commit()
     resp = client.get("/api/admin/llm/audit.csv", headers=admin_headers)
     assert resp.status_code == 200
-    assert "system" in resp.text
+    rows = list(csv.reader(io.StringIO(resp.text)))
+    assert rows[0] == [
+        "timestamp",
+        "actor",
+        "actor_user_id",
+        "event_type",
+        "target_connector",
+        "notes",
+    ]
+    system_rows = [r for r in rows[1:] if r[1] == "system"]
+    assert system_rows, resp.text
+    # NULL-actor system rows carry an empty actor_user_id cell, so a DJ
+    # literally named "system" (who would have a numeric id) can't be confused.
+    assert all(r[2] == "" for r in system_rows)
     assert "user#None" not in resp.text
 
 
@@ -176,3 +192,152 @@ def test_create_org_connector_allows_same_label_different_type(db):
     row = create_connector(db, user_id=None, payload=payload2, scope=SCOPE_ORG)
     db.commit()
     assert row.id is not None
+
+
+# ---------- admin API surface: org connector CRUD ----------
+
+# Known-valid anthropic_apikey body (mirrors tests/test_llm_api.py fixtures —
+# Anthropic keys must start "sk-ant-" and clear the minimum length check).
+_ORG_CREATE_BODY = {
+    "connector_type": "anthropic_apikey",
+    "display_name": "House Claude",
+    "api_key": "sk-ant-1234567890abcdef1234567890abcdef1234567890",
+    "model_hint": "claude-haiku-4-5-20251001",
+}
+
+
+def test_org_crud_requires_admin(client, auth_headers):
+    assert client.get("/api/admin/llm/org-connectors", headers=auth_headers).status_code == 403
+
+
+def test_org_connector_create_list_delete(client, admin_headers):
+    create = client.post(
+        "/api/admin/llm/org-connectors",
+        json=_ORG_CREATE_BODY,
+        headers=admin_headers,
+    )
+    assert create.status_code == 201, create.text
+    body = create.json()
+    assert body["user_id"] is None
+    assert body["scope"] == "org"
+    # Credentials never returned
+    assert "credentials" not in body
+    assert "api_key" not in body
+    cid = body["id"]
+
+    listed = client.get("/api/admin/llm/org-connectors", headers=admin_headers)
+    assert [r["id"] for r in listed.json()] == [cid]
+
+    deleted = client.delete(f"/api/admin/llm/org-connectors/{cid}", headers=admin_headers)
+    assert deleted.status_code == 204
+    assert client.get("/api/admin/llm/org-connectors", headers=admin_headers).json() == []
+
+
+def test_org_connector_create_rejects_bad_key_format(client, admin_headers):
+    resp = client.post(
+        "/api/admin/llm/org-connectors",
+        json={**_ORG_CREATE_BODY, "api_key": "not-a-valid-key"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_org_connector_create_rejects_duplicate_label(client, admin_headers):
+    first = client.post(
+        "/api/admin/llm/org-connectors", json=_ORG_CREATE_BODY, headers=admin_headers
+    )
+    assert first.status_code == 201, first.text
+    dup = client.post("/api/admin/llm/org-connectors", json=_ORG_CREATE_BODY, headers=admin_headers)
+    assert dup.status_code == 400
+    assert "already exists" in dup.json()["detail"]
+
+
+def test_org_connector_delete_clears_default(client, admin_headers, db):
+    org = _mk_org_connector(db, name="House D")
+    client.patch(
+        "/api/admin/llm/policy",
+        json={"llm_default_connector_id": org.id},
+        headers=admin_headers,
+    )
+    client.delete(f"/api/admin/llm/org-connectors/{org.id}", headers=admin_headers)
+    policy = client.get("/api/admin/llm/policy", headers=admin_headers).json()
+    assert policy["llm_default_connector_id"] is None
+
+
+def test_org_connector_rotate(client, admin_headers, db):
+    org = _mk_org_connector(db, name="House R")
+    resp = client.put(
+        f"/api/admin/llm/org-connectors/{org.id}/credentials",
+        json={"api_key": "sk-ant-rotated7890abcdef1234567890abcdef1234567890"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["scope"] == "org"
+    assert "credentials" not in body
+    # Audit row written for the rotation
+    rows = db.execute(
+        text("SELECT event_type FROM llm_audit_event WHERE target_connector_id = :i"),
+        {"i": org.id},
+    ).all()
+    assert ("connector_credentials_rotated",) in rows
+
+
+def test_org_connector_rotate_invalid_key_returns_400(client, admin_headers, db):
+    org = _mk_org_connector(db, name="House RB")
+    resp = client.put(
+        f"/api/admin/llm/org-connectors/{org.id}/credentials",
+        json={"api_key": "bad"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_org_connector_test_endpoint(client, admin_headers, db):
+    from unittest.mock import AsyncMock, patch
+
+    org = _mk_org_connector(db, name="House T")
+    with patch(
+        "app.services.llm.adapters.anthropic_apikey.AnthropicApiKeyAdapter.health_check",
+        new=AsyncMock(return_value=None),
+    ):
+        resp = client.post(f"/api/admin/llm/org-connectors/{org.id}/test", headers=admin_headers)
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+
+def test_org_endpoints_404_for_user_scoped_rows(client, admin_headers, db, test_user):
+    personal = _mk_user_connector(db, test_user.id)
+    assert (
+        client.delete(
+            f"/api/admin/llm/org-connectors/{personal.id}", headers=admin_headers
+        ).status_code
+        == 404
+    )
+    assert (
+        client.put(
+            f"/api/admin/llm/org-connectors/{personal.id}/credentials",
+            json={"api_key": "sk-ant-rotated7890abcdef1234567890abcdef1234567890"},
+            headers=admin_headers,
+        ).status_code
+        == 404
+    )
+    assert (
+        client.post(
+            f"/api/admin/llm/org-connectors/{personal.id}/test", headers=admin_headers
+        ).status_code
+        == 404
+    )
+
+
+# ---------- legacy Anthropic env-var surface removal ----------
+
+
+def test_ai_settings_no_longer_exposes_api_key_or_model(client, admin_headers):
+    resp = client.get("/api/admin/ai/settings", headers=admin_headers)
+    assert resp.status_code == 200
+    assert set(resp.json()) == {"llm_enabled", "llm_rate_limit_per_minute"}
+
+
+def test_ai_models_endpoint_removed(client, admin_headers):
+    assert client.get("/api/admin/ai/models", headers=admin_headers).status_code == 404

--- a/server/tests/test_llm_org_connector.py
+++ b/server/tests/test_llm_org_connector.py
@@ -1,0 +1,72 @@
+"""Org-scoped connector storage + resolution tests (org-llm-connector spec)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from app.models.llm_connector import SCOPE_ORG, SCOPE_USER, STATUS_ACTIVE
+from app.services.llm.connector_storage import (
+    CreateConnectorPayload,
+    create_connector,
+    get_user_label,
+    list_connectors_for_user,
+    list_org_connectors,
+)
+
+
+def _payload(name: str = "Org Key") -> CreateConnectorPayload:
+    return CreateConnectorPayload(
+        connector_type="anthropic_apikey",
+        display_name=name,
+        credentials={"api_key": "sk-ant-test-0000000000000000"},
+        base_url_plain=None,
+        model_hint=None,
+    )
+
+
+def test_create_org_connector_has_null_user_and_org_scope(db):
+    row = create_connector(db, user_id=None, payload=_payload(), scope=SCOPE_ORG)
+    db.commit()
+    assert row.user_id is None
+    assert row.scope == SCOPE_ORG
+    assert row.status == STATUS_ACTIVE
+    # Credentials encrypted at rest: raw column value must not contain the key.
+    raw = db.execute(
+        text("SELECT credentials FROM llm_connectors WHERE id = :i"), {"i": row.id}
+    ).scalar()
+    assert "sk-ant-test" not in (raw or "")
+
+
+def test_create_user_connector_defaults_to_user_scope(db, test_user):
+    row = create_connector(db, user_id=test_user.id, payload=_payload("Mine"))
+    db.commit()
+    assert row.scope == SCOPE_USER
+    assert row.user_id == test_user.id
+
+
+def test_list_org_connectors_excludes_user_rows(db, test_user):
+    create_connector(db, user_id=test_user.id, payload=_payload("Mine"))
+    org = create_connector(db, user_id=None, payload=_payload("House"), scope=SCOPE_ORG)
+    db.commit()
+    rows = list_org_connectors(db)
+    assert [r.id for r in rows] == [org.id]
+
+
+def test_list_connectors_for_user_excludes_org_rows(db, test_user):
+    mine = create_connector(db, user_id=test_user.id, payload=_payload("Mine"))
+    create_connector(db, user_id=None, payload=_payload("House"), scope=SCOPE_ORG)
+    db.commit()
+    rows = list_connectors_for_user(db, test_user.id)
+    assert [r.id for r in rows] == [mine.id]
+
+
+def test_create_org_connector_rejects_duplicate_label(db):
+    create_connector(db, user_id=None, payload=_payload("House"), scope=SCOPE_ORG)
+    db.commit()
+    with pytest.raises(ValueError, match="already exists"):
+        create_connector(db, user_id=None, payload=_payload("House"), scope=SCOPE_ORG)
+
+
+def test_get_user_label_for_org_rows(db):
+    assert get_user_label(db, None) == "Organization"


### PR DESCRIPTION
## Summary

Implements the approved design in `docs/superpowers/specs/2026-06-09-admin-ai-policy-design.md` (testing-feedback items 3+4: legacy env-var AI panel + org-default billing ambiguity).

- **Dedicated org connector**: `llm_connectors.scope` ('user'/'org'), nullable `user_id` with CHECK (org ⇔ NULL owner). The house credential belongs to the organization, never a DJ account.
- **`llm_enabled` rescoped**: it now gates ONLY the org-connector fallback. DJs with their own connector are never blocked by it (headline regression pinned in tests).
- **Legacy Anthropic env-var surface removed**: API Key Status panel, `GET /api/admin/ai/models`, `llm_model` setting, `anthropic_api_key` config, `ANTHROPIC_MODEL` response-label fallback. `anthropic_model` stays in config solely for applied migration 047.
- **Migration 056**: converts the 047-seeded env-var default to org scope **in place** (zero admin action); clears defaults pointing at a DJ's personal connector. Downgrade preserves the org credential (reattached to the first admin) and purges NULL-actor audit rows.
- **Admin API**: org connector CRUD (`/api/admin/llm/org-connectors` — list/create/test/rotate/delete), policy validation rejecting non-org defaults, per-DJ effective-source endpoint (`/dj-status`), NULL-actor audit rows render as "system" (CSV gains an `actor_user_id` column).
- **Admin UI** (`/admin/ai`): Organization connector section (create/test/delete, house-billed copy), recopied fallback toggle, org-only default dropdown, per-DJ "DJ access" badges (Own connector / Org fallback / None — AI unavailable), usage rows labeled "Organization".
- **DJ UI** (`/account`): connector-less DJs see "using the organization's connector — billed to the organization" or "AI features unavailable" (fail-closed; copy honors the connector-creation policy).

## Spec deviations (sanctioned during implementation)

- Rotate is `PUT /org-connectors/{id}/credentials` (mirrors the DJ rotation endpoint) rather than `POST /{id}/rotate`.
- §5 DJ visibility lives in `AiProvidersSection` on `/account` — the spec's `/settings/ai` page doesn't exist.

## Deploy notes

- Deployments whose org default is the 047-seeded env-var connector: **no action** — migration converts it in place.
- Deployments whose default was a DJ's personal key: it is **cleared**; an admin must create an Organization connector on `/admin/ai` after deploy.
- Local testing instance picks up migration 056 on its next deploy.

## Test plan

- [x] Headline regression: BYO DJ dispatch + availability with `llm_enabled=False`
- [x] Behavior matrix (own/org-fallback/none × toggle on/off × actor/system) pinned in `test_llm_gateway.py::TestOrgScopedResolution`, `test_llm_hooks.py`, `test_llm_org_connector.py` (29 tests)
- [x] Org CRUD: admin-only, encrypted at rest (raw-column assertion), audit rows, 404-for-user-scoped, delete clears default
- [x] Migration: `alembic upgrade head && alembic check` clean on scratch Postgres 16 + downgrade round-trip with seeded data (both backfill branches)
- [x] Full local CI: backend ruff/format/bandit/pytest **2705 passed @ 88.26%**; frontend lint/tsc(0)/vitest **1106 passed**
- [ ] Manual: create org connector on `/admin/ai`, verify dj-status badges + DJ banners on `/account`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization-level LLM connector management (create, test, rotate, delete)
  * Per-DJ effective credential source indicators and a DJ access list
  * Organization-fallback banner for DJs without personal connectors

* **Improvements**
  * Admin AI settings simplified to enablement + rate limits
  * Removed legacy API-key/status panel; org-default options sourced from org connectors
  * Updated help text clarifying org-fallback behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->