### PR TITLE
feat: add setbuilder document history

### DIFF
--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { use, useEffect, useState } from 'react';
+import { use, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
@@ -72,7 +72,7 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [builderSettings, setBuilderSettings] = useState(DEFAULT_SETTINGS);
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
-  const [confirmResolver, setConfirmResolver] = useState<((value: boolean) => void) | null>(null);
+  const confirmResolverRef = useRef<((value: boolean) => void) | null>(null);
   const history = useSetDocumentHistory(numericSetId);
 
   useEffect(() => {
@@ -103,13 +103,14 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
 
   const requestConfirmation = (action: ConfirmAction) =>
     new Promise<boolean>((resolve) => {
+      confirmResolverRef.current?.(false);
+      confirmResolverRef.current = (value: boolean) => resolve(value);
       setConfirmAction(action);
-      setConfirmResolver(() => resolve);
     });
 
   const closeConfirm = (value: boolean) => {
-    confirmResolver?.(value);
-    setConfirmResolver(null);
+    confirmResolverRef.current?.(value);
+    confirmResolverRef.current = null;
     setConfirmAction(null);
   };
 

--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -7,29 +7,73 @@ import { useAuth } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { SetDetail } from '@/lib/api-types';
 import { ThemeToggle } from '@/components/ThemeToggle';
+import BuilderBrandMenu from '../components/BuilderBrandMenu';
 import BuilderWorkspace from '../components/BuilderWorkspace';
 import ChatSidebar from '../components/ChatSidebar';
 import PairingsOverlay from '../components/PairingsOverlay';
+import BuilderSettingsModal, { type BuilderSettings } from '../components/BuilderSettingsModal';
+import ConfirmActionDialog, { type ConfirmAction } from '../components/ConfirmActionDialog';
+import HistoryControls from '../components/HistoryControls';
 import PoolPanel from '../components/PoolPanel';
+import { useSetDocumentHistory } from '../components/useSetDocumentHistory';
 import SetActionsMenu from '../SetActionsMenu';
 import styles from '../setbuilder.module.css';
 
 type OpenPairingsEvent = CustomEvent<{ pairingId?: number | null }>;
 
+const SETTINGS_KEY = 'wrzdj.setbuilder.settings';
+
+const DEFAULT_SETTINGS: BuilderSettings = {
+  suggestReplacements: true,
+  confirmRecompute: true,
+  confirmSlotRemoval: true,
+  playOnDoubleClick: true,
+  scrubOnCurveClick: true,
+  showSlotMarkers: true,
+  agentChimes: false,
+  autoExpandPairings: true,
+};
+
+function readBuilderSettings(): BuilderSettings {
+  try {
+    const raw = window.localStorage.getItem(SETTINGS_KEY);
+    return raw ? { ...DEFAULT_SETTINGS, ...JSON.parse(raw) } : DEFAULT_SETTINGS;
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
+}
+
+function writeBuilderSettings(settings: BuilderSettings): void {
+  try {
+    window.localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+    window.localStorage.setItem(
+      'wrzdj.curve.suggestReplacements',
+      String(settings.suggestReplacements),
+    );
+  } catch {
+    // Best-effort browser preference.
+  }
+}
+
 export default function BuilderPage({ params }: { params: Promise<{ setId: string }> }) {
   const { setId } = use(params);
+  const numericSetId = Number(setId);
   const { isAuthenticated, isLoading, role } = useAuth();
   const router = useRouter();
   const [set, setSet] = useState<SetDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [chatOpen, setChatOpen] = useState(false);
   const [refreshToken, setRefreshToken] = useState(0);
-  const [confirmBuild, setConfirmBuild] = useState(false);
   const [building, setBuilding] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
   const [pairingsOpen, setPairingsOpen] = useState(false);
   const [pairingCount, setPairingCount] = useState(0);
   const [initialPairingId, setInitialPairingId] = useState<number | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [builderSettings, setBuilderSettings] = useState(DEFAULT_SETTINGS);
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
+  const [confirmResolver, setConfirmResolver] = useState<((value: boolean) => void) | null>(null);
+  const history = useSetDocumentHistory(numericSetId);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -42,11 +86,32 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
   useEffect(() => {
     if (isAuthenticated) {
       api
-        .getSet(Number(setId))
+        .getSet(numericSetId)
         .then(setSet)
         .catch(() => setError('Set not found'));
     }
-  }, [isAuthenticated, setId]);
+  }, [isAuthenticated, numericSetId]);
+
+  useEffect(() => {
+    setBuilderSettings(readBuilderSettings());
+  }, []);
+
+  const updateBuilderSettings = (next: BuilderSettings) => {
+    setBuilderSettings(next);
+    writeBuilderSettings(next);
+  };
+
+  const requestConfirmation = (action: ConfirmAction) =>
+    new Promise<boolean>((resolve) => {
+      setConfirmAction(action);
+      setConfirmResolver(() => resolve);
+    });
+
+  const closeConfirm = (value: boolean) => {
+    confirmResolver?.(value);
+    setConfirmResolver(null);
+    setConfirmAction(null);
+  };
 
   useEffect(() => {
     if (!toast) return;
@@ -57,15 +122,40 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
   const runBuild = async () => {
     setBuilding(true);
     try {
-      const result = await api.buildSet(Number(setId), true);
+      const result = await history.commit('Recompute set order', () => api.buildSet(numericSetId, true));
       setRefreshToken((v) => v + 1);
       setToast(`Pass 1 rebuilt ${result.slot_count} slots · ${result.iterations} refine steps`);
-      setConfirmBuild(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to recompute set');
     } finally {
       setBuilding(false);
     }
+  };
+
+  const requestBuild = async () => {
+    if (builderSettings.confirmRecompute) {
+      const ok = await requestConfirmation({
+        title: 'Recompute set order?',
+        body: (
+          <>
+            <p>
+              This reruns deterministic pass 1 and may overwrite unlocked manual order using the
+              current pool, curve targets, transition scoring, and saved pairings.
+            </p>
+            <ul>
+              <li>Locked slots stay fixed.</li>
+              <li>Unlocked manual reorders may be replaced.</li>
+              <li>Saved pairings are weighted into scoring.</li>
+              <li>The action is undoable from the topbar or with Ctrl/Cmd+Z.</li>
+            </ul>
+          </>
+        ),
+        confirmLabel: 'Yes, recompute',
+        kind: 'warning',
+      });
+      if (!ok) return;
+    }
+    void runBuild();
   };
 
   useEffect(() => {
@@ -125,15 +215,35 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
   return (
     <div>
       <div className={styles.topbar}>
-        <Link
-          href="/setbuilder"
-          className="btn btn-sm"
-          style={{ background: 'var(--surface-raised)', textDecoration: 'none', color: 'var(--text)' }}
-        >
-          ← Sets
-        </Link>
-        <span className={styles.topbarTitle}>{set?.name ?? 'Loading…'}</span>
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}>
+        <span className={styles.topbarLeft}>
+          <Link
+            href="/setbuilder"
+            className="btn btn-sm"
+            style={{ background: 'var(--surface-raised)', textDecoration: 'none', color: 'var(--text)' }}
+          >
+            ← Sets
+          </Link>
+          <BuilderBrandMenu
+            name={set?.name ?? 'Loading…'}
+            isDirty={history.isDirty}
+            isSaving={history.isSaving}
+            saveError={history.saveError}
+            lastSavedAt={history.lastSavedAt}
+            onSave={() => void history.saveNow()}
+            onSettings={() => setSettingsOpen(true)}
+          />
+        </span>
+        <span className={styles.topbarActions}>
+          <HistoryControls
+            undoDepth={history.undoDepth}
+            redoDepth={history.redoDepth}
+            nextUndoLabel={history.nextUndoLabel}
+            nextRedoLabel={history.nextRedoLabel}
+            onUndo={() => void history.undo()}
+            onRedo={() => void history.redo()}
+            onSettings={() => setSettingsOpen(true)}
+            isSaving={history.isSaving}
+          />
           <button
             type="button"
             className={styles.topbarPairingsBtn}
@@ -168,9 +278,10 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
           <button
             className="btn btn-sm"
             title="Re-run deterministic pass 1"
-            onClick={() => setConfirmBuild(true)}
+            onClick={() => void requestBuild()}
+            disabled={building}
           >
-            Recompute
+            {building ? 'Recomputing...' : 'Recompute'}
           </button>
           <ThemeToggle />
         </span>
@@ -178,10 +289,29 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
 
       <div className={`${styles.workspace} ${chatOpen ? styles.chatOpen : styles.chatClosed}`}>
         <section className={`${styles.panel} ${styles.panelPool}`} aria-label="Pool">
-          <PoolPanel setId={Number(setId)} />
+          <PoolPanel
+            setId={numericSetId}
+            snapshot={history.snapshot}
+            snapshotVersion={history.snapshotVersion}
+            commit={history.commit}
+            confirmRemovals={builderSettings.confirmSlotRemoval}
+            requestConfirmation={requestConfirmation}
+          />
         </section>
 
-        <BuilderWorkspace setId={Number(setId)} refreshToken={refreshToken} />
+        <BuilderWorkspace
+          setId={numericSetId}
+          refreshToken={refreshToken}
+          snapshot={history.snapshot}
+          snapshotVersion={history.snapshotVersion}
+          commit={history.commit}
+          suggestReplacements={builderSettings.suggestReplacements}
+          onSuggestReplacementsChange={(checked) =>
+            updateBuilderSettings({ ...builderSettings, suggestReplacements: checked })
+          }
+          confirmRecompute={builderSettings.confirmRecompute}
+          requestConfirmation={requestConfirmation}
+        />
 
         <div className={styles.panelChat}>
           <ChatSidebar
@@ -193,43 +323,8 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
           />
         </div>
       </div>
-      {confirmBuild && (
-        <div className={styles.confirmWrap}>
-          <div
-            className={styles.confirmBackdrop}
-            onClick={building ? undefined : () => setConfirmBuild(false)}
-          />
-          <div className={styles.confirmDialog} role="dialog" aria-modal="true">
-            <div className={styles.confirmHeader}>
-              <div className={styles.confirmIcon}>!</div>
-              <div className={styles.confirmTitle}>Recompute set order?</div>
-            </div>
-            <div className={styles.confirmBody}>
-              <p>
-                This reruns deterministic pass 1 and may overwrite unlocked manual order using
-                the current pool, curve targets, transition scoring, and saved pairings.
-              </p>
-              <ul>
-                <li>Locked slots stay fixed.</li>
-                <li>Unlocked manual reorders may be replaced.</li>
-                <li>Saved pairings are weighted into scoring.</li>
-                <li>This action is designed to be undoable once undo/save lands.</li>
-              </ul>
-            </div>
-            <div className={styles.confirmFooter}>
-              <button className="btn" onClick={() => setConfirmBuild(false)} disabled={building}>
-                Cancel
-              </button>
-              <button className="btn btn-primary" onClick={runBuild} disabled={building}>
-                {building ? 'Recomputing...' : 'Yes, recompute'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
       {toast && (
-        <div className={styles.builderToast} role="status" aria-live="polite">
+        <div className={styles.poolToast} role="status" aria-live="polite">
           {toast}
         </div>
       )}
@@ -246,6 +341,24 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
           )
         }
       />
+      <BuilderSettingsModal
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        autosave={history.autosave}
+        onAutosaveChange={history.setAutosave}
+        settings={builderSettings}
+        onSettingsChange={updateBuilderSettings}
+      />
+      <ConfirmActionDialog
+        action={confirmAction}
+        onCancel={() => closeConfirm(false)}
+        onConfirm={() => closeConfirm(true)}
+      />
+      {history.toast && (
+        <div className={styles.poolToast} role="status">
+          {history.toast}
+        </div>
+      )}
     </div>
   );
 }

--- a/dashboard/app/(dj)/setbuilder/components/BuilderBrandMenu.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/BuilderBrandMenu.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import styles from '../setbuilder.module.css';
+
+function formatAgo(date: Date | null, now: number): string {
+  if (!date) return 'just now';
+  const seconds = Math.max(0, Math.floor((now - date.getTime()) / 1000));
+  if (seconds < 5) return 'just now';
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  return `${Math.floor(minutes / 60)}h ago`;
+}
+
+interface BuilderBrandMenuProps {
+  name: string;
+  isDirty: boolean;
+  isSaving: boolean;
+  saveError: string | null;
+  lastSavedAt: Date | null;
+  onSave: () => void;
+  onSettings: () => void;
+}
+
+export default function BuilderBrandMenu({
+  name,
+  isDirty,
+  isSaving,
+  saveError,
+  lastSavedAt,
+  onSave,
+  onSettings,
+}: BuilderBrandMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+  const ref = useRef<HTMLDivElement | null>(null);
+  const dirty = isDirty || isSaving || Boolean(saveError);
+  const label = dirty ? 'Unsaved changes' : 'All saved';
+  const sublabel = saveError
+    ? saveError
+    : dirty
+      ? 'Click to save · Ctrl/Cmd+S'
+      : `${formatAgo(lastSavedAt, now)}`;
+
+  useEffect(() => {
+    const handle = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(handle);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (!ref.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  const save = () => {
+    setOpen(false);
+    onSave();
+  };
+
+  return (
+    <div className={styles.brandMenuWrap} ref={ref}>
+      <button
+        type="button"
+        className={styles.brandButton}
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <span className={styles.brandTitle}>{name}</span>
+        <span className={`${styles.saveDot} ${dirty ? styles.saveDotDirty : ''}`} />
+      </button>
+      {open && (
+        <div className={styles.brandMenu} role="menu">
+          <button
+            type="button"
+            className={`${styles.brandMenuItem} ${styles.brandSaveRow}`}
+            onClick={save}
+            disabled={isSaving}
+            role="menuitem"
+          >
+            <span className={`${styles.saveDot} ${dirty ? styles.saveDotDirty : ''}`} />
+            <span>
+              <span className={styles.saveLabel}>{label}</span>
+              <span className={styles.saveSub}>{sublabel}</span>
+            </span>
+          </button>
+          <button
+            type="button"
+            className={styles.brandMenuItem}
+            onClick={() => {
+              setOpen(false);
+              onSettings();
+            }}
+            role="menuitem"
+          >
+            Settings
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/BuilderSettingsModal.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/BuilderSettingsModal.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import styles from '../setbuilder.module.css';
+
+export interface BuilderSettings {
+  suggestReplacements: boolean;
+  confirmRecompute: boolean;
+  confirmSlotRemoval: boolean;
+  playOnDoubleClick: boolean;
+  scrubOnCurveClick: boolean;
+  showSlotMarkers: boolean;
+  agentChimes: boolean;
+  autoExpandPairings: boolean;
+}
+
+interface BuilderSettingsModalProps {
+  open: boolean;
+  onClose: () => void;
+  autosave: boolean;
+  onAutosaveChange: (value: boolean) => void;
+  settings: BuilderSettings;
+  onSettingsChange: (settings: BuilderSettings) => void;
+}
+
+function ToggleRow({
+  title,
+  description,
+  checked,
+  onChange,
+}: {
+  title: string;
+  description: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className={styles.settingsToggle}>
+      <span>
+        <span className={styles.settingsToggleTitle}>{title}</span>
+        <span className={styles.settingsToggleDescription}>{description}</span>
+      </span>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+      />
+    </label>
+  );
+}
+
+export default function BuilderSettingsModal({
+  open,
+  onClose,
+  autosave,
+  onAutosaveChange,
+  settings,
+  onSettingsChange,
+}: BuilderSettingsModalProps) {
+  if (!open) return null;
+
+  const patch = (partial: Partial<BuilderSettings>) => onSettingsChange({ ...settings, ...partial });
+
+  return (
+    <div className={styles.modalWrap}>
+      <div className={styles.modalBackdrop} onMouseDown={onClose} />
+      <div
+        className={styles.settingsModal}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Builder settings"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className={styles.settingsHeader}>
+          <h2>Builder settings</h2>
+          <button type="button" className="btn btn-sm" onClick={onClose} aria-label="Close settings">
+            Close
+          </button>
+        </div>
+
+        <section className={styles.settingsSection}>
+          <h3>Saving</h3>
+          <ToggleRow
+            title="Autosave"
+            description="Save every 30s while the builder document has unsaved changes."
+            checked={autosave}
+            onChange={onAutosaveChange}
+          />
+        </section>
+
+        <section className={styles.settingsSection}>
+          <h3>Edit prompts</h3>
+          <ToggleRow
+            title="Energy mismatch prompt"
+            description="Offer replacement candidates after large target-energy changes."
+            checked={settings.suggestReplacements}
+            onChange={(checked) => patch({ suggestReplacements: checked })}
+          />
+          <ToggleRow
+            title="Confirm recompute"
+            description="Ask before rerunning builder order or curve recompute actions."
+            checked={settings.confirmRecompute}
+            onChange={(checked) => patch({ confirmRecompute: checked })}
+          />
+          <ToggleRow
+            title="Confirm before removing a slot"
+            description="Ask before destructive removals in the builder document."
+            checked={settings.confirmSlotRemoval}
+            onChange={(checked) => patch({ confirmSlotRemoval: checked })}
+          />
+        </section>
+
+        <section className={styles.settingsSection}>
+          <h3>Interaction</h3>
+          <ToggleRow
+            title="Double-click to play"
+            description="Start playback from a track row with a double click."
+            checked={settings.playOnDoubleClick}
+            onChange={(checked) => patch({ playOnDoubleClick: checked })}
+          />
+          <ToggleRow
+            title="Click curve to scrub"
+            description="Let curve clicks move the transport position."
+            checked={settings.scrubOnCurveClick}
+            onChange={(checked) => patch({ scrubOnCurveClick: checked })}
+          />
+          <ToggleRow
+            title="Show slot markers"
+            description="Show each slot position on the curve editor."
+            checked={settings.showSlotMarkers}
+            onChange={(checked) => patch({ showSlotMarkers: checked })}
+          />
+        </section>
+
+        <section className={styles.settingsSection}>
+          <h3>Agent</h3>
+          <ToggleRow
+            title="Agent chimes"
+            description="Play subtle sound cues for agent suggestions."
+            checked={settings.agentChimes}
+            onChange={(checked) => patch({ agentChimes: checked })}
+          />
+          <ToggleRow
+            title="Auto-expand pairings"
+            description="Open new pairing suggestions as the agent creates them."
+            checked={settings.autoExpandPairings}
+            onChange={(checked) => patch({ autoExpandPairings: checked })}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
@@ -8,11 +8,14 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { api } from '@/lib/api';
+import type { SetDocumentSnapshot } from '@/lib/api-types';
 import CurvePanel from './CurvePanel';
 import TimelinePanel, { type ScrollRequest } from './TimelinePanel';
 import TransportBar from './TransportBar';
+import type { ConfirmAction } from './ConfirmActionDialog';
 import type { SlotView, TrackView } from './types';
 import { slotViewFromApi, trackViewFromPool } from './types';
+import type { BuilderCommit } from './useSetDocumentHistory';
 import {
   commandPayload,
   previousIndex,
@@ -36,13 +39,29 @@ interface JumpSlotEvent extends Event {
   detail?: { idx?: number };
 }
 
+interface BuilderWorkspaceProps {
+  setId: number;
+  refreshToken?: number;
+  snapshot?: SetDocumentSnapshot | null;
+  snapshotVersion?: number;
+  commit?: BuilderCommit;
+  suggestReplacements?: boolean;
+  onSuggestReplacementsChange?: (checked: boolean) => void;
+  confirmRecompute?: boolean;
+  requestConfirmation?: (action: ConfirmAction) => Promise<boolean>;
+}
+
 export default function BuilderWorkspace({
   setId,
   refreshToken = 0,
-}: {
-  setId: number;
-  refreshToken?: number;
-}) {
+  snapshot,
+  snapshotVersion = 0,
+  commit,
+  suggestReplacements,
+  onSuggestReplacementsChange,
+  confirmRecompute = true,
+  requestConfirmation,
+}: BuilderWorkspaceProps) {
   const [slots, setSlots] = useState<SlotView[]>([]);
   const [pool, setPool] = useState<TrackView[]>([]);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
@@ -84,7 +103,7 @@ export default function BuilderWorkspace({
     return () => {
       cancelled = true;
     };
-  }, [loadSlots, refreshToken]);
+  }, [loadSlots, refreshToken, snapshotVersion]);
 
   useEffect(() => {
     const onPairingsChanged = () => {
@@ -248,6 +267,9 @@ export default function BuilderWorkspace({
           setId={setId}
           slots={slots}
           onSlotsChange={(updater) => setSlots(updater)}
+          snapshot={snapshot}
+          snapshotVersion={snapshotVersion}
+          commit={commit}
           hoveredIdx={hoveredIdx}
           onHover={setHoveredIdx}
           onBlockClick={(idx) => setScrollRequest((prev) => ({ idx, n: (prev?.n ?? 0) + 1 }))}
@@ -257,6 +279,10 @@ export default function BuilderWorkspace({
           scrubEnabled={scrubEnabled}
           onScrub={handleScrub}
           pool={pool}
+          suggestReplacementsSetting={suggestReplacements}
+          onSuggestReplacementsChange={onSuggestReplacementsChange}
+          confirmRecompute={confirmRecompute}
+          requestConfirmation={requestConfirmation}
         />
       </section>
 

--- a/dashboard/app/(dj)/setbuilder/components/ConfirmActionDialog.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/ConfirmActionDialog.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import styles from '../setbuilder.module.css';
+
+export interface ConfirmAction {
+  title: string;
+  body: ReactNode;
+  confirmLabel: string;
+  kind?: 'warning' | 'danger' | 'neutral';
+}
+
+interface ConfirmActionDialogProps {
+  action: ConfirmAction | null;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export default function ConfirmActionDialog({
+  action,
+  onCancel,
+  onConfirm,
+}: ConfirmActionDialogProps) {
+  if (!action) return null;
+  const kind = action.kind ?? 'danger';
+  const iconClass =
+    kind === 'warning'
+      ? styles.confirmIconWarning
+      : kind === 'danger'
+        ? styles.confirmIconDanger
+        : styles.confirmIconNeutral;
+  return (
+    <div className={styles.modalWrap}>
+      <div className={styles.modalBackdrop} onMouseDown={onCancel} />
+      <div
+        className={styles.confirmDialog}
+        role="alertdialog"
+        aria-modal="true"
+        aria-label={action.title}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className={styles.confirmHeader}>
+          <span className={`${styles.confirmIcon} ${iconClass}`}>
+            {kind === 'warning' ? '!' : kind === 'danger' ? '×' : 'i'}
+          </span>
+          <h2>{action.title}</h2>
+        </div>
+        <div className={styles.confirmBody}>{action.body}</div>
+        <div className={styles.confirmActions}>
+          <button type="button" className="btn btn-sm" onClick={onCancel}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className={`btn btn-sm ${kind === 'danger' ? styles.dangerBtn : styles.warningBtn}`}
+            onClick={onConfirm}
+          >
+            {action.confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
@@ -171,12 +171,14 @@ export default function CurvePanel({
 
   useEffect(() => {
     if (snapshot || totalSec <= 0 || windowsLoadedFor.current === setId) return;
+    let cancelled = false;
     // Mark eagerly so in-flight fetches dedupe; roll back on failure so a
     // transient error doesn't block the load for the rest of the session.
     windowsLoadedFor.current = setId;
     api
       .getVibeWindows(setId)
       .then((resp) => {
+        if (cancelled) return;
         setWindows(
           resp.windows.map((w, i) => ({
             id: `w-${i}-${w.t0_sec}`,
@@ -187,10 +189,14 @@ export default function CurvePanel({
         );
       })
       .catch(() => {
+        if (cancelled) return;
         if (windowsLoadedFor.current === setId) windowsLoadedFor.current = null;
         setWindows([]);
       });
-  }, [setId, totalSec]);
+    return () => {
+      cancelled = true;
+    };
+  }, [setId, snapshot, totalSec]);
 
   const persistWindows = useCallback(
     (next: VibeWindowView[], label: string) => {

--- a/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
@@ -12,10 +12,11 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '@/lib/api';
-import type { CurveTemplatesResponse } from '@/lib/api-types';
+import type { CurveTemplatesResponse, SetDocumentSnapshot } from '@/lib/api-types';
 import CurveEditor, { type CurveViewMode } from './CurveEditor';
 import CurveToolbar from './CurveToolbar';
 import CurveTemplateEditorOverlay, { type TemplateDraft } from './CurveTemplateEditorOverlay';
+import type { ConfirmAction } from './ConfirmActionDialog';
 import ReplacePopover, { type ReplacePrompt } from './ReplacePopover';
 import {
   REPLACE_PROMPT_THRESHOLD,
@@ -24,6 +25,7 @@ import {
   type VibePreset,
 } from './curveMath';
 import type { SlotView, TrackView, VibeWindowView } from './types';
+import type { BuilderCommit } from './useSetDocumentHistory';
 
 const SUGGEST_KEY = 'wrzdj.curve.suggestReplacements';
 
@@ -54,6 +56,29 @@ interface OverlayState {
 
 const OVERLAY_CLOSED: OverlayState = { open: false, mode: 'create', initial: null, isBuiltIn: false };
 
+function windowsFromSnapshot(
+  snapshot: SetDocumentSnapshot | null | undefined,
+  totalSec: number,
+): VibeWindowView[] | null {
+  if (!snapshot || totalSec <= 0) return null;
+  const rows = [...snapshot.curve_points].sort((a, b) => a.id - b.id);
+  const windows: VibeWindowView[] = [];
+  let open: (typeof rows)[number] | null = null;
+  for (const row of rows) {
+    if (row.is_slow_window_start) open = row;
+    else if (row.is_slow_window_end && open) {
+      windows.push({
+        id: `sw-${open.id}-${row.id}`,
+        t0: Math.min(1, open.position_sec / totalSec),
+        t1: Math.min(1, row.position_sec / totalSec),
+        label: open.label ?? 'Vibe window',
+      });
+      open = null;
+    }
+  }
+  return windows;
+}
+
 export interface CurvePanelProps {
   setId: number;
   slots: SlotView[];
@@ -66,8 +91,15 @@ export interface CurvePanelProps {
   isPlaying?: boolean;
   scrubEnabled?: boolean;
   onScrub?: (positionSec: number) => void;
+  snapshot?: SetDocumentSnapshot | null;
+  snapshotVersion?: number;
+  commit?: BuilderCommit;
   /** Candidate pool for the replacement popover (#388 feeds this). */
   pool?: TrackView[];
+  suggestReplacementsSetting?: boolean;
+  onSuggestReplacementsChange?: (on: boolean) => void;
+  confirmRecompute?: boolean;
+  requestConfirmation?: (action: ConfirmAction) => Promise<boolean>;
 }
 
 export default function CurvePanel({
@@ -82,7 +114,14 @@ export default function CurvePanel({
   isPlaying = false,
   scrubEnabled = false,
   onScrub,
+  snapshot,
+  snapshotVersion = 0,
+  commit,
   pool = [],
+  suggestReplacementsSetting,
+  onSuggestReplacementsChange,
+  confirmRecompute = true,
+  requestConfirmation,
 }: CurvePanelProps) {
   const [view, setView] = useState<CurveViewMode>('normal');
   const [templates, setTemplates] = useState<CurveTemplatesResponse | null>(null);
@@ -96,12 +135,17 @@ export default function CurvePanel({
 
   // Settings toggle persists per browser
   useEffect(() => {
+    if (suggestReplacementsSetting != null) {
+      setSuggestReplacements(suggestReplacementsSetting);
+      return;
+    }
     const stored = readSuggestSetting();
     if (stored != null) setSuggestReplacements(stored);
-  }, []);
+  }, [suggestReplacementsSetting]);
   const setSuggest = (on: boolean) => {
     setSuggestReplacements(on);
     writeSuggestSetting(on);
+    onSuggestReplacementsChange?.(on);
   };
 
   const refreshTemplates = useCallback(() => {
@@ -119,7 +163,14 @@ export default function CurvePanel({
   // first arrive — a later refetch must never wipe in-session edits.
   const windowsLoadedFor = useRef<number | null>(null);
   useEffect(() => {
-    if (totalSec <= 0 || windowsLoadedFor.current === setId) return;
+    const restored = windowsFromSnapshot(snapshot, totalSec);
+    if (restored == null) return;
+    windowsLoadedFor.current = setId;
+    setWindows(restored);
+  }, [setId, snapshot, snapshotVersion, totalSec]);
+
+  useEffect(() => {
+    if (snapshot || totalSec <= 0 || windowsLoadedFor.current === setId) return;
     // Mark eagerly so in-flight fetches dedupe; roll back on failure so a
     // transient error doesn't block the load for the rest of the session.
     windowsLoadedFor.current = setId;
@@ -142,22 +193,23 @@ export default function CurvePanel({
   }, [setId, totalSec]);
 
   const persistWindows = useCallback(
-    (next: VibeWindowView[]) => {
+    (next: VibeWindowView[], label: string) => {
       if (totalSec <= 0) return;
-      api
-        .putVibeWindows(
+      const save = () =>
+        api.putVibeWindows(
           setId,
           next.map((w) => ({
             t0_sec: Math.round(w.t0 * totalSec),
             t1_sec: Math.max(Math.round(w.t0 * totalSec) + 1, Math.round(w.t1 * totalSec)),
             label: w.label,
           })),
-        )
-        .catch(() => {
-          /* keep optimistic local state; next successful PUT reconciles */
-        });
+        );
+      const run = commit ? commit(label, save) : save();
+      run.catch(() => {
+        /* keep optimistic local state; next successful PUT reconciles */
+      });
     },
-    [setId, totalSec],
+    [commit, setId, totalSec],
   );
 
   // --- Target drag ---------------------------------------------------------
@@ -166,7 +218,9 @@ export default function CurvePanel({
     const slot = slots[idx];
     if (!slot) return;
     onSlotsChange((prev) => prev.map((s, i) => (i === idx ? { ...s, targetEnergy: energy } : s)));
-    api.updateSlotTarget(setId, slot.id, energy).catch(() => {
+    const save = () => api.updateSlotTarget(setId, slot.id, energy);
+    const run = commit ? commit(`Retarget slot ${idx + 1}`, save) : save();
+    run.catch(() => {
       /* optimistic; refetch on next load */
     });
     if (suggestReplacements && Math.abs(energy - slot.track.energy) >= REPLACE_PROMPT_THRESHOLD) {
@@ -179,10 +233,49 @@ export default function CurvePanel({
 
   // --- Templates -----------------------------------------------------------
 
-  const applyTemplate = (source: { builtin?: string; template_id?: number }, name: string) => {
+  const applyTemplate = async (source: { builtin?: string; template_id?: number }, name: string) => {
+    if (confirmRecompute && requestConfirmation) {
+      const ok = await requestConfirmation({
+        title: 'Recompute curve targets?',
+        body: (
+          <>
+            <p>This reruns builder placement against the current curve, pool, and pairings.</p>
+            <ul>
+              <li>Unlocked slots may reorder and overwrite manual order changes.</li>
+              <li>Locked slots stay put.</li>
+              <li>Saved pairings are weighted during placement.</li>
+              <li>The action is undoable from the topbar or with Ctrl/Cmd+Z.</li>
+            </ul>
+          </>
+        ),
+        confirmLabel: 'Yes, recompute',
+        kind: 'warning',
+      });
+      if (!ok) return;
+    }
     const midpoints = slots.length > 0 ? slotMidpoints(slots) : undefined;
-    api
-      .applyCurveTemplate(setId, source, midpoints)
+    const save = async () => {
+      const resp = await api.applyCurveTemplate(setId, source, midpoints);
+      if (totalSec > 0) {
+        const next = resp.windows.map((w, i) => ({
+          id: `tw-${i}-${w.t0}`,
+          t0: w.t0,
+          t1: w.t1,
+          label: 'Slow set',
+        }));
+        await api.putVibeWindows(
+          setId,
+          next.map((w) => ({
+            t0_sec: Math.round(w.t0 * totalSec),
+            t1_sec: Math.max(Math.round(w.t0 * totalSec) + 1, Math.round(w.t1 * totalSec)),
+            label: w.label,
+          })),
+        );
+      }
+      return resp;
+    };
+    const run = commit ? commit(`Apply curve ${name}`, save) : save();
+    run
       .then((resp) => {
         const bySlotId = new Map(resp.targets.map((t) => [t.slot_id, t.target_energy]));
         onSlotsChange((prev) =>
@@ -196,7 +289,6 @@ export default function CurvePanel({
           label: 'Slow set',
         }));
         setWindows(next);
-        persistWindows(next);
         setActiveTemplateName(name);
         setPrompt(null);
       })
@@ -259,7 +351,7 @@ export default function CurvePanel({
         ...prev,
         { id: `w-${Date.now()}`, t0, t1: Math.min(1, t0 + span), label: preset.label },
       ];
-      persistWindows(next);
+      persistWindows(next, `Add ${preset.label} window`);
       return next;
     });
   };
@@ -270,7 +362,7 @@ export default function CurvePanel({
 
   const commitWindow = () => {
     setWindows((prev) => {
-      persistWindows(prev);
+      persistWindows(prev, 'Move vibe window');
       return prev;
     });
   };
@@ -278,7 +370,7 @@ export default function CurvePanel({
   const deleteWindow = (id: string) => {
     setWindows((prev) => {
       const next = prev.filter((w) => w.id !== id);
-      persistWindows(next);
+      persistWindows(next, 'Remove vibe window');
       return next;
     });
   };

--- a/dashboard/app/(dj)/setbuilder/components/HistoryControls.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/HistoryControls.tsx
@@ -1,0 +1,57 @@
+import styles from '../setbuilder.module.css';
+
+interface HistoryControlsProps {
+  undoDepth: number;
+  redoDepth: number;
+  nextUndoLabel: string | null;
+  nextRedoLabel: string | null;
+  onUndo: () => void;
+  onRedo: () => void;
+  onSettings: () => void;
+  isSaving: boolean;
+}
+
+export default function HistoryControls({
+  undoDepth,
+  redoDepth,
+  nextUndoLabel,
+  nextRedoLabel,
+  onUndo,
+  onRedo,
+  onSettings,
+  isSaving,
+}: HistoryControlsProps) {
+  return (
+    <span className={styles.historyControls}>
+      <button
+        type="button"
+        className={styles.historyIconButton}
+        onClick={onUndo}
+        disabled={!undoDepth || isSaving}
+        title={nextUndoLabel ? `Undo: ${nextUndoLabel}` : 'Undo'}
+        aria-label={nextUndoLabel ? `Undo: ${nextUndoLabel}` : 'Undo'}
+      >
+        ↶ <span className={styles.depthBadge}>{undoDepth}</span>
+      </button>
+      <button
+        type="button"
+        className={styles.historyIconButton}
+        onClick={onRedo}
+        disabled={!redoDepth || isSaving}
+        title={nextRedoLabel ? `Redo: ${nextRedoLabel}` : 'Redo'}
+        aria-label={nextRedoLabel ? `Redo: ${nextRedoLabel}` : 'Redo'}
+      >
+        ↷ <span className={styles.depthBadge}>{redoDepth}</span>
+      </button>
+      <button
+        type="button"
+        className={styles.historyIconButton}
+        onClick={onSettings}
+        aria-label="Open builder settings"
+        title="Builder settings"
+      >
+        ⚙
+      </button>
+    </span>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/ImportModal.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/ImportModal.tsx
@@ -16,6 +16,7 @@ import type {
 } from '@/lib/api-types';
 import styles from '../setbuilder.module.css';
 import { SourceIcon, sourceColor } from './PoolBadges';
+import type { BuilderCommit } from './useSetDocumentHistory';
 
 export type ImportKind = 'event' | 'tidal' | 'beatport' | 'public_url' | 'manual';
 
@@ -27,6 +28,7 @@ interface ImportModalProps {
   onClose: () => void;
   onImported: (result: PoolImportResult) => void;
   onError: (message: string) => void;
+  commit?: BuilderCommit;
 }
 
 export default function ImportModal(props: ImportModalProps) {
@@ -75,7 +77,15 @@ function errMessage(e: unknown): string {
   return 'Import failed — try again';
 }
 
-function ImportEvent({ setId, existingRefs, onClose, onImported, onError }: ImportModalProps) {
+function runImport(
+  commit: BuilderCommit | undefined,
+  label: string,
+  action: () => Promise<PoolImportResult>,
+) {
+  return commit ? commit(label, action) : action();
+}
+
+function ImportEvent({ setId, existingRefs, onClose, onImported, onError, commit }: ImportModalProps) {
   const [events, setEvents] = useState<Event[] | null>(null);
   const [picked, setPicked] = useState<number | null>(null);
   const [busy, setBusy] = useState(false);
@@ -91,7 +101,7 @@ function ImportEvent({ setId, existingRefs, onClose, onImported, onError }: Impo
     if (picked == null) return;
     setBusy(true);
     try {
-      onImported(await api.importPoolEvent(setId, picked));
+      onImported(await runImport(commit, 'Import event requests', () => api.importPoolEvent(setId, picked)));
     } catch (e) {
       onError(errMessage(e));
     } finally {
@@ -158,7 +168,15 @@ function ImportEvent({ setId, existingRefs, onClose, onImported, onError }: Impo
   );
 }
 
-function ImportPlaylist({ kind, setId, existingRefs, onClose, onImported, onError }: ImportModalProps) {
+function ImportPlaylist({
+  kind,
+  setId,
+  existingRefs,
+  onClose,
+  onImported,
+  onError,
+  commit,
+}: ImportModalProps) {
   const service = kind as 'tidal' | 'beatport';
   const [playlists, setPlaylists] = useState<BuilderPlaylists | null>(null);
   const [picked, setPicked] = useState<string | null>(null);
@@ -185,7 +203,9 @@ function ImportPlaylist({ kind, setId, existingRefs, onClose, onImported, onErro
     setBusy(true);
     try {
       const call = service === 'tidal' ? api.importPoolTidal : api.importPoolBeatport;
-      onImported(await call.call(api, setId, picked, name));
+      onImported(
+        await runImport(commit, `Import ${label} playlist`, () => call.call(api, setId, picked, name)),
+      );
     } catch (e) {
       onError(errMessage(e));
     } finally {
@@ -250,7 +270,7 @@ function ImportPlaylist({ kind, setId, existingRefs, onClose, onImported, onErro
   );
 }
 
-function ImportPublicUrl({ setId, onClose, onImported, onError }: ImportModalProps) {
+function ImportPublicUrl({ setId, onClose, onImported, onError, commit }: ImportModalProps) {
   const [url, setUrl] = useState('');
   const [preview, setPreview] = useState<PoolUrlPreview | null>(null);
   const [validating, setValidating] = useState(false);
@@ -273,7 +293,9 @@ function ImportPublicUrl({ setId, onClose, onImported, onError }: ImportModalPro
   const doImport = async () => {
     setBusy(true);
     try {
-      onImported(await api.importPoolUrl(setId, url.trim()));
+      onImported(
+        await runImport(commit, 'Import public playlist', () => api.importPoolUrl(setId, url.trim())),
+      );
     } catch (e) {
       onError(errMessage(e));
     } finally {
@@ -362,7 +384,7 @@ function ImportPublicUrl({ setId, onClose, onImported, onError }: ImportModalPro
   );
 }
 
-function ImportManual({ setId, onClose, onImported, onError }: ImportModalProps) {
+function ImportManual({ setId, onClose, onImported, onError, commit }: ImportModalProps) {
   const [q, setQ] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
   const [searching, setSearching] = useState(false);
@@ -393,18 +415,20 @@ function ImportManual({ setId, onClose, onImported, onError }: ImportModalProps)
           ? r.source
           : 'manual';
       onImported(
-        await api.importPoolManual(setId, {
-          title: r.title,
-          artist: r.artist,
-          album: r.album ?? null,
-          genre: r.genre ?? null,
-          bpm: r.bpm ?? null,
-          key: r.key ?? null,
-          isrc: r.isrc ?? null,
-          artwork_url: r.album_art?.startsWith('https://') ? r.album_art : null,
-          source_service: service,
-          source_track_id: service === 'spotify' ? (r.spotify_id ?? null) : null,
-        })
+        await runImport(commit, `Add ${r.title}`, () =>
+          api.importPoolManual(setId, {
+            title: r.title,
+            artist: r.artist,
+            album: r.album ?? null,
+            genre: r.genre ?? null,
+            bpm: r.bpm ?? null,
+            key: r.key ?? null,
+            isrc: r.isrc ?? null,
+            artwork_url: r.album_art?.startsWith('https://') ? r.album_art : null,
+            source_service: service,
+            source_track_id: service === 'spotify' ? (r.spotify_id ?? null) : null,
+          }),
+        ),
       );
     } catch (e) {
       onError(errMessage(e));

--- a/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
@@ -8,11 +8,19 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { api, ApiError } from '@/lib/api';
-import type { PoolImportResult, PoolSource, PoolState, TrackVibeState } from '@/lib/api-types';
+import type {
+  PoolImportResult,
+  PoolSource,
+  PoolState,
+  SetDocumentSnapshot,
+  TrackVibeState,
+} from '@/lib/api-types';
 import styles from '../setbuilder.module.css';
+import type { ConfirmAction } from './ConfirmActionDialog';
 import ImportModal, { type ImportKind } from './ImportModal';
 import { BpmBadge, CamelotBadge, EnergyMini, SourceIcon, sourceColor } from './PoolBadges';
 import VibeTiers from './VibeTiers';
+import type { BuilderCommit } from './useSetDocumentHistory';
 
 function buildVibeMap(tracks: TrackVibeState[]): Map<number, TrackVibeState> {
   return new Map(tracks.map((v) => [v.pool_track_id, v]));
@@ -42,7 +50,23 @@ interface ContextMenuState {
   sourceId: number;
 }
 
-export default function PoolPanel({ setId }: { setId: number }) {
+interface PoolPanelProps {
+  setId: number;
+  snapshot?: SetDocumentSnapshot | null;
+  snapshotVersion?: number;
+  commit?: BuilderCommit;
+  confirmRemovals?: boolean;
+  requestConfirmation?: (action: ConfirmAction) => Promise<boolean>;
+}
+
+export default function PoolPanel({
+  setId,
+  snapshot,
+  snapshotVersion = 0,
+  commit,
+  confirmRemovals = false,
+  requestConfirmation,
+}: PoolPanelProps) {
   const [pool, setPool] = useState<PoolState>({ sources: [], tracks: [] });
   const [loaded, setLoaded] = useState(false);
   const [tab, setTab] = useState('all');
@@ -64,12 +88,17 @@ export default function PoolPanel({ setId }: { setId: number }) {
     setVibes(new Map());
     setShowVibes(false);
     setVibesLoaded(false);
+    if (snapshot) {
+      setPool(snapshot.pool);
+      setLoaded(true);
+      return;
+    }
     api
       .getPool(setId)
       .then(setPool)
       .catch(() => setToast('Failed to load pool'))
       .finally(() => setLoaded(true));
-  }, [setId]);
+  }, [setId, snapshot, snapshotVersion]);
 
   useEffect(() => {
     if (!toast) return;
@@ -133,8 +162,20 @@ export default function PoolPanel({ setId }: { setId: number }) {
 
   const removeTracks = useCallback(
     async (ids: number[]) => {
+      if (confirmRemovals && requestConfirmation) {
+        const ok = await requestConfirmation({
+          title: ids.length === 1 ? 'Remove this track?' : `Remove ${ids.length} tracks?`,
+          body: 'Removing pool tracks changes the builder document and can be undone from the topbar.',
+          confirmLabel: 'Remove',
+          kind: 'danger',
+        });
+        if (!ok) return;
+      }
       try {
-        const result = await api.removePoolTracks(setId, ids);
+        const save = () => api.removePoolTracks(setId, ids);
+        const result = commit
+          ? await commit(ids.length === 1 ? 'Remove pool track' : `Remove ${ids.length} pool tracks`, save)
+          : await save();
         setPool(result.pool);
         setSelected(new Set());
         setSelectMode(false);
@@ -143,13 +184,27 @@ export default function PoolPanel({ setId }: { setId: number }) {
         setToast('Remove failed');
       }
     },
-    [setId]
+    [commit, confirmRemovals, requestConfirmation, setId],
   );
 
   const removeSource = useCallback(
     async (sourceId: number) => {
+      const source = pool.sources.find((s) => s.id === sourceId);
+      if (confirmRemovals && requestConfirmation) {
+        const ok = await requestConfirmation({
+          title: `Remove source${source ? ` ${source.label}` : ''}?`,
+          body:
+            'Removing a source removes its imported tracks from the builder document and can be undone from the topbar.',
+          confirmLabel: 'Remove source',
+          kind: 'danger',
+        });
+        if (!ok) return;
+      }
       try {
-        const result = await api.removePoolSource(setId, sourceId);
+        const save = () => api.removePoolSource(setId, sourceId);
+        const result = commit
+          ? await commit(`Remove source${source ? ` ${source.label}` : ''}`, save)
+          : await save();
         setPool(result.pool);
         if (activeSourceId === sourceId) setActiveSourceId(null);
         setToast(`Removed source · ${result.removed} tracks`);
@@ -157,7 +212,7 @@ export default function PoolPanel({ setId }: { setId: number }) {
         setToast('Remove failed');
       }
     },
-    [setId, activeSourceId]
+    [activeSourceId, commit, confirmRemovals, pool.sources, requestConfirmation, setId],
   );
 
   const toggleVibes = useCallback(() => {
@@ -514,6 +569,7 @@ export default function PoolPanel({ setId }: { setId: number }) {
           onClose={() => setImportKind(null)}
           onImported={onImported}
           onError={(msg) => setToast(msg)}
+          commit={commit}
         />
       )}
 

--- a/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
@@ -85,19 +85,32 @@ export default function PoolPanel({
   const [vibesBusy, setVibesBusy] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
     setVibes(new Map());
     setShowVibes(false);
     setVibesLoaded(false);
+    setLoaded(false);
     if (snapshot) {
       setPool(snapshot.pool);
       setLoaded(true);
-      return;
+      return () => {
+        cancelled = true;
+      };
     }
     api
       .getPool(setId)
-      .then(setPool)
-      .catch(() => setToast('Failed to load pool'))
-      .finally(() => setLoaded(true));
+      .then((next) => {
+        if (!cancelled) setPool(next);
+      })
+      .catch(() => {
+        if (!cancelled) setToast('Failed to load pool');
+      })
+      .finally(() => {
+        if (!cancelled) setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [setId, snapshot, snapshotVersion]);
 
   useEffect(() => {

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/ImportModal.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/ImportModal.test.tsx
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import type { BuilderPlaylists, PoolImportResult, SearchResult } from '@/lib/api-types';
 import ImportModal from '../ImportModal';
+import type { BuilderCommit } from '../useSetDocumentHistory';
 
 const mockApi = vi.hoisted(() => ({
   getEvents: vi.fn(),
@@ -132,6 +133,27 @@ describe('ImportModal — event flow', () => {
     fireEvent.click(await screen.findByText('Prom Night'));
     fireEvent.click(screen.getByText('Import requests'));
     await waitFor(() => expect(onError).toHaveBeenCalledWith('Event not found'));
+  });
+
+  it('runs the import mutation inside the document-history commit boundary', async () => {
+    mockApi.getEvents.mockResolvedValue([{ id: 7, code: 'ABC123', name: 'Prom Night' }]);
+    mockApi.importPoolEvent.mockResolvedValue(IMPORT_RESULT);
+    const commitSpy = vi.fn();
+    const commit: BuilderCommit = async (label, action) => {
+      commitSpy(label, action);
+      return action();
+    };
+    const onImported = vi.fn();
+    render(<ImportModal kind="event" {...baseProps} commit={commit} onImported={onImported} />);
+
+    fireEvent.click(await screen.findByText('Prom Night'));
+    fireEvent.click(screen.getByText('Import requests'));
+
+    await waitFor(() =>
+      expect(commitSpy).toHaveBeenCalledWith('Import event requests', expect.any(Function)),
+    );
+    expect(mockApi.importPoolEvent).toHaveBeenCalledWith(1, 7);
+    expect(onImported).toHaveBeenCalledWith(IMPORT_RESULT);
   });
 
   it('closes via the Cancel button and the backdrop', async () => {

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/useSetDocumentHistory.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/useSetDocumentHistory.test.tsx
@@ -1,0 +1,140 @@
+import { act, render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SetDocumentSnapshot } from '@/lib/api-types';
+import { useSetDocumentHistory } from '../useSetDocumentHistory';
+
+const mockApi = vi.hoisted(() => ({
+  getSetDocument: vi.fn(),
+  putSetDocument: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({ api: mockApi }));
+
+function snapshot(targetEnergy: number | null): SetDocumentSnapshot {
+  return {
+    settings: {
+      vibe_theme: null,
+      target_duration_sec: null,
+      bpm_floor: null,
+      bpm_ceiling: null,
+      key_strictness: 0.2,
+    },
+    slots: [
+      {
+        id: 1,
+        position: 0,
+        track_id: 'manual:1',
+        locked: false,
+        notes: null,
+        transition_score: null,
+        transition_warnings: null,
+        target_energy: targetEnergy,
+      },
+    ],
+    curve_points: [],
+    pool: { sources: [], tracks: [] },
+  };
+}
+
+function clone(doc: SetDocumentSnapshot): SetDocumentSnapshot {
+  return JSON.parse(JSON.stringify(doc)) as SetDocumentSnapshot;
+}
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function Harness({ mutate }: { mutate: () => Promise<void> }) {
+  const history = useSetDocumentHistory(5);
+  return (
+    <div>
+      <div data-testid="undo-depth">{history.undoDepth}</div>
+      <div data-testid="redo-depth">{history.redoDepth}</div>
+      <div data-testid="dirty">{String(history.isDirty)}</div>
+      <div data-testid="undo-label">{history.nextUndoLabel ?? ''}</div>
+      <div data-testid="redo-label">{history.nextRedoLabel ?? ''}</div>
+      <div data-testid="slot-target">{history.snapshot?.slots[0]?.target_energy ?? 'none'}</div>
+      <button onClick={() => void history.commit('Retarget slot 1', mutate)}>commit</button>
+      <button onClick={() => void history.undo()}>undo</button>
+      <button onClick={() => void history.redo()}>redo</button>
+      <button onClick={() => void history.saveNow()}>save</button>
+    </div>
+  );
+}
+
+describe('useSetDocumentHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    let serverDoc = snapshot(null);
+    mockApi.getSetDocument.mockImplementation(() => Promise.resolve(clone(serverDoc)));
+    mockApi.putSetDocument.mockImplementation((_setId: number, doc: SetDocumentSnapshot) => {
+      serverDoc = clone(doc);
+      return Promise.resolve(clone(serverDoc));
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('records labeled commits, undo restores the prior snapshot, and redo restores the later one', async () => {
+    let serverDoc = snapshot(null);
+    mockApi.getSetDocument.mockImplementation(() => Promise.resolve(clone(serverDoc)));
+    mockApi.putSetDocument.mockImplementation((_setId: number, doc: SetDocumentSnapshot) => {
+      serverDoc = clone(doc);
+      return Promise.resolve(clone(serverDoc));
+    });
+
+    render(<Harness mutate={() => Promise.resolve().then(() => void (serverDoc = snapshot(8.5)))} />);
+
+    await waitFor(() => expect(screen.getByTestId('slot-target')).toHaveTextContent('none'));
+    fireEvent.click(screen.getByText('commit'));
+
+    await waitFor(() => expect(screen.getByTestId('undo-depth')).toHaveTextContent('1'));
+    expect(screen.getByTestId('undo-label')).toHaveTextContent('Retarget slot 1');
+    expect(screen.getByTestId('slot-target')).toHaveTextContent('8.5');
+
+    fireEvent.click(screen.getByText('undo'));
+    await waitFor(() => expect(screen.getByTestId('slot-target')).toHaveTextContent('none'));
+    expect(screen.getByTestId('redo-depth')).toHaveTextContent('1');
+    expect(screen.getByTestId('redo-label')).toHaveTextContent('Retarget slot 1');
+    expect(mockApi.putSetDocument).toHaveBeenLastCalledWith(5, snapshot(null));
+
+    fireEvent.click(screen.getByText('redo'));
+    await waitFor(() => expect(screen.getByTestId('slot-target')).toHaveTextContent('8.5'));
+    expect(mockApi.putSetDocument).toHaveBeenLastCalledWith(5, snapshot(8.5));
+  });
+
+  it('manual save writes the current snapshot without adding history depth', async () => {
+    render(<Harness mutate={() => Promise.resolve()} />);
+
+    await waitFor(() => expect(mockApi.getSetDocument).toHaveBeenCalledWith(5));
+    fireEvent.click(screen.getByText('save'));
+
+    await waitFor(() => expect(mockApi.putSetDocument).toHaveBeenCalledWith(5, snapshot(null)));
+    expect(screen.getByTestId('undo-depth')).toHaveTextContent('0');
+  });
+
+  it('autosaves every 30s while dirty after a failed save', async () => {
+    vi.useFakeTimers();
+    mockApi.putSetDocument.mockRejectedValueOnce(new Error('network failed'));
+    render(<Harness mutate={() => Promise.resolve()} />);
+
+    await flushReact();
+    expect(mockApi.getSetDocument).toHaveBeenCalledWith(5);
+    fireEvent.click(screen.getByText('save'));
+
+    await flushReact();
+    expect(screen.getByTestId('dirty')).toHaveTextContent('true');
+    mockApi.putSetDocument.mockResolvedValue(clone(snapshot(null)));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    expect(screen.getByTestId('dirty')).toHaveTextContent('false');
+    expect(mockApi.putSetDocument).toHaveBeenCalledTimes(2);
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/components/useSetDocumentHistory.ts
+++ b/dashboard/app/(dj)/setbuilder/components/useSetDocumentHistory.ts
@@ -45,6 +45,17 @@ export function useSetDocumentHistory(setId: number) {
   const [toast, setToast] = useState<string | null>(null);
   const [autosave, setAutosaveState] = useState(true);
   const snapshotRef = useRef<SetDocumentSnapshot | null>(null);
+  const operationInFlightRef = useRef(false);
+
+  const beginOperation = useCallback(() => {
+    if (operationInFlightRef.current) return false;
+    operationInFlightRef.current = true;
+    return true;
+  }, []);
+
+  const finishOperation = useCallback(() => {
+    operationInFlightRef.current = false;
+  }, []);
 
   const publishSnapshot = useCallback((next: SetDocumentSnapshot) => {
     snapshotRef.current = cloneSnapshot(next);
@@ -57,6 +68,11 @@ export function useSetDocumentHistory(setId: number) {
     setSaveError(null);
     setUndoStack([]);
     setRedoStack([]);
+    snapshotRef.current = null;
+    setSnapshot(null);
+    setSnapshotVersion(0);
+    setLastSavedAt(null);
+    setIsDirty(false);
     setAutosaveState(readAutosave());
     api
       .getSetDocument(setId)
@@ -99,11 +115,14 @@ export function useSetDocumentHistory(setId: number) {
 
   const commit: BuilderCommit = useCallback(
     async (label, action) => {
-      const before = await fetchCurrent();
-      setIsSaving(true);
-      setIsDirty(true);
-      setSaveError(null);
+      if (!beginOperation()) {
+        throw new Error('Another document history operation is already in progress');
+      }
       try {
+        const before = await fetchCurrent();
+        setIsSaving(true);
+        setIsDirty(true);
+        setSaveError(null);
         const result = await action();
         const after = await api.getSetDocument(setId);
         setUndoStack((prev) => [...prev, { label, snapshot: before }].slice(-50));
@@ -117,9 +136,10 @@ export function useSetDocumentHistory(setId: number) {
         throw error;
       } finally {
         setIsSaving(false);
+        finishOperation();
       }
     },
-    [fetchCurrent, publishSnapshot, setId],
+    [beginOperation, fetchCurrent, finishOperation, publishSnapshot, setId],
   );
 
   const restore = useCallback(
@@ -127,11 +147,12 @@ export function useSetDocumentHistory(setId: number) {
       const source = direction === 'undo' ? undoStack : redoStack;
       const entry = source[source.length - 1];
       if (!entry) return;
-      const current = await fetchCurrent();
-      setIsSaving(true);
-      setIsDirty(true);
-      setSaveError(null);
+      if (!beginOperation()) return;
       try {
+        const current = await fetchCurrent();
+        setIsSaving(true);
+        setIsDirty(true);
+        setSaveError(null);
         const restored = await api.putSetDocument(setId, entry.snapshot);
         if (direction === 'undo') {
           setUndoStack((prev) => prev.slice(0, -1));
@@ -149,20 +170,22 @@ export function useSetDocumentHistory(setId: number) {
         setSaveError(error instanceof Error ? error.message : 'Restore failed');
       } finally {
         setIsSaving(false);
+        finishOperation();
       }
     },
-    [fetchCurrent, publishSnapshot, redoStack, setId, undoStack],
+    [beginOperation, fetchCurrent, finishOperation, publishSnapshot, redoStack, setId, undoStack],
   );
 
   const undo = useCallback(() => restore('undo'), [restore]);
   const redo = useCallback(() => restore('redo'), [restore]);
 
   const saveNow = useCallback(async () => {
-    const current = await fetchCurrent();
-    setIsSaving(true);
-    setIsDirty(true);
-    setSaveError(null);
+    if (!beginOperation()) return;
     try {
+      const current = await fetchCurrent();
+      setIsSaving(true);
+      setIsDirty(true);
+      setSaveError(null);
       const saved = await api.putSetDocument(setId, current);
       publishSnapshot(saved);
       setLastSavedAt(new Date());
@@ -172,8 +195,9 @@ export function useSetDocumentHistory(setId: number) {
       setSaveError(error instanceof Error ? error.message : 'Save failed');
     } finally {
       setIsSaving(false);
+      finishOperation();
     }
-  }, [fetchCurrent, publishSnapshot, setId]);
+  }, [beginOperation, fetchCurrent, finishOperation, publishSnapshot, setId]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {

--- a/dashboard/app/(dj)/setbuilder/components/useSetDocumentHistory.ts
+++ b/dashboard/app/(dj)/setbuilder/components/useSetDocumentHistory.ts
@@ -1,0 +1,256 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { api } from '@/lib/api';
+import type { SetDocumentSnapshot } from '@/lib/api-types';
+
+const AUTOSAVE_KEY = 'wrzdj.setbuilder.autosave';
+
+export type BuilderCommit = <T>(label: string, action: () => Promise<T> | T) => Promise<T>;
+
+interface HistoryEntry {
+  label: string;
+  snapshot: SetDocumentSnapshot;
+}
+
+function readAutosave(): boolean {
+  try {
+    return window.localStorage.getItem(AUTOSAVE_KEY) !== 'false';
+  } catch {
+    return true;
+  }
+}
+
+function writeAutosave(value: boolean): void {
+  try {
+    window.localStorage.setItem(AUTOSAVE_KEY, String(value));
+  } catch {
+    // Best-effort browser preference.
+  }
+}
+
+function cloneSnapshot(snapshot: SetDocumentSnapshot): SetDocumentSnapshot {
+  return JSON.parse(JSON.stringify(snapshot)) as SetDocumentSnapshot;
+}
+
+export function useSetDocumentHistory(setId: number) {
+  const [snapshot, setSnapshot] = useState<SetDocumentSnapshot | null>(null);
+  const [snapshotVersion, setSnapshotVersion] = useState(0);
+  const [undoStack, setUndoStack] = useState<HistoryEntry[]>([]);
+  const [redoStack, setRedoStack] = useState<HistoryEntry[]>([]);
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [autosave, setAutosaveState] = useState(true);
+  const snapshotRef = useRef<SetDocumentSnapshot | null>(null);
+
+  const publishSnapshot = useCallback((next: SetDocumentSnapshot) => {
+    snapshotRef.current = cloneSnapshot(next);
+    setSnapshot(next);
+    setSnapshotVersion((v) => v + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSaveError(null);
+    setUndoStack([]);
+    setRedoStack([]);
+    setAutosaveState(readAutosave());
+    api
+      .getSetDocument(setId)
+      .then((doc) => {
+        if (cancelled) return;
+        publishSnapshot(doc);
+        setLastSavedAt(new Date());
+        setIsDirty(false);
+      })
+      .catch(() => {
+        if (!cancelled) setSaveError('Failed to load document history');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [publishSnapshot, setId]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const handle = window.setTimeout(() => setToast(null), 2500);
+    return () => window.clearTimeout(handle);
+  }, [toast]);
+
+  useEffect(() => {
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!isDirty && !isSaving && !saveError) return;
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, [isDirty, isSaving, saveError]);
+
+  const fetchCurrent = useCallback(async () => {
+    if (snapshotRef.current) return cloneSnapshot(snapshotRef.current);
+    const current = await api.getSetDocument(setId);
+    publishSnapshot(current);
+    return cloneSnapshot(current);
+  }, [publishSnapshot, setId]);
+
+  const commit: BuilderCommit = useCallback(
+    async (label, action) => {
+      const before = await fetchCurrent();
+      setIsSaving(true);
+      setIsDirty(true);
+      setSaveError(null);
+      try {
+        const result = await action();
+        const after = await api.getSetDocument(setId);
+        setUndoStack((prev) => [...prev, { label, snapshot: before }].slice(-50));
+        setRedoStack([]);
+        publishSnapshot(after);
+        setLastSavedAt(new Date());
+        setIsDirty(false);
+        return result;
+      } catch (error) {
+        setSaveError(error instanceof Error ? error.message : 'Save failed');
+        throw error;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [fetchCurrent, publishSnapshot, setId],
+  );
+
+  const restore = useCallback(
+    async (direction: 'undo' | 'redo') => {
+      const source = direction === 'undo' ? undoStack : redoStack;
+      const entry = source[source.length - 1];
+      if (!entry) return;
+      const current = await fetchCurrent();
+      setIsSaving(true);
+      setIsDirty(true);
+      setSaveError(null);
+      try {
+        const restored = await api.putSetDocument(setId, entry.snapshot);
+        if (direction === 'undo') {
+          setUndoStack((prev) => prev.slice(0, -1));
+          setRedoStack((prev) => [...prev, { label: entry.label, snapshot: current }].slice(-50));
+          setToast(`Undid ${entry.label}`);
+        } else {
+          setRedoStack((prev) => prev.slice(0, -1));
+          setUndoStack((prev) => [...prev, { label: entry.label, snapshot: current }].slice(-50));
+          setToast(`Redid ${entry.label}`);
+        }
+        publishSnapshot(restored);
+        setLastSavedAt(new Date());
+        setIsDirty(false);
+      } catch (error) {
+        setSaveError(error instanceof Error ? error.message : 'Restore failed');
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [fetchCurrent, publishSnapshot, redoStack, setId, undoStack],
+  );
+
+  const undo = useCallback(() => restore('undo'), [restore]);
+  const redo = useCallback(() => restore('redo'), [restore]);
+
+  const saveNow = useCallback(async () => {
+    const current = await fetchCurrent();
+    setIsSaving(true);
+    setIsDirty(true);
+    setSaveError(null);
+    try {
+      const saved = await api.putSetDocument(setId, current);
+      publishSnapshot(saved);
+      setLastSavedAt(new Date());
+      setIsDirty(false);
+      setToast('Saved');
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : 'Save failed');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [fetchCurrent, publishSnapshot, setId]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const tagName = target?.tagName?.toLowerCase();
+      if (tagName === 'input' || tagName === 'textarea' || target?.isContentEditable) return;
+      const mod = event.metaKey || event.ctrlKey;
+      if (!mod) return;
+      const key = event.key.toLowerCase();
+      if (key === 'z' && event.shiftKey) {
+        event.preventDefault();
+        void redo();
+      } else if (key === 'z') {
+        event.preventDefault();
+        void undo();
+      } else if (key === 'y') {
+        event.preventDefault();
+        void redo();
+      } else if (key === 's') {
+        event.preventDefault();
+        void saveNow();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [redo, saveNow, undo]);
+
+  const setAutosave = useCallback((value: boolean) => {
+    setAutosaveState(value);
+    writeAutosave(value);
+  }, []);
+
+  useEffect(() => {
+    if (!autosave) return;
+    const handle = window.setInterval(() => {
+      if (!isDirty || isSaving) return;
+      void saveNow();
+    }, 30_000);
+    return () => window.clearInterval(handle);
+  }, [autosave, isDirty, isSaving, saveNow]);
+
+  return useMemo(
+    () => ({
+      snapshot,
+      snapshotVersion,
+      commit,
+      undo,
+      redo,
+      saveNow,
+      undoDepth: undoStack.length,
+      redoDepth: redoStack.length,
+      nextUndoLabel: undoStack.at(-1)?.label ?? null,
+      nextRedoLabel: redoStack.at(-1)?.label ?? null,
+      isSaving,
+      isDirty,
+      saveError,
+      lastSavedAt,
+      autosave,
+      setAutosave,
+      toast,
+    }),
+    [
+      autosave,
+      commit,
+      isSaving,
+      isDirty,
+      lastSavedAt,
+      redo,
+      redoStack,
+      saveError,
+      saveNow,
+      setAutosave,
+      snapshot,
+      snapshotVersion,
+      toast,
+      undo,
+      undoStack,
+    ],
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/setbuilder.module.css
+++ b/dashboard/app/(dj)/setbuilder/setbuilder.module.css
@@ -23,17 +23,35 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1rem;
   height: 56px;
   padding: 0 1rem;
   background: var(--card);
   border-bottom: 1px solid var(--border);
 }
 
-.topbarTitle {
+.topbarLeft,
+.topbarActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.topbarActions {
+  flex-shrink: 0;
+}
+
+.topbarTitle,
+.brandTitle {
   font-family: var(--font-display), sans-serif;
   font-weight: 600;
   font-size: 1rem;
   color: var(--text);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .topbarPairingsBtn {
@@ -1456,6 +1474,12 @@
   font-weight: 800;
 }
 
+.warningBtn {
+  background: rgba(245, 158, 11, 0.14) !important;
+  border-color: rgba(245, 158, 11, 0.38) !important;
+  color: #fbbf24 !important;
+}
+
 .poolToast {
   position: absolute;
   left: 50%;
@@ -1762,5 +1786,293 @@
   .pairingStatsGrid,
   .pairingAddGrid {
     grid-template-columns: 1fr;
+  }
+}
+
+/* Document history / settings (#395) - functional styling only. */
+
+.brandMenuWrap {
+  position: relative;
+  min-width: 0;
+}
+
+.brandButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  max-width: min(34vw, 28rem);
+  padding: 0.32rem 0.55rem;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.brandButton:hover,
+.brandButton:focus-visible {
+  background: var(--surface-raised, rgba(255, 255, 255, 0.06));
+  border-color: var(--border-subtle);
+  outline: none;
+}
+
+.brandMenu {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  left: 0;
+  z-index: 60;
+  width: 260px;
+  padding: 0.35rem;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.48);
+}
+
+.brandMenuItem {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.5rem 0.55rem;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.brandMenuItem:hover:not(:disabled) {
+  background: var(--surface-raised, rgba(255, 255, 255, 0.06));
+}
+
+.brandMenuItem:disabled {
+  cursor: default;
+  opacity: 0.72;
+}
+
+.brandSaveRow {
+  align-items: flex-start;
+}
+
+.saveDot {
+  width: 0.55rem;
+  height: 0.55rem;
+  flex-shrink: 0;
+  margin-top: 0.22rem;
+  border-radius: 999px;
+  background: #34d399;
+  box-shadow: 0 0 0 3px rgba(52, 211, 153, 0.1);
+}
+
+.saveDotDirty {
+  background: #f59e0b;
+  animation: savePulse 1.5s ease-in-out infinite;
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.14);
+}
+
+.saveLabel,
+.saveSub {
+  display: block;
+}
+
+.saveLabel {
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.saveSub {
+  margin-top: 0.1rem;
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+  line-height: 1.35;
+}
+
+.historyControls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.historyIconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.15rem;
+  min-width: 2.45rem;
+  height: 2rem;
+  padding: 0 0.45rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--surface-raised, rgba(255, 255, 255, 0.05));
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.historyIconButton:hover:not(:disabled) {
+  border-color: var(--border);
+  background: var(--surface-raised, rgba(255, 255, 255, 0.08));
+}
+
+.historyIconButton:disabled {
+  cursor: default;
+  opacity: 0.48;
+}
+
+.depthBadge {
+  display: inline-block;
+  min-width: 1.15rem;
+  margin-left: 0.2rem;
+  border-radius: 999px;
+  background: var(--surface-raised, rgba(255, 255, 255, 0.08));
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+  line-height: 1.2;
+  text-align: center;
+}
+
+.settingsModal,
+.confirmDialog {
+  position: relative;
+  z-index: 1;
+  width: min(520px, calc(100vw - 2rem));
+  max-height: min(680px, calc(100vh - 4rem));
+  overflow: auto;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--text);
+}
+
+.settingsHeader {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.settingsHeader h2,
+.confirmDialog h2 {
+  margin: 0;
+  flex: 1;
+  font-size: 1rem;
+}
+
+.settingsSection {
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.settingsSection h3 {
+  margin: 0 0 0.55rem;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.settingsToggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.45rem 0;
+}
+
+.settingsToggleTitle,
+.settingsToggleDescription {
+  display: block;
+}
+
+.settingsToggleTitle {
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.settingsToggleDescription,
+.settingsNote,
+.confirmDialog p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.confirmDialog {
+  padding: 1rem;
+}
+
+.confirmHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.confirmIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  flex-shrink: 0;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 800;
+}
+
+.confirmIconWarning {
+  background: rgba(245, 158, 11, 0.14);
+  color: #fbbf24;
+}
+
+.confirmIconDanger {
+  background: rgba(239, 68, 68, 0.14);
+  color: #f87171;
+}
+
+.confirmIconNeutral {
+  background: var(--surface-raised, rgba(255, 255, 255, 0.08));
+  color: var(--text-secondary);
+}
+
+.confirmBody {
+  margin-top: 0.75rem;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.confirmBody p {
+  margin: 0 0 0.45rem;
+}
+
+.confirmBody ul {
+  margin: 0.45rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.confirmBody li + li {
+  margin-top: 0.25rem;
+}
+
+.confirmActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+@keyframes savePulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(0.72);
+    opacity: 0.7;
   }
 }

--- a/dashboard/app/(dj)/setbuilder/setbuilder.module.css
+++ b/dashboard/app/(dj)/setbuilder/setbuilder.module.css
@@ -1868,7 +1868,7 @@
 
 .saveDotDirty {
   background: #f59e0b;
-  animation: savePulse 1.5s ease-in-out infinite;
+  animation: save-pulse 1.5s ease-in-out infinite;
   box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.14);
 }
 
@@ -2065,7 +2065,7 @@
   margin-top: 1rem;
 }
 
-@keyframes savePulse {
+@keyframes save-pulse {
   0%,
   100% {
     transform: scale(1);

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -2726,6 +2726,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/setbuilder/sets/{set_id}/document": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Document Snapshot
+         * @description Full restorable builder document snapshot for one of the current DJ's sets.
+         */
+        get: operations["get_document_snapshot_api_setbuilder_sets__set_id__document_get"];
+        /**
+         * Put Document Snapshot
+         * @description Replace the restorable builder document with a prior snapshot.
+         */
+        put: operations["put_document_snapshot_api_setbuilder_sets__set_id__document_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/setbuilder/sets/{set_id}/duplicate": {
         parameters: {
             query?: never;
@@ -6045,6 +6069,173 @@ export interface components {
             updated_at: string;
             /** Vibe Theme */
             vibe_theme: string | null;
+        };
+        /**
+         * SetDocumentCurvePoint
+         * @description Curve/vibe-window row as stored in a document snapshot.
+         */
+        SetDocumentCurvePoint: {
+            /** Energy */
+            energy: number;
+            /** Id */
+            id: number;
+            /**
+             * Is Slow Window End
+             * @default false
+             */
+            is_slow_window_end: boolean;
+            /**
+             * Is Slow Window Start
+             * @default false
+             */
+            is_slow_window_start: boolean;
+            /** Label */
+            label: string | null;
+            /** Position Sec */
+            position_sec: number;
+        };
+        /**
+         * SetDocumentPool
+         * @description Pool state in a restorable document snapshot.
+         */
+        SetDocumentPool: {
+            /** Sources */
+            sources: components["schemas"]["SetDocumentPoolSource"][];
+            /** Tracks */
+            tracks: components["schemas"]["SetDocumentPoolTrack"][];
+        };
+        /**
+         * SetDocumentPoolSource
+         * @description Pool source row as stored in a document snapshot.
+         */
+        SetDocumentPoolSource: {
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** External Ref */
+            external_ref: string | null;
+            /** Id */
+            id: number;
+            /**
+             * Kind
+             * @enum {string}
+             */
+            kind: "event" | "tidal" | "beatport" | "public_url" | "manual";
+            /** Label */
+            label: string;
+            /** Meta */
+            meta: string | null;
+        };
+        /**
+         * SetDocumentPoolTrack
+         * @description Pool track row as stored in a document snapshot.
+         */
+        SetDocumentPoolTrack: {
+            /** Album */
+            album: string | null;
+            /** Artist */
+            artist: string;
+            /** Artwork Url */
+            artwork_url: string | null;
+            /** Bpm */
+            bpm: number | null;
+            /** Camelot */
+            camelot: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Dedupe Sig */
+            dedupe_sig: string;
+            /** Duration Sec */
+            duration_sec: number | null;
+            /** Energy */
+            energy: number | null;
+            /** Genre */
+            genre: string | null;
+            /** Id */
+            id: number;
+            /** Isrc */
+            isrc: string | null;
+            /** Key */
+            key: string | null;
+            /** Source Id */
+            source_id: number;
+            /** Title */
+            title: string;
+            /** Track Id */
+            track_id: string | null;
+        };
+        /**
+         * SetDocumentSettings
+         * @description Mutable target-setting fields included in history/autosave snapshots.
+         */
+        SetDocumentSettings: {
+            /** Bpm Ceiling */
+            bpm_ceiling: number | null;
+            /** Bpm Floor */
+            bpm_floor: number | null;
+            /**
+             * Key Strictness
+             * @default 0.2
+             */
+            key_strictness: number;
+            /** Target Duration Sec */
+            target_duration_sec: number | null;
+            /** Vibe Theme */
+            vibe_theme: string | null;
+        };
+        /**
+         * SetDocumentSlot
+         * @description Slot row as stored in a document snapshot.
+         */
+        SetDocumentSlot: {
+            /** Id */
+            id: number;
+            /**
+             * Locked
+             * @default false
+             */
+            locked: boolean;
+            /** Notes */
+            notes: string | null;
+            /** Position */
+            position: number;
+            /** Target Energy */
+            target_energy: number | null;
+            /** Track Id */
+            track_id: string | null;
+            /** Transition Score */
+            transition_score: number | null;
+            /** Transition Warnings */
+            transition_warnings: string | null;
+        };
+        /**
+         * SetDocumentSnapshot
+         * @description Full builder document snapshot for undo/redo and autosave.
+         */
+        "SetDocumentSnapshot-Input": {
+            /** Curve Points */
+            curve_points?: components["schemas"]["SetDocumentCurvePoint"][];
+            pool: components["schemas"]["SetDocumentPool"];
+            settings: components["schemas"]["SetDocumentSettings"];
+            /** Slots */
+            slots?: components["schemas"]["SetDocumentSlot"][];
+        };
+        /**
+         * SetDocumentSnapshot
+         * @description Full builder document snapshot for undo/redo and autosave.
+         */
+        "SetDocumentSnapshot-Output": {
+            /** Curve Points */
+            curve_points: components["schemas"]["SetDocumentCurvePoint"][];
+            pool: components["schemas"]["SetDocumentPool"];
+            settings: components["schemas"]["SetDocumentSettings"];
+            /** Slots */
+            slots: components["schemas"]["SetDocumentSlot"][];
         };
         /**
          * SetRename
@@ -11596,6 +11787,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ApplyTemplateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_document_snapshot_api_setbuilder_sets__set_id__document_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetDocumentSnapshot-Output"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    put_document_snapshot_api_setbuilder_sets__set_id__document_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetDocumentSnapshot-Input"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetDocumentSnapshot-Output"];
                 };
             };
             /** @description Validation Error */

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -6219,11 +6219,11 @@ export interface components {
          */
         "SetDocumentSnapshot-Input": {
             /** Curve Points */
-            curve_points?: components["schemas"]["SetDocumentCurvePoint"][];
+            curve_points: components["schemas"]["SetDocumentCurvePoint"][];
             pool: components["schemas"]["SetDocumentPool"];
             settings: components["schemas"]["SetDocumentSettings"];
             /** Slots */
-            slots?: components["schemas"]["SetDocumentSlot"][];
+            slots: components["schemas"]["SetDocumentSlot"][];
         };
         /**
          * SetDocumentSnapshot
@@ -11820,6 +11820,13 @@ export interface operations {
                     "application/json": components["schemas"]["SetDocumentSnapshot-Output"];
                 };
             };
+            /** @description Set not found or not accessible */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -11854,6 +11861,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SetDocumentSnapshot-Output"];
                 };
+            };
+            /** @description Set not found or not accessible */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -206,6 +206,12 @@ export type SlotTargetOut = Schemas['SlotTargetOut'];
 export type ApplyTemplateResponse = Schemas['ApplyTemplateResponse'];
 export type VibeWindow = Schemas['VibeWindowModel'];
 export type VibeWindowsResponse = Schemas['VibeWindowsResponse'];
+export type SetDocumentSettings = Schemas['SetDocumentSettings'];
+export type SetDocumentSlot = Schemas['SetDocumentSlot'];
+export type SetDocumentCurvePoint = Schemas['SetDocumentCurvePoint'];
+export type SetDocumentPoolSource = Schemas['SetDocumentPoolSource'];
+export type SetDocumentPoolTrack = Schemas['SetDocumentPoolTrack'];
+export type SetDocumentSnapshot = Schemas['SetDocumentSnapshot-Output'];
 
 // WrzDJSet two-pass builder (#390)
 export type BuildSetResponse = Schemas['BuildSetResponse'];

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -66,6 +66,7 @@ import type {
   RecommendationResponse,
   SearchResult,
   SetCritique,
+  SetDocumentSnapshot,
   SetDetail,
   SetSlotOut,
   SetSummary,
@@ -167,6 +168,7 @@ export type {
   SearchResult,
   ServiceCapabilities,
   SetCritique,
+  SetDocumentSnapshot,
   SetDetail,
   SetSummary,
   SharedCurvePointView,
@@ -696,6 +698,18 @@ class ApiClient {
   }
   async getSet(setId: number): Promise<SetDetail> {
     return this.fetch(`/api/setbuilder/sets/${setId}`);
+  }
+  async getSetDocument(setId: number): Promise<SetDocumentSnapshot> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/document`);
+  }
+  async putSetDocument(
+    setId: number,
+    snapshot: SetDocumentSnapshot
+  ): Promise<SetDocumentSnapshot> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/document`, {
+      method: 'PUT',
+      body: JSON.stringify(snapshot),
+    });
   }
   async renameSet(setId: number, name: string): Promise<SetDetail> {
     return this.fetch(`/api/setbuilder/sets/${setId}`, {

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -58,6 +58,7 @@ from app.schemas.setbuilder import (
     SetCreate,
     SetCritiqueOut,
     SetDetail,
+    SetDocumentSnapshot,
     SetRename,
     SetSummary,
     SlotOut,
@@ -81,6 +82,7 @@ from app.services.llm.exceptions import NoLlmConfigured
 from app.services.now_playing import get_now_playing
 from app.services.setbuilder import (
     curve,
+    document_snapshot,
     export_common,
     export_files,
     export_tidal,
@@ -637,7 +639,6 @@ def put_vibe_windows(
 
 # ---------------------------------------------------------------------------
 # Transport (issue #393) — queue playback commands for the attached event's Bridge.
-# ---------------------------------------------------------------------------
 
 
 @router.post("/sets/{set_id}/transport/command", response_model=TransportCommandOut)
@@ -702,6 +703,37 @@ def get_transport_status(
         device_name=now_playing.bridge_device_name,
         last_seen=now_playing.bridge_last_seen,
     )
+
+
+# ---------------------------------------------------------------------------
+# Document snapshots (issue #395) — undo/redo + autosave restore surface.
+
+
+@router.get("/sets/{set_id}/document", response_model=SetDocumentSnapshot)
+@limiter.limit("60/minute")
+def get_document_snapshot(
+    set_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> SetDocumentSnapshot:
+    """Full restorable builder document snapshot for one of the current DJ's sets."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    return document_snapshot.build_snapshot(set_obj)
+
+
+@router.put("/sets/{set_id}/document", response_model=SetDocumentSnapshot)
+@limiter.limit("30/minute")
+def put_document_snapshot(
+    set_id: int,
+    payload: SetDocumentSnapshot,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> SetDocumentSnapshot:
+    """Replace the restorable builder document with a prior snapshot."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    return document_snapshot.restore_snapshot(db, set_obj, payload)
 
 
 # ---------------------------------------------------------------------------

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -709,7 +709,11 @@ def get_transport_status(
 # Document snapshots (issue #395) — undo/redo + autosave restore surface.
 
 
-@router.get("/sets/{set_id}/document", response_model=SetDocumentSnapshot)
+@router.get(
+    "/sets/{set_id}/document",
+    response_model=SetDocumentSnapshot,
+    responses={404: {"description": "Set not found or not accessible"}},
+)
 @limiter.limit("60/minute")
 def get_document_snapshot(
     set_id: int,
@@ -722,7 +726,11 @@ def get_document_snapshot(
     return document_snapshot.build_snapshot(set_obj)
 
 
-@router.put("/sets/{set_id}/document", response_model=SetDocumentSnapshot)
+@router.put(
+    "/sets/{set_id}/document",
+    response_model=SetDocumentSnapshot,
+    responses={404: {"description": "Set not found or not accessible"}},
+)
 @limiter.limit("30/minute")
 def put_document_snapshot(
     set_id: int,

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -543,6 +543,110 @@ class TransportStatusOut(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Document snapshots (issue #395)
+
+
+class SetDocumentSettings(BaseModel):
+    """Mutable target-setting fields included in history/autosave snapshots."""
+
+    vibe_theme: str | None = Field(None, max_length=50)
+    target_duration_sec: int | None = Field(None, ge=0, le=36000)
+    bpm_floor: int | None = Field(None, ge=0, le=400)
+    bpm_ceiling: int | None = Field(None, ge=0, le=400)
+    key_strictness: float = Field(0.2, ge=0.0, le=1.0)
+
+    @model_validator(mode="after")
+    def _bpm_ordered(self) -> "SetDocumentSettings":
+        if (
+            self.bpm_floor is not None
+            and self.bpm_ceiling is not None
+            and self.bpm_ceiling < self.bpm_floor
+        ):
+            raise ValueError("bpm_ceiling must be greater than or equal to bpm_floor")
+        return self
+
+
+class SetDocumentSlot(BaseModel):
+    """Slot row as stored in a document snapshot."""
+
+    id: int = Field(..., ge=1)
+    position: int = Field(..., ge=0)
+    track_id: str | None = Field(None, max_length=255)
+    locked: bool = False
+    notes: str | None = None
+    transition_score: float | None = None
+    transition_warnings: str | None = None
+    target_energy: float | None = Field(None, ge=0.0, le=10.0)
+
+
+class SetDocumentCurvePoint(BaseModel):
+    """Curve/vibe-window row as stored in a document snapshot."""
+
+    id: int = Field(..., ge=1)
+    position_sec: int = Field(..., ge=0)
+    energy: int = Field(..., ge=0, le=10)
+    label: str | None = Field(None, max_length=50)
+    is_slow_window_start: bool = False
+    is_slow_window_end: bool = False
+
+
+class SetDocumentPoolSource(BaseModel):
+    """Pool source row as stored in a document snapshot."""
+
+    id: int = Field(..., ge=1)
+    kind: Literal["event", "tidal", "beatport", "public_url", "manual"]
+    external_ref: str | None = Field(None, max_length=500)
+    label: str = Field(..., min_length=1, max_length=200)
+    meta: str | None = Field(None, max_length=200)
+    created_at: datetime
+
+
+class SetDocumentPoolTrack(BaseModel):
+    """Pool track row as stored in a document snapshot."""
+
+    id: int = Field(..., ge=1)
+    source_id: int = Field(..., ge=1)
+    track_id: str | None = Field(None, max_length=255)
+    title: str = Field(..., min_length=1, max_length=255)
+    artist: str = Field(..., min_length=1, max_length=255)
+    album: str | None = Field(None, max_length=255)
+    genre: str | None = Field(None, max_length=100)
+    bpm: float | None = Field(None, ge=0, le=400)
+    key: str | None = Field(None, max_length=20)
+    camelot: str | None = Field(None, max_length=3)
+    energy: int | None = Field(None, ge=0, le=10)
+    isrc: str | None = Field(None, max_length=15)
+    duration_sec: int | None = Field(None, ge=0, le=36000)
+    artwork_url: str | None = Field(None, max_length=500)
+    dedupe_sig: str = Field(..., min_length=1, max_length=64)
+    created_at: datetime
+
+
+class SetDocumentPool(BaseModel):
+    """Pool state in a restorable document snapshot."""
+
+    sources: list[SetDocumentPoolSource] = Field(default_factory=list, max_length=500)
+    tracks: list[SetDocumentPoolTrack] = Field(default_factory=list, max_length=5000)
+
+    @model_validator(mode="after")
+    def _tracks_reference_sources(self) -> "SetDocumentPool":
+        source_ids = {source.id for source in self.sources}
+        missing = [track.source_id for track in self.tracks if track.source_id not in source_ids]
+        if missing:
+            raise ValueError("pool tracks must reference sources in this snapshot")
+        return self
+
+
+class SetDocumentSnapshot(BaseModel):
+    """Full builder document snapshot for undo/redo and autosave."""
+
+    settings: SetDocumentSettings
+    slots: list[SetDocumentSlot] = Field(default_factory=list, max_length=500)
+    curve_points: list[SetDocumentCurvePoint] = Field(default_factory=list, max_length=1000)
+    pool: SetDocumentPool
+
+
+# ---------------------------------------------------------------------------
 # Share links (issue #398)
 
 

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -641,8 +641,8 @@ class SetDocumentSnapshot(BaseModel):
     """Full builder document snapshot for undo/redo and autosave."""
 
     settings: SetDocumentSettings
-    slots: list[SetDocumentSlot] = Field(default_factory=list, max_length=500)
-    curve_points: list[SetDocumentCurvePoint] = Field(default_factory=list, max_length=1000)
+    slots: list[SetDocumentSlot] = Field(..., max_length=500)
+    curve_points: list[SetDocumentCurvePoint] = Field(..., max_length=1000)
     pool: SetDocumentPool
 
 

--- a/server/app/services/setbuilder/document_snapshot.py
+++ b/server/app/services/setbuilder/document_snapshot.py
@@ -107,26 +107,25 @@ def restore_snapshot(
         synchronize_session=False
     )
 
+    source_id_map: dict[int, int] = {}
     for source in snapshot.pool.sources:
-        db.add(
-            SetPoolSource(
-                id=source.id,
-                set_id=set_obj.id,
-                kind=source.kind,
-                external_ref=source.external_ref,
-                label=source.label,
-                meta=source.meta,
-                created_at=source.created_at,
-            )
+        restored_source = SetPoolSource(
+            set_id=set_obj.id,
+            kind=source.kind,
+            external_ref=source.external_ref,
+            label=source.label,
+            meta=source.meta,
+            created_at=source.created_at,
         )
-    db.flush()
+        db.add(restored_source)
+        db.flush()
+        source_id_map[source.id] = restored_source.id
 
     for track in snapshot.pool.tracks:
         db.add(
             SetPoolTrack(
-                id=track.id,
                 set_id=set_obj.id,
-                source_id=track.source_id,
+                source_id=source_id_map[track.source_id],
                 track_id=track.track_id,
                 title=track.title,
                 artist=track.artist,
@@ -147,7 +146,6 @@ def restore_snapshot(
     for slot in snapshot.slots:
         db.add(
             SetSlot(
-                id=slot.id,
                 set_id=set_obj.id,
                 position=slot.position,
                 track_id=slot.track_id,
@@ -162,7 +160,6 @@ def restore_snapshot(
     for point in snapshot.curve_points:
         db.add(
             SetCurvePoint(
-                id=point.id,
                 set_id=set_obj.id,
                 position_sec=point.position_sec,
                 energy=point.energy,

--- a/server/app/services/setbuilder/document_snapshot.py
+++ b/server/app/services/setbuilder/document_snapshot.py
@@ -1,0 +1,177 @@
+"""Restorable WrzDJSet document snapshots for history/autosave (issue #395)."""
+
+from sqlalchemy.orm import Session
+
+from app.models.set import Set, SetCurvePoint, SetSlot
+from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.schemas.setbuilder import (
+    SetDocumentCurvePoint,
+    SetDocumentPool,
+    SetDocumentPoolSource,
+    SetDocumentPoolTrack,
+    SetDocumentSettings,
+    SetDocumentSlot,
+    SetDocumentSnapshot,
+)
+
+
+def build_snapshot(set_obj: Set) -> SetDocumentSnapshot:
+    """Read the current persisted builder document into a restorable snapshot."""
+    return SetDocumentSnapshot(
+        settings=SetDocumentSettings(
+            vibe_theme=set_obj.vibe_theme,
+            target_duration_sec=set_obj.target_duration_sec,
+            bpm_floor=set_obj.bpm_floor,
+            bpm_ceiling=set_obj.bpm_ceiling,
+            key_strictness=set_obj.key_strictness,
+        ),
+        slots=[
+            SetDocumentSlot(
+                id=slot.id,
+                position=slot.position,
+                track_id=slot.track_id,
+                locked=slot.locked,
+                notes=slot.notes,
+                transition_score=slot.transition_score,
+                transition_warnings=slot.transition_warnings,
+                target_energy=slot.target_energy,
+            )
+            for slot in sorted(set_obj.slots, key=lambda s: (s.position, s.id))
+        ],
+        curve_points=[
+            SetDocumentCurvePoint(
+                id=point.id,
+                position_sec=point.position_sec,
+                energy=point.energy,
+                label=point.label,
+                is_slow_window_start=point.is_slow_window_start,
+                is_slow_window_end=point.is_slow_window_end,
+            )
+            for point in sorted(set_obj.curve_points, key=lambda p: p.id)
+        ],
+        pool=SetDocumentPool(
+            sources=[
+                SetDocumentPoolSource(
+                    id=source.id,
+                    kind=source.kind,
+                    external_ref=source.external_ref,
+                    label=source.label,
+                    meta=source.meta,
+                    created_at=source.created_at,
+                )
+                for source in sorted(set_obj.pool_sources, key=lambda s: s.id)
+            ],
+            tracks=[
+                SetDocumentPoolTrack(
+                    id=track.id,
+                    source_id=track.source_id,
+                    track_id=track.track_id,
+                    title=track.title,
+                    artist=track.artist,
+                    album=track.album,
+                    genre=track.genre,
+                    bpm=track.bpm,
+                    key=track.key,
+                    camelot=track.camelot,
+                    energy=track.energy,
+                    isrc=track.isrc,
+                    duration_sec=track.duration_sec,
+                    artwork_url=track.artwork_url,
+                    dedupe_sig=track.dedupe_sig,
+                    created_at=track.created_at,
+                )
+                for track in sorted(set_obj.pool_tracks, key=lambda t: t.id)
+            ],
+        ),
+    )
+
+
+def restore_snapshot(
+    db: Session, set_obj: Set, snapshot: SetDocumentSnapshot
+) -> SetDocumentSnapshot:
+    """Replace restorable document rows with the snapshot and return the stored state."""
+    set_obj.vibe_theme = snapshot.settings.vibe_theme
+    set_obj.target_duration_sec = snapshot.settings.target_duration_sec
+    set_obj.bpm_floor = snapshot.settings.bpm_floor
+    set_obj.bpm_ceiling = snapshot.settings.bpm_ceiling
+    set_obj.key_strictness = snapshot.settings.key_strictness
+
+    db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_obj.id).delete(
+        synchronize_session=False
+    )
+    db.query(SetPoolSource).filter(SetPoolSource.set_id == set_obj.id).delete(
+        synchronize_session=False
+    )
+    db.query(SetSlot).filter(SetSlot.set_id == set_obj.id).delete(synchronize_session=False)
+    db.query(SetCurvePoint).filter(SetCurvePoint.set_id == set_obj.id).delete(
+        synchronize_session=False
+    )
+
+    for source in snapshot.pool.sources:
+        db.add(
+            SetPoolSource(
+                id=source.id,
+                set_id=set_obj.id,
+                kind=source.kind,
+                external_ref=source.external_ref,
+                label=source.label,
+                meta=source.meta,
+                created_at=source.created_at,
+            )
+        )
+    db.flush()
+
+    for track in snapshot.pool.tracks:
+        db.add(
+            SetPoolTrack(
+                id=track.id,
+                set_id=set_obj.id,
+                source_id=track.source_id,
+                track_id=track.track_id,
+                title=track.title,
+                artist=track.artist,
+                album=track.album,
+                genre=track.genre,
+                bpm=track.bpm,
+                key=track.key,
+                camelot=track.camelot,
+                energy=track.energy,
+                isrc=track.isrc,
+                duration_sec=track.duration_sec,
+                artwork_url=track.artwork_url,
+                dedupe_sig=track.dedupe_sig,
+                created_at=track.created_at,
+            )
+        )
+
+    for slot in snapshot.slots:
+        db.add(
+            SetSlot(
+                id=slot.id,
+                set_id=set_obj.id,
+                position=slot.position,
+                track_id=slot.track_id,
+                locked=slot.locked,
+                notes=slot.notes,
+                transition_score=slot.transition_score,
+                transition_warnings=slot.transition_warnings,
+                target_energy=slot.target_energy,
+            )
+        )
+
+    for point in snapshot.curve_points:
+        db.add(
+            SetCurvePoint(
+                id=point.id,
+                set_id=set_obj.id,
+                position_sec=point.position_sec,
+                energy=point.energy,
+                label=point.label,
+                is_slow_window_start=point.is_slow_window_start,
+                is_slow_window_end=point.is_slow_window_end,
+            )
+        )
+
+    db.commit()
+    db.refresh(set_obj)
+    return build_snapshot(set_obj)

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -7651,6 +7651,563 @@
         "title": "SetDetail",
         "type": "object"
       },
+      "SetDocumentCurvePoint": {
+        "description": "Curve/vibe-window row as stored in a document snapshot.",
+        "properties": {
+          "energy": {
+            "maximum": 10.0,
+            "minimum": 0.0,
+            "title": "Energy",
+            "type": "integer"
+          },
+          "id": {
+            "minimum": 1.0,
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_slow_window_end": {
+            "default": false,
+            "title": "Is Slow Window End",
+            "type": "boolean"
+          },
+          "is_slow_window_start": {
+            "default": false,
+            "title": "Is Slow Window Start",
+            "type": "boolean"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "position_sec": {
+            "minimum": 0.0,
+            "title": "Position Sec",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "energy",
+          "id",
+          "is_slow_window_end",
+          "is_slow_window_start",
+          "label",
+          "position_sec"
+        ],
+        "title": "SetDocumentCurvePoint",
+        "type": "object"
+      },
+      "SetDocumentPool": {
+        "description": "Pool state in a restorable document snapshot.",
+        "properties": {
+          "sources": {
+            "items": {
+              "$ref": "#/components/schemas/SetDocumentPoolSource"
+            },
+            "maxItems": 500,
+            "title": "Sources",
+            "type": "array"
+          },
+          "tracks": {
+            "items": {
+              "$ref": "#/components/schemas/SetDocumentPoolTrack"
+            },
+            "maxItems": 5000,
+            "title": "Tracks",
+            "type": "array"
+          }
+        },
+        "required": [
+          "sources",
+          "tracks"
+        ],
+        "title": "SetDocumentPool",
+        "type": "object"
+      },
+      "SetDocumentPoolSource": {
+        "description": "Pool source row as stored in a document snapshot.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "external_ref": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "External Ref"
+          },
+          "id": {
+            "minimum": 1.0,
+            "title": "Id",
+            "type": "integer"
+          },
+          "kind": {
+            "enum": [
+              "event",
+              "tidal",
+              "beatport",
+              "public_url",
+              "manual"
+            ],
+            "title": "Kind",
+            "type": "string"
+          },
+          "label": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Label",
+            "type": "string"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "required": [
+          "created_at",
+          "external_ref",
+          "id",
+          "kind",
+          "label",
+          "meta"
+        ],
+        "title": "SetDocumentPoolSource",
+        "type": "object"
+      },
+      "SetDocumentPoolTrack": {
+        "description": "Pool track row as stored in a document snapshot.",
+        "properties": {
+          "album": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Album"
+          },
+          "artist": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Artist",
+            "type": "string"
+          },
+          "artwork_url": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Artwork Url"
+          },
+          "bpm": {
+            "anyOf": [
+              {
+                "maximum": 400.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm"
+          },
+          "camelot": {
+            "anyOf": [
+              {
+                "maxLength": 3,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Camelot"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "dedupe_sig": {
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Dedupe Sig",
+            "type": "string"
+          },
+          "duration_sec": {
+            "anyOf": [
+              {
+                "maximum": 36000.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Sec"
+          },
+          "energy": {
+            "anyOf": [
+              {
+                "maximum": 10.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Energy"
+          },
+          "genre": {
+            "anyOf": [
+              {
+                "maxLength": 100,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genre"
+          },
+          "id": {
+            "minimum": 1.0,
+            "title": "Id",
+            "type": "integer"
+          },
+          "isrc": {
+            "anyOf": [
+              {
+                "maxLength": 15,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Isrc"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "maxLength": 20,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "source_id": {
+            "minimum": 1.0,
+            "title": "Source Id",
+            "type": "integer"
+          },
+          "title": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          },
+          "track_id": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Track Id"
+          }
+        },
+        "required": [
+          "album",
+          "artist",
+          "artwork_url",
+          "bpm",
+          "camelot",
+          "created_at",
+          "dedupe_sig",
+          "duration_sec",
+          "energy",
+          "genre",
+          "id",
+          "isrc",
+          "key",
+          "source_id",
+          "title",
+          "track_id"
+        ],
+        "title": "SetDocumentPoolTrack",
+        "type": "object"
+      },
+      "SetDocumentSettings": {
+        "description": "Mutable target-setting fields included in history/autosave snapshots.",
+        "properties": {
+          "bpm_ceiling": {
+            "anyOf": [
+              {
+                "maximum": 400.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm Ceiling"
+          },
+          "bpm_floor": {
+            "anyOf": [
+              {
+                "maximum": 400.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm Floor"
+          },
+          "key_strictness": {
+            "default": 0.2,
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Key Strictness",
+            "type": "number"
+          },
+          "target_duration_sec": {
+            "anyOf": [
+              {
+                "maximum": 36000.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Duration Sec"
+          },
+          "vibe_theme": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vibe Theme"
+          }
+        },
+        "required": [
+          "bpm_ceiling",
+          "bpm_floor",
+          "key_strictness",
+          "target_duration_sec",
+          "vibe_theme"
+        ],
+        "title": "SetDocumentSettings",
+        "type": "object"
+      },
+      "SetDocumentSlot": {
+        "description": "Slot row as stored in a document snapshot.",
+        "properties": {
+          "id": {
+            "minimum": 1.0,
+            "title": "Id",
+            "type": "integer"
+          },
+          "locked": {
+            "default": false,
+            "title": "Locked",
+            "type": "boolean"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "position": {
+            "minimum": 0.0,
+            "title": "Position",
+            "type": "integer"
+          },
+          "target_energy": {
+            "anyOf": [
+              {
+                "maximum": 10.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Energy"
+          },
+          "track_id": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Track Id"
+          },
+          "transition_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Transition Score"
+          },
+          "transition_warnings": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Transition Warnings"
+          }
+        },
+        "required": [
+          "id",
+          "locked",
+          "notes",
+          "position",
+          "target_energy",
+          "track_id",
+          "transition_score",
+          "transition_warnings"
+        ],
+        "title": "SetDocumentSlot",
+        "type": "object"
+      },
+      "SetDocumentSnapshot-Input": {
+        "description": "Full builder document snapshot for undo/redo and autosave.",
+        "properties": {
+          "curve_points": {
+            "items": {
+              "$ref": "#/components/schemas/SetDocumentCurvePoint"
+            },
+            "maxItems": 1000,
+            "title": "Curve Points",
+            "type": "array"
+          },
+          "pool": {
+            "$ref": "#/components/schemas/SetDocumentPool"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/SetDocumentSettings"
+          },
+          "slots": {
+            "items": {
+              "$ref": "#/components/schemas/SetDocumentSlot"
+            },
+            "maxItems": 500,
+            "title": "Slots",
+            "type": "array"
+          }
+        },
+        "required": [
+          "settings",
+          "pool"
+        ],
+        "title": "SetDocumentSnapshot",
+        "type": "object"
+      },
+      "SetDocumentSnapshot-Output": {
+        "description": "Full builder document snapshot for undo/redo and autosave.",
+        "properties": {
+          "curve_points": {
+            "items": {
+              "$ref": "#/components/schemas/SetDocumentCurvePoint"
+            },
+            "maxItems": 1000,
+            "title": "Curve Points",
+            "type": "array"
+          },
+          "pool": {
+            "$ref": "#/components/schemas/SetDocumentPool"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/SetDocumentSettings"
+          },
+          "slots": {
+            "items": {
+              "$ref": "#/components/schemas/SetDocumentSlot"
+            },
+            "maxItems": 500,
+            "title": "Slots",
+            "type": "array"
+          }
+        },
+        "required": [
+          "curve_points",
+          "pool",
+          "settings",
+          "slots"
+        ],
+        "title": "SetDocumentSnapshot",
+        "type": "object"
+      },
       "SetRename": {
         "description": "Body for renaming a set.",
         "properties": {
@@ -17099,6 +17656,110 @@
           }
         ],
         "summary": "Apply Curve Template",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/document": {
+      "get": {
+        "description": "Full restorable builder document snapshot for one of the current DJ's sets.",
+        "operationId": "get_document_snapshot_api_setbuilder_sets__set_id__document_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetDocumentSnapshot-Output"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Document Snapshot",
+        "tags": [
+          "setbuilder"
+        ]
+      },
+      "put": {
+        "description": "Replace the restorable builder document with a prior snapshot.",
+        "operationId": "put_document_snapshot_api_setbuilder_sets__set_id__document_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetDocumentSnapshot-Input"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetDocumentSnapshot-Output"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Put Document Snapshot",
         "tags": [
           "setbuilder"
         ]

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -8168,6 +8168,8 @@
         },
         "required": [
           "settings",
+          "slots",
+          "curve_points",
           "pool"
         ],
         "title": "SetDocumentSnapshot",
@@ -17687,6 +17689,9 @@
             },
             "description": "Successful Response"
           },
+          "404": {
+            "description": "Set not found or not accessible"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -17742,6 +17747,9 @@
               }
             },
             "description": "Successful Response"
+          },
+          "404": {
+            "description": "Set not found or not accessible"
           },
           "422": {
             "content": {

--- a/server/tests/test_setbuilder_document_snapshot_api.py
+++ b/server/tests/test_setbuilder_document_snapshot_api.py
@@ -1,0 +1,188 @@
+"""API-boundary tests for WrzDJSet document snapshots (issue #395)."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from app.models.set import SetCurvePoint, SetSlot
+from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.services.auth import get_password_hash
+
+
+def _make_second_dj(db: Session):
+    from app.models.user import User
+
+    user = User(username="snapother", password_hash=get_password_hash("otherpassword1"), role="dj")
+    db.add(user)
+    db.commit()
+    return user
+
+
+def _login(client, username: str, password: str) -> dict[str, str]:
+    resp = client.post("/api/auth/login", data={"username": username, "password": password})
+    assert resp.status_code == 200, resp.json()
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _create_seeded_set(client, db: Session, auth_headers: dict) -> int:
+    created = client.post(
+        "/api/setbuilder/sets", json={"name": "Snapshot Set"}, headers=auth_headers
+    )
+    assert created.status_code == 201, created.json()
+    set_id = created.json()["id"]
+    source = SetPoolSource(
+        set_id=set_id,
+        kind="manual",
+        external_ref=None,
+        label="Manual",
+        meta="Single-track search",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC).replace(tzinfo=None),
+    )
+    db.add(source)
+    db.flush()
+    db.add_all(
+        [
+            SetSlot(
+                id=9001,
+                set_id=set_id,
+                position=0,
+                track_id="manual:1",
+                locked=True,
+                notes="opener",
+                target_energy=5.5,
+            ),
+            SetSlot(
+                id=9002,
+                set_id=set_id,
+                position=1,
+                track_id="manual:2",
+                locked=False,
+                target_energy=7.0,
+            ),
+            SetPoolTrack(
+                id=9101,
+                set_id=set_id,
+                source_id=source.id,
+                track_id="manual:1",
+                title="Snapshot One",
+                artist="Artist One",
+                bpm=124.0,
+                key="8A",
+                camelot="8A",
+                energy=6,
+                duration_sec=300,
+                dedupe_sig="sig-one",
+                created_at=datetime(2026, 1, 1, tzinfo=UTC).replace(tzinfo=None),
+            ),
+            SetPoolTrack(
+                id=9102,
+                set_id=set_id,
+                source_id=source.id,
+                track_id="manual:2",
+                title="Snapshot Two",
+                artist="Artist Two",
+                energy=8,
+                dedupe_sig="sig-two",
+                created_at=datetime(2026, 1, 1, tzinfo=UTC).replace(tzinfo=None),
+            ),
+            SetCurvePoint(
+                id=9201,
+                set_id=set_id,
+                position_sec=30,
+                energy=0,
+                label="Dinner",
+                is_slow_window_start=True,
+            ),
+            SetCurvePoint(
+                id=9202,
+                set_id=set_id,
+                position_sec=90,
+                energy=0,
+                is_slow_window_end=True,
+            ),
+        ]
+    )
+    db.commit()
+    return set_id
+
+
+def test_document_snapshot_round_trips_destructive_builder_state(client, db, auth_headers):
+    set_id = _create_seeded_set(client, db, auth_headers)
+
+    original = client.get(f"/api/setbuilder/sets/{set_id}/document", headers=auth_headers).json()
+
+    client.patch(
+        f"/api/setbuilder/sets/{set_id}/slots/9001/target",
+        json={"target_energy": 9.5},
+        headers=auth_headers,
+    )
+    client.delete(
+        f"/api/setbuilder/sets/{set_id}/pool/sources/{original['pool']['sources'][0]['id']}",
+        headers=auth_headers,
+    )
+    client.put(
+        f"/api/setbuilder/sets/{set_id}/vibe-windows",
+        json={"windows": [{"t0_sec": 120, "t1_sec": 150, "label": "Peak"}]},
+        headers=auth_headers,
+    )
+
+    restore = client.put(
+        f"/api/setbuilder/sets/{set_id}/document", json=original, headers=auth_headers
+    )
+    assert restore.status_code == 200, restore.json()
+    restored = restore.json()
+    assert restored["slots"] == original["slots"]
+    assert restored["pool"] == original["pool"]
+    assert restored["curve_points"] == original["curve_points"]
+
+
+def test_document_snapshot_owner_isolation(client, db, auth_headers):
+    set_id = _create_seeded_set(client, db, auth_headers)
+    _make_second_dj(db)
+    other_headers = _login(client, "snapother", "otherpassword1")
+
+    assert (
+        client.get(f"/api/setbuilder/sets/{set_id}/document", headers=other_headers).status_code
+        == 404
+    )
+    assert (
+        client.put(
+            f"/api/setbuilder/sets/{set_id}/document",
+            json={
+                "settings": {},
+                "slots": [],
+                "curve_points": [],
+                "pool": {"sources": [], "tracks": []},
+            },
+            headers=other_headers,
+        ).status_code
+        == 404
+    )
+
+
+def test_document_snapshot_rejects_tracks_for_missing_source(client, auth_headers):
+    created = client.post(
+        "/api/setbuilder/sets", json={"name": "Bad Snapshot"}, headers=auth_headers
+    )
+    set_id = created.json()["id"]
+    payload = {
+        "settings": {"key_strictness": 0.2},
+        "slots": [],
+        "curve_points": [],
+        "pool": {
+            "sources": [],
+            "tracks": [
+                {
+                    "id": 1,
+                    "source_id": 404,
+                    "track_id": "manual:bad",
+                    "title": "Bad",
+                    "artist": "Actor",
+                    "dedupe_sig": "bad",
+                    "created_at": "2026-01-01T00:00:00",
+                }
+            ],
+        },
+    }
+    resp = client.put(f"/api/setbuilder/sets/{set_id}/document", json=payload, headers=auth_headers)
+    assert resp.status_code == 422

--- a/server/tests/test_setbuilder_document_snapshot_api.py
+++ b/server/tests/test_setbuilder_document_snapshot_api.py
@@ -127,7 +127,9 @@ def _create_seeded_set(client, db: Session, auth_headers: dict) -> int:
 def test_document_snapshot_round_trips_destructive_builder_state(client, db, auth_headers):
     set_id = _create_seeded_set(client, db, auth_headers)
 
-    original = client.get(f"/api/setbuilder/sets/{set_id}/document", headers=auth_headers).json()
+    original_resp = client.get(f"/api/setbuilder/sets/{set_id}/document", headers=auth_headers)
+    assert original_resp.status_code == 200, original_resp.json()
+    original = original_resp.json()
 
     patch_resp = client.patch(
         f"/api/setbuilder/sets/{set_id}/slots/9001/target",
@@ -188,7 +190,9 @@ def test_document_snapshot_restore_ignores_client_primary_keys(client, db, auth_
     )
     db.commit()
 
-    payload = client.get(f"/api/setbuilder/sets/{set_id}/document", headers=auth_headers).json()
+    payload_resp = client.get(f"/api/setbuilder/sets/{set_id}/document", headers=auth_headers)
+    assert payload_resp.status_code == 200, payload_resp.json()
+    payload = payload_resp.json()
     payload["slots"][0]["id"] = 9901
     payload["curve_points"][0]["id"] = 9902
     payload["pool"]["sources"][0]["id"] = 9903
@@ -201,10 +205,13 @@ def test_document_snapshot_restore_ignores_client_primary_keys(client, db, auth_
     )
     assert restore.status_code == 200, restore.json()
     restored = restore.json()
+    restored_source_ids = {source["id"] for source in restored["pool"]["sources"]}
     assert restored["slots"][0]["id"] != 9901
     assert restored["curve_points"][0]["id"] != 9902
     assert restored["pool"]["sources"][0]["id"] != 9903
     assert all(track["id"] != 9904 for track in restored["pool"]["tracks"])
+    assert all(track["source_id"] in restored_source_ids for track in restored["pool"]["tracks"])
+    assert all(track["source_id"] != 9903 for track in restored["pool"]["tracks"])
 
 
 def test_document_snapshot_owner_isolation(client, db, auth_headers):
@@ -235,6 +242,7 @@ def test_document_snapshot_rejects_tracks_for_missing_source(client, auth_header
     created = client.post(
         "/api/setbuilder/sets", json={"name": "Bad Snapshot"}, headers=auth_headers
     )
+    assert created.status_code == 201, created.json()
     set_id = created.json()["id"]
     payload = {
         "settings": {"key_strictness": 0.2},

--- a/server/tests/test_setbuilder_document_snapshot_api.py
+++ b/server/tests/test_setbuilder_document_snapshot_api.py
@@ -9,6 +9,24 @@ from app.models.set_pool import SetPoolSource, SetPoolTrack
 from app.services.auth import get_password_hash
 
 
+def _without_keys(row: dict, *keys: str) -> dict:
+    return {key: value for key, value in row.items() if key not in keys}
+
+
+def _logical_snapshot(snapshot: dict) -> dict:
+    return {
+        "settings": snapshot["settings"],
+        "slots": [_without_keys(slot, "id") for slot in snapshot["slots"]],
+        "curve_points": [_without_keys(point, "id") for point in snapshot["curve_points"]],
+        "pool": {
+            "sources": [_without_keys(source, "id") for source in snapshot["pool"]["sources"]],
+            "tracks": [
+                _without_keys(track, "id", "source_id") for track in snapshot["pool"]["tracks"]
+            ],
+        },
+    }
+
+
 def _make_second_dj(db: Session):
     from app.models.user import User
 
@@ -111,29 +129,82 @@ def test_document_snapshot_round_trips_destructive_builder_state(client, db, aut
 
     original = client.get(f"/api/setbuilder/sets/{set_id}/document", headers=auth_headers).json()
 
-    client.patch(
+    patch_resp = client.patch(
         f"/api/setbuilder/sets/{set_id}/slots/9001/target",
         json={"target_energy": 9.5},
         headers=auth_headers,
     )
-    client.delete(
+    assert patch_resp.status_code == 200, patch_resp.json()
+
+    delete_resp = client.delete(
         f"/api/setbuilder/sets/{set_id}/pool/sources/{original['pool']['sources'][0]['id']}",
         headers=auth_headers,
     )
-    client.put(
+    assert delete_resp.status_code == 200, delete_resp.json()
+
+    windows_resp = client.put(
         f"/api/setbuilder/sets/{set_id}/vibe-windows",
         json={"windows": [{"t0_sec": 120, "t1_sec": 150, "label": "Peak"}]},
         headers=auth_headers,
     )
+    assert windows_resp.status_code == 200, windows_resp.json()
 
     restore = client.put(
         f"/api/setbuilder/sets/{set_id}/document", json=original, headers=auth_headers
     )
     assert restore.status_code == 200, restore.json()
     restored = restore.json()
-    assert restored["slots"] == original["slots"]
-    assert restored["pool"] == original["pool"]
-    assert restored["curve_points"] == original["curve_points"]
+    assert _logical_snapshot(restored) == _logical_snapshot(original)
+
+
+def test_document_snapshot_restore_ignores_client_primary_keys(client, db, auth_headers):
+    set_id = _create_seeded_set(client, db, auth_headers)
+    other = client.post("/api/setbuilder/sets", json={"name": "Other Set"}, headers=auth_headers)
+    assert other.status_code == 201, other.json()
+    other_set_id = other.json()["id"]
+    other_source = SetPoolSource(
+        id=9903,
+        set_id=other_set_id,
+        kind="manual",
+        external_ref=None,
+        label="Other",
+    )
+    db.add(other_source)
+    db.flush()
+    db.add_all(
+        [
+            SetSlot(id=9901, set_id=other_set_id, position=0, track_id="other:1"),
+            SetCurvePoint(id=9902, set_id=other_set_id, position_sec=1, energy=1),
+            SetPoolTrack(
+                id=9904,
+                set_id=other_set_id,
+                source_id=other_source.id,
+                track_id="other:1",
+                title="Other",
+                artist="Artist",
+                dedupe_sig="other",
+            ),
+        ]
+    )
+    db.commit()
+
+    payload = client.get(f"/api/setbuilder/sets/{set_id}/document", headers=auth_headers).json()
+    payload["slots"][0]["id"] = 9901
+    payload["curve_points"][0]["id"] = 9902
+    payload["pool"]["sources"][0]["id"] = 9903
+    for track in payload["pool"]["tracks"]:
+        track["id"] = 9904
+        track["source_id"] = 9903
+
+    restore = client.put(
+        f"/api/setbuilder/sets/{set_id}/document", json=payload, headers=auth_headers
+    )
+    assert restore.status_code == 200, restore.json()
+    restored = restore.json()
+    assert restored["slots"][0]["id"] != 9901
+    assert restored["curve_points"][0]["id"] != 9902
+    assert restored["pool"]["sources"][0]["id"] != 9903
+    assert all(track["id"] != 9904 for track in restored["pool"]["tracks"])
 
 
 def test_document_snapshot_owner_isolation(client, db, auth_headers):


### PR DESCRIPTION
## Why
WrzDJSet builder edits are destructive and need trustable document history, visible save state, keyboard recovery, and confirmation around dangerous actions.

Closes #395

## What
- Added owner-scoped builder document snapshot GET/PUT APIs that restore slots, locks, slot targets, curve/vibe-window rows, pool sources/tracks, and target settings.
- Added a reusable frontend document-history hook with labeled commit boundaries, undo/redo stacks, keyboard shortcuts, save state, beforeunload protection, 30s autosave retry, and undo/redo toasts.
- Wired existing pool imports/removals, slot target edits, curve template application, and vibe-window changes through the history commit API.
- Added compact topbar undo/redo controls, a brand save menu row, settings modal toggles, and shared confirmation dialogs for recompute/removal flows.
- Regenerated OpenAPI and dashboard API types.

## Testing
- `dashboard`: `npm run lint`
- `dashboard`: `npx tsc --noEmit`
- `dashboard`: `npm test -- --run`
- `server`: `/home/adam/github/WrzDJ/server/.venv/bin/ruff check .`
- `server`: `/home/adam/github/WrzDJ/server/.venv/bin/ruff format --check .`
- `server`: `/home/adam/github/WrzDJ/server/.venv/bin/bandit -r app -c pyproject.toml -q`
- `server`: `/home/adam/github/WrzDJ/server/.venv/bin/pytest --tb=short -q` (2802 passed, coverage gate reached at 88.71%)
- `server`: `/home/adam/github/WrzDJ/server/.venv/bin/alembic upgrade head && /home/adam/github/WrzDJ/server/.venv/bin/alembic check` could not run locally because PostgreSQL rejected the configured `wrzdj` credentials; no migrations/model columns were added.

## Design decisions
- The frontend history hook treats the backend snapshot as the document boundary, so future pairings/target/transport work can extend the snapshot schema without rewriting undo/redo mechanics.
- UI-only state such as active slot, hover, playback, and panel mode stays outside document history.
- Existing persisted mutations remain server-authoritative; commits capture the pre-mutation snapshot, refresh the post-mutation snapshot, and restore via PUT for undo/redo.
- The existing curve replacement localStorage gate is preserved while the settings modal becomes the consolidated settings surface.
- Recompute confirmation copy follows the synced prototype and is intentionally distinct from the existing export modal.

Claude assisted with implementation and test coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added document history with undo/redo controls and Ctrl/Cmd keyboard shortcuts, including a live “unsaved changes” indicator and history/settings entry.
  * Enabled automatic and manual saving via restorable document snapshots, including restoring vibe window state.
  * Introduced a centralized confirmation dialog flow for confirmable actions and added a builder settings modal (autosave + interaction options).

* **Tests**
  * Added server snapshot API tests (round-trip, validation, ownership isolation) and client-side history hook/commit coverage (manual save + autosave retry).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->