### PR TITLE
Improve backend CI test efficiency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           DATABASE_URL: postgresql+psycopg://wrzdj:wrzdj@localhost:5432/wrzdj_test
           JWT_SECRET: test-secret-key
           ENV: development
-        run: pytest --cov=app --cov-report=xml --cov-report=term-missing --durations=25 --durations-min=1.0
+        run: pytest -n 4 --dist=loadfile --cov=app --cov-report=xml --cov-report=term-missing --durations=25 --durations-min=1.0
 
       - name: Check Alembic migrations are up to date
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           DATABASE_URL: postgresql+psycopg://wrzdj:wrzdj@localhost:5432/wrzdj_test
           JWT_SECRET: test-secret-key
           ENV: development
-        run: pytest --cov=app --cov-report=xml --cov-report=term-missing
+        run: pytest --cov=app --cov-report=xml --cov-report=term-missing --durations=25 --durations-min=1.0
 
       - name: Check Alembic migrations are up to date
         env:

--- a/docs/superpowers/plans/2026-06-14-backend-ci-efficiency.md
+++ b/docs/superpowers/plans/2026-06-14-backend-ci-efficiency.md
@@ -1,0 +1,801 @@
+# Backend CI Efficiency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut backend CI runtime by removing repeated test-harness overhead, preserving the enforced coverage gate, and adding safe parallelism only after isolation is fixed.
+
+**Architecture:** Keep production behavior unchanged. Refactor the backend pytest harness so the SQLite schema is created once per test process, each test runs inside an externally managed transaction, normal `TestClient` tests use a no-background app lifespan, and common auth headers are direct JWTs instead of repeated login/bcrypt work. Add permanent pytest duration reporting, then introduce conservative xdist execution.
+
+**Tech Stack:** FastAPI, Starlette `TestClient`, SQLAlchemy 2.x, pytest, pytest-cov, pytest-xdist, SQLite `StaticPool`.
+
+**Branch:** `chore/backend-ci-refactor` in worktree `/home/adam/github/WrzDJ/.worktrees/chore/backend-ci-refactor`. Never edit or commit on `main`.
+
+**Python tooling:** Prefer `/home/adam/github/WrzDJ/server/.venv/bin/{pytest,ruff,bandit,alembic}` from this worktree's `server/` directory if `server/.venv` is absent in the worktree.
+
+---
+
+## File Map
+
+- Modify `.github/workflows/ci.yml`: backend pytest command gets duration output, then xdist once isolation is fixed.
+- Modify `server/pyproject.toml`: add `pytest-xdist` to dev dependencies in the final task.
+- Modify `server/tests/conftest.py`: transactional DB fixture, test app fixture, direct JWT header helpers, centralized `SessionLocal` patching.
+- Modify `server/app/main.py`: add a small app factory and no-background lifespan seam.
+- Create `server/tests/test_test_harness.py`: harness regression tests for transaction isolation, auth helper behavior, and direct-session registration.
+- Modify `server/tests/test_api.py`: use the no-background app factory explicitly in the global exception handler test.
+- Keep auth-specific tests in `server/tests/test_auth.py` and `server/tests/test_auth_jwt_revocation.py` on real login/bcrypt paths.
+
+---
+
+### Task 1: Add Permanent Backend Timing Diagnostics
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Write the failing command assertion**
+
+Run from repo root:
+
+```bash
+rg --fixed-strings "--durations=25 --durations-min=1.0" .github/workflows/ci.yml
+```
+
+Expected before the change: no matches and exit code `1`.
+
+- [ ] **Step 2: Update the backend pytest CI command**
+
+In `.github/workflows/ci.yml`, replace the backend test command:
+
+```yaml
+        run: pytest --cov=app --cov-report=xml --cov-report=term-missing
+```
+
+with:
+
+```yaml
+        run: pytest --cov=app --cov-report=xml --cov-report=term-missing --durations=25 --durations-min=1.0
+```
+
+- [ ] **Step 3: Verify the assertion passes**
+
+Run:
+
+```bash
+rg --fixed-strings "--durations=25 --durations-min=1.0" .github/workflows/ci.yml
+git diff --check
+```
+
+Expected: `rg` prints the backend pytest command; `git diff --check` prints nothing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: report slow backend tests" -m "Co-Authored-By: Codex <noreply@openai.com>"
+```
+
+---
+
+### Task 2: Replace Per-Test Schema Rebuild With Transaction Rollback
+
+**Files:**
+- Modify: `server/tests/conftest.py`
+- Create: `server/tests/test_test_harness.py`
+
+- [ ] **Step 1: Write harness regression tests**
+
+Create `server/tests/test_test_harness.py`:
+
+```python
+"""Regression tests for backend pytest harness behavior."""
+
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+
+
+def test_db_fixture_uses_external_transaction(db: Session):
+    """The harness should bind each Session to a transaction-owned Connection."""
+    bind = db.get_bind()
+    assert hasattr(bind, "in_transaction")
+    assert bind.in_transaction() is True
+    assert db.join_transaction_mode == "create_savepoint"
+
+
+def test_committed_rows_are_visible_within_current_test(db: Session):
+    user = User(username="transaction_probe", password_hash="x", role="dj")
+    db.add(user)
+    db.commit()
+
+    assert db.query(User).filter(User.username == "transaction_probe").count() == 1
+
+
+def test_committed_rows_are_rolled_back_between_tests(db: Session):
+    assert db.query(User).filter(User.username == "transaction_probe").count() == 0
+```
+
+- [ ] **Step 2: Run the new harness tests and verify the first one fails**
+
+Run:
+
+```bash
+cd server
+/home/adam/github/WrzDJ/server/.venv/bin/pytest tests/test_test_harness.py -q --no-cov
+```
+
+Expected before the fixture refactor: `test_db_fixture_uses_external_transaction` fails because the existing fixture is not using `join_transaction_mode == "create_savepoint"`.
+
+- [ ] **Step 3: Refactor the DB setup in `conftest.py`**
+
+Replace the top-level sessionmaker and `db` fixture in `server/tests/conftest.py` with this structure. Keep the existing model fixture definitions below it.
+
+```python
+from collections.abc import Generator
+from datetime import timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.api import sse as _sse_module
+from app.api.deps import get_db
+import app.db.session as _db_session_module
+from app.core.time import utcnow
+from app.main import app
+from app.models.base import Base
+from app.models.event import Event
+from app.models.guest import Guest
+from app.models.request import Request, RequestStatus
+from app.models.user import User
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _database_schema() -> Generator[None, None, None]:
+    """Create the in-memory SQLite schema once per pytest process."""
+    Base.metadata.create_all(bind=engine)
+    try:
+        yield
+    finally:
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="function")
+def db(monkeypatch: pytest.MonkeyPatch, _database_schema: None) -> Generator[Session, None, None]:
+    """Run each test inside an externally managed transaction.
+
+    Application code may call Session.commit(); SQLAlchemy keeps those commits
+    inside a SAVEPOINT while this fixture rolls back the outer transaction.
+    """
+    connection = engine.connect()
+    transaction = connection.begin()
+    TestSessionLocal = sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=connection,
+        join_transaction_mode="create_savepoint",
+    )
+    monkeypatch.setattr(_db_session_module, "SessionLocal", TestSessionLocal)
+    monkeypatch.setattr(_sse_module, "SessionLocal", TestSessionLocal, raising=False)
+
+    session = TestSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        transaction.rollback()
+        connection.close()
+```
+
+After adding this, remove the old top-level `TestingSessionLocal` and the old `_sse_module.SessionLocal = TestingSessionLocal` assignment. Later tasks will add back auth helpers and the test app fixture.
+
+- [ ] **Step 4: Run the harness tests**
+
+Run:
+
+```bash
+cd server
+/home/adam/github/WrzDJ/server/.venv/bin/pytest tests/test_test_harness.py -q --no-cov
+```
+
+Expected: all three tests pass.
+
+- [ ] **Step 5: Run representative DB-heavy tests**
+
+Run:
+
+```bash
+cd server
+/home/adam/github/WrzDJ/server/.venv/bin/pytest tests/test_voting.py tests/test_collect_service.py tests/test_llm_call_log_retention.py -q --no-cov
+```
+
+Expected: pass. If a test depended on cross-test state, fix that test by creating its own setup data.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tests/conftest.py server/tests/test_test_harness.py
+git commit -m "test: isolate database tests with transactions" -m "Co-Authored-By: Codex <noreply@openai.com>"
+```
+
+---
+
+### Task 3: Add a No-Background Test Lifespan
+
+**Files:**
+- Modify: `server/app/main.py`
+- Modify: `server/tests/conftest.py`
+- Modify: `server/tests/test_api.py`
+- Modify: `server/tests/test_test_harness.py`
+
+- [ ] **Step 1: Add failing tests for app factory behavior**
+
+Append to `server/tests/test_test_harness.py`:
+
+```python
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app, no_background_lifespan
+
+
+def test_no_background_test_client_skips_lifespan_tasks():
+    with (
+        patch("app.main._tidal_collection_poll_loop") as tidal_loop,
+        patch("app.main._llm_call_log_cleanup_loop") as cleanup_loop,
+        patch("app.services.llm.health_monitor.health_monitor_loop") as health_loop,
+    ):
+        test_app = create_app(lifespan_context=no_background_lifespan)
+        with TestClient(test_app) as client:
+            assert client.get("/health").status_code == 200
+
+    tidal_loop.assert_not_called()
+    cleanup_loop.assert_not_called()
+    health_loop.assert_not_called()
+
+
+def test_real_lifespan_starts_and_cancels_background_tasks():
+    async def neverending():
+        import asyncio
+
+        await asyncio.Event().wait()
+
+    with (
+        patch("app.main._tidal_collection_poll_loop", side_effect=neverending) as tidal_loop,
+        patch("app.main._llm_call_log_cleanup_loop", side_effect=neverending) as cleanup_loop,
+        patch("app.services.llm.health_monitor.health_monitor_loop", side_effect=neverending)
+        as health_loop,
+    ):
+        real_app = create_app()
+        with TestClient(real_app) as client:
+            assert client.get("/health").status_code == 200
+
+    tidal_loop.assert_called_once()
+    cleanup_loop.assert_called_once()
+    health_loop.assert_called_once()
+```
+
+- [ ] **Step 2: Run the tests and verify import failure**
+
+Run:
+
+```bash
+cd server
+/home/adam/github/WrzDJ/server/.venv/bin/pytest tests/test_test_harness.py::test_no_background_test_client_skips_lifespan_tasks -q --no-cov
+```
+
+Expected before implementation: import error for `create_app` or `no_background_lifespan`.
+
+- [ ] **Step 3: Refactor `server/app/main.py` into a small factory**
+
+Keep the existing cleanup/poll functions unchanged. Move `global_exception_handler` above `create_app()`, then replace the current `lifespan`, global `app = FastAPI(...)`, middleware registration, router include, upload mount, and `@app.get("/health")` block with this structure:
+
+```python
+@asynccontextmanager
+async def lifespan(app: FastAPI, *, run_background_tasks: bool = True):
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
+        lg = logging.getLogger(name)
+        lg.handlers.clear()
+        lg.propagate = True
+
+    tasks: list[asyncio.Task] = []
+    if run_background_tasks:
+        from app.services.llm.health_monitor import health_monitor_loop
+
+        tasks = [
+            asyncio.create_task(_tidal_collection_poll_loop()),
+            asyncio.create_task(_llm_call_log_cleanup_loop()),
+            asyncio.create_task(health_monitor_loop()),
+        ]
+    try:
+        yield
+    finally:
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
+@asynccontextmanager
+async def no_background_lifespan(app: FastAPI):
+    async with lifespan(app, run_background_tasks=False):
+        yield
+
+
+def create_app(*, lifespan_context=lifespan) -> FastAPI:
+    application = FastAPI(
+        title="WrzDJ API",
+        description="Song request system for DJs",
+        version="0.1.0",
+        lifespan=lifespan_context,
+        docs_url=None if settings.is_production else "/docs",
+        redoc_url=None if settings.is_production else "/redoc",
+        openapi_url=None if settings.is_production else "/openapi.json",
+    )
+
+    application.state.limiter = limiter
+    application.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
+    application.add_exception_handler(Exception, global_exception_handler)
+    application.add_middleware(SecurityHeadersMiddleware)
+
+    if settings.cors_origins.strip() == "*":
+        application.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_credentials=False,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+    else:
+        origins = [origin.strip() for origin in settings.cors_origins.split(",")]
+        application.add_middleware(
+            CORSMiddleware,
+            allow_origins=origins,
+            allow_credentials=True,
+            allow_methods=CORS_ALLOW_METHODS,
+            allow_headers=["Authorization", "Content-Type", "X-Kiosk-Session"],
+            expose_headers=["Content-Disposition"],
+        )
+
+    application.include_router(api_router, prefix="/api")
+
+    uploads_dir = Path(settings.resolved_uploads_dir)
+    uploads_dir.mkdir(parents=True, exist_ok=True)
+    application.mount("/uploads", StaticFiles(directory=str(uploads_dir)), name="uploads")
+
+    @application.get("/health")
+    def health_check():
+        return {"status": "ok"}
+
+    return application
+
+
+app = create_app()
+```
+
+Leave `global_exception_handler` as a top-level function. Remove the old `@app.exception_handler(Exception)` decorator and register it inside `create_app()` as shown.
+
+- [ ] **Step 4: Use the no-background app in `conftest.py`**
+
+Change the import:
+
+```python
+from app.main import app
+```
+
+to:
+
+```python
+from app.main import create_app, no_background_lifespan
+```
+
+Add this fixture above `client`:
+
+```python
+@pytest.fixture(scope="session")
+def test_app():
+    """FastAPI app instance for tests; lifespan runs without production loops."""
+    return create_app(lifespan_context=no_background_lifespan)
+```
+
+Change the `client` fixture to accept and use `test_app`:
+
+```python
+@pytest.fixture(scope="function")
+def client(db: Session, test_app) -> Generator[TestClient, None, None]:
+    """Create a test client with database override."""
+
+    def override_get_db():
+        try:
+            yield db
+        finally:
+            pass
+
+    test_app.dependency_overrides[get_db] = override_get_db
+    with TestClient(test_app) as c:
+        yield c
+    test_app.dependency_overrides.clear()
+```
+
+- [ ] **Step 5: Update the explicit exception-handler test**
+
+In `server/tests/test_api.py`, replace the local import and client construction in `test_global_exception_handler_returns_500`:
+
+```python
+    from app.main import app
+```
+
+with:
+
+```python
+    from app.main import create_app, no_background_lifespan
+
+    test_app = create_app(lifespan_context=no_background_lifespan)
+```
+
+and replace:
+
+```python
+        with TestClient(app, raise_server_exceptions=False) as c:
+```
+
+with:
+
+```python
+        with TestClient(test_app, raise_server_exceptions=False) as c:
+```
+
+- [ ] **Step 6: Run lifespan and API tests**
+
+Run:
+
+```bash
+cd server
+/home/adam/github/WrzDJ/server/.venv/bin/pytest tests/test_test_harness.py tests/test_api.py -q --no-cov
+```
+
+Expected: pass. If the real-lifespan test hangs, replace the `neverending()` helper with an async function that awaits `asyncio.sleep(3600)`; cancellation during `TestClient` teardown should still exit the context promptly.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/app/main.py server/tests/conftest.py server/tests/test_api.py server/tests/test_test_harness.py
+git commit -m "test: skip production background loops in client fixture" -m "Co-Authored-By: Codex <noreply@openai.com>"
+```
+
+---
+
+### Task 4: Replace Common Auth Fixture Login With Direct JWT Headers
+
+**Files:**
+- Modify: `server/tests/conftest.py`
+- Modify: `server/tests/test_test_harness.py`
+
+- [ ] **Step 1: Add tests for the direct-token helper**
+
+Append to `server/tests/test_test_harness.py`:
+
+```python
+from app.services.auth import decode_token
+from conftest import _auth_headers_for_user
+
+
+def test_auth_headers_for_user_builds_valid_token(test_user: User):
+    headers = _auth_headers_for_user(test_user)
+    token = headers["Authorization"].removeprefix("Bearer ")
+
+    token_data = decode_token(token)
+
+    assert token_data is not None
+    assert token_data.username == "testuser"
+    assert token_data.token_version == test_user.token_version
+```
+
+- [ ] **Step 2: Run the helper test and verify import failure**
+
+Run:
+
+```bash
+cd server
+/home/adam/github/WrzDJ/server/.venv/bin/pytest tests/test_test_harness.py::test_auth_headers_for_user_builds_valid_token -q --no-cov
+```
+
+Expected before implementation: import error for `_auth_headers_for_user`.
+
+- [ ] **Step 3: Add fast bcrypt constants and a direct header helper**
+
+In `server/tests/conftest.py`, update the common fixtures to use precomputed low-round hashes. Do not import `get_password_hash` in `conftest.py`; auth-specific test modules import it themselves when they need to exercise real hashing.
+
+Add this import near the other service imports:
+
+```python
+from app.services.auth import create_access_token
+```
+
+Add near the engine definition:
+
+```python
+TEST_USER_PASSWORD = "testpassword123"
+ADMIN_USER_PASSWORD = "adminpassword123"
+PENDING_USER_PASSWORD = "pendingpassword123"
+
+TEST_USER_PASSWORD_HASH = "$2b$04$BIUR.p93nOe8nGJXBjtYhu6QLsv7BHn22sAfR/Tpt6xMdl9tEf4tS"
+ADMIN_USER_PASSWORD_HASH = "$2b$04$LaJfWm6YwkBoEVVFvnxu7unVKG7HRGM9hiSvk448HhWZK.hPijb7a"
+PENDING_USER_PASSWORD_HASH = "$2b$04$BnvACwtrVGvZhu5TzYdOR.tpGyY6OQ4p5oILNEgHPmvOGWotCWWYu"
+
+
+def _auth_headers_for_user(user: User) -> dict[str, str]:
+    token = create_access_token(data={"sub": user.username, "tv": user.token_version})
+    return {"Authorization": f"Bearer {token}"}
+```
+
+Change `test_user`, `admin_user`, and `pending_user` to use the constants:
+
+```python
+password_hash=TEST_USER_PASSWORD_HASH
+password_hash=ADMIN_USER_PASSWORD_HASH
+password_hash=PENDING_USER_PASSWORD_HASH
+```
+
+Change `auth_headers`, `admin_headers`, and `pending_headers` to remove `client` from their signatures and return direct tokens:
+
+```python
+@pytest.fixture
+def admin_headers(admin_user: User) -> dict[str, str]:
+    """Authentication headers for the admin user without exercising login."""
+    return _auth_headers_for_user(admin_user)
+
+
+@pytest.fixture
+def pending_headers(pending_user: User) -> dict[str, str]:
+    """Authentication headers for the pending user without exercising login."""
+    return _auth_headers_for_user(pending_user)
+
+
+@pytest.fixture
+def auth_headers(test_user: User) -> dict[str, str]:
+    """Authentication headers for the DJ user without exercising login."""
+    return _auth_headers_for_user(test_user)
+```
+
+- [ ] **Step 4: Run auth-focused tests that must still use real login**
+
+Run:
+
+```bash
+cd server
+/home/adam/github/WrzDJ/server/.venv/bin/pytest tests/test_auth.py tests/test_auth_jwt_revocation.py tests/test_api_contracts.py::TestAuthContracts::test_login_response_shape -q --no-cov
+```
+
+Expected: pass. These tests still call `/api/auth/login`, and the low-round bcrypt hashes must verify the documented passwords.
+
+- [ ] **Step 5: Run representative authenticated endpoint tests**
+
+Run:
+
+```bash
+cd server
+/home/adam/github/WrzDJ/server/.venv/bin/pytest tests/test_events.py::TestCreateEvent::test_create_event_success tests/test_admin.py::TestAdminUserManagement::test_list_users tests/test_setbuilder_api.py -q --no-cov
+```
+
+Expected: pass. If a selected node name has changed, run the whole listed file with `-q --no-cov` and keep the failure output for the implementation notes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tests/conftest.py server/tests/test_test_harness.py
+git commit -m "test: build auth fixture headers directly" -m "Co-Authored-By: Codex <noreply@openai.com>"
+```
+
+---
+
+### Task 5: Centralize Direct `SessionLocal` Test Routing
+
+**Files:**
+- Modify: `server/tests/conftest.py`
+- Modify: `server/tests/test_test_harness.py`
+- Modify: `server/tests/test_llm_call_log_retention.py`
+- Modify: `server/tests/test_sse_pool.py` if its local patch duplicates the centralized fixture after this change
+
+- [ ] **Step 1: Add a registration guard test**
+
+Append to `server/tests/test_test_harness.py`:
+
+```python
+from conftest import DIRECT_SESSIONLOCAL_MODULES
+
+
+def test_direct_sessionlocal_module_aliases_are_registered():
+    module_names = {module.__name__ for module in DIRECT_SESSIONLOCAL_MODULES}
+
+    assert "app.api.sse" in module_names
+```
+
+- [ ] **Step 2: Run the guard and verify import failure**
+
+Run:
+
+```bash
+cd server
+/home/adam/github/WrzDJ/server/.venv/bin/pytest tests/test_test_harness.py::test_direct_sessionlocal_module_aliases_are_registered -q --no-cov
+```
+
+Expected before implementation: import error for `DIRECT_SESSIONLOCAL_MODULES`.
+
+- [ ] **Step 3: Define the centralized patch list in `conftest.py`**
+
+Add near the imports in `server/tests/conftest.py`:
+
+```python
+DIRECT_SESSIONLOCAL_MODULES = (_sse_module,)
+```
+
+Change the `db` fixture patching block from:
+
+```python
+    monkeypatch.setattr(_db_session_module, "SessionLocal", TestSessionLocal)
+    monkeypatch.setattr(_sse_module, "SessionLocal", TestSessionLocal, raising=False)
+```
+
+to:
+
+```python
+    monkeypatch.setattr(_db_session_module, "SessionLocal", TestSessionLocal)
+    for module in DIRECT_SESSIONLOCAL_MODULES:
+        monkeypatch.setattr(module, "SessionLocal", TestSessionLocal, raising=False)
+```
+
+- [ ] **Step 4: Remove duplicate per-test SessionLocal monkeypatching where safe**
+
+In `server/tests/test_llm_call_log_retention.py`, remove the two repeated lines that set `app.db.session.SessionLocal` to `lambda: db` and monkeypatch `db.close`. The centralized fixture now points lazy imports at a session factory bound to the test transaction.
+
+The test bodies should call `main_module._run_llm_call_log_cleanup()` directly:
+
+```python
+        import app.main as main_module
+
+        main_module._run_llm_call_log_cleanup()
+```
+
+If `server/tests/test_sse_pool.py` patches `app.api.sse.SessionLocal` only to avoid real Postgres, remove that local patch. Keep any patch that is explicitly testing pool behavior or stream lifetime behavior.
+
+- [ ] **Step 5: Run direct-session tests**
+
+Run:
+
+```bash
+cd server
+/home/adam/github/WrzDJ/server/.venv/bin/pytest tests/test_llm_call_log_retention.py tests/test_sse_pool.py tests/test_sse_security.py tests/test_test_harness.py -q --no-cov
+```
+
+Expected: pass. If cleanup closes a short-lived direct session, it must not close the primary `db` fixture session because the direct session should be a separate `TestSessionLocal()` instance on the same connection.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tests/conftest.py server/tests/test_test_harness.py server/tests/test_llm_call_log_retention.py server/tests/test_sse_pool.py
+git commit -m "test: centralize direct session routing" -m "Co-Authored-By: Codex <noreply@openai.com>"
+```
+
+If `server/tests/test_sse_pool.py` did not need edits, omit it from `git add`.
+
+---
+
+### Task 6: Add Conservative xdist Execution
+
+**Files:**
+- Modify: `server/pyproject.toml`
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add `pytest-xdist` to dev dependencies**
+
+In `server/pyproject.toml`, add this line to `[project.optional-dependencies].dev` next to the pytest entries:
+
+```toml
+    "pytest-xdist>=3.6.0",
+```
+
+- [ ] **Step 2: Update CI pytest command**
+
+In `.github/workflows/ci.yml`, change the backend test command from:
+
+```yaml
+        run: pytest --cov=app --cov-report=xml --cov-report=term-missing --durations=25 --durations-min=1.0
+```
+
+to:
+
+```yaml
+        run: pytest -n 4 --dist=loadfile --cov=app --cov-report=xml --cov-report=term-missing --durations=25 --durations-min=1.0
+```
+
+Use `--dist=loadfile` so tests in the same file stay on the same worker, reducing fixture churn and keeping file-local isolation checks meaningful.
+
+- [ ] **Step 3: Run a local two-worker smoke**
+
+Run:
+
+```bash
+cd server
+/home/adam/github/WrzDJ/server/.venv/bin/pytest -n 2 --dist=loadfile tests/test_test_harness.py tests/test_api.py tests/test_auth.py -q --no-cov
+```
+
+Expected: pass. If `pytest-xdist` is not installed in the local shared venv, run the command after `pip install -e ".[dev]"` from `server/` or let CI install it through the updated dev extra.
+
+- [ ] **Step 4: Run full backend tests with coverage**
+
+Run:
+
+```bash
+cd server
+/home/adam/github/WrzDJ/server/.venv/bin/pytest -n 4 --dist=loadfile --cov=app --cov-report=term-missing --cov-branch --cov-fail-under=85 --durations=25 --durations-min=1.0 --tb=short -q
+```
+
+Expected: pass with coverage at or above 85%. Capture the final runtime and the slowest-test report for the PR body.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/pyproject.toml .github/workflows/ci.yml
+git commit -m "ci: run backend tests with xdist" -m "Co-Authored-By: Codex <noreply@openai.com>"
+```
+
+---
+
+### Task 7: Final Verification and PR Notes
+
+**Files:**
+- No required file edits unless verification finds a defect.
+
+- [ ] **Step 1: Run backend lint, format, security, and tests**
+
+Run:
+
+```bash
+cd server
+/home/adam/github/WrzDJ/server/.venv/bin/ruff check .
+/home/adam/github/WrzDJ/server/.venv/bin/ruff format --check .
+/home/adam/github/WrzDJ/server/.venv/bin/bandit -r app -c pyproject.toml -q
+/home/adam/github/WrzDJ/server/.venv/bin/pytest -n 4 --dist=loadfile --cov=app --cov-report=term-missing --cov-branch --cov-fail-under=85 --durations=25 --durations-min=1.0 --tb=short -q
+/home/adam/github/WrzDJ/server/.venv/bin/alembic upgrade head
+/home/adam/github/WrzDJ/server/.venv/bin/alembic check
+```
+
+Expected: all commands pass. Coverage remains at or above 85%.
+
+- [ ] **Step 2: Inspect branch diff**
+
+Run:
+
+```bash
+git status --short
+git diff origin/main...HEAD --stat
+git diff origin/main...HEAD -- server/tests/conftest.py server/app/main.py .github/workflows/ci.yml server/pyproject.toml
+```
+
+Expected: only backend CI/test-harness changes plus the approved spec/plan docs.
+
+- [ ] **Step 3: Record PR testing notes**
+
+Use this testing section in the PR body and fill the runtime from the full pytest command:
+
+```markdown
+## Testing
+- [ ] Backend lint: `ruff check .`
+- [ ] Backend format: `ruff format --check .`
+- [ ] Backend security: `bandit -r app -c pyproject.toml -q`
+- [ ] Backend tests: `pytest -n 4 --dist=loadfile --cov=app --cov-report=term-missing --cov-branch --cov-fail-under=85 --durations=25 --durations-min=1.0 --tb=short -q` (<runtime>)
+- [ ] Alembic: `alembic upgrade head && alembic check`
+```
+
+No commit is needed for this task unless a verification fix changes files.

