### PR TITLE
feat(setbuilder): TrackVibe LLM enrichment + community vibe display (read) (#391)

### DIFF
--- a/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
@@ -7,11 +7,16 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { api } from '@/lib/api';
-import type { PoolImportResult, PoolSource, PoolState } from '@/lib/api-types';
+import { api, ApiError } from '@/lib/api';
+import type { PoolImportResult, PoolSource, PoolState, TrackVibeState } from '@/lib/api-types';
 import styles from '../setbuilder.module.css';
 import ImportModal, { type ImportKind } from './ImportModal';
 import { BpmBadge, CamelotBadge, EnergyMini, SourceIcon, sourceColor } from './PoolBadges';
+import VibeTiers from './VibeTiers';
+
+function buildVibeMap(tracks: TrackVibeState[]): Map<number, TrackVibeState> {
+  return new Map(tracks.map((v) => [v.pool_track_id, v]));
+}
 
 const TYPE_TABS: { id: string; label: string }[] = [
   { id: 'all', label: 'All' },
@@ -50,6 +55,10 @@ export default function PoolPanel({ setId }: { setId: number }) {
   const [importKind, setImportKind] = useState<ImportKind | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [toast, setToast] = useState<string | null>(null);
+  const [vibes, setVibes] = useState<Map<number, TrackVibeState>>(new Map());
+  const [showVibes, setShowVibes] = useState(false);
+  const [vibesLoaded, setVibesLoaded] = useState(false);
+  const [vibesBusy, setVibesBusy] = useState(false);
 
   useEffect(() => {
     api
@@ -148,6 +157,30 @@ export default function PoolPanel({ setId }: { setId: number }) {
     [setId, activeSourceId]
   );
 
+  const toggleVibes = useCallback(() => {
+    if (!showVibes && !vibesLoaded) {
+      setVibesLoaded(true);
+      api
+        .getPoolVibes(setId)
+        .then((result) => setVibes(buildVibeMap(result.tracks)))
+        .catch(() => setToast('Failed to load vibes'));
+    }
+    setShowVibes((s) => !s);
+  }, [showVibes, vibesLoaded, setId]);
+
+  const analyzeVibes = useCallback(async () => {
+    setVibesBusy(true);
+    try {
+      const result = await api.enrichPoolVibes(setId);
+      setVibes(buildVibeMap(result.vibes.tracks));
+      setToast(`${result.enriched} analyzed · ${result.cached} cached · ${result.failed} failed`);
+    } catch (err) {
+      setToast(err instanceof ApiError && err.status === 400 ? err.message : 'Vibe analysis failed');
+    } finally {
+      setVibesBusy(false);
+    }
+  }, [setId]);
+
   const toggleSelect = (id: number) => {
     setSelected((prev) => {
       const next = new Set(prev);
@@ -165,6 +198,24 @@ export default function PoolPanel({ setId }: { setId: number }) {
           Pool <span className={styles.poolCount}>{pool.tracks.length}</span>
         </span>
         <span style={{ flex: 1 }} />
+        {showVibes && (
+          <button
+            className="btn btn-sm"
+            onClick={analyzeVibes}
+            disabled={vibesBusy}
+            title="Analyze uncached pool tracks with AI"
+          >
+            {vibesBusy ? 'Analyzing…' : 'Analyze'}
+          </button>
+        )}
+        <button
+          className="btn btn-sm"
+          onClick={toggleVibes}
+          aria-pressed={showVibes}
+          title="Show three-tier vibe state per track"
+        >
+          Vibes
+        </button>
         <span style={{ position: 'relative' }} onMouseDown={(e) => e.stopPropagation()}>
           <button
             className="btn btn-sm"
@@ -306,6 +357,7 @@ export default function PoolPanel({ setId }: { setId: number }) {
         {filtered.map((t) => {
           const source = sourceById.get(t.source_id);
           const isSelected = selected.has(t.id);
+          const vibe = showVibes ? vibes.get(t.id) : undefined;
           return (
             <div
               key={t.id}
@@ -345,6 +397,7 @@ export default function PoolPanel({ setId }: { setId: number }) {
                     </span>
                   )}
                 </div>
+                {vibe && <VibeTiers state={vibe} />}
               </div>
               <div
                 className={styles.poolTrackStripe}

--- a/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
@@ -161,19 +161,22 @@ export default function PoolPanel({ setId }: { setId: number }) {
   );
 
   const toggleVibes = useCallback(() => {
-    if (!showVibes && !vibesLoaded) {
-      setVibesLoaded(true);
+    if (!showVibes && !vibesLoaded && !vibesBusy) {
       // vibesBusy also disables Analyze while this first fetch is in flight,
       // so an Analyze response can't be overwritten by a stale initial GET.
+      // vibesLoaded is only set on success so a failed fetch can be retried.
       setVibesBusy(true);
       api
         .getPoolVibes(setId)
-        .then((result) => setVibes(buildVibeMap(result.tracks)))
+        .then((result) => {
+          setVibes(buildVibeMap(result.tracks));
+          setVibesLoaded(true);
+        })
         .catch(() => setToast('Failed to load vibes'))
         .finally(() => setVibesBusy(false));
     }
     setShowVibes((s) => !s);
-  }, [showVibes, vibesLoaded, setId]);
+  }, [showVibes, vibesLoaded, vibesBusy, setId]);
 
   const analyzeVibes = useCallback(async () => {
     setVibesBusy(true);

--- a/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
@@ -61,6 +61,9 @@ export default function PoolPanel({ setId }: { setId: number }) {
   const [vibesBusy, setVibesBusy] = useState(false);
 
   useEffect(() => {
+    setVibes(new Map());
+    setShowVibes(false);
+    setVibesLoaded(false);
     api
       .getPool(setId)
       .then(setPool)
@@ -160,10 +163,14 @@ export default function PoolPanel({ setId }: { setId: number }) {
   const toggleVibes = useCallback(() => {
     if (!showVibes && !vibesLoaded) {
       setVibesLoaded(true);
+      // vibesBusy also disables Analyze while this first fetch is in flight,
+      // so an Analyze response can't be overwritten by a stale initial GET.
+      setVibesBusy(true);
       api
         .getPoolVibes(setId)
         .then((result) => setVibes(buildVibeMap(result.tracks)))
-        .catch(() => setToast('Failed to load vibes'));
+        .catch(() => setToast('Failed to load vibes'))
+        .finally(() => setVibesBusy(false));
     }
     setShowVibes((s) => !s);
   }, [showVibes, vibesLoaded, setId]);

--- a/dashboard/app/(dj)/setbuilder/components/VibeTiers.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/VibeTiers.tsx
@@ -71,17 +71,19 @@ function chipAria(tier: TierView): string {
 }
 
 export default function VibeTiers({ state }: { state: TrackVibeState }) {
-  const winner: TierSource | null = state.resolved.energy_source ?? state.resolved.mood_source;
-
   return (
     <div className={styles.vibeTiers}>
       {buildTiers(state).map((tier) => {
         const empty = tier.energy == null && tier.mood == null;
+        // Per-field winner: a tier wins if it supplies the resolved energy OR mood.
+        const winner =
+          state.resolved.energy_source === tier.source ||
+          state.resolved.mood_source === tier.source;
         const classes = [
           styles.vibeChip,
           empty ? styles.vibeEmpty : '',
           tier.warn ? styles.vibeLow : '',
-          !empty && winner === tier.source ? styles.vibeWinner : '',
+          !empty && winner ? styles.vibeWinner : '',
         ]
           .filter(Boolean)
           .join(' ');

--- a/dashboard/app/(dj)/setbuilder/components/VibeTiers.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/VibeTiers.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+/**
+ * Three-tier vibe display (issue #391) — DJ's own override, community
+ * consensus, and globally-cached LLM guess, side by side. Read-only in v1
+ * (write UX is v1.1). Low-confidence LLM guesses are flagged for review.
+ */
+
+import type { TrackVibeState } from '@/lib/api-types';
+import styles from '../setbuilder.module.css';
+
+type TierSource = 'own' | 'community' | 'llm';
+
+interface TierView {
+  source: TierSource;
+  label: string;
+  ariaName: string;
+  energy: number | null;
+  mood: string | null;
+  suffix: string | null;
+  title: string | undefined;
+  warn: boolean;
+}
+
+function buildTiers(state: TrackVibeState): TierView[] {
+  return [
+    {
+      source: 'own',
+      label: 'You',
+      ariaName: 'Your vibe',
+      energy: state.own?.energy ?? null,
+      mood: state.own?.mood ?? null,
+      suffix: null,
+      title: undefined,
+      warn: false,
+    },
+    {
+      source: 'community',
+      label: 'Crowd',
+      ariaName: 'Community vibe',
+      energy: state.community?.energy ?? null,
+      mood: state.community?.mood ?? null,
+      suffix: state.community ? `·${state.community.sample_size}` : null,
+      title: state.community
+        ? `Community consensus from ${state.community.sample_size} DJs`
+        : undefined,
+      warn: false,
+    },
+    {
+      source: 'llm',
+      label: 'AI',
+      ariaName: 'AI vibe',
+      energy: state.llm?.energy ?? null,
+      mood: state.llm?.mood ?? null,
+      suffix: null,
+      title: state.llm
+        ? state.llm.low_confidence
+          ? 'Low confidence — review'
+          : `AI guess (${state.llm.llm_provider} · ${state.llm.llm_model})`
+        : undefined,
+      warn: state.llm?.low_confidence ?? false,
+    },
+  ];
+}
+
+function chipAria(tier: TierView): string {
+  const parts: string[] = [];
+  if (tier.energy != null) parts.push(`energy ${tier.energy}`);
+  if (tier.mood != null) parts.push(`mood ${tier.mood}`);
+  return `${tier.ariaName}: ${parts.length ? parts.join(', ') : 'not set'}`;
+}
+
+export default function VibeTiers({ state }: { state: TrackVibeState }) {
+  const winner: TierSource | null = state.resolved.energy_source ?? state.resolved.mood_source;
+
+  return (
+    <div className={styles.vibeTiers}>
+      {buildTiers(state).map((tier) => {
+        const empty = tier.energy == null && tier.mood == null;
+        const classes = [
+          styles.vibeChip,
+          empty ? styles.vibeEmpty : '',
+          tier.warn ? styles.vibeLow : '',
+          !empty && winner === tier.source ? styles.vibeWinner : '',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return (
+          <span key={tier.source} className={classes} title={tier.title} aria-label={chipAria(tier)}>
+            {tier.warn && <span aria-hidden>⚠</span>}
+            <span className={styles.vibeChipLabel}>{tier.label}</span>
+            {empty ? (
+              <span>—</span>
+            ) : (
+              <>
+                {tier.energy != null && <span>E{tier.energy}</span>}
+                {tier.mood != null && <span>{tier.mood}</span>}
+                {tier.suffix && <span>{tier.suffix}</span>}
+              </>
+            )}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
@@ -251,6 +251,24 @@ describe('PoolPanel', () => {
     expect(mockApi.getPoolVibes).toHaveBeenCalledTimes(1);
   });
 
+  it('failed initial vibes fetch can be retried on next toggle-on', async () => {
+    mockApi.getPoolVibes.mockRejectedValueOnce(new Error('boom'));
+    mockApi.getPoolVibes.mockResolvedValueOnce(POOL_VIBES);
+    render(<PoolPanel setId={1} />);
+    await screen.findByText('Event Song');
+
+    // first toggle-on: fetch fails, toast shown, no chips
+    fireEvent.click(screen.getByText('Vibes'));
+    expect(await screen.findByText('Failed to load vibes')).toBeTruthy();
+    expect(screen.queryByLabelText('Your vibe: energy 9')).toBeNull();
+
+    // toggle off, then on again: fetch retries and succeeds
+    fireEvent.click(screen.getByText('Vibes'));
+    fireEvent.click(screen.getByText('Vibes'));
+    expect(await screen.findByLabelText('Your vibe: energy 9')).toBeTruthy();
+    expect(mockApi.getPoolVibes).toHaveBeenCalledTimes(2);
+  });
+
   it('Analyze is gated behind Vibes, enriches, updates chips, and toasts counts', async () => {
     mockApi.getPoolVibes.mockResolvedValue(POOL_VIBES);
     mockApi.enrichPoolVibes.mockResolvedValue(ENRICH_RESULT);

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
@@ -5,7 +5,13 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import type { PoolState } from '@/lib/api-types';
+import { ApiError } from '@/lib/api';
+import type {
+  PoolState,
+  PoolVibesState,
+  TrackVibeState,
+  VibeEnrichmentResult,
+} from '@/lib/api-types';
 import PoolPanel from '../PoolPanel';
 
 const mockApi = vi.hoisted(() => ({
@@ -83,6 +89,44 @@ const TRACKS = [
 ];
 
 const POOL: PoolState = { sources: SOURCES, tracks: TRACKS };
+
+// --- Vibe fixtures (issue #391) ---
+
+const VIBE_STATE: TrackVibeState = {
+  pool_track_id: 11,
+  vibe_key: 'event artist|event song',
+  own: { energy: 9, mood: null },
+  community: null,
+  llm: null,
+  resolved: { energy: 9, energy_source: 'own', mood: null, mood_source: null },
+};
+
+const POOL_VIBES: PoolVibesState = { tracks: [VIBE_STATE] };
+
+const ENRICHED_VIBE_STATE: TrackVibeState = {
+  ...VIBE_STATE,
+  llm: {
+    energy: 5,
+    mood: 'happy',
+    confidence: 0.92,
+    low_confidence: false,
+    llm_provider: 'anthropic_apikey',
+    llm_model: 'claude-haiku-4-5',
+    dance_floor: null,
+    era: null,
+    sing_along: null,
+    transitional_role: null,
+  },
+  resolved: { energy: 9, energy_source: 'own', mood: 'happy', mood_source: 'llm' },
+};
+
+const ENRICH_RESULT: VibeEnrichmentResult = {
+  enriched: 2,
+  cached: 0,
+  failed: 0,
+  llm_calls: 2,
+  vibes: { tracks: [ENRICHED_VIBE_STATE] },
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -182,5 +226,67 @@ describe('PoolPanel', () => {
     expect(screen.getByText(/Remove all from “Prom Night”/)).toBeTruthy();
     fireEvent.click(screen.getByText('Remove this track'));
     await waitFor(() => expect(mockApi.removePoolTracks).toHaveBeenCalledWith(1, [11]));
+  });
+
+  it('Vibes toggle fetches once, renders chips on rows, hides on toggle-off', async () => {
+    mockApi.getPoolVibes.mockResolvedValue(POOL_VIBES);
+    render(<PoolPanel setId={1} />);
+    await screen.findByText('Event Song');
+
+    fireEvent.click(screen.getByText('Vibes'));
+    // chips render on the track row once the fetch resolves
+    expect(await screen.findByLabelText('Your vibe: energy 9')).toBeTruthy();
+    expect(screen.getByLabelText('Community vibe: not set')).toBeTruthy();
+    expect(screen.getByLabelText('AI vibe: not set')).toBeTruthy();
+    expect(mockApi.getPoolVibes).toHaveBeenCalledTimes(1);
+    expect(mockApi.getPoolVibes).toHaveBeenCalledWith(1);
+
+    // toggle off hides the chips
+    fireEvent.click(screen.getByText('Vibes'));
+    expect(screen.queryByLabelText('Your vibe: energy 9')).toBeNull();
+
+    // toggle back on does NOT refetch
+    fireEvent.click(screen.getByText('Vibes'));
+    expect(await screen.findByLabelText('Your vibe: energy 9')).toBeTruthy();
+    expect(mockApi.getPoolVibes).toHaveBeenCalledTimes(1);
+  });
+
+  it('Analyze is gated behind Vibes, enriches, updates chips, and toasts counts', async () => {
+    mockApi.getPoolVibes.mockResolvedValue(POOL_VIBES);
+    mockApi.enrichPoolVibes.mockResolvedValue(ENRICH_RESULT);
+    render(<PoolPanel setId={1} />);
+    await screen.findByText('Event Song');
+
+    // Analyze hidden until vibes are shown
+    expect(screen.queryByText('Analyze')).toBeNull();
+
+    fireEvent.click(screen.getByText('Vibes'));
+    // button reads "Analyzing…" while the initial vibe fetch is busy,
+    // then settles to "Analyze" once it resolves
+    fireEvent.click(await screen.findByText('Analyze'));
+    await waitFor(() => expect(mockApi.enrichPoolVibes).toHaveBeenCalledWith(1));
+    expect(await screen.findByText(/2 analyzed · 0 cached · 0 failed/)).toBeTruthy();
+    // chips updated from the enrichment result — AI tier now populated
+    expect(screen.getByLabelText('AI vibe: energy 5, mood happy')).toBeTruthy();
+  });
+
+  it('analyze failure surfaces ApiError 400 message, generic text otherwise', async () => {
+    mockApi.getPoolVibes.mockResolvedValue(POOL_VIBES);
+    mockApi.enrichPoolVibes.mockRejectedValueOnce(
+      new ApiError('No AI connector configured — connect one in Settings → AI.', 400)
+    );
+    render(<PoolPanel setId={1} />);
+    await screen.findByText('Event Song');
+
+    fireEvent.click(screen.getByText('Vibes'));
+    fireEvent.click(await screen.findByText('Analyze'));
+    expect(
+      await screen.findByText('No AI connector configured — connect one in Settings → AI.')
+    ).toBeTruthy();
+
+    // non-ApiError rejection falls back to the generic toast
+    mockApi.enrichPoolVibes.mockRejectedValueOnce(new Error('boom'));
+    fireEvent.click(await screen.findByText('Analyze'));
+    expect(await screen.findByText('Vibe analysis failed')).toBeTruthy();
   });
 });

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
@@ -17,9 +17,14 @@ const mockApi = vi.hoisted(() => ({
   removePoolSource: vi.fn(),
   getEvents: vi.fn(),
   search: vi.fn(),
+  getPoolVibes: vi.fn(),
+  enrichPoolVibes: vi.fn(),
 }));
 
-vi.mock('@/lib/api', () => ({ api: mockApi }));
+vi.mock('@/lib/api', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/lib/api')>();
+  return { api: mockApi, ApiError: original.ApiError };
+});
 
 const SOURCES = [
   {

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/VibeTiers.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/VibeTiers.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * VibeTiers component tests (issue #391) — read-only three-tier vibe chips:
+ * per-tier values, empty placeholders, low-confidence AI flag, sample size,
+ * and winner highlight from the resolved precedence.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { TrackVibeState } from '@/lib/api-types';
+import styles from '../../setbuilder.module.css';
+import VibeTiers from '../VibeTiers';
+
+type LlmTier = NonNullable<TrackVibeState['llm']>;
+
+function makeLlm(overrides: Partial<LlmTier> = {}): LlmTier {
+  return {
+    energy: 5,
+    mood: 'happy',
+    confidence: 0.92,
+    low_confidence: false,
+    llm_provider: 'anthropic_apikey',
+    llm_model: 'claude-haiku-4-5',
+    dance_floor: null,
+    era: null,
+    sing_along: null,
+    transitional_role: null,
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<TrackVibeState> = {}): TrackVibeState {
+  return {
+    pool_track_id: 11,
+    vibe_key: 'event artist|event song',
+    own: { energy: 9, mood: null },
+    community: { energy: 7, mood: 'dark', sample_size: 3 },
+    llm: makeLlm(),
+    resolved: { energy: 9, energy_source: 'own', mood: 'dark', mood_source: 'community' },
+    ...overrides,
+  };
+}
+
+describe('VibeTiers', () => {
+  it('renders all three tiers side-by-side with their values', () => {
+    render(<VibeTiers state={makeState()} />);
+    // labels
+    expect(screen.getByText('You')).toBeTruthy();
+    expect(screen.getByText('Crowd')).toBeTruthy();
+    expect(screen.getByText('AI')).toBeTruthy();
+    // own: E9 (no mood)
+    expect(screen.getByText('E9')).toBeTruthy();
+    // community: E7 "dark" with sample size
+    expect(screen.getByText('E7')).toBeTruthy();
+    expect(screen.getByText('dark')).toBeTruthy();
+    expect(screen.getByText('·3')).toBeTruthy();
+    // llm: E5 "happy"
+    expect(screen.getByText('E5')).toBeTruthy();
+    expect(screen.getByText('happy')).toBeTruthy();
+  });
+
+  it('renders dimmed placeholders for missing tiers', () => {
+    render(
+      <VibeTiers
+        state={makeState({
+          own: null,
+          community: null,
+          llm: null,
+          resolved: { energy: null, energy_source: null, mood: null, mood_source: null },
+        })}
+      />
+    );
+    expect(screen.getAllByText('—')).toHaveLength(3);
+    const own = screen.getByLabelText('Your vibe: not set');
+    const crowd = screen.getByLabelText('Community vibe: not set');
+    const ai = screen.getByLabelText('AI vibe: not set');
+    for (const chip of [own, crowd, ai]) {
+      expect(chip.className).toContain(styles.vibeEmpty);
+    }
+  });
+
+  it('flags low-confidence AI guesses for review', () => {
+    const { unmount } = render(
+      <VibeTiers state={makeState({ llm: makeLlm({ low_confidence: true, confidence: 0.3 }) })} />
+    );
+    expect(screen.getByText('⚠')).toBeTruthy();
+    const lowChip = screen.getByLabelText('AI vibe: energy 5, mood happy');
+    expect(lowChip.getAttribute('title')).toBe('Low confidence — review');
+    expect(lowChip.className).toContain(styles.vibeLow);
+    unmount();
+
+    render(<VibeTiers state={makeState()} />);
+    expect(screen.queryByText('⚠')).toBeNull();
+    const okChip = screen.getByLabelText('AI vibe: energy 5, mood happy');
+    expect(okChip.getAttribute('title')).toBe('AI guess (anthropic_apikey · claude-haiku-4-5)');
+    expect(okChip.className).not.toContain(styles.vibeLow);
+  });
+
+  it('exposes community sample size and highlights the winning tier', () => {
+    render(<VibeTiers state={makeState()} />);
+    const crowd = screen.getByLabelText('Community vibe: energy 7, mood dark');
+    expect(crowd.getAttribute('title')).toBe('Community consensus from 3 DJs');
+    // resolved.energy_source === 'own' → the You chip wins
+    const own = screen.getByLabelText('Your vibe: energy 9');
+    expect(own.className).toContain(styles.vibeWinner);
+    expect(crowd.className).not.toContain(styles.vibeWinner);
+    const ai = screen.getByLabelText('AI vibe: energy 5, mood happy');
+    expect(ai.className).not.toContain(styles.vibeWinner);
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/VibeTiers.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/VibeTiers.test.tsx
@@ -95,14 +95,15 @@ describe('VibeTiers', () => {
     expect(okChip.className).not.toContain(styles.vibeLow);
   });
 
-  it('exposes community sample size and highlights the winning tier', () => {
+  it('exposes community sample size and highlights every per-field winner', () => {
     render(<VibeTiers state={makeState()} />);
     const crowd = screen.getByLabelText('Community vibe: energy 7, mood dark');
     expect(crowd.getAttribute('title')).toBe('Community consensus from 3 DJs');
-    // resolved.energy_source === 'own' → the You chip wins
+    // energy_source === 'own' → the You chip wins energy;
+    // mood_source === 'community' → the Crowd chip wins mood — BOTH highlight.
     const own = screen.getByLabelText('Your vibe: energy 9');
     expect(own.className).toContain(styles.vibeWinner);
-    expect(crowd.className).not.toContain(styles.vibeWinner);
+    expect(crowd.className).toContain(styles.vibeWinner);
     const ai = screen.getByLabelText('AI vibe: energy 5, mood happy');
     expect(ai.className).not.toContain(styles.vibeWinner);
   });

--- a/dashboard/app/(dj)/setbuilder/setbuilder.module.css
+++ b/dashboard/app/(dj)/setbuilder/setbuilder.module.css
@@ -603,3 +603,41 @@
   letter-spacing: 0.05em;
   line-height: 1.6;
 }
+
+/* Three-tier vibe chips (issue #391) */
+
+.vibeTiers {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.vibeChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border, #3a3a3a);
+  color: var(--text-secondary);
+}
+
+.vibeChipLabel {
+  font-weight: 700;
+  opacity: 0.7;
+}
+
+.vibeEmpty {
+  opacity: 0.45;
+}
+
+.vibeLow {
+  border-color: #f59e0b;
+  border-style: dashed;
+  color: #f59e0b;
+}
+
+.vibeWinner {
+  border-color: var(--color-primary, #8b5cf6);
+}

--- a/dashboard/app/admin/settings/__tests__/page.test.tsx
+++ b/dashboard/app/admin/settings/__tests__/page.test.tsx
@@ -44,6 +44,8 @@ const defaultSettings = {
   llm_enabled: true,
   llm_model: 'claude-haiku-4-5-20251001',
   llm_rate_limit_per_minute: 6,
+  vibe_consensus_min_sample: 3,
+  vibe_consensus_max_stddev: 1.5,
 };
 
 describe('AdminSettingsPage', () => {

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -2866,6 +2866,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/setbuilder/sets/{set_id}/pool/vibes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Pool Vibes
+         * @description Three-tier vibe state (own / community / LLM) for the set's pool.
+         */
+        get: operations["get_pool_vibes_api_setbuilder_sets__set_id__pool_vibes_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/pool/vibes/enrich": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enrich Pool Vibes
+         * @description Batch-enrich uncached pool tracks via the LLM gateway (20 tracks/call).
+         */
+        post: operations["enrich_pool_vibes_api_setbuilder_sets__set_id__pool_vibes_enrich_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/setbuilder/sets/{set_id}/share": {
         parameters: {
             query?: never;
@@ -3939,6 +3979,18 @@ export interface components {
             request_id: number;
         };
         /**
+         * CommunityVibeOut
+         * @description Community consensus tier (gated by SystemSettings thresholds).
+         */
+        CommunityVibeOut: {
+            /** Energy */
+            energy: number | null;
+            /** Mood */
+            mood: string | null;
+            /** Sample Size */
+            sample_size: number;
+        };
+        /**
          * ConnectorCreate
          * @description Provider-agnostic create payload.
          *
@@ -4741,6 +4793,32 @@ export interface components {
             /** Join Code */
             join_code: string;
         };
+        /**
+         * LlmVibeOut
+         * @description Globally-cached LLM guess tier.
+         */
+        LlmVibeOut: {
+            /** Confidence */
+            confidence: number | null;
+            /** Dance Floor */
+            dance_floor: boolean | null;
+            /** Energy */
+            energy: number | null;
+            /** Era */
+            era: string | null;
+            /** Llm Model */
+            llm_model: string;
+            /** Llm Provider */
+            llm_provider: string;
+            /** Low Confidence */
+            low_confidence: boolean;
+            /** Mood */
+            mood: string | null;
+            /** Sing Along */
+            sing_along: boolean | null;
+            /** Transitional Role */
+            transitional_role: string | null;
+        };
         /** MePreferencesUpdate */
         MePreferencesUpdate: {
             /** Frictionless Join Default */
@@ -4821,6 +4899,16 @@ export interface components {
             started_at: string;
             /** Title */
             title: string;
+        };
+        /**
+         * OwnVibeOut
+         * @description The DJ's own override tier.
+         */
+        OwnVibeOut: {
+            /** Energy */
+            energy: number | null;
+            /** Mood */
+            mood: string | null;
         };
         /** PaginatedResponse */
         PaginatedResponse: {
@@ -5098,6 +5186,14 @@ export interface components {
             /** Track Count */
             track_count: number | null;
         };
+        /**
+         * PoolVibesState
+         * @description Vibe state for every track in a set's pool.
+         */
+        PoolVibesState: {
+            /** Tracks */
+            tracks: components["schemas"]["TrackVibeStateOut"][];
+        };
         /** PublicEventInfo */
         PublicEventInfo: {
             /** Code */
@@ -5343,6 +5439,20 @@ export interface components {
         /** RequestUpdate */
         RequestUpdate: {
             status: components["schemas"]["RequestStatus"];
+        };
+        /**
+         * ResolvedVibeOut
+         * @description Per-field precedence result: own -> community -> llm.
+         */
+        ResolvedVibeOut: {
+            /** Energy */
+            energy: number | null;
+            /** Energy Source */
+            energy_source: ("own" | "community" | "llm") | null;
+            /** Mood */
+            mood: string | null;
+            /** Mood Source */
+            mood_source: ("own" | "community" | "llm") | null;
         };
         /** SearchResult */
         SearchResult: {
@@ -5626,6 +5736,10 @@ export interface components {
             spotify_enabled: boolean;
             /** Tidal Enabled */
             tidal_enabled: boolean;
+            /** Vibe Consensus Max Stddev */
+            vibe_consensus_max_stddev: number;
+            /** Vibe Consensus Min Sample */
+            vibe_consensus_min_sample: number;
         };
         /** SystemSettingsUpdate */
         SystemSettingsUpdate: {
@@ -5647,6 +5761,10 @@ export interface components {
             spotify_enabled?: boolean | null;
             /** Tidal Enabled */
             tidal_enabled?: boolean | null;
+            /** Vibe Consensus Max Stddev */
+            vibe_consensus_max_stddev?: number | null;
+            /** Vibe Consensus Min Sample */
+            vibe_consensus_min_sample?: number | null;
         };
         /** SystemStats */
         SystemStats: {
@@ -5813,6 +5931,20 @@ export interface components {
              */
             token_type: string;
         };
+        /**
+         * TrackVibeStateOut
+         * @description All three tiers + resolution for one pool track.
+         */
+        TrackVibeStateOut: {
+            community: components["schemas"]["CommunityVibeOut"] | null;
+            llm: components["schemas"]["LlmVibeOut"] | null;
+            own: components["schemas"]["OwnVibeOut"] | null;
+            /** Pool Track Id */
+            pool_track_id: number;
+            resolved: components["schemas"]["ResolvedVibeOut"];
+            /** Vibe Key */
+            vibe_key: string;
+        };
         /** UpdateCollectionSettings */
         UpdateCollectionSettings: {
             /** Collection Opens At */
@@ -5953,6 +6085,21 @@ export interface components {
             expires_in: number;
             /** Verified */
             verified: boolean;
+        };
+        /**
+         * VibeEnrichmentResult
+         * @description Result of an enrichment run, plus the refreshed vibe state.
+         */
+        VibeEnrichmentResult: {
+            /** Cached */
+            cached: number;
+            /** Enriched */
+            enriched: number;
+            /** Failed */
+            failed: number;
+            /** Llm Calls */
+            llm_calls: number;
+            vibes: components["schemas"]["PoolVibesState"];
         };
         /**
          * VibeWindowModel
@@ -11023,6 +11170,68 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PoolUrlPreview"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_pool_vibes_api_setbuilder_sets__set_id__pool_vibes_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PoolVibesState"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    enrich_pool_vibes_api_setbuilder_sets__set_id__pool_vibes_enrich_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VibeEnrichmentResult"];
                 };
             };
             /** @description Validation Error */

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -11234,6 +11234,13 @@ export interface operations {
                     "application/json": components["schemas"]["VibeEnrichmentResult"];
                 };
             };
+            /** @description No LLM connector configured for this DJ or the org. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -217,6 +217,11 @@ export type PoolUrlPreview = Schemas['PoolUrlPreview'];
 export type PoolImportManualIn = Schemas['PoolImportManualIn'];
 export type BuilderPlaylists = Schemas['BuilderPlaylistsOut'];
 
+// TrackVibe three-tier state (issue #391)
+export type PoolVibesState = Schemas['PoolVibesState'];
+export type TrackVibeState = Schemas['TrackVibeStateOut'];
+export type VibeEnrichmentResult = Schemas['VibeEnrichmentResult'];
+
 // WrzDJSet sharing + duplication (issue #398)
 export interface ShareTokenOut {
   share_token: string;

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -54,6 +54,7 @@ import type {
   PoolMutationResult,
   PoolState,
   PoolUrlPreview,
+  PoolVibesState,
   PublicEvent,
   RecommendationResponse,
   SearchResult,
@@ -70,6 +71,7 @@ import type {
   TidalSearchResult,
   TidalSyncResult,
   TidalStatus,
+  VibeEnrichmentResult,
   VibeWindow,
   VibeWindowsResponse,
   VoteResponse,
@@ -726,6 +728,13 @@ class ApiClient {
   // WrzDJSet pool (issue #388)
   async getPool(setId: number): Promise<PoolState> {
     return this.fetch(`/api/setbuilder/sets/${setId}/pool`);
+  }
+  // TrackVibe three-tier state (issue #391)
+  async getPoolVibes(setId: number): Promise<PoolVibesState> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pool/vibes`);
+  }
+  async enrichPoolVibes(setId: number): Promise<VibeEnrichmentResult> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pool/vibes/enrich`, { method: 'POST' });
   }
   async getBuilderPlaylists(): Promise<BuilderPlaylists> {
     return this.fetch('/api/setbuilder/playlists');

--- a/docs/superpowers/plans/2026-06-10-trackvibe-llm-enrichment.md
+++ b/docs/superpowers/plans/2026-06-10-trackvibe-llm-enrichment.md
@@ -1,0 +1,574 @@
+# TrackVibe LLM Enrichment + Community Vibe Display (issue #391) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Batch-enrich pool tracks with LLM-guessed vibe metadata (cached globally in `TrackVibe`), aggregate per-DJ `TrackVibeOverride` rows into a community consensus, and surface all three tiers (own → community → LLM) read-only in the pool panel with low-confidence flagging.
+
+**Architecture:** The `TrackVibe` / `TrackVibeOverride` models and tables already exist (Phase 0 scaffold, migration 046) — no model changes needed there. We add: two SystemSettings threshold columns (migration 057), an additive `provider` field on `ChatResponse` populated by the gateway, three new service modules under `services/setbuilder/` (enrichment, community aggregation, precedence resolver), two owner-scoped endpoints on the setbuilder router, and a read-only three-tier UI strip in the PoolPanel.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2.0 + Alembic (backend), LLM Gateway (`Gateway.dispatch`, forced tool_use), Next.js/React + vanilla CSS (frontend), pytest + vitest.
+
+**Worktree:** `/home/adam/github/WrzDJ/.worktrees/feat/issue-391` — branch `feat/issue-391`. NEVER commit to main.
+**Python tools:** `/home/adam/github/WrzDJ/server/.venv/bin/{pytest,ruff,bandit,alembic}` run from `<worktree>/server`. Never pip install.
+**DB:** dedicated `wrzdj_issue391` already at head 056 (`.env` at worktree root).
+
+---
+
+## Design decisions (document in PR body)
+
+1. **`model_hint="fast"` deviation:** `ChatRequest` has no speed-tier concept — it has `model: str | None` which overrides the *connector's* configured `model_hint`. We dispatch with `model=None` so the DJ's connector-configured model is used. Adding a cross-provider "fast/smart" tier mapping would require per-adapter model tables (rejected as gateway refactoring, which the task forbids).
+2. **Provider/model provenance:** `ChatResponse` did not surface which connector served a call. Minimal additive change: `ChatResponse.provider: str | None`, populated by the gateway's `_attempt` success path from `connector.connector_type` via `model_copy(update=...)`. No other gateway behavior changes.
+3. **Vibe cache key:** `SetPoolTrack.track_id` is nullable. Fallback key is `f"sig:{dedupe_sig}"` (the normalized artist+title hash) — globally stable across sets/DJs, consistent with the namespaced free-form `track_id` convention.
+4. **Cache-hit semantics:** any `TrackVibe` row matching `(track_id, prompt_version=PROMPT_VERSION, schema_version=SCHEMA_VERSION)` is a hit *regardless of provider/model* — that's what makes "second DJ pays zero" true even when DJs use different connectors. Bumping `PROMPT_VERSION` in code makes old rows non-matching → lazy re-enrichment. When multiple rows exist, the newest (highest id) wins at read time.
+5. **`purpose="vibe_enrichment"`** for gateway call logging.
+6. **Batch failure policy:** the first `LlmError` (other than the initial `NoLlmConfigured`, which maps to HTTP 400) marks all remaining tracks failed and stops — no provider hammering after a rate-limit/outage.
+7. **Community consensus:** latest override row per `(track_id, user_id)` counts as that user's vote. Energy consensus: `count >= vibe_consensus_min_sample AND pstdev < vibe_consensus_max_stddev` → `round(mean)`. Mood consensus: most-common non-null mood where mood-vote count ≥ min_sample and strict majority (> 50%).
+8. **`TrackVibeOverride` write UX is v1.1** — table already existed from Phase 0, so no new table needed; we add NO write endpoints (read path only).
+9. **Low-confidence flag** computed backend-side (`confidence is None or < 0.5`) so the frontend stays dumb.
+
+---
+
+### Task 1: SystemSettings threshold columns + migration 057
+
+**Files:**
+- Modify: `server/app/models/system_settings.py`
+- Create: `server/alembic/versions/057_add_vibe_consensus_settings.py`
+- Modify: `server/app/services/system_settings.py`
+- Modify: `server/app/schemas/system_settings.py`
+- Modify: `server/app/api/admin.py` (PATCH /settings passthrough, ~line 264)
+- Test: `server/tests/test_setbuilder_vibes.py` (new — settings section)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/tests/test_setbuilder_vibes.py`:
+
+```python
+"""Tests for TrackVibe LLM enrichment + community consensus + resolver (issue #391)."""
+
+from app.services.system_settings import get_system_settings, update_system_settings
+
+
+class TestVibeConsensusSettings:
+    def test_defaults(self, db):
+        s = get_system_settings(db)
+        assert s.vibe_consensus_min_sample == 3
+        assert s.vibe_consensus_max_stddev == 1.5
+
+    def test_update(self, db):
+        s = update_system_settings(db, vibe_consensus_min_sample=5, vibe_consensus_max_stddev=2.0)
+        assert s.vibe_consensus_min_sample == 5
+        assert s.vibe_consensus_max_stddev == 2.0
+
+    def test_admin_patch_endpoint(self, client, admin_headers):
+        resp = client.patch(
+            "/api/admin/settings",
+            json={"vibe_consensus_min_sample": 4, "vibe_consensus_max_stddev": 1.0},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["vibe_consensus_min_sample"] == 4
+        assert body["vibe_consensus_max_stddev"] == 1.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/adam/github/WrzDJ/.worktrees/feat/issue-391/server && /home/adam/github/WrzDJ/server/.venv/bin/pytest tests/test_setbuilder_vibes.py -v --no-cov`
+Expected: FAIL (AttributeError: vibe_consensus_min_sample)
+
+- [ ] **Step 3: Implement**
+
+In `server/app/models/system_settings.py` — add `Float` to the sqlalchemy import and append columns at the end of the class:
+
+```python
+    # Community vibe consensus gates (issue #391). Consensus over
+    # TrackVibeOverride requires sample_size >= min_sample AND energy stddev
+    # < max_stddev. Bounds enforced at the API layer.
+    vibe_consensus_min_sample: Mapped[int] = mapped_column(
+        Integer, default=3, server_default=text("3")
+    )
+    vibe_consensus_max_stddev: Mapped[float] = mapped_column(
+        Float, default=1.5, server_default=text("1.5")
+    )
+```
+
+Create `server/alembic/versions/057_add_vibe_consensus_settings.py`:
+
+```python
+"""Vibe consensus threshold settings (issue #391).
+
+Revision ID: 057
+Revises: 056
+Create Date: 2026-06-10
+
+Community consensus over track_vibe_overrides is gated on
+sample_size >= vibe_consensus_min_sample AND energy stddev <
+vibe_consensus_max_stddev. Both admin-tunable via PATCH /api/admin/settings.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "057"
+down_revision: str | None = "056"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "system_settings",
+        sa.Column(
+            "vibe_consensus_min_sample", sa.Integer(), nullable=False, server_default=sa.text("3")
+        ),
+    )
+    op.add_column(
+        "system_settings",
+        sa.Column(
+            "vibe_consensus_max_stddev", sa.Float(), nullable=False, server_default=sa.text("1.5")
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("system_settings", "vibe_consensus_max_stddev")
+    op.drop_column("system_settings", "vibe_consensus_min_sample")
+```
+
+In `server/app/services/system_settings.py` — add to `get_system_settings` defaults dict: `vibe_consensus_min_sample=3, vibe_consensus_max_stddev=1.5,`. Add params to `update_system_settings`:
+
+```python
+    vibe_consensus_min_sample: int | None = None,
+    vibe_consensus_max_stddev: float | None = None,
+```
+and the corresponding `if ... is not None:` assignments before `db.commit()`.
+
+In `server/app/schemas/system_settings.py` — `SystemSettingsOut` gains `vibe_consensus_min_sample: int` and `vibe_consensus_max_stddev: float`; `SystemSettingsUpdate` gains:
+
+```python
+    vibe_consensus_min_sample: int | None = Field(None, ge=1, le=100)
+    vibe_consensus_max_stddev: float | None = Field(None, ge=0.1, le=5.0)
+```
+
+In `server/app/api/admin.py` PATCH `/settings` handler — pass both through to `update_system_settings(...)` like the existing fields.
+
+- [ ] **Step 4: Run tests + alembic check**
+
+Run: `cd <worktree>/server && /home/adam/github/WrzDJ/server/.venv/bin/pytest tests/test_setbuilder_vibes.py tests/test_admin.py -q --no-cov`
+Expected: PASS
+Run: `/home/adam/github/WrzDJ/server/.venv/bin/alembic upgrade head && /home/adam/github/WrzDJ/server/.venv/bin/alembic check`
+Expected: "No new upgrade operations detected"
+
+- [ ] **Step 5: Commit** — `feat(setbuilder): vibe consensus threshold settings (migration 057)`
+
+---
+
+### Task 2: ChatResponse.provider populated by the gateway
+
+**Files:**
+- Modify: `server/app/services/llm/base.py` (ChatResponse)
+- Modify: `server/app/services/llm/gateway.py` (`_attempt` success path)
+- Test: `server/tests/test_llm_gateway.py` (append one test)
+
+- [ ] **Step 1: Write the failing test** (append to `test_llm_gateway.py`, reusing `_make_connector`, `_patch_chat`, `dj_user`, `gateway_request` fixtures):
+
+```python
+@pytest.mark.asyncio
+async def test_dispatch_populates_provider_from_connector(db, dj_user, gateway_request):
+    """#391 — vibe enrichment needs provider provenance on the response."""
+    _make_connector(db, dj_user)
+    fake_response = ChatResponse(
+        text="ok", tool_calls=[], stop_reason="end_turn",
+        usage=TokenUsage(prompt=1, completion=1), model="gpt-5-mini",
+    )
+    with _patch_chat(AsyncMock(return_value=fake_response)):
+        resp = await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
+    assert resp.provider == "openai_apikey"
+    assert resp.model == "gpt-5-mini"
+```
+
+- [ ] **Step 2: Run to verify it fails** (`pytest tests/test_llm_gateway.py -k provider -v --no-cov`) — FAIL: ChatResponse has no field "provider".
+
+- [ ] **Step 3: Implement.** In `base.py` `ChatResponse`, after `model`:
+
+```python
+    # The connector_type that served the call (e.g. "anthropic_apikey").
+    # Populated by the gateway from the resolved connector — adapters leave it None.
+    provider: str | None = None
+```
+
+In `gateway.py` `_attempt`, change the final `return response` to:
+
+```python
+    # Surface which connector served the call (issue #391 — vibe provenance).
+    return response.model_copy(update={"provider": connector.connector_type})
+```
+
+- [ ] **Step 4: Run** `pytest tests/test_llm_gateway.py tests/test_llm_gateway_stream.py -q --no-cov` — PASS.
+- [ ] **Step 5: Commit** — `feat(llm): surface serving connector_type as ChatResponse.provider`
+
+---
+
+### Task 3: vibe_enrichment service (batching, caching, defensive parsing)
+
+**Files:**
+- Create: `server/app/services/setbuilder/vibe_enrichment.py`
+- Test: `server/tests/test_setbuilder_vibes.py` (append)
+
+Service contract:
+
+```python
+PURPOSE = "vibe_enrichment"
+PROMPT_VERSION = "v1"
+SCHEMA_VERSION = "v1"
+BATCH_SIZE = 20
+MAX_TOKENS = 4096
+TRANSITIONAL_ROLES = frozenset({"intro", "build", "peak", "cool", "any"})
+
+def vibe_key(track: SetPoolTrack) -> str:
+    """Global cache key — namespaced track_id, else the dedupe signature."""
+    return track.track_id or f"sig:{track.dedupe_sig}"
+
+@dataclass(frozen=True)
+class VibeEnrichmentStats:
+    enriched: int
+    cached: int
+    failed: int
+    llm_calls: int
+
+async def enrich_pool_vibes(db: Session, actor: User, set_obj: Set) -> VibeEnrichmentStats
+```
+
+Implementation outline (full code in the module):
+- Load pool tracks, key them by `vibe_key` (dict de-dupes within the pool).
+- `cached` = keys having a `TrackVibe` row with matching PROMPT_VERSION/SCHEMA_VERSION (any provider/model).
+- Chunk missing keys into batches of `BATCH_SIZE`. For each batch: build a `ChatRequest` (system prompt + numbered track list user message + forced tool `submit_track_vibes`), `await Gateway.dispatch(db, actor, req, purpose=PURPOSE)`, increment `llm_calls`.
+- `NoLlmConfigured` propagates (caller maps to 400). Any other `LlmError`: remaining tracks (current batch + later batches) count as failed; stop.
+- Parse tool output defensively (`_parse_items`): index must be a valid int in range; energy int clamped 0–10 (floats rounded); confidence clamped 0.0–1.0; transitional_role must be in `TRANSITIONAL_ROLES` else None; mood/era truncated to 50 chars; sing_along/dance_floor only if actual bool. Tracks with no parsed entry count as failed.
+- Insert `TrackVibe` rows with `llm_provider=response.provider or "unknown"`, `llm_model=response.model or "unknown"`. Re-check existing keys just before insert and wrap the per-batch commit in `try/except IntegrityError: db.rollback()` (concurrent-enrichment race → treat as cached).
+
+Tool schema (forced tool_use, mirrors `recommendation/llm_client.py` precedent):
+
+```python
+VIBES_TOOL_NAME = "submit_track_vibes"
+VIBES_TOOL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "tracks": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "index": {"type": "integer", "description": "Input track number"},
+                    "energy": {"type": "integer", "minimum": 0, "maximum": 10},
+                    "mood": {"type": "string", "description": "1-2 lowercase words"},
+                    "era": {"type": "string", "description": "decade or scene era"},
+                    "sing_along": {"type": "boolean"},
+                    "dance_floor": {"type": "boolean"},
+                    "transitional_role": {
+                        "type": "string",
+                        "enum": ["intro", "build", "peak", "cool", "any"],
+                    },
+                    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                },
+                "required": ["index", "energy", "confidence"],
+            },
+        }
+    },
+    "required": ["tracks"],
+}
+```
+
+System prompt (verbatim):
+
+```
+You are a music-metadata expert annotating tracks for DJ set planning.
+
+For each numbered track estimate:
+- energy: integer 0-10 (0 = ambient/chill, 10 = peak-time mainstage intensity)
+- mood: one or two lowercase words (e.g. "euphoric", "dark", "feel-good")
+- era: release decade or scene era (e.g. "90s", "2010s", "classic house")
+- sing_along: true if crowds commonly sing the hook out loud
+- dance_floor: true if the track reliably keeps a dance floor moving
+- transitional_role: where it fits in a set arc — "intro", "build", "peak", "cool", or "any"
+- confidence: 0-1 — how certain you are you know this exact track
+  (0.2 = guessing from the title, 0.9 = you know the track well)
+
+Be honest with confidence: if you do not recognize a track, keep confidence
+below 0.4 and infer from title/artist/genre conventions. Return one entry per
+input track, matched by index.
+```
+
+User message: one line per track — `"{i}. {artist} — {title}"` plus ` ({genre}, {bpm:.0f} BPM)` parts when known.
+
+Tests (mock `Gateway.dispatch` with `unittest.mock.patch("app.services.setbuilder.vibe_enrichment.Gateway.dispatch", new=AsyncMock(...))`; build `ChatResponse` fixtures with a `ToolCall(name="submit_track_vibes", input={...})`):
+- `test_100_tracks_costs_5_calls` — seed 100 pool tracks (direct `SetPoolTrack` inserts with distinct `track_id`/`dedupe_sig`), mock returns full batch; assert `llm_calls == 5`, `enriched == 100`, dispatch call count == 5 **(acceptance criterion)**.
+- `test_second_run_is_fully_cached` — run twice; second run: `llm_calls == 0`, `cached == 100` **(acceptance: second DJ pays zero — also assert a different actor/set with the same track keys gets `cached`)**.
+- `test_prompt_version_bump_reenriches` — seed a `TrackVibe` row with `prompt_version="v0"`; assert the track is re-enriched.
+- `test_malformed_items_skipped` — out-of-range index, energy 99 (clamped), bad transitional_role (nulled), confidence 1.7 (clamped); assert stored values.
+- `test_llm_error_marks_remaining_failed` — first dispatch OK, second raises `ProviderUnavailable`; with 40 tracks assert `enriched == 20`, `failed == 20`, `llm_calls` counts only successful+attempted per implementation (assert == 2).
+- `test_no_llm_configured_propagates` — dispatch raises `NoLlmConfigured`; `pytest.raises`.
+- `test_track_without_track_id_uses_sig_key` — track with `track_id=None`; assert TrackVibe row keyed `sig:<dedupe_sig>`.
+
+Steps: write tests → verify fail → implement module → pass → commit `feat(setbuilder): TrackVibe batch LLM enrichment via gateway`.
+
+---
+
+### Task 4: community_vibe aggregation service
+
+**Files:**
+- Create: `server/app/services/setbuilder/community_vibe.py`
+- Test: `server/tests/test_setbuilder_vibes.py` (append)
+
+Contract:
+
+```python
+@dataclass(frozen=True)
+class CommunityVibe:
+    energy: int | None
+    mood: str | None
+    sample_size: int
+
+def community_consensus(
+    db: Session, track_keys: Iterable[str], *, min_sample: int, max_stddev: float
+) -> dict[str, CommunityVibe]
+```
+
+- Fetch all `TrackVibeOverride` rows for the keys ordered by id; keep the **latest row per (track_id, user_id)** as that user's vote.
+- Energy: votes = non-null `energy_override`; consensus when `len(votes) >= min_sample and statistics.pstdev(votes) < max_stddev` → `round(statistics.fmean(votes))`.
+- Mood: votes = non-null `mood_override`; `Counter.most_common(1)` wins when its count `>= min_sample` and `> len(votes)/2`.
+- Include a key in the result only when at least one field reached consensus; `sample_size = max(len(energy_votes), len(mood_votes))`.
+
+Tests (insert `TrackVibeOverride` rows directly; users via `User` model like `test_llm_gateway._make_connector` pattern):
+- `test_consensus_requires_min_sample` — 2 votes, no consensus; 3 votes (energies 7,7,8) → energy 7.
+- `test_consensus_rejected_on_high_stddev` — energies 1, 5, 10 (pstdev ≈ 3.68 ≥ 1.5) → no energy consensus.
+- `test_latest_vote_per_user_wins` — same user votes 2 then 8; only the 8 counts.
+- `test_mood_majority` — moods ["dark","dark","euphoric"] with min_sample=3 → "dark"; ["dark","euphoric","happy"] → None.
+- `test_thresholds_are_tunable` — pass `min_sample=2` and assert 2 votes now reach consensus.
+
+Steps: tests → fail → implement → pass → commit `feat(setbuilder): community vibe consensus aggregation`.
+
+---
+
+### Task 5: precedence resolver + read-time state builder
+
+**Files:**
+- Create: `server/app/services/setbuilder/vibe_resolver.py`
+- Test: `server/tests/test_setbuilder_vibes.py` (append)
+
+Contract:
+
+```python
+LOW_CONFIDENCE_THRESHOLD = 0.5
+
+@dataclass(frozen=True)
+class OwnVibe:
+    energy: int | None
+    mood: str | None
+
+@dataclass(frozen=True)
+class ResolvedVibe:
+    energy: int | None
+    energy_source: str | None  # "own" | "community" | "llm" | None
+    mood: str | None
+    mood_source: str | None
+
+def resolve_vibe(
+    own: OwnVibe | None, community: CommunityVibe | None, llm: TrackVibe | None
+) -> ResolvedVibe
+
+def is_low_confidence(vibe: TrackVibe) -> bool  # confidence is None or < 0.5
+
+@dataclass(frozen=True)
+class TrackVibeState:
+    pool_track_id: int
+    vibe_key: str
+    own: OwnVibe | None
+    community: CommunityVibe | None
+    llm: TrackVibe | None
+    resolved: ResolvedVibe
+
+def build_pool_vibe_states(db: Session, actor: User, set_obj: Set) -> list[TrackVibeState]
+```
+
+- `resolve_vibe` cascades **per field** (own → community → llm); an own override with only energy set still lets mood fall through to community/llm.
+- `build_pool_vibe_states`: loads pool tracks; own tier = latest `TrackVibeOverride` per track for `actor.id` (None when both override fields null); community tier from `community_consensus` using `get_system_settings(db)` thresholds; llm tier = newest matching-version `TrackVibe` row per key.
+
+Tests — **acceptance criterion: resolver covered for all three tiers**:
+- `test_own_override_wins` / `test_community_beats_llm` / `test_llm_fallback` / `test_no_tiers_resolves_none`
+- `test_per_field_cascade` — own has energy only, community has mood only → energy_source "own", mood_source "community".
+- `test_low_confidence_flag` — confidence 0.3 → True; 0.5 → False; None → True.
+- `test_build_pool_vibe_states_end_to_end` — seed 1 pool track + own override + 3 community votes + TrackVibe row; assert all tiers populated and resolved follows precedence.
+
+Steps: tests → fail → implement → pass → commit `feat(setbuilder): three-tier vibe precedence resolver`.
+
+---
+
+### Task 6: API endpoints + schemas
+
+**Files:**
+- Modify: `server/app/schemas/setbuilder.py` (new section)
+- Modify: `server/app/api/setbuilder.py` (two endpoints + imports)
+- Test: `server/tests/test_setbuilder_vibes_api.py` (new)
+
+Schemas (append to `schemas/setbuilder.py`):
+
+```python
+# ---------------------------------------------------------------------------
+# Track vibes (issue #391) — read-only three-tier display + enrichment trigger
+
+
+class OwnVibeOut(BaseModel):
+    energy: int | None
+    mood: str | None
+
+
+class CommunityVibeOut(BaseModel):
+    energy: int | None
+    mood: str | None
+    sample_size: int
+
+
+class LlmVibeOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    energy: int | None
+    mood: str | None
+    era: str | None
+    sing_along: bool | None
+    dance_floor: bool | None
+    transitional_role: str | None
+    confidence: float | None
+    low_confidence: bool
+    llm_provider: str
+    llm_model: str
+
+
+class ResolvedVibeOut(BaseModel):
+    energy: int | None
+    energy_source: Literal["own", "community", "llm"] | None
+    mood: str | None
+    mood_source: Literal["own", "community", "llm"] | None
+
+
+class TrackVibeStateOut(BaseModel):
+    pool_track_id: int
+    vibe_key: str
+    own: OwnVibeOut | None
+    community: CommunityVibeOut | None
+    llm: LlmVibeOut | None
+    resolved: ResolvedVibeOut
+
+
+class PoolVibesState(BaseModel):
+    tracks: list[TrackVibeStateOut]
+
+
+class VibeEnrichmentResult(BaseModel):
+    enriched: int
+    cached: int
+    failed: int
+    llm_calls: int
+    vibes: PoolVibesState
+```
+
+Endpoints (append to `api/setbuilder.py`; `LlmVibeOut` is built via a small helper that injects `low_confidence=is_low_confidence(row)`):
+
+```python
+@router.get("/sets/{set_id}/pool/vibes", response_model=PoolVibesState)
+@limiter.limit("60/minute")
+def get_pool_vibes(set_id, request, db=Depends(get_db), current_user=Depends(get_current_active_user)) -> PoolVibesState:
+    """Three-tier vibe state (own / community / LLM) for the set's pool."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    return _pool_vibes_state(db, current_user, set_obj)
+
+
+@router.post("/sets/{set_id}/pool/vibes/enrich", response_model=VibeEnrichmentResult)
+@limiter.limit("5/minute")
+async def enrich_pool_vibes(set_id, request, db=Depends(get_db), current_user=Depends(get_current_active_user)) -> VibeEnrichmentResult:
+    """Batch-enrich uncached pool tracks via the LLM gateway (20 tracks/call)."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    try:
+        stats = await vibe_enrichment.enrich_pool_vibes(db, current_user, set_obj)
+    except NoLlmConfigured:
+        raise HTTPException(
+            status_code=400,
+            detail="No AI connector configured — connect one in Settings → AI.",
+        ) from None
+    return VibeEnrichmentResult(
+        enriched=stats.enriched, cached=stats.cached, failed=stats.failed,
+        llm_calls=stats.llm_calls, vibes=_pool_vibes_state(db, current_user, set_obj),
+    )
+```
+
+API tests (`test_setbuilder_vibes_api.py`, reuse `set_id`/`other_dj_headers` fixture patterns from `test_setbuilder_pool_api.py`):
+- ownership 404s for both endpoints; 401 without auth.
+- `GET .../vibes` empty pool → `{"tracks": []}`.
+- enrich end-to-end with mocked `Gateway.dispatch` (patch at `app.services.setbuilder.vibe_enrichment.Gateway.dispatch`): seed 2 pool tracks via the manual-import endpoint, assert response counts + `vibes.tracks[*].llm` populated with provider/model + `low_confidence` flags.
+- `NoLlmConfigured` → 400 with the friendly message.
+- precedence visible over API: seed own override row → `resolved.energy_source == "own"`.
+
+Steps: tests → fail → implement → pass → run full backend test suite (`pytest -q`) → commit `feat(setbuilder): pool vibes read + enrich endpoints`.
+
+---
+
+### Task 7: OpenAPI regen + frontend API client
+
+**Files:**
+- Regenerate: `server/openapi.json`, `dashboard/lib/api-types.generated.ts`
+- Modify: `dashboard/lib/api-types.ts`, `dashboard/lib/api.ts`
+
+- [ ] From `<worktree>/server`: `/home/adam/github/WrzDJ/server/.venv/bin/python scripts/export_openapi.py`
+- [ ] From `<worktree>/dashboard`: `npx openapi-typescript ../server/openapi.json -o lib/api-types.generated.ts`
+- [ ] `api-types.ts` — append aliases:
+
+```typescript
+export type PoolVibesState = Schemas['PoolVibesState'];
+export type TrackVibeState = Schemas['TrackVibeStateOut'];
+export type VibeEnrichmentResult = Schemas['VibeEnrichmentResult'];
+```
+
+- [ ] `api.ts` — next to `getPool`:
+
+```typescript
+  async getPoolVibes(setId: number): Promise<PoolVibesState> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pool/vibes`);
+  }
+  async enrichPoolVibes(setId: number): Promise<VibeEnrichmentResult> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pool/vibes/enrich`, { method: 'POST' });
+  }
+```
+
+- [ ] Run `npx tsc --noEmit` from dashboard — PASS. Commit `feat(setbuilder): pool vibes API client + generated types`.
+
+---
+
+### Task 8: VibeTiers component + PoolPanel integration
+
+**Files:**
+- Create: `dashboard/app/(dj)/setbuilder/components/VibeTiers.tsx`
+- Modify: `dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx`
+- Modify: `dashboard/app/(dj)/setbuilder/setbuilder.module.css`
+- Test: `dashboard/app/(dj)/setbuilder/components/__tests__/VibeTiers.test.tsx`
+
+`VibeTiers` (read-only, inline styles + a few module classes, dark theme): renders three side-by-side tier chips — `You`, `Crowd` (with sample size), `AI` — each showing `E{n}` energy + mood text, `—` when the tier is missing. AI chip with `low_confidence` gets warning styling (dashed amber border, `⚠` prefix, `title="Low confidence — review"`). Resolved field sources get a subtle highlight (the winning tier chip gets a brighter border).
+
+PoolPanel additions (state + handlers, following existing patterns):
+- `const [vibes, setVibes] = useState<Map<number, TrackVibeState>>(new Map());`
+- `const [showVibes, setShowVibes] = useState(false);` + `vibesBusy` flag.
+- Header gains a `Vibes` toggle button (fetches `api.getPoolVibes(setId)` on first enable) and, when `showVibes`, an `Analyze` button calling `api.enrichPoolVibes(setId)` → updates map → toast `` `${r.enriched} analyzed · ${r.cached} cached · ${r.failed} failed` `` (errors → toast with API detail when 400).
+- Track rows render `<VibeTiers state={vibes.get(t.id)} />` under `trackMetaRow` when `showVibes`.
+
+Vitest (`VibeTiers.test.tsx`, jsdom + testing-library, mirroring `PoolPanel.test.tsx` conventions): all three tiers rendered side-by-side; missing tiers show placeholders; low-confidence flag visible only when `llm.low_confidence`; sample size shown on community tier.
+
+Steps: tests → fail → implement → `npm run lint && npx tsc --noEmit && npm test -- --run` → commit `feat(setbuilder): three-tier vibe display in pool panel`.
+
+---
+
+### Task 9: Full local CI + finish
+
+- [ ] Backend (from `<worktree>/server`, main venv binaries): `ruff check .` · `ruff format --check .` · `bandit -r app -c pyproject.toml -q` · `pytest --tb=short -q` · `alembic upgrade head && alembic check`
+- [ ] Frontend (from `<worktree>/dashboard`): `npm run lint` · `npx tsc --noEmit` · `npm test -- --run`
+- [ ] `git checkout -- dashboard/next-env.d.ts` if modified
+- [ ] superpowers:finishing-a-development-branch → option 2 (Push + PR). PR body: `Closes #391` + Design decisions section (items 1–9 above).

--- a/server/alembic/versions/057_add_vibe_consensus_settings.py
+++ b/server/alembic/versions/057_add_vibe_consensus_settings.py
@@ -1,0 +1,39 @@
+"""Vibe consensus threshold settings (issue #391).
+
+Revision ID: 057
+Revises: 056
+Create Date: 2026-06-10
+
+Community consensus over track_vibe_overrides is gated on
+sample_size >= vibe_consensus_min_sample AND energy stddev <
+vibe_consensus_max_stddev. Both admin-tunable via PATCH /api/admin/settings.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "057"
+down_revision: str | None = "056"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "system_settings",
+        sa.Column(
+            "vibe_consensus_min_sample", sa.Integer(), nullable=False, server_default=sa.text("3")
+        ),
+    )
+    op.add_column(
+        "system_settings",
+        sa.Column(
+            "vibe_consensus_max_stddev", sa.Float(), nullable=False, server_default=sa.text("1.5")
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("system_settings", "vibe_consensus_max_stddev")
+    op.drop_column("system_settings", "vibe_consensus_min_sample")

--- a/server/app/api/admin.py
+++ b/server/app/api/admin.py
@@ -272,6 +272,8 @@ def admin_update_settings(
         human_verification_enforced=update_data.human_verification_enforced,
         llm_enabled=update_data.llm_enabled,
         llm_rate_limit_per_minute=update_data.llm_rate_limit_per_minute,
+        vibe_consensus_min_sample=update_data.vibe_consensus_min_sample,
+        vibe_consensus_max_stddev=update_data.vibe_consensus_max_stddev,
     )
     return SystemSettingsOut.model_validate(settings)
 

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -637,7 +637,13 @@ def get_pool_vibes(
     return _pool_vibes_state(db, current_user, set_obj)
 
 
-@router.post("/sets/{set_id}/pool/vibes/enrich", response_model=VibeEnrichmentResult)
+@router.post(
+    "/sets/{set_id}/pool/vibes/enrich",
+    response_model=VibeEnrichmentResult,
+    responses={
+        400: {"description": "No LLM connector configured for this DJ or the org."},
+    },
+)
 @limiter.limit("5/minute")
 async def enrich_pool_vibes(
     set_id: int,

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -17,10 +17,13 @@ from app.schemas.setbuilder import (
     ApplyTemplateResponse,
     BuilderPlaylistsOut,
     BuiltinTemplateOut,
+    CommunityVibeOut,
     CurvePointModel,
     CurveTemplateCreate,
     CurveTemplateOut,
     CurveTemplatesResponse,
+    LlmVibeOut,
+    OwnVibeOut,
     PoolImportEventIn,
     PoolImportManualIn,
     PoolImportPlaylistIn,
@@ -32,6 +35,8 @@ from app.schemas.setbuilder import (
     PoolState,
     PoolTrackOut,
     PoolUrlPreview,
+    PoolVibesState,
+    ResolvedVibeOut,
     SetCreate,
     SetDetail,
     SetRename,
@@ -40,11 +45,14 @@ from app.schemas.setbuilder import (
     SlotTargetOut,
     SlotTargetUpdate,
     TemplateWindowOut,
+    TrackVibeStateOut,
+    VibeEnrichmentResult,
     VibeWindowModel,
     VibeWindowsPut,
     VibeWindowsResponse,
 )
-from app.services.setbuilder import curve, pool, set_service
+from app.services.llm.exceptions import NoLlmConfigured
+from app.services.setbuilder import curve, pool, set_service, vibe_enrichment, vibe_resolver
 from app.services.setbuilder.playlist_url import InvalidPlaylistUrl, parse_public_playlist_url
 
 router = APIRouter()
@@ -566,3 +574,90 @@ def remove_pool_source(
         raise HTTPException(status_code=404, detail="Source not found")
     removed = pool.remove_source(db, set_obj, source)
     return PoolMutationResult(removed=removed, pool=_pool_state(db, set_obj.id))
+
+
+# ---------------------------------------------------------------------------
+# Track vibes (issue #391) — read-only three-tier state + LLM enrichment
+
+
+def _pool_vibes_state(db: Session, actor: User, set_obj: Set) -> PoolVibesState:
+    states = vibe_resolver.build_pool_vibe_states(db, actor, set_obj)
+    out = []
+    for s in states:
+        llm_out = None
+        if s.llm is not None:
+            llm_out = LlmVibeOut(
+                energy=s.llm.energy,
+                mood=s.llm.mood,
+                era=s.llm.era,
+                sing_along=s.llm.sing_along,
+                dance_floor=s.llm.dance_floor,
+                transitional_role=s.llm.transitional_role,
+                confidence=s.llm.confidence,
+                low_confidence=vibe_resolver.is_low_confidence(s.llm),
+                llm_provider=s.llm.llm_provider,
+                llm_model=s.llm.llm_model,
+            )
+        out.append(
+            TrackVibeStateOut(
+                pool_track_id=s.pool_track_id,
+                vibe_key=s.vibe_key,
+                own=OwnVibeOut(energy=s.own.energy, mood=s.own.mood) if s.own else None,
+                community=(
+                    CommunityVibeOut(
+                        energy=s.community.energy,
+                        mood=s.community.mood,
+                        sample_size=s.community.sample_size,
+                    )
+                    if s.community
+                    else None
+                ),
+                llm=llm_out,
+                resolved=ResolvedVibeOut(
+                    energy=s.resolved.energy,
+                    energy_source=s.resolved.energy_source,
+                    mood=s.resolved.mood,
+                    mood_source=s.resolved.mood_source,
+                ),
+            )
+        )
+    return PoolVibesState(tracks=out)
+
+
+@router.get("/sets/{set_id}/pool/vibes", response_model=PoolVibesState)
+@limiter.limit("60/minute")
+def get_pool_vibes(
+    set_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PoolVibesState:
+    """Three-tier vibe state (own / community / LLM) for the set's pool."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    return _pool_vibes_state(db, current_user, set_obj)
+
+
+@router.post("/sets/{set_id}/pool/vibes/enrich", response_model=VibeEnrichmentResult)
+@limiter.limit("5/minute")
+async def enrich_pool_vibes(
+    set_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> VibeEnrichmentResult:
+    """Batch-enrich uncached pool tracks via the LLM gateway (20 tracks/call)."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    try:
+        stats = await vibe_enrichment.enrich_pool_vibes(db, current_user, set_obj)
+    except NoLlmConfigured:
+        raise HTTPException(
+            status_code=400,
+            detail="No AI connector configured — connect one in Settings → AI.",
+        ) from None
+    return VibeEnrichmentResult(
+        enriched=stats.enriched,
+        cached=stats.cached,
+        failed=stats.failed,
+        llm_calls=stats.llm_calls,
+        vibes=_pool_vibes_state(db, current_user, set_obj),
+    )

--- a/server/app/models/system_settings.py
+++ b/server/app/models/system_settings.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, ForeignKey, Integer, text
+from sqlalchemy import Boolean, Float, ForeignKey, Integer, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base
@@ -46,4 +46,14 @@ class SystemSettings(Base):
     # FK kept nullable; SET NULL on connector delete to avoid orphan references.
     llm_default_connector_id: Mapped[int | None] = mapped_column(
         ForeignKey("llm_connectors.id", ondelete="SET NULL"), nullable=True
+    )
+
+    # Community vibe consensus gates (issue #391). Consensus over
+    # TrackVibeOverride requires sample_size >= min_sample AND energy stddev
+    # < max_stddev. Bounds enforced at the API layer.
+    vibe_consensus_min_sample: Mapped[int] = mapped_column(
+        Integer, default=3, server_default=text("3")
+    )
+    vibe_consensus_max_stddev: Mapped[float] = mapped_column(
+        Float, default=1.5, server_default=text("1.5")
     )

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -381,3 +381,73 @@ class SharedSetView(BaseModel):
     key_strictness: float
     slots: list[SharedSlotView]
     curve_points: list[SharedCurvePointView]
+
+
+# ---------------------------------------------------------------------------
+# Track vibes (issue #391) — read-only three-tier display + enrichment trigger
+
+
+class OwnVibeOut(BaseModel):
+    """The DJ's own override tier."""
+
+    energy: int | None
+    mood: str | None
+
+
+class CommunityVibeOut(BaseModel):
+    """Community consensus tier (gated by SystemSettings thresholds)."""
+
+    energy: int | None
+    mood: str | None
+    sample_size: int
+
+
+class LlmVibeOut(BaseModel):
+    """Globally-cached LLM guess tier."""
+
+    energy: int | None
+    mood: str | None
+    era: str | None
+    sing_along: bool | None
+    dance_floor: bool | None
+    transitional_role: str | None
+    confidence: float | None
+    low_confidence: bool
+    llm_provider: str
+    llm_model: str
+
+
+class ResolvedVibeOut(BaseModel):
+    """Per-field precedence result: own -> community -> llm."""
+
+    energy: int | None
+    energy_source: Literal["own", "community", "llm"] | None
+    mood: str | None
+    mood_source: Literal["own", "community", "llm"] | None
+
+
+class TrackVibeStateOut(BaseModel):
+    """All three tiers + resolution for one pool track."""
+
+    pool_track_id: int
+    vibe_key: str
+    own: OwnVibeOut | None
+    community: CommunityVibeOut | None
+    llm: LlmVibeOut | None
+    resolved: ResolvedVibeOut
+
+
+class PoolVibesState(BaseModel):
+    """Vibe state for every track in a set's pool."""
+
+    tracks: list[TrackVibeStateOut]
+
+
+class VibeEnrichmentResult(BaseModel):
+    """Result of an enrichment run, plus the refreshed vibe state."""
+
+    enriched: int
+    cached: int
+    failed: int
+    llm_calls: int
+    vibes: PoolVibesState

--- a/server/app/schemas/system_settings.py
+++ b/server/app/schemas/system_settings.py
@@ -13,6 +13,8 @@ class SystemSettingsOut(BaseSchema):
     human_verification_enforced: bool
     llm_enabled: bool
     llm_rate_limit_per_minute: int
+    vibe_consensus_min_sample: int
+    vibe_consensus_max_stddev: float
 
 
 class SystemSettingsUpdate(BaseModel):
@@ -25,3 +27,5 @@ class SystemSettingsUpdate(BaseModel):
     human_verification_enforced: bool | None = None
     llm_enabled: bool | None = None
     llm_rate_limit_per_minute: int | None = Field(None, ge=1, le=30)
+    vibe_consensus_min_sample: int | None = Field(None, ge=1, le=100)
+    vibe_consensus_max_stddev: float | None = Field(None, ge=0.1, le=5.0)

--- a/server/app/services/llm/base.py
+++ b/server/app/services/llm/base.py
@@ -90,6 +90,7 @@ class ChatResponse(BaseModel):
     model: str | None = None
     # The connector_type that served the call (e.g. "anthropic_apikey").
     # Populated by the gateway from the resolved connector — adapters leave it None.
+    # Not surfaced on streamed responses (ChatResponseChunk).
     provider: str | None = None
 
 

--- a/server/app/services/llm/base.py
+++ b/server/app/services/llm/base.py
@@ -88,6 +88,9 @@ class ChatResponse(BaseModel):
     usage: TokenUsage | None = None
     # The provider model id that actually produced the response (for telemetry).
     model: str | None = None
+    # The connector_type that served the call (e.g. "anthropic_apikey").
+    # Populated by the gateway from the resolved connector — adapters leave it None.
+    provider: str | None = None
 
 
 class ToolCallDelta(BaseModel):

--- a/server/app/services/llm/gateway.py
+++ b/server/app/services/llm/gateway.py
@@ -339,7 +339,8 @@ async def _attempt(
         tokens_out=tokens_out,
     )
     db.commit()
-    return response
+    # Surface which connector served the call (issue #391 — vibe provenance).
+    return response.model_copy(update={"provider": connector.connector_type})
 
 
 async def _attempt_stream(

--- a/server/app/services/setbuilder/community_vibe.py
+++ b/server/app/services/setbuilder/community_vibe.py
@@ -12,6 +12,15 @@ masquerades as consensus:
 - ``exclude_user_id`` drops one user's votes — the read-time resolver passes
   the viewing DJ so their own vote (precedence tier 1) never double-counts
   into the community tier they fall back to.
+
+Write-side contract (v1.1 note):
+  Override rows are FULL SNAPSHOTS — the latest row per (track, user) entirely
+  supersedes all earlier rows for that pair.  The future write endpoint MUST
+  carry forward any field the user did not explicitly change when inserting a
+  new row; otherwise a partial edit silently retracts the fields left out.
+  Example: if a user previously set energy=7, mood="dark" and the write UI
+  only sends a new energy=8, the new row must still include mood="dark" or the
+  mood vote is permanently lost for that user.
 """
 
 from collections import Counter, defaultdict
@@ -26,6 +35,12 @@ from app.models.track_vibe import TrackVibeOverride
 
 @dataclass(frozen=True)
 class CommunityVibe:
+    """Aggregated community vibe for a single track.
+
+    ``sample_size`` is the number of votes backing the strongest field — the
+    maximum of the energy-vote count and the mood-vote count.
+    """
+
     energy: int | None
     mood: str | None
     sample_size: int
@@ -53,7 +68,7 @@ def community_consensus(
     exclude_user_id: int | None = None,
 ) -> dict[str, CommunityVibe]:
     """Per-track community consensus; only tracks with >= 1 consensual field appear."""
-    keys = list(track_keys)
+    keys = list(dict.fromkeys(track_keys))
     if not keys:
         return {}
 

--- a/server/app/services/setbuilder/community_vibe.py
+++ b/server/app/services/setbuilder/community_vibe.py
@@ -1,0 +1,88 @@
+"""Community vibe consensus over TrackVibeOverride (issue #391).
+
+Aggregates per-DJ override rows into a community signal, gated so noise never
+masquerades as consensus:
+
+- Only each user's LATEST vote per track counts (later rows supersede earlier).
+- Energy consensus needs >= ``min_sample`` votes whose population stddev is
+  strictly below ``max_stddev``; the value is the rounded mean.
+- Mood consensus needs >= ``min_sample`` mood votes and a strict-majority
+  winner (more than half of the mood votes).
+- Tracks where neither field reaches consensus are omitted from the result.
+- ``exclude_user_id`` drops one user's votes — the read-time resolver passes
+  the viewing DJ so their own vote (precedence tier 1) never double-counts
+  into the community tier they fall back to.
+"""
+
+from collections import Counter, defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+from statistics import fmean, pstdev
+
+from sqlalchemy.orm import Session
+
+from app.models.track_vibe import TrackVibeOverride
+
+
+@dataclass(frozen=True)
+class CommunityVibe:
+    energy: int | None
+    mood: str | None
+    sample_size: int
+
+
+def _energy_consensus(votes: list[int], min_sample: int, max_stddev: float) -> int | None:
+    if not votes or len(votes) < min_sample or pstdev(votes) >= max_stddev:
+        return None
+    return round(fmean(votes))
+
+
+def _mood_consensus(votes: list[str], min_sample: int) -> str | None:
+    if not votes or len(votes) < min_sample:
+        return None
+    winner, count = Counter(votes).most_common(1)[0]
+    return winner if count > len(votes) / 2 else None
+
+
+def community_consensus(
+    db: Session,
+    track_keys: Iterable[str],
+    *,
+    min_sample: int,
+    max_stddev: float,
+    exclude_user_id: int | None = None,
+) -> dict[str, CommunityVibe]:
+    """Per-track community consensus; only tracks with >= 1 consensual field appear."""
+    keys = list(track_keys)
+    if not keys:
+        return {}
+
+    query = db.query(TrackVibeOverride).filter(TrackVibeOverride.track_id.in_(keys))
+    if exclude_user_id is not None:
+        query = query.filter(TrackVibeOverride.user_id != exclude_user_id)
+    rows = query.order_by(TrackVibeOverride.id).all()
+
+    latest: dict[tuple[str, int], TrackVibeOverride] = {}
+    for row in rows:
+        latest[(row.track_id, row.user_id)] = row  # later rows supersede earlier
+
+    votes_by_track: dict[str, list[TrackVibeOverride]] = defaultdict(list)
+    for row in latest.values():
+        votes_by_track[row.track_id].append(row)
+
+    result: dict[str, CommunityVibe] = {}
+    for track_id, votes in votes_by_track.items():
+        energy_votes = [v.energy_override for v in votes if v.energy_override is not None]
+        mood_votes = [v.mood_override for v in votes if v.mood_override is not None]
+
+        energy = _energy_consensus(energy_votes, min_sample, max_stddev)
+        mood = _mood_consensus(mood_votes, min_sample)
+        if energy is None and mood is None:
+            continue
+
+        result[track_id] = CommunityVibe(
+            energy=energy,
+            mood=mood,
+            sample_size=max(len(energy_votes), len(mood_votes)),
+        )
+    return result

--- a/server/app/services/setbuilder/vibe_enrichment.py
+++ b/server/app/services/setbuilder/vibe_enrichment.py
@@ -197,10 +197,72 @@ def _parse_items(response: ChatResponse, batch: list[SetPoolTrack]) -> dict[int,
                 "dance_floor": (
                     item.get("dance_floor") if isinstance(item.get("dance_floor"), bool) else None
                 ),
-                "transitional_role": role if role in TRANSITIONAL_ROLES else None,
+                # isinstance guard first: an unhashable role (list/dict) would
+                # raise TypeError on frozenset membership.
+                "transitional_role": (
+                    role if isinstance(role, str) and role in TRANSITIONAL_ROLES else None
+                ),
                 "confidence": _clamp(item.get("confidence"), 0.0, 1.0, as_int=False),
             }
     return parsed
+
+
+def _vibe_row(key: str, fields: dict, response: ChatResponse) -> TrackVibe:
+    return TrackVibe(
+        track_id=key,
+        **fields,
+        llm_provider=response.provider or "unknown",
+        llm_model=response.model or "unknown",
+        prompt_version=PROMPT_VERSION,
+        schema_version=SCHEMA_VERSION,
+    )
+
+
+def _persist_batch(
+    db: Session,
+    response: ChatResponse,
+    batch: list[SetPoolTrack],
+    parsed: dict[int, dict],
+) -> tuple[int, int]:
+    """Persist one batch's parsed rows; returns ``(enriched, cached)`` deltas.
+
+    Race safety: a concurrent enrichment may have inserted some of these keys
+    since the initial cache check — re-check just before inserting. If the
+    commit still hits an IntegrityError (a winner landed between re-check and
+    commit), roll back, re-query which keys now exist (those count as cached),
+    and re-insert only the still-missing rows so the paid results are kept. A
+    second IntegrityError is a pathological double-race: roll back and count
+    the remainder as cached — bounded, no retry loop.
+    """
+    existing_now = _cached_keys(db, (vibe_key(batch[i]) for i in parsed))
+    cached = 0
+    to_insert: dict[str, dict] = {}
+    for index, fields in parsed.items():
+        key = vibe_key(batch[index])
+        if key in existing_now:
+            cached += 1
+        else:
+            to_insert[key] = fields
+
+    for key, fields in to_insert.items():
+        db.add(_vibe_row(key, fields, response))
+    try:
+        db.commit()
+        return len(to_insert), cached
+    except IntegrityError:
+        db.rollback()
+
+    existing_after = _cached_keys(db, to_insert)
+    cached += len(existing_after)
+    retry = {k: f for k, f in to_insert.items() if k not in existing_after}
+    for key, fields in retry.items():
+        db.add(_vibe_row(key, fields, response))
+    try:
+        db.commit()
+        return len(retry), cached
+    except IntegrityError:
+        db.rollback()
+        return 0, cached + len(retry)
 
 
 async def enrich_pool_vibes(db: Session, actor: User, set_obj: Set) -> VibeEnrichmentStats:
@@ -242,33 +304,15 @@ async def enrich_pool_vibes(db: Session, actor: User, set_obj: Set) -> VibeEnric
 
         parsed = _parse_items(response, batch)
         failed += len(batch) - len(parsed)
-
-        # Race safety: a concurrent enrichment may have inserted some of these
-        # keys since the initial cache check — re-check just before inserting.
-        existing_now = _cached_keys(db, (vibe_key(batch[i]) for i in parsed))
-        rows_added = 0
-        for index, fields in parsed.items():
-            key = vibe_key(batch[index])
-            if key in existing_now:
-                cached += 1
-                continue
-            db.add(
-                TrackVibe(
-                    track_id=key,
-                    **fields,
-                    llm_provider=response.provider or "unknown",
-                    llm_model=response.model or "unknown",
-                    prompt_version=PROMPT_VERSION,
-                    schema_version=SCHEMA_VERSION,
-                )
+        if response.stop_reason == "max_tokens":
+            logger.warning(
+                "vibe enrichment batch truncated at max_tokens: %d/%d items parsed",
+                len(parsed),
+                len(batch),
             )
-            rows_added += 1
-        try:
-            db.commit()
-            enriched += rows_added
-        except IntegrityError:
-            # Concurrent enrichment won the race between re-check and commit.
-            db.rollback()
-            cached += rows_added
+
+        batch_enriched, batch_cached = _persist_batch(db, response, batch, parsed)
+        enriched += batch_enriched
+        cached += batch_cached
 
     return VibeEnrichmentStats(enriched=enriched, cached=cached, failed=failed, llm_calls=llm_calls)

--- a/server/app/services/setbuilder/vibe_enrichment.py
+++ b/server/app/services/setbuilder/vibe_enrichment.py
@@ -1,0 +1,274 @@
+"""WrzDJSet TrackVibe batch LLM enrichment (issue #391).
+
+Fills the global ``track_vibes`` cache for a set's pool via the LLM gateway,
+batching BATCH_SIZE tracks per forced-``tool_use`` dispatch (defensive parsing
+mirrors ``services/recommendation/llm_client.py``). The cache is GLOBAL: any
+row matching (track key, PROMPT_VERSION, SCHEMA_VERSION) — regardless of
+provider/model — counts as cached, so a second DJ pays zero even on a
+different connector. Bumping PROMPT_VERSION lazily invalidates old rows.
+
+Telemetry rule: warnings log counts only — never prompt/completion/track content.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.set import Set
+from app.models.set_pool import SetPoolTrack
+from app.models.track_vibe import TrackVibe
+from app.models.user import User
+from app.services.llm.base import ChatRequest, ChatResponse, Message, ToolSpec
+from app.services.llm.exceptions import LlmError, NoLlmConfigured
+from app.services.llm.gateway import Gateway
+
+logger = logging.getLogger(__name__)
+
+PURPOSE = "vibe_enrichment"
+PROMPT_VERSION = "v1"
+SCHEMA_VERSION = "v1"
+BATCH_SIZE = 20
+MAX_TOKENS = 4096
+TRANSITIONAL_ROLES = frozenset({"intro", "build", "peak", "cool", "any"})
+VIBES_TOOL_NAME = "submit_track_vibes"
+
+SYSTEM_PROMPT = """You are a music-metadata expert annotating tracks for DJ set planning.
+
+For each numbered track estimate:
+- energy: integer 0-10 (0 = ambient/chill, 10 = peak-time mainstage intensity)
+- mood: one or two lowercase words (e.g. "euphoric", "dark", "feel-good")
+- era: release decade or scene era (e.g. "90s", "2010s", "classic house")
+- sing_along: true if crowds commonly sing the hook out loud
+- dance_floor: true if the track reliably keeps a dance floor moving
+- transitional_role: where it fits in a set arc — "intro", "build", "peak", "cool", or "any"
+- confidence: 0-1 — how certain you are you know this exact track
+  (0.2 = guessing from the title, 0.9 = you know the track well)
+
+Be honest with confidence: if you do not recognize a track, keep confidence
+below 0.4 and infer from title/artist/genre conventions. Return one entry per
+input track, matched by index."""
+
+VIBES_TOOL_DESCRIPTION = (
+    "Submit vibe annotations for the input tracks — one entry per track, matched by index."
+)
+
+VIBES_TOOL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "tracks": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "index": {"type": "integer", "description": "Input track number"},
+                    "energy": {"type": "integer", "minimum": 0, "maximum": 10},
+                    "mood": {"type": "string", "description": "1-2 lowercase words"},
+                    "era": {"type": "string", "description": "decade or scene era"},
+                    "sing_along": {"type": "boolean"},
+                    "dance_floor": {"type": "boolean"},
+                    "transitional_role": {
+                        "type": "string",
+                        "enum": ["intro", "build", "peak", "cool", "any"],
+                    },
+                    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                },
+                "required": ["index", "energy", "confidence"],
+            },
+        }
+    },
+    "required": ["tracks"],
+}
+
+
+def vibe_key(track: SetPoolTrack) -> str:
+    """Global cache key — namespaced track_id, else the dedupe signature."""
+    return track.track_id or f"sig:{track.dedupe_sig}"
+
+
+@dataclass(frozen=True)
+class VibeEnrichmentStats:
+    enriched: int
+    cached: int
+    failed: int
+    llm_calls: int
+
+
+def _cached_keys(db: Session, keys: Iterable[str]) -> set[str]:
+    """Keys that already have ANY TrackVibe row at the current prompt/schema version."""
+    keys = list(keys)
+    if not keys:
+        return set()
+    rows = (
+        db.query(TrackVibe.track_id)
+        .filter(
+            TrackVibe.track_id.in_(keys),
+            TrackVibe.prompt_version == PROMPT_VERSION,
+            TrackVibe.schema_version == SCHEMA_VERSION,
+        )
+        .all()
+    )
+    return {row[0] for row in rows}
+
+
+def _track_line(index: int, track: SetPoolTrack) -> str:
+    line = f"{index}. {track.artist} — {track.title}"
+    if track.genre and track.bpm:
+        line += f" ({track.genre}, {track.bpm:.0f} BPM)"
+    elif track.genre:
+        line += f" ({track.genre})"
+    elif track.bpm:
+        line += f" ({track.bpm:.0f} BPM)"
+    return line
+
+
+def _build_request(batch: list[SetPoolTrack]) -> ChatRequest:
+    lines = [_track_line(i, track) for i, track in enumerate(batch)]
+    return ChatRequest(
+        messages=[Message(role="user", content="\n".join(lines))],
+        system=SYSTEM_PROMPT,
+        tools=[
+            ToolSpec(
+                name=VIBES_TOOL_NAME,
+                description=VIBES_TOOL_DESCRIPTION,
+                input_schema=VIBES_TOOL_SCHEMA,
+            )
+        ],
+        force_tool=VIBES_TOOL_NAME,
+        max_tokens=MAX_TOKENS,
+        # IMPORTANT design deviation: issue #391 asked for model_hint="fast",
+        # but the gateway has no speed-tier concept — ChatRequest.model is a
+        # hard override of the connector's configured model. Passing None lets
+        # the connector's own configured model govern.
+        model=None,
+    )
+
+
+def _clamp(value: object, lo: float, hi: float, *, as_int: bool) -> int | float | None:
+    """Clamp a numeric into [lo, hi] (rounded when ``as_int``). Bools / non-numerics -> None."""
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    clamped = max(lo, min(hi, value))
+    return round(clamped) if as_int else float(clamped)
+
+
+def _clean_str(value: object) -> str | None:
+    """Strings only: strip + truncate to 50 chars; empty -> None."""
+    if not isinstance(value, str):
+        return None
+    return value.strip()[:50] or None
+
+
+def _parse_items(response: ChatResponse, batch: list[SetPoolTrack]) -> dict[int, dict]:
+    """Defensively extract per-track vibe fields from the forced tool call.
+
+    Returns ``{batch_index: vibe_fields}`` — first entry per index wins;
+    out-of-range / malformed items are skipped rather than raising.
+    """
+    parsed: dict[int, dict] = {}
+    for tc in response.tool_calls or []:
+        if tc.name != VIBES_TOOL_NAME:
+            continue
+        payload = tc.input if isinstance(tc.input, dict) else {}
+        items = payload.get("tracks")
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            index = item.get("index")
+            # isinstance(True, int) is True — exclude bools explicitly.
+            if isinstance(index, bool) or not isinstance(index, int):
+                continue
+            if not (0 <= index < len(batch)) or index in parsed:
+                continue
+            role = item.get("transitional_role")
+            parsed[index] = {
+                "energy": _clamp(item.get("energy"), 0, 10, as_int=True),
+                "mood": _clean_str(item.get("mood")),
+                "era": _clean_str(item.get("era")),
+                "sing_along": (
+                    item.get("sing_along") if isinstance(item.get("sing_along"), bool) else None
+                ),
+                "dance_floor": (
+                    item.get("dance_floor") if isinstance(item.get("dance_floor"), bool) else None
+                ),
+                "transitional_role": role if role in TRANSITIONAL_ROLES else None,
+                "confidence": _clamp(item.get("confidence"), 0.0, 1.0, as_int=False),
+            }
+    return parsed
+
+
+async def enrich_pool_vibes(db: Session, actor: User, set_obj: Set) -> VibeEnrichmentStats:
+    """Enrich the set's pool with LLM vibe annotations, using the global cache.
+
+    Raises :class:`NoLlmConfigured` (caller maps it to 400); any other
+    :class:`LlmError` aborts remaining batches (no provider hammering) and
+    counts the unprocessed tracks as failed.
+    """
+    tracks = db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_obj.id).all()
+    by_key = {vibe_key(t): t for t in tracks}  # de-dupes within the pool
+
+    already = _cached_keys(db, by_key)
+    cached = len(already)
+    missing = [k for k in by_key if k not in already]
+
+    enriched = 0
+    failed = 0
+    llm_calls = 0
+
+    batches = [missing[i : i + BATCH_SIZE] for i in range(0, len(missing), BATCH_SIZE)]
+    for batch_no, key_batch in enumerate(batches):
+        batch = [by_key[k] for k in key_batch]
+        llm_calls += 1
+        try:
+            response = await Gateway.dispatch(db, actor, _build_request(batch), purpose=PURPOSE)
+        except NoLlmConfigured:
+            raise
+        except LlmError as exc:
+            remaining = sum(len(b) for b in batches[batch_no:])
+            failed += remaining
+            logger.warning(
+                "vibe enrichment aborted on %s: %d tracks unprocessed across %d batches",
+                type(exc).__name__,
+                remaining,
+                len(batches) - batch_no,
+            )
+            break
+
+        parsed = _parse_items(response, batch)
+        failed += len(batch) - len(parsed)
+
+        # Race safety: a concurrent enrichment may have inserted some of these
+        # keys since the initial cache check — re-check just before inserting.
+        existing_now = _cached_keys(db, (vibe_key(batch[i]) for i in parsed))
+        rows_added = 0
+        for index, fields in parsed.items():
+            key = vibe_key(batch[index])
+            if key in existing_now:
+                cached += 1
+                continue
+            db.add(
+                TrackVibe(
+                    track_id=key,
+                    **fields,
+                    llm_provider=response.provider or "unknown",
+                    llm_model=response.model or "unknown",
+                    prompt_version=PROMPT_VERSION,
+                    schema_version=SCHEMA_VERSION,
+                )
+            )
+            rows_added += 1
+        try:
+            db.commit()
+            enriched += rows_added
+        except IntegrityError:
+            # Concurrent enrichment won the race between re-check and commit.
+            db.rollback()
+            cached += rows_added
+
+    return VibeEnrichmentStats(enriched=enriched, cached=cached, failed=failed, llm_calls=llm_calls)

--- a/server/app/services/setbuilder/vibe_resolver.py
+++ b/server/app/services/setbuilder/vibe_resolver.py
@@ -80,9 +80,10 @@ class TrackVibeState:
 
 def _own_overrides(db: Session, user_id: int, keys: list[str]) -> dict[str, OwnVibe]:
     """Latest override per track for one user; rows with both fields null count as no override."""
+    unique_keys = list(dict.fromkeys(keys))
     rows = (
         db.query(TrackVibeOverride)
-        .filter(TrackVibeOverride.user_id == user_id, TrackVibeOverride.track_id.in_(keys))
+        .filter(TrackVibeOverride.user_id == user_id, TrackVibeOverride.track_id.in_(unique_keys))
         .order_by(TrackVibeOverride.id)
         .all()
     )
@@ -98,10 +99,11 @@ def _own_overrides(db: Session, user_id: int, keys: list[str]) -> dict[str, OwnV
 
 def _llm_vibes(db: Session, keys: list[str]) -> dict[str, TrackVibe]:
     """Newest (highest id) current-version TrackVibe row per key — stale versions ignored."""
+    unique_keys = list(dict.fromkeys(keys))
     rows = (
         db.query(TrackVibe)
         .filter(
-            TrackVibe.track_id.in_(keys),
+            TrackVibe.track_id.in_(unique_keys),
             TrackVibe.prompt_version == PROMPT_VERSION,
             TrackVibe.schema_version == SCHEMA_VERSION,
         )

--- a/server/app/services/setbuilder/vibe_resolver.py
+++ b/server/app/services/setbuilder/vibe_resolver.py
@@ -1,0 +1,150 @@
+"""Read-time three-tier vibe precedence (issue #391): own -> community -> LLM cache.
+
+Nothing is materialized: every read resolves each vibe field independently by
+walking the tiers and taking the first non-None value, tagged with its source
+for UI provenance. The viewing DJ's own vote is excluded from the community
+tier (it already IS tier 1), and the LLM tier only trusts rows at the current
+PROMPT_VERSION/SCHEMA_VERSION — stale cache rows stay invisible.
+"""
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from app.models.set import Set
+from app.models.set_pool import SetPoolTrack
+from app.models.track_vibe import TrackVibe, TrackVibeOverride
+from app.models.user import User
+from app.services.setbuilder.community_vibe import CommunityVibe, community_consensus
+from app.services.setbuilder.vibe_enrichment import PROMPT_VERSION, SCHEMA_VERSION, vibe_key
+from app.services.system_settings import get_system_settings
+
+LOW_CONFIDENCE_THRESHOLD = 0.5
+
+
+@dataclass(frozen=True)
+class OwnVibe:
+    energy: int | None
+    mood: str | None
+
+
+@dataclass(frozen=True)
+class ResolvedVibe:
+    energy: int | None
+    energy_source: str | None  # "own" | "community" | "llm" | None
+    mood: str | None
+    mood_source: str | None
+
+
+def is_low_confidence(vibe: TrackVibe) -> bool:
+    """True when the LLM guess should be flagged for DJ review."""
+    return vibe.confidence is None or vibe.confidence < LOW_CONFIDENCE_THRESHOLD
+
+
+def _first(*tiers: tuple[object, str]) -> tuple[object, str | None]:
+    """First non-None value walking the tiers, tagged with its source name."""
+    for value, source in tiers:
+        if value is not None:
+            return value, source
+    return None, None
+
+
+def resolve_vibe(
+    own: OwnVibe | None, community: CommunityVibe | None, llm: TrackVibe | None
+) -> ResolvedVibe:
+    """PER-FIELD cascade: energy and mood resolve independently through the tiers."""
+    energy, energy_source = _first(
+        (own.energy if own else None, "own"),
+        (community.energy if community else None, "community"),
+        (llm.energy if llm else None, "llm"),
+    )
+    mood, mood_source = _first(
+        (own.mood if own else None, "own"),
+        (community.mood if community else None, "community"),
+        (llm.mood if llm else None, "llm"),
+    )
+    return ResolvedVibe(
+        energy=energy, energy_source=energy_source, mood=mood, mood_source=mood_source
+    )
+
+
+@dataclass(frozen=True)
+class TrackVibeState:
+    pool_track_id: int
+    vibe_key: str
+    own: OwnVibe | None
+    community: CommunityVibe | None
+    llm: TrackVibe | None
+    resolved: ResolvedVibe
+
+
+def _own_overrides(db: Session, user_id: int, keys: list[str]) -> dict[str, OwnVibe]:
+    """Latest override per track for one user; rows with both fields null count as no override."""
+    rows = (
+        db.query(TrackVibeOverride)
+        .filter(TrackVibeOverride.user_id == user_id, TrackVibeOverride.track_id.in_(keys))
+        .order_by(TrackVibeOverride.id)
+        .all()
+    )
+    latest: dict[str, TrackVibeOverride] = {}
+    for row in rows:
+        latest[row.track_id] = row  # later rows supersede earlier
+    return {
+        key: OwnVibe(energy=row.energy_override, mood=row.mood_override)
+        for key, row in latest.items()
+        if row.energy_override is not None or row.mood_override is not None
+    }
+
+
+def _llm_vibes(db: Session, keys: list[str]) -> dict[str, TrackVibe]:
+    """Newest (highest id) current-version TrackVibe row per key — stale versions ignored."""
+    rows = (
+        db.query(TrackVibe)
+        .filter(
+            TrackVibe.track_id.in_(keys),
+            TrackVibe.prompt_version == PROMPT_VERSION,
+            TrackVibe.schema_version == SCHEMA_VERSION,
+        )
+        .order_by(TrackVibe.id)
+        .all()
+    )
+    newest: dict[str, TrackVibe] = {}
+    for row in rows:
+        newest[row.track_id] = row  # higher id wins
+    return newest
+
+
+def build_pool_vibe_states(db: Session, actor: User, set_obj: Set) -> list[TrackVibeState]:
+    """One TrackVibeState per pool track; tracks sharing a vibe_key share their tiers."""
+    tracks = (
+        db.query(SetPoolTrack)
+        .filter(SetPoolTrack.set_id == set_obj.id)
+        .order_by(SetPoolTrack.id)
+        .all()
+    )
+    if not tracks:
+        return []
+    keys = [vibe_key(t) for t in tracks]
+
+    settings = get_system_settings(db)
+    own = _own_overrides(db, actor.id, keys)
+    community = community_consensus(
+        db,
+        keys,
+        min_sample=settings.vibe_consensus_min_sample,
+        max_stddev=settings.vibe_consensus_max_stddev,
+        exclude_user_id=actor.id,
+    )
+    llm = _llm_vibes(db, keys)
+
+    return [
+        TrackVibeState(
+            pool_track_id=track.id,
+            vibe_key=key,
+            own=own.get(key),
+            community=community.get(key),
+            llm=llm.get(key),
+            resolved=resolve_vibe(own.get(key), community.get(key), llm.get(key)),
+        )
+        for track, key in zip(tracks, keys, strict=True)
+    ]

--- a/server/app/services/system_settings.py
+++ b/server/app/services/system_settings.py
@@ -27,6 +27,8 @@ def get_system_settings(db: Session) -> SystemSettings:
             llm_compatible_connector_enabled=True,
             llm_default_connector_id=None,
             llm_call_log_retention_days=30,
+            vibe_consensus_min_sample=3,
+            vibe_consensus_max_stddev=1.5,
         )
         db.add(settings)
         db.commit()
@@ -49,6 +51,8 @@ def update_system_settings(
     llm_compatible_connector_enabled: bool | None = None,
     llm_default_connector_id: int | None | object = _UNSET,
     llm_call_log_retention_days: int | None = None,
+    vibe_consensus_min_sample: int | None = None,
+    vibe_consensus_max_stddev: float | None = None,
 ) -> SystemSettings:
     """Update system settings fields."""
     settings = get_system_settings(db)
@@ -78,6 +82,10 @@ def update_system_settings(
         settings.llm_default_connector_id = llm_default_connector_id  # type: ignore[assignment]
     if llm_call_log_retention_days is not None:
         settings.llm_call_log_retention_days = llm_call_log_retention_days
+    if vibe_consensus_min_sample is not None:
+        settings.vibe_consensus_min_sample = vibe_consensus_min_sample
+    if vibe_consensus_max_stddev is not None:
+        settings.vibe_consensus_max_stddev = vibe_consensus_max_stddev
     db.commit()
     db.refresh(settings)
     return settings

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -16500,6 +16500,9 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "No LLM connector configured for this DJ or the org."
+          },
           "422": {
             "content": {
               "application/json": {

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -2226,6 +2226,44 @@
         "title": "CollectVoteRequest",
         "type": "object"
       },
+      "CommunityVibeOut": {
+        "description": "Community consensus tier (gated by SystemSettings thresholds).",
+        "properties": {
+          "energy": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Energy"
+          },
+          "mood": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mood"
+          },
+          "sample_size": {
+            "title": "Sample Size",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "energy",
+          "mood",
+          "sample_size"
+        ],
+        "title": "CommunityVibeOut",
+        "type": "object"
+      },
       "ConnectorCreate": {
         "description": "Provider-agnostic create payload.\n\nField requirements vary by ``connector_type``:\n\n- ``openai_apikey`` / ``anthropic_apikey`` / ``openrouter_apikey`` /\n  ``xai_apikey`` / ``gemini_apikey``: ``api_key`` required; ``base_url``\n  and ``bearer`` are ignored.\n- ``openai_compatible``: ``base_url`` required; ``bearer`` optional;\n  ``api_key`` is ignored.\n- ``bedrock``: ``aws_access_key_id``, ``aws_secret_access_key``,\n  ``aws_region`` and ``aws_model_id`` required; other fields ignored.\n- ``azure_openai``: ``api_key``, ``azure_resource_name``,\n  ``azure_deployment_name`` and ``azure_api_version`` all required.\n\nThe combination is enforced by :meth:`_require_credentials_for_type`.\nSee ``build_create_payload`` in ``services/llm/connector_storage.py``\nfor the full validation flow (including key shape checks).",
         "properties": {
@@ -4513,6 +4551,114 @@
         "title": "LiveJoinCodeResponse",
         "type": "object"
       },
+      "LlmVibeOut": {
+        "description": "Globally-cached LLM guess tier.",
+        "properties": {
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence"
+          },
+          "dance_floor": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dance Floor"
+          },
+          "energy": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Energy"
+          },
+          "era": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Era"
+          },
+          "llm_model": {
+            "title": "Llm Model",
+            "type": "string"
+          },
+          "llm_provider": {
+            "title": "Llm Provider",
+            "type": "string"
+          },
+          "low_confidence": {
+            "title": "Low Confidence",
+            "type": "boolean"
+          },
+          "mood": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mood"
+          },
+          "sing_along": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sing Along"
+          },
+          "transitional_role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Transitional Role"
+          }
+        },
+        "required": [
+          "confidence",
+          "dance_floor",
+          "energy",
+          "era",
+          "llm_model",
+          "llm_provider",
+          "low_confidence",
+          "mood",
+          "sing_along",
+          "transitional_role"
+        ],
+        "title": "LlmVibeOut",
+        "type": "object"
+      },
       "MePreferencesUpdate": {
         "properties": {
           "frictionless_join_default": {
@@ -4748,6 +4894,39 @@
           "title"
         ],
         "title": "NowPlayingResponse",
+        "type": "object"
+      },
+      "OwnVibeOut": {
+        "description": "The DJ's own override tier.",
+        "properties": {
+          "energy": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Energy"
+          },
+          "mood": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mood"
+          }
+        },
+        "required": [
+          "energy",
+          "mood"
+        ],
+        "title": "OwnVibeOut",
         "type": "object"
       },
       "PaginatedResponse": {
@@ -5620,6 +5799,23 @@
         "title": "PoolUrlPreview",
         "type": "object"
       },
+      "PoolVibesState": {
+        "description": "Vibe state for every track in a set's pool.",
+        "properties": {
+          "tracks": {
+            "items": {
+              "$ref": "#/components/schemas/TrackVibeStateOut"
+            },
+            "title": "Tracks",
+            "type": "array"
+          }
+        },
+        "required": [
+          "tracks"
+        ],
+        "title": "PoolVibesState",
+        "type": "object"
+      },
       "PublicEventInfo": {
         "properties": {
           "code": {
@@ -6394,6 +6590,73 @@
           "status"
         ],
         "title": "RequestUpdate",
+        "type": "object"
+      },
+      "ResolvedVibeOut": {
+        "description": "Per-field precedence result: own -> community -> llm.",
+        "properties": {
+          "energy": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Energy"
+          },
+          "energy_source": {
+            "anyOf": [
+              {
+                "enum": [
+                  "own",
+                  "community",
+                  "llm"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Energy Source"
+          },
+          "mood": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mood"
+          },
+          "mood_source": {
+            "anyOf": [
+              {
+                "enum": [
+                  "own",
+                  "community",
+                  "llm"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mood Source"
+          }
+        },
+        "required": [
+          "energy",
+          "energy_source",
+          "mood",
+          "mood_source"
+        ],
+        "title": "ResolvedVibeOut",
         "type": "object"
       },
       "SearchResult": {
@@ -7201,6 +7464,14 @@
           "tidal_enabled": {
             "title": "Tidal Enabled",
             "type": "boolean"
+          },
+          "vibe_consensus_max_stddev": {
+            "title": "Vibe Consensus Max Stddev",
+            "type": "number"
+          },
+          "vibe_consensus_min_sample": {
+            "title": "Vibe Consensus Min Sample",
+            "type": "integer"
           }
         },
         "required": [
@@ -7212,7 +7483,9 @@
           "registration_enabled",
           "search_rate_limit_per_minute",
           "spotify_enabled",
-          "tidal_enabled"
+          "tidal_enabled",
+          "vibe_consensus_max_stddev",
+          "vibe_consensus_min_sample"
         ],
         "title": "SystemSettingsOut",
         "type": "object"
@@ -7321,6 +7594,32 @@
               }
             ],
             "title": "Tidal Enabled"
+          },
+          "vibe_consensus_max_stddev": {
+            "anyOf": [
+              {
+                "maximum": 5.0,
+                "minimum": 0.1,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vibe Consensus Max Stddev"
+          },
+          "vibe_consensus_min_sample": {
+            "anyOf": [
+              {
+                "maximum": 100.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vibe Consensus Min Sample"
           }
         },
         "title": "SystemSettingsUpdate",
@@ -7811,6 +8110,62 @@
         "title": "Token",
         "type": "object"
       },
+      "TrackVibeStateOut": {
+        "description": "All three tiers + resolution for one pool track.",
+        "properties": {
+          "community": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CommunityVibeOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "llm": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LlmVibeOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "own": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OwnVibeOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pool_track_id": {
+            "title": "Pool Track Id",
+            "type": "integer"
+          },
+          "resolved": {
+            "$ref": "#/components/schemas/ResolvedVibeOut"
+          },
+          "vibe_key": {
+            "title": "Vibe Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "community",
+          "llm",
+          "own",
+          "pool_track_id",
+          "resolved",
+          "vibe_key"
+        ],
+        "title": "TrackVibeStateOut",
+        "type": "object"
+      },
       "UpdateCollectionSettings": {
         "properties": {
           "collection_opens_at": {
@@ -8196,6 +8551,39 @@
           "verified"
         ],
         "title": "VerifyStatusResponse",
+        "type": "object"
+      },
+      "VibeEnrichmentResult": {
+        "description": "Result of an enrichment run, plus the refreshed vibe state.",
+        "properties": {
+          "cached": {
+            "title": "Cached",
+            "type": "integer"
+          },
+          "enriched": {
+            "title": "Enriched",
+            "type": "integer"
+          },
+          "failed": {
+            "title": "Failed",
+            "type": "integer"
+          },
+          "llm_calls": {
+            "title": "Llm Calls",
+            "type": "integer"
+          },
+          "vibes": {
+            "$ref": "#/components/schemas/PoolVibesState"
+          }
+        },
+        "required": [
+          "cached",
+          "enriched",
+          "failed",
+          "llm_calls",
+          "vibes"
+        ],
+        "title": "VibeEnrichmentResult",
         "type": "object"
       },
       "VibeWindowModel": {
@@ -16033,6 +16421,102 @@
           }
         ],
         "summary": "Preview Pool Url",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/pool/vibes": {
+      "get": {
+        "description": "Three-tier vibe state (own / community / LLM) for the set's pool.",
+        "operationId": "get_pool_vibes_api_setbuilder_sets__set_id__pool_vibes_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PoolVibesState"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Pool Vibes",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/pool/vibes/enrich": {
+      "post": {
+        "description": "Batch-enrich uncached pool tracks via the LLM gateway (20 tracks/call).",
+        "operationId": "enrich_pool_vibes_api_setbuilder_sets__set_id__pool_vibes_enrich_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VibeEnrichmentResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Enrich Pool Vibes",
         "tags": [
           "setbuilder"
         ]

--- a/server/tests/test_api_contracts.py
+++ b/server/tests/test_api_contracts.py
@@ -151,6 +151,8 @@ SYSTEM_SETTINGS_KEYS = {
     "human_verification_enforced",
     "llm_enabled",
     "llm_rate_limit_per_minute",
+    "vibe_consensus_min_sample",
+    "vibe_consensus_max_stddev",
 }
 
 PUBLIC_SETTINGS_KEYS = {"registration_enabled", "turnstile_site_key"}

--- a/server/tests/test_llm_gateway.py
+++ b/server/tests/test_llm_gateway.py
@@ -599,3 +599,20 @@ class TestOrgScopedResolution:
         assert audit is not None
         assert audit.event_type == "auth_invalid_observed"
         assert audit.actor_user_id is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_populates_provider_from_connector(db, dj_user, gateway_request):
+    """#391 — vibe enrichment needs provider provenance on the response."""
+    _make_connector(db, dj_user)
+    fake_response = ChatResponse(
+        text="ok",
+        tool_calls=[],
+        stop_reason="end_turn",
+        usage=TokenUsage(prompt=1, completion=1),
+        model="gpt-5-mini",
+    )
+    with _patch_chat(AsyncMock(return_value=fake_response)):
+        resp = await Gateway.dispatch(db, dj_user, gateway_request, purpose="test")
+    assert resp.provider == "openai_apikey"
+    assert resp.model == "gpt-5-mini"

--- a/server/tests/test_setbuilder_vibes.py
+++ b/server/tests/test_setbuilder_vibes.py
@@ -1,5 +1,20 @@
 """Tests for TrackVibe LLM enrichment + community consensus + resolver (issue #391)."""
 
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.models.set import Set
+from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.models.track_vibe import TrackVibe
+from app.models.user import User
+from app.services.llm.base import ChatRequest, ChatResponse, ToolCall
+from app.services.llm.exceptions import NoLlmConfigured, ProviderUnavailable
+from app.services.setbuilder.vibe_enrichment import (
+    PROMPT_VERSION,
+    SCHEMA_VERSION,
+    enrich_pool_vibes,
+)
 from app.services.system_settings import get_system_settings, update_system_settings
 
 
@@ -42,3 +57,229 @@ class TestVibeConsensusSettings:
                 headers=admin_headers,
             )
             assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Batch LLM vibe enrichment (services/setbuilder/vibe_enrichment.py)
+# ---------------------------------------------------------------------------
+
+DISPATCH_TARGET = "app.services.setbuilder.vibe_enrichment.Gateway.dispatch"
+
+
+def _seed_pool(db, owner_id: int, n: int) -> Set:
+    s = Set(owner_id=owner_id, name="Vibe Set")
+    db.add(s)
+    db.flush()
+    src = SetPoolSource(set_id=s.id, kind="manual", external_ref=None, label="Manual")
+    db.add(src)
+    db.flush()
+    for i in range(n):
+        db.add(
+            SetPoolTrack(
+                set_id=s.id,
+                source_id=src.id,
+                track_id=f"tidal:{i}",
+                title=f"Track {i}",
+                artist=f"Artist {i}",
+                dedupe_sig=f"sig{i:04d}",
+            )
+        )
+    db.commit()
+    db.refresh(s)
+    return s
+
+
+def _fake_response(
+    batch_size: int, *, provider="anthropic_apikey", model="claude-haiku-4-5"
+) -> ChatResponse:
+    items = [
+        {
+            "index": i,
+            "energy": 7,
+            "mood": "euphoric",
+            "era": "2010s",
+            "sing_along": True,
+            "dance_floor": True,
+            "transitional_role": "peak",
+            "confidence": 0.8,
+        }
+        for i in range(batch_size)
+    ]
+    return ChatResponse(
+        text="",
+        tool_calls=[ToolCall(id="t1", name="submit_track_vibes", input={"tracks": items})],
+        stop_reason="tool_use",
+        model=model,
+        provider=provider,
+    )
+
+
+def _dispatch_side_effect(*args, **kwargs) -> ChatResponse:
+    """Build a fake response sized to the dispatched batch's track-line count."""
+    request: ChatRequest = args[2]
+    user_msg = next(m for m in request.messages if m.role == "user")
+    n_lines = len(str(user_msg.content).strip().splitlines())
+    return _fake_response(n_lines)
+
+
+class TestVibeEnrichment:
+    @pytest.mark.asyncio
+    async def test_100_tracks_costs_5_calls(self, db, test_user):
+        s = _seed_pool(db, test_user.id, 100)
+        mock = AsyncMock(side_effect=_dispatch_side_effect)
+        with patch(DISPATCH_TARGET, new=mock):
+            stats = await enrich_pool_vibes(db, test_user, s)
+        assert stats.llm_calls == 5
+        assert stats.enriched == 100
+        assert stats.failed == 0
+        assert mock.await_count == 5
+        assert db.query(TrackVibe).count() == 100
+
+    @pytest.mark.asyncio
+    async def test_second_run_fully_cached_even_for_other_dj(self, db, test_user):
+        s1 = _seed_pool(db, test_user.id, 100)
+        with patch(DISPATCH_TARGET, new=AsyncMock(side_effect=_dispatch_side_effect)):
+            await enrich_pool_vibes(db, test_user, s1)
+
+        other = User(username="otherdj", password_hash="x", role="dj")
+        db.add(other)
+        db.commit()
+        db.refresh(other)
+        s2 = _seed_pool(db, other.id, 100)  # same track_ids tidal:0..99
+
+        mock = AsyncMock(side_effect=_dispatch_side_effect)
+        with patch(DISPATCH_TARGET, new=mock):
+            stats = await enrich_pool_vibes(db, other, s2)
+        assert stats.llm_calls == 0
+        assert stats.cached == 100
+        assert stats.enriched == 0
+        mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_prompt_version_bump_reenriches(self, db, test_user):
+        s = _seed_pool(db, test_user.id, 1)
+        db.add(
+            TrackVibe(
+                track_id="tidal:0",
+                energy=5,
+                llm_provider="anthropic_apikey",
+                llm_model="claude-haiku-4-5",
+                prompt_version="v0",
+                schema_version=SCHEMA_VERSION,
+            )
+        )
+        db.commit()
+
+        mock = AsyncMock(side_effect=_dispatch_side_effect)
+        with patch(DISPATCH_TARGET, new=mock):
+            stats = await enrich_pool_vibes(db, test_user, s)
+        assert mock.await_count == 1
+        assert stats.enriched == 1
+        rows = db.query(TrackVibe).filter(TrackVibe.track_id == "tidal:0").all()
+        assert {r.prompt_version for r in rows} == {"v0", PROMPT_VERSION}
+        old = next(r for r in rows if r.prompt_version == "v0")
+        assert old.energy == 5  # old row untouched
+
+    @pytest.mark.asyncio
+    async def test_malformed_items_handled(self, db, test_user):
+        s = _seed_pool(db, test_user.id, 3)
+        items = [
+            {
+                "index": 0,
+                "energy": 99,  # clamp -> 10
+                "confidence": 1.7,  # clamp -> 1.0
+                "transitional_role": "banger",  # not in enum -> None
+                "mood": "dark",
+                "era": "90s",
+                "sing_along": "yes",  # not a bool -> None
+                "dance_floor": True,
+            },
+            {
+                "index": 1,
+                "energy": 7,
+                "mood": "euphoric",
+                "era": "2010s",
+                "sing_along": True,
+                "dance_floor": True,
+                "transitional_role": "peak",
+                "confidence": 0.8,
+            },
+            {"index": 7, "energy": 5, "confidence": 0.5},  # out-of-range -> ignored
+        ]
+        response = ChatResponse(
+            text="",
+            tool_calls=[ToolCall(id="t1", name="submit_track_vibes", input={"tracks": items})],
+            stop_reason="tool_use",
+            model="claude-haiku-4-5",
+            provider="anthropic_apikey",
+        )
+        with patch(DISPATCH_TARGET, new=AsyncMock(return_value=response)):
+            stats = await enrich_pool_vibes(db, test_user, s)
+        assert stats.enriched == 2
+        assert stats.failed == 1  # track 2 had no parsed entry
+        row0 = db.query(TrackVibe).filter(TrackVibe.track_id == "tidal:0").one()
+        assert row0.energy == 10
+        assert row0.confidence == 1.0
+        assert row0.transitional_role is None
+        assert row0.sing_along is None
+        assert row0.dance_floor is True
+        assert row0.mood == "dark"
+        row1 = db.query(TrackVibe).filter(TrackVibe.track_id == "tidal:1").one()
+        assert row1.energy == 7
+        assert db.query(TrackVibe).filter(TrackVibe.track_id == "tidal:2").count() == 0
+
+    @pytest.mark.asyncio
+    async def test_llm_error_marks_remaining_failed(self, db, test_user):
+        s = _seed_pool(db, test_user.id, 40)
+        mock = AsyncMock(side_effect=[_fake_response(20), ProviderUnavailable("down")])
+        with patch(DISPATCH_TARGET, new=mock):
+            stats = await enrich_pool_vibes(db, test_user, s)
+        assert stats.enriched == 20
+        assert stats.failed == 20
+        assert stats.llm_calls == 2
+        assert db.query(TrackVibe).count() == 20
+
+    @pytest.mark.asyncio
+    async def test_no_llm_configured_propagates(self, db, test_user):
+        s = _seed_pool(db, test_user.id, 1)
+        with patch(DISPATCH_TARGET, new=AsyncMock(side_effect=NoLlmConfigured("none"))):
+            with pytest.raises(NoLlmConfigured):
+                await enrich_pool_vibes(db, test_user, s)
+
+    @pytest.mark.asyncio
+    async def test_track_without_track_id_uses_sig_key(self, db, test_user):
+        s = Set(owner_id=test_user.id, name="Vibe Set")
+        db.add(s)
+        db.flush()
+        src = SetPoolSource(set_id=s.id, kind="manual", external_ref=None, label="Manual")
+        db.add(src)
+        db.flush()
+        db.add(
+            SetPoolTrack(
+                set_id=s.id,
+                source_id=src.id,
+                track_id=None,
+                title="Track X",
+                artist="Artist X",
+                dedupe_sig="sigx001",
+            )
+        )
+        db.commit()
+        db.refresh(s)
+
+        with patch(DISPATCH_TARGET, new=AsyncMock(side_effect=_dispatch_side_effect)):
+            stats = await enrich_pool_vibes(db, test_user, s)
+        assert stats.enriched == 1
+        row = db.query(TrackVibe).one()
+        assert row.track_id == "sig:sigx001"
+
+    @pytest.mark.asyncio
+    async def test_provider_model_fallback_unknown(self, db, test_user):
+        s = _seed_pool(db, test_user.id, 1)
+        response = _fake_response(1, provider=None, model=None)
+        with patch(DISPATCH_TARGET, new=AsyncMock(return_value=response)):
+            stats = await enrich_pool_vibes(db, test_user, s)
+        assert stats.enriched == 1
+        row = db.query(TrackVibe).one()
+        assert row.llm_provider == "unknown"
+        assert row.llm_model == "unknown"

--- a/server/tests/test_setbuilder_vibes.py
+++ b/server/tests/test_setbuilder_vibes.py
@@ -64,6 +64,7 @@ class TestVibeConsensusSettings:
 # ---------------------------------------------------------------------------
 
 DISPATCH_TARGET = "app.services.setbuilder.vibe_enrichment.Gateway.dispatch"
+CACHED_KEYS_TARGET = "app.services.setbuilder.vibe_enrichment._cached_keys"
 
 
 def _seed_pool(db, owner_id: int, n: int) -> Set:
@@ -134,6 +135,13 @@ class TestVibeEnrichment:
         assert stats.failed == 0
         assert mock.await_count == 5
         assert db.query(TrackVibe).count() == 100
+        # Pin the dispatch contract: forced tool, system prompt, token cap, purpose.
+        args, kwargs = mock.await_args
+        request: ChatRequest = args[2]
+        assert request.force_tool == "submit_track_vibes"
+        assert request.system
+        assert request.max_tokens == 4096
+        assert kwargs["purpose"] == "vibe_enrichment"
 
     @pytest.mark.asyncio
     async def test_second_run_fully_cached_even_for_other_dj(self, db, test_user):
@@ -182,7 +190,7 @@ class TestVibeEnrichment:
 
     @pytest.mark.asyncio
     async def test_malformed_items_handled(self, db, test_user):
-        s = _seed_pool(db, test_user.id, 3)
+        s = _seed_pool(db, test_user.id, 4)
         items = [
             {
                 "index": 0,
@@ -204,6 +212,12 @@ class TestVibeEnrichment:
                 "transitional_role": "peak",
                 "confidence": 0.8,
             },
+            {
+                "index": 2,
+                "energy": 5,
+                "confidence": 0.5,
+                "transitional_role": ["peak"],  # unhashable (list) -> None, must not raise
+            },
             {"index": 7, "energy": 5, "confidence": 0.5},  # out-of-range -> ignored
         ]
         response = ChatResponse(
@@ -215,8 +229,8 @@ class TestVibeEnrichment:
         )
         with patch(DISPATCH_TARGET, new=AsyncMock(return_value=response)):
             stats = await enrich_pool_vibes(db, test_user, s)
-        assert stats.enriched == 2
-        assert stats.failed == 1  # track 2 had no parsed entry
+        assert stats.enriched == 3
+        assert stats.failed == 1  # track 3 had no parsed entry
         row0 = db.query(TrackVibe).filter(TrackVibe.track_id == "tidal:0").one()
         assert row0.energy == 10
         assert row0.confidence == 1.0
@@ -226,7 +240,10 @@ class TestVibeEnrichment:
         assert row0.mood == "dark"
         row1 = db.query(TrackVibe).filter(TrackVibe.track_id == "tidal:1").one()
         assert row1.energy == 7
-        assert db.query(TrackVibe).filter(TrackVibe.track_id == "tidal:2").count() == 0
+        row2 = db.query(TrackVibe).filter(TrackVibe.track_id == "tidal:2").one()
+        assert row2.transitional_role is None  # list role stored as None
+        assert row2.energy == 5
+        assert db.query(TrackVibe).filter(TrackVibe.track_id == "tidal:3").count() == 0
 
     @pytest.mark.asyncio
     async def test_llm_error_marks_remaining_failed(self, db, test_user):
@@ -238,6 +255,55 @@ class TestVibeEnrichment:
         assert stats.failed == 20
         assert stats.llm_calls == 2
         assert db.query(TrackVibe).count() == 20
+
+    @pytest.mark.asyncio
+    async def test_commit_race_keeps_paid_rows_and_counts_conflict_cached(self, db, test_user):
+        """IntegrityError on commit must not discard the batch's non-conflicting rows.
+
+        Forces the race: a conflicting TrackVibe row exists for tidal:1 (same
+        identity the service writes), but ``_cached_keys`` is patched to miss it
+        on both the initial cache check and the pre-insert re-check — so the
+        commit collides. The post-IntegrityError re-query (third call) delegates
+        to the real helper, finds the winner, and only the still-missing rows
+        are re-inserted.
+        """
+        from app.services.setbuilder.vibe_enrichment import _cached_keys as real_cached_keys
+
+        s = _seed_pool(db, test_user.id, 3)
+        db.add(
+            TrackVibe(
+                track_id="tidal:1",
+                energy=3,
+                llm_provider="anthropic_apikey",
+                llm_model="claude-haiku-4-5",
+                prompt_version=PROMPT_VERSION,
+                schema_version=SCHEMA_VERSION,
+            )
+        )
+        db.commit()
+
+        calls: list[int] = []
+
+        def fake_cached_keys(db_arg, keys):
+            calls.append(1)
+            if len(calls) <= 2:  # initial cache check + pre-insert re-check miss the winner
+                return set()
+            return real_cached_keys(db_arg, keys)  # post-IntegrityError re-query is real
+
+        with (
+            patch(DISPATCH_TARGET, new=AsyncMock(side_effect=_dispatch_side_effect)),
+            patch(CACHED_KEYS_TARGET, side_effect=fake_cached_keys),
+        ):
+            stats = await enrich_pool_vibes(db, test_user, s)
+
+        assert stats.enriched == 2  # tidal:0 + tidal:2 survive the lost race
+        assert stats.cached == 1  # the conflicting tidal:1 counts as cached
+        assert stats.failed == 0
+        assert len(calls) == 3
+        for key in ("tidal:0", "tidal:2"):
+            assert db.query(TrackVibe).filter(TrackVibe.track_id == key).count() == 1
+        row1 = db.query(TrackVibe).filter(TrackVibe.track_id == "tidal:1").one()
+        assert row1.energy == 3  # pre-existing winner untouched
 
     @pytest.mark.asyncio
     async def test_no_llm_configured_propagates(self, db, test_user):

--- a/server/tests/test_setbuilder_vibes.py
+++ b/server/tests/test_setbuilder_vibes.py
@@ -11,11 +11,18 @@ from app.models.user import User
 from app.services.auth import get_password_hash
 from app.services.llm.base import ChatRequest, ChatResponse, ToolCall
 from app.services.llm.exceptions import NoLlmConfigured, ProviderUnavailable
-from app.services.setbuilder.community_vibe import community_consensus
+from app.services.setbuilder.community_vibe import CommunityVibe, community_consensus
 from app.services.setbuilder.vibe_enrichment import (
     PROMPT_VERSION,
     SCHEMA_VERSION,
     enrich_pool_vibes,
+)
+from app.services.setbuilder.vibe_resolver import (
+    OwnVibe,
+    ResolvedVibe,
+    build_pool_vibe_states,
+    is_low_confidence,
+    resolve_vibe,
 )
 from app.services.system_settings import get_system_settings, update_system_settings
 
@@ -450,3 +457,114 @@ class TestCommunityConsensus:
         assert vibe.mood == "dark"
         assert vibe.energy is None  # only 2 energy votes < min_sample
         assert vibe.sample_size == 3
+
+
+# ---------------------------------------------------------------------------
+# Three-tier precedence resolver (services/setbuilder/vibe_resolver.py)
+# ---------------------------------------------------------------------------
+
+
+def _llm_vibe(
+    track_id: str = "tidal:0",
+    *,
+    energy: int | None = None,
+    mood: str | None = None,
+    confidence: float | None = None,
+    provider: str = "anthropic_apikey",
+    prompt_version: str = PROMPT_VERSION,
+) -> TrackVibe:
+    return TrackVibe(
+        track_id=track_id,
+        energy=energy,
+        mood=mood,
+        confidence=confidence,
+        llm_provider=provider,
+        llm_model="claude-haiku-4-5",
+        prompt_version=prompt_version,
+        schema_version=SCHEMA_VERSION,
+    )
+
+
+class TestVibeResolver:
+    def test_own_override_wins(self):
+        own = OwnVibe(energy=9, mood="gritty")
+        community = CommunityVibe(energy=5, mood="dark", sample_size=4)
+        llm = _llm_vibe(energy=3, mood="happy", confidence=0.9)
+        resolved = resolve_vibe(own, community, llm)
+        assert (resolved.energy, resolved.energy_source) == (9, "own")
+        assert (resolved.mood, resolved.mood_source) == ("gritty", "own")
+
+    def test_community_beats_llm(self):
+        community = CommunityVibe(energy=5, mood="dark", sample_size=4)
+        llm = _llm_vibe(energy=3, mood="happy", confidence=0.9)
+        resolved = resolve_vibe(None, community, llm)
+        assert (resolved.energy, resolved.energy_source) == (5, "community")
+        assert (resolved.mood, resolved.mood_source) == ("dark", "community")
+
+    def test_llm_fallback(self):
+        llm = _llm_vibe(energy=3, mood="happy", confidence=0.9)
+        resolved = resolve_vibe(None, None, llm)
+        assert (resolved.energy, resolved.energy_source) == (3, "llm")
+        assert (resolved.mood, resolved.mood_source) == ("happy", "llm")
+
+    def test_no_tiers_resolves_none(self):
+        assert resolve_vibe(None, None, None) == ResolvedVibe(None, None, None, None)
+
+    def test_per_field_cascade(self):
+        own = OwnVibe(energy=9, mood=None)
+        community = CommunityVibe(energy=None, mood="dark", sample_size=3)
+        llm = _llm_vibe(energy=4, mood="happy", confidence=0.9)
+        resolved = resolve_vibe(own, community, llm)
+        assert (resolved.energy, resolved.energy_source) == (9, "own")
+        assert (resolved.mood, resolved.mood_source) == ("dark", "community")
+
+    def test_low_confidence_flag(self):
+        assert is_low_confidence(_llm_vibe(confidence=0.3)) is True
+        assert is_low_confidence(_llm_vibe(confidence=0.5)) is False
+        assert is_low_confidence(_llm_vibe(confidence=0.9)) is False
+        assert is_low_confidence(_llm_vibe(confidence=None)) is True
+
+    def test_build_pool_vibe_states_end_to_end(self, db, test_user):
+        s = _seed_pool(db, test_user.id, 1)  # one pool track, key "tidal:0"
+        db.add(_llm_vibe(energy=5, mood="happy", confidence=0.8))
+        voters = _make_users(db, 3)
+        for voter, energy in zip(voters, (7, 7, 8), strict=True):
+            _vote(db, "tidal:0", voter.id, energy=energy, mood="dark")
+        _vote(db, "tidal:0", test_user.id, energy=9)  # own override, no mood
+        db.commit()
+
+        states = build_pool_vibe_states(db, test_user, s)
+        assert len(states) == 1
+        state = states[0]
+        assert state.vibe_key == "tidal:0"
+        assert state.own == OwnVibe(energy=9, mood=None)
+        # Own vote excluded from community: fmean(7,7,8) = 7.33 -> 7, sample 3.
+        assert state.community == CommunityVibe(energy=7, mood="dark", sample_size=3)
+        assert state.llm is not None
+        assert state.llm.energy == 5
+        assert state.resolved == ResolvedVibe(
+            energy=9, energy_source="own", mood="dark", mood_source="community"
+        )
+
+    def test_llm_tier_ignores_stale_prompt_version(self, db, test_user):
+        s = _seed_pool(db, test_user.id, 1)
+        db.add(_llm_vibe(energy=5, mood="happy", confidence=0.8, prompt_version="v0"))
+        db.commit()
+
+        states = build_pool_vibe_states(db, test_user, s)
+        assert len(states) == 1
+        assert states[0].llm is None
+        assert states[0].resolved == ResolvedVibe(None, None, None, None)
+
+    def test_llm_tier_newest_row_wins(self, db, test_user):
+        s = _seed_pool(db, test_user.id, 1)
+        db.add(_llm_vibe(energy=3, mood="dark", confidence=0.7, provider="openai_apikey"))
+        db.commit()
+        db.add(_llm_vibe(energy=6, mood="happy", confidence=0.8, provider="anthropic_apikey"))
+        db.commit()
+
+        states = build_pool_vibe_states(db, test_user, s)
+        assert len(states) == 1
+        assert states[0].llm is not None
+        assert states[0].llm.energy == 6  # higher-id row wins
+        assert (states[0].resolved.energy, states[0].resolved.energy_source) == (6, "llm")

--- a/server/tests/test_setbuilder_vibes.py
+++ b/server/tests/test_setbuilder_vibes.py
@@ -1,0 +1,26 @@
+"""Tests for TrackVibe LLM enrichment + community consensus + resolver (issue #391)."""
+
+from app.services.system_settings import get_system_settings, update_system_settings
+
+
+class TestVibeConsensusSettings:
+    def test_defaults(self, db):
+        s = get_system_settings(db)
+        assert s.vibe_consensus_min_sample == 3
+        assert s.vibe_consensus_max_stddev == 1.5
+
+    def test_update(self, db):
+        s = update_system_settings(db, vibe_consensus_min_sample=5, vibe_consensus_max_stddev=2.0)
+        assert s.vibe_consensus_min_sample == 5
+        assert s.vibe_consensus_max_stddev == 2.0
+
+    def test_admin_patch_endpoint(self, client, admin_headers):
+        resp = client.patch(
+            "/api/admin/settings",
+            json={"vibe_consensus_min_sample": 4, "vibe_consensus_max_stddev": 1.0},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["vibe_consensus_min_sample"] == 4
+        assert body["vibe_consensus_max_stddev"] == 1.0

--- a/server/tests/test_setbuilder_vibes.py
+++ b/server/tests/test_setbuilder_vibes.py
@@ -24,3 +24,21 @@ class TestVibeConsensusSettings:
         body = resp.json()
         assert body["vibe_consensus_min_sample"] == 4
         assert body["vibe_consensus_max_stddev"] == 1.0
+
+    def test_min_sample_bounds_rejected(self, client, admin_headers):
+        for bad in (0, 101):
+            resp = client.patch(
+                "/api/admin/settings",
+                json={"vibe_consensus_min_sample": bad},
+                headers=admin_headers,
+            )
+            assert resp.status_code == 422
+
+    def test_max_stddev_bounds_rejected(self, client, admin_headers):
+        for bad in (0.0, 5.1):
+            resp = client.patch(
+                "/api/admin/settings",
+                json={"vibe_consensus_max_stddev": bad},
+                headers=admin_headers,
+            )
+            assert resp.status_code == 422

--- a/server/tests/test_setbuilder_vibes.py
+++ b/server/tests/test_setbuilder_vibes.py
@@ -6,10 +6,12 @@ import pytest
 
 from app.models.set import Set
 from app.models.set_pool import SetPoolSource, SetPoolTrack
-from app.models.track_vibe import TrackVibe
+from app.models.track_vibe import TrackVibe, TrackVibeOverride
 from app.models.user import User
+from app.services.auth import get_password_hash
 from app.services.llm.base import ChatRequest, ChatResponse, ToolCall
 from app.services.llm.exceptions import NoLlmConfigured, ProviderUnavailable
+from app.services.setbuilder.community_vibe import community_consensus
 from app.services.setbuilder.vibe_enrichment import (
     PROMPT_VERSION,
     SCHEMA_VERSION,
@@ -349,3 +351,102 @@ class TestVibeEnrichment:
         row = db.query(TrackVibe).one()
         assert row.llm_provider == "unknown"
         assert row.llm_model == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Community vibe consensus (services/setbuilder/community_vibe.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_users(db, n: int, prefix: str = "voter") -> list[User]:
+    pw = get_password_hash("password123")  # hash once — bcrypt is slow
+    users = [User(username=f"{prefix}{i}", password_hash=pw, role="dj") for i in range(n)]
+    db.add_all(users)
+    db.commit()
+    for u in users:
+        db.refresh(u)
+    return users
+
+
+def _vote(
+    db,
+    track_id: str,
+    user_id: int,
+    *,
+    energy: int | None = None,
+    mood: str | None = None,
+) -> TrackVibeOverride:
+    row = TrackVibeOverride(
+        track_id=track_id,
+        user_id=user_id,
+        energy_override=energy,
+        mood_override=mood,
+        source="explicit_edit",
+    )
+    db.add(row)
+    db.commit()
+    return row
+
+
+class TestCommunityConsensus:
+    def test_consensus_requires_min_sample(self, db):
+        users = _make_users(db, 3)
+        _vote(db, "tidal:1", users[0].id, energy=7)
+        _vote(db, "tidal:1", users[1].id, energy=7)
+        result = community_consensus(db, ["tidal:1"], min_sample=3, max_stddev=1.5)
+        assert "tidal:1" not in result
+
+        _vote(db, "tidal:1", users[2].id, energy=8)
+        result = community_consensus(db, ["tidal:1"], min_sample=3, max_stddev=1.5)
+        assert result["tidal:1"].energy == 7  # fmean 7.33 rounds to 7
+        assert result["tidal:1"].sample_size == 3
+
+    def test_consensus_rejected_on_high_stddev(self, db):
+        users = _make_users(db, 3)
+        for user, energy in zip(users, (1, 5, 10), strict=True):
+            _vote(db, "tidal:1", user.id, energy=energy)
+        # pstdev([1, 5, 10]) ~= 3.68 >= 1.5 — too scattered; no moods either.
+        result = community_consensus(db, ["tidal:1"], min_sample=3, max_stddev=1.5)
+        assert "tidal:1" not in result
+
+    def test_latest_vote_per_user_wins(self, db):
+        users = _make_users(db, 3)
+        _vote(db, "tidal:1", users[0].id, energy=2)
+        _vote(db, "tidal:1", users[0].id, energy=8)  # supersedes the 2
+        _vote(db, "tidal:1", users[1].id, energy=8)
+        _vote(db, "tidal:1", users[2].id, energy=8)
+        result = community_consensus(db, ["tidal:1"], min_sample=3, max_stddev=1.5)
+        assert result["tidal:1"].energy == 8
+        assert result["tidal:1"].sample_size == 3
+
+    def test_mood_majority(self, db):
+        users = _make_users(db, 3)
+        for user, mood in zip(users, ("dark", "dark", "euphoric"), strict=True):
+            _vote(db, "tidal:1", user.id, mood=mood)
+        result = community_consensus(db, ["tidal:1"], min_sample=3, max_stddev=1.5)
+        assert result["tidal:1"].mood == "dark"  # 2/3 is a strict majority
+
+        for user, mood in zip(users, ("dark", "euphoric", "upbeat"), strict=True):
+            _vote(db, "tidal:2", user.id, mood=mood)
+        result = community_consensus(db, ["tidal:2"], min_sample=3, max_stddev=1.5)
+        assert "tidal:2" not in result  # three-way split: no strict majority
+
+    def test_thresholds_are_tunable(self, db):
+        users = _make_users(db, 2)
+        _vote(db, "tidal:1", users[0].id, energy=7, mood="dark")
+        _vote(db, "tidal:1", users[1].id, energy=7, mood="dark")
+        result = community_consensus(db, ["tidal:1"], min_sample=2, max_stddev=1.5)
+        assert result["tidal:1"].energy == 7
+        assert result["tidal:1"].mood == "dark"
+        assert result["tidal:1"].sample_size == 2
+
+    def test_energy_and_mood_independent(self, db):
+        users = _make_users(db, 3)
+        _vote(db, "tidal:1", users[0].id, energy=7, mood="dark")
+        _vote(db, "tidal:1", users[1].id, energy=7, mood="dark")
+        _vote(db, "tidal:1", users[2].id, mood="dark")  # no energy opinion
+        result = community_consensus(db, ["tidal:1"], min_sample=3, max_stddev=1.5)
+        vibe = result["tidal:1"]
+        assert vibe.mood == "dark"
+        assert vibe.energy is None  # only 2 energy votes < min_sample
+        assert vibe.sample_size == 3

--- a/server/tests/test_setbuilder_vibes.py
+++ b/server/tests/test_setbuilder_vibes.py
@@ -458,6 +458,32 @@ class TestCommunityConsensus:
         assert vibe.energy is None  # only 2 energy votes < min_sample
         assert vibe.sample_size == 3
 
+    def test_stddev_exactly_at_threshold_rejected(self, db):
+        # pstdev([6, 9]) == 1.5; condition is >= so exactly at threshold is rejected.
+        users = _make_users(db, 2)
+        _vote(db, "tidal:1", users[0].id, energy=6)
+        _vote(db, "tidal:1", users[1].id, energy=9)
+        result = community_consensus(db, ["tidal:1"], min_sample=2, max_stddev=1.5)
+        assert "tidal:1" not in result  # boundary value is not strict enough
+
+    def test_min_sample_one_single_vote(self, db):
+        # pstdev of a single-element list is 0.0; any positive max_stddev accepts it.
+        users = _make_users(db, 1)
+        _vote(db, "tidal:1", users[0].id, energy=7)
+        result = community_consensus(db, ["tidal:1"], min_sample=1, max_stddev=1.5)
+        assert result["tidal:1"].energy == 7
+
+    def test_all_null_retraction_row_supersedes(self, db):
+        # user0 votes energy=7, then retracts by writing a row with both fields None.
+        # With min_sample=3, only the 2 surviving votes from user1/user2 remain → no consensus.
+        users = _make_users(db, 3)
+        _vote(db, "tidal:1", users[0].id, energy=7)
+        _vote(db, "tidal:1", users[0].id)  # retraction: both fields None → supersedes the 7
+        _vote(db, "tidal:1", users[1].id, energy=7)
+        _vote(db, "tidal:1", users[2].id, energy=7)
+        result = community_consensus(db, ["tidal:1"], min_sample=3, max_stddev=1.5)
+        assert "tidal:1" not in result  # only 2 effective energy votes, retraction excluded third
+
 
 # ---------------------------------------------------------------------------
 # Three-tier precedence resolver (services/setbuilder/vibe_resolver.py)

--- a/server/tests/test_setbuilder_vibes_api.py
+++ b/server/tests/test_setbuilder_vibes_api.py
@@ -10,7 +10,7 @@ from app.models.set_pool import SetPoolSource, SetPoolTrack
 from app.models.track_vibe import TrackVibe, TrackVibeOverride
 from app.models.user import User
 from app.services.llm.base import ChatResponse, ToolCall
-from app.services.llm.exceptions import NoLlmConfigured
+from app.services.llm.exceptions import NoLlmConfigured, ProviderUnavailable
 from app.services.setbuilder.vibe_enrichment import PROMPT_VERSION, SCHEMA_VERSION
 
 DISPATCH_TARGET = "app.services.setbuilder.vibe_enrichment.Gateway.dispatch"
@@ -212,6 +212,26 @@ class TestEnrichPoolVibes:
             )
         assert resp.status_code == 400
         assert resp.json()["detail"] == NO_LLM_DETAIL
+
+    def test_enrich_provider_failure_returns_counts(self, client, db, auth_headers, set_id):
+        _seed_pool_tracks(db, set_id, 2)
+        with patch(
+            DISPATCH_TARGET,
+            new=AsyncMock(side_effect=ProviderUnavailable("timeout")),
+        ):
+            resp = client.post(
+                f"/api/setbuilder/sets/{set_id}/pool/vibes/enrich", headers=auth_headers
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["enriched"] == 0
+        assert body["failed"] == 2
+        assert body["llm_calls"] == 1
+        assert body["cached"] == 0
+        tracks = body["vibes"]["tracks"]
+        assert len(tracks) == 2
+        for t in tracks:
+            assert t["llm"] is None
 
     def test_second_run_fully_cached(self, client, db, auth_headers, set_id):
         _seed_pool_tracks(db, set_id, 2)

--- a/server/tests/test_setbuilder_vibes_api.py
+++ b/server/tests/test_setbuilder_vibes_api.py
@@ -1,0 +1,235 @@
+"""API-boundary tests for WrzDJSet pool-vibe endpoints (issue #391)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.models.track_vibe import TrackVibe, TrackVibeOverride
+from app.models.user import User
+from app.services.llm.base import ChatResponse, ToolCall
+from app.services.llm.exceptions import NoLlmConfigured
+from app.services.setbuilder.vibe_enrichment import PROMPT_VERSION, SCHEMA_VERSION
+
+DISPATCH_TARGET = "app.services.setbuilder.vibe_enrichment.Gateway.dispatch"
+NO_LLM_DETAIL = "No AI connector configured — connect one in Settings → AI."
+
+
+@pytest.fixture
+def set_id(client: TestClient, auth_headers: dict) -> int:
+    resp = client.post("/api/setbuilder/sets", json={"name": "Vibe Set"}, headers=auth_headers)
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+@pytest.fixture
+def other_dj_headers(client: TestClient, db: Session) -> dict:
+    from app.services.auth import get_password_hash
+
+    user = User(username="otherdj", password_hash=get_password_hash("otherpassword1"), role="dj")
+    db.add(user)
+    db.commit()
+    resp = client.post(
+        "/api/auth/login", data={"username": "otherdj", "password": "otherpassword1"}
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _seed_pool_tracks(db: Session, set_id: int, n: int) -> None:
+    """Direct-model pool seeding — tracks get keys tidal:0..n-1."""
+    src = SetPoolSource(set_id=set_id, kind="manual", external_ref=None, label="Manual")
+    db.add(src)
+    db.flush()
+    for i in range(n):
+        db.add(
+            SetPoolTrack(
+                set_id=set_id,
+                source_id=src.id,
+                track_id=f"tidal:{i}",
+                title=f"Track {i}",
+                artist=f"Artist {i}",
+                dedupe_sig=f"sig{i:04d}",
+            )
+        )
+    db.commit()
+
+
+def _llm_vibe_row(track_id: str = "tidal:0", *, energy: int = 5, confidence: float = 0.8):
+    return TrackVibe(
+        track_id=track_id,
+        energy=energy,
+        mood="happy",
+        confidence=confidence,
+        llm_provider="anthropic_apikey",
+        llm_model="claude-haiku-4-5",
+        prompt_version=PROMPT_VERSION,
+        schema_version=SCHEMA_VERSION,
+    )
+
+
+def _fake_response(batch_size: int, *, confidence: float = 0.8) -> ChatResponse:
+    items = [
+        {
+            "index": i,
+            "energy": 7,
+            "mood": "euphoric",
+            "era": "2010s",
+            "sing_along": True,
+            "dance_floor": True,
+            "transitional_role": "peak",
+            "confidence": confidence,
+        }
+        for i in range(batch_size)
+    ]
+    return ChatResponse(
+        text="",
+        tool_calls=[ToolCall(id="t1", name="submit_track_vibes", input={"tracks": items})],
+        stop_reason="tool_use",
+        model="claude-haiku-4-5",
+        provider="anthropic_apikey",
+    )
+
+
+class TestVibesOwnership:
+    def test_vibes_404_for_other_users_set(self, client, set_id, other_dj_headers):
+        assert (
+            client.get(
+                f"/api/setbuilder/sets/{set_id}/pool/vibes", headers=other_dj_headers
+            ).status_code
+            == 404
+        )
+        assert (
+            client.post(
+                f"/api/setbuilder/sets/{set_id}/pool/vibes/enrich", headers=other_dj_headers
+            ).status_code
+            == 404
+        )
+
+    def test_vibes_require_auth(self, client, set_id):
+        assert client.get(f"/api/setbuilder/sets/{set_id}/pool/vibes").status_code == 401
+        assert client.post(f"/api/setbuilder/sets/{set_id}/pool/vibes/enrich").status_code == 401
+
+
+class TestGetPoolVibes:
+    def test_empty_pool(self, client, auth_headers, set_id):
+        resp = client.get(f"/api/setbuilder/sets/{set_id}/pool/vibes", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json() == {"tracks": []}
+
+    def test_no_vibe_data_all_tiers_null(self, client, db, auth_headers, set_id):
+        _seed_pool_tracks(db, set_id, 2)
+        resp = client.get(f"/api/setbuilder/sets/{set_id}/pool/vibes", headers=auth_headers)
+        assert resp.status_code == 200
+        tracks = resp.json()["tracks"]
+        assert len(tracks) == 2
+        assert [t["vibe_key"] for t in tracks] == ["tidal:0", "tidal:1"]
+        for t in tracks:
+            assert t["own"] is None
+            assert t["community"] is None
+            assert t["llm"] is None
+            assert t["resolved"] == {
+                "energy": None,
+                "energy_source": None,
+                "mood": None,
+                "mood_source": None,
+            }
+
+    def test_own_override_precedence_over_llm(self, client, db, auth_headers, set_id, test_user):
+        _seed_pool_tracks(db, set_id, 1)
+        db.add(_llm_vibe_row("tidal:0", energy=5, confidence=0.8))
+        db.add(
+            TrackVibeOverride(
+                track_id="tidal:0",
+                user_id=test_user.id,
+                energy_override=9,
+                mood_override=None,
+                source="explicit_edit",
+            )
+        )
+        db.commit()
+
+        resp = client.get(f"/api/setbuilder/sets/{set_id}/pool/vibes", headers=auth_headers)
+        assert resp.status_code == 200
+        (track,) = resp.json()["tracks"]
+        assert track["own"] == {"energy": 9, "mood": None}
+        assert track["resolved"]["energy"] == 9
+        assert track["resolved"]["energy_source"] == "own"
+        # mood has no own/community value — cascades to the LLM tier
+        assert track["resolved"]["mood"] == "happy"
+        assert track["resolved"]["mood_source"] == "llm"
+        llm = track["llm"]
+        assert llm is not None
+        assert llm["energy"] == 5
+        assert llm["confidence"] == 0.8
+        assert llm["low_confidence"] is False
+        assert llm["llm_provider"] == "anthropic_apikey"
+        assert llm["llm_model"] == "claude-haiku-4-5"
+
+
+class TestEnrichPoolVibes:
+    def test_enrich_end_to_end(self, client, db, auth_headers, set_id):
+        _seed_pool_tracks(db, set_id, 2)
+        mock = AsyncMock(return_value=_fake_response(2))
+        with patch(DISPATCH_TARGET, new=mock):
+            resp = client.post(
+                f"/api/setbuilder/sets/{set_id}/pool/vibes/enrich", headers=auth_headers
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["enriched"] == 2
+        assert body["cached"] == 0
+        assert body["failed"] == 0
+        assert body["llm_calls"] == 1
+        assert mock.await_count == 1
+        tracks = body["vibes"]["tracks"]
+        assert len(tracks) == 2
+        for t in tracks:
+            llm = t["llm"]
+            assert llm is not None
+            assert llm["llm_provider"] == "anthropic_apikey"
+            assert llm["llm_model"] == "claude-haiku-4-5"
+            assert llm["low_confidence"] is False
+            assert t["resolved"]["energy_source"] == "llm"
+
+    def test_enrich_low_confidence_flagged(self, client, db, auth_headers, set_id):
+        _seed_pool_tracks(db, set_id, 1)
+        with patch(DISPATCH_TARGET, new=AsyncMock(return_value=_fake_response(1, confidence=0.2))):
+            resp = client.post(
+                f"/api/setbuilder/sets/{set_id}/pool/vibes/enrich", headers=auth_headers
+            )
+        assert resp.status_code == 200
+        (track,) = resp.json()["vibes"]["tracks"]
+        assert track["llm"]["confidence"] == 0.2
+        assert track["llm"]["low_confidence"] is True
+
+    def test_enrich_no_llm_configured_400(self, client, db, auth_headers, set_id):
+        _seed_pool_tracks(db, set_id, 1)
+        with patch(DISPATCH_TARGET, new=AsyncMock(side_effect=NoLlmConfigured("none"))):
+            resp = client.post(
+                f"/api/setbuilder/sets/{set_id}/pool/vibes/enrich", headers=auth_headers
+            )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == NO_LLM_DETAIL
+
+    def test_second_run_fully_cached(self, client, db, auth_headers, set_id):
+        _seed_pool_tracks(db, set_id, 2)
+        with patch(DISPATCH_TARGET, new=AsyncMock(return_value=_fake_response(2))):
+            first = client.post(
+                f"/api/setbuilder/sets/{set_id}/pool/vibes/enrich", headers=auth_headers
+            )
+        assert first.status_code == 200
+        assert first.json()["enriched"] == 2
+
+        mock = AsyncMock(return_value=_fake_response(2))
+        with patch(DISPATCH_TARGET, new=mock):
+            second = client.post(
+                f"/api/setbuilder/sets/{set_id}/pool/vibes/enrich", headers=auth_headers
+            )
+        assert second.status_code == 200
+        body = second.json()
+        assert body["cached"] == 2
+        assert body["enriched"] == 0
+        assert body["llm_calls"] == 0
+        mock.assert_not_awaited()


### PR DESCRIPTION
Closes #391

## Summary

- **Batch LLM vibe enrichment** (`services/setbuilder/vibe_enrichment.py`): enriches uncached pool tracks via the LLM gateway with forced `tool_use` (20 tracks/call, `purpose="vibe_enrichment"`), writing to the global `TrackVibe` cache (table pre-existed from the Phase-0 scaffold). 100 tracks cost exactly 5 gateway calls; a second DJ with the same tracks pays zero (test-pinned).
- **Community consensus** (`services/setbuilder/community_vibe.py`): aggregates `TrackVibeOverride` votes (latest row per track+user); energy consensus gated on `sample_size >= 3 AND pstdev < 1.5`, mood on strict majority — both thresholds admin-tunable via new `SystemSettings` columns (migration **057**, `down_revision="056"`).
- **Three-tier precedence resolver** (`services/setbuilder/vibe_resolver.py`): per-field cascade own override → community consensus → LLM cache, with `low_confidence` flagging (`confidence` None or < 0.5).
- **API**: `GET /api/setbuilder/sets/{id}/pool/vibes` (60/min) and `POST .../pool/vibes/enrich` (5/min, `NoLlmConfigured` → friendly 400). Owner-private 404 semantics. OpenAPI + generated dashboard types regenerated.
- **Pool panel UI**: `Vibes` toggle + `Analyze` button; read-only `VibeTiers` chips (You / Crowd / AI) per track, sample-size on the community chip, per-field winner highlight, low-confidence AI guesses flagged with dashed-amber ⚠ styling.
- **Gateway (additive only)**: `ChatResponse.provider` populated from the resolved connector's `connector_type` so the cache can store `llm_provider`/`llm_model` provenance.

## Design decisions

1. **`model_hint="fast"` deviation**: `ChatRequest` has no speed-tier concept — dispatch uses `model=None`, so the DJ's connector-configured model governs. A cross-provider fast/smart mapping would mean refactoring the gateway (out of scope); documented in-code.
2. **Provider provenance**: `ChatResponse` didn't surface which connector served a call. Minimal additive `provider` field, populated in the gateway's `_attempt` success path via `model_copy` — no other gateway behavior changed (streaming path intentionally untouched).
3. **Vibe cache key**: `SetPoolTrack.track_id` is nullable, so the fallback key is `sig:{dedupe_sig}` (normalized artist+title hash) — globally stable, consistent with the namespaced free-form `track_id` convention, and lets manual tracks share the global cache.
4. **Cache-hit semantics**: any `TrackVibe` row matching `(track_id, prompt_version, schema_version)` counts regardless of provider/model — that's what makes "second DJ pays zero" true across different connectors. Newest row wins at read time; bumping `PROMPT_VERSION` in code lazily invalidates old rows.
5. **Batch failure policy**: the first transient `LlmError` marks the current batch + all remaining tracks failed and stops (no provider hammering); `NoLlmConfigured` maps to a friendly 400. A mid-batch insert race keeps the paid LLM rows (re-query winners, re-insert only missing — test-pinned).
6. **Community semantics**: the viewing DJ's own vote is excluded from their community tier (it's already tier 1); override rows are full snapshots (latest per track+user wins) — the v1.1 write endpoint must carry forward unchanged fields, documented in the module docstring.
7. **`TrackVibeOverride` existed** from the Phase-0 scaffold (migration 046), so no new table was needed; per the issue note, **no write endpoints** were added (write UX is v1.1) — this PR is the read path only.
8. **Low-confidence flag computed backend-side** (`LlmVibeOut.low_confidence`) so the frontend stays dumb; threshold 0.5.
9. **Enrichment runs synchronously in-request** behind a 5/min rate limit — acceptable at current pool sizes (100 tracks = 5 sequential calls). A background job is a fair v1.1 follow-up for very large pools.
10. **Thresholds tunable via `PATCH /api/admin/settings`** (bounds 1–100 / 0.1–5.0, 422-tested); admin-UI form controls deferred.

## Test plan

- [x] Backend: ruff check, ruff format, bandit, `alembic upgrade head && alembic check` (single head 057), pytest — 2749 passed, coverage 88.38% (≥85%)
- [x] Frontend: ESLint (0 errors), `tsc --noEmit`, vitest — 1118 passed, coverage thresholds hold
- [x] Acceptance: `test_100_tracks_costs_5_calls`, `test_second_run_fully_cached_even_for_other_dj`, resolver tier tests (`test_own_override_wins` / `test_community_beats_llm` / `test_llm_fallback` / `test_no_tiers_resolves_none`)
- [x] `openapi.json` + `api-types.generated.ts` verified byte-identical to regeneration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-track three-tier "Vibe" display (You / Crowd / AI) with show/hide toggle and an Analyze action to enrich uncached tracks; visual chips, low-confidence warnings, and toasts for results/errors.
  * Admin settings expose configurable community-vibe thresholds.

* **Chores**
  * Database migration and settings plumbing for vibe consensus parameters.
* **Tests**
  * Extensive frontend and backend tests covering UI, enrichment, consensus rules, and API endpoints.
* **Docs**
  * Implementation plan for the vibe/enrichment system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->