### PR TITLE
feat: improve setbuilder locked slot UX

### DIFF
--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -150,6 +150,9 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
 
   const requestBuild = async () => {
     if (builderSettings.confirmRecompute) {
+      const snapshotSlots = history.snapshot?.slots ?? [];
+      const lockedCount = snapshotSlots.filter((slot) => slot.locked).length;
+      const unlockedCount = Math.max(0, snapshotSlots.length - lockedCount);
       const ok = await requestConfirmation({
         title: 'Recompute set order?',
         body: (
@@ -159,8 +162,18 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
               current pool, curve targets, transition scoring, and saved pairings.
             </p>
             <ul>
-              <li>Locked slots stay fixed.</li>
-              <li>Unlocked manual reorders may be replaced.</li>
+              <li>
+                {snapshotSlots.length > 0
+                  ? `${lockedCount} locked ${lockedCount === 1 ? 'slot stays' : 'slots stay'} fixed.`
+                  : 'Locked slots stay fixed.'}
+              </li>
+              <li>
+                {snapshotSlots.length > 0
+                  ? `${unlockedCount} unlocked ${
+                      unlockedCount === 1 ? 'slot may be' : 'slots may be'
+                    } replaced or reordered.`
+                  : 'Unlocked manual reorders may be replaced.'}
+              </li>
               <li>Saved pairings are weighted into scoring.</li>
               <li>The action is undoable from the topbar or with Ctrl/Cmd+Z.</li>
             </ul>

--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -483,6 +483,59 @@ describe('BuilderWorkspace', () => {
     expect(typeof energy).toBe('number');
   });
 
+  it('renders locked timeline and curve affordances while disabling target drag', async () => {
+    mockGetSetSlots.mockResolvedValue(
+      SLOTS.map((slot) => (slot.id === 2 ? { ...slot, locked: true } : slot)),
+    );
+
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('timeline-row-1')).toBeInTheDocument());
+
+    expect(screen.getByTestId('timeline-row-1')).toHaveAttribute('data-locked', 'true');
+    expect(screen.getByTestId('timeline-lock-badge-1')).toHaveTextContent('Locked');
+    expect(screen.getByTestId('slot-block-1')).toHaveAttribute('data-locked', 'true');
+    expect(screen.getByTestId('slot-lock-icon-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('target-handle-1')).not.toBeInTheDocument();
+  });
+
+  it('bulk locks selected timeline rows through the document snapshot', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('timeline-row-2')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('timeline-select-0'));
+    fireEvent.click(screen.getByTestId('timeline-select-2'));
+    fireEvent.click(screen.getByTestId('timeline-lock-selected'));
+
+    await waitFor(() => expect(mockPutSetDocument).toHaveBeenCalledTimes(1));
+    const [setId, snapshot] = mockPutSetDocument.mock.calls[0] as [
+      number,
+      SetDocumentSnapshot,
+    ];
+    expect(setId).toBe(5);
+    expect(snapshot.slots.map((slot) => [slot.id, slot.locked])).toEqual([
+      [1, true],
+      [2, false],
+      [3, true],
+    ]);
+  });
+
+  it('locks every slot that starts before the playhead', async () => {
+    render(<BuilderWorkspace setId={5} />);
+    await waitFor(() => expect(screen.getByTestId('timeline-row-1')).toBeInTheDocument());
+
+    fireEvent.doubleClick(screen.getByTestId('timeline-row-1'));
+    await waitFor(() => expect(mockSendTransportCommand).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByTestId('timeline-lock-before-playhead'));
+
+    await waitFor(() => expect(mockPutSetDocument).toHaveBeenCalledTimes(1));
+    const [, snapshot] = mockPutSetDocument.mock.calls[0] as [number, SetDocumentSnapshot];
+    expect(snapshot.slots.map((slot) => [slot.id, slot.locked])).toEqual([
+      [1, true],
+      [2, false],
+      [3, false],
+    ]);
+  });
+
   it('drag-release with big mismatch opens the replacement popover (gated)', async () => {
     render(<BuilderWorkspace setId={5} />);
     await waitFor(() => expect(screen.getByTestId('target-handle-0')).toBeInTheDocument());

--- a/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/CurveEditor.test.tsx
@@ -65,6 +65,17 @@ describe('CurveEditor', () => {
     expect(screen.getByTestId('curve-line')).toBeInTheDocument();
   });
 
+  it('tints locked blocks and disables their target drag handle', () => {
+    const locked = mkSlot(0);
+    locked.locked = true;
+    renderEditor({ slots: [locked, mkSlot(1)] });
+
+    expect(screen.getByTestId('slot-block-0')).toHaveAttribute('data-locked', 'true');
+    expect(screen.getByTestId('slot-lock-icon-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('target-handle-0')).not.toBeInTheDocument();
+    expect(screen.getByTestId('target-handle-1')).toBeInTheDocument();
+  });
+
   it('renders a purple seam pin for saved DJ pairings', () => {
     const paired = mkSlot(0);
     paired.nextPairingId = 42;

--- a/dashboard/app/(dj)/setbuilder/__tests__/ReplacePopover.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/ReplacePopover.test.tsx
@@ -54,6 +54,33 @@ describe('ReplacePopover', () => {
     expect(onReplace).toHaveBeenCalledWith(11, 'a');
   });
 
+  it('shows locked-slot state and skips replacement actions', () => {
+    const lockedSlot = { ...slot, locked: true };
+    const candidates = rankReplacementCandidates(
+      8,
+      null,
+      [mkTrack({ id: 'a', title: 'Fit A', energy: 8, bpm: 121, key: '8A' })],
+      new Set(),
+    );
+    const onReplace = vi.fn();
+    render(
+      <ReplacePopover
+        prompt={prompt}
+        slot={lockedSlot}
+        candidates={candidates}
+        onReplace={onReplace}
+        onKeep={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('replace-locked')).toHaveTextContent(
+      'Skipped because this slot is locked',
+    );
+    fireEvent.click(screen.getByTestId('replace-candidate-a'));
+    expect(onReplace).not.toHaveBeenCalled();
+  });
+
   it('shows the empty state when no candidates fit', () => {
     render(
       <ReplacePopover

--- a/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
@@ -97,6 +97,20 @@ function insertPoolTrackIntoDocument(
   };
 }
 
+function lockSlotsInDocument(
+  snapshot: SetDocumentSnapshot,
+  slotIds: number[],
+  locked: boolean,
+): SetDocumentSnapshot {
+  const idSet = new Set(slotIds);
+  return {
+    ...snapshot,
+    slots: snapshot.slots.map((slot) =>
+      idSet.has(slot.id) ? { ...slot, locked } : slot,
+    ),
+  };
+}
+
 function TimelineSummary({
   projection,
   overlapSec,
@@ -355,6 +369,7 @@ export default function BuilderWorkspace({
 
   const handlePoolTrackDrop = useCallback(
     async (poolTrackId: number, insertIdx: number) => {
+      if (slots.some((slot, idx) => slot.locked && idx >= insertIdx)) return;
       const save = async () => {
         const current = await api.getSetDocument(setId);
         return api.putSetDocument(
@@ -370,8 +385,43 @@ export default function BuilderWorkspace({
         // Keep the visible timeline unchanged if the document mutation fails.
       }
     },
+    [commit, loadSlots, setId, slots],
+  );
+
+  const handleSlotLockChange = useCallback(
+    async (slotIds: number[], locked: boolean, label?: string) => {
+      if (slotIds.length === 0) return;
+      const slotIdSet = new Set(slotIds);
+      setSlots((prev) =>
+        prev.map((slot) => (slotIdSet.has(slot.id) ? { ...slot, locked } : slot)),
+      );
+      const actionLabel =
+        label ??
+        `${locked ? 'Lock' : 'Unlock'} ${slotIds.length === 1 ? 'slot' : `${slotIds.length} slots`}`;
+      const save = async () => {
+        const current = await api.getSetDocument(setId);
+        return api.putSetDocument(setId, lockSlotsInDocument(current, slotIds, locked));
+      };
+      try {
+        const run = commit ? commit(actionLabel, save) : save();
+        await run;
+        await loadSlots();
+      } catch {
+        await loadSlots();
+      }
+    },
     [commit, loadSlots, setId],
   );
+
+  const handleLockBeforePlayhead = useCallback(async () => {
+    let startSec = 0;
+    const ids: number[] = [];
+    for (const slot of slots) {
+      if (startSec < positionSec && !slot.locked) ids.push(slot.id);
+      startSec += slot.track.durationSec;
+    }
+    await handleSlotLockChange(ids, true, 'Lock slots before playhead');
+  }, [handleSlotLockChange, positionSec, slots]);
 
   useEffect(() => {
     onProjectionChange?.(projection);
@@ -438,6 +488,8 @@ export default function BuilderWorkspace({
           scrollRequest={scrollRequest}
           onPairingAction={handlePairingAction}
           onPoolTrackDrop={handlePoolTrackDrop}
+          onSlotLockChange={handleSlotLockChange}
+          onLockBeforePlayhead={handleLockBeforePlayhead}
         />
       </section>
     </>

--- a/dashboard/app/(dj)/setbuilder/components/ChatSidebar.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/ChatSidebar.tsx
@@ -49,7 +49,10 @@ function formatAgentError(error: unknown): string {
 }
 
 function lockSkipReasons(tool: AppliedToolCall): string[] {
-  const skipped = tool.result.skipped_slots ?? tool.result.skippedSlots ?? tool.result.skipped;
+  const result = tool.result;
+  if (!result || typeof result !== 'object') return [];
+  const data = result as Record<string, unknown>;
+  const skipped = data.skipped_slots ?? data.skippedSlots ?? data.skipped;
   if (!Array.isArray(skipped)) return [];
   return skipped
     .map((item) => {

--- a/dashboard/app/(dj)/setbuilder/components/ChatSidebar.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/ChatSidebar.tsx
@@ -40,14 +40,45 @@ function formatFlag(type: string): string {
   return type.replaceAll('_', ' ');
 }
 
+function formatAgentError(error: unknown): string {
+  const message = error instanceof Error ? error.message : 'Agent request failed';
+  if (/locked/i.test(message)) {
+    return 'Skipped because a locked slot would be changed. Unlock that slot before editing it.';
+  }
+  return message;
+}
+
+function lockSkipReasons(tool: AppliedToolCall): string[] {
+  const skipped = tool.result.skipped_slots ?? tool.result.skippedSlots ?? tool.result.skipped;
+  if (!Array.isArray(skipped)) return [];
+  return skipped
+    .map((item) => {
+      if (!item || typeof item !== 'object') return null;
+      const reason = 'reason' in item ? String(item.reason ?? '') : '';
+      if (!/lock/i.test(reason)) return null;
+      const slot =
+        'slot_position' in item && typeof item.slot_position === 'number'
+          ? `slot ${item.slot_position + 1}`
+          : 'a slot';
+      return `Skipped ${slot} because it is locked.`;
+    })
+    .filter((reason): reason is string => Boolean(reason));
+}
+
 function ToolCard({ tool }: { tool: AppliedToolCall }) {
   const args = JSON.stringify(tool.args);
+  const skippedLocks = lockSkipReasons(tool);
   return (
     <div className={styles.toolCallCard} data-testid="agent-tool-card">
       <span className={styles.toolName}>{tool.name}</span>
       <div className={styles.toolBody}>
         <div className={styles.toolArgs}>{args}</div>
         {tool.rationale && <div className={styles.toolRationale}>&quot;{tool.rationale}&quot;</div>}
+        {skippedLocks.map((reason) => (
+          <div key={reason} className={styles.toolRationale} data-testid="agent-lock-skip">
+            {reason}
+          </div>
+        ))}
       </div>
     </div>
   );
@@ -162,7 +193,7 @@ export default function ChatSidebar({
       ]);
       if (result.tool_calls.some((tool) => tool.mutating)) onMutationApplied();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Agent request failed');
+      setError(formatAgentError(err));
     } finally {
       setBusy(false);
     }
@@ -201,7 +232,11 @@ export default function ChatSidebar({
       </div>
 
       {critique && <CritiqueCard critique={critique} persona={persona} />}
-      {error && <div className={styles.chatError}>{error}</div>}
+      {error && (
+        <div className={styles.chatError} role="alert">
+          {error}
+        </div>
+      )}
 
       <div className={styles.chatScroll} ref={scrollRef}>
         {entries.length === 0 && (

--- a/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurveEditor.tsx
@@ -749,6 +749,8 @@ export default function CurveEditor({
         {/* Slot blocks */}
         {showBlocks &&
           blocks.map((b) => {
+            const slot = slots[b.idx];
+            const isLocked = Boolean(slot?.locked);
             const isHover = hoveredIdx === b.idx;
             const isDragging = dragIdx === b.idx;
             const gap = view === 'normal' ? 1.5 : 4;
@@ -760,6 +762,7 @@ export default function CurveEditor({
               <g
                 key={`sb-${b.idx}`}
                 data-testid={`slot-block-${b.idx}`}
+                data-locked={isLocked ? 'true' : 'false'}
                 onMouseEnter={() => onHover(b.idx)}
                 onMouseLeave={() => onHover(null)}
                 onClick={(ev) => {
@@ -779,10 +782,50 @@ export default function CurveEditor({
                 width={Math.max(1, b.width - gap)}
                 height={blockH}
                 fill={NEON}
-                fillOpacity={isHover ? 0.55 : 0.13}
-                stroke={isHover || isDragging ? NEON : 'transparent'}
+                fillOpacity={isLocked ? (isHover ? 0.28 : 0.18) : isHover ? 0.55 : 0.13}
+                stroke={isLocked ? '#fbbf24' : isHover || isDragging ? NEON : 'transparent'}
                 strokeWidth={isHover || isDragging ? 1.5 : 1}
               />
+              {isLocked && (
+                <>
+                  <rect
+                    x={b.x0 + gap / 2}
+                    y={0}
+                    width={Math.max(1, b.width - gap)}
+                    height={h}
+                    fill="#fbbf24"
+                    fillOpacity={isHover ? 0.08 : 0.045}
+                    pointerEvents="none"
+                  />
+                  <SvgFixedGroup
+                    x={Math.min(Math.max(b.xMid, 12), effectiveViewportWidth - 12)}
+                    y={Math.max(16, h - blockH - 10)}
+                    scaleX={fixedLabelScaleX}
+                    scaleY={fixedLabelScaleY}
+                    pointerEvents="none"
+                    data-testid={`slot-lock-icon-${b.idx}`}
+                  >
+                    <rect
+                      x={-9}
+                      y={-9}
+                      width={18}
+                      height={18}
+                      rx={3}
+                      fill="var(--bg)"
+                      stroke="#fbbf24"
+                      strokeOpacity={0.75}
+                    />
+                    <path
+                      d="M-4 -1v-2.2a4 4 0 0 1 8 0V-1M-5 -1h10v7H-5Z"
+                      fill="none"
+                      stroke="#fbbf24"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="1.3"
+                    />
+                  </SvgFixedGroup>
+                </>
+              )}
               {/* Peak cap */}
               {b.energy >= 8 && (
                 <rect
@@ -1002,6 +1045,7 @@ export default function CurveEditor({
         {/* Drag handles — one per slot at its target energy */}
         {showSlotHandles &&
           blocks.map((b) => {
+            if (slots[b.idx]?.locked) return null;
             const isHover = hoveredIdx === b.idx;
             const isDragging = dragIdx === b.idx;
             const r = isDragging ? 7 : isHover ? 6 : 5;

--- a/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/CurvePanel.tsx
@@ -164,6 +164,8 @@ export default function CurvePanel({
   const zoomLabel = curveFitMode
     ? 'Fit'
     : `${Math.round(effectiveCurvePxPerSecond * 60)} px/min`;
+  const lockedCount = slots.filter((slot) => slot.locked).length;
+  const unlockedCount = Math.max(0, slots.length - lockedCount);
 
   const zoomCurve = (direction: 'in' | 'out') => {
     const next = zoomPxPerSecond({
@@ -278,6 +280,10 @@ export default function CurvePanel({
   const handleTargetDragEnd = (idx: number, energy: number, anchor: { x: number; y: number }) => {
     const slot = slots[idx];
     if (!slot) return;
+    if (slot.locked) {
+      setPrompt(null);
+      return;
+    }
     onSlotsChange((prev) => prev.map((s, i) => (i === idx ? { ...s, targetEnergy: energy } : s)));
     const save = () => api.updateSlotTarget(setId, slot.id, energy);
     const run = commit ? commit(`Retarget slot ${idx + 1}`, save) : save();
@@ -302,8 +308,13 @@ export default function CurvePanel({
           <>
             <p>This reruns builder placement against the current curve, pool, and pairings.</p>
             <ul>
-              <li>Unlocked slots may reorder and overwrite manual order changes.</li>
-              <li>Locked slots stay put.</li>
+              <li>
+                {lockedCount} locked {lockedCount === 1 ? 'slot stays' : 'slots stay'} put.
+              </li>
+              <li>
+                {unlockedCount} unlocked {unlockedCount === 1 ? 'slot may' : 'slots may'} reorder
+                and overwrite manual order changes.
+              </li>
               <li>Saved pairings are weighted during placement.</li>
               <li>The action is undoable from the topbar or with Ctrl/Cmd+Z.</li>
             </ul>

--- a/dashboard/app/(dj)/setbuilder/components/ReplacePopover.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/ReplacePopover.tsx
@@ -38,6 +38,7 @@ export default function ReplacePopover({
   const cur = slot.track;
   const target = prompt.targetEnergy;
   const dir = target - cur.energy > 0 ? 'higher' : 'lower';
+  const replacementDisabled = slot.locked;
 
   return (
     <>
@@ -65,13 +66,22 @@ export default function ReplacePopover({
             </div>
             <div className={styles.popoverSub}>
               &ldquo;{cur.title}&rdquo; is energy {cur.energy} — you&rsquo;ve dialed the target{' '}
-              {dir}. Replace with a track that fits?
+              {dir}.{' '}
+              {replacementDisabled
+                ? 'Replacement was skipped because locked slots are protected.'
+                : 'Replace with a track that fits?'}
             </div>
           </div>
           <button className="btn btn-sm" onClick={onDismiss} title="Keep current track">
             ✕
           </button>
         </div>
+
+        {replacementDisabled && (
+          <div className={styles.popoverLocked} data-testid="replace-locked">
+            Skipped because this slot is locked. Unlock the slot before replacing its track.
+          </div>
+        )}
 
         {candidates.length === 0 && (
           <div className={styles.popoverEmpty} data-testid="replace-empty">
@@ -84,8 +94,13 @@ export default function ReplacePopover({
           {candidates.map((c) => (
             <button
               key={c.track.id}
-              className={styles.candidate}
-              onClick={() => onReplace(slot.id, c.track.id)}
+              className={`${styles.candidate} ${
+                replacementDisabled ? styles.candidateDisabled : ''
+              }`}
+              onClick={() => {
+                if (!replacementDisabled) onReplace(slot.id, c.track.id);
+              }}
+              disabled={replacementDisabled}
               data-testid={`replace-candidate-${c.track.id}`}
             >
               <div style={{ flex: 1, minWidth: 0 }}>

--- a/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
@@ -39,6 +39,8 @@ export interface TimelinePanelProps {
   scrollRequest: ScrollRequest | null;
   onPairingAction?: (idx: number) => void | Promise<void>;
   onPoolTrackDrop?: (poolTrackId: number, insertIdx: number) => void | Promise<void>;
+  onSlotLockChange?: (slotIds: number[], locked: boolean) => void | Promise<void>;
+  onLockBeforePlayhead?: () => void | Promise<void>;
 }
 
 const ESTIMATED_SLOT_GROUP_HEIGHT = 52;
@@ -67,14 +69,28 @@ export default function TimelinePanel({
   scrollRequest,
   onPairingAction,
   onPoolTrackDrop,
+  onSlotLockChange,
+  onLockBeforePlayhead,
 }: TimelinePanelProps) {
   const listRef = useRef<HTMLDivElement>(null);
   const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
   const handledScrollRequestNRef = useRef<number | null>(null);
   const [menu, setMenu] = useState<TimelineMenu | null>(null);
   const [dropIdx, setDropIdx] = useState<number | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(0);
+  const selectedSlotIds = useMemo(() => [...selectedIds], [selectedIds]);
+  const selectedCount = selectedIds.size;
+  const slotsBeforePlayhead = useMemo(() => {
+    let startSec = 0;
+    const ids: number[] = [];
+    for (const slot of slots) {
+      if (startSec < positionSec && !slot.locked) ids.push(slot.id);
+      startSec += slot.track.durationSec;
+    }
+    return ids;
+  }, [positionSec, slots]);
 
   const measurementKey = useMemo(() => timelineMeasurementKey(slots), [slots]);
   const virtual = useMeasuredVirtualList({
@@ -161,6 +177,14 @@ export default function TimelinePanel({
     };
   }, [menu]);
 
+  useEffect(() => {
+    const visibleIds = new Set(slots.map((slot) => slot.id));
+    setSelectedIds((prev) => {
+      const next = new Set([...prev].filter((id) => visibleIds.has(id)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [slots]);
+
   const measureSlotGroup = useCallback(
     (idx: number, el: HTMLDivElement | null) => {
       if (!el) return;
@@ -187,6 +211,11 @@ export default function TimelinePanel({
 
   const markPoolTrackDrop = (event: DragEvent<HTMLElement>, insertIdx: number) => {
     event.preventDefault();
+    if (slots.some((slot, idx) => slot.locked && idx >= insertIdx)) {
+      event.dataTransfer.dropEffect = 'none';
+      setDropIdx(null);
+      return;
+    }
     event.dataTransfer.dropEffect = 'copy';
     setDropIdx(insertIdx);
   };
@@ -195,9 +224,27 @@ export default function TimelinePanel({
     event.preventDefault();
     event.stopPropagation();
     setDropIdx(null);
+    if (slots.some((slot, idx) => slot.locked && idx >= insertIdx)) return;
     const payload = readPoolTrackDragPayload(event.dataTransfer);
     if (!payload) return;
     void onPoolTrackDrop?.(payload.poolTrackId, insertIdx);
+  };
+
+  const setSlotSelected = (slotId: number, selected: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (selected) next.add(slotId);
+      else next.delete(slotId);
+      return next;
+    });
+  };
+
+  const clearSelection = () => setSelectedIds(new Set());
+
+  const changeSelectedLock = (locked: boolean) => {
+    if (selectedSlotIds.length === 0) return;
+    void onSlotLockChange?.(selectedSlotIds, locked);
+    clearSelection();
   };
 
   const markPoolTrackDropAtPointer = (event: DragEvent<HTMLElement>) => {
@@ -229,68 +276,106 @@ export default function TimelinePanel({
   }
 
   return (
-    <div
-      className={`${styles.timelineList} ${dropIdx === slots.length ? styles.timelineListDrop : ''}`}
-      ref={listRef}
-      data-testid="timeline-list"
-      data-virtualized="true"
-      onScroll={handleScroll}
-      onDragOver={markPoolTrackDropAtPointer}
-      onDragLeave={clearDropIfLeaving}
-      onDrop={handlePoolTrackDropAtPointer}
-    >
-      <div style={{ height: beforeHeight }} aria-hidden="true" />
-      {items.map(({ idx }) => {
-        const slot = slots[idx];
-        if (!slot) return null;
-
-        return (
-          <TimelineRow
-            key={slot.id}
-            slot={slot}
-            prevSlot={idx > 0 ? slots[idx - 1] : null}
-            nextSlot={idx < slots.length - 1 ? slots[idx + 1] : null}
-            idx={idx}
-            slots={slots}
-            hoveredIdx={hoveredIdx}
-            currentIdx={currentIdx}
-            positionSec={positionSec}
-            playing={playing}
-            dropIdx={dropIdx}
-            setDropIdx={setDropIdx}
-            onHover={onHover}
-            onRowDoubleClick={onRowDoubleClick}
-            onPoolTrackDrop={onPoolTrackDrop}
-            setMenu={setMenu}
-            setRowRef={(rowIdx, el) => {
-              rowRefs.current[rowIdx] = el;
-            }}
-            measureRef={measureSlotGroup}
-          />
-        );
-      })}
-      <div style={{ height: afterHeight }} aria-hidden="true" />
-      {menu && (
-        <div
-          className={styles.timelineContextMenu}
-          style={{ left: menu.x, top: menu.y }}
-          onClick={(event) => event.stopPropagation()}
-          data-testid="timeline-context-menu"
+    <>
+      <div className={styles.timelineBulkBar} data-testid="timeline-lock-toolbar">
+        <span className={styles.timelineBulkCount}>
+          {selectedCount > 0 ? `${selectedCount} selected` : 'No selection'}
+        </span>
+        <button
+          type="button"
+          className={styles.timelineBulkBtn}
+          onClick={() => changeSelectedLock(true)}
+          disabled={selectedCount === 0}
+          data-testid="timeline-lock-selected"
         >
-          <button
-            type="button"
-            className={styles.timelineContextItem}
-            onClick={() => {
-              onPairingAction?.(menu.idx);
-              setMenu(null);
-            }}
+          Lock selected
+        </button>
+        <button
+          type="button"
+          className={styles.timelineBulkBtn}
+          onClick={() => changeSelectedLock(false)}
+          disabled={selectedCount === 0}
+          data-testid="timeline-unlock-selected"
+        >
+          Unlock selected
+        </button>
+        <button
+          type="button"
+          className={styles.timelineBulkBtn}
+          onClick={() => void onLockBeforePlayhead?.()}
+          disabled={slotsBeforePlayhead.length === 0}
+          data-testid="timeline-lock-before-playhead"
+          title="Lock every unlocked slot whose start time is before the playhead"
+        >
+          Lock before playhead
+        </button>
+      </div>
+      <div
+        className={`${styles.timelineList} ${dropIdx === slots.length ? styles.timelineListDrop : ''}`}
+        ref={listRef}
+        data-testid="timeline-list"
+        data-virtualized="true"
+        onScroll={handleScroll}
+        onDragOver={markPoolTrackDropAtPointer}
+        onDragLeave={clearDropIfLeaving}
+        onDrop={handlePoolTrackDropAtPointer}
+      >
+        <div style={{ height: beforeHeight }} aria-hidden="true" />
+        {items.map(({ idx }) => {
+          const slot = slots[idx];
+          if (!slot) return null;
+
+          return (
+            <TimelineRow
+              key={slot.id}
+              slot={slot}
+              prevSlot={idx > 0 ? slots[idx - 1] : null}
+              nextSlot={idx < slots.length - 1 ? slots[idx + 1] : null}
+              idx={idx}
+              slots={slots}
+              hoveredIdx={hoveredIdx}
+              currentIdx={currentIdx}
+              positionSec={positionSec}
+              playing={playing}
+              selected={selectedIds.has(slot.id)}
+              dropIdx={dropIdx}
+              setDropIdx={setDropIdx}
+              onHover={onHover}
+              onRowDoubleClick={onRowDoubleClick}
+              onPoolTrackDrop={onPoolTrackDrop}
+              onSelectedChange={(selected) => setSlotSelected(slot.id, selected)}
+              onToggleLock={() => void onSlotLockChange?.([slot.id], !slot.locked)}
+              setMenu={setMenu}
+              setRowRef={(rowIdx, el) => {
+                rowRefs.current[rowIdx] = el;
+              }}
+              measureRef={measureSlotGroup}
+            />
+          );
+        })}
+        <div style={{ height: afterHeight }} aria-hidden="true" />
+        {menu && (
+          <div
+            className={styles.timelineContextMenu}
+            style={{ left: menu.x, top: menu.y }}
+            onClick={(event) => event.stopPropagation()}
+            data-testid="timeline-context-menu"
           >
-            {slots[menu.idx]?.nextIsDjPairing
-              ? 'Open saved pairing'
-              : `Save -> ${slots[menu.idx + 1]?.track.title ?? 'next'} as pairing`}
-          </button>
-        </div>
-      )}
-    </div>
+            <button
+              type="button"
+              className={styles.timelineContextItem}
+              onClick={() => {
+                onPairingAction?.(menu.idx);
+                setMenu(null);
+              }}
+            >
+              {slots[menu.idx]?.nextIsDjPairing
+                ? 'Open saved pairing'
+                : `Save -> ${slots[menu.idx + 1]?.track.title ?? 'next'} as pairing`}
+            </button>
+          </div>
+        )}
+      </div>
+    </>
   );
 }

--- a/dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx
@@ -24,11 +24,14 @@ export interface TimelineRowProps {
   currentIdx: number;
   positionSec: number;
   playing: boolean;
+  selected: boolean;
   dropIdx: number | null;
   setDropIdx: Dispatch<SetStateAction<number | null>>;
   onHover: (idx: number | null) => void;
   onRowDoubleClick?: (idx: number) => void;
   onPoolTrackDrop?: (poolTrackId: number, insertIdx: number) => void | Promise<void>;
+  onSelectedChange: (selected: boolean) => void;
+  onToggleLock?: () => void | Promise<void>;
   setMenu: Dispatch<SetStateAction<TimelineMenu | null>>;
   setRowRef?: (idx: number, el: HTMLDivElement | null) => void;
   measureRef?: (idx: number, el: HTMLDivElement | null) => void;
@@ -44,11 +47,14 @@ export default function TimelineRow({
   currentIdx,
   positionSec,
   playing,
+  selected,
   dropIdx,
   setDropIdx,
   onHover,
   onRowDoubleClick,
   onPoolTrackDrop,
+  onSelectedChange,
+  onToggleLock,
   setMenu,
   setRowRef,
   measureRef,
@@ -69,6 +75,9 @@ export default function TimelineRow({
   const pairingActionLabel = slot.nextIsDjPairing
     ? `Open saved pairing after ${slot.track.title}`
     : `Save ${slot.track.title} into ${nextSlot?.track.title ?? 'next track'} as pairing`;
+  const dropWouldMoveLockedSlot = slots.some(
+    (candidate, candidateIdx) => candidate.locked && candidateIdx >= idx,
+  );
   const handleMeasureRef = useCallback(
     (el: HTMLDivElement | null) => {
       measureRef?.(idx, el);
@@ -84,6 +93,11 @@ export default function TimelineRow({
 
   const markPoolTrackDrop = (event: DragEvent<HTMLElement>, insertIdx: number) => {
     event.preventDefault();
+    if (dropWouldMoveLockedSlot) {
+      event.dataTransfer.dropEffect = 'none';
+      setDropIdx(null);
+      return;
+    }
     event.dataTransfer.dropEffect = 'copy';
     setDropIdx(insertIdx);
   };
@@ -92,6 +106,7 @@ export default function TimelineRow({
     event.preventDefault();
     event.stopPropagation();
     setDropIdx(null);
+    if (dropWouldMoveLockedSlot) return;
     const payload = readPoolTrackDragPayload(event.dataTransfer);
     if (!payload) return;
     void onPoolTrackDrop?.(payload.poolTrackId, insertIdx);
@@ -136,7 +151,11 @@ export default function TimelineRow({
         ref={handleRowRef}
         className={`${styles.timelineRow} ${hoveredIdx === idx ? styles.timelineRowHover : ''} ${
           isCurrent ? styles.timelineRowNow : ''
-        } ${dropIdx === idx ? styles.timelineRowDrop : ''}`}
+        } ${dropIdx === idx ? styles.timelineRowDrop : ''} ${
+          slot.locked ? styles.timelineRowLocked : ''
+        }`}
+        data-locked={slot.locked ? 'true' : 'false'}
+        draggable={false}
         onMouseEnter={() => onHover(idx)}
         onMouseLeave={() => onHover(null)}
         onDoubleClick={() => onRowDoubleClick?.(idx)}
@@ -182,6 +201,20 @@ export default function TimelineRow({
             String(idx + 1).padStart(2, '0')
           )}
         </span>
+        <label
+          className={styles.timelineSelect}
+          title={`Select slot ${idx + 1}`}
+          onClick={(event) => event.stopPropagation()}
+          onDoubleClick={(event) => event.stopPropagation()}
+        >
+          <input
+            type="checkbox"
+            checked={selected}
+            aria-label={`Select slot ${idx + 1}`}
+            data-testid={`timeline-select-${idx}`}
+            onChange={(event) => onSelectedChange(event.currentTarget.checked)}
+          />
+        </label>
         <span className={styles.timelineTitle}>
           {slot.track.title}
           {slot.track.artist ? (
@@ -197,6 +230,56 @@ export default function TimelineRow({
         <span className={styles.timelineTarget} title="Target energy">
           ◎ {effectiveTarget(slot).toFixed(1)}
         </span>
+        {slot.locked ? (
+          <span className={styles.timelineLockBadge} data-testid={`timeline-lock-badge-${idx}`}>
+            <svg width="12" height="12" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M7 10V8a5 5 0 0 1 10 0v2M6.5 10h11a1.5 1.5 0 0 1 1.5 1.5v7A1.5 1.5 0 0 1 17.5 20h-11A1.5 1.5 0 0 1 5 18.5v-7A1.5 1.5 0 0 1 6.5 10Z"
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.8"
+              />
+            </svg>
+            Locked
+          </span>
+        ) : null}
+        <button
+          type="button"
+          className={styles.timelineLockToggle}
+          aria-label={`${slot.locked ? 'Unlock' : 'Lock'} slot ${idx + 1}`}
+          title={`${slot.locked ? 'Unlock' : 'Lock'} slot ${idx + 1}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            void onToggleLock?.();
+          }}
+          data-testid={`timeline-lock-toggle-${idx}`}
+        >
+          {slot.locked ? (
+            <svg width="13" height="13" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M8 10V8a4 4 0 0 1 7.6-1.8M6.5 10h11a1.5 1.5 0 0 1 1.5 1.5v7A1.5 1.5 0 0 1 17.5 20h-11A1.5 1.5 0 0 1 5 18.5v-7A1.5 1.5 0 0 1 6.5 10Z"
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.8"
+              />
+            </svg>
+          ) : (
+            <svg width="13" height="13" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M7 10V8a5 5 0 0 1 10 0v2M6.5 10h11a1.5 1.5 0 0 1 1.5 1.5v7A1.5 1.5 0 0 1 17.5 20h-11A1.5 1.5 0 0 1 5 18.5v-7A1.5 1.5 0 0 1 6.5 10Z"
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.8"
+              />
+            </svg>
+          )}
+        </button>
         {idx < slots.length - 1 && (
           <button
             type="button"

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/ChatSidebar.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/ChatSidebar.test.tsx
@@ -64,6 +64,33 @@ describe('ChatSidebar', () => {
     expect(onMutationApplied).toHaveBeenCalledTimes(1);
   });
 
+  it('renders tool calls when an agent result is null', async () => {
+    mockApi.chatWithSetAgent.mockResolvedValueOnce({
+      message: 'Skipped locked slots.',
+      tool_calls: [
+        {
+          id: 'lock-1',
+          name: 'lock_slots',
+          args: { slot_ids: [1] },
+          rationale: null,
+          result: null,
+          mutating: false,
+        },
+      ],
+      slots: [],
+      affected_transition_scores: [],
+    });
+    render(<ChatSidebar setId={9} open onToggle={vi.fn()} onMutationApplied={vi.fn()} />);
+    await screen.findByTestId('critique-card');
+
+    fireEvent.change(screen.getByPlaceholderText(/tell the agent/i), {
+      target: { value: 'lock the opener' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    expect(await screen.findByTestId('agent-tool-card')).toHaveTextContent('lock_slots');
+  });
+
   it('explains when the agent skips an edit because a slot is locked', async () => {
     mockApi.chatWithSetAgent.mockRejectedValueOnce(new Error('Locked slots cannot be moved'));
     render(<ChatSidebar setId={9} open onToggle={vi.fn()} onMutationApplied={vi.fn()} />);

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/ChatSidebar.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/ChatSidebar.test.tsx
@@ -63,4 +63,19 @@ describe('ChatSidebar', () => {
     expect(screen.getByText(/slot 2: 88/i)).toBeInTheDocument();
     expect(onMutationApplied).toHaveBeenCalledTimes(1);
   });
+
+  it('explains when the agent skips an edit because a slot is locked', async () => {
+    mockApi.chatWithSetAgent.mockRejectedValueOnce(new Error('Locked slots cannot be moved'));
+    render(<ChatSidebar setId={9} open onToggle={vi.fn()} onMutationApplied={vi.fn()} />);
+    await screen.findByTestId('critique-card');
+
+    fireEvent.change(screen.getByPlaceholderText(/tell the agent/i), {
+      target: { value: 'move the locked opener' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Skipped because a locked slot would be changed',
+    );
+  });
 });

--- a/dashboard/app/(dj)/setbuilder/components/curve.module.css
+++ b/dashboard/app/(dj)/setbuilder/components/curve.module.css
@@ -646,6 +646,19 @@
   margin-top: 0.2rem;
 }
 
+.popoverLocked {
+  display: flex;
+  align-items: center;
+  margin: 0.35rem 0 0.5rem;
+  padding: 0.45rem 0.55rem;
+  border: 1px solid rgba(251, 191, 36, 0.42);
+  border-radius: 6px;
+  background: rgba(251, 191, 36, 0.1);
+  color: #fbbf24;
+  font-size: 0.6875rem;
+  line-height: 1.35;
+}
+
 .candidate {
   display: flex;
   align-items: center;
@@ -661,6 +674,13 @@
 
 .candidate:hover {
   background: var(--surface-raised);
+}
+
+.candidateDisabled,
+.candidateDisabled:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+  background: transparent;
 }
 
 .candidateTitle {
@@ -915,6 +935,45 @@
 }
 
 /* Timeline panel */
+.timelineBulkBar {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  padding: 0.45rem 0.55rem;
+  border-bottom: 1px solid var(--border-subtle);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.timelineBulkCount {
+  color: var(--text-tertiary);
+  font-size: 0.625rem;
+  font-family: var(--font-mono, monospace);
+  min-width: 6.5rem;
+}
+
+.timelineBulkBtn {
+  min-height: 26px;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-raised);
+  color: var(--text-secondary);
+  font-size: 0.625rem;
+  cursor: pointer;
+}
+
+.timelineBulkBtn:hover:not(:disabled),
+.timelineBulkBtn:focus-visible:not(:disabled) {
+  color: var(--text);
+  border-color: rgba(0, 245, 212, 0.48);
+}
+
+.timelineBulkBtn:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
 .timelineList {
   flex: 1;
   overflow-y: auto;
@@ -980,13 +1039,22 @@
 .timelineRow {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: 0.45rem;
   padding: 0.45rem 0.6rem;
   border-left: 3px solid transparent;
   border-bottom: 1px solid var(--border-subtle);
   cursor: pointer;
   position: relative;
   overflow: hidden;
+}
+
+.timelineRowLocked {
+  background: linear-gradient(90deg, rgba(251, 191, 36, 0.1), rgba(251, 191, 36, 0.025) 42%, transparent);
+  border-left-color: rgba(251, 191, 36, 0.72);
+}
+
+.timelineRowLocked .timelineTitle {
+  color: #f8e4a9;
 }
 
 .timelineRowHover {
@@ -1030,6 +1098,24 @@
   justify-content: center;
   position: relative;
   z-index: 1;
+}
+
+.timelineSelect {
+  width: 16px;
+  height: 16px;
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 16px;
+  position: relative;
+  z-index: 1;
+}
+
+.timelineSelect input {
+  width: 13px;
+  height: 13px;
+  margin: 0;
+  accent-color: #00f5d4;
+  cursor: pointer;
 }
 
 .rowVu {
@@ -1116,6 +1202,45 @@
   white-space: nowrap;
   position: relative;
   z-index: 1;
+}
+
+.timelineLockBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  min-height: 20px;
+  padding: 0.08rem 0.35rem;
+  border: 1px solid rgba(251, 191, 36, 0.48);
+  border-radius: 4px;
+  background: rgba(251, 191, 36, 0.11);
+  color: #fbbf24;
+  font-size: 0.5625rem;
+  font-weight: 700;
+  white-space: nowrap;
+  position: relative;
+  z-index: 1;
+}
+
+.timelineLockToggle {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 24px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  background: var(--surface-raised);
+  color: var(--text-tertiary);
+  cursor: pointer;
+  position: relative;
+  z-index: 1;
+}
+
+.timelineLockToggle:hover,
+.timelineLockToggle:focus-visible {
+  color: #fbbf24;
+  border-color: rgba(251, 191, 36, 0.52);
 }
 
 .timelinePairingAction {


### PR DESCRIPTION
## Summary
- Add clearer locked-slot affordances across timeline rows, curve blocks, replacement prompts, and agent messaging.
- Add bulk lock/unlock controls, including lock-before-playhead behavior.
- Add regression coverage for locked-slot display and lock-aware flows.

## Design decisions
- Kept this scoped to locked-slot UX and did not implement the separate mobile reorder issue.
- Used the existing setbuilder document snapshot path for lock updates so changes remain undoable with current builder history.

## Tests
- npm run lint
- npx tsc --noEmit
- npm test -- --run

Closes #397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added slot lock/unlock for individual rows and bulk selection, plus “Lock before playhead.”
  * Locked slots now show clear visual indicators (badge/icon) and disable actions like moving, replacing, and retargeting.
  * Timeline/curve and recompute dialogs now display locked vs unlocked counts with correct singular/plural grammar.
  * Curve/replace flows now prevent interactions for locked slots and show locked-specific messaging.
* **Accessibility & Improvements**
  * Chat error/skip feedback is now normalized and announced via an alert region.
* **Tests**
  * Added/expanded coverage for lock-related UI behavior and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->