--- a/docs/superpowers/specs/2026-06-14-backend-ci-efficiency-design.md
+++ b/docs/superpowers/specs/2026-06-14-backend-ci-efficiency-design.md
@@ -1,0 +1,242 @@
+# Backend CI Efficiency - Design
+
+**Date:** 2026-06-14
+**Author:** thewrz (design session with Codex)
+**Branch:** `chore/backend-ci-refactor`
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+The backend PR gate is too slow for routine development. The motivating CI run spent
+13m11s inside "Run tests with coverage"; install, lint, and security checks were small
+by comparison. The suite collects roughly 2,800 tests, so the main issue is runtime
+overhead repeated across many tests, not collection.
+
+Current harness hot spots:
+
+- `server/tests/conftest.py` rebuilds all SQLAlchemy tables for every `db` test via
+  `Base.metadata.create_all()` and `drop_all()`.
+- `client` creates `TestClient(app)` as a context manager for every client test, which
+  starts the app lifespan and launches production background loops.
+- Common auth fixtures create real bcrypt hashes and then log in through `/api/auth/login`.
+- A few production paths intentionally bypass FastAPI `get_db` and open `SessionLocal()`
+  directly; in tests this can hit CI Postgres instead of the SQLite test database unless
+  each bypass is patched.
+- CI has no durable slow-test timings and no xdist parallelism.
+
+## Goals
+
+- Move backend CI toward a practical PR-gate target of 3-6 minutes without lowering the
+  enforced coverage gate.
+- Preserve the current test surface and behavior coverage where it is meaningful.
+- Make test isolation stronger before adding parallelism.
+- Keep production app behavior unchanged.
+- Leave a permanent timing signal in CI so future regressions are visible.
+
+## Non-goals
+
+- Lowering `--cov-fail-under=85` or removing branch coverage.
+- Rewriting broad endpoint matrices into service tests in this PR.
+- Migrating backend tests from SQLite to PostgreSQL.
+- Changing production password hashing strength.
+- Disabling the Alembic drift check.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| First-order fix | Refactor the backend test harness, not the product code |
+| Database isolation | Create schema once per pytest session; isolate each test with an outer transaction rollback |
+| HTTP client behavior | Keep `client` function-scoped, but default it to a no-background test lifespan |
+| Auth fixture path | Generate JWT headers directly for common fixtures; keep real login/bcrypt tests where auth is under test |
+| Direct `SessionLocal()` paths | Centralize test patching so intentional bypasses use the test session factory |
+| Parallelism | Add xdist only after transaction/lifespan/global-state isolation is stable |
+| Measurement | Add `--durations=25 --durations-min=1.0` to backend CI pytest |
+
+## 1. Database fixture
+
+Replace the per-test schema rebuild with a session-level schema fixture plus a
+function-level transaction fixture.
+
+Target shape:
+
+- `Base.metadata.create_all(bind=engine)` runs once for the pytest session.
+- Each `db` fixture opens a connection, begins an outer transaction, and binds a
+  `Session` to that connection.
+- Test code may call `db.commit()` normally.
+- Teardown closes the session and rolls back the outer transaction, returning the database
+  to a clean state without dropping tables.
+- `Base.metadata.drop_all(bind=engine)` runs once at session teardown.
+
+This follows SQLAlchemy's documented "join into an external transaction" test recipe.
+SQLAlchemy 2.x specifically supports binding a session to an externally managed
+transaction so application code can call `Session.commit()` while the test harness rolls
+the whole interaction back afterward.
+
+Implementation details to verify during planning:
+
+- Use SQLAlchemy 2.x's supported `join_transaction_mode` if available in the installed
+  version; otherwise use the documented compatible pattern for the local dependency floor.
+- Keep SQLite `StaticPool` so the in-memory database survives across connections for the
+  process.
+- Add a harness regression test that inserts and commits data in one test, then proves the
+  next test starts clean.
+- Audit tests that depend on table DDL side effects, raw connection state, or cross-test
+  persistence. Those should be rewritten; cross-test persistence is a test bug.
+
+## 2. App lifespan and background loops
+
+Normal endpoint tests should not start production background loops. The current `client`
+fixture uses `TestClient(app)` as a context manager, and Starlette documents that lifespan
+handlers run when `TestClient` is used that way.
+
+Design:
+
+- Introduce a test-mode app lifespan path that skips:
+  - Tidal collection polling loop.
+  - LLM call-log cleanup loop.
+  - LLM health monitor loop.
+- Keep a small dedicated lifespan test set that exercises the real lifespan and task
+  cancellation behavior explicitly.
+- Preserve per-test `TestClient` instance isolation for cookies, headers, and app
+  dependency overrides.
+
+Preferred implementation is a small app-factory or lifespan-factory seam in
+`server/app/main.py`, not monkeypatching `asyncio.create_task` globally. The production
+`app` object should still be created with the real lifespan by default; tests can opt into
+the no-background app instance or no-background lifespan.
+
+## 3. Auth fixture fast path
+
+Most endpoint tests need "a valid DJ/admin/pending request", not a bcrypt/login integration
+test. Common fixtures should create users in the database and then build headers directly
+with `create_access_token(data={"sub": user.username, "tv": user.token_version})`.
+
+Keep real bcrypt and login coverage in:
+
+- `/api/auth/login` success and failure tests.
+- JWT token-version and logout/revocation tests where fresh login behavior is under test.
+- Lockout and timing-equalization tests.
+- Password policy/hash tests.
+
+For fixture users:
+
+- Use a precomputed valid bcrypt hash constant or a test helper that avoids repeated
+  expensive hashing where the password is never checked.
+- Keep password hash format realistic enough that accidental login use still fails loudly
+  or is covered by auth-specific tests.
+- Document the helper so new tests choose direct token headers unless they are explicitly
+  testing login.
+
+## 4. Direct SessionLocal bypasses
+
+Some production code deliberately opens fresh sessions to avoid long-lived request session
+problems, notably SSE existence checks, background enrichment/sync helpers, and LLM cleanup
+or health-monitor paths. That is legitimate production design, but the test harness must
+ensure those paths do not talk to CI Postgres during SQLite tests.
+
+Design:
+
+- Centralize test-session patching in `conftest.py` instead of one-off patches.
+- Patch known direct imports that bypass `get_db`, including:
+  - `app.api.sse.SessionLocal`.
+  - `app.db.session.SessionLocal` for code that imports it lazily inside functions.
+  - Any module-level `SessionLocal` aliases found during implementation.
+- Add a guard test or lightweight audit helper that fails if a new direct `SessionLocal`
+  use is added without an explicit test-harness decision.
+
+This should preserve production's pool-safety decisions while making test database routing
+obvious and enforceable.
+
+## 5. Timing diagnostics
+
+Add durable timing output to backend CI:
+
+```bash
+pytest --cov=app --cov-report=xml --cov-report=term-missing --durations=25 --durations-min=1.0
+```
+
+Keep the local default `addopts` coverage gate intact. This gives reviewers a recurring list
+of slow tests after each CI run without adding a new dependency.
+
+## 6. Parallel test execution
+
+After the harness is isolated, add `pytest-xdist` conservatively:
+
+- Add `pytest-xdist` to `server/pyproject.toml` dev dependencies.
+- Start CI with a fixed worker count such as `-n 2` or `-n 4`, not necessarily `-n auto`,
+  to avoid oversubscribing GitHub-hosted runners.
+- Keep pytest-cov as the coverage driver; pytest-cov supports xdist coverage combination.
+- If order/global-state failures appear, fix the isolation problem rather than pinning test
+  order.
+
+Do not land xdist before the transaction and lifespan fixes are passing. xdist runs separate
+worker processes, so session-scoped fixtures execute once per worker, not once for the whole
+job. The DB setup must be cheap and worker-safe before this is useful.
+
+## 7. Testing
+
+Backend focused checks:
+
+- Harness regression: committed rows are visible within a test but absent in the next test.
+- Endpoint smoke: representative `client + db + auth_headers` tests still pass with direct
+  token headers and no background lifespan tasks.
+- Auth coverage: login success/failure still exercises bcrypt and password verification.
+- Lifespan coverage: a dedicated test still invokes the real lifespan and verifies tasks are
+  started and cancelled.
+- Direct-session coverage: SSE and cleanup/monitor paths use the test database under pytest.
+- CI command coverage: `pytest --cov=app --cov-report=xml --cov-report=term-missing
+  --durations=25 --durations-min=1.0`.
+
+Full local checks before PR:
+
+```bash
+cd server
+.venv/bin/ruff check .
+.venv/bin/ruff format --check .
+.venv/bin/bandit -r app -c pyproject.toml -q
+.venv/bin/pytest --tb=short -q
+.venv/bin/alembic upgrade head && .venv/bin/alembic check
+```
+
+## Rollout
+
+Recommended implementation sequence:
+
+1. Add timing diagnostics to CI so subsequent commits expose runtime deltas.
+2. Introduce the session-level schema and transactional `db` fixture with harness
+   regression tests.
+3. Add no-background test lifespan/client behavior and dedicated real-lifespan tests.
+4. Convert common auth headers to direct token construction while preserving auth endpoint
+   tests.
+5. Centralize direct `SessionLocal` test routing and add a guard.
+6. Run the full backend suite and inspect durations.
+7. Add xdist only after the suite is isolated and green.
+
+This can land as one larger PR, but the commits should be reviewable in the sequence above.
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Transaction fixture breaks tests that rely on cross-test state | Treat as a test isolation bug; add explicit setup in those tests |
+| `db.commit()` escapes the rollback boundary | Use SQLAlchemy's documented external-transaction recipe and pin it with a regression test |
+| SQLite DDL or connection behavior differs under session-scoped schema | Keep schema DDL outside individual tests; audit any test that performs DDL |
+| No-background client hides startup bugs | Keep dedicated real-lifespan tests and do not remove production lifespan coverage |
+| Direct token headers skip auth behavior too broadly | Restrict real login tests to auth-specific files and document fixture intent |
+| xdist exposes order/global-state flakes | Add xdist after isolation fixes; fix state leaks rather than marking tests serial by default |
+| In-memory SQLite under xdist creates one DB per worker | Acceptable; each worker has isolated process-local DB and combined coverage |
+
+## Sources
+
+- SQLAlchemy documentation, "Joining a Session into an External Transaction" in
+  Transactions and Connection Management:
+  https://docs.sqlalchemy.org/en/latest/orm/session_transaction.html
+- Starlette TestClient documentation on lifespan behavior:
+  https://starlette.dev/testclient/
+- pytest documentation on `--durations` and `--durations-min`:
+  https://docs.pytest.org/en/stable/how-to/usage.html
+- pytest-cov documentation on xdist coverage support:
+  https://pytest-cov.readthedocs.io/en/latest/xdist.html
+- pytest-xdist documentation on session-scoped fixtures executing once per worker:
+  https://pytest-xdist.readthedocs.io/en/stable/how-to.html

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -107,10 +107,7 @@ async def _tidal_collection_poll_loop() -> None:
 async def global_exception_handler(request: FastAPIRequest, exc: Exception) -> JSONResponse:
     """Catch unhandled exceptions and return a generic 500 response."""
     logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
