### PR TITLE
feat(setbuilder): add DJ-curated pairings

### DIFF
--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -9,9 +9,14 @@ import type { SetDetail } from '@/lib/api-types';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import BuilderWorkspace from '../components/BuilderWorkspace';
 import ChatSidebar from '../components/ChatSidebar';
+import PairingsOverlay from '../components/PairingsOverlay';
 import PoolPanel from '../components/PoolPanel';
 import SetActionsMenu from '../SetActionsMenu';
 import styles from '../setbuilder.module.css';
+
+interface OpenPairingsEvent extends Event {
+  detail?: { pairingId?: number | null };
+}
 
 export default function BuilderPage({ params }: { params: Promise<{ setId: string }> }) {
   const { setId } = use(params);
@@ -24,6 +29,9 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
   const [confirmBuild, setConfirmBuild] = useState(false);
   const [building, setBuilding] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
+  const [pairingsOpen, setPairingsOpen] = useState(false);
+  const [pairingCount, setPairingCount] = useState(0);
+  const [initialPairingId, setInitialPairingId] = useState<number | null>(null);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -62,6 +70,35 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
     }
   };
 
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    let cancelled = false;
+    const refreshCount = () => {
+      api
+        .getPairings(Number(setId))
+        .then((state) => {
+          if (!cancelled) setPairingCount(state.count);
+        })
+        .catch(() => {
+          if (!cancelled) setPairingCount(0);
+        });
+    };
+    const openPairings = (event: Event) => {
+      const detail = (event as OpenPairingsEvent).detail;
+      setInitialPairingId(detail?.pairingId ?? null);
+      setPairingsOpen(true);
+      refreshCount();
+    };
+    refreshCount();
+    window.addEventListener('wrzdj:setbuilder-pairings-changed', refreshCount);
+    window.addEventListener('wrzdj:open-pairings', openPairings);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('wrzdj:setbuilder-pairings-changed', refreshCount);
+      window.removeEventListener('wrzdj:open-pairings', openPairings);
+    };
+  }, [isAuthenticated, setId]);
+
   if (isLoading || !isAuthenticated) {
     return (
       <div className="container">
@@ -99,6 +136,27 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
         </Link>
         <span className={styles.topbarTitle}>{set?.name ?? 'Loading…'}</span>
         <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}>
+          <button
+            type="button"
+            className={styles.topbarPairingsBtn}
+            onClick={() => {
+              setInitialPairingId(null);
+              setPairingsOpen(true);
+            }}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M10.5 13.5 13.5 10.5M8.5 17.5H7.8a4.8 4.8 0 0 1 0-9.6h3.4M12.8 16.1h3.4a4.8 4.8 0 1 0 0-9.6h-.7"
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.8"
+              />
+            </svg>
+            Pairings
+            <span className={styles.topbarPairingsBadge}>{pairingCount}</span>
+          </button>
           {set && (
             <SetActionsMenu
               set={set}
@@ -136,7 +194,6 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
           />
         </div>
       </div>
-
       {confirmBuild && (
         <div className={styles.confirmWrap}>
           <div
@@ -177,6 +234,19 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
           {toast}
         </div>
       )}
+
+      <PairingsOverlay
+        setId={Number(setId)}
+        open={pairingsOpen}
+        initialPairingId={initialPairingId}
+        onClose={() => setPairingsOpen(false)}
+        onChanged={setPairingCount}
+        onJumpSlot={(idx) =>
+          window.dispatchEvent(
+            new CustomEvent('wrzdj:setbuilder-jump-slot', { detail: { idx } }),
+          )
+        }
+      />
     </div>
   );
 }

--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -14,9 +14,7 @@ import PoolPanel from '../components/PoolPanel';
 import SetActionsMenu from '../SetActionsMenu';
 import styles from '../setbuilder.module.css';
 
-interface OpenPairingsEvent extends Event {
-  detail?: { pairingId?: number | null };
-}
+type OpenPairingsEvent = CustomEvent<{ pairingId?: number | null }>;
 
 export default function BuilderPage({ params }: { params: Promise<{ setId: string }> }) {
   const { setId } = use(params);

--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -139,6 +139,7 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
           <button
             type="button"
             className={styles.topbarPairingsBtn}
+            aria-label={`Open pairings (${pairingCount})`}
             onClick={() => {
               setInitialPairingId(null);
               setPairingsOpen(true);

--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import BuilderWorkspace from '../components/BuilderWorkspace';
-import type { SetSlotOut } from '@/lib/api-types';
+import type { PoolTrack, SetSlotOut } from '@/lib/api-types';
 
 beforeAll(() => {
   globalThis.ResizeObserver = class {
@@ -27,6 +27,8 @@ beforeAll(() => {
 const mockGetSetSlots = vi.fn();
 const mockGetCurveTemplates = vi.fn();
 const mockGetVibeWindows = vi.fn();
+const mockGetPool = vi.fn();
+const mockSavePairing = vi.fn();
 const mockUpdateSlotTarget = vi.fn();
 const mockApplyCurveTemplate = vi.fn();
 const mockPutVibeWindows = vi.fn();
@@ -34,6 +36,8 @@ const mockPutVibeWindows = vi.fn();
 vi.mock('@/lib/api', () => ({
   api: {
     getSetSlots: (setId: number) => mockGetSetSlots(setId),
+    getPool: (setId: number) => mockGetPool(setId),
+    savePairing: (setId: number, payload: object) => mockSavePairing(setId, payload),
     getCurveTemplates: () => mockGetCurveTemplates(),
     getVibeWindows: (setId: number) => mockGetVibeWindows(setId),
     updateSlotTarget: (setId: number, slotId: number, t: number | null) =>
@@ -65,6 +69,8 @@ const SLOTS: SetSlotOut[] = [
     camelot: null,
     energy: null,
     duration_sec: null,
+    next_pairing_id: null,
+    next_is_dj_pairing: false,
   },
   {
     id: 2,
@@ -83,6 +89,8 @@ const SLOTS: SetSlotOut[] = [
     camelot: null,
     energy: null,
     duration_sec: null,
+    next_pairing_id: null,
+    next_is_dj_pairing: false,
   },
   {
     id: 3,
@@ -101,6 +109,62 @@ const SLOTS: SetSlotOut[] = [
     camelot: null,
     energy: null,
     duration_sec: null,
+    next_pairing_id: null,
+    next_is_dj_pairing: false,
+  },
+];
+
+const POOL_TRACKS: PoolTrack[] = [
+  {
+    id: 11,
+    source_id: 1,
+    track_id: 'a',
+    title: 'Track A',
+    artist: 'Artist A',
+    album: null,
+    bpm: 120,
+    camelot: '8A',
+    key: '8A',
+    energy: 5,
+    duration_sec: 201,
+    genre: null,
+    isrc: null,
+    artwork_url: null,
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 12,
+    source_id: 1,
+    track_id: 'b',
+    title: 'Track B',
+    artist: 'Artist B',
+    album: null,
+    bpm: 124,
+    camelot: '9A',
+    key: '9A',
+    energy: 7,
+    duration_sec: 211,
+    genre: null,
+    isrc: null,
+    artwork_url: null,
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 13,
+    source_id: 1,
+    track_id: 'c',
+    title: 'Track C',
+    artist: 'Artist C',
+    album: null,
+    bpm: 128,
+    camelot: '10A',
+    key: '10A',
+    energy: 6,
+    duration_sec: 221,
+    genre: null,
+    isrc: null,
+    artwork_url: null,
+    created_at: '2026-01-01T00:00:00Z',
   },
 ];
 
@@ -121,10 +185,12 @@ describe('BuilderWorkspace', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetSetSlots.mockResolvedValue(SLOTS);
+    mockGetPool.mockResolvedValue({ sources: [], tracks: POOL_TRACKS });
     mockGetCurveTemplates.mockResolvedValue(TEMPLATES);
     mockGetVibeWindows.mockResolvedValue({ windows: [] });
     mockUpdateSlotTarget.mockResolvedValue({ slot_id: 1, target_energy: 9 });
     mockPutVibeWindows.mockResolvedValue({ windows: [] });
+    mockSavePairing.mockResolvedValue({ id: 44 });
   });
 
   it('fetches slots and renders curve blocks + timeline rows', async () => {
@@ -218,6 +284,37 @@ describe('BuilderWorkspace', () => {
     // Timeline target chips reflect the applied targets
     await waitFor(() => {
       expect(screen.getByTestId('timeline-row-0')).toHaveTextContent('7.2');
+    });
+  });
+
+  it('shows DJ pairing markers in timeline and curve', async () => {
+    mockGetSetSlots.mockResolvedValue([
+      { ...SLOTS[0], next_pairing_id: 77, next_is_dj_pairing: true, transition_score: 94 },
+      SLOTS[1],
+      SLOTS[2],
+    ]);
+    render(<BuilderWorkspace setId={5} />);
+
+    await waitFor(() => expect(screen.getByTestId('pairing-pin-0')).toBeInTheDocument());
+    expect(screen.getByTestId('timeline-transition-0')).toHaveTextContent('DJ pairing');
+    expect(screen.getByTestId('timeline-transition-0')).toHaveTextContent('94');
+  });
+
+  it('timeline context menu saves the transition to the next slot as a pairing', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('timeline-row-0')).toBeInTheDocument());
+
+    fireEvent.contextMenu(screen.getByTestId('timeline-row-0'), { clientX: 120, clientY: 140 });
+    fireEvent.click(screen.getByText('Save -> Track B as pairing'));
+
+    await waitFor(() => expect(mockSavePairing).toHaveBeenCalledTimes(1));
+    expect(mockSavePairing).toHaveBeenCalledWith(5, {
+      from_track_id: 'a',
+      into_track_id: 'b',
+      cue_in_sec: null,
+      note: null,
+      tags: [],
+      increment_use_count: true,
     });
   });
 

--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -304,7 +304,7 @@ describe('BuilderWorkspace', () => {
     render(<BuilderWorkspace setId={5} />);
     await waitFor(() => expect(screen.getByTestId('timeline-row-0')).toBeInTheDocument());
 
-    fireEvent.contextMenu(screen.getByTestId('timeline-row-0'), { clientX: 120, clientY: 140 });
+    fireEvent.click(screen.getByLabelText('Save Track A into Track B as pairing'));
     fireEvent.click(screen.getByText('Save -> Track B as pairing'));
 
     await waitFor(() => expect(mockSavePairing).toHaveBeenCalledTimes(1));

--- a/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
@@ -22,6 +22,9 @@ function mkSlot(
     position: idx,
     locked: false,
     targetEnergy: target,
+    transitionScore: null,
+    nextPairingId: null,
+    nextIsDjPairing: false,
     track: {
       id: `t${idx}`,
       title: `Track ${idx}`,
@@ -60,6 +63,14 @@ describe('CurveEditor', () => {
     expect(screen.getByTestId('slot-block-0')).toBeInTheDocument();
     expect(screen.getByTestId('slot-block-2')).toBeInTheDocument();
     expect(screen.getByTestId('curve-line')).toBeInTheDocument();
+  });
+
+  it('renders a purple seam pin for saved DJ pairings', () => {
+    const paired = mkSlot(0);
+    paired.nextPairingId = 42;
+    paired.nextIsDjPairing = true;
+    renderEditor({ slots: [paired, mkSlot(1)] });
+    expect(screen.getByTestId('pairing-pin-0')).toBeInTheDocument();
   });
 
   it('renders amber hatch when target > energy and dashed line when target < energy', () => {

--- a/dashboard/app/(dj)/setbuilder/__tests__/ReplacePopover.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/ReplacePopover.test.tsx
@@ -22,6 +22,9 @@ const slot: SlotView = {
   position: 0,
   locked: false,
   targetEnergy: 8,
+  transitionScore: null,
+  nextPairingId: null,
+  nextIsDjPairing: false,
   track: mkTrack(),
 };
 

--- a/dashboard/app/(dj)/setbuilder/__tests__/curveMath.test.ts
+++ b/dashboard/app/(dj)/setbuilder/__tests__/curveMath.test.ts
@@ -221,6 +221,9 @@ describe('slotViewFromApi', () => {
     expect(v.track.durationSec).toBe(210);
     expect(v.track.energy).toBe(5);
     expect(v.targetEnergy).toBeNull();
+    expect(v.transitionScore).toBeNull();
+    expect(v.nextPairingId).toBeNull();
+    expect(v.nextIsDjPairing).toBe(false);
   });
 });
 

--- a/dashboard/app/(dj)/setbuilder/__tests__/curveMath.test.ts
+++ b/dashboard/app/(dj)/setbuilder/__tests__/curveMath.test.ts
@@ -35,6 +35,9 @@ function mkSlot(idx: number, over: Partial<TrackView> = {}, target: number | nul
     position: idx,
     locked: false,
     targetEnergy: target,
+    transitionScore: null,
+    nextPairingId: null,
+    nextIsDjPairing: false,
     track: mkTrack({ id: `t${idx}`, ...over }),
   };
 }
@@ -201,8 +204,8 @@ describe('slotViewFromApi', () => {
       track_id: null,
       locked: false,
       target_energy: null,
-      notes: null,
       transition_score: null,
+      notes: null,
       transition_warnings: null,
       pool_track_id: null,
       title: null,
@@ -212,6 +215,8 @@ describe('slotViewFromApi', () => {
       camelot: null,
       energy: null,
       duration_sec: null,
+      next_pairing_id: null,
+      next_is_dj_pairing: false,
     });
     expect(v.track.durationSec).toBe(210);
     expect(v.track.energy).toBe(5);

--- a/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
@@ -6,33 +6,98 @@
  * the builder page in place of the Phase 0 placeholders.
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { api } from '@/lib/api';
 import CurvePanel from './CurvePanel';
 import TimelinePanel, { type ScrollRequest } from './TimelinePanel';
-import type { SlotView } from './types';
-import { slotViewFromApi } from './types';
+import type { SlotView, TrackView } from './types';
+import { slotViewFromApi, trackViewFromPool } from './types';
 import sbStyles from '../setbuilder.module.css';
 
-export default function BuilderWorkspace({ setId, refreshToken = 0 }: { setId: number; refreshToken?: number }) {
+interface JumpSlotEvent extends Event {
+  detail?: { idx?: number };
+}
+
+export default function BuilderWorkspace({
+  setId,
+  refreshToken = 0,
+}: {
+  setId: number;
+  refreshToken?: number;
+}) {
   const [slots, setSlots] = useState<SlotView[]>([]);
+  const [pool, setPool] = useState<TrackView[]>([]);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const [scrollRequest, setScrollRequest] = useState<ScrollRequest | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-    api
-      .getSetSlots(setId)
-      .then((rows) => {
-        if (!cancelled) setSlots(rows.map(slotViewFromApi));
+  const loadSlots = useCallback(() => {
+    return Promise.all([api.getSetSlots(setId), api.getPool(setId)])
+      .then(([rows, poolState]) => {
+        const poolByTrackId = new Map(
+          poolState.tracks
+            .filter((track) => track.track_id)
+            .map((track) => [track.track_id as string, track]),
+        );
+        setPool(poolState.tracks.map(trackViewFromPool));
+        setSlots(rows.map((slot) => slotViewFromApi(slot, poolByTrackId.get(slot.track_id ?? '') ?? null)));
       })
       .catch(() => {
-        if (!cancelled) setSlots([]);
+        setPool([]);
+        setSlots([]);
       });
+  }, [setId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadSlots().catch(() => {
+      if (!cancelled) setSlots([]);
+    });
     return () => {
       cancelled = true;
     };
-  }, [setId, refreshToken]);
+  }, [loadSlots, refreshToken]);
+
+  useEffect(() => {
+    const onPairingsChanged = () => {
+      loadSlots().catch(() => {});
+    };
+    const onJumpSlot = (event: Event) => {
+      const idx = (event as JumpSlotEvent).detail?.idx;
+      if (typeof idx !== 'number') return;
+      setScrollRequest((prev) => ({ idx, n: (prev?.n ?? 0) + 1 }));
+    };
+    window.addEventListener('wrzdj:setbuilder-pairings-changed', onPairingsChanged);
+    window.addEventListener('wrzdj:setbuilder-jump-slot', onJumpSlot);
+    return () => {
+      window.removeEventListener('wrzdj:setbuilder-pairings-changed', onPairingsChanged);
+      window.removeEventListener('wrzdj:setbuilder-jump-slot', onJumpSlot);
+    };
+  }, [loadSlots]);
+
+  const handlePairingAction = async (idx: number) => {
+    const from = slots[idx];
+    const into = slots[idx + 1];
+    if (!from || !into) return;
+    if (from.nextIsDjPairing && from.nextPairingId) {
+      window.dispatchEvent(
+        new CustomEvent('wrzdj:open-pairings', { detail: { pairingId: from.nextPairingId } }),
+      );
+      return;
+    }
+    const saved = await api.savePairing(setId, {
+      from_track_id: from.track.id,
+      into_track_id: into.track.id,
+      cue_in_sec: null,
+      note: null,
+      tags: [],
+      increment_use_count: true,
+    });
+    window.dispatchEvent(new CustomEvent('wrzdj:setbuilder-pairings-changed'));
+    window.dispatchEvent(
+      new CustomEvent('wrzdj:open-pairings', { detail: { pairingId: saved.id } }),
+    );
+    await loadSlots();
+  };
 
   return (
     <>
@@ -45,6 +110,7 @@ export default function BuilderWorkspace({ setId, refreshToken = 0 }: { setId: n
           hoveredIdx={hoveredIdx}
           onHover={setHoveredIdx}
           onBlockClick={(idx) => setScrollRequest((prev) => ({ idx, n: (prev?.n ?? 0) + 1 }))}
+          pool={pool}
         />
       </section>
 
@@ -55,6 +121,7 @@ export default function BuilderWorkspace({ setId, refreshToken = 0 }: { setId: n
           hoveredIdx={hoveredIdx}
           onHover={setHoveredIdx}
           scrollRequest={scrollRequest}
+          onPairingAction={handlePairingAction}
         />
       </section>
     </>

--- a/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
@@ -96,7 +96,6 @@ export default function BuilderWorkspace({
     window.dispatchEvent(
       new CustomEvent('wrzdj:open-pairings', { detail: { pairingId: saved.id } }),
     );
-    await loadSlots();
   };
 
   return (

--- a/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
@@ -467,6 +467,33 @@ export default function CurveEditor({
             );
           })}
 
+        {/* DJ pairing seam markers */}
+        {blocks.slice(0, -1).map((b, i) => {
+          if (!slots[i].nextIsDjPairing) return null;
+          const next = blocks[i + 1];
+          const seamX = (b.x1 + next.x0) / 2;
+          const markerY = Math.max(18, Math.min(h - 28, (yOf(b.target) + yOf(next.target)) / 2 - 18));
+          return (
+            <g
+              key={`pairing-pin-${i}`}
+              transform={`translate(${seamX}, ${markerY})`}
+              pointerEvents="none"
+              data-testid={`pairing-pin-${i}`}
+            >
+              <line y1={10} y2={Math.max(14, h - markerY - 4)} stroke={NEON_PURPLE} strokeOpacity="0.38" strokeDasharray="2 3" />
+              <circle r="10" fill="rgba(183,139,255,0.18)" stroke={NEON_PURPLE} strokeWidth="1.4" />
+              <path
+                d="M-3.5 2.5-.8-.2M-5.5 5.5h-.7a3.3 3.3 0 0 1 0-6.6h2.3M.9 4.2h2.3a3.3 3.3 0 1 0 0-6.6h-.7"
+                fill="none"
+                stroke={NEON_PURPLE}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.3"
+              />
+            </g>
+          );
+        })}
+
         {/* Derived target curve line */}
         {linePath && (
           <path
@@ -527,8 +554,7 @@ export default function CurveEditor({
           );
         })}
 
-        {/* Pairing seam markers land with #392; transport playhead with #393 */}
-        <g data-color-ref={NEON_PURPLE} display="none" />
+        {/* Transport playhead lands with #393. */}
       </svg>
     </div>
   );

--- a/dashboard/app/(dj)/setbuilder/components/PairingsOverlay.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/PairingsOverlay.tsx
@@ -1,0 +1,627 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { api } from '@/lib/api';
+import type { Pairing, PoolTrack } from '@/lib/api-types';
+import type { CSSProperties } from 'react';
+import {
+  BPM_TIER_COLORS,
+  KEY_TIER_COLORS,
+  bpmPercentDelta,
+  camelotMixTier,
+  fmtTime,
+} from './curveMath';
+import type { SlotView } from './types';
+import { slotViewFromApi } from './types';
+import styles from '../setbuilder.module.css';
+
+const EMPTY_STATE = { count: 0, pairings: [] as Pairing[] };
+
+interface PairingsOverlayProps {
+  setId: number;
+  open: boolean;
+  initialPairingId: number | null;
+  onClose: () => void;
+  onChanged: (count: number) => void;
+  onJumpSlot: (idx: number) => void;
+}
+
+function initials(track: PoolTrack | null | undefined): string {
+  const artist = track?.artist || track?.title || '?';
+  return artist
+    .split(/[,\s]+/)
+    .filter(Boolean)
+    .map((w) => w[0])
+    .slice(0, 2)
+    .join('')
+    .toUpperCase();
+}
+
+function artStyle(trackId: string | null | undefined): CSSProperties {
+  const seed = [...(trackId ?? 'manual')].reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  const h1 = (seed * 37) % 360;
+  const h2 = (h1 + 70) % 360;
+  return { background: `linear-gradient(135deg, hsl(${h1} 58% 35%), hsl(${h2} 54% 24%))` };
+}
+
+function pairingMatches(pairing: Pairing, q: string): boolean {
+  if (!q) return true;
+  const hay = [
+    pairing.from_track?.title,
+    pairing.from_track?.artist,
+    pairing.into_track?.title,
+    pairing.into_track?.artist,
+    pairing.from_track_id,
+    pairing.into_track_id,
+    pairing.note,
+    ...(pairing.tags ?? []),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+  return hay.includes(q.toLowerCase());
+}
+
+function TrackArt({ track }: { track: PoolTrack | null | undefined }) {
+  return (
+    <span className={styles.pairingArt} style={artStyle(track?.track_id)}>
+      {initials(track)}
+    </span>
+  );
+}
+
+function LinkIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        d="M10.5 13.5 13.5 10.5M8.5 17.5H7.8a4.8 4.8 0 0 1 0-9.6h3.4M12.8 16.1h3.4a4.8 4.8 0 1 0 0-9.6h-.7"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
+      />
+    </svg>
+  );
+}
+
+function PairingMini({ pairing }: { pairing: Pairing }) {
+  return (
+    <div className={styles.pairingMini}>
+      <div className={styles.pairingMiniTrack}>
+        <TrackArt track={pairing.from_track} />
+        <span className={styles.pairingMiniInfo}>
+          <span className={styles.pairingMiniTitle}>
+            {pairing.from_track?.title ?? pairing.from_track_id}
+          </span>
+          <span className={styles.pairingMiniArtist}>{pairing.from_track?.artist ?? 'Unknown'}</span>
+        </span>
+      </div>
+      <span className={styles.pairingArrow}>-&gt;</span>
+      <div className={styles.pairingMiniTrack}>
+        <TrackArt track={pairing.into_track} />
+        <span className={styles.pairingMiniInfo}>
+          <span className={styles.pairingMiniTitle}>
+            {pairing.into_track?.title ?? pairing.into_track_id}
+          </span>
+          <span className={styles.pairingMiniArtist}>{pairing.into_track?.artist ?? 'Unknown'}</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function CompatibilityChips({ from, into }: { from?: PoolTrack | null; into?: PoolTrack | null }) {
+  const bpm = bpmPercentDelta(from?.bpm ?? null, into?.bpm ?? null);
+  const key = camelotMixTier(from?.camelot ?? from?.key ?? null, into?.camelot ?? into?.key ?? null);
+  const bpmColor = BPM_TIER_COLORS[bpm.tier];
+  const keyColor = KEY_TIER_COLORS[key.tier];
+  return (
+    <>
+      <span className={styles.pairingMetricChip} style={{ color: bpmColor.chip, background: bpmColor.chipBg }}>
+        {bpm.pct == null ? '? BPM' : `${bpm.pct.toFixed(1)}% BPM`}
+      </span>
+      <span className={styles.pairingMetricChip} style={{ color: keyColor.chip, background: keyColor.chipBg }}>
+        {key.label}
+      </span>
+    </>
+  );
+}
+
+function PairingDetail({
+  pairing,
+  slots,
+  onUpdate,
+  onDelete,
+  onJump,
+}: {
+  pairing: Pairing;
+  slots: SlotView[];
+  onUpdate: (patch: { note?: string; cue_in_sec?: number | null; tags?: string[] }) => Promise<void>;
+  onDelete: () => Promise<void>;
+  onJump: (idx: number) => void;
+}) {
+  const [editingNote, setEditingNote] = useState(false);
+  const [note, setNote] = useState(pairing.note ?? '');
+
+  useEffect(() => {
+    setNote(pairing.note ?? '');
+    setEditingNote(false);
+  }, [pairing.id, pairing.note]);
+
+  const useInSet = useMemo(() => {
+    for (let i = 0; i < slots.length - 1; i += 1) {
+      if (
+        slots[i].track.id === pairing.from_track_id &&
+        slots[i + 1].track.id === pairing.into_track_id
+      ) {
+        return i;
+      }
+    }
+    return null;
+  }, [slots, pairing.from_track_id, pairing.into_track_id]);
+
+  const bpm = bpmPercentDelta(pairing.from_track?.bpm ?? null, pairing.into_track?.bpm ?? null);
+  const key = camelotMixTier(
+    pairing.from_track?.camelot ?? pairing.from_track?.key ?? null,
+    pairing.into_track?.camelot ?? pairing.into_track?.key ?? null,
+  );
+
+  return (
+    <div className={styles.pairingDetail}>
+      <div className={styles.pairingHero}>
+        <div className={styles.pairingHeroTrack}>
+          <span className={styles.pairingRole}>FROM</span>
+          <TrackArt track={pairing.from_track} />
+          <strong>{pairing.from_track?.title ?? pairing.from_track_id}</strong>
+          <span>{pairing.from_track?.artist ?? 'Unknown artist'}</span>
+        </div>
+        <div className={styles.pairingHeroArrow}>
+          <span>-&gt;</span>
+          {pairing.cue_in_sec != null && pairing.cue_in_sec > 0 && (
+            <span className={styles.pairingCue}>cue @ {fmtTime(pairing.cue_in_sec)}</span>
+          )}
+        </div>
+        <div className={styles.pairingHeroTrack}>
+          <span className={styles.pairingRole}>INTO</span>
+          <TrackArt track={pairing.into_track} />
+          <strong>{pairing.into_track?.title ?? pairing.into_track_id}</strong>
+          <span>{pairing.into_track?.artist ?? 'Unknown artist'}</span>
+        </div>
+      </div>
+
+      <div className={styles.pairingStatsGrid}>
+        <div className={styles.pairingStatCard} style={{ borderColor: BPM_TIER_COLORS[bpm.tier].stroke }}>
+          <span>BPM delta</span>
+          <strong style={{ color: BPM_TIER_COLORS[bpm.tier].chip }}>
+            {bpm.pct == null ? '?' : `${bpm.pct.toFixed(1)}%`}
+          </strong>
+          <small>{pairing.from_track?.bpm ?? '-'} -&gt; {pairing.into_track?.bpm ?? '-'}</small>
+        </div>
+        <div className={styles.pairingStatCard} style={{ borderColor: KEY_TIER_COLORS[key.tier].stroke }}>
+          <span>Camelot</span>
+          <strong style={{ color: KEY_TIER_COLORS[key.tier].chip }}>{key.label}</strong>
+          <small>{pairing.from_track?.camelot ?? '-'} -&gt; {pairing.into_track?.camelot ?? '-'}</small>
+        </div>
+        <div className={styles.pairingStatCard}>
+          <span>Energy</span>
+          <strong>
+            {pairing.from_track?.energy ?? '-'} -&gt; {pairing.into_track?.energy ?? '-'}
+          </strong>
+          <small>slot vibe signal</small>
+        </div>
+        <div className={styles.pairingStatCard}>
+          <span>Uses</span>
+          <strong>{pairing.use_count}</strong>
+          <small>captured transitions</small>
+        </div>
+      </div>
+
+      <section className={styles.pairingSection}>
+        <div className={styles.pairingSectionHead}>
+          <span>DJ note</span>
+          {!editingNote && (
+            <button type="button" className="btn btn-sm" onClick={() => setEditingNote(true)}>
+              Edit
+            </button>
+          )}
+        </div>
+        {editingNote ? (
+          <>
+            <textarea
+              className={styles.pairingTextarea}
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              rows={4}
+              autoFocus
+            />
+            <div className={styles.pairingInlineActions}>
+              <button
+                type="button"
+                className="btn btn-primary btn-sm"
+                onClick={() => onUpdate({ note }).then(() => setEditingNote(false))}
+              >
+                Save
+              </button>
+              <button type="button" className="btn btn-sm" onClick={() => setEditingNote(false)}>
+                Cancel
+              </button>
+            </div>
+          </>
+        ) : (
+          <p className={styles.pairingNote}>
+            {pairing.note || 'No note yet. Add cue, mixer, or crowd-read context.'}
+          </p>
+        )}
+      </section>
+
+      <div className={styles.pairingTags}>
+        {(pairing.tags ?? []).map((tag) => (
+          <span key={tag}>#{tag}</span>
+        ))}
+      </div>
+
+      <div className={styles.pairingSetUse}>
+        {useInSet == null ? (
+          <span>This transition is not adjacent in the current set.</span>
+        ) : (
+          <>
+            <span>Currently in this set: slot {String(useInSet + 1).padStart(2, '0')} -&gt; {String(useInSet + 2).padStart(2, '0')}</span>
+            <button type="button" className="btn btn-sm" onClick={() => onJump(useInSet)}>
+              Jump
+            </button>
+          </>
+        )}
+      </div>
+
+      <div className={styles.pairingFooter}>
+        <button type="button" className={`btn btn-sm ${styles.dangerBtn}`} onClick={onDelete}>
+          Delete pairing
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function TrackPicker({
+  label,
+  pool,
+  selected,
+  excludeTrackId,
+  onSelect,
+}: {
+  label: string;
+  pool: PoolTrack[];
+  selected: PoolTrack | null;
+  excludeTrackId: string | null;
+  onSelect: (track: PoolTrack | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState('');
+  const results = pool
+    .filter((track) => track.track_id && track.track_id !== excludeTrackId)
+    .filter((track) => `${track.title} ${track.artist}`.toLowerCase().includes(q.toLowerCase()))
+    .slice(0, 30);
+
+  return (
+    <div className={styles.pairingPicker}>
+      <span className={styles.pairingRole}>{label}</span>
+      {selected ? (
+        <div className={styles.pairingPickerSelected}>
+          <TrackArt track={selected} />
+          <span>
+            <strong>{selected.title}</strong>
+            <small>{selected.artist}</small>
+          </span>
+          <button type="button" className="btn btn-sm" onClick={() => setOpen(true)}>
+            Change
+          </button>
+        </div>
+      ) : (
+        <button type="button" className={styles.pairingPickerEmpty} onClick={() => setOpen(true)}>
+          Pick a track
+        </button>
+      )}
+      {open && (
+        <div className={styles.pairingPickerPopover}>
+          <input
+            className={styles.imInput}
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search pool..."
+            autoFocus
+          />
+          <div className={styles.pairingPickerResults}>
+            {results.map((track) => (
+              <button
+                key={track.id}
+                type="button"
+                className={styles.pairingPickerResult}
+                onClick={() => {
+                  onSelect(track);
+                  setOpen(false);
+                  setQ('');
+                }}
+              >
+                <TrackArt track={track} />
+                <span>
+                  <strong>{track.title}</strong>
+                  <small>{track.artist} · {track.bpm ?? '-'} BPM · {track.camelot ?? track.key ?? '-'}</small>
+                </span>
+              </button>
+            ))}
+            {results.length === 0 && <div className={styles.pairingPickerNone}>No tracks found.</div>}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PairingAddForm({
+  pool,
+  pairings,
+  onCancel,
+  onSave,
+}: {
+  pool: PoolTrack[];
+  pairings: Pairing[];
+  onCancel: () => void;
+  onSave: (payload: { from_track_id: string; into_track_id: string; cue_in_sec: number | null; note: string | null; tags: string[] }) => Promise<void>;
+}) {
+  const [from, setFrom] = useState<PoolTrack | null>(null);
+  const [into, setInto] = useState<PoolTrack | null>(null);
+  const [note, setNote] = useState('');
+  const [cue, setCue] = useState('');
+  const [tagText, setTagText] = useState('');
+
+  const tags = useMemo(
+    () => tagText.split(',').map((tag) => tag.trim().replace(/^#/, '')).filter(Boolean),
+    [tagText],
+  );
+  const duplicate = Boolean(
+    from?.track_id &&
+      into?.track_id &&
+      pairings.some((p) => p.from_track_id === from.track_id && p.into_track_id === into.track_id),
+  );
+  const canSave = Boolean(from?.track_id && into?.track_id && !duplicate);
+
+  return (
+    <div className={styles.pairingAdd}>
+      <h3>New pairing</h3>
+      <p>Capture a directional transition you know works. It will be weighted into pass-1 scoring.</p>
+      <div className={styles.pairingAddFlow}>
+        <TrackPicker
+          label="FROM"
+          pool={pool}
+          selected={from}
+          excludeTrackId={into?.track_id ?? null}
+          onSelect={setFrom}
+        />
+        <span className={styles.pairingHeroArrow}>-&gt;</span>
+        <TrackPicker
+          label="INTO"
+          pool={pool}
+          selected={into}
+          excludeTrackId={from?.track_id ?? null}
+          onSelect={setInto}
+        />
+      </div>
+      {duplicate && from && into && (
+        <div className={styles.pairingWarn}>
+          A pairing already exists for {from.title} -&gt; {into.title}.
+        </div>
+      )}
+      {from && into && !duplicate && (
+        <div className={styles.pairingPreview}>
+          <CompatibilityChips from={from} into={into} />
+          <span className={styles.pairingMetricChip}>E {from.energy ?? '-'} -&gt; {into.energy ?? '-'}</span>
+        </div>
+      )}
+      <label className={styles.pairingField}>
+        <span>Note</span>
+        <textarea
+          className={styles.pairingTextarea}
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          rows={3}
+          placeholder="Cue point, mixer move, vibe read..."
+        />
+      </label>
+      <div className={styles.pairingAddGrid}>
+        <label className={styles.pairingField}>
+          <span>Cue in seconds</span>
+          <input className={styles.imInput} value={cue} onChange={(e) => setCue(e.target.value)} inputMode="numeric" />
+        </label>
+        <label className={styles.pairingField}>
+          <span>Tags</span>
+          <input className={styles.imInput} value={tagText} onChange={(e) => setTagText(e.target.value)} placeholder="wedding, safe, peak" />
+        </label>
+      </div>
+      <div className={styles.pairingFooter}>
+        <button type="button" className="btn" onClick={onCancel}>
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="btn btn-primary"
+          disabled={!canSave}
+          onClick={() => {
+            if (!from?.track_id || !into?.track_id) return;
+            onSave({
+              from_track_id: from.track_id,
+              into_track_id: into.track_id,
+              cue_in_sec: cue.trim() ? Math.max(0, Number.parseInt(cue, 10) || 0) : null,
+              note: note.trim() || null,
+              tags,
+            });
+          }}
+        >
+          Save pairing
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function PairingsOverlay({
+  setId,
+  open,
+  initialPairingId,
+  onClose,
+  onChanged,
+  onJumpSlot,
+}: PairingsOverlayProps) {
+  const [state, setState] = useState(EMPTY_STATE);
+  const [pool, setPool] = useState<PoolTrack[]>([]);
+  const [slots, setSlots] = useState<SlotView[]>([]);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [mode, setMode] = useState<'view' | 'add'>('view');
+  const [filter, setFilter] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const notifyChanged = (count: number) => {
+    onChanged(count);
+    window.dispatchEvent(
+      new CustomEvent('wrzdj:setbuilder-pairings-changed', { detail: { count } }),
+    );
+  };
+
+  const reload = async () => {
+    const [pairings, poolState, slotRows] = await Promise.all([
+      api.getPairings(setId),
+      api.getPool(setId),
+      api.getSetSlots(setId),
+    ]);
+    const poolByTrackId = new Map(
+      poolState.tracks
+        .filter((track) => track.track_id)
+        .map((track) => [track.track_id as string, track]),
+    );
+    setState(pairings);
+    setPool(poolState.tracks);
+    setSlots(slotRows.map((slot) => slotViewFromApi(slot, poolByTrackId.get(slot.track_id ?? '') ?? null)));
+    onChanged(pairings.count);
+    if (initialPairingId) setSelectedId(initialPairingId);
+    else if (!selectedId && pairings.pairings.length > 0) setSelectedId(pairings.pairings[0].id);
+    if (pairings.pairings.length === 0) setMode('add');
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    setFilter('');
+    setError(null);
+    reload().catch(() => setError('Pairings failed to load.'));
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, setId, initialPairingId]);
+
+  if (!open) return null;
+
+  const pairings = state.pairings;
+  const filtered = pairings.filter((pairing) => pairingMatches(pairing, filter));
+  const selected = pairings.find((pairing) => pairing.id === selectedId) ?? null;
+  const totalUses = pairings.reduce((sum, pairing) => sum + pairing.use_count, 0);
+
+  return (
+    <div className={styles.pairingsWrap}>
+      <button type="button" className={styles.pairingsBackdrop} aria-label="Close pairings" onClick={onClose} />
+      <div className={styles.pairingsShell} role="dialog" aria-label="Pairings">
+        <header className={styles.pairingsHeader}>
+          <div className={styles.pairingsIcon}>
+            <LinkIcon />
+          </div>
+          <div className={styles.pairingsHeaderText}>
+            <h2>Pairings</h2>
+            <p>DJ-curated transitions weighted into pass-1 scoring.</p>
+          </div>
+          <div className={styles.pairingsStats}>
+            <span><strong>{pairings.length}</strong> saved</span>
+            <span><strong>{totalUses}</strong> uses</span>
+          </div>
+          <button type="button" className={styles.iconBtn} onClick={onClose} aria-label="Close">
+            x
+          </button>
+        </header>
+        <div className={styles.pairingsBody}>
+          <aside className={styles.pairingsListCol}>
+            <div className={styles.pairingsToolbar}>
+              <input
+                className={styles.imInput}
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                placeholder="Search saved pairings..."
+              />
+              <button type="button" className="btn btn-sm" onClick={() => { setMode('add'); setSelectedId(null); }}>
+                New
+              </button>
+            </div>
+            <div className={styles.pairingsList}>
+              {error && <div className={styles.imError}>{error}</div>}
+              {filtered.map((pairing) => (
+                <button
+                  key={pairing.id}
+                  type="button"
+                  className={`${styles.pairingCard} ${selectedId === pairing.id ? styles.pairingCardActive : ''}`}
+                  onClick={() => { setSelectedId(pairing.id); setMode('view'); }}
+                >
+                  <PairingMini pairing={pairing} />
+                  <div className={styles.pairingCardTags}>
+                    <CompatibilityChips from={pairing.from_track} into={pairing.into_track} />
+                    <span className={styles.pairingUses}>x{pairing.use_count}</span>
+                  </div>
+                </button>
+              ))}
+              {!error && filtered.length === 0 && (
+                <div className={styles.pairingsEmpty}>
+                  {pairings.length === 0 ? 'No pairings yet.' : 'No pairings match that search.'}
+                </div>
+              )}
+            </div>
+          </aside>
+          <main className={styles.pairingsDetailCol}>
+            {mode === 'add' ? (
+              <PairingAddForm
+                pool={pool}
+                pairings={pairings}
+                onCancel={() => setMode('view')}
+                onSave={async (payload) => {
+                  const saved = await api.savePairing(setId, { ...payload, increment_use_count: false });
+                  await reload();
+                  setSelectedId(saved.id);
+                  setMode('view');
+                  notifyChanged(state.count + 1);
+                }}
+              />
+            ) : selected ? (
+              <PairingDetail
+                pairing={selected}
+                slots={slots}
+                onUpdate={async (patch) => {
+                  await api.updatePairing(setId, selected.id, patch);
+                  await reload();
+                  notifyChanged(state.count);
+                }}
+                onDelete={async () => {
+                  await api.deletePairing(setId, selected.id);
+                  await reload();
+                  setSelectedId(null);
+                  notifyChanged(Math.max(0, state.count - 1));
+                }}
+                onJump={(idx) => {
+                  onJumpSlot(idx);
+                  onClose();
+                }}
+              />
+            ) : (
+              <div className={styles.pairingsEmpty}>Pick a pairing or create a new one.</div>
+            )}
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/PairingsOverlay.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/PairingsOverlay.tsx
@@ -239,7 +239,14 @@ function PairingDetail({
               <button
                 type="button"
                 className="btn btn-primary btn-sm"
-                onClick={() => onUpdate({ note }).then(() => setEditingNote(false))}
+                onClick={async () => {
+                  try {
+                    await onUpdate({ note });
+                    setEditingNote(false);
+                  } catch {
+                    // The parent owns user-visible mutation errors.
+                  }
+                }}
               >
                 Save
               </button>
@@ -275,7 +282,13 @@ function PairingDetail({
       </div>
 
       <div className={styles.pairingFooter}>
-        <button type="button" className={`btn btn-sm ${styles.dangerBtn}`} onClick={onDelete}>
+        <button
+          type="button"
+          className={`btn btn-sm ${styles.dangerBtn}`}
+          onClick={() => {
+            void onDelete().catch(() => {});
+          }}
+        >
           Delete pairing
         </button>
       </div>
@@ -446,15 +459,19 @@ function PairingAddForm({
           type="button"
           className="btn btn-primary"
           disabled={!canSave}
-          onClick={() => {
+          onClick={async () => {
             if (!from?.track_id || !into?.track_id) return;
-            onSave({
-              from_track_id: from.track_id,
-              into_track_id: into.track_id,
-              cue_in_sec: cue.trim() ? Math.max(0, Number.parseInt(cue, 10) || 0) : null,
-              note: note.trim() || null,
-              tags,
-            });
+            try {
+              await onSave({
+                from_track_id: from.track_id,
+                into_track_id: into.track_id,
+                cue_in_sec: cue.trim() ? Math.max(0, Number.parseInt(cue, 10) || 0) : null,
+                note: note.trim() || null,
+                tags,
+              });
+            } catch {
+              // The parent owns user-visible mutation errors.
+            }
           }}
         >
           Save pairing
@@ -589,11 +606,20 @@ export default function PairingsOverlay({
                 pairings={pairings}
                 onCancel={() => setMode('view')}
                 onSave={async (payload) => {
-                  const saved = await api.savePairing(setId, { ...payload, increment_use_count: false });
-                  await reload();
-                  setSelectedId(saved.id);
-                  setMode('view');
-                  notifyChanged(state.count + 1);
+                  try {
+                    setError(null);
+                    const saved = await api.savePairing(setId, {
+                      ...payload,
+                      increment_use_count: false,
+                    });
+                    await reload();
+                    setSelectedId(saved.id);
+                    setMode('view');
+                    notifyChanged(state.count + 1);
+                  } catch (err) {
+                    setError('Failed to save pairing.');
+                    throw err;
+                  }
                 }}
               />
             ) : selected ? (
@@ -601,15 +627,27 @@ export default function PairingsOverlay({
                 pairing={selected}
                 slots={slots}
                 onUpdate={async (patch) => {
-                  await api.updatePairing(setId, selected.id, patch);
-                  await reload();
-                  notifyChanged(state.count);
+                  try {
+                    setError(null);
+                    await api.updatePairing(setId, selected.id, patch);
+                    await reload();
+                    notifyChanged(state.count);
+                  } catch (err) {
+                    setError('Failed to update pairing.');
+                    throw err;
+                  }
                 }}
                 onDelete={async () => {
-                  await api.deletePairing(setId, selected.id);
-                  await reload();
-                  setSelectedId(null);
-                  notifyChanged(Math.max(0, state.count - 1));
+                  try {
+                    setError(null);
+                    await api.deletePairing(setId, selected.id);
+                    await reload();
+                    setSelectedId(null);
+                    notifyChanged(Math.max(0, state.count - 1));
+                  } catch (err) {
+                    setError('Failed to delete pairing.');
+                    throw err;
+                  }
                 }}
                 onJump={(idx) => {
                   onJumpSlot(idx);

--- a/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
@@ -7,7 +7,7 @@
  * Full drag-reorder timeline lands with #390/#397.
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { fmtTime } from './curveMath';
 import type { SlotView } from './types';
 import { effectiveTarget } from './types';
@@ -24,6 +24,7 @@ export interface TimelinePanelProps {
   hoveredIdx: number | null;
   onHover: (idx: number | null) => void;
   scrollRequest: ScrollRequest | null;
+  onPairingAction?: (idx: number) => void | Promise<void>;
 }
 
 export default function TimelinePanel({
@@ -31,9 +32,11 @@ export default function TimelinePanel({
   hoveredIdx,
   onHover,
   scrollRequest,
+  onPairingAction,
 }: TimelinePanelProps) {
   const listRef = useRef<HTMLDivElement>(null);
   const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [menu, setMenu] = useState<{ x: number; y: number; idx: number } | null>(null);
 
   useEffect(() => {
     if (!scrollRequest || !listRef.current) return;
@@ -47,6 +50,17 @@ export default function TimelinePanel({
     }
   }, [scrollRequest]);
 
+  useEffect(() => {
+    if (!menu) return;
+    const close = () => setMenu(null);
+    window.addEventListener('click', close);
+    window.addEventListener('keydown', close);
+    return () => {
+      window.removeEventListener('click', close);
+      window.removeEventListener('keydown', close);
+    };
+  }, [menu]);
+
   if (slots.length === 0) {
     return (
       <div className={styles.emptyState} data-testid="timeline-empty">
@@ -57,35 +71,94 @@ export default function TimelinePanel({
 
   return (
     <div className={styles.timelineList} ref={listRef} data-testid="timeline-list">
-      {slots.map((s, i) => (
+      {slots.map((s, i) => {
+        const prev = i > 0 ? slots[i - 1] : null;
+        const seamScore = prev?.transitionScore ?? s.transitionScore;
+        const isPairedSeam = Boolean(prev?.nextIsDjPairing);
+        return (
+          <div key={s.id} className={styles.timelineSlotGroup}>
+            {i > 0 && (isPairedSeam || seamScore != null) && (
+              <div
+                className={`${styles.timelineTransition} ${
+                  isPairedSeam ? styles.timelineTransitionPairing : ''
+                }`}
+                data-testid={`timeline-transition-${i - 1}`}
+              >
+                {seamScore != null && (
+                  <span className={styles.timelineScoreChip}>{Math.round(seamScore)}</span>
+                )}
+                {isPairedSeam && (
+                  <span className={styles.timelinePairingChip}>
+                    <svg width="12" height="12" viewBox="0 0 24 24" aria-hidden="true">
+                      <path
+                        d="M10.5 13.5 13.5 10.5M8.5 17.5H7.8a4.8 4.8 0 0 1 0-9.6h3.4M12.8 16.1h3.4a4.8 4.8 0 1 0 0-9.6h-.7"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="1.9"
+                      />
+                    </svg>
+                    DJ pairing
+                  </span>
+                )}
+              </div>
+            )}
+            <div
+              ref={(el) => {
+                rowRefs.current[i] = el;
+              }}
+              className={`${styles.timelineRow} ${hoveredIdx === i ? styles.timelineRowHover : ''}`}
+              onMouseEnter={() => onHover(i)}
+              onMouseLeave={() => onHover(null)}
+              onContextMenu={(event) => {
+                if (i >= slots.length - 1) return;
+                event.preventDefault();
+                setMenu({ x: event.clientX, y: event.clientY, idx: i });
+              }}
+              data-testid={`timeline-row-${i}`}
+            >
+              <span className={styles.timelinePos}>{String(i + 1).padStart(2, '0')}</span>
+              <span className={styles.timelineTitle}>
+                {s.track.title}
+                {s.track.artist ? (
+                  <span className={styles.timelineArtist}> — {s.track.artist}</span>
+                ) : null}
+              </span>
+              <span className={styles.timelineBadge}>{fmtTime(s.track.durationSec)}</span>
+              <span className={styles.timelineBadge}>
+                {s.track.bpm != null ? `${Math.round(s.track.bpm)} BPM` : '— BPM'}
+              </span>
+              <span className={styles.timelineBadge}>{s.track.key ?? '—'}</span>
+              <span className={styles.timelineBadge}>e{s.track.energy}</span>
+              <span className={styles.timelineTarget} title="Target energy">
+                ◎ {effectiveTarget(s).toFixed(1)}
+              </span>
+            </div>
+          </div>
+        );
+      })}
+      {menu && (
         <div
-          key={s.id}
-          ref={(el) => {
-            rowRefs.current[i] = el;
-          }}
-          className={`${styles.timelineRow} ${hoveredIdx === i ? styles.timelineRowHover : ''}`}
-          onMouseEnter={() => onHover(i)}
-          onMouseLeave={() => onHover(null)}
-          data-testid={`timeline-row-${i}`}
+          className={styles.timelineContextMenu}
+          style={{ left: menu.x, top: menu.y }}
+          onClick={(event) => event.stopPropagation()}
+          data-testid="timeline-context-menu"
         >
-          <span className={styles.timelinePos}>{String(i + 1).padStart(2, '0')}</span>
-          <span className={styles.timelineTitle}>
-            {s.track.title}
-            {s.track.artist ? (
-              <span className={styles.timelineArtist}> — {s.track.artist}</span>
-            ) : null}
-          </span>
-          <span className={styles.timelineBadge}>{fmtTime(s.track.durationSec)}</span>
-          <span className={styles.timelineBadge}>
-            {s.track.bpm != null ? `${Math.round(s.track.bpm)} BPM` : '— BPM'}
-          </span>
-          <span className={styles.timelineBadge}>{s.track.key ?? '—'}</span>
-          <span className={styles.timelineBadge}>e{s.track.energy}</span>
-          <span className={styles.timelineTarget} title="Target energy">
-            ◎ {effectiveTarget(s).toFixed(1)}
-          </span>
+          <button
+            type="button"
+            className={styles.timelineContextItem}
+            onClick={() => {
+              onPairingAction?.(menu.idx);
+              setMenu(null);
+            }}
+          >
+            {slots[menu.idx]?.nextIsDjPairing
+              ? 'Open saved pairing'
+              : `Save -> ${slots[menu.idx + 1]?.track.title ?? 'next'} as pairing`}
+          </button>
         </div>
-      ))}
+      )}
     </div>
   );
 }

--- a/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
@@ -75,6 +75,9 @@ export default function TimelinePanel({
         const prev = i > 0 ? slots[i - 1] : null;
         const seamScore = prev?.transitionScore ?? s.transitionScore;
         const isPairedSeam = Boolean(prev?.nextIsDjPairing);
+        const pairingActionLabel = s.nextIsDjPairing
+          ? `Open saved pairing after ${s.track.title}`
+          : `Save ${s.track.title} into ${slots[i + 1]?.track.title ?? 'next track'} as pairing`;
         return (
           <div key={s.id} className={styles.timelineSlotGroup}>
             {i > 0 && (isPairedSeam || seamScore != null) && (
@@ -134,6 +137,30 @@ export default function TimelinePanel({
               <span className={styles.timelineTarget} title="Target energy">
                 ◎ {effectiveTarget(s).toFixed(1)}
               </span>
+              {i < slots.length - 1 && (
+                <button
+                  type="button"
+                  className={styles.timelinePairingAction}
+                  aria-label={pairingActionLabel}
+                  title={pairingActionLabel}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    const rect = event.currentTarget.getBoundingClientRect();
+                    setMenu({ x: rect.left, y: rect.bottom + 4, idx: i });
+                  }}
+                >
+                  <svg width="13" height="13" viewBox="0 0 24 24" aria-hidden="true">
+                    <path
+                      d="M10.5 13.5 13.5 10.5M8.5 17.5H7.8a4.8 4.8 0 0 1 0-9.6h3.4M12.8 16.1h3.4a4.8 4.8 0 1 0 0-9.6h-.7"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="1.9"
+                    />
+                  </svg>
+                </button>
+              )}
             </div>
           </div>
         );

--- a/dashboard/app/(dj)/setbuilder/components/curve.module.css
+++ b/dashboard/app/(dj)/setbuilder/components/curve.module.css
@@ -629,6 +629,27 @@
   white-space: nowrap;
 }
 
+.timelinePairingAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  border: 1px solid rgba(183, 139, 255, 0.45);
+  border-radius: 5px;
+  background: rgba(183, 139, 255, 0.1);
+  color: #c4a4ff;
+  cursor: pointer;
+}
+
+.timelinePairingAction:hover,
+.timelinePairingAction:focus-visible {
+  background: rgba(183, 139, 255, 0.18);
+  color: #e4d7ff;
+  outline: none;
+}
+
 .timelineContextMenu {
   position: fixed;
   z-index: 80;

--- a/dashboard/app/(dj)/setbuilder/components/curve.module.css
+++ b/dashboard/app/(dj)/setbuilder/components/curve.module.css
@@ -522,6 +522,56 @@
   flex: 1;
   overflow-y: auto;
   padding: 0.4rem;
+  position: relative;
+}
+
+.timelineSlotGroup {
+  min-width: 0;
+}
+
+.timelineTransition {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 22px;
+  margin: 0.05rem 0 0.1rem 2.25rem;
+  color: var(--text-secondary);
+}
+
+.timelineTransitionPairing {
+  color: #c4a4ff;
+}
+
+.timelineScoreChip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 18px;
+  padding: 0 0.35rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.625rem;
+  font-weight: 700;
+}
+
+.timelinePairingChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  height: 18px;
+  padding: 0 0.45rem;
+  border: 1px solid rgba(183, 139, 255, 0.52);
+  border-radius: 4px;
+  background: rgba(183, 139, 255, 0.14);
+  color: #c4a4ff;
+  font-size: 0.625rem;
+  font-weight: 700;
+  white-space: nowrap;
 }
 
 .timelineRow {
@@ -577,6 +627,34 @@
   font-size: 0.5625rem;
   color: #00f5d4;
   white-space: nowrap;
+}
+
+.timelineContextMenu {
+  position: fixed;
+  z-index: 80;
+  min-width: 210px;
+  padding: 0.25rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.48);
+}
+
+.timelineContextItem {
+  width: 100%;
+  padding: 0.45rem 0.55rem;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.75rem;
+  text-align: left;
+}
+
+.timelineContextItem:hover {
+  background: rgba(183, 139, 255, 0.14);
+  color: #d8c6ff;
 }
 
 .emptyState {

--- a/dashboard/app/(dj)/setbuilder/components/types.ts
+++ b/dashboard/app/(dj)/setbuilder/components/types.ts
@@ -6,7 +6,7 @@
  * renderable from the bare Phase 0 slot rows.
  */
 
-import type { SetSlotOut } from '@/lib/api-types';
+import type { PoolTrack, SetSlotOut } from '@/lib/api-types';
 
 export interface TrackView {
   id: string;
@@ -26,6 +26,9 @@ export interface SlotView {
   locked: boolean;
   /** Explicit target; null = fall back to track energy. */
   targetEnergy: number | null;
+  transitionScore: number | null;
+  nextPairingId: number | null;
+  nextIsDjPairing: boolean;
   track: TrackView;
 }
 
@@ -40,13 +43,29 @@ export interface VibeWindowView {
 export const DEFAULT_TRACK_DURATION_SEC = 210;
 export const DEFAULT_TRACK_ENERGY = 5;
 
-export function slotViewFromApi(slot: SetSlotOut): SlotView {
+export function trackViewFromPool(track: PoolTrack): TrackView {
+  return {
+    id: track.track_id ?? `pool-${track.id}`,
+    title: track.title,
+    artist: track.artist,
+    durationSec: track.duration_sec ?? DEFAULT_TRACK_DURATION_SEC,
+    energy: track.energy ?? DEFAULT_TRACK_ENERGY,
+    bpm: track.bpm,
+    key: track.camelot ?? track.key,
+  };
+}
+
+export function slotViewFromApi(slot: SetSlotOut, poolTrack?: PoolTrack | null): SlotView {
+  const track = poolTrack ? trackViewFromPool(poolTrack) : null;
   return {
     id: slot.id,
     position: slot.position,
     locked: slot.locked,
     targetEnergy: slot.target_energy ?? null,
-    track: {
+    transitionScore: slot.transition_score ?? null,
+    nextPairingId: slot.next_pairing_id ?? null,
+    nextIsDjPairing: slot.next_is_dj_pairing ?? false,
+    track: track ?? {
       id: slot.track_id ?? `slot-${slot.id}`,
       title: slot.title ?? slot.track_id ?? `Slot ${slot.position + 1}`,
       artist: slot.artist ?? '',

--- a/dashboard/app/(dj)/setbuilder/setbuilder.module.css
+++ b/dashboard/app/(dj)/setbuilder/setbuilder.module.css
@@ -35,6 +35,41 @@
   color: var(--text);
 }
 
+.topbarPairingsBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  height: 32px;
+  padding: 0 0.65rem;
+  border: 1px solid rgba(183, 139, 255, 0.5);
+  border-radius: 8px;
+  background: rgba(139, 92, 246, 0.15);
+  color: #d8c6ff;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.topbarPairingsBtn:hover {
+  background: rgba(139, 92, 246, 0.24);
+  border-color: rgba(183, 139, 255, 0.75);
+}
+
+.topbarPairingsBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 0.3rem;
+  border-radius: 999px;
+  background: #b78bff;
+  color: #12091f;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.625rem;
+  font-weight: 800;
+}
+
 .panel {
   background: var(--bg);
   display: flex;
@@ -845,6 +880,578 @@
   color: #f87171 !important;
 }
 
+/* ------------------------------------------------------------------ */
+/* Pairings overlay (issue #392)                                      */
+
+.pairingsWrap {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem;
+}
+
+.pairingsBackdrop {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(0, 0, 0, 0.68);
+  cursor: default;
+}
+
+.pairingsShell {
+  position: relative;
+  width: min(1180px, 100%);
+  height: min(760px, calc(100vh - 2.5rem));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid rgba(183, 139, 255, 0.22);
+  border-radius: 8px;
+  background: var(--card);
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.58);
+}
+
+.pairingsHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.pairingsIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid rgba(183, 139, 255, 0.48);
+  border-radius: 8px;
+  background: rgba(183, 139, 255, 0.14);
+  color: #c4a4ff;
+}
+
+.pairingsHeaderText {
+  flex: 1;
+  min-width: 0;
+}
+
+.pairingsHeaderText h2 {
+  margin: 0;
+  font-family: var(--font-display), sans-serif;
+  font-size: 1rem;
+}
+
+.pairingsHeaderText p {
+  margin: 0.12rem 0 0;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.pairingsStats {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+}
+
+.pairingsStats span {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  padding: 0.25rem 0.45rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--surface-raised);
+}
+
+.pairingsStats strong {
+  color: var(--text);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.8125rem;
+}
+
+.pairingsBody {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 360px minmax(0, 1fr);
+}
+
+.pairingsListCol {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-right: 1px solid var(--border-subtle);
+  background: rgba(255, 255, 255, 0.015);
+}
+
+.pairingsToolbar {
+  display: flex;
+  gap: 0.45rem;
+  padding: 0.7rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.pairingsToolbar input {
+  flex: 1;
+  min-width: 0;
+}
+
+.pairingsList {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.55rem;
+}
+
+.pairingCard {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  margin-bottom: 0.4rem;
+  padding: 0.6rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.pairingCard:hover,
+.pairingCardActive {
+  border-color: rgba(183, 139, 255, 0.52);
+  background: rgba(183, 139, 255, 0.1);
+}
+
+.pairingCardTags,
+.pairingPreview {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.pairingMetricChip,
+.pairingUses {
+  display: inline-flex;
+  align-items: center;
+  min-height: 18px;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  background: var(--surface-raised);
+  color: var(--text-secondary);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.625rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.pairingUses {
+  margin-left: auto;
+  color: #c4a4ff;
+}
+
+.pairingsEmpty {
+  padding: 1rem;
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  text-align: center;
+}
+
+.pairingsDetailCol {
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.85rem;
+}
+
+.pairingDetail,
+.pairingAdd {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.pairingAdd h3 {
+  margin: 0;
+  font-family: var(--font-display), sans-serif;
+  font-size: 0.95rem;
+}
+
+.pairingAdd p {
+  margin: -0.45rem 0 0;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.pairingHero,
+.pairingAddFlow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+.pairingHeroTrack,
+.pairingPickerSelected {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-width: 0;
+  padding: 0.7rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg);
+}
+
+.pairingHeroTrack {
+  flex-direction: column;
+  text-align: center;
+}
+
+.pairingHeroTrack strong,
+.pairingPickerSelected strong,
+.pairingMiniTitle {
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pairingHeroTrack span,
+.pairingPickerSelected small,
+.pairingMiniArtist {
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--text-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pairingRole {
+  color: var(--text-tertiary);
+  font-size: 0.5625rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pairingHeroArrow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  color: #c4a4ff;
+  font-family: var(--font-mono, monospace);
+  font-weight: 800;
+}
+
+.pairingCue {
+  padding: 0.12rem 0.35rem;
+  border: 1px solid rgba(183, 139, 255, 0.38);
+  border-radius: 4px;
+  background: rgba(183, 139, 255, 0.12);
+  font-size: 0.625rem;
+  white-space: nowrap;
+}
+
+.pairingStatsGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.pairingStatCard {
+  min-width: 0;
+  padding: 0.65rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg);
+}
+
+.pairingStatCard span,
+.pairingStatCard small {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 0.625rem;
+}
+
+.pairingStatCard strong {
+  display: block;
+  margin: 0.2rem 0;
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.pairingSection {
+  padding: 0.7rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg);
+}
+
+.pairingSectionHead,
+.pairingFooter,
+.pairingSetUse {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.pairingSectionHead {
+  margin-bottom: 0.5rem;
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.pairingTextarea {
+  width: 100%;
+  resize: vertical;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.55rem 0.65rem;
+  color: var(--text);
+  font-size: 0.8125rem;
+}
+
+.pairingTextarea:focus {
+  outline: none;
+  border-color: rgba(183, 139, 255, 0.72);
+}
+
+.pairingInlineActions {
+  display: flex;
+  gap: 0.45rem;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}
+
+.pairingNote {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.pairingTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.pairingTags span {
+  padding: 0.15rem 0.45rem;
+  border: 1px solid rgba(183, 139, 255, 0.35);
+  border-radius: 999px;
+  background: rgba(183, 139, 255, 0.1);
+  color: #d8c6ff;
+  font-size: 0.6875rem;
+}
+
+.pairingSetUse {
+  padding: 0.55rem 0.65rem;
+  border: 1px dashed rgba(183, 139, 255, 0.38);
+  border-radius: 8px;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.pairingPicker {
+  position: relative;
+  min-width: 0;
+}
+
+.pairingPicker .pairingRole {
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.pairingPickerSelected {
+  min-height: 68px;
+}
+
+.pairingPickerSelected > span {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.pairingPickerEmpty {
+  width: 100%;
+  min-height: 68px;
+  border: 1px dashed rgba(183, 139, 255, 0.4);
+  border-radius: 8px;
+  background: rgba(183, 139, 255, 0.08);
+  color: #d8c6ff;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.pairingPickerPopover {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% + 0.35rem);
+  z-index: 130;
+  padding: 0.45rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.5);
+}
+
+.pairingPickerPopover input {
+  width: 100%;
+}
+
+.pairingPickerResults {
+  max-height: 250px;
+  overflow-y: auto;
+  margin-top: 0.45rem;
+}
+
+.pairingPickerResult {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  width: 100%;
+  padding: 0.45rem;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.pairingPickerResult:hover {
+  background: var(--surface-raised);
+}
+
+.pairingPickerResult span {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.pairingPickerResult strong,
+.pairingPickerResult small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pairingPickerResult small,
+.pairingPickerNone {
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+}
+
+.pairingPickerNone {
+  padding: 0.7rem;
+  text-align: center;
+}
+
+.pairingWarn {
+  padding: 0.55rem 0.7rem;
+  border: 1px solid rgba(245, 158, 11, 0.42);
+  border-radius: 8px;
+  background: rgba(245, 158, 11, 0.1);
+  color: #fbbf24;
+  font-size: 0.75rem;
+}
+
+.pairingField {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+  font-weight: 700;
+}
+
+.pairingAddGrid {
+  display: grid;
+  grid-template-columns: 180px 1fr;
+  gap: 0.6rem;
+}
+
+.pairingArt {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 auto;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.86);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.pairingHeroTrack .pairingArt {
+  width: 60px;
+  height: 60px;
+  font-size: 0.95rem;
+}
+
+.pairingMini {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 0.45rem;
+  align-items: center;
+  min-width: 0;
+}
+
+.pairingMiniTrack {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.pairingMiniInfo {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.pairingMiniTitle,
+.pairingMiniArtist {
+  display: block;
+}
+
+.pairingMiniTitle {
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.pairingMiniArtist {
+  font-size: 0.6563rem;
+}
+
+.pairingArrow {
+  color: #c4a4ff;
+  font-family: var(--font-mono, monospace);
+  font-weight: 800;
+}
+
 .poolToast {
   position: absolute;
   left: 50%;
@@ -1095,4 +1702,61 @@
 
 .vibeWinner {
   border-color: var(--color-primary, #8b5cf6);
+}
+
+@media (max-width: 980px) {
+  .pairingsShell {
+    height: calc(100vh - 1.5rem);
+  }
+
+  .pairingsBody {
+    grid-template-columns: 1fr;
+  }
+
+  .pairingsListCol {
+    max-height: 42vh;
+    border-right: 0;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .pairingStatsGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .topbarPairingsBtn {
+    padding: 0 0.5rem;
+    font-size: 0;
+  }
+
+  .topbarPairingsBadge {
+    font-size: 0.625rem;
+  }
+
+  .pairingsWrap {
+    padding: 0.5rem;
+  }
+
+  .pairingsHeader {
+    align-items: flex-start;
+  }
+
+  .pairingsStats {
+    display: none;
+  }
+
+  .pairingHero,
+  .pairingAddFlow {
+    grid-template-columns: 1fr;
+  }
+
+  .pairingHeroArrow {
+    min-height: 24px;
+  }
+
+  .pairingStatsGrid,
+  .pairingAddGrid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -2806,6 +2806,54 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/setbuilder/sets/{set_id}/pairings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Set Pairings
+         * @description Searchable pairings overlay state for one of the current DJ's sets.
+         */
+        get: operations["list_set_pairings_api_setbuilder_sets__set_id__pairings_get"];
+        put?: never;
+        /**
+         * Create Set Pairing
+         * @description Create or update a DJ-curated transition pairing.
+         */
+        post: operations["create_set_pairing_api_setbuilder_sets__set_id__pairings_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/pairings/{pairing_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Set Pairing
+         * @description Delete a pairing from one of the current DJ's sets.
+         */
+        delete: operations["delete_set_pairing_api_setbuilder_sets__set_id__pairings__pairing_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Set Pairing
+         * @description Inline-edit note, tags, and cue-in for a pairing.
+         */
+        patch: operations["update_set_pairing_api_setbuilder_sets__set_id__pairings__pairing_id__patch"];
+        trace?: never;
+    };
     "/api/setbuilder/sets/{set_id}/pool": {
         parameters: {
             query?: never;
@@ -5227,6 +5275,83 @@ export interface components {
             /** Total */
             total: number;
         };
+        /**
+         * PairingCreate
+         * @description Create/update a DJ-curated from->into pairing.
+         */
+        PairingCreate: {
+            /** Cue In Sec */
+            cue_in_sec?: number | null;
+            /** From Track Id */
+            from_track_id: string;
+            /**
+             * Increment Use Count
+             * @default false
+             */
+            increment_use_count: boolean;
+            /** Into Track Id */
+            into_track_id: string;
+            /** Note */
+            note?: string | null;
+            /** Tags */
+            tags?: string[];
+        };
+        /**
+         * PairingOut
+         * @description Pairing card/detail payload for the overlay.
+         */
+        PairingOut: {
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Cue In Sec */
+            cue_in_sec: number | null;
+            from_track: components["schemas"]["PoolTrackOut"] | null;
+            /** From Track Id */
+            from_track_id: string;
+            /** Id */
+            id: number;
+            into_track: components["schemas"]["PoolTrackOut"] | null;
+            /** Into Track Id */
+            into_track_id: string;
+            /** Note */
+            note: string | null;
+            /** Set Id */
+            set_id: number;
+            /** Tags */
+            tags: string[];
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** Use Count */
+            use_count: number;
+        };
+        /**
+         * PairingUpdate
+         * @description Editable pairing details.
+         */
+        PairingUpdate: {
+            /** Cue In Sec */
+            cue_in_sec?: number | null;
+            /** Note */
+            note?: string | null;
+            /** Tags */
+            tags?: string[] | null;
+        };
+        /**
+         * PairingsState
+         * @description Pairings list response.
+         */
+        PairingsState: {
+            /** Count */
+            count: number;
+            /** Pairings */
+            pairings: components["schemas"]["PairingOut"][];
+        };
         /** PendingReviewResponse */
         PendingReviewResponse: {
             /** Requests */
@@ -6007,6 +6132,13 @@ export interface components {
             key: string | null;
             /** Locked */
             locked: boolean;
+            /**
+             * Next Is Dj Pairing
+             * @default false
+             */
+            next_is_dj_pairing: boolean;
+            /** Next Pairing Id */
+            next_pairing_id: number | null;
             /** Notes */
             notes: string | null;
             /** Pool Track Id */
@@ -11531,6 +11663,140 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    list_set_pairings_api_setbuilder_sets__set_id__pairings_get: {
+        parameters: {
+            query?: {
+                query?: string | null;
+            };
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PairingsState"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_set_pairing_api_setbuilder_sets__set_id__pairings_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PairingCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PairingOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_set_pairing_api_setbuilder_sets__set_id__pairings__pairing_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+                pairing_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_set_pairing_api_setbuilder_sets__set_id__pairings__pairing_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+                pairing_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PairingUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PairingOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
             };
         };
     };

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -11714,6 +11714,15 @@ export interface operations {
             };
         };
         responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PairingOut"];
+                };
+            };
             /** @description Successful Response */
             201: {
                 headers: {

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -215,6 +215,12 @@ export type AgentChatOut = Schemas['AgentChatOut'];
 export type AppliedToolCall = Schemas['AppliedToolCallOut'];
 export type TransitionScore = Schemas['TransitionScoreOut'];
 
+// WrzDJSet pairings (issue #392)
+export type PairingCreate = Schemas['PairingCreate'];
+export type PairingUpdate = Schemas['PairingUpdate'];
+export type Pairing = Schemas['PairingOut'];
+export type PairingsState = Schemas['PairingsState'];
+
 // WrzDJSet pool (issue #388)
 export type PoolSource = Schemas['PoolSourceOut'];
 export type PoolTrack = Schemas['PoolTrackOut'];

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -50,6 +50,10 @@ import type {
   MyRequestsResponse,
   NowPlayingInfo,
   PaginatedResponse,
+  Pairing,
+  PairingCreate,
+  PairingUpdate,
+  PairingsState,
   PlayHistoryResponse,
   PlaylistListResponse,
   PoolImportManualIn,
@@ -146,6 +150,10 @@ export type {
   MyRequestsResponse,
   NowPlayingInfo,
   PaginatedResponse,
+  Pairing,
+  PairingCreate,
+  PairingUpdate,
+  PairingsState,
   PlayHistoryItem,
   PlayHistoryResponse,
   PublicBridgeStatus,
@@ -761,6 +769,29 @@ class ApiClient {
     return this.fetch(`/api/setbuilder/sets/${setId}/vibe-windows`, {
       method: 'PUT',
       body: JSON.stringify({ windows }),
+    });
+  }
+
+  // WrzDJSet pairings (issue #392)
+  async getPairings(setId: number, query?: string): Promise<PairingsState> {
+    const qs = query?.trim() ? `?query=${encodeURIComponent(query.trim())}` : '';
+    return this.fetch(`/api/setbuilder/sets/${setId}/pairings${qs}`);
+  }
+  async savePairing(setId: number, pairing: PairingCreate): Promise<Pairing> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pairings`, {
+      method: 'POST',
+      body: JSON.stringify(pairing),
+    });
+  }
+  async updatePairing(setId: number, pairingId: number, patch: PairingUpdate): Promise<Pairing> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pairings/${pairingId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(patch),
+    });
+  }
+  async deletePairing(setId: number, pairingId: number): Promise<void> {
+    await this.rawFetch(`/api/setbuilder/sets/${setId}/pairings/${pairingId}`, {
+      method: 'DELETE',
     });
   }
 

--- a/server/alembic/versions/058_add_set_pairings.py
+++ b/server/alembic/versions/058_add_set_pairings.py
@@ -1,0 +1,56 @@
+"""Add WrzDJSet pairing table (issue #392).
+
+Revision ID: 058
+Revises: 057
+Create Date: 2026-06-13
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "058"
+down_revision: str | None = "057"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "set_pairings",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "set_id",
+            sa.Integer(),
+            sa.ForeignKey("sets.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("from_track_id", sa.String(255), nullable=False),
+        sa.Column("into_track_id", sa.String(255), nullable=False),
+        sa.Column("cue_in_sec", sa.Integer(), nullable=True),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("tags_json", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("use_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint(
+            "set_id",
+            "from_track_id",
+            "into_track_id",
+            name="uq_set_pairing_tracks",
+        ),
+    )
+    op.create_index("ix_set_pairings_set_id", "set_pairings", ["set_id"])
+    op.create_index("ix_set_pairings_from_track_id", "set_pairings", ["from_track_id"])
+    op.create_index("ix_set_pairings_into_track_id", "set_pairings", ["into_track_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_set_pairings_into_track_id", table_name="set_pairings")
+    op.drop_index("ix_set_pairings_from_track_id", table_name="set_pairings")
+    op.drop_index("ix_set_pairings_set_id", table_name="set_pairings")
+    op.drop_table("set_pairings")

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -38,6 +38,10 @@ from app.schemas.setbuilder import (
     ExportTidalOut,
     LlmVibeOut,
     OwnVibeOut,
+    PairingCreate,
+    PairingOut,
+    PairingsState,
+    PairingUpdate,
     PoolImportEventIn,
     PoolImportManualIn,
     PoolImportPlaylistIn,
@@ -75,6 +79,7 @@ from app.services.setbuilder import (
     export_common,
     export_files,
     export_tidal,
+    pairings,
     pass1_deterministic,
     pass2_agent,
     pool,
@@ -92,45 +97,6 @@ def _get_owned_or_404(db: Session, set_id: int, user: User) -> Set:
     if set_obj is None:
         raise HTTPException(status_code=404, detail="Set not found")
     return set_obj
-
-
-def _slots_out(db: Session, set_obj: Set) -> list[SlotOut]:
-    """Ordered slots with pool metadata joined by namespaced track_id."""
-    slots = sorted(set_obj.slots, key=lambda s: s.position)
-    track_ids = [s.track_id for s in slots if s.track_id]
-    tracks_by_id: dict[str, SetPoolTrack] = {}
-    if track_ids:
-        tracks = (
-            db.query(SetPoolTrack)
-            .filter(SetPoolTrack.set_id == set_obj.id, SetPoolTrack.track_id.in_(track_ids))
-            .all()
-        )
-        tracks_by_id = {t.track_id: t for t in tracks if t.track_id}
-
-    out: list[SlotOut] = []
-    for slot in slots:
-        track = tracks_by_id.get(slot.track_id or "")
-        out.append(
-            SlotOut(
-                id=slot.id,
-                position=slot.position,
-                track_id=slot.track_id,
-                locked=slot.locked,
-                target_energy=slot.target_energy,
-                notes=slot.notes,
-                transition_score=slot.transition_score,
-                transition_warnings=slot.transition_warnings,
-                pool_track_id=track.id if track else None,
-                title=track.title if track else None,
-                artist=track.artist if track else None,
-                bpm=track.bpm if track else None,
-                key=track.key if track else None,
-                camelot=track.camelot if track else None,
-                energy=track.energy if track else None,
-                duration_sec=track.duration_sec if track else None,
-            )
-        )
-    return out
 
 
 def _transition_scores_out(
@@ -240,6 +206,74 @@ def _get_owned_template_or_404(db: Session, template_id: int, user: User):
     return tpl
 
 
+def _pairing_out(view: pairings.PairingView) -> PairingOut:
+    p = view.pairing
+    return PairingOut(
+        id=p.id,
+        set_id=p.set_id,
+        from_track_id=p.from_track_id,
+        into_track_id=p.into_track_id,
+        cue_in_sec=p.cue_in_sec,
+        note=p.note,
+        tags=pairings.tags_for_pairing(p),
+        use_count=p.use_count,
+        from_track=PoolTrackOut.model_validate(view.from_track) if view.from_track else None,
+        into_track=PoolTrackOut.model_validate(view.into_track) if view.into_track else None,
+        created_at=p.created_at,
+        updated_at=p.updated_at,
+    )
+
+
+def _pairings_state(db: Session, set_obj: Set, query: str | None = None) -> PairingsState:
+    views = pairings.list_pairings(db, set_obj, query)
+    return PairingsState(count=len(views), pairings=[_pairing_out(v) for v in views])
+
+
+def _slots_out(db: Session, set_obj: Set) -> list[SlotOut]:
+    """Ordered slots with pool metadata and saved-pairing seam markers."""
+    ordered = sorted(set_obj.slots, key=lambda s: s.position)
+    track_ids = [s.track_id for s in ordered if s.track_id]
+    tracks_by_id: dict[str, SetPoolTrack] = {}
+    if track_ids:
+        tracks = (
+            db.query(SetPoolTrack)
+            .filter(SetPoolTrack.set_id == set_obj.id, SetPoolTrack.track_id.in_(track_ids))
+            .all()
+        )
+        tracks_by_id = {t.track_id: t for t in tracks if t.track_id}
+    by_transition = {(p.from_track_id, p.into_track_id): p.id for p in set_obj.pairings}
+    out: list[SlotOut] = []
+    for idx, slot in enumerate(ordered):
+        track = tracks_by_id.get(slot.track_id or "")
+        next_slot = ordered[idx + 1] if idx + 1 < len(ordered) else None
+        pairing_id = None
+        if slot.track_id and next_slot and next_slot.track_id:
+            pairing_id = by_transition.get((slot.track_id, next_slot.track_id))
+        out.append(
+            SlotOut(
+                id=slot.id,
+                position=slot.position,
+                track_id=slot.track_id,
+                locked=slot.locked,
+                target_energy=slot.target_energy,
+                notes=slot.notes,
+                transition_score=slot.transition_score,
+                transition_warnings=slot.transition_warnings,
+                pool_track_id=track.id if track else None,
+                title=track.title if track else None,
+                artist=track.artist if track else None,
+                bpm=track.bpm if track else None,
+                key=track.key if track else None,
+                camelot=track.camelot if track else None,
+                energy=track.energy if track else None,
+                duration_sec=track.duration_sec if track else None,
+                next_pairing_id=pairing_id,
+                next_is_dj_pairing=pairing_id is not None,
+            )
+        )
+    return out
+
+
 @router.get("/curve-templates", response_model=CurveTemplatesResponse)
 @limiter.limit("60/minute")
 def list_curve_templates(
@@ -308,6 +342,104 @@ def list_set_slots(
     """Ordered timeline slots for one of the current DJ's sets."""
     set_obj = _get_owned_or_404(db, set_id, current_user)
     return _slots_out(db, set_obj)
+
+
+@router.get("/sets/{set_id}/pairings", response_model=PairingsState)
+@limiter.limit("60/minute")
+def list_set_pairings(
+    set_id: int,
+    request: Request,
+    query: str | None = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PairingsState:
+    """Searchable pairings overlay state for one of the current DJ's sets."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    return _pairings_state(db, set_obj, query)
+
+
+@router.post(
+    "/sets/{set_id}/pairings",
+    response_model=PairingOut,
+    status_code=status.HTTP_201_CREATED,
+)
+@limiter.limit("30/minute")
+def create_set_pairing(
+    set_id: int,
+    payload: PairingCreate,
+    response: Response,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PairingOut:
+    """Create or update a DJ-curated transition pairing."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    try:
+        pairing, created = pairings.upsert_pairing(
+            db,
+            set_obj,
+            from_track_id=payload.from_track_id,
+            into_track_id=payload.into_track_id,
+            cue_in_sec=payload.cue_in_sec,
+            note=payload.note,
+            tags=payload.tags,
+            increment_use_count=payload.increment_use_count,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if not created:
+        response.status_code = status.HTTP_200_OK
+    view = pairings.list_pairings(db, set_obj)
+    return _pairing_out(next(v for v in view if v.pairing.id == pairing.id))
+
+
+@router.patch("/sets/{set_id}/pairings/{pairing_id}", response_model=PairingOut)
+@limiter.limit("30/minute")
+def update_set_pairing(
+    set_id: int,
+    pairing_id: int,
+    payload: PairingUpdate,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PairingOut:
+    """Inline-edit note, tags, and cue-in for a pairing."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    pairing = pairings.get_pairing(db, set_obj, pairing_id)
+    if pairing is None:
+        raise HTTPException(status_code=404, detail="Pairing not found")
+    fields = payload.model_fields_set
+    tags = (
+        payload.tags
+        if "tags" in fields and payload.tags is not None
+        else pairings.tags_for_pairing(pairing)
+    )
+    updated = pairings.update_pairing(
+        db,
+        pairing,
+        cue_in_sec=payload.cue_in_sec if "cue_in_sec" in fields else pairing.cue_in_sec,
+        note=payload.note if "note" in fields else pairing.note,
+        tags=tags,
+    )
+    view = pairings.list_pairings(db, set_obj)
+    return _pairing_out(next(v for v in view if v.pairing.id == updated.id))
+
+
+@router.delete("/sets/{set_id}/pairings/{pairing_id}", status_code=status.HTTP_204_NO_CONTENT)
+@limiter.limit("30/minute")
+def delete_set_pairing(
+    set_id: int,
+    pairing_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> None:
+    """Delete a pairing from one of the current DJ's sets."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    pairing = pairings.get_pairing(db, set_obj, pairing_id)
+    if pairing is None:
+        raise HTTPException(status_code=404, detail="Pairing not found")
+    pairings.delete_pairing(db, pairing)
 
 
 @router.patch("/sets/{set_id}/slots/{slot_id}/target", response_model=SlotTargetOut)

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -390,8 +390,7 @@ def create_set_pairing(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not created:
         response.status_code = status.HTTP_200_OK
-    view = pairings.list_pairings(db, set_obj)
-    return _pairing_out(next(v for v in view if v.pairing.id == pairing.id))
+    return _pairing_out(pairings.pairing_view(db, set_obj, pairing))
 
 
 @router.patch("/sets/{set_id}/pairings/{pairing_id}", response_model=PairingOut)
@@ -422,8 +421,7 @@ def update_set_pairing(
         note=payload.note if "note" in fields else pairing.note,
         tags=tags,
     )
-    view = pairings.list_pairings(db, set_obj)
-    return _pairing_out(next(v for v in view if v.pairing.id == updated.id))
+    return _pairing_out(pairings.pairing_view(db, set_obj, updated))
 
 
 @router.delete("/sets/{set_id}/pairings/{pairing_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -7,7 +7,7 @@ missing-or-unowned sets return 404 to avoid leaking existence.
 
 from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_active_user, get_db
@@ -349,7 +349,7 @@ def list_set_slots(
 def list_set_pairings(
     set_id: int,
     request: Request,
-    query: str | None = None,
+    query: str | None = Query(default=None, max_length=200),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ) -> PairingsState:
@@ -362,6 +362,7 @@ def list_set_pairings(
     "/sets/{set_id}/pairings",
     response_model=PairingOut,
     status_code=status.HTTP_201_CREATED,
+    responses={status.HTTP_200_OK: {"model": PairingOut}},
 )
 @limiter.limit("30/minute")
 def create_set_pairing(

--- a/server/app/models/__init__.py
+++ b/server/app/models/__init__.py
@@ -16,6 +16,7 @@ from app.models.request import Request
 from app.models.request_vote import RequestVote
 from app.models.search_cache import SearchCache
 from app.models.set import Set, SetCollaborator, SetCurvePoint, SetSlot
+from app.models.set_pairing import SetPairing
 from app.models.set_pool import SetPoolSource, SetPoolTrack
 from app.models.system_settings import SystemSettings
 from app.models.track_vibe import TrackVibe, TrackVibeOverride
@@ -44,6 +45,7 @@ __all__ = [
     "SetCollaborator",
     "SetCurvePoint",
     "SetCurveTemplate",
+    "SetPairing",
     "SetPoolSource",
     "SetPoolTrack",
     "SetSlot",

--- a/server/app/models/set.py
+++ b/server/app/models/set.py
@@ -91,6 +91,11 @@ class Set(Base):
         back_populates="set",
         cascade="all, delete-orphan",
     )
+    pairings: Mapped[list["SetPairing"]] = relationship(
+        "SetPairing",
+        back_populates="set",
+        cascade="all, delete-orphan",
+    )
 
 
 class SetSlot(Base):

--- a/server/app/models/set_pairing.py
+++ b/server/app/models/set_pairing.py
@@ -1,0 +1,33 @@
+"""WrzDJSet DJ-curated transition pairings (issue #392)."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.time import utcnow
+from app.models.base import Base
+
+
+class SetPairing(Base):
+    """A set-scoped "from track -> into track" transition the DJ trusts."""
+
+    __tablename__ = "set_pairings"
+    __table_args__ = (
+        UniqueConstraint("set_id", "from_track_id", "into_track_id", name="uq_set_pairing_tracks"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    set_id: Mapped[int] = mapped_column(
+        ForeignKey("sets.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    from_track_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    into_track_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    cue_in_sec: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    tags_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]", server_default="[]")
+    use_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow, onupdate=utcnow)
+
+    set: Mapped["Set"] = relationship("Set", back_populates="pairings")

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -88,6 +88,70 @@ class PoolTrackOut(BaseModel):
     created_at: datetime
 
 
+def _validate_pairing_tags(tags: list[str]) -> list[str]:
+    """Shape-only tag guard; service handles normalization/de-dupe."""
+    if len(tags) > 12:
+        raise ValueError("too many tags")
+    for tag in tags:
+        if len(tag.strip()) > 32:
+            raise ValueError("tags must be 32 characters or fewer")
+    return tags
+
+
+class PairingCreate(BaseModel):
+    """Create/update a DJ-curated from->into pairing."""
+
+    from_track_id: str = Field(..., min_length=1, max_length=255)
+    into_track_id: str = Field(..., min_length=1, max_length=255)
+    cue_in_sec: int | None = Field(None, ge=0, le=36000)
+    note: str | None = Field(None, max_length=2000)
+    tags: list[str] = Field(default_factory=list)
+    increment_use_count: bool = False
+
+    _check_tags = field_validator("tags")(_validate_pairing_tags)
+
+
+class PairingUpdate(BaseModel):
+    """Editable pairing details."""
+
+    cue_in_sec: int | None = Field(None, ge=0, le=36000)
+    note: str | None = Field(None, max_length=2000)
+    tags: list[str] | None = None
+
+    @field_validator("tags")
+    @classmethod
+    def _check_tags_optional(cls, tags: list[str] | None) -> list[str] | None:
+        if tags is not None:
+            return _validate_pairing_tags(tags)
+        return tags
+
+
+class PairingOut(BaseModel):
+    """Pairing card/detail payload for the overlay."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    set_id: int
+    from_track_id: str
+    into_track_id: str
+    cue_in_sec: int | None
+    note: str | None
+    tags: list[str]
+    use_count: int
+    from_track: PoolTrackOut | None = None
+    into_track: PoolTrackOut | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class PairingsState(BaseModel):
+    """Pairings list response."""
+
+    count: int
+    pairings: list[PairingOut]
+
+
 class PoolState(BaseModel):
     """Full pool snapshot: sources + tracks."""
 
@@ -254,6 +318,8 @@ class SlotOut(BaseModel):
     camelot: str | None = None
     energy: int | None = None
     duration_sec: int | None = None
+    next_pairing_id: int | None = None
+    next_is_dj_pairing: bool = False
 
 
 class SlotTargetUpdate(BaseModel):

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -93,6 +93,10 @@ def _validate_pairing_tags(tags: list[str]) -> list[str]:
     if len(tags) > 12:
         raise ValueError("too many tags")
     for tag in tags:
+        if len(tag) > 50:
+            raise ValueError("tags must be 50 characters or fewer")
+        if not tag.strip():
+            raise ValueError("tags cannot be empty or whitespace-only")
         if len(tag.strip()) > 32:
             raise ValueError("tags must be 32 characters or fewer")
     return tags

--- a/server/app/services/setbuilder/pairing_scoring.py
+++ b/server/app/services/setbuilder/pairing_scoring.py
@@ -1,0 +1,48 @@
+"""Pass-1 scoring hook for DJ-curated pairings (#392).
+
+Auto-fill/recompute lives in adjacent setbuilder work. This module is the
+small contract that scorer can call when evaluating a transition candidate.
+"""
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from app.models.set_pairing import SetPairing
+
+PAIRING_SCORE_BOOST = 20.0
+MAX_TRANSITION_SCORE = 100.0
+
+
+@dataclass(frozen=True)
+class PairingScoreResult:
+    score: float
+    is_dj_pairing: bool
+    pairing_id: int | None
+    pairing_boost: float
+
+
+def load_pairing_index(db: Session, set_id: int) -> dict[tuple[str, str], SetPairing]:
+    """Load saved pairings into an O(1) lookup for pass-1 candidate scoring."""
+    rows = db.query(SetPairing).filter(SetPairing.set_id == set_id).all()
+    return {(p.from_track_id, p.into_track_id): p for p in rows}
+
+
+def apply_pairing_boost(
+    from_track_id: str | None,
+    into_track_id: str | None,
+    base_score: float,
+    pairings: dict[tuple[str, str], SetPairing],
+) -> PairingScoreResult:
+    """Boost a transition score by +20 when the exact saved pairing exists."""
+    if not from_track_id or not into_track_id:
+        return PairingScoreResult(base_score, False, None, 0.0)
+    pairing = pairings.get((from_track_id, into_track_id))
+    if pairing is None:
+        return PairingScoreResult(base_score, False, None, 0.0)
+    return PairingScoreResult(
+        score=min(MAX_TRANSITION_SCORE, base_score + PAIRING_SCORE_BOOST),
+        is_dj_pairing=True,
+        pairing_id=pairing.id,
+        pairing_boost=PAIRING_SCORE_BOOST,
+    )

--- a/server/app/services/setbuilder/pairings.py
+++ b/server/app/services/setbuilder/pairings.py
@@ -1,0 +1,186 @@
+"""Set-scoped DJ-curated pairings for WrzDJSet (#392)."""
+
+import json
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from app.models.set import Set
+from app.models.set_pairing import SetPairing
+from app.models.set_pool import SetPoolTrack
+
+MAX_TAGS = 12
+
+
+@dataclass(frozen=True)
+class PairingView:
+    pairing: SetPairing
+    from_track: SetPoolTrack | None
+    into_track: SetPoolTrack | None
+
+
+def normalize_tags(tags: list[str]) -> list[str]:
+    """Lowercase, trim, de-dupe, and cap DJ-entered tags."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in tags:
+        tag = raw.strip().lower()
+        if not tag or tag in seen:
+            continue
+        seen.add(tag)
+        out.append(tag[:32])
+        if len(out) >= MAX_TAGS:
+            break
+    return out
+
+
+def tags_for_pairing(pairing: SetPairing) -> list[str]:
+    """Parse the stored JSON tag list; bad historical data reads as empty."""
+    try:
+        value = json.loads(pairing.tags_json or "[]")
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(value, list):
+        return []
+    return normalize_tags([v for v in value if isinstance(v, str)])
+
+
+def _tags_json(tags: list[str]) -> str:
+    return json.dumps(normalize_tags(tags), separators=(",", ":"))
+
+
+def get_pairing(db: Session, set_obj: Set, pairing_id: int) -> SetPairing | None:
+    """Fetch a pairing scoped to the set."""
+    return (
+        db.query(SetPairing)
+        .filter(SetPairing.id == pairing_id, SetPairing.set_id == set_obj.id)
+        .one_or_none()
+    )
+
+
+def find_pairing(
+    db: Session, set_id: int, from_track_id: str, into_track_id: str
+) -> SetPairing | None:
+    """Find a pairing by its transition identity."""
+    return (
+        db.query(SetPairing)
+        .filter(
+            SetPairing.set_id == set_id,
+            SetPairing.from_track_id == from_track_id,
+            SetPairing.into_track_id == into_track_id,
+        )
+        .one_or_none()
+    )
+
+
+def upsert_pairing(
+    db: Session,
+    set_obj: Set,
+    *,
+    from_track_id: str,
+    into_track_id: str,
+    cue_in_sec: int | None,
+    note: str | None,
+    tags: list[str],
+    increment_use_count: bool = False,
+) -> tuple[SetPairing, bool]:
+    """Create or update a transition pairing. Returns (row, created)."""
+    if from_track_id == into_track_id:
+        raise ValueError("from_track_id and into_track_id must be different")
+    existing = find_pairing(db, set_obj.id, from_track_id, into_track_id)
+    if existing is not None:
+        existing.cue_in_sec = cue_in_sec
+        existing.note = note
+        existing.tags_json = _tags_json(tags)
+        if increment_use_count:
+            existing.use_count += 1
+        db.commit()
+        db.refresh(existing)
+        return existing, False
+
+    pairing = SetPairing(
+        set_id=set_obj.id,
+        from_track_id=from_track_id,
+        into_track_id=into_track_id,
+        cue_in_sec=cue_in_sec,
+        note=note,
+        tags_json=_tags_json(tags),
+        use_count=1 if increment_use_count else 0,
+    )
+    db.add(pairing)
+    db.commit()
+    db.refresh(pairing)
+    return pairing, True
+
+
+def update_pairing(
+    db: Session,
+    pairing: SetPairing,
+    *,
+    cue_in_sec: int | None,
+    note: str | None,
+    tags: list[str],
+) -> SetPairing:
+    """Update editable pairing details."""
+    pairing.cue_in_sec = cue_in_sec
+    pairing.note = note
+    pairing.tags_json = _tags_json(tags)
+    db.commit()
+    db.refresh(pairing)
+    return pairing
+
+
+def delete_pairing(db: Session, pairing: SetPairing) -> None:
+    db.delete(pairing)
+    db.commit()
+
+
+def list_pairings(db: Session, set_obj: Set, query: str | None = None) -> list[PairingView]:
+    """List pairings with optional pool-track display data."""
+    term = (query or "").strip()
+    rows = (
+        db.query(SetPairing)
+        .filter(SetPairing.set_id == set_obj.id)
+        .order_by(SetPairing.updated_at.desc(), SetPairing.id.desc())
+        .all()
+    )
+    return _attach_pool_tracks(db, set_obj.id, rows, term)
+
+
+def _attach_pool_tracks(
+    db: Session, set_id: int, rows: list[SetPairing], term: str
+) -> list[PairingView]:
+    track_ids = {p.from_track_id for p in rows} | {p.into_track_id for p in rows}
+    pool_rows = (
+        db.query(SetPoolTrack)
+        .filter(SetPoolTrack.set_id == set_id, SetPoolTrack.track_id.in_(track_ids))
+        .all()
+        if track_ids
+        else []
+    )
+    by_track_id = {t.track_id: t for t in pool_rows if t.track_id}
+    views = [
+        PairingView(
+            pairing=p,
+            from_track=by_track_id.get(p.from_track_id),
+            into_track=by_track_id.get(p.into_track_id),
+        )
+        for p in rows
+    ]
+    if not term:
+        return views
+    needle = term.lower()
+    return [v for v in views if _view_matches(v, needle)]
+
+
+def _view_matches(view: PairingView, needle: str) -> bool:
+    haystacks = [
+        view.pairing.from_track_id,
+        view.pairing.into_track_id,
+        view.pairing.note or "",
+        " ".join(tags_for_pairing(view.pairing)),
+    ]
+    for track in [view.from_track, view.into_track]:
+        if track is not None:
+            haystacks.extend([track.title, track.artist, track.camelot or "", str(track.bpm or "")])
+    return any(needle in h.lower() for h in haystacks)

--- a/server/app/services/setbuilder/pairings.py
+++ b/server/app/services/setbuilder/pairings.py
@@ -150,6 +150,11 @@ def delete_pairing(db: Session, pairing: SetPairing) -> None:
     db.commit()
 
 
+def pairing_view(db: Session, set_obj: Set, pairing: SetPairing) -> PairingView:
+    """Build display data for one pairing without loading every set pairing."""
+    return _attach_pool_tracks(db, set_obj.id, [pairing], "")[0]
+
+
 def list_pairings(db: Session, set_obj: Set, query: str | None = None) -> list[PairingView]:
     """List pairings with optional pool-track display data."""
     term = (query or "").strip()

--- a/server/app/services/setbuilder/pairings.py
+++ b/server/app/services/setbuilder/pairings.py
@@ -3,6 +3,7 @@
 import json
 from dataclasses import dataclass
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models.set import Set
@@ -108,7 +109,21 @@ def upsert_pairing(
         use_count=1 if increment_use_count else 0,
     )
     db.add(pairing)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        existing = find_pairing(db, set_obj.id, from_track_id, into_track_id)
+        if existing is None:
+            raise
+        existing.cue_in_sec = cue_in_sec
+        existing.note = note
+        existing.tags_json = _tags_json(tags)
+        if increment_use_count:
+            existing.use_count += 1
+        db.commit()
+        db.refresh(existing)
+        return existing, False
     db.refresh(pairing)
     return pairing, True
 

--- a/server/app/services/setbuilder/share_service.py
+++ b/server/app/services/setbuilder/share_service.py
@@ -12,6 +12,7 @@ import secrets
 from sqlalchemy.orm import Session
 
 from app.models.set import Set, SetCurvePoint, SetSlot
+from app.models.set_pairing import SetPairing
 
 _MAX_NAME = 120
 _COPY_SUFFIX = " (copy)"
@@ -44,10 +45,13 @@ def get_set_by_share_token(db: Session, token: str) -> Set | None:
 
 
 def duplicate_set(db: Session, src: Set) -> Set:
-    """Copy a set (slots, curve, targets, vibe windows); reset lifecycle state.
+    """Copy a set (slots, curve, targets, vibe windows, pairings); reset lifecycle state.
 
     The copy is always private ("draft", no share token, no export state)
     regardless of the source's status, per issue #398.
+
+    Pairings are copied because they are set-scoped DJ curation over the
+    copied timeline, not global learned recommendations.
     """
     name = src.name + _COPY_SUFFIX
     if len(name) > _MAX_NAME:
@@ -87,6 +91,18 @@ def duplicate_set(db: Session, src: Set) -> Set:
                 label=point.label,
                 is_slow_window_start=point.is_slow_window_start,
                 is_slow_window_end=point.is_slow_window_end,
+            )
+        )
+    for pairing in src.pairings:
+        db.add(
+            SetPairing(
+                set_id=dup.id,
+                from_track_id=pairing.from_track_id,
+                into_track_id=pairing.into_track_id,
+                cue_in_sec=pairing.cue_in_sec,
+                note=pairing.note,
+                tags_json=pairing.tags_json,
+                use_count=pairing.use_count,
             )
         )
     db.commit()

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -5350,6 +5350,234 @@
         "title": "PaginatedResponse",
         "type": "object"
       },
+      "PairingCreate": {
+        "description": "Create/update a DJ-curated from->into pairing.",
+        "properties": {
+          "cue_in_sec": {
+            "anyOf": [
+              {
+                "maximum": 36000.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cue In Sec"
+          },
+          "from_track_id": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "From Track Id",
+            "type": "string"
+          },
+          "increment_use_count": {
+            "default": false,
+            "title": "Increment Use Count",
+            "type": "boolean"
+          },
+          "into_track_id": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Into Track Id",
+            "type": "string"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
+          }
+        },
+        "required": [
+          "from_track_id",
+          "into_track_id"
+        ],
+        "title": "PairingCreate",
+        "type": "object"
+      },
+      "PairingOut": {
+        "description": "Pairing card/detail payload for the overlay.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "cue_in_sec": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cue In Sec"
+          },
+          "from_track": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PoolTrackOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "from_track_id": {
+            "title": "From Track Id",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "into_track": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PoolTrackOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "into_track_id": {
+            "title": "Into Track Id",
+            "type": "string"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "set_id": {
+            "title": "Set Id",
+            "type": "integer"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "use_count": {
+            "title": "Use Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "created_at",
+          "cue_in_sec",
+          "from_track",
+          "from_track_id",
+          "id",
+          "into_track",
+          "into_track_id",
+          "note",
+          "set_id",
+          "tags",
+          "updated_at",
+          "use_count"
+        ],
+        "title": "PairingOut",
+        "type": "object"
+      },
+      "PairingUpdate": {
+        "description": "Editable pairing details.",
+        "properties": {
+          "cue_in_sec": {
+            "anyOf": [
+              {
+                "maximum": 36000.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cue In Sec"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          }
+        },
+        "title": "PairingUpdate",
+        "type": "object"
+      },
+      "PairingsState": {
+        "description": "Pairings list response.",
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "pairings": {
+            "items": {
+              "$ref": "#/components/schemas/PairingOut"
+            },
+            "title": "Pairings",
+            "type": "array"
+          }
+        },
+        "required": [
+          "count",
+          "pairings"
+        ],
+        "title": "PairingsState",
+        "type": "object"
+      },
       "PendingReviewResponse": {
         "properties": {
           "requests": {
@@ -7786,6 +8014,22 @@
             "title": "Locked",
             "type": "boolean"
           },
+          "next_is_dj_pairing": {
+            "default": false,
+            "title": "Next Is Dj Pairing",
+            "type": "boolean"
+          },
+          "next_pairing_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Pairing Id"
+          },
           "notes": {
             "anyOf": [
               {
@@ -7877,6 +8121,8 @@
           "id",
           "key",
           "locked",
+          "next_is_dj_pairing",
+          "next_pairing_id",
           "notes",
           "pool_track_id",
           "position",
@@ -16951,6 +17197,241 @@
           }
         ],
         "summary": "Export Set Tidal",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/pairings": {
+      "get": {
+        "description": "Searchable pairings overlay state for one of the current DJ's sets.",
+        "operationId": "list_set_pairings_api_setbuilder_sets__set_id__pairings_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairingsState"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Set Pairings",
+        "tags": [
+          "setbuilder"
+        ]
+      },
+      "post": {
+        "description": "Create or update a DJ-curated transition pairing.",
+        "operationId": "create_set_pairing_api_setbuilder_sets__set_id__pairings_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PairingCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairingOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Create Set Pairing",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/pairings/{pairing_id}": {
+      "delete": {
+        "description": "Delete a pairing from one of the current DJ's sets.",
+        "operationId": "delete_set_pairing_api_setbuilder_sets__set_id__pairings__pairing_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pairing_id",
+            "required": true,
+            "schema": {
+              "title": "Pairing Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Set Pairing",
+        "tags": [
+          "setbuilder"
+        ]
+      },
+      "patch": {
+        "description": "Inline-edit note, tags, and cue-in for a pairing.",
+        "operationId": "update_set_pairing_api_setbuilder_sets__set_id__pairings__pairing_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pairing_id",
+            "required": true,
+            "schema": {
+              "title": "Pairing Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PairingUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairingOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Set Pairing",
         "tags": [
           "setbuilder"
         ]

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -17223,6 +17223,7 @@
             "schema": {
               "anyOf": [
                 {
+                  "maxLength": 200,
                   "type": "string"
                 },
                 {
@@ -17290,6 +17291,16 @@
           "required": true
         },
         "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairingOut"
+                }
+              }
+            },
+            "description": "OK"
+          },
           "201": {
             "content": {
               "application/json": {

--- a/server/tests/test_event_bus.py
+++ b/server/tests/test_event_bus.py
@@ -123,8 +123,8 @@ class TestSSEEndpoint:
     """Tests for the SSE endpoint route registration."""
 
     def test_sse_route_is_registered(self):
-        """Verify the SSE endpoint route exists in the app."""
-        from app.api import api_router
+        """Verify the SSE endpoint route exists on the SSE router."""
+        from app.api.sse import router
 
-        routes = [r.path for r in api_router.routes if hasattr(r, "path")]
-        assert "/public/events/{code}/stream" in routes
+        routes = [r.path for r in router.routes if hasattr(r, "path")]
+        assert "/events/{code}/stream" in routes

--- a/server/tests/test_event_bus.py
+++ b/server/tests/test_event_bus.py
@@ -124,7 +124,7 @@ class TestSSEEndpoint:
 
     def test_sse_route_is_registered(self):
         """Verify the SSE endpoint route exists in the app."""
-        from app.main import app
+        from app.api import api_router
 
-        routes = [r.path for r in app.routes if hasattr(r, "path")]
-        assert "/api/public/events/{code}/stream" in routes
+        routes = [r.path for r in api_router.routes if hasattr(r, "path")]
+        assert "/public/events/{code}/stream" in routes

--- a/server/tests/test_setbuilder_pairings.py
+++ b/server/tests/test_setbuilder_pairings.py
@@ -82,7 +82,9 @@ def test_create_list_update_pairing_owner_scoped(client, auth_headers, db):
 def test_pairings_join_pool_track_display_and_search(client, auth_headers, db):
     set_obj = _mk_set(client, auth_headers)
     from_track = _mk_pool_track(db, set_obj["id"], "tidal:1", "Strobe", "deadmau5")
-    _mk_pool_track(db, set_obj["id"], "tidal:2", "Ghosts", "Deadmau5", bpm=124, camelot="9A")
+    into_track = _mk_pool_track(
+        db, set_obj["id"], "tidal:2", "Ghosts", "Deadmau5", bpm=124, camelot="9A"
+    )
 
     resp = client.post(
         f"/api/setbuilder/sets/{set_obj['id']}/pairings",
@@ -90,6 +92,21 @@ def test_pairings_join_pool_track_display_and_search(client, auth_headers, db):
         headers=auth_headers,
     )
     assert resp.status_code == 201, resp.json()
+    created = resp.json()
+    assert created["from_track"]["id"] == from_track.id
+    assert created["from_track"]["title"] == "Strobe"
+    assert created["into_track"]["id"] == into_track.id
+    assert created["into_track"]["camelot"] == "9A"
+
+    resp = client.patch(
+        f"/api/setbuilder/sets/{set_obj['id']}/pairings/{created['id']}",
+        json={"note": "Updated with metadata"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.json()
+    updated = resp.json()
+    assert updated["from_track"]["title"] == "Strobe"
+    assert updated["into_track"]["camelot"] == "9A"
 
     resp = client.get(
         f"/api/setbuilder/sets/{set_obj['id']}/pairings?query=strobe",

--- a/server/tests/test_setbuilder_pairings.py
+++ b/server/tests/test_setbuilder_pairings.py
@@ -1,8 +1,11 @@
 """API + service tests for WrzDJSet DJ-curated pairings (#392)."""
 
-from app.models.set import SetSlot
+from sqlalchemy.exc import IntegrityError
+
+from app.models.set import Set, SetSlot
+from app.models.set_pairing import SetPairing
 from app.models.set_pool import SetPoolSource, SetPoolTrack
-from app.services.setbuilder import pairing_scoring
+from app.services.setbuilder import pairing_scoring, pairings
 
 
 def _mk_set(client, auth_headers, name="Pair Set"):
@@ -119,6 +122,57 @@ def test_pairing_create_is_idempotent_and_can_increment_uses(client, auth_header
     assert second.json()["use_count"] == 2
 
 
+def test_pairing_insert_race_returns_existing_pairing(client, auth_headers, db, monkeypatch):
+    """Regression for 9e57f7e: concurrent upsert unique races stay idempotent."""
+    set_obj = _mk_set(client, auth_headers)
+    set_model = db.get(Set, set_obj["id"])
+    assert set_model is not None
+
+    real_commit = db.commit
+    real_rollback = db.rollback
+    raised = False
+
+    def flaky_commit():
+        nonlocal raised
+        if not raised:
+            raised = True
+            raise IntegrityError("insert set_pairings", {}, Exception("duplicate"))
+        real_commit()
+
+    def seed_concurrent_row():
+        real_rollback()
+        db.add(
+            SetPairing(
+                set_id=set_obj["id"],
+                from_track_id="tidal:race-a",
+                into_track_id="tidal:race-b",
+                note="other writer",
+                tags_json="[]",
+            )
+        )
+        real_commit()
+
+    monkeypatch.setattr(db, "commit", flaky_commit)
+    monkeypatch.setattr(db, "rollback", seed_concurrent_row)
+
+    pairing, created = pairings.upsert_pairing(
+        db,
+        set_model,
+        from_track_id="tidal:race-a",
+        into_track_id="tidal:race-b",
+        cue_in_sec=16,
+        note="winner",
+        tags=["Peak"],
+        increment_use_count=True,
+    )
+
+    assert created is False
+    assert pairing.note == "winner"
+    assert pairing.cue_in_sec == 16
+    assert pairing.use_count == 1
+    assert pairings.tags_for_pairing(pairing) == ["peak"]
+
+
 def test_pairing_validation_and_owner_isolation(client, auth_headers, db):
     set_obj = _mk_set(client, auth_headers)
     resp = client.post(
@@ -127,6 +181,19 @@ def test_pairing_validation_and_owner_isolation(client, auth_headers, db):
         headers=auth_headers,
     )
     assert resp.status_code == 400
+
+    resp = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/pairings",
+        json={"from_track_id": "tidal:a", "into_track_id": "tidal:b", "tags": [" x" * 30]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+    resp = client.get(
+        f"/api/setbuilder/sets/{set_obj['id']}/pairings?query={'x' * 201}",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
 
     from app.models.user import User
     from app.services.auth import get_password_hash
@@ -164,6 +231,29 @@ def test_pairing_routes_require_active_dj(client, auth_headers, pending_headers)
         client.post(
             f"/api/setbuilder/sets/{set_obj['id']}/pairings",
             json=payload,
+            headers=pending_headers,
+        ).status_code
+        == 403
+    )
+    assert (
+        client.patch(
+            f"/api/setbuilder/sets/{set_obj['id']}/pairings/1",
+            json={"note": "x"},
+        ).status_code
+        == 401
+    )
+    assert client.delete(f"/api/setbuilder/sets/{set_obj['id']}/pairings/1").status_code == 401
+    assert (
+        client.patch(
+            f"/api/setbuilder/sets/{set_obj['id']}/pairings/1",
+            json={"note": "x"},
+            headers=pending_headers,
+        ).status_code
+        == 403
+    )
+    assert (
+        client.delete(
+            f"/api/setbuilder/sets/{set_obj['id']}/pairings/1",
             headers=pending_headers,
         ).status_code
         == 403

--- a/server/tests/test_setbuilder_pairings.py
+++ b/server/tests/test_setbuilder_pairings.py
@@ -1,0 +1,222 @@
+"""API + service tests for WrzDJSet DJ-curated pairings (#392)."""
+
+from app.models.set import SetSlot
+from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.services.setbuilder import pairing_scoring
+
+
+def _mk_set(client, auth_headers, name="Pair Set"):
+    resp = client.post("/api/setbuilder/sets", json={"name": name}, headers=auth_headers)
+    assert resp.status_code == 201, resp.json()
+    return resp.json()
+
+
+def _mk_pool_track(db, set_id, track_id, title, artist, *, bpm=120.0, camelot="8A"):
+    source = (
+        db.query(SetPoolSource)
+        .filter(SetPoolSource.set_id == set_id, SetPoolSource.kind == "manual")
+        .one_or_none()
+    )
+    if source is None:
+        source = SetPoolSource(set_id=set_id, kind="manual", label="Manual")
+        db.add(source)
+        db.flush()
+    track = SetPoolTrack(
+        set_id=set_id,
+        source_id=source.id,
+        track_id=track_id,
+        title=title,
+        artist=artist,
+        bpm=bpm,
+        key=camelot,
+        camelot=camelot,
+        dedupe_sig=f"sig-{track_id}",
+    )
+    db.add(track)
+    db.commit()
+    db.refresh(track)
+    return track
+
+
+def test_create_list_update_pairing_owner_scoped(client, auth_headers, db):
+    set_obj = _mk_set(client, auth_headers)
+
+    resp = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/pairings",
+        json={
+            "from_track_id": "tidal:from",
+            "into_track_id": "tidal:into",
+            "cue_in_sec": 48,
+            "note": "Loop the outro before the vocal.",
+            "tags": ["vocal", "safe"],
+            "increment_use_count": True,
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.json()
+    created = resp.json()
+    assert created["from_track_id"] == "tidal:from"
+    assert created["into_track_id"] == "tidal:into"
+    assert created["use_count"] == 1
+    assert created["tags"] == ["vocal", "safe"]
+
+    resp = client.get(f"/api/setbuilder/sets/{set_obj['id']}/pairings", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+    assert resp.json()["pairings"][0]["note"] == "Loop the outro before the vocal."
+
+    resp = client.patch(
+        f"/api/setbuilder/sets/{set_obj['id']}/pairings/{created['id']}",
+        json={"note": "Updated", "tags": ["Peak"], "cue_in_sec": None},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.json()
+    assert resp.json()["note"] == "Updated"
+    assert resp.json()["cue_in_sec"] is None
+    assert resp.json()["tags"] == ["peak"]
+
+
+def test_pairings_join_pool_track_display_and_search(client, auth_headers, db):
+    set_obj = _mk_set(client, auth_headers)
+    from_track = _mk_pool_track(db, set_obj["id"], "tidal:1", "Strobe", "deadmau5")
+    _mk_pool_track(db, set_obj["id"], "tidal:2", "Ghosts", "Deadmau5", bpm=124, camelot="9A")
+
+    resp = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/pairings",
+        json={"from_track_id": "tidal:1", "into_track_id": "tidal:2", "tags": ["progressive"]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.json()
+
+    resp = client.get(
+        f"/api/setbuilder/sets/{set_obj['id']}/pairings?query=strobe",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["count"] == 1
+    assert body["pairings"][0]["from_track"]["id"] == from_track.id
+    assert body["pairings"][0]["from_track"]["title"] == "Strobe"
+    assert body["pairings"][0]["into_track"]["camelot"] == "9A"
+
+
+def test_pairing_create_is_idempotent_and_can_increment_uses(client, auth_headers):
+    set_obj = _mk_set(client, auth_headers)
+    payload = {
+        "from_track_id": "tidal:a",
+        "into_track_id": "tidal:b",
+        "increment_use_count": True,
+    }
+    first = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/pairings", json=payload, headers=auth_headers
+    )
+    assert first.status_code == 201, first.json()
+    second = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/pairings", json=payload, headers=auth_headers
+    )
+    assert second.status_code == 200, second.json()
+    assert second.json()["id"] == first.json()["id"]
+    assert second.json()["use_count"] == 2
+
+
+def test_pairing_validation_and_owner_isolation(client, auth_headers, db):
+    set_obj = _mk_set(client, auth_headers)
+    resp = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/pairings",
+        json={"from_track_id": "tidal:a", "into_track_id": "tidal:a"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+
+    from app.models.user import User
+    from app.services.auth import get_password_hash
+
+    other = User(username="otherpair", password_hash=get_password_hash("x" * 12), role="dj")
+    db.add(other)
+    db.commit()
+    login = client.post(
+        "/api/auth/login",
+        data={"username": "otherpair", "password": "xxxxxxxxxxxx"},
+    )
+    other_headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    their_set = _mk_set(client, other_headers, "Theirs")
+
+    resp = client.get(f"/api/setbuilder/sets/{their_set['id']}/pairings", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_pairing_routes_require_active_dj(client, auth_headers, pending_headers):
+    set_obj = _mk_set(client, auth_headers)
+    payload = {"from_track_id": "tidal:a", "into_track_id": "tidal:b"}
+
+    assert client.get(f"/api/setbuilder/sets/{set_obj['id']}/pairings").status_code == 401
+    assert (
+        client.post(f"/api/setbuilder/sets/{set_obj['id']}/pairings", json=payload).status_code
+        == 401
+    )
+    assert (
+        client.get(
+            f"/api/setbuilder/sets/{set_obj['id']}/pairings", headers=pending_headers
+        ).status_code
+        == 403
+    )
+    assert (
+        client.post(
+            f"/api/setbuilder/sets/{set_obj['id']}/pairings",
+            json=payload,
+            headers=pending_headers,
+        ).status_code
+        == 403
+    )
+
+
+def test_delete_pairing_removes_timeline_marker(client, auth_headers, db):
+    set_obj = _mk_set(client, auth_headers)
+    db.add(SetSlot(set_id=set_obj["id"], position=0, track_id="tidal:a"))
+    db.add(SetSlot(set_id=set_obj["id"], position=1, track_id="tidal:b"))
+    db.commit()
+    created = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/pairings",
+        json={"from_track_id": "tidal:a", "into_track_id": "tidal:b"},
+        headers=auth_headers,
+    ).json()
+
+    resp = client.delete(
+        f"/api/setbuilder/sets/{set_obj['id']}/pairings/{created['id']}",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 204
+    slots = client.get(f"/api/setbuilder/sets/{set_obj['id']}/slots", headers=auth_headers).json()
+    assert slots[0]["next_pairing_id"] is None
+    assert slots[0]["next_is_dj_pairing"] is False
+
+
+def test_timeline_capture_pairing_marks_slots_and_score_hook(client, auth_headers, db):
+    set_obj = _mk_set(client, auth_headers)
+    db.add(SetSlot(set_id=set_obj["id"], position=0, track_id="tidal:a"))
+    db.add(SetSlot(set_id=set_obj["id"], position=1, track_id="tidal:b"))
+    db.commit()
+
+    resp = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/pairings",
+        json={
+            "from_track_id": "tidal:a",
+            "into_track_id": "tidal:b",
+            "increment_use_count": True,
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.json()
+
+    slots = client.get(f"/api/setbuilder/sets/{set_obj['id']}/slots", headers=auth_headers).json()
+    assert slots[0]["next_pairing_id"] == resp.json()["id"]
+    assert slots[0]["next_is_dj_pairing"] is True
+    assert slots[1]["next_is_dj_pairing"] is False
+
+    pairings = pairing_scoring.load_pairing_index(db, set_obj["id"])
+    paired = pairing_scoring.apply_pairing_boost("tidal:a", "tidal:b", 82.0, pairings)
+    unpaired = pairing_scoring.apply_pairing_boost("tidal:a", "tidal:c", 95.0, pairings)
+    assert paired.score == 100.0
+    assert paired.is_dj_pairing is True
+    assert paired.pairing_boost == 20.0
+    assert paired.score > unpaired.score

--- a/server/tests/test_setbuilder_share.py
+++ b/server/tests/test_setbuilder_share.py
@@ -7,6 +7,7 @@ projection (no ids / owner identity leakage), auth gating.
 """
 
 from app.models.set import Set, SetCurvePoint, SetSlot
+from app.models.set_pairing import SetPairing
 from app.services.auth import get_password_hash
 from app.services.setbuilder import share_service
 
@@ -39,6 +40,17 @@ def _seed_set(db, owner_id, **overrides) -> Set:
         )
     )
     db.add(SetSlot(set_id=set_obj.id, position=2, track_id="tidal:222"))
+    db.add(
+        SetPairing(
+            set_id=set_obj.id,
+            from_track_id="tidal:111",
+            into_track_id="tidal:222",
+            cue_in_sec=32,
+            note="Tested mix",
+            tags_json='["safe"]',
+            use_count=3,
+        )
+    )
     db.add(
         SetCurvePoint(
             set_id=set_obj.id,
@@ -120,6 +132,14 @@ def test_duplicate_copies_children_and_resets_state(db, test_user):
     ]
     assert points[0].is_slow_window_start is True
     assert points[1].is_slow_window_end is True
+    assert len(dup.pairings) == 1
+    pairing = dup.pairings[0]
+    assert pairing.from_track_id == "tidal:111"
+    assert pairing.into_track_id == "tidal:222"
+    assert pairing.cue_in_sec == 32
+    assert pairing.note == "Tested mix"
+    assert pairing.tags_json == '["safe"]'
+    assert pairing.use_count == 3
     # source untouched
     db.refresh(src)
     assert src.status == "locked"


### PR DESCRIPTION
## Why

DJ-curated directional transitions need to be first-class WrzDJSet data so trusted “these two work together” decisions can influence pass-1 scoring and be visible as trust markers in the builder.

Closes #392

## What

- Added set-scoped pairings with migration `058_add_set_pairings.py`, model, schemas, owner-private active-DJ API endpoints, and generated API types.
- Added pairings service behavior for idempotent saves, search, tags, cue-in/note editing, use counts, pool-track display metadata, and slot seam metadata.
- Added a pass-1 scoring hook contract that applies a directional saved-pairing boost of `+20`, capped at 100, with tests showing a paired transition wins over a marginally better unpaired candidate.
- Added the Pairings overlay, topbar count badge, timeline context capture/open action, purple timeline `DJ pairing` chips, and purple curve seam pins from the synced WrzDJSet prototype guidance.
- Updated set duplication to copy set-scoped pairings along with the copied timeline/curve context.

## Testing

- `cd server && /home/adam/github/WrzDJ/server/.venv/bin/ruff check .`
- `cd server && /home/adam/github/WrzDJ/server/.venv/bin/ruff format --check .`
- `cd server && /home/adam/github/WrzDJ/server/.venv/bin/bandit -r app -c pyproject.toml -q`
- `cd server && /home/adam/github/WrzDJ/server/.venv/bin/pytest --tb=short -q` — 2806 passed, coverage 88.70% / required 85%
- `cd server && /home/adam/github/WrzDJ/server/.venv/bin/alembic heads` — single head `058`
- `cd dashboard && npx tsc --noEmit`
- `cd dashboard && npm run lint`
- `cd dashboard && npm test -- --run` — 82 files, 1142 tests passed

`alembic upgrade head && alembic check` could not complete locally because the configured local PostgreSQL instance rejects the `wrzdj` user password on `localhost:5432`; this is an environment credential issue. Single-head validation passed.

## Design decisions

- Pairings are set-scoped child rows, not global track data, because track IDs remain namespaced free-form strings and MVP pairings are DJ-curated for a set context.
- Pairings are directional (`from_track_id` -> `into_track_id`) so scoring and UI markers only apply to the saved transition order.
- Duplicate copies pairings because duplicate already copies the set timeline/curve targets, and pairings represent owner-curated transitions over that copied set context.
- Share/public read paths are left unchanged; pairings remain owner-private builder data in this issue.
- The pass-1 hook is a small service-level contract (`+20`, cap 100) so the concurrent #390 algorithm branch can call it without inheriting UI/API coupling.
- Timeline and curve visuals consume backend seam metadata (`next_pairing_id`, `next_is_dj_pairing`) so recompute/slot refresh remains the source of truth.

## AI credit

Co-authored with Claude.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* **DJ Pairings Overlay**: Added a “Pairings” overlay to create, edit, search, and delete transition pairings (DJ notes, cue-in seconds, tags), with a pairing detail panel and jump-to-seam action.
* **Timeline + Curve Visuals**: Timeline rows and curve seams now show DJ pairing indicators; right-click/row actions let you open saved pairings or save the next transition as a pairing.
* **Live Pairings Count**: The “Pairings” button displays a badge that updates when pairings change.

## Enhancements
* **Pairings Duplication**: Set duplication now preserves saved pairings in the duplicated draft.

## Tests
* Expanded API and UI tests for pairing CRUD, search, and timeline/curve marker behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->