### PR TITLE
[codex] Stabilize DAW curve timeline and large set rendering

### DIFF
--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -1,6 +1,8 @@
 import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import BuilderWorkspace from '../components/BuilderWorkspace';
+import { timelineMeasurementKey } from '../components/TimelinePanel';
+import { slotViewFromApi } from '../components/types';
 import type { PoolTrack, SetDocumentSnapshot, SetSlotOut } from '@/lib/api-types';
 
 beforeAll(() => {
@@ -528,6 +530,26 @@ describe('BuilderWorkspace', () => {
     expect(screen.getByTestId('timeline-transition-0')).toHaveTextContent('94');
   });
 
+  it('measurement key changes when transition or pairing metadata changes without slot reorder', () => {
+    const baseSlots = SLOTS.map((slot, idx) => slotViewFromApi(slot, POOL_TRACKS[idx]));
+    const scoreChangedSlots = SLOTS.map((slot, idx) =>
+      slotViewFromApi(idx === 0 ? { ...slot, transition_score: 94 } : slot, POOL_TRACKS[idx]),
+    );
+    const pairingChangedSlots = SLOTS.map((slot, idx) =>
+      slotViewFromApi(
+        idx === 0 ? { ...slot, next_pairing_id: 77, next_is_dj_pairing: true } : slot,
+        POOL_TRACKS[idx],
+      ),
+    );
+
+    expect(scoreChangedSlots.map((slot) => slot.id)).toEqual(baseSlots.map((slot) => slot.id));
+    expect(pairingChangedSlots.map((slot) => slot.id)).toEqual(baseSlots.map((slot) => slot.id));
+    expect(timelineMeasurementKey(scoreChangedSlots)).not.toBe(timelineMeasurementKey(baseSlots));
+    expect(timelineMeasurementKey(pairingChangedSlots)).not.toBe(
+      timelineMeasurementKey(baseSlots),
+    );
+  });
+
   it('timeline context menu saves the transition to the next slot as a pairing', async () => {
     render(<BuilderWorkspace setId={5} />);
     await waitFor(() => expect(screen.getByTestId('timeline-row-0')).toBeInTheDocument());
@@ -553,6 +575,39 @@ describe('BuilderWorkspace', () => {
     // scrollIntoView only fires when out of view; with jsdom 0-rects rows are
     // "in view", so just assert no crash and the row exists.
     expect(screen.getByTestId('timeline-row-2')).toBeInTheDocument();
+  });
+
+  it('click on a curve block scrolls once and does not replay after manual scroll measurement', async () => {
+    const slots = largeSlots(120);
+    const tracks = largePoolTracks(120);
+    mockGetSetSlots.mockResolvedValue(slots);
+    mockGetPool.mockResolvedValue({ sources: [], tracks });
+
+    let measuredRowHeight = 52;
+    const offsetHeightSpy = vi
+      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockImplementation(() => measuredRowHeight);
+
+    try {
+      render(<BuilderWorkspace setId={5} />);
+      await waitFor(() => expect(screen.getByTestId('slot-block-80')).toBeInTheDocument());
+
+      const timelineList = screen.getByTestId('timeline-list');
+      fireEvent.click(screen.getByTestId('slot-block-80'));
+
+      await waitFor(() => expect(screen.getByTestId('timeline-row-80')).toBeInTheDocument());
+      expect(timelineList.scrollTop).toBeGreaterThan(0);
+
+      measuredRowHeight = 60;
+      fireEvent.scroll(timelineList, { target: { scrollTop: 0 } });
+
+      await waitFor(() => expect(screen.getByTestId('timeline-row-0')).toBeInTheDocument());
+      await act(async () => {});
+
+      expect(timelineList.scrollTop).toBe(0);
+    } finally {
+      offsetHeightSpy.mockRestore();
+    }
   });
 
   it('dropping a pool track on a timeline row inserts it before that row', async () => {

--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -314,17 +314,61 @@ describe('BuilderWorkspace', () => {
   it('zooms the curve timeline in, out, and back to fit', async () => {
     render(<BuilderWorkspace setId={5} />);
     await waitFor(() => expect(screen.getByTestId('curve-toolbar')).toBeInTheDocument());
+    expect(screen.getByRole('group', { name: 'Curve zoom controls' })).toBeInTheDocument();
 
     const canvas = screen.getByTestId('curve-canvas');
     const initialScale = canvas.getAttribute('data-px-per-second');
 
     fireEvent.click(screen.getByTestId('curve-zoom-in'));
-    expect(screen.getByTestId('curve-canvas').getAttribute('data-px-per-second')).not.toBe(initialScale);
+    expect(screen.getByTestId('curve-canvas').getAttribute('data-px-per-second')).not.toBe(
+      initialScale,
+    );
 
     fireEvent.click(screen.getByTestId('curve-zoom-out'));
     fireEvent.click(screen.getByTestId('curve-zoom-fit'));
+    fireEvent.scroll(screen.getByTestId('curve-scroll-viewport'), { target: { scrollLeft: 0 } });
 
     expect(screen.getByTestId('curve-zoom-label')).toHaveTextContent('Fit');
+  });
+
+  it('zooms the curve using the overlap-adjusted target domain', async () => {
+    render(
+      <BuilderWorkspace
+        setId={5}
+        targetSettings={{ targetDurationSec: 1000, avgTransitionOverlapSec: 10 }}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('curve-toolbar')).toBeInTheDocument());
+
+    expect(screen.getByTestId('curve-canvas')).toHaveAttribute('data-px-per-second', '0.7843');
+  });
+
+  it('zooms the curve from fit scroll without snapping scale and clamps stale scroll', async () => {
+    const { rerender } = render(
+      <BuilderWorkspace
+        setId={5}
+        targetSettings={{ targetDurationSec: 60_000, avgTransitionOverlapSec: 0 }}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('curve-toolbar')).toBeInTheDocument());
+
+    const initialScale = screen.getByTestId('curve-canvas').getAttribute('data-px-per-second');
+    fireEvent.scroll(screen.getByTestId('curve-scroll-viewport'), { target: { scrollLeft: 120 } });
+
+    await waitFor(() => expect(screen.getByTestId('curve-zoom-label')).toHaveTextContent('1 px/min'));
+    expect(screen.getByTestId('curve-canvas')).toHaveAttribute('data-px-per-second', initialScale);
+    expect(screen.getByTestId('curve-canvas')).toHaveAttribute('data-scroll-left', '120');
+
+    rerender(
+      <BuilderWorkspace
+        setId={5}
+        targetSettings={{ targetDurationSec: 600, avgTransitionOverlapSec: 0 }}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('curve-canvas')).toHaveAttribute('data-scroll-left', '0'),
+    );
   });
 
   it('reports effective target projection from loaded slots', async () => {

--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -178,6 +178,41 @@ const POOL_TRACKS: PoolTrack[] = [
   },
 ];
 
+function largeSlots(count: number): SetSlotOut[] {
+  return Array.from({ length: count }, (_, idx) => ({
+    ...SLOTS[idx % SLOTS.length],
+    id: 1_000 + idx,
+    position: idx,
+    track_id: `large-${idx}`,
+    target_energy: idx % 3 === 0 ? null : 5 + (idx % 5),
+    title: null,
+    artist: null,
+    bpm: null,
+    key: null,
+    camelot: null,
+    energy: null,
+    duration_sec: null,
+    next_pairing_id: null,
+    next_is_dj_pairing: false,
+  }));
+}
+
+function largePoolTracks(count: number): PoolTrack[] {
+  return Array.from({ length: count }, (_, idx) => ({
+    ...POOL_TRACKS[idx % POOL_TRACKS.length],
+    id: 2_000 + idx,
+    track_id: `large-${idx}`,
+    title: `Large Track ${idx}`,
+    artist: `Large Artist ${idx}`,
+    bpm: 118 + (idx % 24),
+    camelot: `${(idx % 12) + 1}A`,
+    key: `${(idx % 12) + 1}A`,
+    energy: 4 + (idx % 6),
+    duration_sec: 180 + (idx % 90),
+    created_at: '2026-01-01T00:00:00Z',
+  }));
+}
+
 const EXTRA_POOL_TRACK: PoolTrack = {
   id: 14,
   source_id: 1,
@@ -624,6 +659,32 @@ describe('BuilderWorkspace', () => {
       }),
     );
     expect(screen.getByTestId('timeline-vu-1')).toBeInTheDocument();
+  });
+
+  it('virtualizes hundreds of timeline rows while preserving visible row actions', async () => {
+    // TODO(Task 7): replace with the final bugfix commit SHA once this fix lands.
+    const slots = largeSlots(400);
+    const tracks = largePoolTracks(400);
+    mockGetSetSlots.mockResolvedValue(slots);
+    mockGetPool.mockResolvedValue({ sources: [], tracks });
+
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('timeline-row-0')).toBeInTheDocument());
+
+    expect(screen.getByTestId('timeline-list')).toHaveAttribute('data-virtualized', 'true');
+    expect(screen.queryAllByTestId(/^timeline-row-/).length).toBeLessThan(60);
+
+    fireEvent.doubleClick(screen.getByTestId('timeline-row-1'));
+
+    await waitFor(() => expect(mockSendTransportCommand).toHaveBeenCalledTimes(1));
+    expect(mockSendTransportCommand).toHaveBeenCalledWith(
+      5,
+      expect.objectContaining({
+        action: 'play',
+        slot_index: 1,
+        title: 'Large Track 1',
+      }),
+    );
   });
 
   it('click-to-scrub queues a seek command and keeps the active row in sync', async () => {

--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -311,6 +311,22 @@ describe('BuilderWorkspace', () => {
     expect(mockGetSetSlots).toHaveBeenCalledWith(5);
   });
 
+  it('zooms the curve timeline in, out, and back to fit', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('curve-toolbar')).toBeInTheDocument());
+
+    const canvas = screen.getByTestId('curve-canvas');
+    const initialScale = canvas.getAttribute('data-px-per-second');
+
+    fireEvent.click(screen.getByTestId('curve-zoom-in'));
+    expect(screen.getByTestId('curve-canvas').getAttribute('data-px-per-second')).not.toBe(initialScale);
+
+    fireEvent.click(screen.getByTestId('curve-zoom-out'));
+    fireEvent.click(screen.getByTestId('curve-zoom-fit'));
+
+    expect(screen.getByTestId('curve-zoom-label')).toHaveTextContent('Fit');
+  });
+
   it('reports effective target projection from loaded slots', async () => {
     const onProjectionChange = vi.fn();
     render(

--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -337,6 +337,7 @@ describe('BuilderWorkspace', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    window.localStorage.clear();
   });
 
   it('fetches slots and renders curve blocks + timeline rows', async () => {
@@ -509,7 +510,6 @@ describe('BuilderWorkspace', () => {
 
     await waitFor(() => expect(mockUpdateSlotTarget).toHaveBeenCalled());
     expect(screen.queryByTestId('replace-popover')).not.toBeInTheDocument();
-    window.localStorage.removeItem('wrzdj.curve.suggestReplacements');
   });
 
   it('applying a built-in template re-targets slots from the server response', async () => {
@@ -618,8 +618,7 @@ describe('BuilderWorkspace', () => {
 
     fireEvent.click(screen.getByTestId('slot-block-2'));
 
-    await act(async () => {});
-    expect(timelineList.scrollTop).toBe(52);
+    await waitFor(() => expect(timelineList.scrollTop).toBe(52));
   });
 
   it('click on a row with a clipped transition strip keeps the visible row stable', async () => {
@@ -685,8 +684,7 @@ describe('BuilderWorkspace', () => {
 
       fireEvent.click(screen.getByTestId('slot-block-2'));
 
-      await act(async () => {});
-      expect(timelineList.scrollTop).toBe(112);
+      await waitFor(() => expect(timelineList.scrollTop).toBe(112));
     } finally {
       rectSpy.mockRestore();
     }
@@ -703,8 +701,7 @@ describe('BuilderWorkspace', () => {
     });
 
     window.dispatchEvent(new CustomEvent('wrzdj:setbuilder-jump-slot', { detail: { idx: 80 } }));
-    await act(async () => {});
-    expect(timelineList.scrollTop).toBe(0);
+    await waitFor(() => expect(timelineList.scrollTop).toBe(0));
 
     const slots = largeSlots(120);
     const tracks = largePoolTracks(120);
@@ -741,9 +738,7 @@ describe('BuilderWorkspace', () => {
       fireEvent.scroll(timelineList, { target: { scrollTop: 0 } });
 
       await waitFor(() => expect(screen.getByTestId('timeline-row-0')).toBeInTheDocument());
-      await act(async () => {});
-
-      expect(timelineList.scrollTop).toBe(0);
+      await waitFor(() => expect(timelineList.scrollTop).toBe(0));
     } finally {
       offsetHeightSpy.mockRestore();
     }

--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -577,6 +577,53 @@ describe('BuilderWorkspace', () => {
     expect(screen.getByTestId('timeline-row-2')).toBeInTheDocument();
   });
 
+  it('click on a visible curve block keeps the timeline scroll position stable', async () => {
+    const slots = largeSlots(40);
+    const tracks = largePoolTracks(40);
+    mockGetSetSlots.mockResolvedValue(slots);
+    mockGetPool.mockResolvedValue({ sources: [], tracks });
+
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('slot-block-2')).toBeInTheDocument());
+
+    const timelineList = screen.getByTestId('timeline-list');
+    Object.defineProperty(timelineList, 'clientHeight', {
+      value: 260,
+      configurable: true,
+    });
+    timelineList.scrollTop = 52;
+    fireEvent.scroll(timelineList);
+
+    fireEvent.click(screen.getByTestId('slot-block-2'));
+
+    await act(async () => {});
+    expect(timelineList.scrollTop).toBe(52);
+  });
+
+  it('external jump requests wait for the requested row to exist', async () => {
+    const { rerender } = render(<BuilderWorkspace setId={5} refreshToken={0} />);
+    await waitFor(() => expect(screen.getByTestId('timeline-row-0')).toBeInTheDocument());
+
+    const timelineList = screen.getByTestId('timeline-list');
+    Object.defineProperty(timelineList, 'clientHeight', {
+      value: 260,
+      configurable: true,
+    });
+
+    window.dispatchEvent(new CustomEvent('wrzdj:setbuilder-jump-slot', { detail: { idx: 80 } }));
+    await act(async () => {});
+    expect(timelineList.scrollTop).toBe(0);
+
+    const slots = largeSlots(120);
+    const tracks = largePoolTracks(120);
+    mockGetSetSlots.mockResolvedValue(slots);
+    mockGetPool.mockResolvedValue({ sources: [], tracks });
+    rerender(<BuilderWorkspace setId={5} refreshToken={1} />);
+
+    await waitFor(() => expect(screen.getByTestId('timeline-row-80')).toBeInTheDocument());
+    expect(timelineList.scrollTop).toBeGreaterThan(0);
+  });
+
   it('click on a curve block scrolls once and does not replay after manual scroll measurement', async () => {
     const slots = largeSlots(120);
     const tracks = largePoolTracks(120);

--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -856,7 +856,7 @@ describe('BuilderWorkspace', () => {
   });
 
   it('virtualizes hundreds of timeline rows while preserving visible row actions', async () => {
-    // TODO(Task 7): replace with the final bugfix commit SHA once this fix lands.
+    // Regression for 7459707: large timelines must not mount every row.
     const slots = largeSlots(400);
     const tracks = largePoolTracks(400);
     mockGetSetSlots.mockResolvedValue(slots);

--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -408,6 +408,28 @@ describe('BuilderWorkspace', () => {
     );
   });
 
+  it('uses overview curve LOD for hundreds of tracks at fit zoom', async () => {
+    // Regression for b2d595a: fit zoom must not render hundreds of target handles.
+    mockGetSetSlots.mockResolvedValue(largeSlots(400));
+    mockGetPool.mockResolvedValue({ sources: [], tracks: largePoolTracks(400) });
+
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('curve-canvas')).toBeInTheDocument());
+
+    expect(screen.getByTestId('curve-lod')).toHaveTextContent('overview');
+    expect(screen.queryAllByTestId(/^target-handle-/)).toHaveLength(0);
+    expect(screen.getByTestId('curve-line')).toBeInTheDocument();
+
+    const initialScale = screen.getByTestId('curve-canvas').getAttribute('data-px-per-second');
+    fireEvent.click(screen.getByTestId('curve-zoom-in'));
+    fireEvent.click(screen.getByTestId('curve-zoom-in'));
+    fireEvent.click(screen.getByTestId('curve-zoom-in'));
+
+    expect(screen.getByTestId('curve-canvas').getAttribute('data-px-per-second')).not.toBe(
+      initialScale,
+    );
+  });
+
   it('reports effective target projection from loaded slots', async () => {
     const onProjectionChange = vi.fn();
     render(

--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -600,6 +600,76 @@ describe('BuilderWorkspace', () => {
     expect(timelineList.scrollTop).toBe(52);
   });
 
+  it('click on a row with a clipped transition strip keeps the visible row stable', async () => {
+    const slots = largeSlots(40).map((slot, idx) =>
+      idx === 1 ? { ...slot, transition_score: 88 } : slot,
+    );
+    const tracks = largePoolTracks(40);
+    mockGetSetSlots.mockResolvedValue(slots);
+    mockGetPool.mockResolvedValue({ sources: [], tracks });
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function mockTimelineRects(this: HTMLElement) {
+        if (this.dataset.testid === 'timeline-list') {
+          return {
+            x: 0,
+            y: 0,
+            width: 320,
+            height: 260,
+            top: 0,
+            right: 320,
+            bottom: 260,
+            left: 0,
+            toJSON: () => ({}),
+          } as DOMRect;
+        }
+        if (this.dataset.testid === 'timeline-row-2') {
+          return {
+            x: 0,
+            y: 14,
+            width: 320,
+            height: 32,
+            top: 14,
+            right: 320,
+            bottom: 46,
+            left: 0,
+            toJSON: () => ({}),
+          } as DOMRect;
+        }
+        return {
+          x: 0,
+          y: 0,
+          width: 0,
+          height: 0,
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          toJSON: () => ({}),
+        } as DOMRect;
+      });
+
+    try {
+      render(<BuilderWorkspace setId={5} />);
+      await waitFor(() => expect(screen.getByTestId('timeline-transition-1')).toBeInTheDocument());
+
+      const timelineList = screen.getByTestId('timeline-list');
+      Object.defineProperty(timelineList, 'clientHeight', {
+        value: 260,
+        configurable: true,
+      });
+      timelineList.scrollTop = 112;
+      fireEvent.scroll(timelineList);
+
+      fireEvent.click(screen.getByTestId('slot-block-2'));
+
+      await act(async () => {});
+      expect(timelineList.scrollTop).toBe(112);
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
   it('external jump requests wait for the requested row to exist', async () => {
     const { rerender } = render(<BuilderWorkspace setId={5} refreshToken={0} />);
     await waitFor(() => expect(screen.getByTestId('timeline-row-0')).toBeInTheDocument());

--- a/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
@@ -292,6 +292,54 @@ describe('CurveEditor', () => {
     expect(onWindowChange).toHaveBeenLastCalledWith('w1', {
       t1: expect.closeTo(190 / 600, 5),
     });
+
+    onWindowChange.mockClear();
+    const leftHandle = rectHandles[1];
+    expect(leftHandle).toBeDefined();
+
+    fireEvent.pointerDown(leftHandle, { clientX: 40 });
+    fireEvent.pointerMove(window, { clientX: 20 });
+    expect(onWindowChange).toHaveBeenLastCalledWith('w1', {
+      t0: expect.closeTo(110 / 600, 5),
+    });
+  });
+
+  it('updates visible slots from internal scroll when uncontrolled', () => {
+    const slots = Array.from({ length: 200 }, (_, i) => mkSlot(i, { durationSec: 60 }));
+    renderEditor({
+      slots,
+      pxPerSecond: 2,
+      viewportWidth: 600,
+    });
+
+    expect(screen.getByTestId('slot-block-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('slot-block-50')).not.toBeInTheDocument();
+
+    const scrollViewport = screen.getByTestId('curve-scroll-viewport');
+    fireEvent.scroll(scrollViewport, {
+      target: { scrollLeft: 60 * 50 * 2 },
+    });
+
+    expect(screen.queryByTestId('slot-block-0')).not.toBeInTheDocument();
+    expect(screen.getByTestId('slot-block-50')).toBeInTheDocument();
+  });
+
+  it('forwards wheel input over the svg overlay to horizontal scrolling', () => {
+    const onScrollLeftChange = vi.fn();
+    const slots = Array.from({ length: 200 }, (_, i) => mkSlot(i, { durationSec: 60 }));
+    const { container } = renderEditor({
+      slots,
+      pxPerSecond: 2,
+      viewportWidth: 600,
+      onScrollLeftChange,
+    });
+
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    fireEvent.wheel(svg as SVGSVGElement, { deltaY: 60 });
+
+    expect(screen.getByTestId('curve-scroll-viewport')).toHaveProperty('scrollLeft', 60);
+    expect(onScrollLeftChange).toHaveBeenLastCalledWith(60);
   });
 
   it('renders only viewport-visible slot blocks in detail zoom', () => {

--- a/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
@@ -239,6 +239,47 @@ describe('CurveEditor', () => {
     expect(screen.getByTestId('curve-scrub-hit')).toBeInTheDocument();
   });
 
+  it('uses the rendered canvas size before ResizeObserver emits', () => {
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue({
+        x: 0,
+        y: 0,
+        left: 0,
+        top: 0,
+        right: 226,
+        bottom: 160,
+        width: 226,
+        height: 160,
+        toJSON: () => ({}),
+      } as DOMRect);
+
+    try {
+      const { container } = renderEditor();
+      expect(container.querySelector('svg')).toHaveAttribute('viewBox', '0 0 226 160');
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('exposes a dedicated horizontal scroll hit target for the curve timeline', () => {
+    renderEditor({
+      pxPerSecond: 2,
+      viewportWidth: 600,
+    });
+
+    expect(screen.getByTestId('curve-scroll-viewport')).toHaveAttribute(
+      'aria-label',
+      'Curve timeline horizontal scroll',
+    );
+    expect(screen.getByTestId('curve-scroll-viewport')).toHaveAttribute(
+      'data-scrollbar-affordance',
+      'true',
+    );
+    expect(screen.getByTestId('curve-scrollbar')).toBeInTheDocument();
+    expect(screen.getByTestId('curve-scrollbar-thumb')).toBeInTheDocument();
+  });
+
   it('maps vibe-window move and resize through the visible viewport seconds', () => {
     const onWindowChange = vi.fn();
     const onWindowCommit = vi.fn();

--- a/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
@@ -220,4 +220,35 @@ describe('CurveEditor', () => {
     fireEvent.contextMenu(screen.getByTestId('vibe-window-header-w1'));
     expect(onWindowDelete).toHaveBeenCalledWith('w1');
   });
+
+  it('renders only viewport-visible slot blocks in detail zoom', () => {
+    // Regression for b2d595a: large sets must not render every SVG slot node at once.
+    const slots = Array.from({ length: 200 }, (_, i) => mkSlot(i, { durationSec: 60 }));
+    renderEditor({
+      slots,
+      pxPerSecond: 2,
+      scrollLeft: 60 * 50 * 2,
+      viewportWidth: 600,
+    });
+
+    expect(screen.queryByTestId('slot-block-0')).not.toBeInTheDocument();
+    expect(screen.getByTestId('slot-block-50')).toBeInTheDocument();
+    expect(document.querySelectorAll('[data-testid^="slot-block-"]').length).toBeLessThan(30);
+  });
+
+  it('hides per-slot drag handles at overview zoom', () => {
+    // Regression for b2d595a: overview mode should not expose hundreds of tiny handles.
+    const slots = Array.from({ length: 200 }, (_, i) => mkSlot(i, { durationSec: 60 }));
+    renderEditor({
+      slots,
+      pxPerSecond: 0.02,
+      scrollLeft: 0,
+      viewportWidth: 600,
+    });
+
+    expect(screen.getByTestId('curve-lod')).toHaveTextContent('overview');
+    expect(screen.queryByTestId('target-handle-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slot-block-0')).not.toBeInTheDocument();
+    expect(screen.getByTestId('curve-line')).toBeInTheDocument();
+  });
 });

--- a/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
@@ -221,6 +221,79 @@ describe('CurveEditor', () => {
     expect(onWindowDelete).toHaveBeenCalledWith('w1');
   });
 
+  it('keeps the viewport-local svg outside the horizontal scroll layer', () => {
+    const { container } = renderEditor({
+      pxPerSecond: 2,
+      scrollLeft: 200,
+      viewportWidth: 600,
+      scrubEnabled: true,
+      onScrub: vi.fn(),
+    });
+
+    const scrollViewport = screen.getByTestId('curve-scroll-viewport');
+    const svg = container.querySelector('svg');
+
+    expect(svg).not.toBeNull();
+    expect(scrollViewport.querySelector('svg')).toBeNull();
+    expect(svg?.parentElement).toBe(screen.getByTestId('curve-canvas'));
+    expect(screen.getByTestId('curve-scrub-hit')).toBeInTheDocument();
+  });
+
+  it('maps vibe-window move and resize through the visible viewport seconds', () => {
+    const onWindowChange = vi.fn();
+    const onWindowCommit = vi.fn();
+    const { container } = renderEditor({
+      slots: [
+        mkSlot(0, { durationSec: 200 }),
+        mkSlot(1, { durationSec: 200 }),
+        mkSlot(2, { durationSec: 200 }),
+      ],
+      windows: [{ id: 'w1', t0: 0.2, t1: 0.3, label: 'First Dance' }],
+      pxPerSecond: 2,
+      scrollLeft: 200,
+      viewportWidth: 200,
+      onWindowChange,
+      onWindowCommit,
+    });
+
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    vi.spyOn(svg as SVGSVGElement, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 160,
+      width: 200,
+      height: 160,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.pointerDown(screen.getByTestId('vibe-window-header-w1'), { clientX: 80 });
+    fireEvent.pointerMove(window, { clientX: 130 });
+    expect(onWindowChange).toHaveBeenLastCalledWith('w1', {
+      t0: expect.closeTo(145 / 600, 5),
+      t1: expect.closeTo(205 / 600, 5),
+    });
+    fireEvent.pointerUp(window);
+    expect(onWindowCommit).toHaveBeenCalledWith('w1');
+
+    onWindowChange.mockClear();
+    onWindowCommit.mockClear();
+    const rectHandles = screen
+      .getByTestId('vibe-window-w1')
+      .querySelectorAll('rect[data-scrub-ignore="1"]');
+    const rightHandle = rectHandles[2];
+    expect(rightHandle).toBeDefined();
+
+    fireEvent.pointerDown(rightHandle, { clientX: 160 });
+    fireEvent.pointerMove(window, { clientX: 180 });
+    expect(onWindowChange).toHaveBeenLastCalledWith('w1', {
+      t1: expect.closeTo(190 / 600, 5),
+    });
+  });
+
   it('renders only viewport-visible slot blocks in detail zoom', () => {
     // Regression for b2d595a: large sets must not render every SVG slot node at once.
     const slots = Array.from({ length: 200 }, (_, i) => mkSlot(i, { durationSec: 60 }));

--- a/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
@@ -372,4 +372,29 @@ describe('CurveEditor', () => {
     expect(screen.queryByTestId('slot-block-0')).not.toBeInTheDocument();
     expect(screen.getByTestId('curve-line')).toBeInTheDocument();
   });
+
+  it('keeps svg label text from stretching when the rendered viewport and viewBox diverge', () => {
+    renderEditor({
+      targetDurationSec: 900,
+      viewportWidth: 600,
+      playheadSec: 120,
+      windows: [{ id: 'w1', t0: 0.15, t1: 0.35, label: 'Build' }],
+    });
+
+    expect(screen.getByTestId('curve-target-label')).toHaveAttribute(
+      'data-fixed-svg-label',
+      'true',
+    );
+    expect(screen.getByTestId('vibe-window-label-w1')).toHaveAttribute(
+      'data-fixed-svg-label',
+      'true',
+    );
+    expect(screen.getByTestId('curve-playhead-label')).toHaveAttribute(
+      'data-fixed-svg-label',
+      'true',
+    );
+    expect(screen.getByTestId('curve-target-label').getAttribute('transform')).toContain(
+      'scale(0.7500 1.0000)',
+    );
+  });
 });

--- a/dashboard/app/(dj)/setbuilder/__tests__/curveViewport.test.ts
+++ b/dashboard/app/(dj)/setbuilder/__tests__/curveViewport.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { SlotView } from '../components/types';
+import {
+  CURVE_LOD_THRESHOLDS,
+  clampPxPerSecond,
+  curveViewportRange,
+  fitPxPerSecond,
+  lodForMedianSlotWidth,
+  slotTimeRanges,
+  visibleBlocksFromSlots,
+  zoomPxPerSecond,
+} from '../components/curveViewport';
+
+function mkSlot(idx: number, durationSec = 200): SlotView {
+  return {
+    id: idx + 1,
+    position: idx,
+    locked: false,
+    targetEnergy: null,
+    transitionScore: null,
+    nextPairingId: null,
+    nextIsDjPairing: false,
+    track: {
+      id: `t${idx}`,
+      title: `Track ${idx}`,
+      artist: `Artist ${idx}`,
+      durationSec,
+      energy: 5 + (idx % 4),
+      bpm: 120,
+      key: '8A',
+    },
+  };
+}
+
+describe('curveViewport helpers', () => {
+  it('computes slot time ranges from ordered slot durations', () => {
+    const ranges = slotTimeRanges([mkSlot(0, 100), mkSlot(1, 200), mkSlot(2, 300)]);
+    expect(ranges.map((r) => [r.startSec, r.endSec, r.midSec])).toEqual([
+      [0, 100, 50],
+      [100, 300, 200],
+      [300, 600, 450],
+    ]);
+  });
+
+  it('fits full duration into the visible viewport with a bounded scale', () => {
+    expect(fitPxPerSecond({ totalSec: 1000, viewportWidth: 500 })).toBe(0.5);
+    expect(fitPxPerSecond({ totalSec: 0, viewportWidth: 500 })).toBe(
+      CURVE_LOD_THRESHOLDS.minPxPerSecond,
+    );
+    expect(fitPxPerSecond({ totalSec: 1000, viewportWidth: 1 })).toBe(
+      CURVE_LOD_THRESHOLDS.minPxPerSecond,
+    );
+  });
+
+  it('derives visible seconds from scroll and scale', () => {
+    expect(
+      curveViewportRange({ scrollLeft: 250, viewportWidth: 500, pxPerSecond: 2, totalSec: 1000 }),
+    ).toEqual({
+      startSec: 125,
+      endSec: 375,
+    });
+  });
+
+  it('returns only visible blocks plus overscan in viewport-local coordinates', () => {
+    const slots = Array.from({ length: 20 }, (_, i) => mkSlot(i, 60));
+    const blocks = visibleBlocksFromSlots({
+      slots,
+      visibleStartSec: 300,
+      visibleEndSec: 600,
+      pxPerSecond: 2,
+      overscanSec: 60,
+    });
+    expect(blocks[0].idx).toBe(4);
+    expect(blocks.at(-1)?.idx).toBe(10);
+    expect(blocks[0].x0).toBe(-120);
+    expect(blocks[1].x0).toBe(0);
+    expect(blocks[1].width).toBe(120);
+  });
+
+  it('uses median visible slot width for LOD thresholds', () => {
+    expect(lodForMedianSlotWidth([2, 3, 4])).toBe('overview');
+    expect(lodForMedianSlotWidth([6, 12, 20])).toBe('medium');
+    expect(lodForMedianSlotWidth([28, 60, 90])).toBe('detail');
+  });
+
+  it('zooms around a center point without exceeding configured bounds', () => {
+    const next = zoomPxPerSecond({
+      currentPxPerSecond: 1,
+      direction: 'in',
+      scrollLeft: 200,
+      viewportWidth: 400,
+      totalSec: 1000,
+    });
+    expect(next.pxPerSecond).toBeCloseTo(1.35);
+    expect(next.scrollLeft).toBeCloseTo(340);
+
+    const clamped = clampPxPerSecond(999);
+    expect(clamped).toBe(CURVE_LOD_THRESHOLDS.maxPxPerSecond);
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/__tests__/curveViewport.test.ts
+++ b/dashboard/app/(dj)/setbuilder/__tests__/curveViewport.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { SlotView } from '../components/types';
+import { effectiveTarget, type SlotView } from '../components/types';
 import {
   CURVE_LOD_THRESHOLDS,
   clampPxPerSecond,
@@ -61,8 +61,20 @@ describe('curveViewport helpers', () => {
     });
   });
 
+  it('clamps stale scroll into a valid viewport range', () => {
+    expect(
+      curveViewportRange({ scrollLeft: 200, viewportWidth: 50, pxPerSecond: 1, totalSec: 100 }),
+    ).toEqual({
+      startSec: 50,
+      endSec: 100,
+    });
+  });
+
   it('returns only visible blocks plus overscan in viewport-local coordinates', () => {
-    const slots = Array.from({ length: 20 }, (_, i) => mkSlot(i, 60));
+    const explicitTargetSlot = { ...mkSlot(5, 60), targetEnergy: 9 };
+    const slots = Array.from({ length: 20 }, (_, i) =>
+      i === 5 ? explicitTargetSlot : mkSlot(i, 60),
+    );
     const blocks = visibleBlocksFromSlots({
       slots,
       visibleStartSec: 300,
@@ -75,6 +87,9 @@ describe('curveViewport helpers', () => {
     expect(blocks[0].x0).toBe(-120);
     expect(blocks[1].x0).toBe(0);
     expect(blocks[1].width).toBe(120);
+    expect(blocks.find((block) => block.idx === 5)?.target).toBe(
+      effectiveTarget(explicitTargetSlot),
+    );
   });
 
   it('uses median visible slot width for LOD thresholds', () => {

--- a/dashboard/app/(dj)/setbuilder/__tests__/curveViewport.test.ts
+++ b/dashboard/app/(dj)/setbuilder/__tests__/curveViewport.test.ts
@@ -94,6 +94,15 @@ describe('curveViewport helpers', () => {
     expect(next.pxPerSecond).toBeCloseTo(1.35);
     expect(next.scrollLeft).toBeCloseTo(340);
 
+    const maxZoom = zoomPxPerSecond({
+      currentPxPerSecond: CURVE_LOD_THRESHOLDS.maxPxPerSecond,
+      direction: 'in',
+      scrollLeft: 200,
+      viewportWidth: 400,
+      totalSec: 1000,
+    });
+    expect(maxZoom.pxPerSecond).toBe(CURVE_LOD_THRESHOLDS.maxPxPerSecond);
+
     const clamped = clampPxPerSecond(999);
     expect(clamped).toBe(CURVE_LOD_THRESHOLDS.maxPxPerSecond);
   });

--- a/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
@@ -11,7 +11,11 @@
  */
 
 import { useEffect, useRef, useState } from 'react';
-import type { MouseEvent as ReactMouseEvent } from 'react';
+import type {
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+  SVGProps,
+} from 'react';
 import {
   BPM_TIER_COLORS,
   KEY_TIER_COLORS,
@@ -34,6 +38,70 @@ export type CurveViewMode = 'normal' | 'bpm' | 'key';
 const NEON = '#00f5d4';
 const NEON_PURPLE = '#b78bff';
 const WARNING = '#f59e0b';
+
+interface SvgFixedGroupProps extends SVGProps<SVGGElement> {
+  x: number;
+  y: number;
+  scaleX: number;
+  scaleY: number;
+  children: ReactNode;
+}
+
+interface SvgFixedTextProps extends Omit<SVGProps<SVGTextElement>, 'x' | 'y'> {
+  x: number;
+  y: number;
+  scaleX: number;
+  scaleY: number;
+  testId?: string;
+  children: ReactNode;
+}
+
+function fixedLabelTransform(x: number, y: number, scaleX: number, scaleY: number) {
+  return `translate(${x} ${y}) scale(${scaleX.toFixed(4)} ${scaleY.toFixed(4)})`;
+}
+
+function SvgFixedGroup({
+  x,
+  y,
+  scaleX,
+  scaleY,
+  children,
+  ...props
+}: SvgFixedGroupProps) {
+  return (
+    <g
+      {...props}
+      data-fixed-svg-label="true"
+      transform={fixedLabelTransform(x, y, scaleX, scaleY)}
+    >
+      {children}
+    </g>
+  );
+}
+
+function SvgFixedText({
+  x,
+  y,
+  scaleX,
+  scaleY,
+  testId,
+  children,
+  ...textProps
+}: SvgFixedTextProps) {
+  return (
+    <SvgFixedGroup
+      x={x}
+      y={y}
+      scaleX={scaleX}
+      scaleY={scaleY}
+      data-testid={testId}
+    >
+      <text x={0} y={0} {...textProps}>
+        {children}
+      </text>
+    </SvgFixedGroup>
+  );
+}
 
 interface WindowDrag {
   id: string;
@@ -165,6 +233,12 @@ export default function CurveEditor({
   const showDenseSeams = lod === 'detail';
   const scrollableWidth = Math.max(effectiveViewportWidth, domainSec * effectivePxPerSecond);
   const maxScrollLeft = Math.max(0, scrollableWidth - effectiveViewportWidth);
+  const viewBoxWidth = effectiveViewportWidth;
+  const viewBoxHeight = h;
+  const renderedSvgWidth = w;
+  const renderedSvgHeight = h;
+  const fixedLabelScaleX = viewBoxWidth / Math.max(1, renderedSvgWidth);
+  const fixedLabelScaleY = viewBoxHeight / Math.max(1, renderedSvgHeight);
 
   const commitScrollLeft = (next: number) => {
     const clamped = Math.max(0, Math.min(maxScrollLeft, next));
@@ -398,16 +472,19 @@ export default function CurveEditor({
               strokeWidth="1.5"
               strokeDasharray="5 4"
             />
-            <text
+            <SvgFixedText
               x={Math.min(Math.max((targetX ?? 0) + 6, 34), effectiveViewportWidth - 28)}
               y={13}
+              scaleX={fixedLabelScaleX}
+              scaleY={fixedLabelScaleY}
+              testId="curve-target-label"
               fill="#fbbf24"
               fontSize="9"
               fontWeight="800"
               letterSpacing="0.08em"
             >
               TARGET
-            </text>
+            </SvgFixedText>
           </g>
         )}
 
@@ -462,9 +539,12 @@ export default function CurveEditor({
                 }}
                 onPointerDown={startWindowDrag(win.id, 'move', win.t0, win.t1)}
               />
-              <text
+              <SvgFixedText
                 x={x + 7}
                 y={headerH / 2 + 3.5}
+                scaleX={fixedLabelScaleX}
+                scaleY={fixedLabelScaleY}
+                testId={`vibe-window-label-${win.id}`}
                 fontSize="9.5"
                 fill="rgb(220,200,255)"
                 fontWeight="700"
@@ -472,7 +552,7 @@ export default function CurveEditor({
                 pointerEvents="none"
               >
                 {win.label.toUpperCase()}
-              </text>
+              </SvgFixedText>
               {/* Resize handles */}
               <rect
                 x={x - 5}
@@ -634,11 +714,14 @@ export default function CurveEditor({
                 />
                 <circle cx={seamX} cy={h - 1} r={isClash ? 3.5 : 3} fill={color.stroke} />
                 {isHovered && (
-                  <g
-                    transform={`translate(${Math.min(
+                  <SvgFixedGroup
+                    x={Math.min(
                       Math.max(seamX, 40),
                       effectiveViewportWidth - 40,
-                    )}, ${h - 18})`}
+                    )}
+                    y={h - 18}
+                    scaleX={fixedLabelScaleX}
+                    scaleY={fixedLabelScaleY}
                     data-testid={`seam-chip-${b.idx}`}
                   >
                     <rect
@@ -661,7 +744,7 @@ export default function CurveEditor({
                     >
                       {chipText}
                     </text>
-                  </g>
+                  </SvgFixedGroup>
                 )}
               </g>
             );
@@ -710,11 +793,15 @@ export default function CurveEditor({
               stroke={isPlaying ? '#00f5d4' : 'rgba(255,255,255,0.7)'}
               strokeWidth={1.5}
             />
-            <g
-              transform={`translate(${Math.min(
+            <SvgFixedGroup
+              x={Math.min(
                 Math.max(playheadX, 24),
                 effectiveViewportWidth - 24,
-              )}, 14)`}
+              )}
+              y={14}
+              scaleX={fixedLabelScaleX}
+              scaleY={fixedLabelScaleY}
+              data-testid="curve-playhead-label"
             >
               <rect x={-22} y={-10} width={44} height={18} rx={3} fill="var(--bg)" stroke="#00f5d4" strokeOpacity="0.6" />
               <text
@@ -727,7 +814,7 @@ export default function CurveEditor({
               >
                 {fmtTime(playheadSec)}
               </text>
-            </g>
+            </SvgFixedGroup>
           </g>
         )}
 
@@ -774,7 +861,14 @@ export default function CurveEditor({
               />
               {/* Live value chip while dragging */}
               {isDragging && (
-                <g transform="translate(0,-22)" pointerEvents="none" data-testid="drag-chip">
+                <SvgFixedGroup
+                  x={0}
+                  y={-22}
+                  scaleX={fixedLabelScaleX}
+                  scaleY={fixedLabelScaleY}
+                  pointerEvents="none"
+                  data-testid="drag-chip"
+                >
                   <rect x={-26} y={-11} width="52" height="20" rx="3" fill="var(--bg)" stroke={NEON} />
                   <text
                     x="0"
@@ -786,7 +880,7 @@ export default function CurveEditor({
                   >
                     {(dragEnergy ?? b.target).toFixed(1)}
                   </text>
-                </g>
+                </SvgFixedGroup>
               )}
               </g>
             );

--- a/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
@@ -311,6 +311,8 @@ export default function CurveEditor({
       ref={wrapRef}
       data-testid="curve-canvas"
       data-lod={lod}
+      data-px-per-second={effectivePxPerSecond.toFixed(4)}
+      data-scroll-left={effectiveScrollLeft.toFixed(0)}
     >
       <span data-testid="curve-lod" className={styles.srOnly}>
         {lod}

--- a/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
@@ -18,8 +18,13 @@ import {
   bpmPercentDelta,
   camelotMixTier,
   fmtTime,
-  slotBlocksFromSlots,
 } from './curveMath';
+import {
+  curveViewportRange,
+  fitPxPerSecond,
+  lodForMedianSlotWidth,
+  visibleBlocksFromSlots,
+} from './curveViewport';
 import { rawTargetSecForSlots } from './targetMath';
 import type { SlotView, VibeWindowView } from './types';
 import styles from './curve.module.css';
@@ -56,6 +61,11 @@ export interface CurveEditorProps {
   onWindowDelete?: (id: string) => void;
   targetDurationSec?: number | null;
   avgTransitionOverlapSec?: number;
+  pxPerSecond?: number;
+  scrollLeft?: number;
+  viewportWidth?: number;
+  onScrollLeftChange?: (scrollLeft: number) => void;
+  onViewportWidthChange?: (width: number) => void;
 }
 
 export default function CurveEditor({
@@ -76,8 +86,14 @@ export default function CurveEditor({
   onWindowDelete,
   targetDurationSec = null,
   avgTransitionOverlapSec = 0,
+  pxPerSecond,
+  scrollLeft = 0,
+  viewportWidth,
+  onScrollLeftChange,
+  onViewportWidthChange,
 }: CurveEditorProps) {
   const wrapRef = useRef<HTMLDivElement>(null);
+  const scrollViewportRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
   const [w, setW] = useState(800);
   const [h, setH] = useState(220);
@@ -89,13 +105,22 @@ export default function CurveEditor({
     if (!wrapRef.current) return;
     const ro = new ResizeObserver((entries) => {
       for (const e of entries) {
-        setW(Math.max(300, e.contentRect.width));
-        setH(Math.max(140, e.contentRect.height));
+        const nextW = Math.max(300, e.contentRect.width);
+        const nextH = Math.max(140, e.contentRect.height);
+        setW(nextW);
+        setH(nextH);
+        onViewportWidthChange?.(nextW);
       }
     });
     ro.observe(wrapRef.current);
     return () => ro.disconnect();
-  }, []);
+  }, [onViewportWidthChange]);
+
+  useEffect(() => {
+    if (!scrollViewportRef.current) return;
+    if (Math.abs(scrollViewportRef.current.scrollLeft - scrollLeft) < 1) return;
+    scrollViewportRef.current.scrollLeft = scrollLeft;
+  }, [scrollLeft]);
 
   const yOf = (e: number) => h - (e / 10) * h;
   const eOfY = (y: number) => Math.max(0, Math.min(10, (1 - y / h) * 10));
@@ -107,11 +132,36 @@ export default function CurveEditor({
     avgTransitionOverlapSec,
   );
   const domainSec = Math.max(totalSec, rawTargetSec ?? 0, 1);
-  const targetX = rawTargetSec == null ? null : Math.round((rawTargetSec / domainSec) * w);
-  const baseBlocks = slotBlocksFromSlots(slots, w, domainSec);
+  const effectiveViewportWidth = viewportWidth ?? w;
+  const effectivePxPerSecond = pxPerSecond ?? fitPxPerSecond({
+    totalSec: domainSec,
+    viewportWidth: effectiveViewportWidth,
+  });
+  const visibleRange = curveViewportRange({
+    scrollLeft,
+    viewportWidth: effectiveViewportWidth,
+    pxPerSecond: effectivePxPerSecond,
+    totalSec: domainSec,
+  });
+  const overscanSec = Math.max(30, effectiveViewportWidth / effectivePxPerSecond);
+  const targetX = rawTargetSec == null
+    ? null
+    : Math.round((rawTargetSec - visibleRange.startSec) * effectivePxPerSecond);
+  const baseBlocks = visibleBlocksFromSlots({
+    slots,
+    visibleStartSec: visibleRange.startSec,
+    visibleEndSec: visibleRange.endSec,
+    pxPerSecond: effectivePxPerSecond,
+    overscanSec,
+  });
   const blocks = baseBlocks.map((b) =>
     dragIdx === b.idx && dragEnergy != null ? { ...b, target: dragEnergy } : b,
   );
+  const lod = lodForMedianSlotWidth(blocks.map((b) => b.width));
+  const showBlocks = lod !== 'overview';
+  const showSlotHandles = lod === 'detail';
+  const showDenseSeams = lod === 'detail';
+  const scrollableWidth = Math.max(effectiveViewportWidth, domainSec * effectivePxPerSecond);
 
   // Per-slot handle drag (vertical only)
   useEffect(() => {
@@ -125,14 +175,14 @@ export default function CurveEditor({
     };
     const onUp = () => {
       if (dragEnergy != null && onTargetDragEnd) {
-        const b = blocks[dragIdx];
+        const b = blocks.find((block) => block.idx === dragIdx);
         // Convert SVG-local coords to viewport coords — the popover positions
         // with `position: fixed`.
         const rect = svgRef.current?.getBoundingClientRect();
         const anchor =
           b && rect
             ? {
-                x: rect.left + (b.xMid / Math.max(1, w)) * rect.width,
+                x: rect.left + (b.xMid / Math.max(1, effectiveViewportWidth)) * rect.width,
                 y: rect.top + (yOf(dragEnergy) / Math.max(1, h)) * rect.height,
               }
             : { x: 0, y: 0 };
@@ -195,13 +245,15 @@ export default function CurveEditor({
   const linePath = blocks
     .map((b, i) => `${i === 0 ? 'M' : 'L'} ${b.xMid.toFixed(2)} ${yOf(b.target).toFixed(2)}`)
     .join(' ');
-  const secToX = (sec: number) => (Math.max(0, Math.min(domainSec, sec)) / domainSec) * w;
+  const secToX = (sec: number) =>
+    (Math.max(0, Math.min(domainSec, sec)) - visibleRange.startSec) * effectivePxPerSecond;
   const playheadX = domainSec > 0 ? secToX(playheadSec) : 0;
   const scrubFromClientX = (clientX: number) => {
     if (!svgRef.current || !scrubEnabled || !onScrub || totalSec <= 0) return;
     const rect = svgRef.current.getBoundingClientRect();
     const t = Math.max(0, Math.min(1, (clientX - rect.left) / Math.max(1, rect.width)));
-    onScrub(Math.min(totalSec, t * domainSec));
+    const sec = visibleRange.startSec + t * (effectiveViewportWidth / effectivePxPerSecond);
+    onScrub(Math.min(totalSec, Math.max(0, sec)));
   };
   const handleSvgClickCapture = (ev: ReactMouseEvent<SVGSVGElement>) => {
     if (!scrubEnabled || !onScrub || totalSec <= 0) return;
@@ -224,37 +276,44 @@ export default function CurveEditor({
   }
 
   return (
-    <div className={styles.canvasWrap} ref={wrapRef} data-testid="curve-canvas">
-      <div className={styles.yaxis}>
-        <div>10·peak</div>
-        <div>7</div>
-        <div>5</div>
-        <div>2</div>
-        <div>0</div>
-      </div>
-      <div className={styles.xaxis}>
-        {[0, 0.25, 0.5, 0.75, 1].map((t) => (
-          <div key={t}>{fmtTime(t * domainSec)}</div>
-        ))}
-      </div>
-      <svg
-        ref={svgRef}
-        className={styles.svg}
-        viewBox={`0 0 ${w} ${h}`}
-        preserveAspectRatio="none"
-        onClickCapture={handleSvgClickCapture}
+    <div
+      className={styles.canvasWrap}
+      ref={wrapRef}
+      data-testid="curve-canvas"
+      data-lod={lod}
+    >
+      <span data-testid="curve-lod" className={styles.srOnly}>
+        {lod}
+      </span>
+      <div
+        ref={scrollViewportRef}
+        className={styles.curveScrollViewport}
+        data-testid="curve-scroll-viewport"
+        onScroll={(event) => onScrollLeftChange?.(event.currentTarget.scrollLeft)}
       >
+        <div
+          className={styles.curveScrollInner}
+          style={{ width: scrollableWidth }}
+          aria-hidden="true"
+        />
+        <svg
+          ref={svgRef}
+          className={styles.svg}
+          viewBox={`0 0 ${effectiveViewportWidth} ${h}`}
+          preserveAspectRatio="none"
+          onClickCapture={handleSvgClickCapture}
+        >
         <defs>
           <pattern
             id="curveGrid"
             x="0"
             y="0"
-            width={w / 8}
+            width={effectiveViewportWidth / 8}
             height={h / 5}
             patternUnits="userSpaceOnUse"
           >
             <path
-              d={`M ${w / 8} 0 L 0 0 0 ${h / 5}`}
+              d={`M ${effectiveViewportWidth / 8} 0 L 0 0 0 ${h / 5}`}
               fill="none"
               stroke="rgba(255,255,255,0.04)"
               strokeWidth="1"
@@ -270,10 +329,10 @@ export default function CurveEditor({
           </pattern>
         </defs>
 
-        <rect width={w} height={h} fill="url(#curveGrid)" />
+        <rect width={effectiveViewportWidth} height={h} fill="url(#curveGrid)" />
         {scrubEnabled && (
           <rect
-            width={w}
+            width={effectiveViewportWidth}
             height={h}
             fill="transparent"
             data-testid="curve-scrub-hit"
@@ -290,7 +349,7 @@ export default function CurveEditor({
                 data-testid="curve-over-region"
                 x={targetX}
                 y={0}
-                width={Math.max(0, ((totalSec - rawTargetSec) / domainSec) * w)}
+                width={Math.max(0, (totalSec - rawTargetSec) * effectivePxPerSecond)}
                 height={h}
                 fill="rgba(245,158,11,0.12)"
               />
@@ -306,7 +365,7 @@ export default function CurveEditor({
               strokeDasharray="5 4"
             />
             <text
-              x={Math.min(Math.max((targetX ?? 0) + 6, 34), w - 28)}
+              x={Math.min(Math.max((targetX ?? 0) + 6, 34), effectiveViewportWidth - 28)}
               y={13}
               fill="#fbbf24"
               fontSize="9"
@@ -322,7 +381,7 @@ export default function CurveEditor({
         <line
           x1="0"
           y1={yOf(8)}
-          x2={w}
+          x2={effectiveViewportWidth}
           y2={yOf(8)}
           stroke="rgba(255,157,63,0.18)"
           strokeDasharray="3 4"
@@ -331,8 +390,10 @@ export default function CurveEditor({
 
         {/* Vibe windows */}
         {windows.map((win) => {
-          const x = win.t0 * w;
-          const width = Math.max(2, (win.t1 - win.t0) * w);
+          const startSec = win.t0 * domainSec;
+          const endSec = win.t1 * domainSec;
+          const x = (startSec - visibleRange.startSec) * effectivePxPerSecond;
+          const width = Math.max(2, (endSec - startSec) * effectivePxPerSecond);
           const isDragging = winDrag?.id === win.id;
           const headerH = 22;
           return (
@@ -404,30 +465,31 @@ export default function CurveEditor({
         })}
 
         {/* Slot blocks */}
-        {blocks.map((b) => {
-          const isHover = hoveredIdx === b.idx;
-          const isDragging = dragIdx === b.idx;
-          const gap = view === 'normal' ? 1.5 : 4;
-          const blockH = (b.energy / 10) * h;
-          const targetY = yOf(b.target);
-          const targetAbove = b.target > b.energy + 0.5;
-          const targetBelow = b.energy > b.target + 0.5;
-          return (
-            <g
-              key={`sb-${b.idx}`}
-              data-testid={`slot-block-${b.idx}`}
-              onMouseEnter={() => onHover(b.idx)}
-              onMouseLeave={() => onHover(null)}
-              onClick={(ev) => {
-                if ((ev.target as SVGElement).dataset?.handle) return;
-                if (onBlockClick) onBlockClick(b.idx);
-              }}
-              onDoubleClick={(ev) => {
-                ev.preventDefault();
-                if (onBlockDoubleClick) onBlockDoubleClick(b.idx);
-              }}
-              style={{ cursor: 'pointer' }}
-            >
+        {showBlocks &&
+          blocks.map((b) => {
+            const isHover = hoveredIdx === b.idx;
+            const isDragging = dragIdx === b.idx;
+            const gap = view === 'normal' ? 1.5 : 4;
+            const blockH = (b.energy / 10) * h;
+            const targetY = yOf(b.target);
+            const targetAbove = b.target > b.energy + 0.5;
+            const targetBelow = b.energy > b.target + 0.5;
+            return (
+              <g
+                key={`sb-${b.idx}`}
+                data-testid={`slot-block-${b.idx}`}
+                onMouseEnter={() => onHover(b.idx)}
+                onMouseLeave={() => onHover(null)}
+                onClick={(ev) => {
+                  if ((ev.target as SVGElement).dataset?.handle) return;
+                  if (onBlockClick) onBlockClick(b.idx);
+                }}
+                onDoubleClick={(ev) => {
+                  ev.preventDefault();
+                  if (onBlockDoubleClick) onBlockDoubleClick(b.idx);
+                }}
+                style={{ cursor: 'pointer' }}
+              >
               {/* Block (intrinsic energy) */}
               <rect
                 x={b.x0 + gap / 2}
@@ -486,16 +548,17 @@ export default function CurveEditor({
               )}
               {/* Invisible hit-target */}
               <rect x={b.x0} y={0} width={b.width} height={h} fill="transparent" />
-            </g>
-          );
-        })}
+              </g>
+            );
+          })}
 
         {/* Friction seams (BPM / Key views) */}
-        {view !== 'normal' &&
+        {showDenseSeams &&
+          view !== 'normal' &&
           blocks.slice(0, -1).map((b, i) => {
             const next = blocks[i + 1];
-            const a = slots[i].track;
-            const z = slots[i + 1].track;
+            const a = slots[b.idx].track;
+            const z = slots[next.idx].track;
             let color: { stroke: string };
             let chipText: string;
             let isClash: boolean;
@@ -517,11 +580,15 @@ export default function CurveEditor({
             const seamW = Math.max(3, next.x0 - b.x1 - 0.5);
             // Band sized to the SHORTER neighbor block
             const meetTop = h - Math.min((b.energy / 10) * h, (next.energy / 10) * h);
-            const isHovered = hoveredIdx === i || hoveredIdx === i + 1;
+            const isHovered = hoveredIdx === b.idx || hoveredIdx === next.idx;
             return (
-              <g key={`seam-${i}`} pointerEvents="none" data-testid={`seam-${view}-${i}`}>
+              <g
+                key={`seam-${b.idx}`}
+                pointerEvents="none"
+                data-testid={`seam-${view}-${b.idx}`}
+              >
                 <rect
-                  data-testid={`seam-band-${i}`}
+                  data-testid={`seam-band-${b.idx}`}
                   data-stroke={color.stroke}
                   x={seamX - seamW / 2}
                   y={meetTop}
@@ -534,8 +601,11 @@ export default function CurveEditor({
                 <circle cx={seamX} cy={h - 1} r={isClash ? 3.5 : 3} fill={color.stroke} />
                 {isHovered && (
                   <g
-                    transform={`translate(${Math.min(Math.max(seamX, 40), w - 40)}, ${h - 18})`}
-                    data-testid={`seam-chip-${i}`}
+                    transform={`translate(${Math.min(
+                      Math.max(seamX, 40),
+                      effectiveViewportWidth - 40,
+                    )}, ${h - 18})`}
+                    data-testid={`seam-chip-${b.idx}`}
                   >
                     <rect
                       x={-Math.max(30, chipText.length * 3.4 + 7)}
@@ -564,18 +634,22 @@ export default function CurveEditor({
           })}
 
         {/* DJ pairing seam markers */}
-        {blocks.slice(0, -1).map((b, i) => {
-          if (!slots[i].nextIsDjPairing) return null;
-          const next = blocks[i + 1];
-          const seamX = (b.x1 + next.x0) / 2;
-          const markerY = Math.max(18, Math.min(h - 28, (yOf(b.target) + yOf(next.target)) / 2 - 18));
-          return (
-            <g
-              key={`pairing-pin-${i}`}
-              transform={`translate(${seamX}, ${markerY})`}
-              pointerEvents="none"
-              data-testid={`pairing-pin-${i}`}
-            >
+        {showDenseSeams &&
+          blocks.slice(0, -1).map((b, i) => {
+            if (!slots[b.idx].nextIsDjPairing) return null;
+            const next = blocks[i + 1];
+            const seamX = (b.x1 + next.x0) / 2;
+            const markerY = Math.max(
+              18,
+              Math.min(h - 28, (yOf(b.target) + yOf(next.target)) / 2 - 18),
+            );
+            return (
+              <g
+                key={`pairing-pin-${b.idx}`}
+                transform={`translate(${seamX}, ${markerY})`}
+                pointerEvents="none"
+                data-testid={`pairing-pin-${b.idx}`}
+              >
               <line y1={10} y2={Math.max(14, h - markerY - 4)} stroke={NEON_PURPLE} strokeOpacity="0.38" strokeDasharray="2 3" />
               <circle r="10" fill="rgba(183,139,255,0.18)" stroke={NEON_PURPLE} strokeWidth="1.4" />
               <path
@@ -586,11 +660,11 @@ export default function CurveEditor({
                 strokeLinejoin="round"
                 strokeWidth="1.3"
               />
-            </g>
-          );
-        })}
+              </g>
+            );
+          })}
 
-        {/* Derived target curve line */}
+        {/* Transport playhead */}
         {totalSec > 0 && (
           <g pointerEvents="none" data-testid="curve-playhead">
             <rect x={0} y={0} width={playheadX} height={h} fill="rgba(0,0,0,0.22)" />
@@ -602,7 +676,12 @@ export default function CurveEditor({
               stroke={isPlaying ? '#00f5d4' : 'rgba(255,255,255,0.7)'}
               strokeWidth={1.5}
             />
-            <g transform={`translate(${Math.min(Math.max(playheadX, 24), w - 24)}, 14)`}>
+            <g
+              transform={`translate(${Math.min(
+                Math.max(playheadX, 24),
+                effectiveViewportWidth - 24,
+              )}, 14)`}
+            >
               <rect x={-22} y={-10} width={44} height={18} rx={3} fill="var(--bg)" stroke="#00f5d4" strokeOpacity="0.6" />
               <text
                 x="0"
@@ -632,13 +711,14 @@ export default function CurveEditor({
         )}
 
         {/* Drag handles — one per slot at its target energy */}
-        {blocks.map((b) => {
-          const isHover = hoveredIdx === b.idx;
-          const isDragging = dragIdx === b.idx;
-          const r = isDragging ? 7 : isHover ? 6 : 5;
-          const targetY = yOf(b.target);
-          return (
-            <g key={`h-${b.idx}`} transform={`translate(${b.xMid},${targetY})`}>
+        {showSlotHandles &&
+          blocks.map((b) => {
+            const isHover = hoveredIdx === b.idx;
+            const isDragging = dragIdx === b.idx;
+            const r = isDragging ? 7 : isHover ? 6 : 5;
+            const targetY = yOf(b.target);
+            return (
+              <g key={`h-${b.idx}`} transform={`translate(${b.xMid},${targetY})`}>
               <circle
                 r={12}
                 fill="transparent"
@@ -674,12 +754,25 @@ export default function CurveEditor({
                   </text>
                 </g>
               )}
-            </g>
-          );
-        })}
+              </g>
+            );
+          })}
 
         {/* Transport playhead lands with #393. */}
       </svg>
+      </div>
+      <div className={styles.yaxis}>
+        <div>10·peak</div>
+        <div>7</div>
+        <div>5</div>
+        <div>2</div>
+        <div>0</div>
+      </div>
+      <div className={styles.xaxis}>
+        {[0, 0.25, 0.5, 0.75, 1].map((t) => (
+          <div key={t}>{fmtTime(t * domainSec)}</div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
@@ -10,8 +10,9 @@
  * BPM/Key view modes render tier-colored friction bands at block seams.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type {
+  KeyboardEvent as ReactKeyboardEvent,
   MouseEvent as ReactMouseEvent,
   ReactNode,
   SVGProps,
@@ -111,6 +112,13 @@ interface WindowDrag {
   startT1: number;
 }
 
+interface ScrollbarDrag {
+  startClientX: number;
+  startScrollLeft: number;
+  trackScrollablePx: number;
+  maxScrollLeft: number;
+}
+
 export interface CurveEditorProps {
   slots: SlotView[];
   view: CurveViewMode;
@@ -161,6 +169,7 @@ export default function CurveEditor({
   onViewportWidthChange,
 }: CurveEditorProps) {
   const wrapRef = useRef<HTMLDivElement>(null);
+  const measureFrameRef = useRef<number | null>(null);
   const scrollViewportRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
   const [w, setW] = useState(800);
@@ -169,22 +178,69 @@ export default function CurveEditor({
   const [dragEnergy, setDragEnergy] = useState<number | null>(null);
   const [internalScrollLeft, setInternalScrollLeft] = useState(0);
   const [winDrag, setWinDrag] = useState<WindowDrag | null>(null);
+  const [scrollbarDrag, setScrollbarDrag] = useState<ScrollbarDrag | null>(null);
   const effectiveScrollLeft = scrollLeft ?? internalScrollLeft;
+
+  const commitMeasuredSize = useCallback(
+    (width: number, height: number) => {
+      if (width <= 0 || height <= 0) return;
+      const nextW = Math.max(1, width);
+      const nextH = Math.max(1, height);
+      setW((prev) => (Math.abs(prev - nextW) < 0.5 ? prev : nextW));
+      setH((prev) => (Math.abs(prev - nextH) < 0.5 ? prev : nextH));
+      onViewportWidthChange?.(nextW);
+    },
+    [onViewportWidthChange],
+  );
+
+  const measureWrap = useCallback(() => {
+    const rect = wrapRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    commitMeasuredSize(rect.width, rect.height);
+  }, [commitMeasuredSize]);
+
+  const setWrapNode = useCallback(
+    (node: HTMLDivElement | null) => {
+      wrapRef.current = node;
+      if (measureFrameRef.current != null) {
+        window.cancelAnimationFrame(measureFrameRef.current);
+        measureFrameRef.current = null;
+      }
+      if (!node) return;
+      const measureNode = () => {
+        const rect = node.getBoundingClientRect();
+        commitMeasuredSize(rect.width, rect.height);
+      };
+      measureNode();
+      measureFrameRef.current = window.requestAnimationFrame(measureNode);
+    },
+    [commitMeasuredSize],
+  );
+
+  useLayoutEffect(() => {
+    measureWrap();
+  }, [measureWrap]);
 
   useEffect(() => {
     if (!wrapRef.current) return;
+    const node = wrapRef.current;
+    measureWrap();
     const ro = new ResizeObserver((entries) => {
       for (const e of entries) {
-        const nextW = Math.max(300, e.contentRect.width);
-        const nextH = Math.max(140, e.contentRect.height);
-        setW(nextW);
-        setH(nextH);
-        onViewportWidthChange?.(nextW);
+        commitMeasuredSize(e.contentRect.width, e.contentRect.height);
       }
     });
-    ro.observe(wrapRef.current);
-    return () => ro.disconnect();
-  }, [onViewportWidthChange]);
+    ro.observe(node);
+    window.addEventListener('resize', measureWrap);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('resize', measureWrap);
+      if (measureFrameRef.current != null) {
+        window.cancelAnimationFrame(measureFrameRef.current);
+        measureFrameRef.current = null;
+      }
+    };
+  }, [commitMeasuredSize, measureWrap]);
 
   useEffect(() => {
     if (!scrollViewportRef.current) return;
@@ -233,6 +289,16 @@ export default function CurveEditor({
   const showDenseSeams = lod === 'detail';
   const scrollableWidth = Math.max(effectiveViewportWidth, domainSec * effectivePxPerSecond);
   const maxScrollLeft = Math.max(0, scrollableWidth - effectiveViewportWidth);
+  const canScrollTimeline = maxScrollLeft > 1;
+  const scrollThumbWidthPct = canScrollTimeline
+    ? Math.min(100, Math.max(8, (effectiveViewportWidth / scrollableWidth) * 100))
+    : 100;
+  const scrollThumbLeftPct = canScrollTimeline
+    ? Math.min(
+        100 - scrollThumbWidthPct,
+        (effectiveScrollLeft / Math.max(1, scrollableWidth)) * 100,
+      )
+    : 0;
   const viewBoxWidth = effectiveViewportWidth;
   const viewBoxHeight = h;
   const renderedSvgWidth = w;
@@ -249,6 +315,79 @@ export default function CurveEditor({
 
   const handleScroll = (event: React.UIEvent<HTMLDivElement>) => {
     commitScrollLeft(event.currentTarget.scrollLeft);
+  };
+
+  const scrollByDelta = (delta: number) => {
+    commitScrollLeft(effectiveScrollLeft + delta);
+  };
+
+  const handleScrollbarPointerDown = (ev: React.PointerEvent<HTMLDivElement>) => {
+    if (!canScrollTimeline) return;
+    ev.preventDefault();
+    const track = ev.currentTarget;
+    const trackRect = track.getBoundingClientRect();
+    const thumb = track.querySelector<HTMLElement>('[data-scrollbar-thumb="1"]');
+    const thumbRect = thumb?.getBoundingClientRect();
+    const thumbWidth = thumbRect?.width ?? 0;
+    const trackScrollablePx = Math.max(1, trackRect.width - thumbWidth);
+    const clickedThumb =
+      ev.target instanceof Element && Boolean(ev.target.closest('[data-scrollbar-thumb="1"]'));
+    let nextScrollLeft = effectiveScrollLeft;
+
+    if (!clickedThumb) {
+      const nextThumbLeft = Math.max(
+        0,
+        Math.min(trackScrollablePx, ev.clientX - trackRect.left - thumbWidth / 2),
+      );
+      nextScrollLeft = (nextThumbLeft / trackScrollablePx) * maxScrollLeft;
+      commitScrollLeft(nextScrollLeft);
+    }
+
+    setScrollbarDrag({
+      startClientX: ev.clientX,
+      startScrollLeft: nextScrollLeft,
+      trackScrollablePx,
+      maxScrollLeft,
+    });
+    track.setPointerCapture(ev.pointerId);
+  };
+
+  const handleScrollbarPointerMove = (ev: React.PointerEvent<HTMLDivElement>) => {
+    if (!scrollbarDrag) return;
+    const dx = ev.clientX - scrollbarDrag.startClientX;
+    const nextScrollLeft =
+      scrollbarDrag.startScrollLeft +
+      (dx / scrollbarDrag.trackScrollablePx) * scrollbarDrag.maxScrollLeft;
+    commitScrollLeft(nextScrollLeft);
+  };
+
+  const endScrollbarDrag = (ev: React.PointerEvent<HTMLDivElement>) => {
+    if (!scrollbarDrag) return;
+    setScrollbarDrag(null);
+    ev.currentTarget.releasePointerCapture(ev.pointerId);
+  };
+
+  const handleScrollbarKeyDown = (ev: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (!canScrollTimeline) return;
+    if (ev.key === 'ArrowLeft') {
+      ev.preventDefault();
+      scrollByDelta(-effectiveViewportWidth / 8);
+    } else if (ev.key === 'ArrowRight') {
+      ev.preventDefault();
+      scrollByDelta(effectiveViewportWidth / 8);
+    } else if (ev.key === 'PageUp') {
+      ev.preventDefault();
+      scrollByDelta(-effectiveViewportWidth * 0.8);
+    } else if (ev.key === 'PageDown') {
+      ev.preventDefault();
+      scrollByDelta(effectiveViewportWidth * 0.8);
+    } else if (ev.key === 'Home') {
+      ev.preventDefault();
+      commitScrollLeft(0);
+    } else if (ev.key === 'End') {
+      ev.preventDefault();
+      commitScrollLeft(maxScrollLeft);
+    }
   };
 
   const handleWheel = (event: React.WheelEvent<SVGSVGElement>) => {
@@ -382,7 +521,7 @@ export default function CurveEditor({
   return (
     <div
       className={styles.canvasWrap}
-      ref={wrapRef}
+      ref={setWrapNode}
       data-testid="curve-canvas"
       data-lod={lod}
       data-px-per-second={effectivePxPerSecond.toFixed(4)}
@@ -395,12 +534,41 @@ export default function CurveEditor({
         ref={scrollViewportRef}
         className={styles.curveScrollViewport}
         data-testid="curve-scroll-viewport"
+        data-scrollbar-affordance="true"
+        aria-label="Curve timeline horizontal scroll"
         onScroll={handleScroll}
       >
         <div
           className={styles.curveScrollInner}
           style={{ width: scrollableWidth }}
           aria-hidden="true"
+        />
+      </div>
+      <div
+        className={styles.curveScrollbar}
+        data-testid="curve-scrollbar"
+        data-enabled={canScrollTimeline ? 'true' : 'false'}
+        role="scrollbar"
+        aria-label="Curve timeline scroll position"
+        aria-orientation="horizontal"
+        aria-valuemin={0}
+        aria-valuemax={Math.round(maxScrollLeft)}
+        aria-valuenow={Math.round(effectiveScrollLeft)}
+        tabIndex={canScrollTimeline ? 0 : -1}
+        onPointerDown={handleScrollbarPointerDown}
+        onPointerMove={handleScrollbarPointerMove}
+        onPointerUp={endScrollbarDrag}
+        onPointerCancel={endScrollbarDrag}
+        onKeyDown={handleScrollbarKeyDown}
+      >
+        <div
+          className={styles.curveScrollbarThumb}
+          data-testid="curve-scrollbar-thumb"
+          data-scrollbar-thumb="1"
+          style={{
+            left: `${scrollThumbLeftPct}%`,
+            width: `${scrollThumbWidthPct}%`,
+          }}
         />
       </div>
       <svg

--- a/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
@@ -87,7 +87,7 @@ export default function CurveEditor({
   targetDurationSec = null,
   avgTransitionOverlapSec = 0,
   pxPerSecond,
-  scrollLeft = 0,
+  scrollLeft,
   viewportWidth,
   onScrollLeftChange,
   onViewportWidthChange,
@@ -99,7 +99,9 @@ export default function CurveEditor({
   const [h, setH] = useState(220);
   const [dragIdx, setDragIdx] = useState<number | null>(null);
   const [dragEnergy, setDragEnergy] = useState<number | null>(null);
+  const [internalScrollLeft, setInternalScrollLeft] = useState(0);
   const [winDrag, setWinDrag] = useState<WindowDrag | null>(null);
+  const effectiveScrollLeft = scrollLeft ?? internalScrollLeft;
 
   useEffect(() => {
     if (!wrapRef.current) return;
@@ -118,9 +120,9 @@ export default function CurveEditor({
 
   useEffect(() => {
     if (!scrollViewportRef.current) return;
-    if (Math.abs(scrollViewportRef.current.scrollLeft - scrollLeft) < 1) return;
-    scrollViewportRef.current.scrollLeft = scrollLeft;
-  }, [scrollLeft]);
+    if (Math.abs(scrollViewportRef.current.scrollLeft - effectiveScrollLeft) < 1) return;
+    scrollViewportRef.current.scrollLeft = effectiveScrollLeft;
+  }, [effectiveScrollLeft]);
 
   const yOf = (e: number) => h - (e / 10) * h;
   const eOfY = (y: number) => Math.max(0, Math.min(10, (1 - y / h) * 10));
@@ -138,7 +140,7 @@ export default function CurveEditor({
     viewportWidth: effectiveViewportWidth,
   });
   const visibleRange = curveViewportRange({
-    scrollLeft,
+    scrollLeft: effectiveScrollLeft,
     viewportWidth: effectiveViewportWidth,
     pxPerSecond: effectivePxPerSecond,
     totalSec: domainSec,
@@ -162,6 +164,27 @@ export default function CurveEditor({
   const showSlotHandles = lod === 'detail';
   const showDenseSeams = lod === 'detail';
   const scrollableWidth = Math.max(effectiveViewportWidth, domainSec * effectivePxPerSecond);
+  const maxScrollLeft = Math.max(0, scrollableWidth - effectiveViewportWidth);
+
+  const commitScrollLeft = (next: number) => {
+    const clamped = Math.max(0, Math.min(maxScrollLeft, next));
+    if (scrollLeft == null) setInternalScrollLeft(clamped);
+    onScrollLeftChange?.(clamped);
+    return clamped;
+  };
+
+  const handleScroll = (event: React.UIEvent<HTMLDivElement>) => {
+    commitScrollLeft(event.currentTarget.scrollLeft);
+  };
+
+  const handleWheel = (event: React.WheelEvent<SVGSVGElement>) => {
+    if (!scrollViewportRef.current || maxScrollLeft <= 0) return;
+    const delta = event.deltaX !== 0 ? event.deltaX : event.deltaY;
+    if (delta === 0) return;
+    const next = commitScrollLeft(scrollViewportRef.current.scrollLeft + delta);
+    scrollViewportRef.current.scrollLeft = next;
+    event.preventDefault();
+  };
 
   const clientXToDomainT = (clientX: number) => {
     if (!svgRef.current || domainSec <= 0) return 0;
@@ -296,7 +319,7 @@ export default function CurveEditor({
         ref={scrollViewportRef}
         className={styles.curveScrollViewport}
         data-testid="curve-scroll-viewport"
-        onScroll={(event) => onScrollLeftChange?.(event.currentTarget.scrollLeft)}
+        onScroll={handleScroll}
       >
         <div
           className={styles.curveScrollInner}
@@ -310,6 +333,7 @@ export default function CurveEditor({
         viewBox={`0 0 ${effectiveViewportWidth} ${h}`}
         preserveAspectRatio="none"
         onClickCapture={handleSvgClickCapture}
+        onWheel={handleWheel}
       >
         <defs>
           <pattern

--- a/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
@@ -163,6 +163,15 @@ export default function CurveEditor({
   const showDenseSeams = lod === 'detail';
   const scrollableWidth = Math.max(effectiveViewportWidth, domainSec * effectivePxPerSecond);
 
+  const clientXToDomainT = (clientX: number) => {
+    if (!svgRef.current || domainSec <= 0) return 0;
+    const rect = svgRef.current.getBoundingClientRect();
+    const viewportT = (clientX - rect.left) / Math.max(1, rect.width);
+    const sec =
+      visibleRange.startSec + viewportT * (effectiveViewportWidth / effectivePxPerSecond);
+    return Math.max(0, Math.min(1, sec / domainSec));
+  };
+
   // Per-slot handle drag (vertical only)
   useEffect(() => {
     if (dragIdx == null) return;
@@ -204,8 +213,7 @@ export default function CurveEditor({
     if (!winDrag) return;
     const onMove = (ev: PointerEvent) => {
       if (!svgRef.current || !onWindowChange) return;
-      const rect = svgRef.current.getBoundingClientRect();
-      const mouseT = Math.max(0, Math.min(1, (ev.clientX - rect.left) / Math.max(1, rect.width)));
+      const mouseT = clientXToDomainT(ev.clientX);
       const dt = mouseT - winDrag.startMouseT;
       if (winDrag.mode === 'move') {
         const span = winDrag.startT1 - winDrag.startT0;
@@ -237,8 +245,7 @@ export default function CurveEditor({
       if (!svgRef.current || !onWindowChange) return;
       ev.preventDefault();
       ev.stopPropagation();
-      const rect = svgRef.current.getBoundingClientRect();
-      const mouseT = (ev.clientX - rect.left) / Math.max(1, rect.width);
+      const mouseT = clientXToDomainT(ev.clientX);
       setWinDrag({ id, mode, startMouseT: mouseT, startT0: t0, startT1: t1 });
     };
 
@@ -296,13 +303,14 @@ export default function CurveEditor({
           style={{ width: scrollableWidth }}
           aria-hidden="true"
         />
-        <svg
-          ref={svgRef}
-          className={styles.svg}
-          viewBox={`0 0 ${effectiveViewportWidth} ${h}`}
-          preserveAspectRatio="none"
-          onClickCapture={handleSvgClickCapture}
-        >
+      </div>
+      <svg
+        ref={svgRef}
+        className={styles.svg}
+        viewBox={`0 0 ${effectiveViewportWidth} ${h}`}
+        preserveAspectRatio="none"
+        onClickCapture={handleSvgClickCapture}
+      >
         <defs>
           <pattern
             id="curveGrid"
@@ -760,7 +768,6 @@ export default function CurveEditor({
 
         {/* Transport playhead lands with #393. */}
       </svg>
-      </div>
       <div className={styles.yaxis}>
         <div>10·peak</div>
         <div>7</div>

--- a/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
@@ -24,6 +24,7 @@ import {
   slotMidpoints,
   type VibePreset,
 } from './curveMath';
+import { fitPxPerSecond, zoomPxPerSecond } from './curveViewport';
 import type { SlotView, TrackView, VibeWindowView } from './types';
 import type { BuilderCommit } from './useSetDocumentHistory';
 
@@ -134,8 +135,39 @@ export default function CurvePanel({
   const [overlay, setOverlay] = useState<OverlayState>(OVERLAY_CLOSED);
   const [prompt, setPrompt] = useState<ReplacePrompt | null>(null);
   const [suggestReplacements, setSuggestReplacements] = useState(true);
+  const [curveViewportWidth, setCurveViewportWidth] = useState(800);
+  const [curvePxPerSecond, setCurvePxPerSecond] = useState(0.08);
+  const [curveScrollLeft, setCurveScrollLeft] = useState(0);
+  const [curveFitMode, setCurveFitMode] = useState(true);
 
   const totalSec = slots.reduce((acc, s) => acc + s.track.durationSec, 0);
+  const curveDomainSec = Math.max(totalSec, targetDurationSec ?? 0, 1);
+  const fitScale = fitPxPerSecond({
+    totalSec: curveDomainSec,
+    viewportWidth: curveViewportWidth,
+  });
+  const effectiveCurvePxPerSecond = curveFitMode ? fitScale : curvePxPerSecond;
+  const zoomLabel = curveFitMode
+    ? 'Fit'
+    : `${Math.round(effectiveCurvePxPerSecond * 60)} px/min`;
+
+  const zoomCurve = (direction: 'in' | 'out') => {
+    const next = zoomPxPerSecond({
+      currentPxPerSecond: effectiveCurvePxPerSecond,
+      direction,
+      scrollLeft: curveScrollLeft,
+      viewportWidth: curveViewportWidth,
+      totalSec: curveDomainSec,
+    });
+    setCurveFitMode(false);
+    setCurvePxPerSecond(next.pxPerSecond);
+    setCurveScrollLeft(next.scrollLeft);
+  };
+
+  const fitCurve = () => {
+    setCurveFitMode(true);
+    setCurveScrollLeft(0);
+  };
 
   // Settings toggle persists per browser
   useEffect(() => {
@@ -414,6 +446,10 @@ export default function CurvePanel({
         onViewChange={setView}
         templates={templates}
         activeTemplateName={activeTemplateName}
+        zoomLabel={zoomLabel}
+        onZoomIn={() => zoomCurve('in')}
+        onZoomOut={() => zoomCurve('out')}
+        onZoomFit={fitCurve}
         onApplyBuiltin={(name) => applyTemplate({ builtin: name }, name)}
         onApplyUser={(id) => {
           const tpl = templates?.user.find((t) => t.id === id);
@@ -443,6 +479,14 @@ export default function CurvePanel({
         onWindowDelete={deleteWindow}
         targetDurationSec={targetDurationSec}
         avgTransitionOverlapSec={avgTransitionOverlapSec}
+        pxPerSecond={effectiveCurvePxPerSecond}
+        scrollLeft={curveScrollLeft}
+        viewportWidth={curveViewportWidth}
+        onScrollLeftChange={(next) => {
+          setCurveFitMode(false);
+          setCurveScrollLeft(next);
+        }}
+        onViewportWidthChange={setCurveViewportWidth}
       />
       <CurveTemplateEditorOverlay
         open={overlay.open}

--- a/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
@@ -25,6 +25,7 @@ import {
   type VibePreset,
 } from './curveMath';
 import { fitPxPerSecond, zoomPxPerSecond } from './curveViewport';
+import { rawTargetSecForSlots } from './targetMath';
 import type { SlotView, TrackView, VibeWindowView } from './types';
 import type { BuilderCommit } from './useSetDocumentHistory';
 
@@ -141,12 +142,25 @@ export default function CurvePanel({
   const [curveFitMode, setCurveFitMode] = useState(true);
 
   const totalSec = slots.reduce((acc, s) => acc + s.track.durationSec, 0);
-  const curveDomainSec = Math.max(totalSec, targetDurationSec ?? 0, 1);
+  const rawTargetSec = rawTargetSecForSlots(
+    targetDurationSec,
+    slots.length,
+    avgTransitionOverlapSec,
+  );
+  const curveDomainSec = Math.max(totalSec, rawTargetSec ?? 0, 1);
   const fitScale = fitPxPerSecond({
     totalSec: curveDomainSec,
     viewportWidth: curveViewportWidth,
   });
   const effectiveCurvePxPerSecond = curveFitMode ? fitScale : curvePxPerSecond;
+  const curveMaxScrollLeft = Math.max(
+    0,
+    curveDomainSec * effectiveCurvePxPerSecond - curveViewportWidth,
+  );
+  const clampedCurveScrollLeft = Math.max(
+    0,
+    Math.min(curveMaxScrollLeft, curveScrollLeft),
+  );
   const zoomLabel = curveFitMode
     ? 'Fit'
     : `${Math.round(effectiveCurvePxPerSecond * 60)} px/min`;
@@ -155,7 +169,7 @@ export default function CurvePanel({
     const next = zoomPxPerSecond({
       currentPxPerSecond: effectiveCurvePxPerSecond,
       direction,
-      scrollLeft: curveScrollLeft,
+      scrollLeft: clampedCurveScrollLeft,
       viewportWidth: curveViewportWidth,
       totalSec: curveDomainSec,
     });
@@ -168,6 +182,11 @@ export default function CurvePanel({
     setCurveFitMode(true);
     setCurveScrollLeft(0);
   };
+
+  useEffect(() => {
+    if (Math.abs(clampedCurveScrollLeft - curveScrollLeft) < 1) return;
+    setCurveScrollLeft(clampedCurveScrollLeft);
+  }, [clampedCurveScrollLeft, curveScrollLeft]);
 
   // Settings toggle persists per browser
   useEffect(() => {
@@ -480,11 +499,14 @@ export default function CurvePanel({
         targetDurationSec={targetDurationSec}
         avgTransitionOverlapSec={avgTransitionOverlapSec}
         pxPerSecond={effectiveCurvePxPerSecond}
-        scrollLeft={curveScrollLeft}
+        scrollLeft={clampedCurveScrollLeft}
         viewportWidth={curveViewportWidth}
         onScrollLeftChange={(next) => {
+          const clampedNext = Math.max(0, Math.min(curveMaxScrollLeft, next));
+          if (Math.abs(clampedNext - clampedCurveScrollLeft) < 1) return;
+          if (curveFitMode) setCurvePxPerSecond(effectiveCurvePxPerSecond);
           setCurveFitMode(false);
-          setCurveScrollLeft(next);
+          setCurveScrollLeft(clampedNext);
         }}
         onViewportWidthChange={setCurveViewportWidth}
       />

--- a/dashboard/app/(dj)/setbuilder/components/CurveToolbar.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveToolbar.tsx
@@ -88,7 +88,7 @@ export default function CurveToolbar({
         ))}
       </div>
 
-      <div className={styles.zoomControls} aria-label="Curve zoom controls">
+      <div className={styles.zoomControls} role="group" aria-label="Curve zoom controls">
         <button
           type="button"
           className={styles.toolbarIconBtn}

--- a/dashboard/app/(dj)/setbuilder/components/CurveToolbar.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveToolbar.tsx
@@ -17,6 +17,10 @@ export interface CurveToolbarProps {
   onViewChange: (view: CurveViewMode) => void;
   templates: CurveTemplatesResponse | null;
   activeTemplateName: string | null;
+  zoomLabel: string;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onZoomFit: () => void;
   onApplyBuiltin: (name: string) => void;
   onApplyUser: (templateId: number) => void;
   onCreateTemplate: () => void;
@@ -50,6 +54,10 @@ export default function CurveToolbar({
   onViewChange,
   templates,
   activeTemplateName,
+  zoomLabel,
+  onZoomIn,
+  onZoomOut,
+  onZoomFit,
   onApplyBuiltin,
   onApplyUser,
   onCreateTemplate,
@@ -78,6 +86,40 @@ export default function CurveToolbar({
             {VIEW_LABELS[mode]}
           </button>
         ))}
+      </div>
+
+      <div className={styles.zoomControls} aria-label="Curve zoom controls">
+        <button
+          type="button"
+          className={styles.toolbarIconBtn}
+          onClick={onZoomOut}
+          data-testid="curve-zoom-out"
+          aria-label="Zoom out"
+          title="Zoom out"
+        >
+          -
+        </button>
+        <span className={styles.zoomLabel} data-testid="curve-zoom-label">
+          {zoomLabel}
+        </span>
+        <button
+          type="button"
+          className={styles.toolbarIconBtn}
+          onClick={onZoomIn}
+          data-testid="curve-zoom-in"
+          aria-label="Zoom in"
+          title="Zoom in"
+        >
+          +
+        </button>
+        <button
+          type="button"
+          className={styles.toolbarBtn}
+          onClick={onZoomFit}
+          data-testid="curve-zoom-fit"
+        >
+          Fit
+        </button>
       </div>
 
       {/* Template dropdown */}

--- a/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
@@ -117,12 +117,28 @@ export default function TimelinePanel({
   useEffect(() => {
     if (!scrollRequest || !listRef.current) return;
     if (handledScrollRequestNRef.current === scrollRequest.n) return;
+    if (scrollRequest.idx < 0 || scrollRequest.idx >= slots.length) return;
     handledScrollRequestNRef.current = scrollRequest.n;
 
-    const nextScrollTop = scrollTopForIndex(scrollRequest.idx);
-    listRef.current.scrollTop = nextScrollTop;
+    const list = listRef.current;
+    const rowTop = scrollTopForIndex(scrollRequest.idx);
+    const rowBottom = scrollTopForIndex(scrollRequest.idx + 1);
+    const rowHeight = Math.max(1, rowBottom - rowTop);
+    const visibleTop = list.scrollTop;
+    const visibleHeight =
+      viewportHeight || list.clientHeight || list.getBoundingClientRect().height || rowHeight;
+    const visibleBottom = visibleTop + visibleHeight;
+    let nextScrollTop = visibleTop;
+
+    if (rowTop < visibleTop) {
+      nextScrollTop = rowTop;
+    } else if (rowBottom > visibleBottom) {
+      nextScrollTop = Math.max(0, rowBottom - visibleHeight);
+    }
+
+    list.scrollTop = nextScrollTop;
     setScrollTop(nextScrollTop);
-  }, [scrollRequest, scrollTopForIndex]);
+  }, [scrollRequest, scrollTopForIndex, slots.length, viewportHeight]);
 
   useEffect(() => {
     if (!menu) return;

--- a/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
@@ -3,14 +3,23 @@
 /**
  * Minimal timeline list (#389) — ordered slot rows with BPM/key/energy
  * badges and bidirectional hover sync with the curve. Clicking a curve
- * block scrolls the matching row into view (only when out of view).
+ * block scrolls the matching row into view, including virtualized rows.
  * Full drag-reorder timeline lands with #390/#397.
  */
 
-import { type DragEvent, useEffect, useRef, useState } from 'react';
+import {
+  type DragEvent,
+  type UIEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { readPoolTrackDragPayload } from './dnd';
 import TimelineRow, { type TimelineMenu } from './TimelineRow';
 import type { SlotView } from './types';
+import { useMeasuredVirtualList } from './useMeasuredVirtualList';
 import styles from './curve.module.css';
 
 export interface ScrollRequest {
@@ -32,6 +41,9 @@ export interface TimelinePanelProps {
   onPoolTrackDrop?: (poolTrackId: number, insertIdx: number) => void | Promise<void>;
 }
 
+const ESTIMATED_SLOT_GROUP_HEIGHT = 52;
+const TIMELINE_OVERSCAN_ROWS = 8;
+
 export default function TimelinePanel({
   slots,
   hoveredIdx,
@@ -48,18 +60,54 @@ export default function TimelinePanel({
   const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
   const [menu, setMenu] = useState<TimelineMenu | null>(null);
   const [dropIdx, setDropIdx] = useState<number | null>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportHeight, setViewportHeight] = useState(0);
+
+  const measurementKey = useMemo(() => slots.map((slot) => slot.id).join(':'), [slots]);
+  const virtual = useMeasuredVirtualList({
+    itemCount: slots.length,
+    estimateHeight: ESTIMATED_SLOT_GROUP_HEIGHT,
+    viewportHeight,
+    scrollTop,
+    overscan: TIMELINE_OVERSCAN_ROWS,
+    measurementKey,
+  });
+  const {
+    afterHeight,
+    beforeHeight,
+    indexFromScrollTop,
+    items,
+    scrollTopForIndex,
+    setMeasuredHeight,
+    totalHeight,
+  } = virtual;
+
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+
+    const measure = () => {
+      setViewportHeight(list.clientHeight || list.getBoundingClientRect().height || 0);
+    };
+
+    measure();
+
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', measure);
+      return () => window.removeEventListener('resize', measure);
+    }
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(list);
+    return () => observer.disconnect();
+  }, [slots.length]);
 
   useEffect(() => {
     if (!scrollRequest || !listRef.current) return;
-    const row = rowRefs.current[scrollRequest.idx];
-    if (!row) return;
-    const list = listRef.current.getBoundingClientRect();
-    const r = row.getBoundingClientRect();
-    const outOfView = r.top < list.top || r.bottom > list.bottom;
-    if (outOfView) {
-      row.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-    }
-  }, [scrollRequest]);
+    const nextScrollTop = scrollTopForIndex(scrollRequest.idx);
+    listRef.current.scrollTop = nextScrollTop;
+    setScrollTop(nextScrollTop);
+  }, [scrollRequest, scrollTopForIndex]);
 
   useEffect(() => {
     if (!menu) return;
@@ -71,6 +119,30 @@ export default function TimelinePanel({
       window.removeEventListener('keydown', close);
     };
   }, [menu]);
+
+  const measureSlotGroup = useCallback(
+    (idx: number, el: HTMLDivElement | null) => {
+      if (!el) return;
+      setMeasuredHeight(idx, el.offsetHeight || el.getBoundingClientRect().height);
+    },
+    [setMeasuredHeight],
+  );
+
+  const handleScroll = (event: UIEvent<HTMLDivElement>) => {
+    setScrollTop(event.currentTarget.scrollTop);
+  };
+
+  const insertIndexFromPointer = (event: DragEvent<HTMLElement>) => {
+    const list = listRef.current;
+    if (!list) return slots.length;
+
+    const rect = list.getBoundingClientRect();
+    const pointerTop = event.clientY - rect.top + list.scrollTop;
+    const insertIdx =
+      pointerTop >= totalHeight ? slots.length : indexFromScrollTop(pointerTop);
+
+    return Math.max(0, Math.min(slots.length, insertIdx));
+  };
 
   const markPoolTrackDrop = (event: DragEvent<HTMLElement>, insertIdx: number) => {
     event.preventDefault();
@@ -85,6 +157,14 @@ export default function TimelinePanel({
     const payload = readPoolTrackDragPayload(event.dataTransfer);
     if (!payload) return;
     void onPoolTrackDrop?.(payload.poolTrackId, insertIdx);
+  };
+
+  const markPoolTrackDropAtPointer = (event: DragEvent<HTMLElement>) => {
+    markPoolTrackDrop(event, insertIndexFromPointer(event));
+  };
+
+  const handlePoolTrackDropAtPointer = (event: DragEvent<HTMLElement>) => {
+    handlePoolTrackDrop(event, insertIndexFromPointer(event));
   };
 
   const clearDropIfLeaving = (event: DragEvent<HTMLElement>) => {
@@ -112,33 +192,43 @@ export default function TimelinePanel({
       className={`${styles.timelineList} ${dropIdx === slots.length ? styles.timelineListDrop : ''}`}
       ref={listRef}
       data-testid="timeline-list"
-      onDragOver={(event) => markPoolTrackDrop(event, slots.length)}
+      data-virtualized="true"
+      onScroll={handleScroll}
+      onDragOver={markPoolTrackDropAtPointer}
       onDragLeave={clearDropIfLeaving}
-      onDrop={(event) => handlePoolTrackDrop(event, slots.length)}
+      onDrop={handlePoolTrackDropAtPointer}
     >
-      {slots.map((slot, idx) => (
-        <TimelineRow
-          key={slot.id}
-          slot={slot}
-          prevSlot={idx > 0 ? slots[idx - 1] : null}
-          nextSlot={idx < slots.length - 1 ? slots[idx + 1] : null}
-          idx={idx}
-          slots={slots}
-          hoveredIdx={hoveredIdx}
-          currentIdx={currentIdx}
-          positionSec={positionSec}
-          playing={playing}
-          dropIdx={dropIdx}
-          setDropIdx={setDropIdx}
-          onHover={onHover}
-          onRowDoubleClick={onRowDoubleClick}
-          onPoolTrackDrop={onPoolTrackDrop}
-          setMenu={setMenu}
-          setRowRef={(rowIdx, el) => {
-            rowRefs.current[rowIdx] = el;
-          }}
-        />
-      ))}
+      <div style={{ height: beforeHeight }} aria-hidden="true" />
+      {items.map(({ idx }) => {
+        const slot = slots[idx];
+        if (!slot) return null;
+
+        return (
+          <TimelineRow
+            key={slot.id}
+            slot={slot}
+            prevSlot={idx > 0 ? slots[idx - 1] : null}
+            nextSlot={idx < slots.length - 1 ? slots[idx + 1] : null}
+            idx={idx}
+            slots={slots}
+            hoveredIdx={hoveredIdx}
+            currentIdx={currentIdx}
+            positionSec={positionSec}
+            playing={playing}
+            dropIdx={dropIdx}
+            setDropIdx={setDropIdx}
+            onHover={onHover}
+            onRowDoubleClick={onRowDoubleClick}
+            onPoolTrackDrop={onPoolTrackDrop}
+            setMenu={setMenu}
+            setRowRef={(rowIdx, el) => {
+              rowRefs.current[rowIdx] = el;
+            }}
+            measureRef={measureSlotGroup}
+          />
+        );
+      })}
+      <div style={{ height: afterHeight }} aria-hidden="true" />
       {menu && (
         <div
           className={styles.timelineContextMenu}

--- a/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
@@ -44,6 +44,18 @@ export interface TimelinePanelProps {
 const ESTIMATED_SLOT_GROUP_HEIGHT = 52;
 const TIMELINE_OVERSCAN_ROWS = 8;
 
+export function timelineMeasurementKey(slots: SlotView[]): string {
+  return slots
+    .map((slot) =>
+      [
+        slot.id,
+        slot.transitionScore ?? '',
+        slot.nextIsDjPairing ? 1 : 0,
+      ].join(','),
+    )
+    .join(':');
+}
+
 export default function TimelinePanel({
   slots,
   hoveredIdx,
@@ -57,13 +69,13 @@ export default function TimelinePanel({
   onPoolTrackDrop,
 }: TimelinePanelProps) {
   const listRef = useRef<HTMLDivElement>(null);
-  const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const handledScrollRequestNRef = useRef<number | null>(null);
   const [menu, setMenu] = useState<TimelineMenu | null>(null);
   const [dropIdx, setDropIdx] = useState<number | null>(null);
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(0);
 
-  const measurementKey = useMemo(() => slots.map((slot) => slot.id).join(':'), [slots]);
+  const measurementKey = useMemo(() => timelineMeasurementKey(slots), [slots]);
   const virtual = useMeasuredVirtualList({
     itemCount: slots.length,
     estimateHeight: ESTIMATED_SLOT_GROUP_HEIGHT,
@@ -104,6 +116,9 @@ export default function TimelinePanel({
 
   useEffect(() => {
     if (!scrollRequest || !listRef.current) return;
+    if (handledScrollRequestNRef.current === scrollRequest.n) return;
+    handledScrollRequestNRef.current = scrollRequest.n;
+
     const nextScrollTop = scrollTopForIndex(scrollRequest.idx);
     listRef.current.scrollTop = nextScrollTop;
     setScrollTop(nextScrollTop);
@@ -221,9 +236,6 @@ export default function TimelinePanel({
             onRowDoubleClick={onRowDoubleClick}
             onPoolTrackDrop={onPoolTrackDrop}
             setMenu={setMenu}
-            setRowRef={(rowIdx, el) => {
-              rowRefs.current[rowIdx] = el;
-            }}
             measureRef={measureSlotGroup}
           />
         );

--- a/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
@@ -8,11 +8,9 @@
  */
 
 import { type DragEvent, useEffect, useRef, useState } from 'react';
-import { fmtTime } from './curveMath';
 import { readPoolTrackDragPayload } from './dnd';
-import { localPositionSec } from './transportMath';
+import TimelineRow, { type TimelineMenu } from './TimelineRow';
 import type { SlotView } from './types';
-import { effectiveTarget } from './types';
 import styles from './curve.module.css';
 
 export interface ScrollRequest {
@@ -48,7 +46,7 @@ export default function TimelinePanel({
 }: TimelinePanelProps) {
   const listRef = useRef<HTMLDivElement>(null);
   const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
-  const [menu, setMenu] = useState<{ x: number; y: number; idx: number } | null>(null);
+  const [menu, setMenu] = useState<TimelineMenu | null>(null);
   const [dropIdx, setDropIdx] = useState<number | null>(null);
 
   useEffect(() => {
@@ -118,148 +116,29 @@ export default function TimelinePanel({
       onDragLeave={clearDropIfLeaving}
       onDrop={(event) => handlePoolTrackDrop(event, slots.length)}
     >
-      {slots.map((s, i) => {
-        const prev = i > 0 ? slots[i - 1] : null;
-        const seamScore = prev?.transitionScore ?? s.transitionScore;
-        const isPairedSeam = Boolean(prev?.nextIsDjPairing);
-        const isCurrent = currentIdx === i;
-        const progress =
-          isCurrent && s.track.durationSec > 0
-            ? Math.min(
-                100,
-                Math.max(
-                  0,
-                  (localPositionSec(slots, i, positionSec) / s.track.durationSec) * 100,
-                ),
-              )
-            : 0;
-        const pairingActionLabel = s.nextIsDjPairing
-          ? `Open saved pairing after ${s.track.title}`
-          : `Save ${s.track.title} into ${slots[i + 1]?.track.title ?? 'next track'} as pairing`;
-        return (
-          <div key={s.id} className={styles.timelineSlotGroup}>
-            {i > 0 && (isPairedSeam || seamScore != null) && (
-              <div
-                className={`${styles.timelineTransition} ${
-                  isPairedSeam ? styles.timelineTransitionPairing : ''
-                }`}
-                data-testid={`timeline-transition-${i - 1}`}
-              >
-                {seamScore != null && (
-                  <span className={styles.timelineScoreChip}>{Math.round(seamScore)}</span>
-                )}
-                {isPairedSeam && (
-                  <span className={styles.timelinePairingChip}>
-                    <svg width="12" height="12" viewBox="0 0 24 24" aria-hidden="true">
-                      <path
-                        d="M10.5 13.5 13.5 10.5M8.5 17.5H7.8a4.8 4.8 0 0 1 0-9.6h3.4M12.8 16.1h3.4a4.8 4.8 0 1 0 0-9.6h-.7"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="1.9"
-                      />
-                    </svg>
-                    DJ pairing
-                  </span>
-                )}
-              </div>
-            )}
-            <div
-              ref={(el) => {
-                rowRefs.current[i] = el;
-              }}
-              className={`${styles.timelineRow} ${hoveredIdx === i ? styles.timelineRowHover : ''} ${
-                isCurrent ? styles.timelineRowNow : ''
-              } ${dropIdx === i ? styles.timelineRowDrop : ''}`}
-              onMouseEnter={() => onHover(i)}
-              onMouseLeave={() => onHover(null)}
-              onDoubleClick={() => onRowDoubleClick?.(i)}
-              onDragOver={(event) => {
-                event.stopPropagation();
-                markPoolTrackDrop(event, i);
-              }}
-              onDragLeave={clearDropIfLeaving}
-              onDrop={(event) => handlePoolTrackDrop(event, i)}
-              onContextMenu={(event) => {
-                if (i >= slots.length - 1) return;
-                event.preventDefault();
-                setMenu({ x: event.clientX, y: event.clientY, idx: i });
-              }}
-              data-testid={`timeline-row-${i}`}
-            >
-              {isCurrent ? (
-                <span
-                  className={styles.timelineRowProgress}
-                  style={{ width: `${progress}%` }}
-                  aria-hidden="true"
-                />
-              ) : null}
-              <span className={styles.timelinePos}>
-                {isCurrent ? (
-                  playing ? (
-                    <span
-                      className={`${styles.rowVu} ${styles.rowVuActive}`}
-                      data-testid={`timeline-vu-${i}`}
-                    >
-                      <span />
-                      <span />
-                      <span />
-                      <span />
-                    </span>
-                  ) : (
-                    <span className={styles.timelinePauseIcon} data-testid={`timeline-pause-${i}`}>
-                      <span />
-                      <span />
-                    </span>
-                  )
-                ) : (
-                  String(i + 1).padStart(2, '0')
-                )}
-              </span>
-              <span className={styles.timelineTitle}>
-                {s.track.title}
-                {s.track.artist ? (
-                  <span className={styles.timelineArtist}> — {s.track.artist}</span>
-                ) : null}
-              </span>
-              <span className={styles.timelineBadge}>{fmtTime(s.track.durationSec)}</span>
-              <span className={styles.timelineBadge}>
-                {s.track.bpm != null ? `${Math.round(s.track.bpm)} BPM` : '— BPM'}
-              </span>
-              <span className={styles.timelineBadge}>{s.track.key ?? '—'}</span>
-              <span className={styles.timelineBadge}>e{s.track.energy}</span>
-              <span className={styles.timelineTarget} title="Target energy">
-                ◎ {effectiveTarget(s).toFixed(1)}
-              </span>
-              {i < slots.length - 1 && (
-                <button
-                  type="button"
-                  className={styles.timelinePairingAction}
-                  aria-label={pairingActionLabel}
-                  title={pairingActionLabel}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    const rect = event.currentTarget.getBoundingClientRect();
-                    setMenu({ x: rect.left, y: rect.bottom + 4, idx: i });
-                  }}
-                >
-                  <svg width="13" height="13" viewBox="0 0 24 24" aria-hidden="true">
-                    <path
-                      d="M10.5 13.5 13.5 10.5M8.5 17.5H7.8a4.8 4.8 0 0 1 0-9.6h3.4M12.8 16.1h3.4a4.8 4.8 0 1 0 0-9.6h-.7"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="1.9"
-                    />
-                  </svg>
-                </button>
-              )}
-            </div>
-          </div>
-        );
-      })}
+      {slots.map((slot, idx) => (
+        <TimelineRow
+          key={slot.id}
+          slot={slot}
+          prevSlot={idx > 0 ? slots[idx - 1] : null}
+          nextSlot={idx < slots.length - 1 ? slots[idx + 1] : null}
+          idx={idx}
+          slots={slots}
+          hoveredIdx={hoveredIdx}
+          currentIdx={currentIdx}
+          positionSec={positionSec}
+          playing={playing}
+          dropIdx={dropIdx}
+          setDropIdx={setDropIdx}
+          onHover={onHover}
+          onRowDoubleClick={onRowDoubleClick}
+          onPoolTrackDrop={onPoolTrackDrop}
+          setMenu={setMenu}
+          setRowRef={(rowIdx, el) => {
+            rowRefs.current[rowIdx] = el;
+          }}
+        />
+      ))}
       {menu && (
         <div
           className={styles.timelineContextMenu}

--- a/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
@@ -69,6 +69,7 @@ export default function TimelinePanel({
   onPoolTrackDrop,
 }: TimelinePanelProps) {
   const listRef = useRef<HTMLDivElement>(null);
+  const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
   const handledScrollRequestNRef = useRef<number | null>(null);
   const [menu, setMenu] = useState<TimelineMenu | null>(null);
   const [dropIdx, setDropIdx] = useState<number | null>(null);
@@ -121,8 +122,17 @@ export default function TimelinePanel({
     handledScrollRequestNRef.current = scrollRequest.n;
 
     const list = listRef.current;
-    const rowTop = scrollTopForIndex(scrollRequest.idx);
-    const rowBottom = scrollTopForIndex(scrollRequest.idx + 1);
+    const row = rowRefs.current[scrollRequest.idx];
+    const listRect = row ? list.getBoundingClientRect() : null;
+    const rowRect = row ? row.getBoundingClientRect() : null;
+    const rowTop =
+      rowRect && listRect
+        ? list.scrollTop + rowRect.top - listRect.top
+        : scrollTopForIndex(scrollRequest.idx);
+    const rowBottom =
+      rowRect && listRect
+        ? list.scrollTop + rowRect.bottom - listRect.top
+        : scrollTopForIndex(scrollRequest.idx + 1);
     const rowHeight = Math.max(1, rowBottom - rowTop);
     const visibleTop = list.scrollTop;
     const visibleHeight =
@@ -252,6 +262,9 @@ export default function TimelinePanel({
             onRowDoubleClick={onRowDoubleClick}
             onPoolTrackDrop={onPoolTrackDrop}
             setMenu={setMenu}
+            setRowRef={(rowIdx, el) => {
+              rowRefs.current[rowIdx] = el;
+            }}
             measureRef={measureSlotGroup}
           />
         );

--- a/dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { type Dispatch, type DragEvent, type SetStateAction } from 'react';
+import { fmtTime } from './curveMath';
+import { readPoolTrackDragPayload } from './dnd';
+import { localPositionSec } from './transportMath';
+import type { SlotView } from './types';
+import { effectiveTarget } from './types';
+import styles from './curve.module.css';
+
+export interface TimelineMenu {
+  x: number;
+  y: number;
+  idx: number;
+}
+
+export interface TimelineRowProps {
+  slot: SlotView;
+  prevSlot: SlotView | null;
+  nextSlot: SlotView | null;
+  idx: number;
+  slots: SlotView[];
+  hoveredIdx: number | null;
+  currentIdx: number;
+  positionSec: number;
+  playing: boolean;
+  dropIdx: number | null;
+  setDropIdx: Dispatch<SetStateAction<number | null>>;
+  onHover: (idx: number | null) => void;
+  onRowDoubleClick?: (idx: number) => void;
+  onPoolTrackDrop?: (poolTrackId: number, insertIdx: number) => void | Promise<void>;
+  setMenu: Dispatch<SetStateAction<TimelineMenu | null>>;
+  setRowRef: (idx: number, el: HTMLDivElement | null) => void;
+}
+
+export default function TimelineRow({
+  slot,
+  prevSlot,
+  nextSlot,
+  idx,
+  slots,
+  hoveredIdx,
+  currentIdx,
+  positionSec,
+  playing,
+  dropIdx,
+  setDropIdx,
+  onHover,
+  onRowDoubleClick,
+  onPoolTrackDrop,
+  setMenu,
+  setRowRef,
+}: TimelineRowProps) {
+  const seamScore = prevSlot?.transitionScore ?? slot.transitionScore;
+  const isPairedSeam = Boolean(prevSlot?.nextIsDjPairing);
+  const isCurrent = currentIdx === idx;
+  const progress =
+    isCurrent && slot.track.durationSec > 0
+      ? Math.min(
+          100,
+          Math.max(
+            0,
+            (localPositionSec(slots, idx, positionSec) / slot.track.durationSec) * 100,
+          ),
+        )
+      : 0;
+  const pairingActionLabel = slot.nextIsDjPairing
+    ? `Open saved pairing after ${slot.track.title}`
+    : `Save ${slot.track.title} into ${nextSlot?.track.title ?? 'next track'} as pairing`;
+
+  const markPoolTrackDrop = (event: DragEvent<HTMLElement>, insertIdx: number) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+    setDropIdx(insertIdx);
+  };
+
+  const handlePoolTrackDrop = (event: DragEvent<HTMLElement>, insertIdx: number) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setDropIdx(null);
+    const payload = readPoolTrackDragPayload(event.dataTransfer);
+    if (!payload) return;
+    void onPoolTrackDrop?.(payload.poolTrackId, insertIdx);
+  };
+
+  const clearDropIfLeaving = (event: DragEvent<HTMLElement>) => {
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
+    setDropIdx(null);
+  };
+
+  return (
+    <div className={styles.timelineSlotGroup}>
+      {idx > 0 && (isPairedSeam || seamScore != null) && (
+        <div
+          className={`${styles.timelineTransition} ${
+            isPairedSeam ? styles.timelineTransitionPairing : ''
+          }`}
+          data-testid={`timeline-transition-${idx - 1}`}
+        >
+          {seamScore != null && (
+            <span className={styles.timelineScoreChip}>{Math.round(seamScore)}</span>
+          )}
+          {isPairedSeam && (
+            <span className={styles.timelinePairingChip}>
+              <svg width="12" height="12" viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M10.5 13.5 13.5 10.5M8.5 17.5H7.8a4.8 4.8 0 0 1 0-9.6h3.4M12.8 16.1h3.4a4.8 4.8 0 1 0 0-9.6h-.7"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.9"
+                />
+              </svg>
+              DJ pairing
+            </span>
+          )}
+        </div>
+      )}
+      <div
+        ref={(el) => {
+          setRowRef(idx, el);
+        }}
+        className={`${styles.timelineRow} ${hoveredIdx === idx ? styles.timelineRowHover : ''} ${
+          isCurrent ? styles.timelineRowNow : ''
+        } ${dropIdx === idx ? styles.timelineRowDrop : ''}`}
+        onMouseEnter={() => onHover(idx)}
+        onMouseLeave={() => onHover(null)}
+        onDoubleClick={() => onRowDoubleClick?.(idx)}
+        onDragOver={(event) => {
+          event.stopPropagation();
+          markPoolTrackDrop(event, idx);
+        }}
+        onDragLeave={clearDropIfLeaving}
+        onDrop={(event) => handlePoolTrackDrop(event, idx)}
+        onContextMenu={(event) => {
+          if (idx >= slots.length - 1) return;
+          event.preventDefault();
+          setMenu({ x: event.clientX, y: event.clientY, idx });
+        }}
+        data-testid={`timeline-row-${idx}`}
+      >
+        {isCurrent ? (
+          <span
+            className={styles.timelineRowProgress}
+            style={{ width: `${progress}%` }}
+            aria-hidden="true"
+          />
+        ) : null}
+        <span className={styles.timelinePos}>
+          {isCurrent ? (
+            playing ? (
+              <span
+                className={`${styles.rowVu} ${styles.rowVuActive}`}
+                data-testid={`timeline-vu-${idx}`}
+              >
+                <span />
+                <span />
+                <span />
+                <span />
+              </span>
+            ) : (
+              <span className={styles.timelinePauseIcon} data-testid={`timeline-pause-${idx}`}>
+                <span />
+                <span />
+              </span>
+            )
+          ) : (
+            String(idx + 1).padStart(2, '0')
+          )}
+        </span>
+        <span className={styles.timelineTitle}>
+          {slot.track.title}
+          {slot.track.artist ? (
+            <span className={styles.timelineArtist}> — {slot.track.artist}</span>
+          ) : null}
+        </span>
+        <span className={styles.timelineBadge}>{fmtTime(slot.track.durationSec)}</span>
+        <span className={styles.timelineBadge}>
+          {slot.track.bpm != null ? `${Math.round(slot.track.bpm)} BPM` : '— BPM'}
+        </span>
+        <span className={styles.timelineBadge}>{slot.track.key ?? '—'}</span>
+        <span className={styles.timelineBadge}>e{slot.track.energy}</span>
+        <span className={styles.timelineTarget} title="Target energy">
+          ◎ {effectiveTarget(slot).toFixed(1)}
+        </span>
+        {idx < slots.length - 1 && (
+          <button
+            type="button"
+            className={styles.timelinePairingAction}
+            aria-label={pairingActionLabel}
+            title={pairingActionLabel}
+            onClick={(event) => {
+              event.stopPropagation();
+              const rect = event.currentTarget.getBoundingClientRect();
+              setMenu({ x: rect.left, y: rect.bottom + 4, idx });
+            }}
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M10.5 13.5 13.5 10.5M8.5 17.5H7.8a4.8 4.8 0 0 1 0-9.6h3.4M12.8 16.1h3.4a4.8 4.8 0 1 0 0-9.6h-.7"
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.9"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx
@@ -31,6 +31,7 @@ export interface TimelineRowProps {
   onPoolTrackDrop?: (poolTrackId: number, insertIdx: number) => void | Promise<void>;
   setMenu: Dispatch<SetStateAction<TimelineMenu | null>>;
   setRowRef: (idx: number, el: HTMLDivElement | null) => void;
+  measureRef?: (idx: number, el: HTMLDivElement | null) => void;
 }
 
 export default function TimelineRow({
@@ -50,6 +51,7 @@ export default function TimelineRow({
   onPoolTrackDrop,
   setMenu,
   setRowRef,
+  measureRef,
 }: TimelineRowProps) {
   const seamScore = prevSlot?.transitionScore ?? slot.transitionScore;
   const isPairedSeam = Boolean(prevSlot?.nextIsDjPairing);
@@ -90,7 +92,7 @@ export default function TimelineRow({
   };
 
   return (
-    <div className={styles.timelineSlotGroup}>
+    <div className={styles.timelineSlotGroup} ref={(el) => measureRef?.(idx, el)}>
       {idx > 0 && (isPairedSeam || seamScore != null) && (
         <div
           className={`${styles.timelineTransition} ${

--- a/dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type Dispatch, type DragEvent, type SetStateAction } from 'react';
+import { type Dispatch, type DragEvent, type SetStateAction, useCallback } from 'react';
 import { fmtTime } from './curveMath';
 import { readPoolTrackDragPayload } from './dnd';
 import { localPositionSec } from './transportMath';
@@ -30,7 +30,6 @@ export interface TimelineRowProps {
   onRowDoubleClick?: (idx: number) => void;
   onPoolTrackDrop?: (poolTrackId: number, insertIdx: number) => void | Promise<void>;
   setMenu: Dispatch<SetStateAction<TimelineMenu | null>>;
-  setRowRef: (idx: number, el: HTMLDivElement | null) => void;
   measureRef?: (idx: number, el: HTMLDivElement | null) => void;
 }
 
@@ -50,7 +49,6 @@ export default function TimelineRow({
   onRowDoubleClick,
   onPoolTrackDrop,
   setMenu,
-  setRowRef,
   measureRef,
 }: TimelineRowProps) {
   const seamScore = prevSlot?.transitionScore ?? slot.transitionScore;
@@ -69,6 +67,12 @@ export default function TimelineRow({
   const pairingActionLabel = slot.nextIsDjPairing
     ? `Open saved pairing after ${slot.track.title}`
     : `Save ${slot.track.title} into ${nextSlot?.track.title ?? 'next track'} as pairing`;
+  const handleMeasureRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      measureRef?.(idx, el);
+    },
+    [idx, measureRef],
+  );
 
   const markPoolTrackDrop = (event: DragEvent<HTMLElement>, insertIdx: number) => {
     event.preventDefault();
@@ -92,7 +96,7 @@ export default function TimelineRow({
   };
 
   return (
-    <div className={styles.timelineSlotGroup} ref={(el) => measureRef?.(idx, el)}>
+    <div className={styles.timelineSlotGroup} ref={handleMeasureRef}>
       {idx > 0 && (isPairedSeam || seamScore != null) && (
         <div
           className={`${styles.timelineTransition} ${
@@ -121,9 +125,6 @@ export default function TimelineRow({
         </div>
       )}
       <div
-        ref={(el) => {
-          setRowRef(idx, el);
-        }}
         className={`${styles.timelineRow} ${hoveredIdx === idx ? styles.timelineRowHover : ''} ${
           isCurrent ? styles.timelineRowNow : ''
         } ${dropIdx === idx ? styles.timelineRowDrop : ''}`}

--- a/dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx
@@ -30,6 +30,7 @@ export interface TimelineRowProps {
   onRowDoubleClick?: (idx: number) => void;
   onPoolTrackDrop?: (poolTrackId: number, insertIdx: number) => void | Promise<void>;
   setMenu: Dispatch<SetStateAction<TimelineMenu | null>>;
+  setRowRef?: (idx: number, el: HTMLDivElement | null) => void;
   measureRef?: (idx: number, el: HTMLDivElement | null) => void;
 }
 
@@ -49,6 +50,7 @@ export default function TimelineRow({
   onRowDoubleClick,
   onPoolTrackDrop,
   setMenu,
+  setRowRef,
   measureRef,
 }: TimelineRowProps) {
   const seamScore = prevSlot?.transitionScore ?? slot.transitionScore;
@@ -72,6 +74,12 @@ export default function TimelineRow({
       measureRef?.(idx, el);
     },
     [idx, measureRef],
+  );
+  const handleRowRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      setRowRef?.(idx, el);
+    },
+    [idx, setRowRef],
   );
 
   const markPoolTrackDrop = (event: DragEvent<HTMLElement>, insertIdx: number) => {
@@ -125,6 +133,7 @@ export default function TimelineRow({
         </div>
       )}
       <div
+        ref={handleRowRef}
         className={`${styles.timelineRow} ${hoveredIdx === idx ? styles.timelineRowHover : ''} ${
           isCurrent ? styles.timelineRowNow : ''
         } ${dropIdx === idx ? styles.timelineRowDrop : ''}`}

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/useMeasuredVirtualList.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/useMeasuredVirtualList.test.tsx
@@ -42,6 +42,32 @@ describe('useMeasuredVirtualList', () => {
     expect(result.current.indexFromScrollTop(100)).toBe(2);
   });
 
+  it('resets measured heights when the measurement key changes', () => {
+    const { result, rerender } = renderHook(
+      ({ measurementKey }) =>
+        useMeasuredVirtualList({
+          itemCount: 10,
+          estimateHeight: 50,
+          viewportHeight: 150,
+          scrollTop: 0,
+          overscan: 1,
+          measurementKey,
+        }),
+      { initialProps: { measurementKey: 'initial-structure' } },
+    );
+
+    act(() => {
+      result.current.setMeasuredHeight(0, 80);
+    });
+
+    expect(result.current.scrollTopForIndex(1)).toBe(80);
+
+    rerender({ measurementKey: 'reordered-structure' });
+
+    expect(result.current.scrollTopForIndex(1)).toBe(50);
+    expect(result.current.totalHeight).toBe(500);
+  });
+
   it('clamps invalid list bounds', () => {
     const { result } = renderHook(() =>
       useMeasuredVirtualList({

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/useMeasuredVirtualList.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/useMeasuredVirtualList.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useMeasuredVirtualList } from '../useMeasuredVirtualList';
+
+describe('useMeasuredVirtualList', () => {
+  it('returns a bounded visible range with spacer heights', () => {
+    const { result } = renderHook(() =>
+      useMeasuredVirtualList({
+        itemCount: 500,
+        estimateHeight: 48,
+        viewportHeight: 240,
+        scrollTop: 480,
+        overscan: 2,
+      }),
+    );
+
+    expect(result.current.startIdx).toBe(8);
+    expect(result.current.endIdx).toBe(17);
+    expect(result.current.beforeHeight).toBe(384);
+    expect(result.current.afterHeight).toBe((500 - 17) * 48);
+    expect(result.current.items.map((item) => item.idx)).toEqual([8, 9, 10, 11, 12, 13, 14, 15, 16]);
+  });
+
+  it('uses measured heights for offsets and scroll targets', () => {
+    const { result } = renderHook(() =>
+      useMeasuredVirtualList({
+        itemCount: 10,
+        estimateHeight: 50,
+        viewportHeight: 150,
+        scrollTop: 0,
+        overscan: 1,
+      }),
+    );
+
+    act(() => {
+      result.current.setMeasuredHeight(0, 80);
+      result.current.setMeasuredHeight(1, 20);
+    });
+
+    expect(result.current.scrollTopForIndex(2)).toBe(100);
+    expect(result.current.indexFromScrollTop(99)).toBe(1);
+    expect(result.current.indexFromScrollTop(100)).toBe(2);
+  });
+
+  it('clamps invalid list bounds', () => {
+    const { result } = renderHook(() =>
+      useMeasuredVirtualList({
+        itemCount: Number.NaN,
+        estimateHeight: 0,
+        viewportHeight: -10,
+        scrollTop: -20,
+        overscan: -1,
+      }),
+    );
+
+    expect(result.current.startIdx).toBe(0);
+    expect(result.current.endIdx).toBe(0);
+    expect(result.current.beforeHeight).toBe(0);
+    expect(result.current.afterHeight).toBe(0);
+    expect(result.current.totalHeight).toBe(0);
+    expect(result.current.items).toEqual([]);
+    expect(result.current.scrollTopForIndex(2)).toBe(0);
+    expect(result.current.indexFromScrollTop(-1)).toBe(0);
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/components/curve.module.css
+++ b/dashboard/app/(dj)/setbuilder/components/curve.module.css
@@ -86,7 +86,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/dashboard/app/(dj)/setbuilder/components/curve.module.css
+++ b/dashboard/app/(dj)/setbuilder/components/curve.module.css
@@ -7,6 +7,31 @@
   margin: 0 8px 18px 36px;
 }
 
+.curveScrollViewport {
+  position: absolute;
+  inset: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
+
+.curveScrollInner {
+  height: 1px;
+  pointer-events: none;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .svg {
   position: absolute;
   inset: 0;

--- a/dashboard/app/(dj)/setbuilder/components/curve.module.css
+++ b/dashboard/app/(dj)/setbuilder/components/curve.module.css
@@ -3,21 +3,80 @@
 .canvasWrap {
   position: relative;
   flex: 1;
-  min-height: 160px;
+  min-height: 120px;
   margin: 0 8px 18px 36px;
+  --curve-scrollbar-height: 14px;
 }
 
 .curveScrollViewport {
   position: absolute;
-  inset: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+  z-index: 0;
   overflow-x: auto;
   overflow-y: hidden;
-  scrollbar-width: thin;
+  pointer-events: none;
+  scrollbar-width: none;
 }
 
 .curveScrollInner {
   height: 1px;
   pointer-events: none;
+}
+
+.curveScrollViewport::-webkit-scrollbar {
+  display: none;
+}
+
+.curveScrollbar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 6;
+  height: var(--curve-scrollbar-height);
+  cursor: pointer;
+  touch-action: none;
+}
+
+.curveScrollbar::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 5px;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.curveScrollbar:focus-visible {
+  outline: 1px solid #00f5d4;
+  outline-offset: 2px;
+}
+
+.curveScrollbar[data-enabled='false'] {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.curveScrollbarThumb {
+  position: absolute;
+  top: 2px;
+  bottom: 2px;
+  min-width: 34px;
+  border: 1px solid rgba(0, 245, 212, 0.75);
+  border-radius: 999px;
+  background: rgba(0, 245, 212, 0.45);
+  box-shadow: 0 0 10px rgba(0, 245, 212, 0.18);
+}
+
+.curveScrollbar:hover .curveScrollbarThumb,
+.curveScrollbar:focus-visible .curveScrollbarThumb {
+  background: rgba(0, 245, 212, 0.7);
+  border-color: #00f5d4;
 }
 
 .srOnly {

--- a/dashboard/app/(dj)/setbuilder/components/curve.module.css
+++ b/dashboard/app/(dj)/setbuilder/components/curve.module.css
@@ -38,7 +38,7 @@
   width: 100%;
   height: 100%;
   display: block;
-  overflow: visible;
+  overflow: hidden;
 }
 
 .yaxis {

--- a/dashboard/app/(dj)/setbuilder/components/curve.module.css
+++ b/dashboard/app/(dj)/setbuilder/components/curve.module.css
@@ -391,6 +391,41 @@
   color: var(--color-curve-accent);
 }
 
+.zoomControls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding-left: 0.25rem;
+}
+
+.toolbarIconBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-raised);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: var(--font-mono), monospace;
+  font-size: 0.875rem;
+}
+
+.toolbarIconBtn:hover {
+  color: var(--text);
+  border-color: var(--text-tertiary);
+}
+
+.zoomLabel {
+  min-width: 2.75rem;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono), monospace;
+  font-size: 0.625rem;
+  text-align: center;
+}
+
 .toolbarBtn {
   background: var(--surface-raised);
   border: 1px solid var(--border);

--- a/dashboard/app/(dj)/setbuilder/components/curveViewport.ts
+++ b/dashboard/app/(dj)/setbuilder/components/curveViewport.ts
@@ -59,11 +59,13 @@ export function curveViewportRange({
   totalSec: number;
 }): { startSec: number; endSec: number } {
   const scale = clampPxPerSecond(pxPerSecond);
-  const startSec = Math.max(0, scrollLeft / scale);
   const spanSec = Math.max(1, viewportWidth / scale);
+  const maxSec = Math.max(totalSec, 1);
+  const maxStartSec = Math.max(0, maxSec - spanSec);
+  const startSec = Math.min(maxStartSec, Math.max(0, scrollLeft / scale));
   return {
     startSec,
-    endSec: Math.min(Math.max(totalSec, 1), startSec + spanSec),
+    endSec: Math.min(maxSec, startSec + spanSec),
   };
 }
 

--- a/dashboard/app/(dj)/setbuilder/components/curveViewport.ts
+++ b/dashboard/app/(dj)/setbuilder/components/curveViewport.ts
@@ -1,0 +1,159 @@
+import type { SlotView } from './types';
+import { effectiveTarget } from './types';
+
+export type CurveLod = 'overview' | 'medium' | 'detail';
+
+export const CURVE_LOD_THRESHOLDS = {
+  overviewMaxMedianSlotPx: 6,
+  detailMinMedianSlotPx: 28,
+  minPxPerSecond: 0.02,
+  maxPxPerSecond: 12,
+  zoomStep: 1.35,
+} as const;
+
+export interface SlotTimeRange {
+  idx: number;
+  slot: SlotView;
+  startSec: number;
+  endSec: number;
+  midSec: number;
+}
+
+export interface VisibleSlotBlock extends SlotTimeRange {
+  x0: number;
+  x1: number;
+  xMid: number;
+  width: number;
+  energy: number;
+  target: number;
+}
+
+export function clampPxPerSecond(pxPerSecond: number): number {
+  if (!Number.isFinite(pxPerSecond)) return CURVE_LOD_THRESHOLDS.minPxPerSecond;
+  return Math.min(
+    CURVE_LOD_THRESHOLDS.maxPxPerSecond,
+    Math.max(CURVE_LOD_THRESHOLDS.minPxPerSecond, pxPerSecond),
+  );
+}
+
+export function fitPxPerSecond({
+  totalSec,
+  viewportWidth,
+}: {
+  totalSec: number;
+  viewportWidth: number;
+}): number {
+  if (totalSec <= 0 || viewportWidth <= 1) return CURVE_LOD_THRESHOLDS.minPxPerSecond;
+  return clampPxPerSecond(viewportWidth / totalSec);
+}
+
+export function curveViewportRange({
+  scrollLeft,
+  viewportWidth,
+  pxPerSecond,
+  totalSec,
+}: {
+  scrollLeft: number;
+  viewportWidth: number;
+  pxPerSecond: number;
+  totalSec: number;
+}): { startSec: number; endSec: number } {
+  const scale = clampPxPerSecond(pxPerSecond);
+  const startSec = Math.max(0, scrollLeft / scale);
+  const spanSec = Math.max(1, viewportWidth / scale);
+  return {
+    startSec,
+    endSec: Math.min(Math.max(totalSec, 1), startSec + spanSec),
+  };
+}
+
+export function slotTimeRanges(slots: SlotView[]): SlotTimeRange[] {
+  let cursor = 0;
+  return slots.map((slot, idx) => {
+    const durationSec = Math.max(0, slot.track.durationSec);
+    const startSec = cursor;
+    const endSec = cursor + durationSec;
+    cursor = endSec;
+    return {
+      idx,
+      slot,
+      startSec,
+      endSec,
+      midSec: startSec + durationSec / 2,
+    };
+  });
+}
+
+export function visibleBlocksFromSlots({
+  slots,
+  visibleStartSec,
+  visibleEndSec,
+  pxPerSecond,
+  overscanSec = 0,
+}: {
+  slots: SlotView[];
+  visibleStartSec: number;
+  visibleEndSec: number;
+  pxPerSecond: number;
+  overscanSec?: number;
+}): VisibleSlotBlock[] {
+  const start = Math.max(0, visibleStartSec - overscanSec);
+  const end = visibleEndSec + overscanSec;
+  const scale = clampPxPerSecond(pxPerSecond);
+  return slotTimeRanges(slots)
+    .filter((range) => range.endSec > start && range.startSec < end)
+    .map((range) => {
+      const x0 = (range.startSec - visibleStartSec) * scale;
+      const x1 = (range.endSec - visibleStartSec) * scale;
+      return {
+        ...range,
+        x0,
+        x1,
+        xMid: (range.midSec - visibleStartSec) * scale,
+        width: Math.max(0, x1 - x0),
+        energy: range.slot.track.energy,
+        target: effectiveTarget(range.slot),
+      };
+    });
+}
+
+export function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+export function lodForMedianSlotWidth(widths: number[]): CurveLod {
+  const med = median(widths);
+  if (med < CURVE_LOD_THRESHOLDS.overviewMaxMedianSlotPx) return 'overview';
+  if (med < CURVE_LOD_THRESHOLDS.detailMinMedianSlotPx) return 'medium';
+  return 'detail';
+}
+
+export function zoomPxPerSecond({
+  currentPxPerSecond,
+  direction,
+  scrollLeft,
+  viewportWidth,
+  totalSec,
+}: {
+  currentPxPerSecond: number;
+  direction: 'in' | 'out';
+  scrollLeft: number;
+  viewportWidth: number;
+  totalSec: number;
+}): { pxPerSecond: number; scrollLeft: number } {
+  const current = clampPxPerSecond(currentPxPerSecond);
+  const multiplier =
+    direction === 'in' ? CURVE_LOD_THRESHOLDS.zoomStep : 1 / CURVE_LOD_THRESHOLDS.zoomStep;
+  const nextScale = clampPxPerSecond(current * multiplier);
+  const centerPx = scrollLeft + viewportWidth / 2;
+  const centerSec = centerPx / current;
+  const nextScroll = centerSec * nextScale - viewportWidth / 2;
+  const maxScroll = Math.max(0, totalSec * nextScale - viewportWidth);
+  return {
+    pxPerSecond: nextScale,
+    scrollLeft: Math.min(maxScroll, Math.max(0, nextScroll)),
+  };
+}

--- a/dashboard/app/(dj)/setbuilder/components/useMeasuredVirtualList.ts
+++ b/dashboard/app/(dj)/setbuilder/components/useMeasuredVirtualList.ts
@@ -1,0 +1,159 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+
+export interface VirtualListItem {
+  idx: number;
+  key: number;
+  top: number;
+  height: number;
+}
+
+export interface UseMeasuredVirtualListInput {
+  itemCount: number;
+  estimateHeight: number;
+  viewportHeight: number;
+  scrollTop: number;
+  overscan?: number;
+}
+
+export interface UseMeasuredVirtualListResult {
+  startIdx: number;
+  endIdx: number;
+  beforeHeight: number;
+  afterHeight: number;
+  totalHeight: number;
+  items: VirtualListItem[];
+  setMeasuredHeight: (idx: number, height: number) => void;
+  scrollTopForIndex: (idx: number) => number;
+  indexFromScrollTop: (top: number) => number;
+}
+
+function buildOffsets(itemCount: number, estimateHeight: number, measured: Map<number, number>) {
+  const offsets: number[] = new Array(itemCount + 1);
+  offsets[0] = 0;
+
+  for (let i = 0; i < itemCount; i++) {
+    offsets[i + 1] = offsets[i] + (measured.get(i) ?? estimateHeight);
+  }
+
+  return offsets;
+}
+
+function findIndexAtOffset(offsets: number[], top: number): number {
+  if (offsets.length <= 1) return 0;
+
+  const target = Number.isFinite(top) ? Math.max(0, top) : 0;
+  let lo = 0;
+  let hi = offsets.length - 2;
+
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2);
+
+    if (offsets[mid + 1] <= target) lo = mid + 1;
+    else if (offsets[mid] > target) hi = mid - 1;
+    else return mid;
+  }
+
+  return Math.max(0, Math.min(offsets.length - 2, lo));
+}
+
+function findIndexBeforeOffset(offsets: number[], top: number): number {
+  if (offsets.length <= 1) return 0;
+
+  const target = Number.isFinite(top) ? Math.max(0, top) : 0;
+  let lo = 0;
+  let hi = offsets.length - 1;
+
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2);
+
+    if (offsets[mid] < target) lo = mid + 1;
+    else hi = mid;
+  }
+
+  const insertionIdx = offsets[lo] < target ? lo + 1 : lo;
+  return Math.max(0, Math.min(offsets.length - 2, insertionIdx - 1));
+}
+
+export function useMeasuredVirtualList({
+  itemCount,
+  estimateHeight,
+  viewportHeight,
+  scrollTop,
+  overscan = 4,
+}: UseMeasuredVirtualListInput): UseMeasuredVirtualListResult {
+  const safeItemCount = Number.isFinite(itemCount) ? Math.max(0, Math.floor(itemCount)) : 0;
+  const safeEstimateHeight = Number.isFinite(estimateHeight) && estimateHeight > 0 ? estimateHeight : 1;
+  const safeViewportHeight = Number.isFinite(viewportHeight) ? Math.max(0, viewportHeight) : 0;
+  const safeScrollTop = Number.isFinite(scrollTop) ? Math.max(0, scrollTop) : 0;
+  const safeOverscan = Number.isFinite(overscan) ? Math.max(0, Math.floor(overscan)) : 0;
+
+  const [measuredHeights, setMeasuredHeights] = useState<Map<number, number>>(() => new Map());
+
+  const offsets = useMemo(
+    () => buildOffsets(safeItemCount, safeEstimateHeight, measuredHeights),
+    [safeEstimateHeight, safeItemCount, measuredHeights],
+  );
+
+  const totalHeight = offsets[safeItemCount] ?? 0;
+  const rawStart = findIndexAtOffset(offsets, safeScrollTop);
+  const rawEnd = findIndexBeforeOffset(offsets, safeScrollTop + safeViewportHeight);
+  const startIdx = Math.max(0, rawStart - safeOverscan);
+  const endIdx = Math.min(safeItemCount, rawEnd + safeOverscan + 1);
+  const beforeHeight = offsets[startIdx] ?? 0;
+  const afterHeight = Math.max(0, totalHeight - (offsets[endIdx] ?? totalHeight));
+
+  const items = useMemo(
+    () =>
+      Array.from({ length: Math.max(0, endIdx - startIdx) }, (_, offset) => {
+        const idx = startIdx + offset;
+        const top = offsets[idx] ?? 0;
+
+        return {
+          idx,
+          key: idx,
+          top,
+          height: (offsets[idx + 1] ?? top) - top,
+        };
+      }),
+    [endIdx, offsets, startIdx],
+  );
+
+  const setMeasuredHeight = useCallback((idx: number, height: number) => {
+    if (!Number.isFinite(idx) || !Number.isFinite(height) || height <= 0) return;
+
+    const safeIdx = Math.floor(idx);
+    if (safeIdx < 0 || safeIdx >= safeItemCount) return;
+
+    setMeasuredHeights((prev) => {
+      if (prev.get(safeIdx) === height) return prev;
+
+      const next = new Map(prev);
+      next.set(safeIdx, height);
+      return next;
+    });
+  }, [safeItemCount]);
+
+  const scrollTopForIndex = useCallback(
+    (idx: number) => {
+      const safeIdx = Number.isFinite(idx) ? Math.max(0, Math.min(safeItemCount, Math.floor(idx))) : 0;
+      return offsets[safeIdx] ?? 0;
+    },
+    [safeItemCount, offsets],
+  );
+
+  const indexFromScrollTop = useCallback((top: number) => findIndexAtOffset(offsets, top), [offsets]);
+
+  return {
+    startIdx,
+    endIdx,
+    beforeHeight,
+    afterHeight,
+    totalHeight,
+    items,
+    setMeasuredHeight,
+    scrollTopForIndex,
+    indexFromScrollTop,
+  };
+}

--- a/dashboard/app/(dj)/setbuilder/components/useMeasuredVirtualList.ts
+++ b/dashboard/app/(dj)/setbuilder/components/useMeasuredVirtualList.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 export interface VirtualListItem {
   idx: number;
@@ -15,19 +15,30 @@ export interface UseMeasuredVirtualListInput {
   viewportHeight: number;
   scrollTop: number;
   overscan?: number;
+  /** Changing this clears cached measured heights after structural list changes. */
+  measurementKey?: string | number;
 }
 
 export interface UseMeasuredVirtualListResult {
   startIdx: number;
+  /** Exclusive upper bound for visible item indices. */
   endIdx: number;
   beforeHeight: number;
   afterHeight: number;
   totalHeight: number;
   items: VirtualListItem[];
   setMeasuredHeight: (idx: number, height: number) => void;
+  /** Returns totalHeight when called with itemCount. */
   scrollTopForIndex: (idx: number) => number;
   indexFromScrollTop: (top: number) => number;
 }
+
+interface MeasurementState {
+  key: string | number | undefined;
+  heights: Map<number, number>;
+}
+
+const EMPTY_MEASURED_HEIGHTS = new Map<number, number>();
 
 function buildOffsets(itemCount: number, estimateHeight: number, measured: Map<number, number>) {
   const offsets: number[] = new Array(itemCount + 1);
@@ -82,6 +93,7 @@ export function useMeasuredVirtualList({
   viewportHeight,
   scrollTop,
   overscan = 4,
+  measurementKey,
 }: UseMeasuredVirtualListInput): UseMeasuredVirtualListResult {
   const safeItemCount = Number.isFinite(itemCount) ? Math.max(0, Math.floor(itemCount)) : 0;
   const safeEstimateHeight = Number.isFinite(estimateHeight) && estimateHeight > 0 ? estimateHeight : 1;
@@ -89,7 +101,24 @@ export function useMeasuredVirtualList({
   const safeScrollTop = Number.isFinite(scrollTop) ? Math.max(0, scrollTop) : 0;
   const safeOverscan = Number.isFinite(overscan) ? Math.max(0, Math.floor(overscan)) : 0;
 
-  const [measuredHeights, setMeasuredHeights] = useState<Map<number, number>>(() => new Map());
+  const [measurementState, setMeasurementState] = useState<MeasurementState>(() => ({
+    key: measurementKey,
+    heights: new Map(),
+  }));
+  const measuredHeights = Object.is(measurementState.key, measurementKey)
+    ? measurementState.heights
+    : EMPTY_MEASURED_HEIGHTS;
+
+  useEffect(() => {
+    setMeasurementState((prev) => {
+      if (Object.is(prev.key, measurementKey)) return prev;
+
+      return {
+        key: measurementKey,
+        heights: new Map(),
+      };
+    });
+  }, [measurementKey]);
 
   const offsets = useMemo(
     () => buildOffsets(safeItemCount, safeEstimateHeight, measuredHeights),
@@ -126,14 +155,22 @@ export function useMeasuredVirtualList({
     const safeIdx = Math.floor(idx);
     if (safeIdx < 0 || safeIdx >= safeItemCount) return;
 
-    setMeasuredHeights((prev) => {
-      if (prev.get(safeIdx) === height) return prev;
+    setMeasurementState((prev) => {
+      const prevHeights = Object.is(prev.key, measurementKey)
+        ? prev.heights
+        : EMPTY_MEASURED_HEIGHTS;
 
-      const next = new Map(prev);
+      if (Object.is(prev.key, measurementKey) && prevHeights.get(safeIdx) === height) return prev;
+
+      const next = new Map(prevHeights);
       next.set(safeIdx, height);
-      return next;
+
+      return {
+        key: measurementKey,
+        heights: next,
+      };
     });
-  }, [safeItemCount]);
+  }, [measurementKey, safeItemCount]);
 
   const scrollTopForIndex = useCallback(
     (idx: number) => {

--- a/docs/superpowers/plans/2026-06-15-setbuilder-daw-curve-virtual-list.md
+++ b/docs/superpowers/plans/2026-06-15-setbuilder-daw-curve-virtual-list.md
@@ -1,0 +1,1794 @@
+# Setbuilder DAW Curve Virtual List Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add DAW-style horizontal curve zoom and large-set-safe virtualized timeline list rendering.
+
+**Architecture:** `CurvePanel` owns curve zoom/scroll state and passes viewport props into `CurveEditor`, which renders a visible time range with level-of-detail rules. `TimelinePanel` keeps the vertical set list workflow but delegates row markup to a row component and uses a local measured virtualizer so only visible slot groups mount.
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, vanilla CSS modules, Vitest, Testing Library, no new runtime dependency.
+
+---
+
+## File Map
+
+- Create: `dashboard/app/(dj)/setbuilder/components/curveViewport.ts`
+  - Pure time/zoom/LOD helpers for the DAW curve viewport.
+- Create: `dashboard/app/(dj)/setbuilder/__tests__/curveViewport.test.ts`
+  - Unit tests for visible-range geometry, fit scale, zooming, and LOD thresholds.
+- Modify: `dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx`
+  - Render visible slot geometry, hide handles/actions by LOD, expose horizontal scroll events.
+- Modify: `dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx`
+  - Own `pxPerSecond`, `scrollLeft`, and viewport width; wire toolbar zoom controls.
+- Modify: `dashboard/app/(dj)/setbuilder/components/CurveToolbar.tsx`
+  - Add zoom out, zoom in, and fit controls.
+- Create: `dashboard/app/(dj)/setbuilder/components/useMeasuredVirtualList.ts`
+  - Local measured virtualizer hook for vertical slot groups.
+- Create: `dashboard/app/(dj)/setbuilder/components/__tests__/useMeasuredVirtualList.test.tsx`
+  - Unit-style hook/component tests for visible ranges and scroll-to-index math.
+- Create: `dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx`
+  - Extract one slot group row with the current timeline interactions.
+- Modify: `dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx`
+  - Use the virtualizer, render spacers and visible rows, preserve row actions.
+- Modify: `dashboard/app/(dj)/setbuilder/components/curve.module.css`
+  - Add curve scroll viewport styles and virtualized list spacer/group styles.
+- Modify: `dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx`
+  - Update expectations for LOD and visible-range rendering.
+- Modify: `dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx`
+  - Add large-set regression tests for curve simplification and virtualized list behavior.
+
+---
+
+### Task 1: Add Pure Curve Viewport Helpers
+
+**Files:**
+- Create: `dashboard/app/(dj)/setbuilder/components/curveViewport.ts`
+- Create: `dashboard/app/(dj)/setbuilder/__tests__/curveViewport.test.ts`
+
+- [ ] **Step 1: Write failing tests for curve viewport math**
+
+Create `dashboard/app/(dj)/setbuilder/__tests__/curveViewport.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import type { SlotView } from '../components/types';
+import {
+  CURVE_LOD_THRESHOLDS,
+  clampPxPerSecond,
+  curveViewportRange,
+  fitPxPerSecond,
+  lodForMedianSlotWidth,
+  slotTimeRanges,
+  visibleBlocksFromSlots,
+  zoomPxPerSecond,
+} from '../components/curveViewport';
+
+function mkSlot(idx: number, durationSec = 200): SlotView {
+  return {
+    id: idx + 1,
+    position: idx,
+    locked: false,
+    targetEnergy: null,
+    transitionScore: null,
+    nextPairingId: null,
+    nextIsDjPairing: false,
+    track: {
+      id: `t${idx}`,
+      title: `Track ${idx}`,
+      artist: `Artist ${idx}`,
+      durationSec,
+      energy: 5 + (idx % 4),
+      bpm: 120,
+      key: '8A',
+    },
+  };
+}
+
+describe('curveViewport helpers', () => {
+  it('computes slot time ranges from ordered slot durations', () => {
+    const ranges = slotTimeRanges([mkSlot(0, 100), mkSlot(1, 200), mkSlot(2, 300)]);
+    expect(ranges.map((r) => [r.startSec, r.endSec, r.midSec])).toEqual([
+      [0, 100, 50],
+      [100, 300, 200],
+      [300, 600, 450],
+    ]);
+  });
+
+  it('fits full duration into the visible viewport with a bounded scale', () => {
+    expect(fitPxPerSecond({ totalSec: 1000, viewportWidth: 500 })).toBe(0.5);
+    expect(fitPxPerSecond({ totalSec: 0, viewportWidth: 500 })).toBe(CURVE_LOD_THRESHOLDS.minPxPerSecond);
+    expect(fitPxPerSecond({ totalSec: 1000, viewportWidth: 1 })).toBe(CURVE_LOD_THRESHOLDS.minPxPerSecond);
+  });
+
+  it('derives visible seconds from scroll and scale', () => {
+    expect(curveViewportRange({ scrollLeft: 250, viewportWidth: 500, pxPerSecond: 2, totalSec: 1000 })).toEqual({
+      startSec: 125,
+      endSec: 375,
+    });
+  });
+
+  it('returns only visible blocks plus overscan in viewport-local coordinates', () => {
+    const slots = Array.from({ length: 20 }, (_, i) => mkSlot(i, 60));
+    const blocks = visibleBlocksFromSlots({
+      slots,
+      visibleStartSec: 300,
+      visibleEndSec: 600,
+      pxPerSecond: 2,
+      overscanSec: 60,
+    });
+    expect(blocks[0].idx).toBe(4);
+    expect(blocks.at(-1)?.idx).toBe(10);
+    expect(blocks[0].x0).toBe(-120);
+    expect(blocks[1].x0).toBe(0);
+    expect(blocks[1].width).toBe(120);
+  });
+
+  it('uses median visible slot width for LOD thresholds', () => {
+    expect(lodForMedianSlotWidth([2, 3, 4])).toBe('overview');
+    expect(lodForMedianSlotWidth([6, 12, 20])).toBe('medium');
+    expect(lodForMedianSlotWidth([28, 60, 90])).toBe('detail');
+  });
+
+  it('zooms around a center point without exceeding configured bounds', () => {
+    const next = zoomPxPerSecond({
+      currentPxPerSecond: 1,
+      direction: 'in',
+      scrollLeft: 200,
+      viewportWidth: 400,
+      totalSec: 1000,
+    });
+    expect(next.pxPerSecond).toBeCloseTo(1.35);
+    expect(next.scrollLeft).toBeCloseTo(340);
+
+    const clamped = clampPxPerSecond(999);
+    expect(clamped).toBe(CURVE_LOD_THRESHOLDS.maxPxPerSecond);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cd dashboard
+npm test -- --run app/\(dj\)/setbuilder/__tests__/curveViewport.test.ts
+```
+
+Expected: FAIL because `../components/curveViewport` does not exist.
+
+- [ ] **Step 3: Implement curve viewport helpers**
+
+Create `dashboard/app/(dj)/setbuilder/components/curveViewport.ts`:
+
+```ts
+import type { SlotView } from './types';
+import { effectiveTarget } from './types';
+
+export type CurveLod = 'overview' | 'medium' | 'detail';
+
+export const CURVE_LOD_THRESHOLDS = {
+  overviewMaxMedianSlotPx: 6,
+  detailMinMedianSlotPx: 28,
+  minPxPerSecond: 0.02,
+  maxPxPerSecond: 12,
+  zoomStep: 1.35,
+} as const;
+
+export interface SlotTimeRange {
+  idx: number;
+  slot: SlotView;
+  startSec: number;
+  endSec: number;
+  midSec: number;
+}
+
+export interface VisibleSlotBlock extends SlotTimeRange {
+  x0: number;
+  x1: number;
+  xMid: number;
+  width: number;
+  energy: number;
+  target: number;
+}
+
+export function clampPxPerSecond(pxPerSecond: number): number {
+  if (!Number.isFinite(pxPerSecond)) return CURVE_LOD_THRESHOLDS.minPxPerSecond;
+  return Math.min(
+    CURVE_LOD_THRESHOLDS.maxPxPerSecond,
+    Math.max(CURVE_LOD_THRESHOLDS.minPxPerSecond, pxPerSecond),
+  );
+}
+
+export function fitPxPerSecond({
+  totalSec,
+  viewportWidth,
+}: {
+  totalSec: number;
+  viewportWidth: number;
+}): number {
+  if (totalSec <= 0 || viewportWidth <= 1) return CURVE_LOD_THRESHOLDS.minPxPerSecond;
+  return clampPxPerSecond(viewportWidth / totalSec);
+}
+
+export function curveViewportRange({
+  scrollLeft,
+  viewportWidth,
+  pxPerSecond,
+  totalSec,
+}: {
+  scrollLeft: number;
+  viewportWidth: number;
+  pxPerSecond: number;
+  totalSec: number;
+}): { startSec: number; endSec: number } {
+  const scale = clampPxPerSecond(pxPerSecond);
+  const startSec = Math.max(0, scrollLeft / scale);
+  const spanSec = Math.max(1, viewportWidth / scale);
+  return {
+    startSec,
+    endSec: Math.min(Math.max(totalSec, 1), startSec + spanSec),
+  };
+}
+
+export function slotTimeRanges(slots: SlotView[]): SlotTimeRange[] {
+  let cursor = 0;
+  return slots.map((slot, idx) => {
+    const durationSec = Math.max(0, slot.track.durationSec);
+    const startSec = cursor;
+    const endSec = cursor + durationSec;
+    cursor = endSec;
+    return {
+      idx,
+      slot,
+      startSec,
+      endSec,
+      midSec: startSec + durationSec / 2,
+    };
+  });
+}
+
+export function visibleBlocksFromSlots({
+  slots,
+  visibleStartSec,
+  visibleEndSec,
+  pxPerSecond,
+  overscanSec = 0,
+}: {
+  slots: SlotView[];
+  visibleStartSec: number;
+  visibleEndSec: number;
+  pxPerSecond: number;
+  overscanSec?: number;
+}): VisibleSlotBlock[] {
+  const start = Math.max(0, visibleStartSec - overscanSec);
+  const end = visibleEndSec + overscanSec;
+  const scale = clampPxPerSecond(pxPerSecond);
+  return slotTimeRanges(slots)
+    .filter((range) => range.endSec > start && range.startSec < end)
+    .map((range) => {
+      const x0 = (range.startSec - visibleStartSec) * scale;
+      const x1 = (range.endSec - visibleStartSec) * scale;
+      return {
+        ...range,
+        x0,
+        x1,
+        xMid: (range.midSec - visibleStartSec) * scale,
+        width: Math.max(0, x1 - x0),
+        energy: range.slot.track.energy,
+        target: effectiveTarget(range.slot),
+      };
+    });
+}
+
+export function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+export function lodForMedianSlotWidth(widths: number[]): CurveLod {
+  const med = median(widths);
+  if (med < CURVE_LOD_THRESHOLDS.overviewMaxMedianSlotPx) return 'overview';
+  if (med < CURVE_LOD_THRESHOLDS.detailMinMedianSlotPx) return 'medium';
+  return 'detail';
+}
+
+export function zoomPxPerSecond({
+  currentPxPerSecond,
+  direction,
+  scrollLeft,
+  viewportWidth,
+  totalSec,
+}: {
+  currentPxPerSecond: number;
+  direction: 'in' | 'out';
+  scrollLeft: number;
+  viewportWidth: number;
+  totalSec: number;
+}): { pxPerSecond: number; scrollLeft: number } {
+  const current = clampPxPerSecond(currentPxPerSecond);
+  const multiplier = direction === 'in'
+    ? CURVE_LOD_THRESHOLDS.zoomStep
+    : 1 / CURVE_LOD_THRESHOLDS.zoomStep;
+  const nextScale = clampPxPerSecond(current * multiplier);
+  const centerPx = scrollLeft + viewportWidth / 2;
+  const centerSec = centerPx / current;
+  const nextScroll = centerSec * nextScale - viewportWidth / 2;
+  const maxScroll = Math.max(0, totalSec * nextScale - viewportWidth);
+  return {
+    pxPerSecond: nextScale,
+    scrollLeft: Math.min(maxScroll, Math.max(0, nextScroll)),
+  };
+}
+```
+
+- [ ] **Step 4: Run the viewport helper test**
+
+Run:
+
+```bash
+cd dashboard
+npm test -- --run app/\(dj\)/setbuilder/__tests__/curveViewport.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/app/\(dj\)/setbuilder/components/curveViewport.ts \
+  dashboard/app/\(dj\)/setbuilder/__tests__/curveViewport.test.ts
+git commit -m "test: add curve viewport math"
+```
+
+---
+
+### Task 2: Render Curve By Viewport And Hide Dense Actions By LOD
+
+**Files:**
+- Modify: `dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx`
+- Modify: `dashboard/app/(dj)/setbuilder/components/curve.module.css`
+- Modify: `dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx`
+
+- [ ] **Step 1: Add failing CurveEditor tests for LOD and visible range**
+
+Append these tests inside the existing `describe('CurveEditor', () => { ... })` block in `dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx`:
+
+```tsx
+  it('renders only viewport-visible slot blocks in detail zoom', () => {
+    // Regression for b2d595a: large sets must not render every SVG slot node at once.
+    const slots = Array.from({ length: 200 }, (_, i) => mkSlot(i, { durationSec: 60 }));
+    renderEditor({
+      slots,
+      pxPerSecond: 2,
+      scrollLeft: 60 * 50 * 2,
+      viewportWidth: 600,
+    });
+
+    expect(screen.queryByTestId('slot-block-0')).not.toBeInTheDocument();
+    expect(screen.getByTestId('slot-block-50')).toBeInTheDocument();
+    expect(document.querySelectorAll('[data-testid^="slot-block-"]').length).toBeLessThan(30);
+  });
+
+  it('hides per-slot drag handles at overview zoom', () => {
+    // Regression for b2d595a: overview mode should not expose hundreds of tiny handles.
+    const slots = Array.from({ length: 200 }, (_, i) => mkSlot(i, { durationSec: 60 }));
+    renderEditor({
+      slots,
+      pxPerSecond: 0.02,
+      scrollLeft: 0,
+      viewportWidth: 600,
+    });
+
+    expect(screen.getByTestId('curve-lod')).toHaveTextContent('overview');
+    expect(screen.queryByTestId('target-handle-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slot-block-0')).not.toBeInTheDocument();
+    expect(screen.getByTestId('curve-line')).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cd dashboard
+npm test -- --run app/\(dj\)/setbuilder/__tests__/CurveEditor.test.tsx
+```
+
+Expected: FAIL because `CurveEditorProps` does not accept `pxPerSecond`, `scrollLeft`, or `viewportWidth`, and it renders all blocks/handles.
+
+- [ ] **Step 3: Add viewport props and imports to CurveEditor**
+
+Modify `dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx` imports:
+
+```ts
+import {
+  curveViewportRange,
+  fitPxPerSecond,
+  lodForMedianSlotWidth,
+  visibleBlocksFromSlots,
+} from './curveViewport';
+```
+
+Extend `CurveEditorProps`:
+
+```ts
+  pxPerSecond?: number;
+  scrollLeft?: number;
+  viewportWidth?: number;
+  onScrollLeftChange?: (scrollLeft: number) => void;
+  onViewportWidthChange?: (width: number) => void;
+```
+
+Add defaults in the component parameter list:
+
+```ts
+  pxPerSecond,
+  scrollLeft = 0,
+  viewportWidth,
+  onScrollLeftChange,
+  onViewportWidthChange,
+```
+
+Add a scroll viewport ref next to the existing refs:
+
+```ts
+  const scrollViewportRef = useRef<HTMLDivElement>(null);
+```
+
+- [ ] **Step 4: Replace curve geometry setup in CurveEditor**
+
+Replace the current block from `const totalSec = ...` through `const blocks = ...` with:
+
+```ts
+  const totalSec = slots.reduce((acc, s) => acc + s.track.durationSec, 0);
+  const rawTargetSec = rawTargetSecForSlots(
+    targetDurationSec,
+    slots.length,
+    avgTransitionOverlapSec,
+  );
+  const domainSec = Math.max(totalSec, rawTargetSec ?? 0, 1);
+  const effectiveViewportWidth = viewportWidth ?? w;
+  const effectivePxPerSecond = pxPerSecond ?? fitPxPerSecond({
+    totalSec: domainSec,
+    viewportWidth: effectiveViewportWidth,
+  });
+  const visibleRange = curveViewportRange({
+    scrollLeft,
+    viewportWidth: effectiveViewportWidth,
+    pxPerSecond: effectivePxPerSecond,
+    totalSec: domainSec,
+  });
+  const overscanSec = Math.max(30, effectiveViewportWidth / effectivePxPerSecond);
+  const targetX = rawTargetSec == null
+    ? null
+    : Math.round((rawTargetSec - visibleRange.startSec) * effectivePxPerSecond);
+  const baseBlocks = visibleBlocksFromSlots({
+    slots,
+    visibleStartSec: visibleRange.startSec,
+    visibleEndSec: visibleRange.endSec,
+    pxPerSecond: effectivePxPerSecond,
+    overscanSec,
+  });
+  const blocks = baseBlocks.map((b) =>
+    dragIdx === b.idx && dragEnergy != null ? { ...b, target: dragEnergy } : b,
+  );
+  const lod = lodForMedianSlotWidth(blocks.map((b) => b.width));
+  const showBlocks = lod !== 'overview';
+  const showSlotHandles = lod === 'detail';
+  const showDenseSeams = lod === 'detail';
+  const scrollableWidth = Math.max(effectiveViewportWidth, domainSec * effectivePxPerSecond);
+```
+
+Replace the target-drag `onUp` block lookup:
+
+```ts
+        const b = blocks.find((block) => block.idx === dragIdx);
+```
+
+This matters because `blocks` becomes a visible subset while `dragIdx` remains the global slot
+index.
+
+- [ ] **Step 5: Add scroll container behavior**
+
+Wrap the existing `<svg ...>` with a scroll viewport and an inner spacer. The return should start:
+
+```tsx
+    <div
+      className={styles.canvasWrap}
+      ref={wrapRef}
+      data-testid="curve-canvas"
+      data-lod={lod}
+    >
+      <span data-testid="curve-lod" className={styles.srOnly}>{lod}</span>
+      <div
+        ref={scrollViewportRef}
+        className={styles.curveScrollViewport}
+        data-testid="curve-scroll-viewport"
+        onScroll={(event) => onScrollLeftChange?.(event.currentTarget.scrollLeft)}
+      >
+        <div
+          className={styles.curveScrollInner}
+          style={{ width: scrollableWidth }}
+          aria-hidden="true"
+        />
+        <svg
+          ref={svgRef}
+          className={styles.svg}
+          viewBox={`0 0 ${effectiveViewportWidth} ${h}`}
+          preserveAspectRatio="none"
+          onClickCapture={handleSvgClickCapture}
+        >
+```
+
+Close the two new divs after `</svg>`.
+
+Update the resize observer to notify `CurvePanel`:
+
+```ts
+        const nextW = Math.max(300, e.contentRect.width);
+        const nextH = Math.max(140, e.contentRect.height);
+        setW(nextW);
+        setH(nextH);
+        onViewportWidthChange?.(nextW);
+```
+
+Keep the effect dependency array as `[onViewportWidthChange]`.
+
+Add this effect after the resize observer so programmatic zoom/fit scroll state updates the DOM
+scroll container:
+
+```ts
+  useEffect(() => {
+    if (!scrollViewportRef.current) return;
+    if (Math.abs(scrollViewportRef.current.scrollLeft - scrollLeft) < 1) return;
+    scrollViewportRef.current.scrollLeft = scrollLeft;
+  }, [scrollLeft]);
+```
+
+- [ ] **Step 6: Gate dense SVG groups by LOD**
+
+Wrap current slot block rendering:
+
+```tsx
+        {showBlocks && blocks.map((b) => {
+```
+
+Wrap friction seams and use global slot indices from each visible block:
+
+```tsx
+        {showDenseSeams && view !== 'normal' &&
+          blocks.slice(0, -1).map((b, i) => {
+            const next = blocks[i + 1];
+            const a = slots[b.idx].track;
+            const z = slots[next.idx].track;
+```
+
+Inside the existing seam block, replace local-index hover and test IDs with global-index values:
+
+```tsx
+            const isHovered = hoveredIdx === b.idx || hoveredIdx === next.idx;
+            return (
+              <g key={`seam-${b.idx}`} pointerEvents="none" data-testid={`seam-${view}-${b.idx}`}>
+```
+
+Use `b.idx` for `seam-band` and `seam-chip` test IDs:
+
+```tsx
+                  data-testid={`seam-band-${b.idx}`}
+```
+
+```tsx
+                    data-testid={`seam-chip-${b.idx}`}
+```
+
+Wrap pairing seam markers and use global slot indices:
+
+```tsx
+        {showDenseSeams && blocks.slice(0, -1).map((b, i) => {
+          if (!slots[b.idx].nextIsDjPairing) return null;
+          const next = blocks[i + 1];
+```
+
+Use `b.idx` in the pairing key/test ID:
+
+```tsx
+              key={`pairing-pin-${b.idx}`}
+              data-testid={`pairing-pin-${b.idx}`}
+```
+
+Wrap target handles:
+
+```tsx
+        {showSlotHandles && blocks.map((b) => {
+```
+
+Keep the derived `curve-line` rendering in all LOD modes.
+
+- [ ] **Step 7: Fix viewport-local coordinate calculations**
+
+Replace target marker and over-region width calculations with viewport-local math:
+
+```tsx
+            {totalSec > rawTargetSec && targetX != null ? (
+              <rect
+                data-testid="curve-over-region"
+                x={targetX}
+                y={0}
+                width={Math.max(0, ((totalSec - rawTargetSec) * effectivePxPerSecond))}
+                height={h}
+                fill="rgba(245,158,11,0.12)"
+              />
+            ) : null}
+```
+
+Replace `secToX`:
+
+```ts
+  const secToX = (sec: number) =>
+    (Math.max(0, Math.min(domainSec, sec)) - visibleRange.startSec) * effectivePxPerSecond;
+```
+
+Replace scrub mapping:
+
+```ts
+    const sec = visibleRange.startSec + t * (effectiveViewportWidth / effectivePxPerSecond);
+    onScrub(Math.min(totalSec, Math.max(0, sec)));
+```
+
+Replace vibe window x/width math:
+
+```ts
+          const startSec = win.t0 * domainSec;
+          const endSec = win.t1 * domainSec;
+          const x = (startSec - visibleRange.startSec) * effectivePxPerSecond;
+          const width = Math.max(2, (endSec - startSec) * effectivePxPerSecond);
+```
+
+- [ ] **Step 8: Add CSS for curve scroll viewport**
+
+Add to `dashboard/app/(dj)/setbuilder/components/curve.module.css` near `.canvasWrap`:
+
+```css
+.curveScrollViewport {
+  position: absolute;
+  inset: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
+
+.curveScrollInner {
+  height: 1px;
+  pointer-events: none;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+```
+
+Keep `.svg` absolute and visible as it is today.
+
+- [ ] **Step 9: Run CurveEditor tests**
+
+Run:
+
+```bash
+cd dashboard
+npm test -- --run app/\(dj\)/setbuilder/__tests__/curveViewport.test.ts app/\(dj\)/setbuilder/__tests__/CurveEditor.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add dashboard/app/\(dj\)/setbuilder/components/CurveEditor.tsx \
+  dashboard/app/\(dj\)/setbuilder/components/curve.module.css \
+  dashboard/app/\(dj\)/setbuilder/__tests__/CurveEditor.test.tsx
+git commit -m "fix: render setbuilder curve by viewport"
+```
+
+---
+
+### Task 3: Add Curve Toolbar Zoom Controls And CurvePanel State
+
+**Files:**
+- Modify: `dashboard/app/(dj)/setbuilder/components/CurveToolbar.tsx`
+- Modify: `dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx`
+- Modify: `dashboard/app/(dj)/setbuilder/components/curve.module.css`
+- Modify: `dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx`
+
+- [ ] **Step 1: Add failing integration test for zoom controls**
+
+Add this test to `BuilderWorkspace.test.tsx`:
+
+```tsx
+  it('zooms the curve timeline in, out, and back to fit', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('curve-toolbar')).toBeInTheDocument());
+
+    const canvas = screen.getByTestId('curve-canvas');
+    const initialScale = canvas.getAttribute('data-px-per-second');
+
+    fireEvent.click(screen.getByTestId('curve-zoom-in'));
+    expect(screen.getByTestId('curve-canvas').getAttribute('data-px-per-second')).not.toBe(initialScale);
+
+    fireEvent.click(screen.getByTestId('curve-zoom-out'));
+    fireEvent.click(screen.getByTestId('curve-zoom-fit'));
+
+    expect(screen.getByTestId('curve-zoom-label')).toHaveTextContent('Fit');
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd dashboard
+npm test -- --run app/\(dj\)/setbuilder/__tests__/BuilderWorkspace.test.tsx -t "zooms the curve"
+```
+
+Expected: FAIL because zoom controls do not exist.
+
+- [ ] **Step 3: Extend CurveToolbar props and markup**
+
+In `CurveToolbarProps`, add:
+
+```ts
+  zoomLabel: string;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onZoomFit: () => void;
+```
+
+Destructure these props:
+
+```ts
+  zoomLabel,
+  onZoomIn,
+  onZoomOut,
+  onZoomFit,
+```
+
+Insert this block after the view switch:
+
+```tsx
+      <div className={styles.zoomControls} aria-label="Curve zoom controls">
+        <button
+          type="button"
+          className={styles.toolbarIconBtn}
+          onClick={onZoomOut}
+          data-testid="curve-zoom-out"
+          aria-label="Zoom out"
+          title="Zoom out"
+        >
+          -
+        </button>
+        <span className={styles.zoomLabel} data-testid="curve-zoom-label">
+          {zoomLabel}
+        </span>
+        <button
+          type="button"
+          className={styles.toolbarIconBtn}
+          onClick={onZoomIn}
+          data-testid="curve-zoom-in"
+          aria-label="Zoom in"
+          title="Zoom in"
+        >
+          +
+        </button>
+        <button
+          type="button"
+          className={styles.toolbarBtn}
+          onClick={onZoomFit}
+          data-testid="curve-zoom-fit"
+        >
+          Fit
+        </button>
+      </div>
+```
+
+- [ ] **Step 4: Add toolbar CSS**
+
+Add near toolbar styles in `curve.module.css`:
+
+```css
+.zoomControls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding-left: 0.25rem;
+}
+
+.toolbarIconBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-raised);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: var(--font-mono), monospace;
+  font-size: 0.875rem;
+}
+
+.toolbarIconBtn:hover {
+  color: var(--text);
+  border-color: var(--text-tertiary);
+}
+
+.zoomLabel {
+  min-width: 2.75rem;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono), monospace;
+  font-size: 0.625rem;
+  text-align: center;
+}
+```
+
+- [ ] **Step 5: Wire CurvePanel zoom state**
+
+In `CurvePanel.tsx`, import helpers:
+
+```ts
+import {
+  fitPxPerSecond,
+  zoomPxPerSecond,
+} from './curveViewport';
+```
+
+Add state near existing `useState` calls:
+
+```ts
+  const [curveViewportWidth, setCurveViewportWidth] = useState(800);
+  const [curvePxPerSecond, setCurvePxPerSecond] = useState(0.08);
+  const [curveScrollLeft, setCurveScrollLeft] = useState(0);
+  const [curveFitMode, setCurveFitMode] = useState(true);
+```
+
+Add derived values and handlers after `totalSec`:
+
+```ts
+  const curveDomainSec = Math.max(totalSec, targetDurationSec ?? 0, 1);
+  const fitScale = fitPxPerSecond({
+    totalSec: curveDomainSec,
+    viewportWidth: curveViewportWidth,
+  });
+  const effectiveCurvePxPerSecond = curveFitMode ? fitScale : curvePxPerSecond;
+  const zoomLabel = curveFitMode ? 'Fit' : `${Math.round(effectiveCurvePxPerSecond * 60)} px/min`;
+
+  const zoomCurve = (direction: 'in' | 'out') => {
+    const next = zoomPxPerSecond({
+      currentPxPerSecond: effectiveCurvePxPerSecond,
+      direction,
+      scrollLeft: curveScrollLeft,
+      viewportWidth: curveViewportWidth,
+      totalSec: curveDomainSec,
+    });
+    setCurveFitMode(false);
+    setCurvePxPerSecond(next.pxPerSecond);
+    setCurveScrollLeft(next.scrollLeft);
+  };
+
+  const fitCurve = () => {
+    setCurveFitMode(true);
+    setCurveScrollLeft(0);
+  };
+```
+
+Pass the new props to `CurveToolbar`:
+
+```tsx
+        zoomLabel={zoomLabel}
+        onZoomIn={() => zoomCurve('in')}
+        onZoomOut={() => zoomCurve('out')}
+        onZoomFit={fitCurve}
+```
+
+Pass viewport props to `CurveEditor`:
+
+```tsx
+        pxPerSecond={effectiveCurvePxPerSecond}
+        scrollLeft={curveScrollLeft}
+        viewportWidth={curveViewportWidth}
+        onScrollLeftChange={(next) => {
+          setCurveFitMode(false);
+          setCurveScrollLeft(next);
+        }}
+        onViewportWidthChange={setCurveViewportWidth}
+```
+
+- [ ] **Step 6: Expose scale for tests**
+
+In `CurveEditor.tsx`, add these attributes to `curve-canvas`:
+
+```tsx
+      data-px-per-second={effectivePxPerSecond.toFixed(4)}
+      data-scroll-left={scrollLeft.toFixed(0)}
+```
+
+- [ ] **Step 7: Run BuilderWorkspace zoom test**
+
+Run:
+
+```bash
+cd dashboard
+npm test -- --run app/\(dj\)/setbuilder/__tests__/BuilderWorkspace.test.tsx -t "zooms the curve"
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add dashboard/app/\(dj\)/setbuilder/components/CurveToolbar.tsx \
+  dashboard/app/\(dj\)/setbuilder/components/CurvePanel.tsx \
+  dashboard/app/\(dj\)/setbuilder/components/CurveEditor.tsx \
+  dashboard/app/\(dj\)/setbuilder/components/curve.module.css \
+  dashboard/app/\(dj\)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+git commit -m "feat: add DAW curve zoom controls"
+```
+
+---
+
+### Task 4: Add A Local Measured Virtual List Hook
+
+**Files:**
+- Create: `dashboard/app/(dj)/setbuilder/components/useMeasuredVirtualList.ts`
+- Create: `dashboard/app/(dj)/setbuilder/components/__tests__/useMeasuredVirtualList.test.tsx`
+
+- [ ] **Step 1: Write failing virtualizer tests**
+
+Create `dashboard/app/(dj)/setbuilder/components/__tests__/useMeasuredVirtualList.test.tsx`:
+
+```tsx
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useMeasuredVirtualList } from '../useMeasuredVirtualList';
+
+describe('useMeasuredVirtualList', () => {
+  it('returns a bounded visible range with spacer heights', () => {
+    const { result } = renderHook(() =>
+      useMeasuredVirtualList({
+        itemCount: 500,
+        estimateHeight: 48,
+        viewportHeight: 240,
+        scrollTop: 480,
+        overscan: 2,
+      }),
+    );
+
+    expect(result.current.startIdx).toBe(8);
+    expect(result.current.endIdx).toBe(17);
+    expect(result.current.beforeHeight).toBe(384);
+    expect(result.current.afterHeight).toBe((500 - 17) * 48);
+    expect(result.current.items.map((item) => item.idx)).toEqual([8, 9, 10, 11, 12, 13, 14, 15, 16]);
+  });
+
+  it('uses measured heights for offsets and scroll targets', () => {
+    const { result } = renderHook(() =>
+      useMeasuredVirtualList({
+        itemCount: 10,
+        estimateHeight: 50,
+        viewportHeight: 150,
+        scrollTop: 0,
+        overscan: 1,
+      }),
+    );
+
+    act(() => {
+      result.current.setMeasuredHeight(0, 80);
+      result.current.setMeasuredHeight(1, 20);
+    });
+
+    expect(result.current.scrollTopForIndex(2)).toBe(100);
+    expect(result.current.indexFromScrollTop(99)).toBe(1);
+    expect(result.current.indexFromScrollTop(100)).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd dashboard
+npm test -- --run app/\(dj\)/setbuilder/components/__tests__/useMeasuredVirtualList.test.tsx
+```
+
+Expected: FAIL because the hook does not exist.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `dashboard/app/(dj)/setbuilder/components/useMeasuredVirtualList.ts`:
+
+```ts
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+
+export interface VirtualListItem {
+  idx: number;
+  key: number;
+  top: number;
+  height: number;
+}
+
+export interface UseMeasuredVirtualListInput {
+  itemCount: number;
+  estimateHeight: number;
+  viewportHeight: number;
+  scrollTop: number;
+  overscan?: number;
+}
+
+export interface UseMeasuredVirtualListResult {
+  startIdx: number;
+  endIdx: number;
+  beforeHeight: number;
+  afterHeight: number;
+  totalHeight: number;
+  items: VirtualListItem[];
+  setMeasuredHeight: (idx: number, height: number) => void;
+  scrollTopForIndex: (idx: number) => number;
+  indexFromScrollTop: (top: number) => number;
+}
+
+function buildOffsets(itemCount: number, estimateHeight: number, measured: Map<number, number>) {
+  const offsets: number[] = new Array(itemCount + 1);
+  offsets[0] = 0;
+  for (let i = 0; i < itemCount; i++) {
+    offsets[i + 1] = offsets[i] + (measured.get(i) ?? estimateHeight);
+  }
+  return offsets;
+}
+
+function findIndexAtOffset(offsets: number[], top: number): number {
+  if (offsets.length <= 1) return 0;
+  let lo = 0;
+  let hi = offsets.length - 2;
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    if (offsets[mid + 1] <= top) lo = mid + 1;
+    else if (offsets[mid] > top) hi = mid - 1;
+    else return mid;
+  }
+  return Math.max(0, Math.min(offsets.length - 2, lo));
+}
+
+export function useMeasuredVirtualList({
+  itemCount,
+  estimateHeight,
+  viewportHeight,
+  scrollTop,
+  overscan = 4,
+}: UseMeasuredVirtualListInput): UseMeasuredVirtualListResult {
+  const [measuredHeights, setMeasuredHeights] = useState<Map<number, number>>(() => new Map());
+
+  const offsets = useMemo(
+    () => buildOffsets(itemCount, estimateHeight, measuredHeights),
+    [estimateHeight, itemCount, measuredHeights],
+  );
+
+  const totalHeight = offsets[itemCount] ?? 0;
+  const rawStart = findIndexAtOffset(offsets, Math.max(0, scrollTop));
+  const rawEnd = findIndexAtOffset(offsets, Math.max(0, scrollTop + viewportHeight));
+  const startIdx = Math.max(0, rawStart - overscan);
+  const endIdx = Math.min(itemCount, rawEnd + overscan + 1);
+  const beforeHeight = offsets[startIdx] ?? 0;
+  const afterHeight = Math.max(0, totalHeight - (offsets[endIdx] ?? totalHeight));
+
+  const items = useMemo(
+    () =>
+      Array.from({ length: Math.max(0, endIdx - startIdx) }, (_, offset) => {
+        const idx = startIdx + offset;
+        return {
+          idx,
+          key: idx,
+          top: offsets[idx] ?? 0,
+          height: (offsets[idx + 1] ?? 0) - (offsets[idx] ?? 0),
+        };
+      }),
+    [endIdx, offsets, startIdx],
+  );
+
+  const setMeasuredHeight = useCallback((idx: number, height: number) => {
+    if (!Number.isFinite(height) || height <= 0) return;
+    setMeasuredHeights((prev) => {
+      if (prev.get(idx) === height) return prev;
+      const next = new Map(prev);
+      next.set(idx, height);
+      return next;
+    });
+  }, []);
+
+  const scrollTopForIndex = useCallback(
+    (idx: number) => offsets[Math.max(0, Math.min(itemCount, idx))] ?? 0,
+    [itemCount, offsets],
+  );
+
+  const indexFromScrollTop = useCallback(
+    (top: number) => findIndexAtOffset(offsets, top),
+    [offsets],
+  );
+
+  return {
+    startIdx,
+    endIdx,
+    beforeHeight,
+    afterHeight,
+    totalHeight,
+    items,
+    setMeasuredHeight,
+    scrollTopForIndex,
+    indexFromScrollTop,
+  };
+}
+```
+
+- [ ] **Step 4: Run virtualizer tests**
+
+Run:
+
+```bash
+cd dashboard
+npm test -- --run app/\(dj\)/setbuilder/components/__tests__/useMeasuredVirtualList.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/app/\(dj\)/setbuilder/components/useMeasuredVirtualList.ts \
+  dashboard/app/\(dj\)/setbuilder/components/__tests__/useMeasuredVirtualList.test.tsx
+git commit -m "test: add measured timeline virtualizer"
+```
+
+---
+
+### Task 5: Extract Timeline Row Without Changing Behavior
+
+**Files:**
+- Create: `dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx`
+- Modify: `dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx`
+
+- [ ] **Step 1: Create TimelineRow component**
+
+Create `dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx` by moving the slot-group JSX from `TimelinePanel.tsx` into this component:
+
+```tsx
+'use client';
+
+import { type DragEvent, useState } from 'react';
+import { fmtTime } from './curveMath';
+import { readPoolTrackDragPayload } from './dnd';
+import { localPositionSec } from './transportMath';
+import type { SlotView } from './types';
+import { effectiveTarget } from './types';
+import styles from './curve.module.css';
+
+export interface TimelineRowProps {
+  slot: SlotView;
+  prevSlot: SlotView | null;
+  nextSlot: SlotView | null;
+  idx: number;
+  slots: SlotView[];
+  hoveredIdx: number | null;
+  currentIdx: number;
+  positionSec: number;
+  playing: boolean;
+  dropIdx: number | null;
+  setDropIdx: (idx: number | null) => void;
+  onHover: (idx: number | null) => void;
+  onRowDoubleClick?: (idx: number) => void;
+  onPoolTrackDrop?: (poolTrackId: number, insertIdx: number) => void | Promise<void>;
+  setMenu: (menu: { x: number; y: number; idx: number } | null) => void;
+  setRowRef?: (idx: number, el: HTMLDivElement | null) => void;
+  measureRef?: (idx: number, el: HTMLDivElement | null) => void;
+}
+
+export default function TimelineRow({
+  slot,
+  prevSlot,
+  nextSlot,
+  idx,
+  slots,
+  hoveredIdx,
+  currentIdx,
+  positionSec,
+  playing,
+  dropIdx,
+  setDropIdx,
+  onHover,
+  onRowDoubleClick,
+  onPoolTrackDrop,
+  setMenu,
+  setRowRef,
+  measureRef,
+}: TimelineRowProps) {
+  const [localDropIdx, setLocalDropIdx] = useState<number | null>(null);
+  const seamScore = prevSlot?.transitionScore ?? slot.transitionScore;
+  const isPairedSeam = Boolean(prevSlot?.nextIsDjPairing);
+  const isCurrent = currentIdx === idx;
+  const progress =
+    isCurrent && slot.track.durationSec > 0
+      ? Math.min(
+          100,
+          Math.max(0, (localPositionSec(slots, idx, positionSec) / slot.track.durationSec) * 100),
+        )
+      : 0;
+  const pairingActionLabel = slot.nextIsDjPairing
+    ? `Open saved pairing after ${slot.track.title}`
+    : `Save ${slot.track.title} into ${nextSlot?.track.title ?? 'next track'} as pairing`;
+
+  const markPoolTrackDrop = (event: DragEvent<HTMLElement>, insertIdx: number) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+    setDropIdx(insertIdx);
+    setLocalDropIdx(insertIdx);
+  };
+
+  const handlePoolTrackDrop = (event: DragEvent<HTMLElement>, insertIdx: number) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setDropIdx(null);
+    setLocalDropIdx(null);
+    const payload = readPoolTrackDragPayload(event.dataTransfer);
+    if (!payload) return;
+    void onPoolTrackDrop?.(payload.poolTrackId, insertIdx);
+  };
+
+  const clearDropIfLeaving = (event: DragEvent<HTMLElement>) => {
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
+    setDropIdx(null);
+    setLocalDropIdx(null);
+  };
+
+  const groupDropIdx = localDropIdx ?? dropIdx;
+
+  return (
+    <div
+      className={styles.timelineSlotGroup}
+      ref={(el) => measureRef?.(idx, el)}
+      data-testid={`timeline-slot-group-${idx}`}
+    >
+      {idx > 0 && (isPairedSeam || seamScore != null) && (
+        <div
+          className={`${styles.timelineTransition} ${
+            isPairedSeam ? styles.timelineTransitionPairing : ''
+          }`}
+          data-testid={`timeline-transition-${idx - 1}`}
+        >
+          {seamScore != null && (
+            <span className={styles.timelineScoreChip}>{Math.round(seamScore)}</span>
+          )}
+          {isPairedSeam && (
+            <span className={styles.timelinePairingChip}>
+              <svg width="12" height="12" viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M10.5 13.5 13.5 10.5M8.5 17.5H7.8a4.8 4.8 0 0 1 0-9.6h3.4M12.8 16.1h3.4a4.8 4.8 0 1 0 0-9.6h-.7"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.9"
+                />
+              </svg>
+              DJ pairing
+            </span>
+          )}
+        </div>
+      )}
+      <div
+        ref={(el) => setRowRef?.(idx, el)}
+        className={`${styles.timelineRow} ${hoveredIdx === idx ? styles.timelineRowHover : ''} ${
+          isCurrent ? styles.timelineRowNow : ''
+        } ${groupDropIdx === idx ? styles.timelineRowDrop : ''}`}
+        onMouseEnter={() => onHover(idx)}
+        onMouseLeave={() => onHover(null)}
+        onDoubleClick={() => onRowDoubleClick?.(idx)}
+        onDragOver={(event) => {
+          event.stopPropagation();
+          markPoolTrackDrop(event, idx);
+        }}
+        onDragLeave={clearDropIfLeaving}
+        onDrop={(event) => handlePoolTrackDrop(event, idx)}
+        onContextMenu={(event) => {
+          if (!nextSlot) return;
+          event.preventDefault();
+          setMenu({ x: event.clientX, y: event.clientY, idx });
+        }}
+        data-testid={`timeline-row-${idx}`}
+      >
+        {isCurrent ? (
+          <span
+            className={styles.timelineRowProgress}
+            style={{ width: `${progress}%` }}
+            aria-hidden="true"
+          />
+        ) : null}
+        <span className={styles.timelinePos}>
+          {isCurrent ? (
+            playing ? (
+              <span className={`${styles.rowVu} ${styles.rowVuActive}`} data-testid={`timeline-vu-${idx}`}>
+                <span />
+                <span />
+                <span />
+                <span />
+              </span>
+            ) : (
+              <span className={styles.timelinePauseIcon} data-testid={`timeline-pause-${idx}`}>
+                <span />
+                <span />
+              </span>
+            )
+          ) : (
+            String(idx + 1).padStart(2, '0')
+          )}
+        </span>
+        <span className={styles.timelineTitle}>
+          {slot.track.title}
+          {slot.track.artist ? (
+            <span className={styles.timelineArtist}> - {slot.track.artist}</span>
+          ) : null}
+        </span>
+        <span className={styles.timelineBadge}>{fmtTime(slot.track.durationSec)}</span>
+        <span className={styles.timelineBadge}>
+          {slot.track.bpm != null ? `${Math.round(slot.track.bpm)} BPM` : '- BPM'}
+        </span>
+        <span className={styles.timelineBadge}>{slot.track.key ?? '-'}</span>
+        <span className={styles.timelineBadge}>e{slot.track.energy}</span>
+        <span className={styles.timelineTarget} title="Target energy">
+          ◎ {effectiveTarget(slot).toFixed(1)}
+        </span>
+        {nextSlot && (
+          <button
+            type="button"
+            className={styles.timelinePairingAction}
+            aria-label={pairingActionLabel}
+            title={pairingActionLabel}
+            onClick={(event) => {
+              event.stopPropagation();
+              const rect = event.currentTarget.getBoundingClientRect();
+              setMenu({ x: rect.left, y: rect.bottom + 4, idx });
+            }}
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M10.5 13.5 13.5 10.5M8.5 17.5H7.8a4.8 4.8 0 0 1 0-9.6h3.4M12.8 16.1h3.4a4.8 4.8 0 1 0 0-9.6h-.7"
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.9"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Replace TimelinePanel map body with TimelineRow**
+
+In `TimelinePanel.tsx`, remove imports that moved to `TimelineRow`:
+
+```ts
+import { type DragEvent, useEffect, useRef, useState } from 'react';
+```
+
+should become:
+
+```ts
+import { type DragEvent, useEffect, useRef, useState } from 'react';
+import TimelineRow from './TimelineRow';
+```
+
+Keep current top-level list drop helpers.
+
+Replace the full `slots.map((s, i) => { ... })` JSX with:
+
+```tsx
+      {slots.map((slot, i) => (
+        <TimelineRow
+          key={slot.id}
+          slot={slot}
+          prevSlot={i > 0 ? slots[i - 1] : null}
+          nextSlot={slots[i + 1] ?? null}
+          idx={i}
+          slots={slots}
+          hoveredIdx={hoveredIdx}
+          currentIdx={currentIdx}
+          positionSec={positionSec}
+          playing={playing}
+          dropIdx={dropIdx}
+          setDropIdx={setDropIdx}
+          onHover={onHover}
+          onRowDoubleClick={onRowDoubleClick}
+          onPoolTrackDrop={onPoolTrackDrop}
+          setMenu={setMenu}
+          setRowRef={(idx, el) => {
+            rowRefs.current[idx] = el;
+          }}
+        />
+      ))}
+```
+
+- [ ] **Step 3: Run existing timeline behavior tests**
+
+Run:
+
+```bash
+cd dashboard
+npm test -- --run app/\(dj\)/setbuilder/__tests__/BuilderWorkspace.test.tsx -t "timeline|dropping|double-clicking|pairing"
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dashboard/app/\(dj\)/setbuilder/components/TimelineRow.tsx \
+  dashboard/app/\(dj\)/setbuilder/components/TimelinePanel.tsx
+git commit -m "refactor: extract setbuilder timeline row"
+```
+
+---
+
+### Task 6: Virtualize TimelinePanel While Preserving Row Actions
+
+**Files:**
+- Modify: `dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx`
+- Modify: `dashboard/app/(dj)/setbuilder/components/curve.module.css`
+- Modify: `dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx`
+
+- [ ] **Step 1: Add failing large-list virtualized behavior test**
+
+Add helpers near `documentSnapshot()` in `BuilderWorkspace.test.tsx`:
+
+```ts
+function largeSlots(count: number): SetSlotOut[] {
+  return Array.from({ length: count }, (_, idx) => ({
+    ...SLOTS[idx % SLOTS.length],
+    id: idx + 1,
+    position: idx,
+    track_id: `large-${idx}`,
+    target_energy: idx % 3 === 0 ? 7 : null,
+  }));
+}
+
+function largePoolTracks(count: number): PoolTrack[] {
+  return Array.from({ length: count }, (_, idx) => ({
+    ...POOL_TRACKS[idx % POOL_TRACKS.length],
+    id: 1000 + idx,
+    track_id: `large-${idx}`,
+    title: `Large Track ${idx}`,
+    artist: `Large Artist ${idx}`,
+    duration_sec: 180 + (idx % 40),
+  }));
+}
+```
+
+Add test:
+
+```tsx
+  it('virtualizes hundreds of timeline rows while preserving visible row actions', async () => {
+    // Regression for b2d595a: large timelines must not mount every row.
+    mockGetSetSlots.mockResolvedValue(largeSlots(400));
+    mockGetPool.mockResolvedValue({ sources: [], tracks: largePoolTracks(400) });
+
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('timeline-row-0')).toBeInTheDocument());
+
+    expect(screen.getByTestId('timeline-list')).toHaveAttribute('data-virtualized', 'true');
+    expect(document.querySelectorAll('[data-testid^="timeline-row-"]').length).toBeLessThan(60);
+
+    fireEvent.doubleClick(screen.getByTestId('timeline-row-1'));
+    await waitFor(() => expect(mockSendTransportCommand).toHaveBeenCalledTimes(1));
+    expect(mockSendTransportCommand).toHaveBeenCalledWith(
+      5,
+      expect.objectContaining({
+        action: 'play',
+        slot_index: 1,
+        title: 'Large Track 1',
+      }),
+    );
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd dashboard
+npm test -- --run app/\(dj\)/setbuilder/__tests__/BuilderWorkspace.test.tsx -t "virtualizes hundreds"
+```
+
+Expected: FAIL because `TimelinePanel` still renders every row and has no `data-virtualized` attribute.
+
+- [ ] **Step 3: Import virtualizer in TimelinePanel**
+
+In `TimelinePanel.tsx`, add:
+
+```ts
+import { useMeasuredVirtualList } from './useMeasuredVirtualList';
+```
+
+Add constants near imports:
+
+```ts
+const TIMELINE_ESTIMATED_SLOT_GROUP_HEIGHT = 52;
+const TIMELINE_OVERSCAN = 8;
+```
+
+- [ ] **Step 4: Add viewport height and scroll state**
+
+Inside `TimelinePanel`, add state after existing `dropIdx`:
+
+```ts
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportHeight, setViewportHeight] = useState(480);
+```
+
+Add resize observer:
+
+```ts
+  useEffect(() => {
+    if (!listRef.current) return;
+    const list = listRef.current;
+    const update = () => setViewportHeight(Math.max(1, list.clientHeight));
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(list);
+    return () => ro.disconnect();
+  }, []);
+```
+
+Create virtualizer:
+
+```ts
+  const virtual = useMeasuredVirtualList({
+    itemCount: slots.length,
+    estimateHeight: TIMELINE_ESTIMATED_SLOT_GROUP_HEIGHT,
+    viewportHeight,
+    scrollTop,
+    overscan: TIMELINE_OVERSCAN,
+  });
+```
+
+- [ ] **Step 5: Replace scrollRequest DOM-ref behavior**
+
+Replace the `scrollRequest` effect with:
+
+```ts
+  useEffect(() => {
+    if (!scrollRequest || !listRef.current) return;
+    listRef.current.scrollTop = virtual.scrollTopForIndex(scrollRequest.idx);
+    setScrollTop(listRef.current.scrollTop);
+  }, [scrollRequest, virtual.scrollTopForIndex]);
+```
+
+- [ ] **Step 6: Render virtual spacers and visible TimelineRows**
+
+Add `onScroll` to the list div:
+
+```tsx
+      onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
+      data-virtualized="true"
+```
+
+Replace the row render block with:
+
+```tsx
+      <div style={{ height: virtual.beforeHeight }} aria-hidden="true" />
+      {virtual.items.map(({ idx }) => {
+        const slot = slots[idx];
+        if (!slot) return null;
+        return (
+          <TimelineRow
+            key={slot.id}
+            slot={slot}
+            prevSlot={idx > 0 ? slots[idx - 1] : null}
+            nextSlot={slots[idx + 1] ?? null}
+            idx={idx}
+            slots={slots}
+            hoveredIdx={hoveredIdx}
+            currentIdx={currentIdx}
+            positionSec={positionSec}
+            playing={playing}
+            dropIdx={dropIdx}
+            setDropIdx={setDropIdx}
+            onHover={onHover}
+            onRowDoubleClick={onRowDoubleClick}
+            onPoolTrackDrop={onPoolTrackDrop}
+            setMenu={setMenu}
+            setRowRef={(rowIdx, el) => {
+              rowRefs.current[rowIdx] = el;
+            }}
+            measureRef={(rowIdx, el) => {
+              if (el) virtual.setMeasuredHeight(rowIdx, el.getBoundingClientRect().height);
+            }}
+          />
+        );
+      })}
+      <div style={{ height: virtual.afterHeight }} aria-hidden="true" />
+```
+
+- [ ] **Step 7: Preserve list-level append drop behavior**
+
+Keep existing list-level `onDragOver`, `onDragLeave`, and `onDrop`. Update append drop index to use pointer position when dropping on the virtualized list background:
+
+```ts
+  const insertIdxFromListPointer = (event: DragEvent<HTMLElement>) => {
+    const list = listRef.current;
+    if (!list) return slots.length;
+    const rect = list.getBoundingClientRect();
+    const top = list.scrollTop + Math.max(0, event.clientY - rect.top);
+    return Math.max(0, Math.min(slots.length, virtual.indexFromScrollTop(top)));
+  };
+```
+
+Use it in list-level handlers:
+
+```tsx
+      onDragOver={(event) => markPoolTrackDrop(event, insertIdxFromListPointer(event))}
+      onDrop={(event) => handlePoolTrackDrop(event, insertIdxFromListPointer(event))}
+```
+
+Visible row drops still use exact row index from `TimelineRow`.
+
+- [ ] **Step 8: Run timeline virtualizer test**
+
+Run:
+
+```bash
+cd dashboard
+npm test -- --run app/\(dj\)/setbuilder/__tests__/BuilderWorkspace.test.tsx -t "virtualizes hundreds"
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Run existing timeline behavior tests**
+
+Run:
+
+```bash
+cd dashboard
+npm test -- --run app/\(dj\)/setbuilder/__tests__/BuilderWorkspace.test.tsx -t "timeline|dropping|double-clicking|pairing|click on a curve block"
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add dashboard/app/\(dj\)/setbuilder/components/TimelinePanel.tsx \
+  dashboard/app/\(dj\)/setbuilder/components/curve.module.css \
+  dashboard/app/\(dj\)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+git commit -m "fix: virtualize setbuilder timeline list"
+```
+
+---
+
+### Task 7: Large-Set Curve Integration And Full Verification
+
+**Files:**
+- Modify: `dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx`
+
+- [ ] **Step 1: Add large-set curve regression test**
+
+Add this test to `BuilderWorkspace.test.tsx`:
+
+```tsx
+  it('uses overview curve LOD for hundreds of tracks at fit zoom', async () => {
+    // Regression for b2d595a: fit zoom must not render hundreds of target handles.
+    mockGetSetSlots.mockResolvedValue(largeSlots(400));
+    mockGetPool.mockResolvedValue({ sources: [], tracks: largePoolTracks(400) });
+
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('curve-canvas')).toBeInTheDocument());
+
+    expect(screen.getByTestId('curve-lod')).toHaveTextContent('overview');
+    expect(document.querySelectorAll('[data-testid^="target-handle-"]').length).toBe(0);
+    expect(screen.getByTestId('curve-line')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('curve-zoom-in'));
+    fireEvent.click(screen.getByTestId('curve-zoom-in'));
+    fireEvent.click(screen.getByTestId('curve-zoom-in'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('curve-canvas').getAttribute('data-px-per-second')).not.toBe('0.0200'),
+    );
+  });
+```
+
+- [ ] **Step 2: Run focused large-set tests**
+
+Run:
+
+```bash
+cd dashboard
+npm test -- --run app/\(dj\)/setbuilder/__tests__/BuilderWorkspace.test.tsx -t "hundreds|large"
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run setbuilder frontend tests**
+
+Run:
+
+```bash
+cd dashboard
+npm test -- --run app/\(dj\)/setbuilder/__tests__/curveViewport.test.ts \
+  app/\(dj\)/setbuilder/__tests__/CurveEditor.test.tsx \
+  app/\(dj\)/setbuilder/__tests__/BuilderWorkspace.test.tsx \
+  app/\(dj\)/setbuilder/components/__tests__/useMeasuredVirtualList.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run frontend lint and typecheck**
+
+Run:
+
+```bash
+cd dashboard
+npm run lint
+npx tsc --noEmit
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full dashboard Vitest suite**
+
+Run:
+
+```bash
+cd dashboard
+npm test -- --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/app/\(dj\)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+git commit -m "test: cover large setbuilder timelines"
+```
+
+---
+
+## Completion Checklist
+
+- [ ] `git status --short` shows only intentional files or is clean.
+- [ ] `cd dashboard && npm run lint` passes.
+- [ ] `cd dashboard && npx tsc --noEmit` passes.
+- [ ] `cd dashboard && npm test -- --run` passes.
+- [ ] The curve can zoom in/out/fit from the toolbar.
+- [ ] Fit zoom on hundreds of songs renders overview LOD with no target handles.
+- [ ] Detail zoom renders handles only for visible slots.
+- [ ] The vertical timeline list keeps row interactions while mounting a bounded number of rows.

--- a/docs/superpowers/specs/2026-06-14-setbuilder-daw-curve-virtual-list-design.md
+++ b/docs/superpowers/specs/2026-06-14-setbuilder-daw-curve-virtual-list-design.md
@@ -1,0 +1,181 @@
+# Setbuilder DAW Curve Zoom And Virtual Timeline List Design
+
+Date: 2026-06-14
+Branch: `fix/setbuilder-daw-curve-virtual-list`
+
+## Context
+
+The setbuilder curve currently maps the full set duration into the visible curve panel width. In
+`CurveEditor`, `slotBlocksFromSlots()` creates one SVG block and one draggable handle per slot,
+and each block is clamped to at least one pixel wide. With several hundred songs, the logical time
+domain and the forced minimum block widths diverge: blocks, handles, hit targets, seam markers,
+and text labels overlap inside a fixed-width SVG. This causes the curve timeline to look stretched
+and distorted.
+
+The set list below the curve also renders every row directly. Each row can include badges, pairing
+actions, progress state, drag/drop handlers, hover handlers, and transition chips. At several
+hundred songs this creates too many DOM nodes and event targets, which can make scrolling and row
+interactions unstable.
+
+## Goals
+
+- Add DAW-style horizontal zoom for the curve timeline.
+- Stop compressing the full set into one fixed-width SVG at large set sizes.
+- Reduce curve DOM/SVG work by rendering only visible time-range detail.
+- Keep the set list as an independent vertical list with no zoom behavior.
+- Preserve all current set list row functionality.
+- Make large sets with hundreds of songs scroll and render predictably.
+
+## Non-Goals
+
+- Do not redesign the set list as a DAW lane.
+- Do not add numbered pagination as the primary list experience.
+- Do not add Tailwind or a UI framework.
+- Do not change backend setbuilder APIs unless implementation uncovers a hard data limitation.
+- Do not remove existing row actions, drag/drop insertion, playback controls, or pairing actions.
+
+## Approved Approach
+
+Use a DAW-style curve viewport plus a local virtualized vertical set list.
+
+The curve owns horizontal scale and scroll state. Zoom changes seconds-per-pixel instead of
+changing song data. The full set has a logical pixel width derived from total duration and zoom,
+while the visible SVG renders the current time range plus small overscan.
+
+The set list remains a vertical list. It switches from rendering every row to rendering only rows
+inside the visible scroll window plus overscan. Row behavior stays attached to the row component,
+so visible rows keep the same interactions as today.
+
+## Curve Architecture
+
+The curve needs explicit viewport state:
+
+- `pxPerSecond`: horizontal zoom scale.
+- `scrollLeft`: horizontal scroll position in pixels.
+- `viewportWidth`: measured curve viewport width.
+- `visibleStartSec` and `visibleEndSec`: derived from scroll and zoom.
+- `fit` action: compute a scale that fits the full set duration in the panel.
+
+`CurvePanel` should own this state because it already coordinates `CurveToolbar` and
+`CurveEditor`. `BuilderWorkspace` should continue to own slots, playback position, and list
+navigation. Low-level math helpers should remain pure and receive a viewport input rather than
+reading DOM state.
+
+The curve editor should render inside a horizontal scroll container. The scrollable inner width is
+`max(viewportWidth, totalSec * pxPerSecond)`. The SVG itself can stay viewport-sized and translate
+time values into viewport-local x coordinates:
+
+```text
+x = (slotTimeSec - visibleStartSec) * pxPerSecond
+```
+
+Visible block generation should filter slots by time intersection with the visible range plus
+overscan. The current all-slots `slotBlocksFromSlots()` helper can be kept for tests or small
+cases, but the new curve rendering path should use viewport-aware geometry.
+
+## Curve Levels Of Detail
+
+Curve zoom should intentionally reduce interactivity when zoomed out:
+
+- Overview zoom: show a simplified target curve, playhead, coarse grid, target-duration marker,
+  and broad energy shapes. Hide draggable target handles, dense hit targets, seam chips, tiny
+  labels, and per-slot drag actions.
+- Medium zoom: show visible slot blocks and readable hover/click targets. Keep target handles
+  hidden until slots have enough horizontal space.
+- Detail zoom: show draggable target handles, mismatch overlays, seam details, pairing markers,
+  and existing slot-level interactions.
+
+LOD thresholds should be based on rendered pixels per slot or pixels per second, not on the raw
+number of songs alone. This keeps behavior consistent across short and long tracks.
+
+Default thresholds:
+
+- Overview: median visible slot width is below 6 px.
+- Medium: median visible slot width is at least 6 px but below 28 px.
+- Detail: median visible slot width is at least 28 px.
+
+At fit/overview zoom, clicks should prefer scrub or coarse navigation. Slot-level editing should
+only appear once targets are large enough to avoid accidental tiny clicks.
+
+## Set List Architecture
+
+`TimelinePanel` should be split into a lightweight virtualizer and a row component:
+
+- The scroll container owns `scrollTop` and measured viewport height.
+- Virtual items should represent current slot groups, not only bare rows, because each slot can
+  include a transition band above it.
+- Use a measured-height virtualizer with a conservative default estimate. Cache each mounted slot
+  group's measured height, and use prefix-sum offsets to compute spacer heights and scroll targets.
+- The renderer computes `startIdx` and `endIdx` from scroll position, cached/estimated item
+  offsets, viewport height, and overscan.
+- Top and bottom spacer elements preserve total scroll height.
+- Only visible rows and nearby overscan rows are mounted.
+
+Current row behavior should move into a reusable row component:
+
+- hover sync with the curve
+- double-click to jump/play
+- pool-track drag/drop insertion
+- pairing context menu/action
+- current row progress and VU/pause state
+- target, BPM, key, duration, energy, and pairing badges
+
+The list should keep a list-level drop target for appending. For large virtualized lists, insertion
+around the visible window should use pointer-position-to-index calculation in the scroll container,
+with visible row drop targets still handling direct row drops.
+
+Curve-to-list navigation must use virtualizer offsets instead of DOM refs for every row. When the
+curve requests row `idx`, the virtual list should scroll to that index using the measured offset
+cache, falling back to estimated offsets for rows not yet measured.
+
+## Playback And Scroll Behavior
+
+The playhead should remain visible on the curve while playback advances unless the user has
+manually scrolled away from the playhead. A simple follow mode can be implicit:
+
+- If the playhead is visible or the user has not manually scrolled recently, keep it in view.
+- If the user scrolls horizontally away, stop auto-follow until the user presses a follow/fit action
+  or playback jumps back into view.
+
+The vertical set list should not auto-zoom or change density. Current-track visibility should be
+handled by virtualized index scrolling when playback jumps or when the user chooses a curve/list
+navigation action.
+
+## Testing Plan
+
+Unit and component tests should pin the large-set regression:
+
+- Render hundreds of slots and assert the curve renders a bounded visible subset in detail mode.
+- Assert overview zoom hides target handles and dense slot hit targets.
+- Assert detail zoom restores handles for visible slots.
+- Assert fit/full-set mode does not render one handle per song for hundreds of songs.
+- Assert virtualized `TimelinePanel` renders a bounded number of rows with spacer height matching
+  the full set length.
+- Assert visible timeline rows keep double-click, hover, pairing action, current-track state, and
+  drag/drop insertion behavior.
+- Assert curve-click-to-list navigation scrolls the virtualized list to the requested row.
+
+For the bug-fix regression tests, include the eventual fix commit SHA in the test comment as
+required by project testing notes.
+
+## Implementation Notes
+
+- Create the implementation branch before editing code.
+- Keep frontend styling in vanilla CSS modules or inline React styles.
+- Avoid adding a virtualization dependency. The required behavior is narrow enough for a local
+  measured virtualizer.
+- Prefer pure helpers for viewport/time math so behavior is easy to test without a browser.
+- Preserve existing test IDs where practical for visible rows and existing curve elements. Tests
+  that assumed every row or every handle is always mounted will need updates to reflect
+  virtualization and LOD behavior.
+
+## Risks
+
+- Drag/drop into virtualized gaps can be awkward if insertion index math is not explicit.
+- SVG interactions may need careful event handling because overview mode and detail mode expose
+  different hit targets.
+- Current tests may rely on all rows existing in the DOM; those expectations must be updated to
+  visible-window semantics.
+- Follow-playhead behavior can fight user scrolling if the manual-scroll escape hatch is unclear.
+  Use implicit follow mode initially: auto-follow only while the playhead remains visible or until
+  the user manually scrolls away.


### PR DESCRIPTION
## What changed

- Added DAW-style curve zoom controls with fit/zoom state and horizontal curve scrolling.
- Reduced curve timeline detail at overview zoom so large sets render as a simplified line without hundreds of handles/actions.
- Virtualized the set list below the curve so hundreds of songs keep the list responsive while preserving row interactions.
- Fixed SVG timeline label distortion by measuring the actual rendered curve viewport and keeping SVG/viewBox dimensions in sync before ResizeObserver emits.
- Added a visible custom horizontal curve scrollbar/thumb so the zoomed DAW timeline can be clicked and dragged reliably.

## Root cause

The curve SVG could keep its default `800 x 220` coordinate space while CSS rendered it much narrower. Because the SVG used `preserveAspectRatio="none"`, text glyphs inside the playhead/label chips were scaled non-uniformly. The previous fix counter-scaled labels, but it still depended on stale viewport measurements in live responsive layouts.

The native horizontal scrollbar was also effectively too small/hidden for this UI and could be overlapped by neighboring grid rows when the curve toolbar wrapped.

## Impact

Large set-builder documents should no longer mount all timeline rows or dense curve handles at fit zoom, and the curve timeline should behave more like a DAW: zoomable, horizontally scrollable, and visually simplified when zoomed out. The set list remains a plain list and does not inherit curve zoom.

## Validation

- `npm test -- --run app/(dj)/setbuilder/__tests__/curveViewport.test.ts app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx app/(dj)/setbuilder/components/__tests__/useMeasuredVirtualList.test.tsx` — 60 passed
- `npx tsc --noEmit` — passed
- `npm run lint` — passed
- Local browser probe against `https://192.168.20.5/setbuilder/1` confirmed narrow viewport playhead label CTM scale `a=1, d=1` and custom scrollbar click/drag updated `scrollLeft`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added curve zoom controls (zoom in/out and zoom to fit) with a dedicated zoom label
  * Introduced horizontal scrolling with a custom scrollbar for the curve editor
  * Virtualized the timeline list for smoother performance on large datasets
* **Bug Fixes**
  * Improved stability for timeline scrolling and row selection when viewing many rows
  * Enhanced large-set behavior using zoom level of detail (reduced handles when zoomed out)
* **Refactor**
  * Extracted timeline rows into a dedicated component
* **Tests**
  * Expanded coverage for curve viewport/zoom math, virtualization, and interaction regressions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->