-    content = {"detail": "Internal server error"}
-    if not settings.is_production:
-        content["debug"] = str(exc)
-    return JSONResponse(status_code=500, content=content)
+    return JSONResponse(status_code=500, content={"detail": "Internal server error"})
 
 
 @asynccontextmanager

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -104,21 +104,31 @@ async def _tidal_collection_poll_loop() -> None:
             logger.exception("Tidal collection poll loop error")
 
 
+async def global_exception_handler(request: FastAPIRequest, exc: Exception) -> JSONResponse:
+    """Catch unhandled exceptions and return a generic 500 response."""
+    logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
+    content = {"detail": "Internal server error"}
+    if not settings.is_production:
+        content["debug"] = str(exc)
+    return JSONResponse(status_code=500, content=content)
+
+
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI, *, run_background_tasks: bool = True):
     for name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
         lg = logging.getLogger(name)
         lg.handlers.clear()
         lg.propagate = True
-    # Import lazily so test runs that mock out the loop module don't trigger
-    # adapter imports at startup-time.
-    from app.services.llm.health_monitor import health_monitor_loop
 
-    tasks = [
-        asyncio.create_task(_tidal_collection_poll_loop()),
-        asyncio.create_task(_llm_call_log_cleanup_loop()),
-        asyncio.create_task(health_monitor_loop()),
-    ]
+    tasks: list[asyncio.Task] = []
+    if run_background_tasks:
+        from app.services.llm.health_monitor import health_monitor_loop
+
+        tasks = [
+            asyncio.create_task(_tidal_collection_poll_loop()),
+            asyncio.create_task(_llm_call_log_cleanup_loop()),
+            asyncio.create_task(health_monitor_loop()),
+        ]
     try:
         yield
     finally:
