### PR TITLE
feat(setbuilder): target duration and overlap settings

### DIFF
--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { use, useEffect, useRef, useState } from 'react';
+import { use, useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
@@ -16,6 +16,12 @@ import ConfirmActionDialog, { type ConfirmAction } from '../components/ConfirmAc
 import HistoryControls from '../components/HistoryControls';
 import PoolPanel from '../components/PoolPanel';
 import { useSetDocumentHistory } from '../components/useSetDocumentHistory';
+import TargetEditor from '../components/TargetEditor';
+import {
+  DEFAULT_AVG_TRANSITION_OVERLAP_SEC,
+  type TargetProjection,
+  type TargetSettings,
+} from '../components/targetMath';
 import SetActionsMenu from '../SetActionsMenu';
 import styles from '../setbuilder.module.css';
 
@@ -74,6 +80,13 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
   const confirmResolverRef = useRef<((value: boolean) => void) | null>(null);
   const history = useSetDocumentHistory(numericSetId);
+  const [targetOpen, setTargetOpen] = useState(false);
+  const [targetSettings, setTargetSettings] = useState<TargetSettings>({
+    targetDurationSec: null,
+    avgTransitionOverlapSec: DEFAULT_AVG_TRANSITION_OVERLAP_SEC,
+  });
+  const [targetProjection, setTargetProjection] = useState<TargetProjection | null>(null);
+  const [savingTarget, setSavingTarget] = useState(false);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -188,6 +201,49 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
     };
   }, [isAuthenticated, setId]);
 
+  useEffect(() => {
+    if (!set) return;
+    setTargetSettings({
+      targetDurationSec: set.target_duration_sec,
+      avgTransitionOverlapSec:
+        set.avg_transition_overlap_sec ?? DEFAULT_AVG_TRANSITION_OVERLAP_SEC,
+    });
+  }, [set?.id, set?.target_duration_sec, set?.avg_transition_overlap_sec]);
+
+  const targetDirty =
+    !!set &&
+    (targetSettings.targetDurationSec !== set.target_duration_sec ||
+      targetSettings.avgTransitionOverlapSec !==
+        (set.avg_transition_overlap_sec ?? DEFAULT_AVG_TRANSITION_OVERLAP_SEC));
+
+  const undoTarget = () => {
+    if (!set) return;
+    setTargetSettings({
+      targetDurationSec: set.target_duration_sec,
+      avgTransitionOverlapSec:
+        set.avg_transition_overlap_sec ?? DEFAULT_AVG_TRANSITION_OVERLAP_SEC,
+    });
+  };
+
+  const saveTarget = async () => {
+    if (!set || !targetDirty) return;
+    setSavingTarget(true);
+    try {
+      const updated = await api.updateSetTargetSettings(
+        set.id,
+        targetSettings.targetDurationSec,
+        targetSettings.avgTransitionOverlapSec,
+      );
+      setSet(updated);
+    } finally {
+      setSavingTarget(false);
+    }
+  };
+
+  const handleProjectionChange = useCallback((projection: TargetProjection) => {
+    setTargetProjection(projection);
+  }, []);
+
   if (isLoading || !isAuthenticated) {
     return (
       <div className="container">
@@ -235,6 +291,29 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
           />
         </span>
         <span className={styles.topbarActions}>
+          <span className={styles.topbarStats}>
+            {targetProjection ? (
+              <>
+                <span>
+                  <strong>{targetProjection.slotCount}</strong> tracks
+                </span>
+                <span className={styles.statDot} />
+              </>
+            ) : null}
+            {set && (
+              <TargetEditor
+                settings={targetSettings}
+                projection={targetProjection}
+                dirty={targetDirty}
+                saving={savingTarget}
+                open={targetOpen}
+                onOpenChange={setTargetOpen}
+                onSettingsChange={setTargetSettings}
+                onSave={saveTarget}
+                onUndo={undoTarget}
+              />
+            )}
+          </span>
           <HistoryControls
             undoDepth={history.undoDepth}
             redoDepth={history.redoDepth}
@@ -312,6 +391,8 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
           }
           confirmRecompute={builderSettings.confirmRecompute}
           requestConfirmation={requestConfirmation}
+          targetSettings={targetSettings}
+          onProjectionChange={handleProjectionChange}
         />
 
         <div className={styles.panelChat}>

--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -87,6 +87,7 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
   });
   const [targetProjection, setTargetProjection] = useState<TargetProjection | null>(null);
   const [savingTarget, setSavingTarget] = useState(false);
+  const [targetError, setTargetError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -218,6 +219,7 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
 
   const undoTarget = () => {
     if (!set) return;
+    setTargetError(null);
     setTargetSettings({
       targetDurationSec: set.target_duration_sec,
       avgTransitionOverlapSec:
@@ -225,9 +227,15 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
     });
   };
 
+  const updateTargetSettings = useCallback((settings: TargetSettings) => {
+    setTargetError(null);
+    setTargetSettings(settings);
+  }, []);
+
   const saveTarget = async () => {
     if (!set || !targetDirty) return;
     setSavingTarget(true);
+    setTargetError(null);
     try {
       const updated = await api.updateSetTargetSettings(
         set.id,
@@ -235,6 +243,10 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
         targetSettings.avgTransitionOverlapSec,
       );
       setSet(updated);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save target settings';
+      setTargetError(message);
+      setToast(message);
     } finally {
       setSavingTarget(false);
     }
@@ -308,11 +320,16 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
                 saving={savingTarget}
                 open={targetOpen}
                 onOpenChange={setTargetOpen}
-                onSettingsChange={setTargetSettings}
+                onSettingsChange={updateTargetSettings}
                 onSave={saveTarget}
                 onUndo={undoTarget}
               />
             )}
+            {targetError ? (
+              <span className={styles.targetSaveError} role="alert">
+                {targetError}
+              </span>
+            ) : null}
           </span>
           <HistoryControls
             undoDepth={history.undoDepth}

--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -223,6 +223,30 @@ describe('BuilderWorkspace', () => {
     expect(mockGetSetSlots).toHaveBeenCalledWith(5);
   });
 
