### PR TITLE
[codex] Fix pool import UI and setbuilder auth gating

### DIFF
--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -79,7 +79,8 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
   const [builderSettings, setBuilderSettings] = useState(DEFAULT_SETTINGS);
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
   const confirmResolverRef = useRef<((value: boolean) => void) | null>(null);
-  const history = useSetDocumentHistory(numericSetId);
+  const historyEnabled = !isLoading && isAuthenticated && role !== 'pending';
+  const history = useSetDocumentHistory(numericSetId, { enabled: historyEnabled });
   const [targetOpen, setTargetOpen] = useState(false);
   const [targetSettings, setTargetSettings] = useState<TargetSettings>({
     targetDurationSec: null,

--- a/dashboard/app/(dj)/setbuilder/components/ImportModal.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/ImportModal.tsx
@@ -85,9 +85,21 @@ function runImport(
   return commit ? commit(label, action) : action();
 }
 
+function appendImportResult(
+  aggregate: PoolImportResult | null,
+  result: PoolImportResult,
+): PoolImportResult {
+  if (!aggregate) return result;
+  return {
+    ...result,
+    added: aggregate.added + result.added,
+    deduped: aggregate.deduped + result.deduped,
+  };
+}
+
 function ImportEvent({ setId, existingRefs, onClose, onImported, onError, commit }: ImportModalProps) {
   const [events, setEvents] = useState<Event[] | null>(null);
-  const [picked, setPicked] = useState<number | null>(null);
+  const [picked, setPicked] = useState<Set<number>>(new Set());
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
@@ -97,12 +109,29 @@ function ImportEvent({ setId, existingRefs, onClose, onImported, onError, commit
       .catch(() => setEvents([]));
   }, []);
 
+  const togglePicked = (eventId: number) => {
+    setPicked((prev) => {
+      const next = new Set(prev);
+      if (next.has(eventId)) next.delete(eventId);
+      else next.add(eventId);
+      return next;
+    });
+  };
+
   const doImport = async () => {
-    if (picked == null) return;
+    if (!picked.size) return;
     setBusy(true);
+    let aggregate: PoolImportResult | null = null;
     try {
-      onImported(await runImport(commit, 'Import event requests', () => api.importPoolEvent(setId, picked)));
+      for (const eventId of (events ?? []).map((event) => event.id).filter((eventId) => picked.has(eventId))) {
+        const result = await runImport(commit, 'Import event requests', () =>
+          api.importPoolEvent(setId, eventId),
+        );
+        aggregate = appendImportResult(aggregate, result);
+      }
+      if (aggregate) onImported(aggregate);
     } catch (e) {
+      if (aggregate) onImported(aggregate);
       onError(errMessage(e));
     } finally {
       setBusy(false);
@@ -125,13 +154,20 @@ function ImportEvent({ setId, existingRefs, onClose, onImported, onError, commit
         <div className={styles.imList}>
           {(events ?? []).map((e) => {
             const already = existingRefs.has(`event:${e.id}`);
+            const checked = picked.has(e.id);
             return (
-              <button
+              <label
                 key={e.id}
-                className={`${styles.imListItem} ${picked === e.id ? styles.imPicked : ''}`}
-                onClick={() => setPicked(e.id)}
-                disabled={busy}
+                className={`${styles.imListItem} ${checked ? styles.imPicked : ''}`}
+                aria-disabled={busy}
               >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => togglePicked(e.id)}
+                  disabled={busy}
+                  aria-label={`Select ${e.name}`}
+                />
                 <span style={{ color: sourceColor('event') }}>
                   <SourceIcon kind="event" size={16} />
                 </span>
@@ -142,7 +178,7 @@ function ImportEvent({ setId, existingRefs, onClose, onImported, onError, commit
                   </span>
                   <span className={styles.imListSub}>{e.code}</span>
                 </span>
-              </button>
+              </label>
             );
           })}
         </div>
@@ -158,7 +194,7 @@ function ImportEvent({ setId, existingRefs, onClose, onImported, onError, commit
         <span style={{ flex: 1 }} />
         <button
           className="btn btn-primary btn-sm"
-          disabled={picked == null || busy}
+          disabled={!picked.size || busy}
           onClick={doImport}
         >
           {busy ? 'Importing…' : 'Import requests'}

--- a/dashboard/app/(dj)/setbuilder/components/ImportModal.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/ImportModal.tsx
@@ -77,10 +77,10 @@ function errMessage(e: unknown): string {
   return 'Import failed — try again';
 }
 
-function runImport(
+function runImport<T>(
   commit: BuilderCommit | undefined,
   label: string,
-  action: () => Promise<PoolImportResult>,
+  action: () => Promise<T>,
 ) {
   return commit ? commit(label, action) : action();
 }
@@ -119,19 +119,30 @@ function ImportEvent({ setId, existingRefs, onClose, onImported, onError, commit
   };
 
   const doImport = async () => {
-    if (!picked.size) return;
+    const selectedEventIds = (events ?? [])
+      .map((event) => event.id)
+      .filter((eventId) => picked.has(eventId));
+    if (!selectedEventIds.length) return;
     setBusy(true);
-    let aggregate: PoolImportResult | null = null;
     try {
-      for (const eventId of (events ?? []).map((event) => event.id).filter((eventId) => picked.has(eventId))) {
-        const result = await runImport(commit, 'Import event requests', () =>
-          api.importPoolEvent(setId, eventId),
-        );
-        aggregate = appendImportResult(aggregate, result);
+      const outcome = await runImport(commit, 'Import event requests', async () => {
+        let aggregate: PoolImportResult | null = null;
+        for (const eventId of selectedEventIds) {
+          try {
+            const result = await api.importPoolEvent(setId, eventId);
+            aggregate = appendImportResult(aggregate, result);
+          } catch (e) {
+            if (!aggregate) throw e;
+            return { aggregate, error: e };
+          }
+        }
+        return { aggregate, error: null };
+      });
+      if (outcome.aggregate) onImported(outcome.aggregate);
+      if (outcome.error) {
+        onError(errMessage(outcome.error));
       }
-      if (aggregate) onImported(aggregate);
     } catch (e) {
-      if (aggregate) onImported(aggregate);
       onError(errMessage(e));
     } finally {
       setBusy(false);

--- a/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
@@ -6,7 +6,7 @@
  * multi-select removal, per-track context menu, import toast.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { api, ApiError } from '@/lib/api';
 import type {
   PoolImportResult,
@@ -83,6 +83,8 @@ export default function PoolPanel({
   const [showVibes, setShowVibes] = useState(false);
   const [vibesLoaded, setVibesLoaded] = useState(false);
   const [vibesBusy, setVibesBusy] = useState(false);
+  const addMenuRef = useRef<HTMLSpanElement | null>(null);
+  const contextMenuRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -119,11 +121,13 @@ export default function PoolPanel({
     return () => clearTimeout(handle);
   }, [toast]);
 
-  // Close popovers on outside click
+  // Close popovers on outside clicks without pre-empting their own click handlers.
   useEffect(() => {
-    const onDoc = () => {
-      setAddMenuOpen(false);
-      setContextMenu(null);
+    const onDoc = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+      if (!addMenuRef.current?.contains(target)) setAddMenuOpen(false);
+      if (!contextMenuRef.current?.contains(target)) setContextMenu(null);
     };
     document.addEventListener('mousedown', onDoc);
     return () => document.removeEventListener('mousedown', onDoc);
@@ -294,7 +298,7 @@ export default function PoolPanel({
         >
           Vibes
         </button>
-        <span style={{ position: 'relative' }} onMouseDown={(e) => e.stopPropagation()}>
+        <span ref={addMenuRef} style={{ position: 'relative' }}>
           <button
             className="btn btn-sm"
             onClick={() => setAddMenuOpen((o) => !o)}
@@ -526,9 +530,9 @@ export default function PoolPanel({
       {/* Context menu */}
       {contextMenu && (
         <div
+          ref={contextMenuRef}
           className={styles.popoverMenu}
           style={{ position: 'fixed', left: contextMenu.x, top: contextMenu.y, right: 'auto' }}
-          onMouseDown={(e) => e.stopPropagation()}
         >
           <button
             className={styles.popoverItem}

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/ImportModal.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/ImportModal.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { act, render, screen, waitFor, fireEvent } from '@testing-library/react';
 import type { BuilderPlaylists, PoolImportResult, SearchResult } from '@/lib/api-types';
 import ImportModal from '../ImportModal';
 import type { BuilderCommit } from '../useSetDocumentHistory';
@@ -36,6 +36,44 @@ const IMPORT_RESULT: PoolImportResult = {
   },
   pool: { sources: [], tracks: [] },
 } as unknown as PoolImportResult;
+
+function importResult(eventId: number, added: number, deduped: number): PoolImportResult {
+  return {
+    added,
+    deduped,
+    source: {
+      id: eventId,
+      kind: 'event',
+      external_ref: String(eventId),
+      label: `Event ${eventId}`,
+      meta: null,
+      created_at: '2026-06-09T00:00:00Z',
+    },
+    pool: {
+      sources: [
+        {
+          id: eventId,
+          kind: 'event',
+          external_ref: String(eventId),
+          label: `Event ${eventId}`,
+          meta: null,
+          created_at: '2026-06-09T00:00:00Z',
+        },
+      ],
+      tracks: [],
+    },
+  } as unknown as PoolImportResult;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 const PLAYLISTS: BuilderPlaylists = {
   tidal_connected: true,
@@ -98,31 +136,77 @@ describe('ImportModal — event flow', () => {
     expect(await screen.findByText('No events yet.')).toBeTruthy();
   });
 
-  it('marks already-imported events and imports the picked event', async () => {
+  it('renders owned events as checkboxes, marks imported ones, and keeps import disabled until selection', async () => {
     mockApi.getEvents.mockResolvedValue([
       { id: 7, code: 'ABC123', name: 'Prom Night' },
       { id: 8, code: 'DEF456', name: 'Warehouse' },
     ]);
     mockApi.importPoolEvent.mockResolvedValue(IMPORT_RESULT);
-    const onImported = vi.fn();
     render(
       <ImportModal
         kind="event"
         {...baseProps}
-        onImported={onImported}
         existingRefs={new Set(['event:7'])}
       />
     );
-    await screen.findByText('Prom Night');
+    expect(await screen.findByLabelText('Select Prom Night')).toHaveAttribute('type', 'checkbox');
+    expect(screen.getByLabelText('Select Warehouse')).toHaveAttribute('type', 'checkbox');
     expect(screen.getByText('· already imported')).toBeTruthy();
-    // import button disabled until a pick
     const importBtn = screen.getByText('Import requests') as HTMLButtonElement;
     expect(importBtn.disabled).toBe(true);
-    fireEvent.click(screen.getByText('Warehouse'));
+    fireEvent.click(screen.getByLabelText('Select Prom Night'));
     expect(importBtn.disabled).toBe(false);
-    fireEvent.click(importBtn);
+  });
+
+  it('imports selected events sequentially and reports aggregate added/deduped totals', async () => {
+    const first = deferred<PoolImportResult>();
+    const second = importResult(8, 3, 2);
+    mockApi.getEvents.mockResolvedValue([
+      { id: 7, code: 'ABC123', name: 'Prom Night' },
+      { id: 8, code: 'DEF456', name: 'Warehouse' },
+    ]);
+    mockApi.importPoolEvent.mockImplementation((_setId: number, eventId: number) =>
+      eventId === 7 ? first.promise : Promise.resolve(second),
+    );
+    const onImported = vi.fn();
+    render(<ImportModal kind="event" {...baseProps} onImported={onImported} />);
+
+    fireEvent.click(await screen.findByLabelText('Select Prom Night'));
+    fireEvent.click(screen.getByLabelText('Select Warehouse'));
+    fireEvent.click(screen.getByText('Import requests'));
+
+    await waitFor(() => expect(mockApi.importPoolEvent).toHaveBeenCalledWith(1, 7));
+    expect(mockApi.importPoolEvent).not.toHaveBeenCalledWith(1, 8);
+
+    await act(async () => {
+      first.resolve(importResult(7, 2, 1));
+      await first.promise;
+    });
+
     await waitFor(() => expect(mockApi.importPoolEvent).toHaveBeenCalledWith(1, 8));
-    expect(onImported).toHaveBeenCalledWith(IMPORT_RESULT);
+    await waitFor(() =>
+      expect(onImported).toHaveBeenCalledWith(
+        expect.objectContaining({
+          added: 5,
+          deduped: 3,
+          pool: second.pool,
+          source: second.source,
+        }),
+      ),
+    );
+  });
+
+  it('allows already-imported events to be selected again for new requests', async () => {
+    mockApi.getEvents.mockResolvedValue([{ id: 7, code: 'ABC123', name: 'Prom Night' }]);
+    mockApi.importPoolEvent.mockResolvedValue(IMPORT_RESULT);
+    render(<ImportModal kind="event" {...baseProps} existingRefs={new Set(['event:7'])} />);
+
+    const checkbox = await screen.findByLabelText('Select Prom Night');
+    expect(checkbox).not.toBeDisabled();
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByText('Import requests'));
+
+    await waitFor(() => expect(mockApi.importPoolEvent).toHaveBeenCalledWith(1, 7));
   });
 
   it('surfaces import errors via onError with the Error message', async () => {
@@ -130,7 +214,7 @@ describe('ImportModal — event flow', () => {
     mockApi.importPoolEvent.mockRejectedValue(new Error('Event not found'));
     const onError = vi.fn();
     render(<ImportModal kind="event" {...baseProps} onError={onError} />);
-    fireEvent.click(await screen.findByText('Prom Night'));
+    fireEvent.click(await screen.findByLabelText('Select Prom Night'));
     fireEvent.click(screen.getByText('Import requests'));
     await waitFor(() => expect(onError).toHaveBeenCalledWith('Event not found'));
   });
@@ -146,7 +230,7 @@ describe('ImportModal — event flow', () => {
     const onImported = vi.fn();
     render(<ImportModal kind="event" {...baseProps} commit={commit} onImported={onImported} />);
 
-    fireEvent.click(await screen.findByText('Prom Night'));
+    fireEvent.click(await screen.findByLabelText('Select Prom Night'));
     fireEvent.click(screen.getByText('Import requests'));
 
     await waitFor(() =>

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/ImportModal.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/ImportModal.test.tsx
@@ -196,6 +196,54 @@ describe('ImportModal — event flow', () => {
     );
   });
 
+  it('wraps a multi-event import in a single document-history commit', async () => {
+    mockApi.getEvents.mockResolvedValue([
+      { id: 7, code: 'ABC123', name: 'Prom Night' },
+      { id: 8, code: 'DEF456', name: 'Warehouse' },
+    ]);
+    mockApi.importPoolEvent
+      .mockResolvedValueOnce(importResult(7, 2, 1))
+      .mockResolvedValueOnce(importResult(8, 3, 2));
+    const commitSpy = vi.fn();
+    const commit: BuilderCommit = async (label, action) => {
+      commitSpy(label, action);
+      return action();
+    };
+    render(<ImportModal kind="event" {...baseProps} commit={commit} />);
+
+    fireEvent.click(await screen.findByLabelText('Select Prom Night'));
+    fireEvent.click(screen.getByLabelText('Select Warehouse'));
+    fireEvent.click(screen.getByText('Import requests'));
+
+    await waitFor(() => expect(mockApi.importPoolEvent).toHaveBeenCalledWith(1, 8));
+    expect(commitSpy).toHaveBeenCalledTimes(1);
+    expect(commitSpy).toHaveBeenCalledWith('Import event requests', expect.any(Function));
+  });
+
+  it('reports partial import results before surfacing a later event failure', async () => {
+    const partial = importResult(7, 2, 1);
+    mockApi.getEvents.mockResolvedValue([
+      { id: 7, code: 'ABC123', name: 'Prom Night' },
+      { id: 8, code: 'DEF456', name: 'Warehouse' },
+    ]);
+    mockApi.importPoolEvent
+      .mockResolvedValueOnce(partial)
+      .mockRejectedValueOnce(new Error('Warehouse import failed'));
+    const onImported = vi.fn();
+    const onError = vi.fn();
+    render(<ImportModal kind="event" {...baseProps} onImported={onImported} onError={onError} />);
+
+    fireEvent.click(await screen.findByLabelText('Select Prom Night'));
+    fireEvent.click(screen.getByLabelText('Select Warehouse'));
+    fireEvent.click(screen.getByText('Import requests'));
+
+    await waitFor(() => expect(onImported).toHaveBeenCalledWith(partial));
+    expect(onError).toHaveBeenCalledWith('Warehouse import failed');
+    expect(onImported.mock.invocationCallOrder[0]).toBeLessThan(
+      onError.mock.invocationCallOrder[0],
+    );
+  });
+
   it('allows already-imported events to be selected again for new requests', async () => {
     mockApi.getEvents.mockResolvedValue([{ id: 7, code: 'ABC123', name: 'Prom Night' }]);
     mockApi.importPoolEvent.mockResolvedValue(IMPORT_RESULT);

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
@@ -207,12 +207,46 @@ describe('PoolPanel', () => {
     render(<PoolPanel setId={1} />);
     await screen.findByText('Event Song');
     fireEvent.click(screen.getByText('+ Add'));
-    fireEvent.click(screen.getByText('WrzDJ Event Requests'));
+    const eventImportItem = screen.getByText('WrzDJ Event Requests').closest('button')!;
+    fireEvent.mouseDown(eventImportItem);
+    fireEvent.click(eventImportItem);
     // event picker modal: pick the event then import
-    fireEvent.click(await screen.findByText('ABC123'));
+    fireEvent.click(await screen.findByLabelText('Select Prom Night'));
     fireEvent.click(screen.getByText('Import requests'));
     await waitFor(() => expect(mockApi.importPoolEvent).toHaveBeenCalledWith(1, 7));
     expect(await screen.findByText('3 new · 2 de-duped')).toBeTruthy();
+  });
+
+  it('opens every Add-menu import modal after the browser mousedown/click sequence', async () => {
+    mockApi.getEvents.mockResolvedValue([]);
+    mockApi.getBuilderPlaylists.mockResolvedValue({
+      tidal_connected: true,
+      beatport_connected: true,
+      tidal: [],
+      beatport: [],
+    });
+    render(<PoolPanel setId={1} />);
+    await screen.findByText('Event Song');
+
+    const cases = [
+      ['WrzDJ Event Requests', 'Import event requests'],
+      ['Tidal Playlist', 'Import Tidal playlist'],
+      ['Beatport Playlist', 'Import Beatport playlist'],
+      ['Public Playlist URL', 'Import public playlist'],
+      ['Add single track', 'Add a single track'],
+    ] as const;
+
+    for (const [menuLabel, modalTitle] of cases) {
+      fireEvent.click(screen.getByText('+ Add'));
+      const menuItem = screen.getByText(menuLabel).closest('button')!;
+      fireEvent.mouseDown(menuItem);
+      fireEvent.click(menuItem);
+
+      expect(await screen.findByRole('dialog')).toBeTruthy();
+      expect(screen.getByText(modalTitle)).toBeTruthy();
+      fireEvent.click(screen.getByLabelText('Close'));
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    }
   });
 
   it('context menu offers per-track and per-source removal', async () => {

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/useSetDocumentHistory.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/useSetDocumentHistory.test.tsx
@@ -46,8 +46,8 @@ async function flushReact() {
   });
 }
 
-function Harness({ mutate }: { mutate: () => Promise<void> }) {
-  const history = useSetDocumentHistory(5);
+function Harness({ mutate, enabled = true }: { mutate: () => Promise<void>; enabled?: boolean }) {
+  const history = useSetDocumentHistory(5, { enabled });
   return (
     <div>
       <div data-testid="undo-depth">{history.undoDepth}</div>
@@ -115,6 +115,18 @@ describe('useSetDocumentHistory', () => {
 
     await waitFor(() => expect(mockApi.putSetDocument).toHaveBeenCalledWith(5, snapshot(null)));
     expect(screen.getByTestId('undo-depth')).toHaveTextContent('0');
+  });
+
+  it('does not fetch the set document until history is enabled', async () => {
+    const { rerender } = render(<Harness mutate={() => Promise.resolve()} enabled={false} />);
+
+    await flushReact();
+    expect(mockApi.getSetDocument).not.toHaveBeenCalled();
+
+    rerender(<Harness mutate={() => Promise.resolve()} enabled />);
+
+    await waitFor(() => expect(mockApi.getSetDocument).toHaveBeenCalledWith(5));
+    expect(screen.getByTestId('slot-target')).toHaveTextContent('none');
   });
 
   it('autosaves every 30s while dirty after a failed save', async () => {

--- a/dashboard/app/(dj)/setbuilder/components/useSetDocumentHistory.ts
+++ b/dashboard/app/(dj)/setbuilder/components/useSetDocumentHistory.ts
@@ -13,6 +13,10 @@ interface HistoryEntry {
   snapshot: SetDocumentSnapshot;
 }
 
+interface UseSetDocumentHistoryOptions {
+  enabled?: boolean;
+}
+
 function readAutosave(): boolean {
   try {
     return window.localStorage.getItem(AUTOSAVE_KEY) !== 'false';
@@ -33,7 +37,10 @@ function cloneSnapshot(snapshot: SetDocumentSnapshot): SetDocumentSnapshot {
   return JSON.parse(JSON.stringify(snapshot)) as SetDocumentSnapshot;
 }
 
-export function useSetDocumentHistory(setId: number) {
+export function useSetDocumentHistory(
+  setId: number,
+  { enabled = true }: UseSetDocumentHistoryOptions = {},
+) {
   const [snapshot, setSnapshot] = useState<SetDocumentSnapshot | null>(null);
   const [snapshotVersion, setSnapshotVersion] = useState(0);
   const [undoStack, setUndoStack] = useState<HistoryEntry[]>([]);
@@ -74,6 +81,11 @@ export function useSetDocumentHistory(setId: number) {
     setLastSavedAt(null);
     setIsDirty(false);
     setAutosaveState(readAutosave());
+    if (!enabled) {
+      return () => {
+        cancelled = true;
+      };
+    }
     api
       .getSetDocument(setId)
       .then((doc) => {
@@ -88,7 +100,7 @@ export function useSetDocumentHistory(setId: number) {
     return () => {
       cancelled = true;
     };
-  }, [publishSnapshot, setId]);
+  }, [enabled, publishSnapshot, setId]);
 
   useEffect(() => {
     if (!toast) return;
@@ -107,11 +119,12 @@ export function useSetDocumentHistory(setId: number) {
   }, [isDirty, isSaving, saveError]);
 
   const fetchCurrent = useCallback(async () => {
+    if (!enabled) throw new Error('Document history is not ready');
     if (snapshotRef.current) return cloneSnapshot(snapshotRef.current);
     const current = await api.getSetDocument(setId);
     publishSnapshot(current);
     return cloneSnapshot(current);
-  }, [publishSnapshot, setId]);
+  }, [enabled, publishSnapshot, setId]);
 
   const commit: BuilderCommit = useCallback(
     async (label, action) => {


### PR DESCRIPTION
## Summary
- Fix the setbuilder pool Add menu so mousedown outside-click handling no longer prevents import modal actions.
- Convert WrzDJ event request import to checkbox multi-select with sequential event imports and aggregate added/deduped counts.
- Gate setbuilder document history loading until auth is ready to avoid direct-reload requests before the API token is set.

## Test Plan
- `npm test -- --run app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx app/(dj)/setbuilder/components/__tests__/ImportModal.test.tsx app/(dj)/setbuilder/components/__tests__/useSetDocumentHistory.test.tsx`
- `npm run lint`
- `npx tsc --noEmit`
- `git diff --check`

Closes #430


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now select and import multiple events at once in the import modal, with results aggregated across all selections.

* **Improvements**
  * Document history functionality is now properly disabled during authentication loading and when user role is pending.
  * Enhanced popover and menu closing behavior for better click-outside detection.

* **Tests**
  * Added comprehensive test coverage for multi-event import workflows and import result aggregation.
  * Added test coverage for document history enabled/disabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->