@@ -129,65 +139,58 @@ async def lifespan(app: FastAPI):
                 await task
 
 
-app = FastAPI(
-    title="WrzDJ API",
-    description="Song request system for DJs",
-    version="0.1.0",
-    lifespan=lifespan,
-    # Disable API docs in production
-    docs_url=None if settings.is_production else "/docs",
-    redoc_url=None if settings.is_production else "/redoc",
-    openapi_url=None if settings.is_production else "/openapi.json",
-)
-
-# Rate limiting
-app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
+@asynccontextmanager
+async def no_background_lifespan(app: FastAPI):
+    async with lifespan(app, run_background_tasks=False):
+        yield
 
 
-@app.exception_handler(Exception)
-async def global_exception_handler(request: FastAPIRequest, exc: Exception) -> JSONResponse:
-    """Catch unhandled exceptions and return a generic 500 response."""
-    logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
-    content = {"detail": "Internal server error"}
-    if not settings.is_production:
-        content["debug"] = str(exc)
-    return JSONResponse(status_code=500, content=content)
-
-
-# Security headers (added first, runs last in middleware chain)
-app.add_middleware(SecurityHeadersMiddleware)
-
-# CORS
-if settings.cors_origins.strip() == "*":
-    # Allow all origins for local development (no credentials needed for Bearer token auth)
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=False,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
-else:
-    origins = [origin.strip() for origin in settings.cors_origins.split(",")]
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=origins,
-        allow_credentials=True,
-        allow_methods=CORS_ALLOW_METHODS,
-        allow_headers=["Authorization", "Content-Type", "X-Kiosk-Session"],
-        expose_headers=["Content-Disposition"],
+def create_app(*, lifespan_context=lifespan) -> FastAPI:
+    application = FastAPI(
+        title="WrzDJ API",
+        description="Song request system for DJs",
+        version="0.1.0",
+        lifespan=lifespan_context,
+        docs_url=None if settings.is_production else "/docs",
+        redoc_url=None if settings.is_production else "/redoc",
+        openapi_url=None if settings.is_production else "/openapi.json",
     )
 
