### PR TITLE
feat(setbuilder): add Bridge-backed transport playback

### DIFF
--- a/bridge-app/src/main/__tests__/bridge-runner.test.ts
+++ b/bridge-app/src/main/__tests__/bridge-runner.test.ts
@@ -538,4 +538,32 @@ describe('BridgeRunner', () => {
     expect(logs.some((l) => l.message.includes('Starting bridge') && l.level === 'info')).toBe(true);
     expect(logs.some((l) => l.message.includes('ABC123'))).toBe(true);
   });
+
+  it('logs setbuilder transport command payloads from the command poller', () => {
+    const logs: Array<{ message: string; level: string }> = [];
+    runner.on('log', (msg: { message: string; level: string }) => logs.push(msg));
+    const handleCommand = (
+      runner as unknown as {
+        handleCommand: (type: string, command?: { payload?: Record<string, unknown> }) => void;
+      }
+    ).handleCommand.bind(runner);
+
+    handleCommand('setbuilder_transport', {
+      payload: { action: 'play', title: 'Track A', position_sec: 12.25 },
+    });
+    handleCommand('setbuilder_transport');
+
+    expect(
+      logs.some(
+        (l) =>
+          l.level === 'info' &&
+          l.message === 'Setbuilder transport command received: play "Track A" @ 12.3s',
+      ),
+    ).toBe(true);
+    expect(
+      logs.some(
+        (l) => l.level === 'info' && l.message === 'Setbuilder transport command received: unknown @ 0.0s',
+      ),
+    ).toBe(true);
+  });
 });

--- a/bridge-app/src/main/bridge-runner.ts
+++ b/bridge-app/src/main/bridge-runner.ts
@@ -13,6 +13,7 @@ import { PluginBridge } from '@bridge/plugin-bridge.js';
 import { getPlugin } from '@bridge/plugin-registry.js';
 import { CircuitBreaker } from '@bridge/circuit-breaker.js';
 import { CommandPoller } from '@bridge/command-poller.js';
+import type { BridgeCommand } from '@bridge/command-poller.js';
 import { Logger, type LogLevel } from '@bridge/logger.js';
 import { TrackHistoryBuffer } from '@bridge/track-history-buffer.js';
 import type { DeckLiveEvent, DeckState } from '@bridge/deck-state.js';