+  it('reports effective target projection from loaded slots', async () => {
+    const onProjectionChange = vi.fn();
+    render(
+      <BuilderWorkspace
+        setId={5}
+        targetSettings={{ targetDurationSec: 600, avgTransitionOverlapSec: 10 }}
+        onProjectionChange={onProjectionChange}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('slot-block-0')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(onProjectionChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          rawTotalSec: 633,
+          effectiveSec: 613,
+          deltaSec: 13,
+          tier: 'on-target',
+        }),
+      ),
+    );
+    expect(screen.getByTestId('timeline-summary')).toHaveTextContent('10:33 raw');
+    expect(screen.getByTestId('timeline-summary')).toHaveTextContent('10:13 live, est.');
+  });
+
   it('hover on a curve block highlights the timeline row (and back)', async () => {
     render(<BuilderWorkspace setId={5} />);
     await waitFor(() => expect(screen.getByTestId('slot-block-1')).toBeInTheDocument());

--- a/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
@@ -73,6 +73,32 @@ describe('CurveEditor', () => {
     expect(screen.getByTestId('pairing-pin-0')).toBeInTheDocument();
   });
 
+  it('renders target marker and amber over-region using overlap-adjusted raw target', () => {
+    const slots = [
+      mkSlot(0, { durationSec: 400 }),
+      mkSlot(1, { durationSec: 300 }),
+      mkSlot(2, { durationSec: 300 }),
+    ];
+    const { rerender, props } = renderEditor({
+      slots,
+      targetDurationSec: 500,
+      avgTransitionOverlapSec: 0,
+    });
+
+    const marker = screen.getByTestId('curve-target-marker');
+    expect(marker).toHaveAttribute('x1', '400');
+    expect(screen.getByTestId('curve-over-region')).toBeInTheDocument();
+
+    rerender(
+      <CurveEditor
+        {...props}
+        targetDurationSec={500}
+        avgTransitionOverlapSec={30}
+      />,
+    );
+    expect(screen.getByTestId('curve-target-marker')).toHaveAttribute('x1', '448');
+  });
+
   it('renders amber hatch when target > energy and dashed line when target < energy', () => {
     renderEditor({
       slots: [

--- a/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
@@ -99,6 +99,45 @@ describe('CurveEditor', () => {
     expect(screen.getByTestId('curve-target-marker')).toHaveAttribute('x1', '448');
   });
 
+  it('maps playhead and scrub positions against the extended target domain', () => {
+    const onScrub = vi.fn();
+    const { container } = renderEditor({
+      slots: [
+        mkSlot(0, { durationSec: 200 }),
+        mkSlot(1, { durationSec: 200 }),
+        mkSlot(2, { durationSec: 200 }),
+      ],
+      targetDurationSec: 900,
+      avgTransitionOverlapSec: 0,
+      playheadSec: 300,
+      scrubEnabled: true,
+      onScrub,
+    });
+
+    const playheadLine = screen.getByTestId('curve-playhead').querySelector('line');
+    expect(Number(playheadLine?.getAttribute('x1'))).toBeCloseTo(266.67);
+
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    vi.spyOn(svg as SVGSVGElement, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 800,
+      bottom: 160,
+      width: 800,
+      height: 160,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.click(screen.getByTestId('curve-scrub-hit'), { clientX: 400 });
+    expect(onScrub).toHaveBeenLastCalledWith(450);
+
+    fireEvent.click(screen.getByTestId('curve-scrub-hit'), { clientX: 800 });
+    expect(onScrub).toHaveBeenLastCalledWith(600);
+  });
+
   it('renders amber hatch when target > energy and dashed line when target < energy', () => {
     renderEditor({
       slots: [

--- a/dashboard/app/(dj)/setbuilder/__tests__/TargetEditor.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/TargetEditor.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import TargetEditor from '../components/TargetEditor';
+import { projectTarget } from '../components/targetMath';
+import type { SlotView } from '../components/types';
+
+const slots: SlotView[] = [
+  {
+    id: 1,
+    position: 0,
+    locked: false,
+    targetEnergy: null,
+    transitionScore: null,
+    nextPairingId: null,
+    nextIsDjPairing: false,
+    track: {
+      id: 'a',
+      title: 'A',
+      artist: '',
+      durationSec: 1800,
+      energy: 5,
+      bpm: null,
+      key: null,
+    },
+  },
+  {
+    id: 2,
+    position: 1,
+    locked: false,
+    targetEnergy: null,
+    transitionScore: null,
+    nextPairingId: null,
+    nextIsDjPairing: false,
+    track: {
+      id: 'b',
+      title: 'B',
+      artist: '',
+      durationSec: 1800,
+      energy: 5,
+      bpm: null,
+      key: null,
+    },
+  },
+];
+
+describe('TargetEditor', () => {
+  it('opens the popover, edits overlap live, and exposes save/undo dirty state', () => {
+    const onOpenChange = vi.fn();
+    const onSettingsChange = vi.fn();
+    const onSave = vi.fn();
+    const onUndo = vi.fn();
+    render(
+      <TargetEditor
+        settings={{ targetDurationSec: 3600, avgTransitionOverlapSec: 8 }}
+        projection={projectTarget(slots, {
+          targetDurationSec: 3600,
+          avgTransitionOverlapSec: 8,
+        })}
+        dirty
+        saving={false}
+        open
+        onOpenChange={onOpenChange}
+        onSettingsChange={onSettingsChange}
+        onSave={onSave}
+        onUndo={onUndo}
+      />,
+    );
+
+    expect(screen.getByTestId('target-popover')).toBeInTheDocument();
+    expect(screen.getByTestId('target-pill')).toHaveTextContent('60:00');
+    fireEvent.change(screen.getByRole('slider'), { target: { value: '20' } });
+    expect(onSettingsChange).toHaveBeenCalledWith({
+      targetDurationSec: 3600,
+      avgTransitionOverlapSec: 20,
+    });
+    expect(screen.getByText('Sum of track durations')).toBeInTheDocument();
+    expect(screen.getByText('Projected playing time')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(onSave).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onUndo).toHaveBeenCalled();
+  });
+
+  it('preset chips update the draft target immediately', () => {
+    const onSettingsChange = vi.fn();
+    render(
+      <TargetEditor
+        settings={{ targetDurationSec: 3600, avgTransitionOverlapSec: 8 }}
+        projection={null}
+        dirty={false}
+        saving={false}
+        open
+        onOpenChange={vi.fn()}
+        onSettingsChange={onSettingsChange}
+        onSave={vi.fn()}
+        onUndo={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('target-preset-club-opener'));
+    expect(onSettingsChange).toHaveBeenCalledWith({
+      targetDurationSec: 2700,
+      avgTransitionOverlapSec: 8,
+    });
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/__tests__/curveMath.test.ts
+++ b/dashboard/app/(dj)/setbuilder/__tests__/curveMath.test.ts
@@ -194,6 +194,14 @@ describe('slotBlocksFromSlots / effectiveTarget', () => {
     expect(blocks[1].target).toBe(9);
     expect(effectiveTarget(slots[0])).toBe(4);
   });
+
+  it('uses a larger target domain without stretching raw slot blocks', () => {
+    const slots = [mkSlot(0, { durationSec: 100 }), mkSlot(1, { durationSec: 300 })];
+    const blocks = slotBlocksFromSlots(slots, 800, 800);
+    expect(blocks[0].width).toBeCloseTo(100);
+    expect(blocks[1].width).toBeCloseTo(300);
+    expect(blocks[1].x1).toBeCloseTo(400);
+  });
 });
 
 describe('slotViewFromApi', () => {

--- a/dashboard/app/(dj)/setbuilder/__tests__/targetMath.test.ts
+++ b/dashboard/app/(dj)/setbuilder/__tests__/targetMath.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  effectiveDurationSec,
+  formatDelta,
+  projectTarget,
+  rawTargetSecForSlots,
+  targetDeltaTier,
+} from '../components/targetMath';
+import type { SlotView } from '../components/types';
+
+function slot(durationSec: number): SlotView {
+  return {
+    id: durationSec,
+    position: 0,
+    locked: false,
+    targetEnergy: null,
+    transitionScore: null,
+    nextPairingId: null,
+    nextIsDjPairing: false,
+    track: {
+      id: `t-${durationSec}`,
+      title: 'Track',
+      artist: 'Artist',
+      durationSec,
+      energy: 5,
+      bpm: null,
+      key: null,
+    },
+  };
+}
+
+describe('targetMath', () => {
+  it('subtracts transition overlap from effective duration', () => {
+    expect(effectiveDurationSec(1800, 6, 8)).toBe(1760);
+    expect(effectiveDurationSec(1800, 1, 8)).toBe(1800);
+  });
+
+  it('projects raw, overlap, effective and delta', () => {
+    const projection = projectTarget([slot(300), slot(300), slot(300)], {
+      targetDurationSec: 870,
+      avgTransitionOverlapSec: 15,
+    });
+
+    expect(projection.rawTotalSec).toBe(900);
+    expect(projection.transitionOverlapSec).toBe(30);
+    expect(projection.effectiveSec).toBe(870);
+    expect(projection.deltaSec).toBe(0);
+    expect(projection.tier).toBe('on-target');
+  });
+
+  it('moves the raw target marker as overlap changes', () => {
+    expect(rawTargetSecForSlots(600, 4, 0)).toBe(600);
+    expect(rawTargetSecForSlots(600, 4, 10)).toBe(630);
+  });
+
+  it('tiers deltas by target-relative severity', () => {
+    expect(targetDeltaTier(20, 3600)).toBe('on-target');
+    expect(targetDeltaTier(-600, 3600)).toBe('under');
+    expect(targetDeltaTier(300, 3600)).toBe('over');
+    expect(targetDeltaTier(700, 3600)).toBe('over-hard');
+  });
+
+  it('formats signed delta labels', () => {
+    expect(formatDelta(0)).toBe('On target');
+    expect(formatDelta(600)).toBe('+10:00');
+    expect(formatDelta(-3600)).toBe('-60:00');
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
@@ -13,6 +13,12 @@ import CurvePanel from './CurvePanel';
 import TimelinePanel, { type ScrollRequest } from './TimelinePanel';
 import TransportBar from './TransportBar';
 import type { ConfirmAction } from './ConfirmActionDialog';
+import {
+  formatTimecode,
+  projectTarget,
+  type TargetProjection,
+  type TargetSettings,
+} from './targetMath';
 import type { SlotView, TrackView } from './types';
 import { slotViewFromApi, trackViewFromPool } from './types';
 import type { BuilderCommit } from './useSetDocumentHistory';
@@ -49,6 +55,55 @@ interface BuilderWorkspaceProps {
   onSuggestReplacementsChange?: (checked: boolean) => void;
   confirmRecompute?: boolean;
   requestConfirmation?: (action: ConfirmAction) => Promise<boolean>;
+  targetSettings?: TargetSettings;
+  onProjectionChange?: (projection: TargetProjection) => void;
+}
+
+const DEFAULT_TARGET_SETTINGS: TargetSettings = {
+  targetDurationSec: null,
+  avgTransitionOverlapSec: 8,
+};
+
+function TimelineSummary({
+  projection,
+  overlapSec,
+}: {
+  projection: TargetProjection;
+  overlapSec: number;
+}) {
+  const avgTrackSec = projection.slotCount > 0 ? projection.rawTotalSec / projection.slotCount : 0;
+  const overlapPct = avgTrackSec > 0 ? (overlapSec / avgTrackSec) * 100 : 0;
+  return (
+    <div className={sbStyles.timelineSummary} data-testid="timeline-summary">
+      <span>
+        <strong>{projection.slotCount}</strong> tracks
+      </span>
+      <span>
+        <strong>{formatTimecode(projection.rawTotalSec)}</strong> raw
+      </span>
+      {projection.slotCount > 1 && overlapSec > 0 ? (
+        <span className={sbStyles.timelineLiveWrap}>
+          <span className={sbStyles.timelineLive}>
+            <strong>{formatTimecode(projection.effectiveSec)}</strong> live, est.
+          </span>
+          <span className={sbStyles.timelineTooltip} role="tooltip">
+            <strong>Estimated live runtime</strong>
+            <span>Actual runtime depends on how you blend on the night.</span>
+            <span className={sbStyles.timelineTooltipGrid}>
+              <span>Raw total</span>
+              <b>{formatTimecode(projection.rawTotalSec)}</b>
+              <span>Transitions</span>
+              <b>{projection.transitionCount} x {overlapSec}s overlap</b>
+              <span>~% of avg track</span>
+              <b>{overlapPct.toFixed(1)}%</b>
+              <span>Live (est.)</span>
+              <b>{formatTimecode(projection.effectiveSec)}</b>
+            </span>
+          </span>
+        </span>
+      ) : null}
+    </div>
+  );
 }
 
 export default function BuilderWorkspace({
@@ -61,6 +116,8 @@ export default function BuilderWorkspace({
   onSuggestReplacementsChange,
   confirmRecompute = true,
   requestConfirmation,
+  targetSettings = DEFAULT_TARGET_SETTINGS,
+  onProjectionChange,
 }: BuilderWorkspaceProps) {
   const [slots, setSlots] = useState<SlotView[]>([]);
   const [pool, setPool] = useState<TrackView[]>([]);
@@ -77,6 +134,10 @@ export default function BuilderWorkspace({
   });
 
   const totalSec = useMemo(() => totalDuration(slots), [slots]);
+  const projection = useMemo(
+    () => projectTarget(slots, targetSettings),
+    [slots, targetSettings],
+  );
 
   const loadSlots = useCallback(() => {
     return Promise.all([api.getSetSlots(setId), api.getPool(setId)])
@@ -259,6 +320,10 @@ export default function BuilderWorkspace({
     sendCommand(idx, 'seek', bounded);
   };
 
+  useEffect(() => {
+    onProjectionChange?.(projection);
+  }, [projection, onProjectionChange]);
+
   return (
     <>
       <section className={`${sbStyles.panel} ${sbStyles.panelCurve}`} aria-label="Curve">
@@ -283,6 +348,8 @@ export default function BuilderWorkspace({
           onSuggestReplacementsChange={onSuggestReplacementsChange}
           confirmRecompute={confirmRecompute}
           requestConfirmation={requestConfirmation}
+          targetDurationSec={targetSettings.targetDurationSec}
+          avgTransitionOverlapSec={targetSettings.avgTransitionOverlapSec}
         />
       </section>
 
@@ -300,7 +367,13 @@ export default function BuilderWorkspace({
       </section>
 
       <section className={`${sbStyles.panel} ${sbStyles.panelTimeline}`} aria-label="Timeline">
-        <div className={sbStyles.panelHeader}>Timeline</div>
+        <div className={sbStyles.panelHeaderRow}>
+          <div className={sbStyles.panelHeader}>Timeline</div>
+          <TimelineSummary
+            projection={projection}
+            overlapSec={targetSettings.avgTransitionOverlapSec}
+          />
+        </div>
         <TimelinePanel
           slots={slots}
           hoveredIdx={hoveredIdx}

--- a/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
@@ -83,7 +83,7 @@ function TimelineSummary({
       </span>
       {projection.slotCount > 1 && overlapSec > 0 ? (
         <span className={sbStyles.timelineLiveWrap}>
-          <span className={sbStyles.timelineLive}>
+          <span className={sbStyles.timelineLive} tabIndex={0}>
             <strong>{formatTimecode(projection.effectiveSec)}</strong> live, est.
           </span>
           <span className={sbStyles.timelineTooltip} role="tooltip">

--- a/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
@@ -20,6 +20,7 @@ import {
   fmtTime,
   slotBlocksFromSlots,
 } from './curveMath';
+import { rawTargetSecForSlots } from './targetMath';
 import type { SlotView, VibeWindowView } from './types';
 import styles from './curve.module.css';
 
@@ -53,6 +54,8 @@ export interface CurveEditorProps {
   onWindowChange?: (id: string, patch: Partial<VibeWindowView>) => void;
   onWindowCommit?: (id: string) => void;
   onWindowDelete?: (id: string) => void;
+  targetDurationSec?: number | null;
+  avgTransitionOverlapSec?: number;
 }
 
 export default function CurveEditor({
@@ -71,6 +74,8 @@ export default function CurveEditor({
   onWindowChange,
   onWindowCommit,
   onWindowDelete,
+  targetDurationSec = null,
+  avgTransitionOverlapSec = 0,
 }: CurveEditorProps) {
   const wrapRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
@@ -96,7 +101,14 @@ export default function CurveEditor({
   const eOfY = (y: number) => Math.max(0, Math.min(10, (1 - y / h) * 10));
 
   const totalSec = slots.reduce((acc, s) => acc + s.track.durationSec, 0);
-  const baseBlocks = slotBlocksFromSlots(slots, w);
+  const rawTargetSec = rawTargetSecForSlots(
+    targetDurationSec,
+    slots.length,
+    avgTransitionOverlapSec,
+  );
+  const domainSec = Math.max(totalSec, rawTargetSec ?? 0, 1);
+  const targetX = rawTargetSec == null ? null : Math.round((rawTargetSec / domainSec) * w);
+  const baseBlocks = slotBlocksFromSlots(slots, w, domainSec);
   const blocks = baseBlocks.map((b) =>
     dragIdx === b.idx && dragEnergy != null ? { ...b, target: dragEnergy } : b,
   );
@@ -221,7 +233,7 @@ export default function CurveEditor({
       </div>
       <div className={styles.xaxis}>
         {[0, 0.25, 0.5, 0.75, 1].map((t) => (
-          <div key={t}>{fmtTime(t * totalSec)}</div>
+          <div key={t}>{fmtTime(t * domainSec)}</div>
         ))}
       </div>
       <svg
@@ -266,6 +278,43 @@ export default function CurveEditor({
             data-testid="curve-scrub-hit"
             style={{ cursor: 'crosshair' }}
           />
+        )}
+
+        {/* Target marker + over-target region. The marker is expressed in raw
+            timeline seconds needed to hit the effective target after overlaps. */}
+        {rawTargetSec != null && (
+          <g pointerEvents="none">
+            {totalSec > rawTargetSec && targetX != null ? (
+              <rect
+                data-testid="curve-over-region"
+                x={targetX}
+                y={0}
+                width={Math.max(0, ((totalSec - rawTargetSec) / domainSec) * w)}
+                height={h}
+                fill="rgba(245,158,11,0.12)"
+              />
+            ) : null}
+            <line
+              data-testid="curve-target-marker"
+              x1={targetX ?? 0}
+              x2={targetX ?? 0}
+              y1={0}
+              y2={h}
+              stroke="rgba(251,191,36,0.95)"
+              strokeWidth="1.5"
+              strokeDasharray="5 4"
+            />
+            <text
+              x={Math.min(Math.max((targetX ?? 0) + 6, 34), w - 28)}
+              y={13}
+              fill="#fbbf24"
+              fontSize="9"
+              fontWeight="800"
+              letterSpacing="0.08em"
+            >
+              TARGET
+            </text>
+          </g>
         )}
 
         {/* Peak floor reference */}

--- a/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
@@ -195,12 +195,13 @@ export default function CurveEditor({
   const linePath = blocks
     .map((b, i) => `${i === 0 ? 'M' : 'L'} ${b.xMid.toFixed(2)} ${yOf(b.target).toFixed(2)}`)
     .join(' ');
-  const playheadX = totalSec > 0 ? Math.max(0, Math.min(1, playheadSec / totalSec)) * w : 0;
+  const secToX = (sec: number) => (Math.max(0, Math.min(domainSec, sec)) / domainSec) * w;
+  const playheadX = domainSec > 0 ? secToX(playheadSec) : 0;
   const scrubFromClientX = (clientX: number) => {
     if (!svgRef.current || !scrubEnabled || !onScrub || totalSec <= 0) return;
     const rect = svgRef.current.getBoundingClientRect();
     const t = Math.max(0, Math.min(1, (clientX - rect.left) / Math.max(1, rect.width)));
-    onScrub(t * totalSec);
+    onScrub(Math.min(totalSec, t * domainSec));
   };
   const handleSvgClickCapture = (ev: ReactMouseEvent<SVGSVGElement>) => {
     if (!scrubEnabled || !onScrub || totalSec <= 0) return;

--- a/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
@@ -100,6 +100,8 @@ export interface CurvePanelProps {
   onSuggestReplacementsChange?: (on: boolean) => void;
   confirmRecompute?: boolean;
   requestConfirmation?: (action: ConfirmAction) => Promise<boolean>;
+  targetDurationSec?: number | null;
+  avgTransitionOverlapSec?: number;
 }
 
 export default function CurvePanel({
@@ -122,6 +124,8 @@ export default function CurvePanel({
   onSuggestReplacementsChange,
   confirmRecompute = true,
   requestConfirmation,
+  targetDurationSec = null,
+  avgTransitionOverlapSec = 0,
 }: CurvePanelProps) {
   const [view, setView] = useState<CurveViewMode>('normal');
   const [templates, setTemplates] = useState<CurveTemplatesResponse | null>(null);
@@ -437,6 +441,8 @@ export default function CurvePanel({
         onWindowChange={changeWindow}
         onWindowCommit={commitWindow}
         onWindowDelete={deleteWindow}
+        targetDurationSec={targetDurationSec}
+        avgTransitionOverlapSec={avgTransitionOverlapSec}
       />
       <CurveTemplateEditorOverlay
         open={overlay.open}

--- a/dashboard/app/(dj)/setbuilder/components/TargetEditor.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TargetEditor.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import {
+  TARGET_PRESETS,
+  formatDelta,
+  formatTimecode,
+  type TargetProjection,
+  type TargetSettings,
+} from './targetMath';
+import styles from '../setbuilder.module.css';
+
+interface TargetEditorProps {
+  settings: TargetSettings;
+  projection: TargetProjection | null;
+  dirty: boolean;
+  saving: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSettingsChange: (settings: TargetSettings) => void;
+  onSave: () => void;
+  onUndo: () => void;
+}
+
+function hoursMinutes(sec: number | null): { hours: number; minutes: number } {
+  if (sec == null) return { hours: 0, minutes: 0 };
+  const totalMinutes = Math.max(0, Math.round(sec / 60));
+  return { hours: Math.floor(totalMinutes / 60), minutes: totalMinutes % 60 };
+}
+
+function durationFromParts(hours: number, minutes: number): number | null {
+  const safeHours = Math.max(0, Math.min(24, hours));
+  const safeMinutes = Math.max(0, Math.min(59, minutes));
+  const total = safeHours * 3600 + safeMinutes * 60;
+  return total > 0 ? total : null;
+}
+
+export default function TargetEditor({
+  settings,
+  projection,
+  dirty,
+  saving,
+  open,
+  onOpenChange,
+  onSettingsChange,
+  onSave,
+  onUndo,
+}: TargetEditorProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const parts = hoursMinutes(settings.targetDurationSec);
+  const tier = projection?.tier ?? 'none';
+  const totalMinutes = Math.round((settings.targetDurationSec ?? 0) / 60);
+
+  const updateTargetPart = (patch: Partial<{ hours: number; minutes: number }>) => {
+    const next = { ...parts, ...patch };
+    onSettingsChange({ ...settings, targetDurationSec: durationFromParts(next.hours, next.minutes) });
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (ev: MouseEvent) => {
+      if (ref.current && !ref.current.contains(ev.target as Node)) onOpenChange(false);
+    };
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.key === 'Escape') onOpenChange(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open, onOpenChange]);
+
+  const cancel = () => {
+    onUndo();
+    onOpenChange(false);
+  };
+
+  const apply = () => {
+    onSave();
+    onOpenChange(false);
+  };
+
+  return (
+    <div className={styles.targetWrap} ref={ref}>
+      <button
+        type="button"
+        className={`${styles.targetPill} ${styles[`targetTier_${tier}`]}`}
+        onClick={() => onOpenChange(!open)}
+        aria-expanded={open}
+        data-testid="target-pill"
+        title="Click to edit the target set length"
+      >
+        <span className={styles.targetIcon} aria-hidden="true">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="9" />
+            <circle cx="12" cy="12" r="5" />
+            <circle cx="12" cy="12" r="1.5" fill="currentColor" />
+          </svg>
+        </span>
+        <span>{formatTimecode(settings.targetDurationSec)}</span>
+        <span className={styles.targetPillLabel}>target</span>
+        {dirty ? <span className={styles.targetDirty} aria-label="Unsaved target changes" /> : null}
+      </button>
+
+      {open ? (
+        <div className={styles.targetPopover} data-testid="target-popover">
+          <div className={styles.targetArrow} />
+          <div className={styles.targetPopoverHeader}>
+            <div>
+              <div className={styles.targetTitle}>Set length target</div>
+              <div className={styles.targetSub}>
+                Used for pacing guidance. Actual playing time varies with cuts and transitions.
+              </div>
+            </div>
+          </div>
+
+          <div className={styles.targetSectionLabel}>Common</div>
+          <div className={styles.targetPresetGrid}>
+            {TARGET_PRESETS.map((preset) => (
+              <button
+                type="button"
+                key={preset.id}
+                className={`${styles.targetPreset} ${totalMinutes === preset.seconds / 60 ? styles.targetPresetActive : ''}`}
+                onClick={() => onSettingsChange({ ...settings, targetDurationSec: preset.seconds })}
+                data-testid={`target-preset-${preset.id}`}
+              >
+                <span>{preset.label}</span>
+                <small>{preset.hint}</small>
+              </button>
+            ))}
+          </div>
+
+          <div className={styles.targetSectionLabel}>Custom</div>
+          <div className={styles.targetInputs}>
+            <label>
+              <span>hr</span>
+              <input
+                type="number"
+                min={0}
+                max={12}
+                value={parts.hours}
+                onChange={(ev) => updateTargetPart({ hours: Number(ev.target.value) })}
+              />
+            </label>
+            <label>
+              <span>min</span>
+              <input
+                type="number"
+                min={0}
+                max={59}
+                value={parts.minutes}
+                onChange={(ev) => updateTargetPart({ minutes: Number(ev.target.value) })}
+              />
+            </label>
+            <span className={styles.targetEquivalent}>
+              = {formatTimecode(settings.targetDurationSec)}
+            </span>
+          </div>
+
+          <div className={styles.targetSectionLabel}>Avg transition overlap</div>
+          <div className={styles.targetHelp}>
+            DJs blend tracks rather than gap them. Estimate seconds of overlap per transition.
+          </div>
+          <label className={styles.targetSlider}>
+            <span>
+              <b>{settings.avgTransitionOverlapSec}s</b>
+            </span>
+            <input
+              type="range"
+              min={0}
+              max={32}
+              value={settings.avgTransitionOverlapSec}
+              onChange={(ev) =>
+                onSettingsChange({
+                  ...settings,
+                  avgTransitionOverlapSec: Number(ev.target.value),
+                })
+              }
+            />
+          </label>
+
+          <div className={styles.targetProjectionCard}>
+            {projection ? (
+              <>
+                <div className={styles.targetProjectionRow}>
+                  <span>Sum of track durations</span>
+                  <strong>{formatTimecode(projection.rawTotalSec)}</strong>
+                </div>
+                <div className={styles.targetProjectionRow}>
+                  <span>- {projection.transitionCount} transitions x {settings.avgTransitionOverlapSec}s</span>
+                  <strong className={styles.targetMuted}>-{formatTimecode(projection.transitionOverlapSec)}</strong>
+                </div>
+                <div className={`${styles.targetProjectionRow} ${styles.targetProjectionEffective}`}>
+                  <span>Projected playing time</span>
+                  <strong>{formatTimecode(projection.effectiveSec)}</strong>
+                </div>
+                <div className={styles.targetProjectionRow}>
+                  <span>vs target {formatTimecode(settings.targetDurationSec)}</span>
+                  <strong className={`${styles.targetDeltaValue} ${styles[`targetTier_${tier}`]}`}>
+                    {formatDelta(projection.deltaSec)}
+                  </strong>
+                </div>
+              </>
+            ) : (
+              <div className={styles.targetProjectionRow}>
+                <span>Projection</span>
+                <strong>No tracks</strong>
+              </div>
+            )}
+          </div>
+
+          <div className={styles.targetActions}>
+            <button type="button" className="btn btn-ghost btn-sm" onClick={cancel} disabled={saving}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className={`btn btn-sm ${dirty ? 'btn-primary' : 'btn-ghost'}`}
+              onClick={apply}
+              disabled={!dirty || saving}
+            >
+              {saving ? 'Saving...' : 'Apply'}
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/ExportModal.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/ExportModal.test.tsx
@@ -41,6 +41,7 @@ function makeSet(overrides: Partial<SetDetail> = {}): SetDetail {
     share_token: null,
     vibe_theme: null,
     target_duration_sec: null,
+    avg_transition_overlap_sec: 8,
     bpm_floor: null,
     bpm_ceiling: null,
     key_strictness: 0,

--- a/dashboard/app/(dj)/setbuilder/components/curveMath.ts
+++ b/dashboard/app/(dj)/setbuilder/components/curveMath.ts
@@ -220,15 +220,20 @@ export interface SlotBlock {
   target: number;
 }
 
-export function slotBlocksFromSlots(slots: SlotView[], width: number): SlotBlock[] {
+export function slotBlocksFromSlots(
+  slots: SlotView[],
+  width: number,
+  domainSec?: number,
+): SlotBlock[] {
   const total = slots.reduce((acc, s) => acc + s.track.durationSec, 0);
   if (total <= 0) return [];
+  const domain = Math.max(1, domainSec ?? total);
   const blocks: SlotBlock[] = [];
   let cur = 0;
   for (let i = 0; i < slots.length; i++) {
     const s = slots[i];
-    const t0 = cur / total;
-    const t1 = (cur + s.track.durationSec) / total;
+    const t0 = cur / domain;
+    const t1 = (cur + s.track.durationSec) / domain;
     blocks.push({
       idx: i,
       slot: s,

--- a/dashboard/app/(dj)/setbuilder/components/targetMath.ts
+++ b/dashboard/app/(dj)/setbuilder/components/targetMath.ts
@@ -1,0 +1,111 @@
+import type { SlotView } from './types';
+
+export const DEFAULT_AVG_TRANSITION_OVERLAP_SEC = 8;
+
+export interface TargetSettings {
+  targetDurationSec: number | null;
+  avgTransitionOverlapSec: number;
+}
+
+export interface TargetProjection {
+  rawTotalSec: number;
+  slotCount: number;
+  transitionCount: number;
+  transitionOverlapSec: number;
+  effectiveSec: number;
+  deltaSec: number | null;
+  tier: TargetDeltaTier;
+}
+
+export type TargetDeltaTier = 'none' | 'on-target' | 'under' | 'over' | 'over-hard';
+
+export interface TargetPreset {
+  id: string;
+  label: string;
+  hint: string;
+  seconds: number;
+}
+
+export const TARGET_PRESETS: TargetPreset[] = [
+  { id: 'cocktail', label: '30m', hint: 'cocktail', seconds: 30 * 60 },
+  { id: 'club-opener', label: '45m', hint: 'club opener', seconds: 45 * 60 },
+  { id: 'wedding-dance', label: '1h', hint: 'wedding', seconds: 60 * 60 },
+  { id: 'residency-short', label: '90m', hint: 'residency', seconds: 90 * 60 },
+  { id: 'main-room', label: '2h', hint: 'main room', seconds: 120 * 60 },
+  { id: 'late-night', label: '3h', hint: 'late night', seconds: 180 * 60 },
+  { id: 'festival', label: '4h', hint: 'festival', seconds: 240 * 60 },
+  { id: 'marathon', label: '6h', hint: 'all night', seconds: 360 * 60 },
+];
+
+export function effectiveDurationSec(totalSec: number, slotCount: number, overlapSec: number): number {
+  const transitions = Math.max(0, slotCount - 1);
+  return Math.max(0, Math.round(totalSec) - transitions * Math.max(0, Math.round(overlapSec)));
+}
+
+export function rawTargetSecForSlots(
+  targetDurationSec: number | null,
+  slotCount: number,
+  overlapSec: number,
+): number | null {
+  if (targetDurationSec == null) return null;
+  const transitions = Math.max(0, slotCount - 1);
+  return Math.max(0, targetDurationSec + transitions * Math.max(0, Math.round(overlapSec)));
+}
+
+export function targetDeltaTier(deltaSec: number | null, targetDurationSec: number | null): TargetDeltaTier {
+  if (deltaSec == null || targetDurationSec == null || targetDurationSec <= 0) return 'none';
+  const tolerance = Math.max(60, targetDurationSec * 0.03);
+  if (Math.abs(deltaSec) <= tolerance) return 'on-target';
+  if (deltaSec < 0) return 'under';
+  if (deltaSec > targetDurationSec * 0.15) return 'over-hard';
+  return 'over';
+}
+
+export function projectTarget(slots: SlotView[], settings: TargetSettings): TargetProjection {
+  const rawTotalSec = slots.reduce((acc, s) => acc + s.track.durationSec, 0);
+  const slotCount = slots.length;
+  const transitionCount = Math.max(0, slotCount - 1);
+  const transitionOverlapSec = transitionCount * settings.avgTransitionOverlapSec;
+  const effectiveSec = effectiveDurationSec(
+    rawTotalSec,
+    slotCount,
+    settings.avgTransitionOverlapSec,
+  );
+  const deltaSec =
+    settings.targetDurationSec == null ? null : effectiveSec - settings.targetDurationSec;
+  return {
+    rawTotalSec,
+    slotCount,
+    transitionCount,
+    transitionOverlapSec,
+    effectiveSec,
+    deltaSec,
+    tier: targetDeltaTier(deltaSec, settings.targetDurationSec),
+  };
+}
+
+export function formatDuration(sec: number | null): string {
+  if (sec == null) return 'No target';
+  const rounded = Math.max(0, Math.round(sec / 60) * 60);
+  const h = Math.floor(rounded / 3600);
+  const m = Math.floor((rounded % 3600) / 60);
+  if (h > 0 && m > 0) return `${h}h ${m}m`;
+  if (h > 0) return `${h}h`;
+  return `${m}m`;
+}
+
+export function formatTimecode(sec: number | null): string {
+  if (sec == null) return '--:--';
+  const rounded = Math.max(0, Math.round(sec));
+  const m = Math.floor(rounded / 60);
+  const s = String(rounded % 60).padStart(2, '0');
+  return `${m}:${s}`;
+}
+
+export function formatDelta(deltaSec: number | null): string {
+  if (deltaSec == null) return 'Set target';
+  const roundedDelta = Math.round(deltaSec / 60) * 60;
+  const abs = formatTimecode(Math.abs(roundedDelta));
+  if (roundedDelta === 0) return 'On target';
+  return `${roundedDelta > 0 ? '+' : '-'}${abs}`;
+}

--- a/dashboard/app/(dj)/setbuilder/setbuilder.module.css
+++ b/dashboard/app/(dj)/setbuilder/setbuilder.module.css
@@ -174,6 +174,14 @@
   box-shadow: 0 0 5px rgba(0, 245, 212, 0.75);
 }
 
+.targetSaveError {
+  max-width: min(18rem, 40vw);
+  overflow: hidden;
+  color: var(--color-danger);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .targetPopover {
   position: absolute;
   top: calc(100% + 8px);

--- a/dashboard/app/(dj)/setbuilder/setbuilder.module.css
+++ b/dashboard/app/(dj)/setbuilder/setbuilder.module.css
@@ -89,6 +89,352 @@
   font-weight: 800;
 }
 
+.topbarMeta {
+  display: flex;
+  align-items: baseline;
+  gap: 0.875rem;
+  min-width: 0;
+  flex: 1;
+  padding: 0 1rem;
+}
+
+.topbarStats {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  min-width: 0;
+  font-family: var(--font-mono), monospace;
+  font-size: 0.6875rem;
+  color: var(--text-tertiary, var(--text-secondary));
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.topbarStats strong {
+  color: var(--text-secondary);
+  font-weight: 700;
+}
+
+.statDot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--text-tertiary, var(--text-secondary));
+}
+
+.targetWrap {
+  position: relative;
+}
+
+.targetPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3125rem;
+  padding: 0.125rem 0.5625rem 0.125rem 0.4375rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-deep, var(--bg));
+  color: var(--text);
+  font-family: var(--font-mono), monospace;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: all 0.12s;
+  white-space: nowrap;
+}
+
+.targetPill:hover {
+  border-color: #00f5d4;
+  background: rgba(0, 245, 212, 0.04);
+  color: #00f5d4;
+}
+
+.targetIcon {
+  display: grid;
+  place-items: center;
+  color: #00f5d4;
+}
+
+.targetPillLabel {
+  margin-left: 0.125rem;
+  font-family: var(--font-display), sans-serif;
+  font-size: 0.5625rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.targetDirty {
+  width: 0.35rem;
+  height: 0.35rem;
+  border-radius: 999px;
+  background: #00f5d4;
+  box-shadow: 0 0 5px rgba(0, 245, 212, 0.75);
+}
+
+.targetPopover {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 80;
+  width: min(420px, 92vw);
+  padding: 0.875rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--card);
+  box-shadow:
+    0 0 0 1px rgba(0, 245, 212, 0.1),
+    0 20px 60px -8px rgba(0, 0, 0, 0.7);
+}
+
+.targetArrow {
+  position: absolute;
+  top: -6px;
+  left: 28px;
+  width: 12px;
+  height: 12px;
+  background: var(--card);
+  border-top: 1px solid var(--border);
+  border-left: 1px solid var(--border);
+  transform: rotate(45deg);
+}
+
+.targetPopoverHeader {
+  margin-bottom: 0.875rem;
+}
+
+.targetTitle {
+  font-family: var(--font-display), sans-serif;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.targetSub {
+  margin-top: 0.1875rem;
+  color: var(--text-secondary);
+  font-size: 0.7188rem;
+  line-height: 1.5;
+}
+
+.targetSectionLabel {
+  margin-bottom: 0.375rem;
+  font-family: var(--font-display), sans-serif;
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.targetHelp {
+  margin: -0.125rem 0 0.5rem;
+  color: var(--text-tertiary, var(--text-secondary));
+  font-size: 0.6875rem;
+  line-height: 1.5;
+}
+
+.targetTier_none {
+  border-color: var(--border);
+}
+
+.targetTier_on-target {
+  border-color: rgba(34, 197, 94, 0.55);
+  background: rgba(34, 197, 94, 0.12);
+  color: #86efac;
+}
+
+.targetTier_under {
+  border-color: rgba(59, 130, 246, 0.55);
+  background: rgba(59, 130, 246, 0.12);
+  color: #93c5fd;
+}
+
+.targetTier_over {
+  border-color: rgba(245, 158, 11, 0.6);
+  background: rgba(245, 158, 11, 0.13);
+  color: #fbbf24;
+}
+
+.targetTier_over-hard {
+  border-color: rgba(239, 68, 68, 0.6);
+  background: rgba(239, 68, 68, 0.13);
+  color: #fca5a5;
+}
+
+.targetPresetGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.25rem;
+  margin-bottom: 0.875rem;
+}
+
+.targetPreset {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.125rem;
+  min-height: 2.75rem;
+  padding: 0.375rem 0.25rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-deep, var(--bg));
+  color: var(--text);
+  cursor: pointer;
+  transition: all 0.1s;
+}
+
+.targetPreset:hover {
+  border-color: var(--text-tertiary, var(--text-secondary));
+  background: var(--surface-raised, rgba(255, 255, 255, 0.04));
+}
+
+.targetPresetActive {
+  border-color: #00f5d4;
+  background: rgba(0, 245, 212, 0.06);
+  color: #00f5d4;
+}
+
+.targetPreset span {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.targetPreset small {
+  color: var(--text-tertiary, var(--text-secondary));
+  font-size: 0.5625rem;
+  letter-spacing: 0.02em;
+  line-height: 1.1;
+}
+
+.targetInputs {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.875rem;
+}
+
+.targetInputs label {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-deep, var(--bg));
+}
+
+.targetInputs label:focus-within {
+  border-color: #00f5d4;
+}
+
+.targetInputs label span {
+  margin-left: 0.25rem;
+  color: var(--text-tertiary, var(--text-secondary));
+  font-family: var(--font-mono), monospace;
+  font-size: 0.625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.targetInputs input {
+  width: 2.25rem;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-mono), monospace;
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-align: center;
+}
+
+.targetInputs input:focus {
+  outline: none;
+}
+
+.targetEquivalent {
+  margin-left: auto;
+  color: var(--text-tertiary, var(--text-secondary));
+  font-family: var(--font-mono), monospace;
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+}
+
+.targetSlider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.875rem;
+}
+
+.targetSlider span {
+  order: 2;
+  min-width: 2.25rem;
+  text-align: right;
+  color: #00f5d4;
+  font-family: var(--font-mono), monospace;
+  font-size: 0.75rem;
+}
+
+.targetSlider input {
+  flex: 1;
+  width: 100%;
+  accent-color: #00f5d4;
+}
+
+.targetProjectionCard {
+  margin-bottom: 0.875rem;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-deep, var(--bg));
+}
+
+.targetProjectionRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.125rem 0;
+  font-size: 0.7188rem;
+}
+
+.targetProjectionRow span {
+  color: var(--text-secondary);
+}
+
+.targetProjectionRow strong {
+  color: var(--text);
+  font-family: var(--font-mono), monospace;
+  font-size: 0.7188rem;
+}
+
+.targetMuted {
+  color: var(--text-tertiary, var(--text-secondary)) !important;
+}
+
+.targetProjectionEffective {
+  margin-top: 0.125rem;
+  padding-top: 0.25rem;
+  border-top: 1px dashed var(--border-subtle);
+}
+
+.targetDeltaValue {
+  padding: 0.125rem 0.4rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+}
+
+.targetActions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-top: 0.625rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
 .panel {
   background: var(--bg);
   display: flex;
@@ -131,6 +477,97 @@
   text-transform: uppercase;
   color: var(--text-secondary);
   border-bottom: 1px solid var(--border-subtle);
+}
+
+.panelHeaderRow {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.panelHeaderRow .panelHeader {
+  border-bottom: none;
+  flex-shrink: 0;
+}
+
+.timelineSummary {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.875rem;
+  flex: 1;
+  min-width: 0;
+  padding-right: 1rem;
+  color: var(--text-tertiary, var(--text-secondary));
+  font-family: var(--font-mono), monospace;
+  font-size: 0.6563rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.timelineSummary strong {
+  color: var(--text-secondary);
+  font-weight: 700;
+}
+
+.timelineLiveWrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.timelineLive {
+  cursor: help;
+}
+
+.timelineTooltip {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 70;
+  display: none;
+  width: 280px;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-raised, var(--card));
+  color: var(--text-secondary);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  font-family: var(--font-body), sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.timelineLiveWrap:hover .timelineTooltip,
+.timelineLiveWrap:focus-within .timelineTooltip {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.timelineTooltip strong {
+  color: var(--text);
+  font-family: var(--font-body), sans-serif;
+}
+
+.timelineTooltipGrid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.1875rem 0.625rem;
+  margin-top: 0.125rem;
+}
+
+.timelineTooltipGrid span {
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.timelineTooltipGrid b {
+  color: var(--text);
+  font-family: var(--font-mono), monospace;
+  font-weight: 500;
 }
 
 .panelBody {

--- a/dashboard/app/shared/[token]/__tests__/page.test.tsx
+++ b/dashboard/app/shared/[token]/__tests__/page.test.tsx
@@ -21,6 +21,7 @@ function makeView(overrides: Partial<SharedSetView> = {}): SharedSetView {
     status: 'draft',
     vibe_theme: 'dark-techno',
     target_duration_sec: 3600,
+    avg_transition_overlap_sec: 8,
     bpm_floor: 124,
     bpm_ceiling: 132,
     key_strictness: 0.7,

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -3162,6 +3162,26 @@ export interface paths {
         patch: operations["update_slot_target_api_setbuilder_sets__set_id__slots__slot_id__target_patch"];
         trace?: never;
     };
+    "/api/setbuilder/sets/{set_id}/target": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update Set Target
+         * @description Update set-length target + average transition overlap.
+         */
+        put: operations["update_set_target_api_setbuilder_sets__set_id__target_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/setbuilder/sets/{set_id}/transport/command": {
         parameters: {
             query?: never;
@@ -6027,6 +6047,8 @@ export interface components {
          * @description Full set record (Phase 0: no slot/curve expansion yet).
          */
         SetDetail: {
+            /** Avg Transition Overlap Sec */
+            avg_transition_overlap_sec: number;
             /** Bpm Ceiling */
             bpm_ceiling: number | null;
             /** Bpm Floor */
@@ -6280,6 +6302,16 @@ export interface components {
             updated_at: string;
         };
         /**
+         * SetTargetUpdate
+         * @description Body for updating set-length planning settings.
+         */
+        SetTargetUpdate: {
+            /** Avg Transition Overlap Sec */
+            avg_transition_overlap_sec: number;
+            /** Target Duration Sec */
+            target_duration_sec?: number | null;
+        };
+        /**
          * ShareTokenOut
          * @description Owner response after creating/rotating a share token (issue #398).
          */
@@ -6311,6 +6343,8 @@ export interface components {
          *     collaborator info, or the token itself.
          */
         SharedSetView: {
+            /** Avg Transition Overlap Sec */
+            avg_transition_overlap_sec: number;
             /** Bpm Ceiling */
             bpm_ceiling: number | null;
             /** Bpm Floor */
@@ -12691,6 +12725,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SlotTargetOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_set_target_api_setbuilder_sets__set_id__target_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetTargetUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetDetail"];
                 };
             };
             /** @description Validation Error */

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -189,6 +189,7 @@ export interface SetSummary {
 export interface SetDetail extends SetSummary {
   vibe_theme: string | null;
   target_duration_sec: number | null;
+  avg_transition_overlap_sec: number;
   bpm_floor: number | null;
   bpm_ceiling: number | null;
   key_strictness: number;
@@ -274,6 +275,7 @@ export interface SharedSetView {
   status: 'draft' | 'locked' | 'exported';
   vibe_theme: string | null;
   target_duration_sec: number | null;
+  avg_transition_overlap_sec: number;
   bpm_floor: number | null;
   bpm_ceiling: number | null;
   key_strictness: number;

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -717,6 +717,19 @@ class ApiClient {
       body: JSON.stringify({ name }),
     });
   }
+  async updateSetTargetSettings(
+    setId: number,
+    targetDurationSec: number | null,
+    avgTransitionOverlapSec: number,
+  ): Promise<SetDetail> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/target`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        target_duration_sec: targetDurationSec,
+        avg_transition_overlap_sec: avgTransitionOverlapSec,
+      }),
+    });
+  }
   async deleteSet(setId: number): Promise<void> {
     await this.rawFetch(`/api/setbuilder/sets/${setId}`, { method: 'DELETE' });
   }

--- a/server/alembic/versions/059_add_set_transition_overlap.py
+++ b/server/alembic/versions/059_add_set_transition_overlap.py
@@ -1,0 +1,36 @@
+"""Add WrzDJSet transition overlap setting (issue #394).
+
+Revision ID: 059
+Revises: 058
+Create Date: 2026-06-13
+
+Average transition overlap is a per-set planning input. It shrinks effective
+playtime as tracks blend: total - (slots - 1) * overlap.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "059"
+down_revision: str | None = "058"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sets",
+        sa.Column(
+            "avg_transition_overlap_sec",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("8"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("sets", "avg_transition_overlap_sec")

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -61,6 +61,7 @@ from app.schemas.setbuilder import (
     SetDocumentSnapshot,
     SetRename,
     SetSummary,
+    SetTargetUpdate,
     SlotOut,
     SlotTargetOut,
     SlotTargetUpdate,
@@ -170,6 +171,27 @@ def rename_set(
     """Rename one of the current DJ's sets, or 404."""
     set_obj = _get_owned_or_404(db, set_id, current_user)
     return SetDetail.model_validate(set_service.rename_set(db, set_obj, payload.name))
+
+
+@router.put("/sets/{set_id}/target", response_model=SetDetail)
+@limiter.limit("30/minute")
+def update_set_target(
+    set_id: int,
+    payload: SetTargetUpdate,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> SetDetail:
+    """Update set-length target + average transition overlap."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    return SetDetail.model_validate(
+        set_service.update_target_settings(
+            db,
+            set_obj,
+            target_duration_sec=payload.target_duration_sec,
+            avg_transition_overlap_sec=payload.avg_transition_overlap_sec,
+        )
+    )
 
 
 @router.delete("/sets/{set_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/server/app/api/setbuilder_share.py
+++ b/server/app/api/setbuilder_share.py
@@ -103,6 +103,7 @@ def view_shared_set(
         status=set_obj.status,
         vibe_theme=set_obj.vibe_theme,
         target_duration_sec=set_obj.target_duration_sec,
+        avg_transition_overlap_sec=set_obj.avg_transition_overlap_sec,
         bpm_floor=set_obj.bpm_floor,
         bpm_ceiling=set_obj.bpm_ceiling,
         key_strictness=set_obj.key_strictness,

--- a/server/app/models/set.py
+++ b/server/app/models/set.py
@@ -40,6 +40,9 @@ class Set(Base):
     vibe_theme: Mapped[str | None] = mapped_column(String(50), nullable=True)
 
     target_duration_sec: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    avg_transition_overlap_sec: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=8, server_default="8"
+    )
     bpm_floor: Mapped[int | None] = mapped_column(Integer, nullable=True)
     bpm_ceiling: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # 0.0 ignore Camelot ... 1.0 strict +/-1

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -21,6 +21,13 @@ class SetRename(BaseModel):
     name: str = Field(..., min_length=1, max_length=120)
 
 
+class SetTargetUpdate(BaseModel):
+    """Body for updating set-length planning settings."""
+
+    target_duration_sec: int | None = Field(None, ge=60, le=24 * 3600)
+    avg_transition_overlap_sec: int = Field(..., ge=0, le=32)
+
+
 class SetSummary(BaseModel):
     """Set list item (no children)."""
 
@@ -42,6 +49,7 @@ class SetDetail(SetSummary):
 
     vibe_theme: str | None
     target_duration_sec: int | None
+    avg_transition_overlap_sec: int
     bpm_floor: int | None
     bpm_ceiling: int | None
     key_strictness: float
@@ -691,6 +699,7 @@ class SharedSetView(BaseModel):
     status: Literal["draft", "locked", "exported"]
     vibe_theme: str | None
     target_duration_sec: int | None
+    avg_transition_overlap_sec: int
     bpm_floor: int | None
     bpm_ceiling: int | None
     key_strictness: float

--- a/server/app/services/setbuilder/set_service.py
+++ b/server/app/services/setbuilder/set_service.py
@@ -37,6 +37,21 @@ def rename_set(db: Session, set_obj: Set, name: str) -> Set:
     return set_obj
 
 
+def update_target_settings(
+    db: Session,
+    set_obj: Set,
+    *,
+    target_duration_sec: int | None,
+    avg_transition_overlap_sec: int,
+) -> Set:
+    """Update set-length planning settings."""
+    set_obj.target_duration_sec = target_duration_sec
+    set_obj.avg_transition_overlap_sec = avg_transition_overlap_sec
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
 def delete_set(db: Session, set_obj: Set) -> None:
     """Delete a set (children cascade via FK ondelete + ORM cascade)."""
     db.delete(set_obj)

--- a/server/app/services/setbuilder/share_service.py
+++ b/server/app/services/setbuilder/share_service.py
@@ -62,6 +62,7 @@ def duplicate_set(db: Session, src: Set) -> Set:
         name=name,
         vibe_theme=src.vibe_theme,
         target_duration_sec=src.target_duration_sec,
+        avg_transition_overlap_sec=src.avg_transition_overlap_sec,
         bpm_floor=src.bpm_floor,
         bpm_ceiling=src.bpm_ceiling,
         key_strictness=src.key_strictness,

--- a/server/app/services/setbuilder/targeting.py
+++ b/server/app/services/setbuilder/targeting.py
@@ -1,0 +1,101 @@
+"""Set-duration targeting helpers for WrzDJSet.
+
+The pass-1 slot generator consumes this contract so target length and average
+transition overlap stay consistent with the UI projection.
+"""
+
+from dataclasses import dataclass
+from math import ceil
+
+DEFAULT_AVG_TRANSITION_OVERLAP_SEC = 8
+
+
+@dataclass(frozen=True)
+class SlotBudget:
+    """Target-driven slot count and projected effective duration."""
+
+    slot_count: int
+    projected_total_sec: int
+    projected_effective_sec: int
+    delta_sec: int | None
+    within_overflow_tolerance: bool | None = None
+
+
+def effective_duration_sec(total_sec: int, slots: int, overlap_sec: int) -> int:
+    """Effective playtime after blend overlaps."""
+    transitions = max(0, slots - 1)
+    return max(0, int(total_sec) - transitions * max(0, int(overlap_sec)))
+
+
+def pass1_slot_budget(
+    *,
+    target_duration_sec: int | None,
+    avg_track_duration_sec: int,
+    avg_transition_overlap_sec: int = DEFAULT_AVG_TRANSITION_OVERLAP_SEC,
+) -> SlotBudget:
+    """Compute the minimum slot count that reaches a target effective duration.
+
+    For n tracks with average duration d and transition overlap o:
+    effective = n*d - (n-1)*o = n*(d-o) + o.
+    """
+    if target_duration_sec is None or target_duration_sec <= 0:
+        return SlotBudget(0, 0, 0, None)
+
+    track_sec = max(1, int(avg_track_duration_sec))
+    overlap_sec = max(0, int(avg_transition_overlap_sec))
+    effective_per_added_track = max(1, track_sec - overlap_sec)
+    slot_count = max(1, ceil((target_duration_sec - overlap_sec) / effective_per_added_track))
+    total_sec = slot_count * track_sec
+    projected_effective = effective_duration_sec(total_sec, slot_count, overlap_sec)
+    delta_sec = projected_effective - target_duration_sec
+    return SlotBudget(
+        slot_count=slot_count,
+        projected_total_sec=total_sec,
+        projected_effective_sec=projected_effective,
+        delta_sec=delta_sec,
+        within_overflow_tolerance=delta_sec <= target_duration_sec * 0.10,
+    )
+
+
+def pass1_slot_budget_from_durations(
+    *,
+    target_duration_sec: int | None,
+    track_durations_sec: list[int],
+    avg_transition_overlap_sec: int = DEFAULT_AVG_TRANSITION_OVERLAP_SEC,
+    overflow_tolerance: float = 0.10,
+) -> SlotBudget:
+    """Compute a target budget from actual selected track durations.
+
+    The deterministic pass can call this as it builds candidate timelines:
+    actual durations win over uniform buckets, while ``within_overflow_tolerance``
+    tells callers whether the selected prefix has exceeded the target by more
+    than the allowed tolerance.
+    """
+    if target_duration_sec is None or target_duration_sec <= 0:
+        return SlotBudget(0, 0, 0, None)
+
+    overlap_sec = max(0, int(avg_transition_overlap_sec))
+    total_sec = 0
+    slot_count = 0
+    projected_effective = 0
+    for duration_sec in track_durations_sec:
+        if duration_sec <= 0:
+            continue
+        slot_count += 1
+        total_sec += int(duration_sec)
+        projected_effective = effective_duration_sec(total_sec, slot_count, overlap_sec)
+        if projected_effective >= target_duration_sec:
+            break
+
+    if slot_count == 0:
+        return SlotBudget(0, 0, 0, -target_duration_sec, False)
+
+    delta_sec = projected_effective - target_duration_sec
+    max_overflow = target_duration_sec * max(0.0, overflow_tolerance)
+    return SlotBudget(
+        slot_count=slot_count,
+        projected_total_sec=total_sec,
+        projected_effective_sec=projected_effective,
+        delta_sec=delta_sec,
+        within_overflow_tolerance=delta_sec <= max_overflow,
+    )

--- a/server/app/services/setbuilder/targeting.py
+++ b/server/app/services/setbuilder/targeting.py
@@ -43,6 +43,16 @@ def pass1_slot_budget(
 
     track_sec = max(1, int(avg_track_duration_sec))
     overlap_sec = max(0, int(avg_transition_overlap_sec))
+    if track_sec <= overlap_sec:
+        delta_sec = track_sec - target_duration_sec
+        return SlotBudget(
+            slot_count=1,
+            projected_total_sec=track_sec,
+            projected_effective_sec=track_sec,
+            delta_sec=delta_sec,
+            within_overflow_tolerance=0 <= delta_sec <= target_duration_sec * 0.10,
+        )
+
     effective_per_added_track = max(1, track_sec - overlap_sec)
     slot_count = max(1, ceil((target_duration_sec - overlap_sec) / effective_per_added_track))
     total_sec = slot_count * track_sec

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -7502,6 +7502,10 @@
       "SetDetail": {
         "description": "Full set record (Phase 0: no slot/curve expansion yet).",
         "properties": {
+          "avg_transition_overlap_sec": {
+            "title": "Avg Transition Overlap Sec",
+            "type": "integer"
+          },
           "bpm_ceiling": {
             "anyOf": [
               {
@@ -7632,6 +7636,7 @@
           }
         },
         "required": [
+          "avg_transition_overlap_sec",
           "bpm_ceiling",
           "bpm_floor",
           "created_at",
@@ -8300,6 +8305,35 @@
         "title": "SetSummary",
         "type": "object"
       },
+      "SetTargetUpdate": {
+        "description": "Body for updating set-length planning settings.",
+        "properties": {
+          "avg_transition_overlap_sec": {
+            "maximum": 32.0,
+            "minimum": 0.0,
+            "title": "Avg Transition Overlap Sec",
+            "type": "integer"
+          },
+          "target_duration_sec": {
+            "anyOf": [
+              {
+                "maximum": 86400.0,
+                "minimum": 60.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Duration Sec"
+          }
+        },
+        "required": [
+          "avg_transition_overlap_sec"
+        ],
+        "title": "SetTargetUpdate",
+        "type": "object"
+      },
       "ShareTokenOut": {
         "description": "Owner response after creating/rotating a share token (issue #398).",
         "properties": {
@@ -8358,6 +8392,10 @@
       "SharedSetView": {
         "description": "Public read-only projection of a shared set (issue #398).\n\nNever include owner identity, internal ids, event linkage,\ncollaborator info, or the token itself.",
         "properties": {
+          "avg_transition_overlap_sec": {
+            "title": "Avg Transition Overlap Sec",
+            "type": "integer"
+          },
           "bpm_ceiling": {
             "anyOf": [
               {
@@ -8435,6 +8473,7 @@
           }
         },
         "required": [
+          "avg_transition_overlap_sec",
           "bpm_ceiling",
           "bpm_floor",
           "curve_points",
@@ -19094,6 +19133,64 @@
           }
         ],
         "summary": "Update Slot Target",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/target": {
+      "put": {
+        "description": "Update set-length target + average transition overlap.",
+        "operationId": "update_set_target_api_setbuilder_sets__set_id__target_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetTargetUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetDetail"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Set Target",
         "tags": [
           "setbuilder"
         ]

--- a/server/tests/test_setbuilder_api.py
+++ b/server/tests/test_setbuilder_api.py
@@ -103,6 +103,54 @@ def test_rename_other_dj_set_returns_404(client, auth_headers, db):
     assert resp.status_code == 404
 
 
+def test_update_target_settings_persists_target_and_overlap(client, auth_headers):
+    created = client.post(
+        "/api/setbuilder/sets", json={"name": "Targeted"}, headers=auth_headers
+    ).json()
+    assert created["avg_transition_overlap_sec"] == 8
+
+    resp = client.put(
+        f"/api/setbuilder/sets/{created['id']}/target",
+        json={"target_duration_sec": 5400, "avg_transition_overlap_sec": 12},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200, resp.json()
+    body = resp.json()
+    assert body["target_duration_sec"] == 5400
+    assert body["avg_transition_overlap_sec"] == 12
+
+    fetched = client.get(f"/api/setbuilder/sets/{created['id']}", headers=auth_headers).json()
+    assert fetched["target_duration_sec"] == 5400
+    assert fetched["avg_transition_overlap_sec"] == 12
+
+
+def test_update_target_settings_validates_overlap_range(client, auth_headers):
+    created = client.post(
+        "/api/setbuilder/sets", json={"name": "Targeted"}, headers=auth_headers
+    ).json()
+    resp = client.put(
+        f"/api/setbuilder/sets/{created['id']}/target",
+        json={"target_duration_sec": 3600, "avg_transition_overlap_sec": 33},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_update_target_settings_owner_scoped(client, auth_headers, db):
+    _make_second_dj(db)
+    other_headers = _login(client, "otherdj", "xxxxxxxxxxxx")
+    theirs = client.post(
+        "/api/setbuilder/sets", json={"name": "Theirs"}, headers=other_headers
+    ).json()
+    resp = client.put(
+        f"/api/setbuilder/sets/{theirs['id']}/target",
+        json={"target_duration_sec": 3600, "avg_transition_overlap_sec": 8},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404
+
+
 def test_delete_set(client, auth_headers):
     created = client.post(
         "/api/setbuilder/sets", json={"name": "Doomed"}, headers=auth_headers

--- a/server/tests/test_setbuilder_models.py
+++ b/server/tests/test_setbuilder_models.py
@@ -111,6 +111,7 @@ def test_set_persists_with_defaults(db):
     assert s.status == "draft"
     assert s.sharing_mode == "private"
     assert s.key_strictness == 0.2
+    assert s.avg_transition_overlap_sec == 8
     assert s.event_id is None
     assert s.created_at is not None
     assert s.updated_at is not None

--- a/server/tests/test_setbuilder_share.py
+++ b/server/tests/test_setbuilder_share.py
@@ -18,6 +18,7 @@ def _seed_set(db, owner_id, **overrides) -> Set:
         "name": "Warehouse Closer",
         "vibe_theme": "dark-techno",
         "target_duration_sec": 3600,
+        "avg_transition_overlap_sec": 12,
         "bpm_floor": 124,
         "bpm_ceiling": 132,
         "key_strictness": 0.7,
@@ -108,6 +109,7 @@ def test_duplicate_copies_children_and_resets_state(db, test_user):
     # targets + vibe copied
     assert dup.vibe_theme == "dark-techno"
     assert dup.target_duration_sec == 3600
+    assert dup.avg_transition_overlap_sec == 12
     assert dup.bpm_floor == 124
     assert dup.bpm_ceiling == 132
     assert dup.key_strictness == 0.7
@@ -291,6 +293,7 @@ def test_public_shared_view_projection(client, auth_headers, db, test_user):
     assert body["name"] == "Warehouse Closer"
     assert body["vibe_theme"] == "dark-techno"
     assert body["bpm_floor"] == 124
+    assert body["avg_transition_overlap_sec"] == 12
     assert [s["position"] for s in body["slots"]] == [1, 2]
     assert body["slots"][0]["notes"] == "opener"
     assert [c["energy"] for c in body["curve_points"]] == [4, 9]

--- a/server/tests/test_setbuilder_targeting.py
+++ b/server/tests/test_setbuilder_targeting.py
@@ -1,0 +1,62 @@
+"""Duration targeting contract for WrzDJSet pass-1 slot generation (issue #394)."""
+
+from app.services.setbuilder import targeting
+
+
+def test_effective_duration_subtracts_transition_overlap():
+    assert targeting.effective_duration_sec(total_sec=1800, slots=6, overlap_sec=8) == 1760
+    assert targeting.effective_duration_sec(total_sec=1800, slots=1, overlap_sec=8) == 1800
+    assert targeting.effective_duration_sec(total_sec=10, slots=5, overlap_sec=8) == 0
+
+
+def test_pass1_slot_budget_uses_effective_track_playtime():
+    budget = targeting.pass1_slot_budget(
+        target_duration_sec=3600,
+        avg_track_duration_sec=210,
+        avg_transition_overlap_sec=10,
+    )
+
+    assert budget.slot_count == 18
+    assert budget.projected_total_sec == 3780
+    assert budget.projected_effective_sec == 3610
+    assert budget.delta_sec == 10
+
+
+def test_pass1_slot_budget_without_target_returns_empty_contract():
+    budget = targeting.pass1_slot_budget(
+        target_duration_sec=None,
+        avg_track_duration_sec=210,
+        avg_transition_overlap_sec=8,
+    )
+
+    assert budget.slot_count == 0
+    assert budget.projected_effective_sec == 0
+    assert budget.delta_sec is None
+
+
+def test_pass1_slot_budget_from_actual_durations_respects_overflow_tolerance():
+    budget = targeting.pass1_slot_budget_from_durations(
+        target_duration_sec=600,
+        track_durations_sec=[240, 240, 240],
+        avg_transition_overlap_sec=10,
+        overflow_tolerance=0.10,
+    )
+
+    assert budget.slot_count == 3
+    assert budget.projected_total_sec == 720
+    assert budget.projected_effective_sec == 700
+    assert budget.delta_sec == 100
+    assert budget.within_overflow_tolerance is False
+
+
+def test_pass1_slot_budget_from_actual_durations_prefers_tolerated_overflow():
+    budget = targeting.pass1_slot_budget_from_durations(
+        target_duration_sec=600,
+        track_durations_sec=[210, 210, 210],
+        avg_transition_overlap_sec=10,
+        overflow_tolerance=0.10,
+    )
+
+    assert budget.slot_count == 3
+    assert budget.projected_effective_sec == 610
+    assert budget.within_overflow_tolerance is True

--- a/server/tests/test_setbuilder_targeting.py
+++ b/server/tests/test_setbuilder_targeting.py
@@ -34,6 +34,21 @@ def test_pass1_slot_budget_without_target_returns_empty_contract():
     assert budget.delta_sec is None
 
 
+def test_pass1_slot_budget_guards_non_increasing_effective_duration():
+    # Regression for dc018e8: overlap >= average track duration cannot use the closed form.
+    budget = targeting.pass1_slot_budget(
+        target_duration_sec=120,
+        avg_track_duration_sec=30,
+        avg_transition_overlap_sec=30,
+    )
+
+    assert budget.slot_count == 1
+    assert budget.projected_total_sec == 30
+    assert budget.projected_effective_sec == 30
+    assert budget.delta_sec == -90
+    assert budget.within_overflow_tolerance is False
+
+
 def test_pass1_slot_budget_from_actual_durations_respects_overflow_tolerance():
     budget = targeting.pass1_slot_budget_from_durations(
         target_duration_sec=600,


### PR DESCRIPTION
## Why

Closes #394.

Set length needs to be a first-class WrzDJSet planning constraint. DJs blend transitions and cut tracks, so planning should account for target duration, average transition overlap, actual track durations where available, and visible over/under target feedback.

## What

- Adds persisted per-set `avg_transition_overlap_sec` alongside the existing `target_duration_sec`, with API/schema/OpenAPI/client type coverage and duplicate/share projections.
- Adds target settings update API and shared target-duration helpers for effective duration and pass-1 slot budgeting from average or actual durations.
- Adds the topbar target pill and target editor popover with presets, custom hour/minute inputs, 0-32s overlap control, projection rows, dirty/undo behavior, and delta tiering.
- Updates timeline and curve views to use effective duration math, show raw vs estimated live runtime, render the target marker, and tint the over-target region.
- Adds backend and frontend regression tests for persistence, validation, projection math, curve marker/domain behavior, and editor interactions.

## Design decisions

- Did not re-add `target_duration_sec`; the existing Set field is reused and only the missing overlap setting is migrated.
- Migration is `059_add_set_transition_overlap.py` with revision `059`, leaving `058` available for #392 as requested; this branch has a single Alembic head.
- Effective time is derived as `sum(track durations) - (slot_count - 1) * overlap`; the curve remains derived and piecewise-linear, with the target marker placed at the raw timeline position needed to hit the effective target after overlaps.
- The UI follows the synced WrzDJSet prototype direction using vanilla CSS/React styles in the existing setbuilder surface, while avoiding separate duplicated curve state.
- Overlap validation allows 0-32 seconds to match the final handoff timing range.

## Testing

- ✅ `server/.venv/bin/ruff check .`
- ✅ `server/.venv/bin/ruff format --check .`
- ✅ `server/.venv/bin/bandit -r app -c pyproject.toml -q`
- ✅ `server/.venv/bin/pytest --tb=short -q` — 2807 passed, coverage 88.65% / 85%
- ✅ `server/.venv/bin/alembic heads` — `059 (head)`
- ⚠️ `server/.venv/bin/alembic upgrade head && server/.venv/bin/alembic check` blocked locally by PostgreSQL auth: password authentication failed for user `wrzdj` on localhost:5432
- ✅ `dashboard npm run lint`
- ✅ `dashboard npx tsc --noEmit`
- ✅ `dashboard npm test -- --run` — 84 files, 1149 tests passed

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a set **Target** editor with a target pill and popover for configuring target duration and average transition overlap.
  * Included preset quick-selects, an overlap slider, and **Apply/Cancel** with undo support.
  * Updated the timeline to show projection details (including live estimated timing) and added a visual target marker with an over-target region in the curve view.

* **Tests**
  * Expanded coverage for target configuration, projection math, and curve/marker rendering behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->