-# Include API router
-app.include_router(api_router, prefix="/api")
+    application.state.limiter = limiter
+    application.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
+    application.add_exception_handler(Exception, global_exception_handler)
+    application.add_middleware(SecurityHeadersMiddleware)
 
-# Serve uploaded files (banners, etc.)
-uploads_dir = Path(settings.resolved_uploads_dir)
-uploads_dir.mkdir(parents=True, exist_ok=True)
-app.mount("/uploads", StaticFiles(directory=str(uploads_dir)), name="uploads")
+    if settings.cors_origins.strip() == "*":
+        application.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_credentials=False,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+    else:
+        origins = [origin.strip() for origin in settings.cors_origins.split(",")]
+        application.add_middleware(
+            CORSMiddleware,
+            allow_origins=origins,
+            allow_credentials=True,
+            allow_methods=CORS_ALLOW_METHODS,
+            allow_headers=["Authorization", "Content-Type", "X-Kiosk-Session"],
+            expose_headers=["Content-Disposition"],
+        )
+
+    application.include_router(api_router, prefix="/api")
+
+    uploads_dir = Path(settings.resolved_uploads_dir)
+    uploads_dir.mkdir(parents=True, exist_ok=True)
+    application.mount("/uploads", StaticFiles(directory=str(uploads_dir)), name="uploads")
+
+    @application.get("/health")
+    def health_check():
+        return {"status": "ok"}
+
+    return application
 
 
-@app.get("/health")
-def health_check():
-    return {"status": "ok"}
+app = create_app()

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=4.1.0",
+    "pytest-xdist>=3.6.0",
     "bandit>=1.7.0",
     "pip-audit>=2.6.0",
     "freezegun>=1.2.0",

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -19,7 +19,7 @@ from app.models.event import Event
 from app.models.guest import Guest
 from app.models.request import Request, RequestStatus
 from app.models.user import User