@@ -593,8 +594,8 @@ export class BridgeRunner extends EventEmitter {
   private startCommandPoller(): void {
     if (!this.config) return;
     this.commandPoller = new CommandPoller(this.circuitBreaker, this.logger);
-    this.commandPoller.on('command', (type: string) => {
-      this.handleCommand(type);
+    this.commandPoller.on('command', (type: string, command?: BridgeCommand) => {
+      this.handleCommand(type, command);
     });
     this.commandPoller.start(this.config.apiUrl, this.config.apiKey, this.config.eventCode);
   }
@@ -606,7 +607,7 @@ export class BridgeRunner extends EventEmitter {
     }
   }
 
-  private handleCommand(type: string): void {
+  private handleCommand(type: string, command?: BridgeCommand): void {
     switch (type) {
       case 'ping':
         this.log('Ping received from dashboard');
@@ -621,9 +622,22 @@ export class BridgeRunner extends EventEmitter {
       case 'restart':
         this.restartBridge();
         break;
+      case 'setbuilder_transport':
+        this.handleSetbuilderTransport(command?.payload ?? {});
+        break;
       default:
         this.log(`Unknown command: ${type}`, 'warn');
     }
+  }
+
+  private handleSetbuilderTransport(payload: Record<string, unknown>): void {
+    const action = typeof payload.action === 'string' ? payload.action : 'unknown';
+    const title = typeof payload.title === 'string' ? payload.title : '';
+    const position = typeof payload.position_sec === 'number' ? payload.position_sec : 0;
+
+    this.log(
+      `Setbuilder transport command received: ${action}${title ? ` "${title}"` : ''} @ ${position.toFixed(1)}s`
+    );
   }
 
   // --- Status emission ---

--- a/bridge/src/__tests__/command-poller.test.ts
+++ b/bridge/src/__tests__/command-poller.test.ts
@@ -120,6 +120,23 @@ describe("CommandPoller", () => {
       expect(received).toEqual(["reset_decks", "reconnect"]);
     });
 
+    it("emits the full command as the second argument", async () => {
+      const command = {
+        command_id: "1",
+        command_type: "setbuilder_transport",
+        payload: { action: "play", track_id: "tidal:1" },
+      };
+      mockFetch.mockResolvedValue(createMockResponse(200, { commands: [command] }));
+
+      const received: unknown[] = [];
+      poller.on("command", (_type: string, cmd: unknown) => received.push(cmd));
+
+      poller.start("http://localhost:8000", "key", "EVT1");
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(received).toEqual([command]);
+    });
+
     it("sends correct URL and headers", async () => {
       mockFetch.mockResolvedValue(createMockResponse(200, { commands: [] }));
 

--- a/bridge/src/command-poller.ts
+++ b/bridge/src/command-poller.ts
@@ -18,6 +18,7 @@ const FETCH_TIMEOUT_MS = 10_000;
 export interface BridgeCommand {
   readonly command_id: string;
   readonly command_type: string;
+  readonly payload?: Record<string, unknown>;
 }
 
 /**
@@ -25,6 +26,7 @@ export interface BridgeCommand {
  *
  * Events emitted:
  *   'command' — fired for each command received, with the command type string
+ *               and the full command payload as the second argument
  */
 export class CommandPoller extends EventEmitter {
   private pollTimer: ReturnType<typeof setInterval> | null = null;
@@ -99,7 +101,7 @@ export class CommandPoller extends EventEmitter {
         const body = (await response.json()) as { commands: BridgeCommand[] };
         for (const cmd of body.commands) {
           this.log.info(`Received command: ${cmd.command_type}`);
-          this.emit("command", cmd.command_type);
+          this.emit("command", cmd.command_type, cmd);
         }
       } finally {
         clearTimeout(timeoutId);

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -26,6 +26,7 @@ import {
   updateLastTrack,
 } from "./bridge.js";
 import { CommandPoller } from "./command-poller.js";
+import type { BridgeCommand } from "./command-poller.js";
 import type { DeckLiveEvent } from "./deck-state.js";
 import { Logger } from "./logger.js";
 import { getPlugin } from "./plugin-registry.js";
@@ -129,7 +130,7 @@ async function main(): Promise<void> {
   const cmdLog = log.child("CommandPoller");
   commandPoller = new CommandPoller(getCircuitBreaker(), cmdLog);
 
-  commandPoller.on("command", async (commandType: string) => {
+  commandPoller.on("command", async (commandType: string, command?: BridgeCommand) => {
     if (!pluginBridge) return;
 
     cmdLog.info(`Executing command: ${commandType}`);
@@ -143,6 +144,9 @@ async function main(): Promise<void> {
           break;
         case "restart":
           await pluginBridge.restart();
+          break;
+        case "setbuilder_transport":
+          handleSetbuilderTransport(command?.payload ?? {});
           break;
         default:
           cmdLog.warn(`Unknown command type: ${commandType}`);
@@ -178,6 +182,16 @@ async function main(): Promise<void> {
   // Immediate handshake — tell the backend we're online and listening
   log.info("Bridge online — sending initial status to backend");
   await postBridgeStatus(true, undefined, buildEnrichedStatus());
+}
+
+function handleSetbuilderTransport(payload: Record<string, unknown>): void {
+  const action = typeof payload.action === "string" ? payload.action : "unknown";
+  const title = typeof payload.title === "string" ? payload.title : "";
+  const position = typeof payload.position_sec === "number" ? payload.position_sec : 0;
+
+  log.info(
+    `Setbuilder transport command received: ${action}${title ? ` "${title}"` : ""} @ ${position.toFixed(1)}s`
+  );
 }
 
 // Run the bridge

--- a/dashboard/app/(dj)/events/[code]/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/__tests__/page.test.tsx
@@ -231,7 +231,11 @@ function setupDefaultMocks() {
     circuit_breaker_state: null, buffer_size: null, plugin_id: null,
     deck_count: null, uptime_seconds: null,
   });
-  vi.mocked(api.sendBridgeCommand).mockResolvedValue({ command_id: 'test', command_type: 'ping' });
+  vi.mocked(api.sendBridgeCommand).mockResolvedValue({
+    command_id: 'test',
+    command_type: 'ping',
+    payload: {},
+  });
 }
 
 describe('EventQueuePage', () => {

--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import BuilderWorkspace from '../components/BuilderWorkspace';
 import type { PoolTrack, SetSlotOut } from '@/lib/api-types';
 
@@ -32,6 +32,8 @@ const mockSavePairing = vi.fn();
 const mockUpdateSlotTarget = vi.fn();
 const mockApplyCurveTemplate = vi.fn();
 const mockPutVibeWindows = vi.fn();
+const mockGetTransportStatus = vi.fn();
+const mockSendTransportCommand = vi.fn();
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -45,6 +47,9 @@ vi.mock('@/lib/api', () => ({
     applyCurveTemplate: (setId: number, source: object, mids?: number[]) =>
       mockApplyCurveTemplate(setId, source, mids),
     putVibeWindows: (setId: number, windows: object[]) => mockPutVibeWindows(setId, windows),
+    getTransportStatus: (setId: number) => mockGetTransportStatus(setId),
+    sendTransportCommand: (setId: number, payload: object) =>
+      mockSendTransportCommand(setId, payload),
     createCurveTemplate: vi.fn(),
     updateCurveTemplate: vi.fn(),
     deleteCurveTemplate: vi.fn(),
@@ -191,6 +196,22 @@ describe('BuilderWorkspace', () => {
     mockUpdateSlotTarget.mockResolvedValue({ slot_id: 1, target_energy: 9 });
     mockPutVibeWindows.mockResolvedValue({ windows: [] });
     mockSavePairing.mockResolvedValue({ id: 44 });
+    mockGetTransportStatus.mockResolvedValue({
+      connected: true,
+      active_source: 'setbuilder:tidal',
+      device_name: 'Bridge App',
+      last_seen: null,
+    });
+    mockSendTransportCommand.mockResolvedValue({
+      command_id: 'cmd-1',
+      command_type: 'setbuilder_transport',
+      action: 'play',
+      active_source: 'tidal',
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('fetches slots and renders curve blocks + timeline rows', async () => {
@@ -339,5 +360,113 @@ describe('BuilderWorkspace', () => {
     expect(windows).toHaveLength(1);
     expect(windows[0].label).toBe('First Dance');
     expect(screen.getByText('FIRST DANCE')).toBeInTheDocument();
+  });
+
+  it('play queues a Tidal Bridge command for the current slot', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('transport-bar')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Play' }));
+
+    await waitFor(() => expect(mockSendTransportCommand).toHaveBeenCalledTimes(1));
+    expect(mockSendTransportCommand).toHaveBeenCalledWith(
+      5,
+      expect.objectContaining({
+        action: 'play',
+        source: 'tidal',
+        slot_index: 0,
+        track_id: 'a',
+        title: 'Track A',
+      }),
+    );
+    expect(screen.getByTestId('timeline-vu-0')).toBeInTheDocument();
+  });
+
+  it('double-clicking a timeline row jumps and plays that slot', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('timeline-row-1')).toBeInTheDocument());
+
+    fireEvent.doubleClick(screen.getByTestId('timeline-row-1'));
+
+    await waitFor(() => expect(mockSendTransportCommand).toHaveBeenCalledTimes(1));
+    expect(mockSendTransportCommand).toHaveBeenCalledWith(
+      5,
+      expect.objectContaining({
+        action: 'play',
+        slot_index: 1,
+        position_sec: 0,
+        title: 'Track B',
+      }),
+    );
+    expect(screen.getByTestId('timeline-vu-1')).toBeInTheDocument();
+  });
+
+  it('click-to-scrub queues a seek command and keeps the active row in sync', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('timeline-row-1')).toBeInTheDocument());
+    fireEvent.doubleClick(screen.getByTestId('timeline-row-1'));
+    await waitFor(() => expect(mockSendTransportCommand).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByTestId('curve-scrub-hit'), { clientX: 0 });
+
+    await waitFor(() => expect(mockSendTransportCommand).toHaveBeenCalledTimes(2));
+    expect(mockSendTransportCommand).toHaveBeenLastCalledWith(
+      5,
+      expect.objectContaining({
+        action: 'seek',
+        slot_index: 0,
+        position_sec: 0,
+      }),
+    );
+    expect(screen.getByTestId('timeline-vu-0')).toBeInTheDocument();
+  });
+
+  it('auto-pauses Bridge when playback reaches the end of the set', async () => {
+    mockGetSetSlots.mockResolvedValue([SLOTS[0]]);
+    mockGetPool.mockResolvedValue({
+      sources: [],
+      tracks: [{ ...POOL_TRACKS[0], duration_sec: 1 }],
+    });
+
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('transport-bar')).toBeInTheDocument());
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByRole('button', { name: 'Play' }));
+    expect(mockSendTransportCommand).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(mockSendTransportCommand).toHaveBeenCalledTimes(2);
+    expect(mockSendTransportCommand).toHaveBeenLastCalledWith(
+      5,
+      expect.objectContaining({
+        action: 'pause',
+        slot_index: 0,
+        position_sec: 1,
+      }),
+    );
+    expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument();
+  });
+
+  it('scrubs when clicking a curve block covered by the block hit target', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('timeline-row-1')).toBeInTheDocument());
+    fireEvent.doubleClick(screen.getByTestId('timeline-row-1'));
+    await waitFor(() => expect(mockSendTransportCommand).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByTestId('slot-block-0'), { clientX: 0 });
+
+    await waitFor(() => expect(mockSendTransportCommand).toHaveBeenCalledTimes(2));
+    expect(mockSendTransportCommand).toHaveBeenLastCalledWith(
+      5,
+      expect.objectContaining({
+        action: 'seek',
+        slot_index: 0,
+        position_sec: 0,
+      }),
+    );
   });
 });

--- a/dashboard/app/(dj)/setbuilder/__tests__/transportMath.test.ts
+++ b/dashboard/app/(dj)/setbuilder/__tests__/transportMath.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  commandPayload,
+  localPositionSec,
+  previousIndex,
+  slotIndexAtPosition,
+  slotStartSec,
+  totalDuration,
+} from '../components/transportMath';
+import type { SlotView } from '../components/types';
+
+function slot(idx: number, durationSec: number): SlotView {
+  return {
+    id: idx + 1,
+    position: idx,
+    locked: false,
+    targetEnergy: null,
+    transitionScore: null,
+    nextPairingId: null,
+    nextIsDjPairing: false,
+    track: {
+      id: `tidal:${idx + 1}`,
+      title: `Track ${idx + 1}`,
+      artist: `Artist ${idx + 1}`,
+      durationSec,
+      energy: 5,
+      bpm: 120 + idx,
+      key: '8A',
+    },
+  };
+}
+
+const slots = [slot(0, 100), slot(1, 200), slot(2, 150)];
+
+describe('transportMath', () => {
+  it('maps absolute set positions to slots and local track time', () => {
+    expect(totalDuration(slots)).toBe(450);
+    expect(slotStartSec(slots, 2)).toBe(300);
+    expect(slotIndexAtPosition(slots, 0)).toBe(0);
+    expect(slotIndexAtPosition(slots, 100)).toBe(1);
+    expect(slotIndexAtPosition(slots, 449.5)).toBe(2);
+    expect(localPositionSec(slots, 1, 125)).toBe(25);
+  });
+
+  it('uses the 3-second previous convention', () => {
+    expect(previousIndex(slots, 1, 101)).toBe(0);
+    expect(previousIndex(slots, 1, 103)).toBe(1);
+    expect(previousIndex(slots, 0, 12)).toBe(0);
+  });
+
+  it('builds a Tidal-only Bridge transport payload', () => {
+    expect(commandPayload(slots, 1, 'play', 125)).toEqual({
+      action: 'play',
+      source: 'tidal',
+      slot_index: 1,
+      track_id: 'tidal:2',
+      title: 'Track 2',
+      artist: 'Artist 2',
+      position_sec: 25,
+      duration_sec: 200,
+    });
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
@@ -6,13 +6,31 @@
  * the builder page in place of the Phase 0 placeholders.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { api } from '@/lib/api';
 import CurvePanel from './CurvePanel';
 import TimelinePanel, { type ScrollRequest } from './TimelinePanel';
+import TransportBar from './TransportBar';
 import type { SlotView, TrackView } from './types';
 import { slotViewFromApi, trackViewFromPool } from './types';
+import {
+  commandPayload,
+  previousIndex,
+  slotIndexAtPosition,
+  slotStartSec,
+  totalDuration,
+} from './transportMath';
 import sbStyles from '../setbuilder.module.css';
+
+const SCRUB_KEY = 'wrzdj.transport.scrubEnabled';
+
+function readScrubSetting(): boolean {
+  try {
+    return window.localStorage.getItem(SCRUB_KEY) !== 'false';
+  } catch {
+    return true;
+  }
+}
 
 interface JumpSlotEvent extends Event {
   detail?: { idx?: number };
@@ -29,6 +47,17 @@ export default function BuilderWorkspace({
   const [pool, setPool] = useState<TrackView[]>([]);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const [scrollRequest, setScrollRequest] = useState<ScrollRequest | null>(null);
+  const [positionSec, setPositionSec] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [currentIdx, setCurrentIdx] = useState(0);
+  const [scrubEnabled, setScrubEnabled] = useState(true);
+  const [bridgeStatus, setBridgeStatus] = useState({
+    connected: false,
+    active_source: null as string | null,
+    device_name: null as string | null,
+  });
+
+  const totalSec = useMemo(() => totalDuration(slots), [slots]);
 
   const loadSlots = useCallback(() => {
     return Promise.all([api.getSetSlots(setId), api.getPool(setId)])
@@ -98,6 +127,119 @@ export default function BuilderWorkspace({
     );
   };
 
+  useEffect(() => {
+    setScrubEnabled(readScrubSetting());
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadStatus = () => {
+      api
+        .getTransportStatus(setId)
+        .then((status) => {
+          if (!cancelled) {
+            setBridgeStatus({
+              connected: status.connected,
+              active_source: status.active_source,
+              device_name: status.device_name,
+            });
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setBridgeStatus({ connected: false, active_source: null, device_name: null });
+          }
+        });
+    };
+    loadStatus();
+    const timer = window.setInterval(loadStatus, 10_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [setId]);
+
+  const sendCommand = useCallback(
+    (idx: number, action: 'load' | 'play' | 'pause' | 'seek', absolutePosition: number) => {
+      const payload = commandPayload(slots, idx, action, absolutePosition);
+      if (!payload) return;
+      api
+        .sendTransportCommand(setId, payload)
+        .then((resp) => {
+          setBridgeStatus((prev) => ({ ...prev, active_source: resp.active_source }));
+        })
+        .catch(() => {});
+    },
+    [setId, slots],
+  );
+
+  useEffect(() => {
+    if (!playing || totalSec <= 0) return;
+    const timer = window.setInterval(() => {
+      setPositionSec((prev) => {
+        const next = Math.min(totalSec, prev + 1);
+        if (next >= totalSec) {
+          const finalIdx = slotIndexAtPosition(slots, Math.max(0, totalSec - 0.001));
+          if (finalIdx >= 0) {
+            sendCommand(finalIdx, 'pause', totalSec);
+          }
+          setPlaying(false);
+          return totalSec;
+        }
+        const nextIdx = slotIndexAtPosition(slots, next);
+        setCurrentIdx((oldIdx) => {
+          if (nextIdx !== oldIdx && nextIdx >= 0) {
+            sendCommand(nextIdx, 'play', next);
+            return nextIdx;
+          }
+          return oldIdx;
+        });
+        return next;
+      });
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [playing, sendCommand, slots, totalSec]);
+
+  const jumpToSlot = (idx: number, shouldPlay: boolean) => {
+    const next = Math.max(0, Math.min(idx, slots.length - 1));
+    const pos = slotStartSec(slots, next);
+    setPositionSec(pos);
+    setCurrentIdx(next);
+    setPlaying(shouldPlay);
+    sendCommand(next, shouldPlay ? 'play' : 'load', pos);
+  };
+
+  const handlePrev = () => {
+    if (slots.length === 0) return;
+    const nextIdx = previousIndex(slots, currentIdx, positionSec);
+    jumpToSlot(nextIdx, playing);
+  };
+
+  const handleNext = () => {
+    if (slots.length === 0) return;
+    const nextIdx = Math.min(slots.length - 1, currentIdx + 1);
+    jumpToSlot(nextIdx, playing);
+  };
+
+  const handleToggle = () => {
+    if (slots.length === 0) return;
+    const idx = slotIndexAtPosition(slots, positionSec);
+    setCurrentIdx(idx);
+    setPlaying((wasPlaying) => {
+      sendCommand(idx, wasPlaying ? 'pause' : 'play', positionSec);
+      return !wasPlaying;
+    });
+  };
+
+  const handleScrub = (nextPosition: number) => {
+    if (!scrubEnabled || slots.length === 0) return;
+    const bounded = Math.max(0, Math.min(totalSec, nextPosition));
+    const idx = slotIndexAtPosition(slots, bounded);
+    setPositionSec(bounded);
+    setCurrentIdx(idx);
+    sendCommand(idx, 'seek', bounded);
+  };
+
   return (
     <>
       <section className={`${sbStyles.panel} ${sbStyles.panelCurve}`} aria-label="Curve">
@@ -109,7 +251,25 @@ export default function BuilderWorkspace({
           hoveredIdx={hoveredIdx}
           onHover={setHoveredIdx}
           onBlockClick={(idx) => setScrollRequest((prev) => ({ idx, n: (prev?.n ?? 0) + 1 }))}
+          onBlockDoubleClick={(idx) => jumpToSlot(idx, true)}
+          playheadSec={positionSec}
+          isPlaying={playing}
+          scrubEnabled={scrubEnabled}
+          onScrub={handleScrub}
           pool={pool}
+        />
+      </section>
+
+      <section className={`${sbStyles.panel} ${sbStyles.panelTransport}`} aria-label="Transport">
+        <TransportBar
+          slots={slots}
+          currentIdx={currentIdx}
+          positionSec={positionSec}
+          playing={playing}
+          status={bridgeStatus}
+          onPrev={handlePrev}
+          onToggle={handleToggle}
+          onNext={handleNext}
         />
       </section>
 
@@ -118,7 +278,11 @@ export default function BuilderWorkspace({
         <TimelinePanel
           slots={slots}
           hoveredIdx={hoveredIdx}
+          currentIdx={currentIdx}
+          positionSec={positionSec}
+          playing={playing}
           onHover={setHoveredIdx}
+          onRowDoubleClick={(idx) => jumpToSlot(idx, true)}
           scrollRequest={scrollRequest}
           onPairingAction={handlePairingAction}
         />

--- a/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
@@ -11,6 +11,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react';
+import type { MouseEvent as ReactMouseEvent } from 'react';
 import {
   BPM_TIER_COLORS,
   KEY_TIER_COLORS,
@@ -43,6 +44,11 @@ export interface CurveEditorProps {
   hoveredIdx: number | null;
   onHover: (idx: number | null) => void;
   onBlockClick?: (idx: number) => void;
+  onBlockDoubleClick?: (idx: number) => void;
+  playheadSec?: number;
+  isPlaying?: boolean;
+  scrubEnabled?: boolean;
+  onScrub?: (positionSec: number) => void;
   onTargetDragEnd?: (idx: number, energy: number, anchor: { x: number; y: number }) => void;
   onWindowChange?: (id: string, patch: Partial<VibeWindowView>) => void;
   onWindowCommit?: (id: string) => void;
@@ -56,6 +62,11 @@ export default function CurveEditor({
   hoveredIdx,
   onHover,
   onBlockClick,
+  onBlockDoubleClick,
+  playheadSec = 0,
+  isPlaying = false,
+  scrubEnabled = false,
+  onScrub,
   onTargetDragEnd,
   onWindowChange,
   onWindowCommit,
@@ -172,6 +183,24 @@ export default function CurveEditor({
   const linePath = blocks
     .map((b, i) => `${i === 0 ? 'M' : 'L'} ${b.xMid.toFixed(2)} ${yOf(b.target).toFixed(2)}`)
     .join(' ');
+  const playheadX = totalSec > 0 ? Math.max(0, Math.min(1, playheadSec / totalSec)) * w : 0;
+  const scrubFromClientX = (clientX: number) => {
+    if (!svgRef.current || !scrubEnabled || !onScrub || totalSec <= 0) return;
+    const rect = svgRef.current.getBoundingClientRect();
+    const t = Math.max(0, Math.min(1, (clientX - rect.left) / Math.max(1, rect.width)));
+    onScrub(t * totalSec);
+  };
+  const handleSvgClickCapture = (ev: ReactMouseEvent<SVGSVGElement>) => {
+    if (!scrubEnabled || !onScrub || totalSec <= 0) return;
+    const target = ev.target;
+    if (
+      target instanceof Element &&
+      target.closest('[data-handle="1"], [data-scrub-ignore="1"]')
+    ) {
+      return;
+    }
+    scrubFromClientX(ev.clientX);
+  };
 
   if (slots.length === 0) {
     return (
@@ -200,6 +229,7 @@ export default function CurveEditor({
         className={styles.svg}
         viewBox={`0 0 ${w} ${h}`}
         preserveAspectRatio="none"
+        onClickCapture={handleSvgClickCapture}
       >
         <defs>
           <pattern
@@ -228,6 +258,15 @@ export default function CurveEditor({
         </defs>
 
         <rect width={w} height={h} fill="url(#curveGrid)" />
+        {scrubEnabled && (
+          <rect
+            width={w}
+            height={h}
+            fill="transparent"
+            data-testid="curve-scrub-hit"
+            style={{ cursor: 'crosshair' }}
+          />
+        )}
 
         {/* Peak floor reference */}
         <line
@@ -271,6 +310,7 @@ export default function CurveEditor({
                 strokeWidth="0.5"
                 style={{ cursor: 'move' }}
                 data-testid={`vibe-window-header-${win.id}`}
+                data-scrub-ignore="1"
                 onContextMenu={(ev) => {
                   ev.preventDefault();
                   if (onWindowDelete) onWindowDelete(win.id);
@@ -296,6 +336,7 @@ export default function CurveEditor({
                 height={h}
                 fill="transparent"
                 style={{ cursor: 'ew-resize' }}
+                data-scrub-ignore="1"
                 onPointerDown={startWindowDrag(win.id, 'left', win.t0, win.t1)}
               />
               <rect
@@ -305,6 +346,7 @@ export default function CurveEditor({
                 height={h}
                 fill="transparent"
                 style={{ cursor: 'ew-resize' }}
+                data-scrub-ignore="1"
                 onPointerDown={startWindowDrag(win.id, 'right', win.t0, win.t1)}
               />
             </g>
@@ -329,6 +371,10 @@ export default function CurveEditor({
               onClick={(ev) => {
                 if ((ev.target as SVGElement).dataset?.handle) return;
                 if (onBlockClick) onBlockClick(b.idx);
+              }}
+              onDoubleClick={(ev) => {
+                ev.preventDefault();
+                if (onBlockDoubleClick) onBlockDoubleClick(b.idx);
               }}
               style={{ cursor: 'pointer' }}
             >
@@ -493,6 +539,34 @@ export default function CurveEditor({
             </g>
           );
         })}
+
+        {/* Derived target curve line */}
+        {totalSec > 0 && (
+          <g pointerEvents="none" data-testid="curve-playhead">
+            <rect x={0} y={0} width={playheadX} height={h} fill="rgba(0,0,0,0.22)" />
+            <line
+              x1={playheadX}
+              y1={0}
+              x2={playheadX}
+              y2={h}
+              stroke={isPlaying ? '#00f5d4' : 'rgba(255,255,255,0.7)'}
+              strokeWidth={1.5}
+            />
+            <g transform={`translate(${Math.min(Math.max(playheadX, 24), w - 24)}, 14)`}>
+              <rect x={-22} y={-10} width={44} height={18} rx={3} fill="var(--bg)" stroke="#00f5d4" strokeOpacity="0.6" />
+              <text
+                x="0"
+                y="3"
+                fontSize="9"
+                fill="#00f5d4"
+                fontWeight="700"
+                textAnchor="middle"
+              >
+                {fmtTime(playheadSec)}
+              </text>
+            </g>
+          </g>
+        )}
 
         {/* Derived target curve line */}
         {linePath && (

--- a/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
@@ -61,6 +61,11 @@ export interface CurvePanelProps {
   hoveredIdx: number | null;
   onHover: (idx: number | null) => void;
   onBlockClick: (idx: number) => void;
+  onBlockDoubleClick?: (idx: number) => void;
+  playheadSec?: number;
+  isPlaying?: boolean;
+  scrubEnabled?: boolean;
+  onScrub?: (positionSec: number) => void;
   /** Candidate pool for the replacement popover (#388 feeds this). */
   pool?: TrackView[];
 }
@@ -72,6 +77,11 @@ export default function CurvePanel({
   hoveredIdx,
   onHover,
   onBlockClick,
+  onBlockDoubleClick,
+  playheadSec = 0,
+  isPlaying = false,
+  scrubEnabled = false,
+  onScrub,
   pool = [],
 }: CurvePanelProps) {
   const [view, setView] = useState<CurveViewMode>('normal');
@@ -320,6 +330,11 @@ export default function CurvePanel({
         hoveredIdx={hoveredIdx}
         onHover={onHover}
         onBlockClick={onBlockClick}
+        onBlockDoubleClick={onBlockDoubleClick}
+        playheadSec={playheadSec}
+        isPlaying={isPlaying}
+        scrubEnabled={scrubEnabled}
+        onScrub={onScrub}
         onTargetDragEnd={handleTargetDragEnd}
         onWindowChange={changeWindow}
         onWindowCommit={commitWindow}

--- a/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
@@ -9,6 +9,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { fmtTime } from './curveMath';
+import { localPositionSec } from './transportMath';
 import type { SlotView } from './types';
 import { effectiveTarget } from './types';
 import styles from './curve.module.css';
@@ -22,7 +23,11 @@ export interface ScrollRequest {
 export interface TimelinePanelProps {
   slots: SlotView[];
   hoveredIdx: number | null;
+  currentIdx: number;
+  positionSec: number;
+  playing: boolean;
   onHover: (idx: number | null) => void;
+  onRowDoubleClick?: (idx: number) => void;
   scrollRequest: ScrollRequest | null;
   onPairingAction?: (idx: number) => void | Promise<void>;
 }
@@ -30,7 +35,11 @@ export interface TimelinePanelProps {
 export default function TimelinePanel({
   slots,
   hoveredIdx,
+  currentIdx,
+  positionSec,
+  playing,
   onHover,
+  onRowDoubleClick,
   scrollRequest,
   onPairingAction,
 }: TimelinePanelProps) {
@@ -75,6 +84,17 @@ export default function TimelinePanel({
         const prev = i > 0 ? slots[i - 1] : null;
         const seamScore = prev?.transitionScore ?? s.transitionScore;
         const isPairedSeam = Boolean(prev?.nextIsDjPairing);
+        const isCurrent = currentIdx === i;
+        const progress =
+          isCurrent && s.track.durationSec > 0
+            ? Math.min(
+                100,
+                Math.max(
+                  0,
+                  (localPositionSec(slots, i, positionSec) / s.track.durationSec) * 100,
+                ),
+              )
+            : 0;
         const pairingActionLabel = s.nextIsDjPairing
           ? `Open saved pairing after ${s.track.title}`
           : `Save ${s.track.title} into ${slots[i + 1]?.track.title ?? 'next track'} as pairing`;
@@ -111,9 +131,12 @@ export default function TimelinePanel({
               ref={(el) => {
                 rowRefs.current[i] = el;
               }}
-              className={`${styles.timelineRow} ${hoveredIdx === i ? styles.timelineRowHover : ''}`}
+              className={`${styles.timelineRow} ${hoveredIdx === i ? styles.timelineRowHover : ''} ${
+                isCurrent ? styles.timelineRowNow : ''
+              }`}
               onMouseEnter={() => onHover(i)}
               onMouseLeave={() => onHover(null)}
+              onDoubleClick={() => onRowDoubleClick?.(i)}
               onContextMenu={(event) => {
                 if (i >= slots.length - 1) return;
                 event.preventDefault();
@@ -121,7 +144,35 @@ export default function TimelinePanel({
               }}
               data-testid={`timeline-row-${i}`}
             >
-              <span className={styles.timelinePos}>{String(i + 1).padStart(2, '0')}</span>
+              {isCurrent ? (
+                <span
+                  className={styles.timelineRowProgress}
+                  style={{ width: `${progress}%` }}
+                  aria-hidden="true"
+                />
+              ) : null}
+              <span className={styles.timelinePos}>
+                {isCurrent ? (
+                  playing ? (
+                    <span
+                      className={`${styles.rowVu} ${styles.rowVuActive}`}
+                      data-testid={`timeline-vu-${i}`}
+                    >
+                      <span />
+                      <span />
+                      <span />
+                      <span />
+                    </span>
+                  ) : (
+                    <span className={styles.timelinePauseIcon} data-testid={`timeline-pause-${i}`}>
+                      <span />
+                      <span />
+                    </span>
+                  )
+                ) : (
+                  String(i + 1).padStart(2, '0')
+                )}
+              </span>
               <span className={styles.timelineTitle}>
                 {s.track.title}
                 {s.track.artist ? (

--- a/dashboard/app/(dj)/setbuilder/components/TransportBar.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TransportBar.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { fmtTime } from './curveMath';
+import { localPositionSec, totalDuration } from './transportMath';
+import type { SlotView } from './types';
+import styles from './curve.module.css';
+
+interface TransportStatus {
+  connected: boolean;
+  active_source: string | null;
+  device_name: string | null;
+}
+
+interface TransportBarProps {
+  slots: SlotView[];
+  currentIdx: number;
+  positionSec: number;
+  playing: boolean;
+  status: TransportStatus;
+  onPrev: () => void;
+  onToggle: () => void;
+  onNext: () => void;
+}
+
+function VuMeter({ playing }: { playing: boolean }) {
+  return (
+    <span className={`${styles.vuMeter} ${playing ? styles.vuMeterActive : ''}`} aria-hidden="true">
+      {[0, 1, 2, 3].map((i) => (
+        <span key={i} />
+      ))}
+    </span>
+  );
+}
+
+function Icon({ name }: { name: 'prev' | 'play' | 'pause' | 'next' }) {
+  if (name === 'prev') {
+    return (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M6 5h2v14H6zM9 12l9-7v14z" />
+      </svg>
+    );
+  }
+  if (name === 'next') {
+    return (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M16 5h2v14h-2zM6 5l9 7-9 7z" />
+      </svg>
+    );
+  }
+  if (name === 'pause') {
+    return (
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M7 5h4v14H7zM13 5h4v14h-4z" />
+      </svg>
+    );
+  }
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M8 5v14l11-7z" />
+    </svg>
+  );
+}
+
+export default function TransportBar({
+  slots,
+  currentIdx,
+  positionSec,
+  playing,
+  status,
+  onPrev,
+  onToggle,
+  onNext,
+}: TransportBarProps) {
+  const totalSec = totalDuration(slots);
+  const current = slots[currentIdx] ?? null;
+  const localElapsed = current ? localPositionSec(slots, currentIdx, positionSec) : 0;
+  const progressPct = totalSec > 0 ? Math.min(100, Math.max(0, (positionSec / totalSec) * 100)) : 0;
+  const source = status.active_source?.replace(/^setbuilder:/, '') ?? 'tidal';
+  const slotLabel = current ? String(currentIdx + 1).padStart(2, '0') : '--';
+  const meta = current
+    ? [
+        current.track.artist || 'Unknown artist',
+        current.track.bpm != null ? `${Math.round(current.track.bpm)} BPM` : '-- BPM',
+        current.track.key ?? '--',
+      ].join(' · ')
+    : 'Bridge playback is idle';
+
+  return (
+    <section className={styles.transportBar} aria-label="Transport" data-testid="transport-bar">
+      <div className={styles.transportProgress} aria-hidden="true">
+        <span style={{ width: `${progressPct}%` }} />
+      </div>
+      <div className={styles.transportControls}>
+        <button type="button" className={styles.transportBtn} onClick={onPrev} aria-label="Previous track">
+          <Icon name="prev" />
+        </button>
+        <button
+          type="button"
+          className={`${styles.transportBtn} ${styles.transportPlayBtn}`}
+          onClick={onToggle}
+          aria-label={playing ? 'Pause' : 'Play'}
+          disabled={slots.length === 0}
+        >
+          <Icon name={playing ? 'pause' : 'play'} />
+        </button>
+        <button type="button" className={styles.transportBtn} onClick={onNext} aria-label="Next track">
+          <Icon name="next" />
+        </button>
+      </div>
+
+      <div className={styles.nowPlayingReadout}>
+        <div className={styles.artTile}>{current ? current.track.title.slice(0, 1).toUpperCase() : '-'}</div>
+        <div className={styles.nowPlayingText}>
+          <div className={styles.nowTitle}>
+            <VuMeter playing={playing} />
+            <span className={styles.slotChip}>Slot {slotLabel}</span>
+            <span className={styles.nowTitleText}>{current?.track.title ?? 'No track loaded'}</span>
+          </div>
+          <div className={styles.nowMeta}>{meta}</div>
+        </div>
+      </div>
+
+      <div className={styles.transportTimes}>
+        <span className={styles.transportTimePrimary}>
+          {fmtTime(localElapsed)} / {fmtTime(current?.track.durationSec ?? 0)}
+        </span>
+        <span className={styles.transportTimeDivider} aria-hidden="true" />
+        <span className={styles.transportTimeSet}>
+          {fmtTime(positionSec)} / {fmtTime(totalSec)}
+        </span>
+      </div>
+
+      <div
+        className={`${styles.bridgePill} ${status.connected ? styles.bridgePillOn : styles.bridgePillOff}`}
+        title={status.device_name ?? undefined}
+      >
+        <span className={styles.bridgeDot} aria-hidden="true" />
+        <span className={styles.bridgeText}>
+          <span>Bridge {status.connected ? 'online' : 'offline'}</span>
+          <span>{source}</span>
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/curve.module.css
+++ b/dashboard/app/(dj)/setbuilder/components/curve.module.css
@@ -55,6 +55,284 @@
   fill: #00f5d4;
 }
 
+/* Transport bar */
+.transportBar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  min-height: 56px;
+  padding: 0 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--surface, #1a1a1a);
+  overflow: hidden;
+}
+
+.transportProgress {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.transportProgress span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, #00f5d4, #5dffea);
+  box-shadow: 0 0 10px rgba(0, 245, 212, 0.6);
+  transition: width 80ms linear;
+}
+
+.transportControls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex: 0 0 auto;
+}
+
+.transportBtn {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-raised);
+  color: var(--text-secondary);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.transportBtn:hover:not(:disabled) {
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+.transportBtn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.transportPlayBtn {
+  width: 36px;
+  height: 36px;
+  border-color: transparent;
+  background: #00f5d4;
+  color: #051015;
+  box-shadow: 0 0 0 1px rgba(0, 245, 212, 0.4), 0 0 14px rgba(0, 245, 212, 0.3);
+}
+
+.transportPlayBtn:hover:not(:disabled) {
+  background: #0fd9ba;
+  color: #051015;
+}
+
+.nowPlayingReadout {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  min-width: 0;
+  flex: 1 1 auto;
+  max-width: 460px;
+  padding-left: 0.875rem;
+  border-left: 1px solid var(--border-subtle);
+}
+
+.artTile {
+  width: 34px;
+  height: 34px;
+  flex: 0 0 34px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(0, 245, 212, 0.24);
+  border-radius: 6px;
+  background: linear-gradient(135deg, rgba(0, 245, 212, 0.18), rgba(245, 158, 11, 0.12));
+  color: #00f5d4;
+  font-weight: 800;
+  font-size: 0.75rem;
+}
+
+.nowPlayingText {
+  min-width: 0;
+  flex: 1;
+  line-height: 1.2;
+}
+
+.slotChip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 16px;
+  padding: 0 0.3125rem;
+  border: 1px solid rgba(0, 245, 212, 0.25);
+  border-radius: 4px;
+  background: rgba(0, 245, 212, 0.08);
+  color: #00f5d4;
+  font-size: 0.625rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.nowTitle {
+  display: flex;
+  align-items: center;
+  gap: 0.4375rem;
+  color: var(--text);
+  font-size: 0.75rem;
+  font-weight: 600;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.nowTitleText {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.nowMeta {
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+  font-family: var(--font-mono, monospace);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 0.125rem;
+}
+
+.vuMeter {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 1.5px;
+  height: 13px;
+  width: 15px;
+  flex: 0 0 auto;
+}
+
+.vuMeter span {
+  width: 2.5px;
+  height: 2px;
+  border-radius: 1px;
+  background: #00f5d4;
+  box-shadow: 0 0 4px rgba(0, 245, 212, 0.6);
+  transition: height 120ms ease;
+}
+
+.vuMeterActive span:nth-child(1) {
+  animation: vu1 650ms ease-in-out infinite;
+}
+
+.vuMeterActive span:nth-child(2) {
+  animation: vu2 730ms ease-in-out infinite;
+}
+
+.vuMeterActive span:nth-child(3) {
+  animation: vu3 580ms ease-in-out infinite;
+}
+
+.vuMeterActive span:nth-child(4) {
+  animation: vu4 790ms ease-in-out infinite;
+}
+
+@keyframes vu1 {
+  50% { height: 10px; }
+}
+
+@keyframes vu2 {
+  50% { height: 13px; }
+}
+
+@keyframes vu3 {
+  50% { height: 8px; }
+}
+
+@keyframes vu4 {
+  50% { height: 11px; }
+}
+
+.transportTimes {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex: 0 0 auto;
+  color: var(--text-secondary);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.6875rem;
+  white-space: nowrap;
+  text-align: right;
+}
+
+.transportTimePrimary {
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.transportTimeDivider {
+  width: 1px;
+  height: 14px;
+  margin: 0 0.375rem;
+  background: var(--border-subtle);
+}
+
+.transportTimeSet {
+  color: var(--text-tertiary);
+}
+
+.bridgePill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4375rem;
+  flex: 0 0 auto;
+  min-width: 116px;
+  min-height: 34px;
+  padding: 0.3125rem 0.5625rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--surface-raised);
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.bridgeDot {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 7px;
+  border-radius: 50%;
+}
+
+.bridgePillOn .bridgeDot {
+  background: #00f5d4;
+  box-shadow: 0 0 6px #00f5d4;
+}
+
+.bridgePillOff .bridgeDot {
+  background: #ef4444;
+}
+
+.bridgeText {
+  display: grid;
+  gap: 0.0625rem;
+}
+
+.bridgeText span:first-child {
+  font-size: 0.59375rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.bridgeText span:last-child {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.59375rem;
+  color: var(--text-tertiary);
+}
+
 /* Toolbar */
 .toolbar {
   display: flex;
@@ -579,14 +857,38 @@
   align-items: center;
   gap: 0.6rem;
   padding: 0.45rem 0.6rem;
-  border-radius: 6px;
-  border: 1px solid transparent;
+  border-left: 3px solid transparent;
+  border-bottom: 1px solid var(--border-subtle);
   cursor: pointer;
+  position: relative;
+  overflow: hidden;
 }
 
 .timelineRowHover {
   background: var(--surface-raised);
-  border-color: rgba(0, 245, 212, 0.45);
+  border-left-color: rgba(0, 245, 212, 0.6);
+}
+
+.timelineRowNow {
+  background: linear-gradient(90deg, rgba(0, 245, 212, 0.14), rgba(0, 245, 212, 0.04) 40%, transparent);
+  border-left-color: #00f5d4;
+  box-shadow: inset 2px 0 0 #00f5d4;
+}
+
+.timelineRowNow .timelineTitle {
+  color: #00f5d4;
+  font-weight: 600;
+}
+
+.timelineRowProgress {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 2px;
+  background: #00f5d4;
+  box-shadow: 0 0 6px rgba(0, 245, 212, 0.75);
+  pointer-events: none;
+  transition: width 80ms linear;
 }
 
 .timelinePos {
@@ -594,6 +896,57 @@
   font-size: 0.625rem;
   color: var(--text-tertiary);
   width: 22px;
+  display: inline-flex;
+  justify-content: center;
+  position: relative;
+  z-index: 1;
+}
+
+.rowVu {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 1.5px;
+  height: 13px;
+}
+
+.rowVu span {
+  width: 2.5px;
+  height: 2px;
+  border-radius: 1px;
+  background: #00f5d4;
+  box-shadow: 0 0 4px rgba(0, 245, 212, 0.7);
+}
+
+.rowVuActive span:nth-child(1) {
+  animation: vu1 620ms ease-in-out infinite;
+}
+
+.rowVuActive span:nth-child(2) {
+  animation: vu2 720ms ease-in-out infinite;
+}
+
+.rowVuActive span:nth-child(3) {
+  animation: vu3 580ms ease-in-out infinite;
+}
+
+.rowVuActive span:nth-child(4) {
+  animation: vu4 790ms ease-in-out infinite;
+}
+
+.timelinePauseIcon {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  height: 13px;
+}
+
+.timelinePauseIcon span {
+  display: block;
+  width: 3px;
+  height: 10px;
+  border-radius: 1px;
+  background: #00f5d4;
+  opacity: 0.75;
 }
 
 .timelineTitle {
@@ -604,6 +957,8 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  position: relative;
+  z-index: 1;
 }
 
 .timelineArtist {
@@ -620,6 +975,8 @@
   border-radius: 4px;
   padding: 0.1rem 0.3rem;
   white-space: nowrap;
+  position: relative;
+  z-index: 1;
 }
 
 .timelineTarget {
@@ -627,6 +984,8 @@
   font-size: 0.5625rem;
   color: #00f5d4;
   white-space: nowrap;
+  position: relative;
+  z-index: 1;
 }
 
 .timelinePairingAction {

--- a/dashboard/app/(dj)/setbuilder/components/transportMath.ts
+++ b/dashboard/app/(dj)/setbuilder/components/transportMath.ts
@@ -1,0 +1,54 @@
+import type { TransportCommandIn } from '@/lib/api-types';
+import type { SlotView } from './types';
+
+export const PREV_RESTART_THRESHOLD_SEC = 3;
+
+export function totalDuration(slots: SlotView[]): number {
+  return slots.reduce((acc, slot) => acc + slot.track.durationSec, 0);
+}
+
+export function slotStartSec(slots: SlotView[], idx: number): number {
+  return slots.slice(0, Math.max(0, idx)).reduce((acc, slot) => acc + slot.track.durationSec, 0);
+}
+
+export function slotIndexAtPosition(slots: SlotView[], positionSec: number): number {
+  if (slots.length === 0) return -1;
+  const clamped = Math.max(0, Math.min(positionSec, Math.max(0, totalDuration(slots) - 0.001)));
+  let cursor = 0;
+  for (let i = 0; i < slots.length; i++) {
+    cursor += slots[i].track.durationSec;
+    if (clamped < cursor) return i;
+  }
+  return slots.length - 1;
+}
+
+export function localPositionSec(slots: SlotView[], idx: number, positionSec: number): number {
+  const slot = slots[idx];
+  if (!slot) return 0;
+  return Math.max(0, Math.min(slot.track.durationSec, positionSec - slotStartSec(slots, idx)));
+}
+
+export function previousIndex(slots: SlotView[], idx: number, positionSec: number): number {
+  if (idx <= 0) return 0;
+  return localPositionSec(slots, idx, positionSec) >= PREV_RESTART_THRESHOLD_SEC ? idx : idx - 1;
+}
+
+export function commandPayload(
+  slots: SlotView[],
+  idx: number,
+  action: TransportCommandIn['action'],
+  positionSec: number,
+): TransportCommandIn | null {
+  const slot = slots[idx];
+  if (!slot) return null;
+  return {
+    action,
+    source: 'tidal',
+    slot_index: idx,
+    track_id: slot.track.id,
+    title: slot.track.title,
+    artist: slot.track.artist,
+    position_sec: localPositionSec(slots, idx, positionSec),
+    duration_sec: slot.track.durationSec,
+  };
+}

--- a/dashboard/app/(dj)/setbuilder/setbuilder.module.css
+++ b/dashboard/app/(dj)/setbuilder/setbuilder.module.css
@@ -1,9 +1,10 @@
 .workspace {
   display: grid;
   grid-template-columns: 320px 1fr 360px;
-  grid-template-rows: minmax(200px, 40%) 1fr;
+  grid-template-rows: minmax(200px, 40%) auto 1fr;
   grid-template-areas:
     'pool curve chat'
+    'pool transport chat'
     'pool timeline chat';
   gap: 1px;
   height: calc(100vh - 56px);
@@ -85,6 +86,9 @@
 }
 .panelTimeline {
   grid-area: timeline;
+}
+.panelTransport {
+  grid-area: transport;
 }
 .panelChat {
   grid-area: chat;

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -3138,6 +3138,46 @@ export interface paths {
         patch: operations["update_slot_target_api_setbuilder_sets__set_id__slots__slot_id__target_patch"];
         trace?: never;
     };
+    "/api/setbuilder/sets/{set_id}/transport/command": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Queue Transport Command
+         * @description Queue a setbuilder playback command for the set's attached event Bridge.
+         */
+        post: operations["queue_transport_command_api_setbuilder_sets__set_id__transport_command_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/transport/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Transport Status
+         * @description Return Bridge connection/source status for the set's attached event.
+         */
+        get: operations["get_transport_status_api_setbuilder_sets__set_id__transport_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/setbuilder/sets/{set_id}/vibe-windows": {
         parameters: {
             query?: never;
@@ -3888,6 +3928,13 @@ export interface components {
              * @description The command type that was queued
              */
             command_type: string;
+            /**
+             * Payload
+             * @description Queued command payload
+             */
+            payload: {
+                [key: string]: unknown;
+            };
         };
         /**
          * BridgeCommandsPollResponse
@@ -6428,6 +6475,79 @@ export interface components {
             slot_id: number;
             /** Warnings */
             warnings: string[];
+        };
+        /**
+         * TransportCommandIn
+         * @description One setbuilder transport command queued to the Bridge client.
+         */
+        TransportCommandIn: {
+            /**
+             * Action
+             * @description Transport action for the Bridge playback client
+             * @enum {string}
+             */
+            action: "load" | "play" | "pause" | "seek";
+            /**
+             * Artist
+             * @default
+             */
+            artist: string;
+            /** Duration Sec */
+            duration_sec: number;
+            /**
+             * Position Sec
+             * @default 0
+             */
+            position_sec: number;
+            /** Slot Index */
+            slot_index: number;
+            /**
+             * Source
+             * @default tidal
+             * @constant
+             */
+            source: "tidal";
+            /** Title */
+            title: string;
+            /** Track Id */
+            track_id?: string | null;
+        };
+        /**
+         * TransportCommandOut
+         * @description Bridge command queued for a setbuilder transport action.
+         */
+        TransportCommandOut: {
+            /**
+             * Action
+             * @enum {string}
+             */
+            action: "load" | "play" | "pause" | "seek";
+            /**
+             * Active Source
+             * @constant
+             */
+            active_source: "tidal";
+            /** Command Id */
+            command_id: string;
+            /**
+             * Command Type
+             * @constant
+             */
+            command_type: "setbuilder_transport";
+        };
+        /**
+         * TransportStatusOut
+         * @description Set-scoped Bridge playback status for the transport bar.
+         */
+        TransportStatusOut: {
+            /** Active Source */
+            active_source: string | null;
+            /** Connected */
+            connected: boolean;
+            /** Device Name */
+            device_name: string | null;
+            /** Last Seen */
+            last_seen: string | null;
         };
         /**
          * UnresolvedTrackOut
@@ -12300,6 +12420,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SlotTargetOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    queue_transport_command_api_setbuilder_sets__set_id__transport_command_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TransportCommandIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TransportCommandOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_transport_status_api_setbuilder_sets__set_id__transport_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TransportStatusOut"];
                 };
             };
             /** @description Validation Error */

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -221,6 +221,11 @@ export type PairingUpdate = Schemas['PairingUpdate'];
 export type Pairing = Schemas['PairingOut'];
 export type PairingsState = Schemas['PairingsState'];
 
+// WrzDJSet transport (issue #393)
+export type TransportCommandIn = Schemas['TransportCommandIn'];
+export type TransportCommandOut = Schemas['TransportCommandOut'];
+export type TransportStatusOut = Schemas['TransportStatusOut'];
+
 // WrzDJSet pool (issue #388)
 export type PoolSource = Schemas['PoolSourceOut'];
 export type PoolTrack = Schemas['PoolTrackOut'];

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -79,6 +79,9 @@ import type {
   TidalSearchResult,
   TidalSyncResult,
   TidalStatus,
+  TransportCommandIn,
+  TransportCommandOut,
+  TransportStatusOut,
   VibeEnrichmentResult,
   VibeWindow,
   VibeWindowsResponse,
@@ -178,6 +181,9 @@ export type {
   TidalSearchResult,
   TidalSyncResult,
   TidalStatus,
+  TransportCommandIn,
+  TransportCommandOut,
+  TransportStatusOut,
   VoteResponse,
   ExportTarget,
   ExportFileFormat,
@@ -792,6 +798,20 @@ class ApiClient {
   async deletePairing(setId: number, pairingId: number): Promise<void> {
     await this.rawFetch(`/api/setbuilder/sets/${setId}/pairings/${pairingId}`, {
       method: 'DELETE',
+    });
+  }
+
+  async getTransportStatus(setId: number): Promise<TransportStatusOut> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/transport/status`);
+  }
+
+  async sendTransportCommand(
+    setId: number,
+    payload: TransportCommandIn,
+  ): Promise<TransportCommandOut> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/transport/command`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
     });
   }
 

--- a/server/app/api/bridge.py
+++ b/server/app/api/bridge.py
@@ -310,7 +310,11 @@ def get_bridge_commands(
     commands = poll_commands(code.upper())
     return BridgeCommandsPollResponse(
         commands=[
-            BridgeCommandResponse(command_id=cmd["id"], command_type=cmd["type"])
+            BridgeCommandResponse(
+                command_id=cmd["id"],
+                command_type=cmd["type"],
+                payload=cmd.get("payload", {}),
+            )
             for cmd in commands
         ]
     )

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -66,6 +66,9 @@ from app.schemas.setbuilder import (
     TemplateWindowOut,
     TrackVibeStateOut,
     TransitionScoreOut,
+    TransportCommandIn,
+    TransportCommandOut,
+    TransportStatusOut,
     UnresolvedTrackOut,
     UnresolvedTracksError,
     VibeEnrichmentResult,
@@ -73,7 +76,9 @@ from app.schemas.setbuilder import (
     VibeWindowsPut,
     VibeWindowsResponse,
 )
+from app.services.bridge_integration import queue_command
 from app.services.llm.exceptions import NoLlmConfigured
+from app.services.now_playing import get_now_playing
 from app.services.setbuilder import (
     curve,
     export_common,
@@ -628,6 +633,75 @@ def put_vibe_windows(
     set_obj = _get_owned_or_404(db, set_id, current_user)
     stored = curve.replace_vibe_windows(db, set_obj, [w.model_dump() for w in payload.windows])
     return VibeWindowsResponse(windows=[VibeWindowModel(**w) for w in stored])
+
+
+# ---------------------------------------------------------------------------
+# Transport (issue #393) — queue playback commands for the attached event's Bridge.
+# ---------------------------------------------------------------------------
+
+
+@router.post("/sets/{set_id}/transport/command", response_model=TransportCommandOut)
+@limiter.limit("30/minute")
+def queue_transport_command(
+    set_id: int,
+    payload: TransportCommandIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> TransportCommandOut:
+    """Queue a setbuilder playback command for the set's attached event Bridge."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    if set_obj.event_id is None:
+        raise HTTPException(status_code=400, detail="Set must be attached to an event for playback")
+
+    from app.models.event import Event
+
+    event = db.get(Event, set_obj.event_id)
+    if event is None or event.created_by_user_id != current_user.id:
+        raise HTTPException(status_code=400, detail="Set event is unavailable for playback")
+
+    command_id = queue_command(
+        event.code.upper(),
+        "setbuilder_transport",
+        payload.model_dump(),
+    )
+    return TransportCommandOut(
+        command_id=command_id,
+        command_type="setbuilder_transport",
+        action=payload.action,
+        active_source=payload.source,
+    )
+
+
+@router.get("/sets/{set_id}/transport/status", response_model=TransportStatusOut)
+@limiter.limit("60/minute")
+def get_transport_status(
+    set_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> TransportStatusOut:
+    """Return Bridge connection/source status for the set's attached event."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    if set_obj.event_id is None:
+        return TransportStatusOut(connected=False)
+
+    from app.models.event import Event
+
+    event = db.get(Event, set_obj.event_id)
+    if event is None or event.created_by_user_id != current_user.id:
+        return TransportStatusOut(connected=False)
+
+    now_playing = get_now_playing(db, set_obj.event_id)
+    if now_playing is None:
+        return TransportStatusOut(connected=False)
+
+    return TransportStatusOut(
+        connected=now_playing.bridge_connected,
+        active_source=now_playing.source,
+        device_name=now_playing.bridge_device_name,
+        last_seen=now_playing.bridge_last_seen,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/server/app/schemas/bridge_commands.py
+++ b/server/app/schemas/bridge_commands.py
@@ -1,14 +1,21 @@
 """Schemas for bridge admin command endpoints."""
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
+
+BridgeCommandType = Literal[
+    "ping",
+    "reset_decks",
+    "reconnect",
+    "restart",
+]
 
 
 class BridgeCommandRequest(BaseModel):
     """Request body for queuing a bridge command."""
 
-    command_type: Literal["ping", "reset_decks", "reconnect", "restart"] = Field(
+    command_type: BridgeCommandType = Field(
         ..., description="The type of command to send to the bridge"
     )
 
@@ -18,6 +25,7 @@ class BridgeCommandResponse(BaseModel):
 
     command_id: str = Field(..., description="UUID of the queued command")
     command_type: str = Field(..., description="The command type that was queued")
+    payload: dict[str, Any] = Field(default_factory=dict, description="Queued command payload")
 
 
 class BridgeCommandsPollResponse(BaseModel):

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -505,6 +505,44 @@ class AgentChatOut(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Transport (issue #393) — setbuilder playback commands via Bridge
+# ---------------------------------------------------------------------------
+
+
+class TransportCommandIn(BaseModel):
+    """One setbuilder transport command queued to the Bridge client."""
+
+    action: Literal["load", "play", "pause", "seek"] = Field(
+        ..., description="Transport action for the Bridge playback client"
+    )
+    source: Literal["tidal"] = "tidal"
+    slot_index: int = Field(..., ge=0)
+    track_id: str | None = Field(None, max_length=255)
+    title: str = Field(..., min_length=1, max_length=255)
+    artist: str = Field("", max_length=255)
+    position_sec: float = Field(0, ge=0)
+    duration_sec: float = Field(..., gt=0, le=36000)
+
+
+class TransportCommandOut(BaseModel):
+    """Bridge command queued for a setbuilder transport action."""
+
+    command_id: str
+    command_type: Literal["setbuilder_transport"]
+    action: Literal["load", "play", "pause", "seek"]
+    active_source: Literal["tidal"]
+
+
+class TransportStatusOut(BaseModel):
+    """Set-scoped Bridge playback status for the transport bar."""
+
+    connected: bool
+    active_source: str | None = None
+    device_name: str | None = None
+    last_seen: datetime | None = None
+
+
+# ---------------------------------------------------------------------------
 # Share links (issue #398)
 
 

--- a/server/app/services/bridge_integration.py
+++ b/server/app/services/bridge_integration.py
@@ -6,6 +6,7 @@ import logging
 import threading
 import uuid
 from datetime import UTC, datetime
+from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -33,12 +34,13 @@ _commands: dict[str, list[dict]] = {}
 _lock = threading.Lock()
 
 
-def queue_command(event_code: str, command_type: str) -> str:
+def queue_command(event_code: str, command_type: str, payload: dict[str, Any] | None = None) -> str:
     """Queue a command for the bridge to pick up. Returns the UUID command_id."""
     command_id = str(uuid.uuid4())
     entry = {
         "id": command_id,
         "type": command_type,
+        "payload": payload or {},
         "created_at": utcnow(),
     }
     with _lock:

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1323,11 +1323,18 @@
             "description": "The command type that was queued",
             "title": "Command Type",
             "type": "string"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "description": "Queued command payload",
+            "title": "Payload",
+            "type": "object"
           }
         },
         "required": [
           "command_id",
-          "command_type"
+          "command_type",
+          "payload"
         ],
         "title": "BridgeCommandResponse",
         "type": "object"
@@ -8981,6 +8988,165 @@
           "warnings"
         ],
         "title": "TransitionScoreOut",
+        "type": "object"
+      },
+      "TransportCommandIn": {
+        "description": "One setbuilder transport command queued to the Bridge client.",
+        "properties": {
+          "action": {
+            "description": "Transport action for the Bridge playback client",
+            "enum": [
+              "load",
+              "play",
+              "pause",
+              "seek"
+            ],
+            "title": "Action",
+            "type": "string"
+          },
+          "artist": {
+            "default": "",
+            "maxLength": 255,
+            "title": "Artist",
+            "type": "string"
+          },
+          "duration_sec": {
+            "exclusiveMinimum": 0.0,
+            "maximum": 36000.0,
+            "title": "Duration Sec",
+            "type": "number"
+          },
+          "position_sec": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Position Sec",
+            "type": "number"
+          },
+          "slot_index": {
+            "minimum": 0.0,
+            "title": "Slot Index",
+            "type": "integer"
+          },
+          "source": {
+            "const": "tidal",
+            "default": "tidal",
+            "title": "Source",
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          },
+          "track_id": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Track Id"
+          }
+        },
+        "required": [
+          "action",
+          "slot_index",
+          "title",
+          "duration_sec"
+        ],
+        "title": "TransportCommandIn",
+        "type": "object"
+      },
+      "TransportCommandOut": {
+        "description": "Bridge command queued for a setbuilder transport action.",
+        "properties": {
+          "action": {
+            "enum": [
+              "load",
+              "play",
+              "pause",
+              "seek"
+            ],
+            "title": "Action",
+            "type": "string"
+          },
+          "active_source": {
+            "const": "tidal",
+            "title": "Active Source",
+            "type": "string"
+          },
+          "command_id": {
+            "title": "Command Id",
+            "type": "string"
+          },
+          "command_type": {
+            "const": "setbuilder_transport",
+            "title": "Command Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action",
+          "active_source",
+          "command_id",
+          "command_type"
+        ],
+        "title": "TransportCommandOut",
+        "type": "object"
+      },
+      "TransportStatusOut": {
+        "description": "Set-scoped Bridge playback status for the transport bar.",
+        "properties": {
+          "active_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Active Source"
+          },
+          "connected": {
+            "title": "Connected",
+            "type": "boolean"
+          },
+          "device_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Name"
+          },
+          "last_seen": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Seen"
+          }
+        },
+        "required": [
+          "active_source",
+          "connected",
+          "device_name",
+          "last_seen"
+        ],
+        "title": "TransportStatusOut",
         "type": "object"
       },
       "UnresolvedTrackOut": {
@@ -18259,6 +18425,112 @@
           }
         ],
         "summary": "Update Slot Target",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/transport/command": {
+      "post": {
+        "description": "Queue a setbuilder playback command for the set's attached event Bridge.",
+        "operationId": "queue_transport_command_api_setbuilder_sets__set_id__transport_command_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransportCommandIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransportCommandOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Queue Transport Command",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/transport/status": {
+      "get": {
+        "description": "Return Bridge connection/source status for the set's attached event.",
+        "operationId": "get_transport_status_api_setbuilder_sets__set_id__transport_status_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransportStatusOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Transport Status",
         "tags": [
           "setbuilder"
         ]

--- a/server/tests/test_bridge_commands.py
+++ b/server/tests/test_bridge_commands.py
@@ -134,8 +134,8 @@ class TestPostBridgeCommand:
     def test_all_valid_command_types(
         self, client: TestClient, auth_headers: dict, test_event: Event
     ):
-        """All three valid command types are accepted."""
-        for cmd in ("reset_decks", "reconnect", "restart"):
+        """All valid generic command types are accepted."""
+        for cmd in ("ping", "reset_decks", "reconnect", "restart"):
             response = client.post(
                 "/api/bridge/commands/TEST01",
                 json={"command_type": cmd},
@@ -143,6 +143,20 @@ class TestPostBridgeCommand:
             )
             assert response.status_code == 200
             assert response.json()["command_type"] == cmd
+
+    def test_generic_endpoint_rejects_setbuilder_transport(
+        self, client: TestClient, auth_headers: dict, test_event: Event
+    ):
+        """Setbuilder playback commands must go through the set-scoped transport endpoint."""
+        response = client.post(
+            "/api/bridge/commands/TEST01",
+            json={
+                "command_type": "setbuilder_transport",
+                "payload": {"action": "play"},
+            },
+            headers=auth_headers,
+        )
+        assert response.status_code == 422
 
 
 class TestGetBridgeCommands:
@@ -182,6 +196,32 @@ class TestGetBridgeCommands:
         assert len(data["commands"]) == 2
         types = {cmd["command_type"] for cmd in data["commands"]}
         assert types == {"reset_decks", "reconnect"}
+        assert all(cmd["payload"] == {} for cmd in data["commands"])
+
+    @patch("app.core.bridge_auth.get_settings")
+    def test_poll_returns_payload(
+        self,
+        mock_settings,
+        client: TestClient,
+        auth_headers: dict,
+        bridge_headers: dict,
+        test_event: Event,
+    ):
+        """Polling preserves structured command payloads."""
+        mock_settings.return_value.bridge_api_key = "test-bridge-key"
+        from app.services.bridge_integration import queue_command
+
+        queue_command(
+            "TEST01",
+            "setbuilder_transport",
+            {"action": "seek", "position_sec": 12.5},
+        )
+
+        response = client.get("/api/bridge/commands/TEST01", headers=bridge_headers)
+        assert response.status_code == 200
+        command = response.json()["commands"][0]
+        assert command["command_type"] == "setbuilder_transport"
+        assert command["payload"] == {"action": "seek", "position_sec": 12.5}
 
     @patch("app.core.bridge_auth.get_settings")
     def test_poll_clears_queue(

--- a/server/tests/test_setbuilder_api.py
+++ b/server/tests/test_setbuilder_api.py
@@ -6,6 +6,8 @@ rename/delete happy paths.
 """
 
 from app.services.auth import get_password_hash
+from app.services.bridge_integration import clear_all as clear_command_queue
+from app.services.bridge_integration import poll_commands
 
 
 def _make_second_dj(db):
@@ -120,3 +122,91 @@ def test_delete_other_dj_set_returns_404(client, auth_headers, db):
     ).json()
     resp = client.delete(f"/api/setbuilder/sets/{theirs['id']}", headers=auth_headers)
     assert resp.status_code == 404
+
+
+def test_transport_command_queues_bridge_payload(client, auth_headers, test_event):
+    clear_command_queue()
+    created = client.post(
+        "/api/setbuilder/sets",
+        json={"name": "Playable", "event_id": test_event.id},
+        headers=auth_headers,
+    ).json()
+    payload = {
+        "action": "play",
+        "source": "tidal",
+        "slot_index": 0,
+        "track_id": "tidal:123",
+        "title": "Track One",
+        "artist": "Artist One",
+        "position_sec": 0,
+        "duration_sec": 210,
+    }
+
+    resp = client.post(
+        f"/api/setbuilder/sets/{created['id']}/transport/command",
+        json=payload,
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200, resp.json()
+    assert resp.json()["command_type"] == "setbuilder_transport"
+    assert resp.json()["action"] == "play"
+    queued = poll_commands("TEST01")
+    assert len(queued) == 1
+    assert queued[0]["type"] == "setbuilder_transport"
+    assert queued[0]["payload"]["track_id"] == "tidal:123"
+    assert queued[0]["payload"]["slot_index"] == 0
+
+
+def test_transport_command_requires_attached_event(client, auth_headers):
+    created = client.post(
+        "/api/setbuilder/sets", json={"name": "No Event"}, headers=auth_headers
+    ).json()
+
+    resp = client.post(
+        f"/api/setbuilder/sets/{created['id']}/transport/command",
+        json={
+            "action": "play",
+            "source": "tidal",
+            "slot_index": 0,
+            "track_id": "tidal:123",
+            "title": "Track One",
+            "artist": "Artist One",
+            "position_sec": 0,
+            "duration_sec": 210,
+        },
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 400
+
+
+def test_transport_status_reads_attached_event_bridge_state(client, auth_headers, db, test_event):
+    from app.models.now_playing import NowPlaying
+
+    created = client.post(
+        "/api/setbuilder/sets",
+        json={"name": "Playable", "event_id": test_event.id},
+        headers=auth_headers,
+    ).json()
+    db.add(
+        NowPlaying(
+            event_id=test_event.id,
+            title="",
+            artist="",
+            source="setbuilder:tidal",
+            bridge_connected=True,
+            bridge_device_name="Bridge App",
+        )
+    )
+    db.commit()
+
+    resp = client.get(
+        f"/api/setbuilder/sets/{created['id']}/transport/status",
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["connected"] is True
+    assert resp.json()["active_source"] == "setbuilder:tidal"
+    assert resp.json()["device_name"] == "Bridge App"


### PR DESCRIPTION
## Why

WrzDJSet needs the timeline to behave like a real audition player for v1, routing transport intent through Bridge -> streaming/Tidal while keeping the curve playhead, timeline row state, and transport readout in sync.

Closes #393

## What

- Added a full-width setbuilder transport bar between curve and timeline with prev/play-pause/next, now-playing art/readout, flattened/animated VU state, per-track and set time, Bridge status, and a thin progress rail.
- Added shared transport math/state for prev restart behavior, auto-advance, end-of-set pause, click-to-scrub, curve block double-click, and timeline row double-click.
- Added curve playhead rendering with consumed-region dimming and scrub hit target, plus timeline now-playing row accent/VU/pause/progress states.
- Added set-scoped transport API endpoints that queue narrow structured `setbuilder_transport` Bridge commands for attached events; generic bridge admin commands remain limited to existing command types.
- Updated Bridge and Bridge App command pollers to preserve structured command payloads and receive `setbuilder_transport` commands without faking Tidal/local playback.
- Regenerated OpenAPI/dashboard API types.

## Testing

- `server`: `/home/adam/github/WrzDJ/server/.venv/bin/ruff check .`
- `server`: `/home/adam/github/WrzDJ/server/.venv/bin/ruff format --check .`
- `server`: `/home/adam/github/WrzDJ/server/.venv/bin/bandit -r app -c pyproject.toml -q`
- `server`: `/home/adam/github/WrzDJ/server/.venv/bin/pytest tests/test_bridge_commands.py tests/test_setbuilder_api.py --tb=short -q --no-cov`
- `server`: `/home/adam/github/WrzDJ/server/.venv/bin/pytest --tb=short -q` -> 2804 passed, coverage 88.63% / 85% required
- `server`: `DATABASE_URL=postgresql+psycopg://wrzdj:wrzdj@127.0.0.1:55432/wrzdj PYTHONPATH=. /home/adam/github/WrzDJ/server/.venv/bin/alembic upgrade head && ... alembic check` using temporary Postgres 16 on port 55432 -> no new upgrade operations detected
- `dashboard`: `npx tsc --noEmit`
- `dashboard`: `npm run lint`
- `dashboard`: `npm test -- --run 'app/(dj)/setbuilder'`
- `dashboard`: `npm test -- --run` -> 83 files, 1145 tests passed
- `root`: `git diff --check`

Not run:

- `bridge` / `bridge-app` TypeScript and Vitest checks. This shell only has Node v26.2.0; `npm ci` fails before checks because `better-sqlite3@12.6.2` has no Node 26 prebuild and its native build fails against Node 26 V8 APIs. Project docs require Node 22 for these packages.

Notes:

- The normal pre-commit hook expects `server/.venv` in the worktree; this isolated worktree uses the shared `/home/adam/github/WrzDJ/server/.venv` per project instructions, so the commit was made with `--no-verify` after running the equivalent checks above.

## Design decisions

- Kept Bridge integration narrow: setbuilder queues structured playback intent, and bridge clients receive/log the command hook without pretending to control Tidal where no real playback SDK exists in this codebase.
- Kept local-library audio out of scope for v1; all transport command payloads declare `source: "tidal"`.
- Made `BuilderWorkspace` the single owner of transport position/current-slot/playing state so transport readout, curve playhead, and timeline row state derive from the same source.
- Matched the synced prototype in repo-native React/CSS modules rather than copying prototype internals: compact full-width transport strip, bottom progress rail, cyan active row treatment, consumed curve region, and VU flattening when paused.
- Left public/shared set views read-only; transport affordances are only added to the owner setbuilder workspace.

Claude-assisted implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a transport bar with play/pause/previous/next controls, now-playing readout, and live bridge connection status
  * Enabled interactive timeline playback with a visible playhead, row “now” highlighting, double-click jump, and click-to-scrub seeking
  * Extended bridge command handling to carry structured payloads, including support for `setbuilder_transport` with action/title/position
  * Introduced set-scoped transport command and status endpoints to queue commands and fetch transport state
* **Tests**
  * Added unit and UI test coverage for full command payload emission and transport playback/scrubbing behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->