-from app.services.auth import get_password_hash
+from app.services.auth import create_access_token
 
 # Use SQLite in-memory for tests (fast, isolated)
 SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
@@ -29,6 +29,19 @@ engine = create_engine(
     connect_args={"check_same_thread": False},
     poolclass=StaticPool,
 )
+
+TEST_USER_PASSWORD = "testpassword123"
+ADMIN_USER_PASSWORD = "adminpassword123"
+PENDING_USER_PASSWORD = "pendingpassword123"
+
+TEST_USER_PASSWORD_HASH = "$2b$04$BIUR.p93nOe8nGJXBjtYhu6QLsv7BHn22sAfR/Tpt6xMdl9tEf4tS"
+ADMIN_USER_PASSWORD_HASH = "$2b$04$LaJfWm6YwkBoEVVFvnxu7unVKG7HRGM9hiSvk448HhWZK.hPijb7a"
+PENDING_USER_PASSWORD_HASH = "$2b$04$BnvACwtrVGvZhu5TzYdOR.tpGyY6OQ4p5oILNEgHPmvOGWotCWWYu"
+
+
+def _auth_headers_for_user(user: User) -> dict[str, str]:
+    token = create_access_token(data={"sub": user.username, "tv": user.token_version})
+    return {"Authorization": f"Bearer {token}"}
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -107,7 +120,7 @@ def test_user(db: Session) -> User:
     """Create a test user with DJ role."""
     user = User(
         username="testuser",
-        password_hash=get_password_hash("testpassword123"),
+        password_hash=TEST_USER_PASSWORD_HASH,
         role="dj",
     )
     db.add(user)
@@ -121,7 +134,7 @@ def admin_user(db: Session) -> User:
     """Create an admin test user."""
     user = User(
         username="adminuser",
-        password_hash=get_password_hash("adminpassword123"),
+        password_hash=ADMIN_USER_PASSWORD_HASH,
         role="admin",
     )
     db.add(user)
@@ -131,15 +144,9 @@ def admin_user(db: Session) -> User:
 
 
 @pytest.fixture
-def admin_headers(client: TestClient, admin_user: User) -> dict[str, str]:
-    """Get authentication headers for the admin user."""
-    response = client.post(
-        "/api/auth/login",
-        data={"username": "adminuser", "password": "adminpassword123"},
-    )
-    assert response.status_code == 200, f"Login failed: {response.json()}"
-    token = response.json()["access_token"]
-    return {"Authorization": f"Bearer {token}"}
+def admin_headers(admin_user: User) -> dict[str, str]:
+    """Authentication headers for the admin user without exercising login."""
+    return _auth_headers_for_user(admin_user)
 
 
 @pytest.fixture
@@ -147,7 +154,7 @@ def pending_user(db: Session) -> User:
     """Create a pending test user."""
     user = User(
         username="pendinguser",
-        password_hash=get_password_hash("pendingpassword123"),
+        password_hash=PENDING_USER_PASSWORD_HASH,
         role="pending",
     )
     db.add(user)
@@ -157,27 +164,15 @@ def pending_user(db: Session) -> User:
 
 
 @pytest.fixture
-def pending_headers(client: TestClient, pending_user: User) -> dict[str, str]:
-    """Get authentication headers for the pending user."""
-    response = client.post(
-        "/api/auth/login",
-        data={"username": "pendinguser", "password": "pendingpassword123"},
-    )
-    assert response.status_code == 200, f"Login failed: {response.json()}"
-    token = response.json()["access_token"]
-    return {"Authorization": f"Bearer {token}"}
+def pending_headers(pending_user: User) -> dict[str, str]:
+    """Authentication headers for the pending user without exercising login."""
+    return _auth_headers_for_user(pending_user)
 
 
 @pytest.fixture
-def auth_headers(client: TestClient, test_user: User) -> dict[str, str]:
-    """Get authentication headers for the test user."""
-    response = client.post(
-        "/api/auth/login",
-        data={"username": "testuser", "password": "testpassword123"},
-    )
-    assert response.status_code == 200, f"Login failed: {response.json()}"
-    token = response.json()["access_token"]
-    return {"Authorization": f"Bearer {token}"}
+def auth_headers(test_user: User) -> dict[str, str]:
+    """Authentication headers for the DJ user without exercising login."""
+    return _auth_headers_for_user(test_user)
 
 
 @pytest.fixture

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -13,7 +13,7 @@ import app.db.session as _db_session_module
 from app.api import sse as _sse_module
 from app.api.deps import get_db
 from app.core.time import utcnow
-from app.main import app
+from app.main import create_app, no_background_lifespan
 from app.models.base import Base
 from app.models.event import Event
 from app.models.guest import Guest
@@ -80,8 +80,14 @@ def db(monkeypatch: pytest.MonkeyPatch, _database_schema: None) -> Generator[Ses
         connection.close()
 
 
+@pytest.fixture(scope="session")
+def test_app():
+    """FastAPI app instance for tests; lifespan runs without production loops."""
+    return create_app(lifespan_context=no_background_lifespan)
+
+
 @pytest.fixture(scope="function")
-def client(db: Session) -> Generator[TestClient, None, None]:
+def client(db: Session, test_app) -> Generator[TestClient, None, None]:
     """Create a test client with database override."""
 
     def override_get_db():
@@ -90,10 +96,10 @@ def client(db: Session) -> Generator[TestClient, None, None]:
         finally:
             pass  # Don't close the session here, let the db fixture handle it
 
-    app.dependency_overrides[get_db] = override_get_db
-    with TestClient(app) as c:
+    test_app.dependency_overrides[get_db] = override_get_db
+    with TestClient(test_app) as c:
         yield c
-    app.dependency_overrides.clear()
+    test_app.dependency_overrides.clear()
 
 
 @pytest.fixture

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 import app.db.session as _db_session_module
+from app.api import deps as _deps_module
 from app.api import sse as _sse_module
 from app.api.deps import get_db
 from app.core.time import utcnow
@@ -22,6 +23,7 @@ from app.models.user import User
 from app.services.auth import create_access_token
 
 DIRECT_SESSIONLOCAL_MODULES = (_sse_module,)
+DEPENDENCY_OVERRIDE_SESSIONLOCAL_MODULES = (_deps_module,)
 
 # Use SQLite in-memory for tests (fast, isolated)
 SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -9,6 +9,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
+import app.db.session as _db_session_module
 from app.api import sse as _sse_module
 from app.api.deps import get_db
 from app.core.time import utcnow
@@ -28,29 +29,55 @@ engine = create_engine(
     connect_args={"check_same_thread": False},
     poolclass=StaticPool,
 )
-TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-# The SSE endpoint (``app.api.sse``) opens its own short-lived
-# ``with SessionLocal() as db:`` block for the existence check, bypassing the
-# FastAPI ``get_db`` dependency that other endpoints use. The
-# ``app.dependency_overrides[get_db]`` swap below never reaches it, so the SSE
-# handler would hit the real ``DATABASE_URL`` (Postgres in CI) instead of the
-# in-memory SQLite test DB and fail with "relation does not exist". Swap only
-# the SSE module's ``SessionLocal`` reference — scoped so we don't disturb
-# other modules that also import the production ``SessionLocal``.
-_sse_module.SessionLocal = TestingSessionLocal
+
+@pytest.fixture(scope="session", autouse=True)
+def _database_schema() -> Generator[None, None, None]:
+    """Create the in-memory SQLite schema once per pytest process."""
+    Base.metadata.create_all(bind=engine)
+    try:
+        yield
+    finally:
+        Base.metadata.drop_all(bind=engine)
 
 
 @pytest.fixture(scope="function")
-def db() -> Generator[Session, None, None]:
-    """Create a fresh database for each test."""
-    Base.metadata.create_all(bind=engine)
-    session = TestingSessionLocal()
+def db(monkeypatch: pytest.MonkeyPatch, _database_schema: None) -> Generator[Session, None, None]:
+    """Run each test inside an externally managed transaction.
+
+    Application code may call Session.commit(); SQLAlchemy keeps those commits
+    inside a SAVEPOINT while this fixture rolls back the outer transaction.
+    """
+    connection = engine.connect()
+    # SQLite's legacy transaction control does not always emit BEGIN before the
+    # first SAVEPOINT, so start the driver transaction explicitly.
+    connection.exec_driver_sql("BEGIN")
+    transaction = connection.get_transaction()
+    assert transaction is not None
+    TestSessionLocal = sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=connection,
+        join_transaction_mode="create_savepoint",
+    )
+    AppSessionLocal = sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=connection,
+        # Detached app sessions can overlap with the fixture session; avoid
+        # competing SAVEPOINT ownership while keeping their writes rollback-bound.
+        join_transaction_mode="rollback_only",
+    )
+    monkeypatch.setattr(_db_session_module, "SessionLocal", AppSessionLocal)
+    monkeypatch.setattr(_sse_module, "SessionLocal", AppSessionLocal, raising=False)
+
+    session = TestSessionLocal()
     try:
         yield session
     finally:
         session.close()
-        Base.metadata.drop_all(bind=engine)
+        transaction.rollback()
+        connection.close()
 
 
 @pytest.fixture(scope="function")

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -21,6 +21,8 @@ from app.models.request import Request, RequestStatus
 from app.models.user import User
 from app.services.auth import create_access_token
 
+DIRECT_SESSIONLOCAL_MODULES = (_sse_module,)
+
 # Use SQLite in-memory for tests (fast, isolated)
 SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
 
@@ -82,7 +84,8 @@ def db(monkeypatch: pytest.MonkeyPatch, _database_schema: None) -> Generator[Ses
         join_transaction_mode="rollback_only",
     )
     monkeypatch.setattr(_db_session_module, "SessionLocal", AppSessionLocal)
-    monkeypatch.setattr(_sse_module, "SessionLocal", AppSessionLocal, raising=False)
+    for module in DIRECT_SESSIONLOCAL_MODULES:
+        monkeypatch.setattr(module, "SessionLocal", AppSessionLocal, raising=False)
 
     session = TestSessionLocal()
     try:

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -35,13 +35,15 @@ def test_search_requires_query(client: TestClient, auth_headers: dict):
 
 def test_global_exception_handler_returns_500():
     """Test that unhandled exceptions return 500 with generic message."""
-    from app.main import app
+    from app.main import create_app, no_background_lifespan
+
+    test_app = create_app(lifespan_context=no_background_lifespan)
 
     with patch(
         "app.api.auth.get_system_settings",
         side_effect=RuntimeError("boom"),
     ):
-        with TestClient(app, raise_server_exceptions=False) as c:
+        with TestClient(test_app, raise_server_exceptions=False) as c:
             response = c.get("/api/auth/settings")
     assert response.status_code == 500
     body = response.json()

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -48,5 +48,4 @@ def test_global_exception_handler_returns_500():
     assert response.status_code == 500
     body = response.json()
     assert body["detail"] == "Internal server error"
-    # Dev mode includes debug info
-    assert "boom" in body["debug"]
+    assert "debug" not in body

--- a/server/tests/test_llm_call_log_retention.py
+++ b/server/tests/test_llm_call_log_retention.py
@@ -112,7 +112,7 @@ class TestCleanupReadsSettings:
     """The daily cleanup job must read the retention window from settings each
     run, not from a hardcoded constant."""
 
-    def test_cleanup_honors_admin_changed_window(self, db: Session, test_user, monkeypatch):
+    def test_cleanup_honors_admin_changed_window(self, db: Session, test_user):
         connector = _make_connector(db, test_user.id)
         # A row aged 20 days survives the default 30-day window but should be
         # purged once the admin shortens retention to 7 days.
@@ -121,29 +121,18 @@ class TestCleanupReadsSettings:
         # Admin shortens retention.
         update_system_settings(db, llm_call_log_retention_days=7)
 
-        # The cleanup job opens its own session via `from app.db.session import
-        # SessionLocal`; point that factory at the test session so the in-memory
-        # SQLite state is shared.
         import app.main as main_module
-
-        monkeypatch.setattr("app.db.session.SessionLocal", lambda: db, raising=False)
-
-        # Prevent the job's db.close() from tearing down the shared test session.
-        monkeypatch.setattr(db, "close", lambda: None)
 
         main_module._run_llm_call_log_cleanup()
 
         assert db.query(LlmCallLog).count() == 0
 
-    def test_cleanup_keeps_rows_within_window(self, db: Session, test_user, monkeypatch):
+    def test_cleanup_keeps_rows_within_window(self, db: Session, test_user):
         connector = _make_connector(db, test_user.id)
         _seed_call_log(db, connector.id, age_days=20)
 
         # Default window (30) keeps the 20-day-old row.
         import app.main as main_module
-
-        monkeypatch.setattr("app.db.session.SessionLocal", lambda: db, raising=False)
-        monkeypatch.setattr(db, "close", lambda: None)
 
         main_module._run_llm_call_log_cleanup()
 

--- a/server/tests/test_test_harness.py
+++ b/server/tests/test_test_harness.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from app.main import create_app, no_background_lifespan
 from app.models.user import User
 from app.services.auth import decode_token
-from tests.conftest import _auth_headers_for_user
+from tests.conftest import DIRECT_SESSIONLOCAL_MODULES, _auth_headers_for_user
 
 
 def test_db_fixture_uses_external_transaction(db: Session):
@@ -77,3 +77,9 @@ def test_auth_headers_for_user_builds_valid_token(test_user: User):
     assert token_data is not None
     assert token_data.username == "testuser"
     assert token_data.token_version == test_user.token_version
+
+
+def test_direct_sessionlocal_module_aliases_are_registered():
+    module_names = {module.__name__ for module in DIRECT_SESSIONLOCAL_MODULES}
+
+    assert "app.api.sse" in module_names

--- a/server/tests/test_test_harness.py
+++ b/server/tests/test_test_harness.py
@@ -1,0 +1,25 @@
+"""Regression tests for backend pytest harness behavior."""
+
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+
+
+def test_db_fixture_uses_external_transaction(db: Session):
+    """The harness should bind each Session to a transaction-owned Connection."""
+    bind = db.get_bind()
+    assert hasattr(bind, "in_transaction")
+    assert bind.in_transaction() is True
+    assert db.join_transaction_mode == "create_savepoint"
+
+
+def test_committed_rows_are_visible_within_current_test(db: Session):
+    user = User(username="transaction_probe", password_hash="x", role="dj")
+    db.add(user)
+    db.commit()
+
+    assert db.query(User).filter(User.username == "transaction_probe").count() == 1
+
+
+def test_committed_rows_are_rolled_back_between_tests(db: Session):
+    assert db.query(User).filter(User.username == "transaction_probe").count() == 0

--- a/server/tests/test_test_harness.py
+++ b/server/tests/test_test_harness.py
@@ -7,6 +7,8 @@ from sqlalchemy.orm import Session
 
 from app.main import create_app, no_background_lifespan
 from app.models.user import User
+from app.services.auth import decode_token
+from tests.conftest import _auth_headers_for_user
 
 
 def test_db_fixture_uses_external_transaction(db: Session):
@@ -64,3 +66,14 @@ def test_real_lifespan_starts_and_cancels_background_tasks():
     tidal_loop.assert_called_once()
     cleanup_loop.assert_called_once()
     health_loop.assert_called_once()
+
+
+def test_auth_headers_for_user_builds_valid_token(test_user: User):
+    headers = _auth_headers_for_user(test_user)
+    token = headers["Authorization"].removeprefix("Bearer ")
+
+    token_data = decode_token(token)
+
+    assert token_data is not None
+    assert token_data.username == "testuser"
+    assert token_data.token_version == test_user.token_version

--- a/server/tests/test_test_harness.py
+++ b/server/tests/test_test_harness.py
@@ -1,7 +1,11 @@
 """Regression tests for backend pytest harness behavior."""
 
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.main import create_app, no_background_lifespan
 from app.models.user import User
 
 
@@ -23,3 +27,40 @@ def test_committed_rows_are_visible_within_current_test(db: Session):
 
 def test_committed_rows_are_rolled_back_between_tests(db: Session):
     assert db.query(User).filter(User.username == "transaction_probe").count() == 0
+
+
+def test_no_background_test_client_skips_lifespan_tasks():
+    with (
+        patch("app.main._tidal_collection_poll_loop") as tidal_loop,
+        patch("app.main._llm_call_log_cleanup_loop") as cleanup_loop,
+        patch("app.services.llm.health_monitor.health_monitor_loop") as health_loop,
+    ):
+        test_app = create_app(lifespan_context=no_background_lifespan)
+        with TestClient(test_app) as client:
+            assert client.get("/health").status_code == 200
+
+    tidal_loop.assert_not_called()
+    cleanup_loop.assert_not_called()
+    health_loop.assert_not_called()
+
+
+def test_real_lifespan_starts_and_cancels_background_tasks():
+    async def neverending():
+        import asyncio
+
+        await asyncio.Event().wait()
+
+    with (
+        patch("app.main._tidal_collection_poll_loop", side_effect=neverending) as tidal_loop,
+        patch("app.main._llm_call_log_cleanup_loop", side_effect=neverending) as cleanup_loop,
+        patch(
+            "app.services.llm.health_monitor.health_monitor_loop", side_effect=neverending
+        ) as health_loop,
+    ):
+        real_app = create_app()
+        with TestClient(real_app) as client:
+            assert client.get("/health").status_code == 200
+
+    tidal_loop.assert_called_once()
+    cleanup_loop.assert_called_once()
+    health_loop.assert_called_once()

--- a/server/tests/test_test_harness.py
+++ b/server/tests/test_test_harness.py
@@ -1,5 +1,7 @@
 """Regression tests for backend pytest harness behavior."""
 
+import ast
+from pathlib import Path
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
@@ -8,6 +10,7 @@ from sqlalchemy.orm import Session
 from app.main import create_app, no_background_lifespan
 from app.models.user import User
 from app.services.auth import decode_token
+from tests import conftest as test_fixtures
 from tests.conftest import DIRECT_SESSIONLOCAL_MODULES, _auth_headers_for_user
 
 
@@ -83,3 +86,30 @@ def test_direct_sessionlocal_module_aliases_are_registered():
     module_names = {module.__name__ for module in DIRECT_SESSIONLOCAL_MODULES}
 
     assert "app.api.sse" in module_names
+
+
+def test_module_level_sessionlocal_aliases_are_classified():
+    app_root = Path(__file__).parents[1] / "app"
+    searched_roots = (app_root / "api", app_root / "services", app_root / "main.py")
+    discovered_module_names: set[str] = set()
+
+    for root in searched_roots:
+        paths = [root] if root.is_file() else root.rglob("*.py")
+        for path in paths:
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for statement in tree.body:
+                if (
+                    isinstance(statement, ast.ImportFrom)
+                    and statement.module == "app.db.session"
+                    and any(alias.name == "SessionLocal" for alias in statement.names)
+                ):
+                    relative_path = path.relative_to(app_root.parent).with_suffix("")
+                    discovered_module_names.add(".".join(relative_path.parts))
+
+    direct_module_names = {module.__name__ for module in DIRECT_SESSIONLOCAL_MODULES}
+    dependency_override_names = {
+        module.__name__
+        for module in getattr(test_fixtures, "DEPENDENCY_OVERRIDE_SESSIONLOCAL_MODULES", ())
+    }
+
+    assert discovered_module_names <= direct_module_names | dependency_override_names

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -503,6 +503,15 @@ wheels = [
 ]
 
 [[package]]
+name = "coolname"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/45/deae12f31934301a488df985880240a200119aca2e4b5ceba71d73bc5e86/coolname-5.0.0.tar.gz", hash = "sha256:594bc6c98ebc75ddd51c0ce10efbb5d2556c14eac60b5b36900dfdd5db20eecf", size = 45800, upload-time = "2026-04-23T06:04:50.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/35/cf824e535233c432048bd7455b28808776471ab5861375772b2c98ea4cbd/coolname-5.0.0-py3-none-any.whl", hash = "sha256:b86eea9670aa0620965167d1bfadfe654fabec839a5b51e8da611c4a64f86192", size = 47368, upload-time = "2026-04-23T06:04:49.374Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.13.3"
 source = { registry = "https://pypi.org/simple" }
@@ -728,6 +737,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -2017,6 +2035,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2732,6 +2763,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "bcrypt" },
     { name = "better-profanity" },
+    { name = "coolname" },
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -2767,6 +2799,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -2778,6 +2811,7 @@ requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "better-profanity", specifier = ">=0.7.0" },
+    { name = "coolname", specifier = "==5.0.0" },
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "fastapi", specifier = ">=0.109.0" },
     { name = "freezegun", marker = "extra == 'dev'", specifier = ">=1.2.0" },
@@ -2796,6 +2830,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-json-logger", specifier = ">=3.0" },
     { name = "python-multipart", specifier = ">=0.0.27" },


### PR DESCRIPTION
## Summary
- Rework backend pytest fixtures to keep one SQLite schema per process and isolate each test with transaction rollback.
- Add a no-background FastAPI test lifespan and direct JWT auth headers to remove repeated startup and bcrypt overhead from ordinary endpoint tests.
- Add slow-test duration reporting, conservative xdist execution, and a SessionLocal alias audit guard.

## Impact
- Keeps production app startup behavior unchanged: `app = create_app()` still uses the real lifespan.
- Keeps the backend coverage gate enforced at 85%.
- Cuts the local full backend run to about one minute with `pytest -n 4 --dist=loadfile`.

## Testing
- [x] Backend lint: `ruff check .`
- [x] Backend format: `ruff format --check .`
- [x] Backend security: `bandit -r app -c pyproject.toml -q`
- [x] Lockfile: `uv lock --check`
- [x] Backend tests: `pytest -n 4 --dist=loadfile --cov=app --cov-report=term-missing --cov-branch --cov-fail-under=85 --durations=25 --durations-min=1.0 --tb=short -q` (`2827 passed`, coverage `87.90%`, `63.21s`)
- [x] Alembic: `alembic upgrade head && alembic check` against temporary Postgres 16 (`No new upgrade operations detected`)

Note: local default `localhost:5432` was occupied by another project database, so Alembic was verified with an explicit temporary Postgres URL on port `55432`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized backend CI to run tests in parallel and added test duration reporting to help spot slowdowns.
  * Updated development tooling to support parallel pytest runs locally.

* **Tests**
  * Improved backend test harness reliability with tighter in-memory SQLite isolation, transaction/savepoint handling, and regression coverage for lifespan/background task behavior.
  * Streamlined authentication setup by generating test auth tokens directly (no login requests).

* **Bug Fixes**
  * Standardized 500 error responses to avoid exposing debug details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->