### PR TITLE
feat: add setbuilder community vibe controls

### DIFF
--- a/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
@@ -85,7 +85,7 @@ export default function PoolPanel({
   const [showVibes, setShowVibes] = useState(false);
   const [vibesLoaded, setVibesLoaded] = useState(false);
   const [vibesBusy, setVibesBusy] = useState(false);
-  const [vibeWriteBusyId, setVibeWriteBusyId] = useState<number | null>(null);
+  const [vibeWriteBusyIds, setVibeWriteBusyIds] = useState<Set<number>>(new Set());
   const addMenuRef = useRef<HTMLSpanElement | null>(null);
   const contextMenuRef = useRef<HTMLDivElement | null>(null);
 
@@ -268,16 +268,22 @@ export default function PoolPanel({
 
   const agreeVibe = useCallback(
     async (poolTrackId: number) => {
-      setVibeWriteBusyId(poolTrackId);
+      setVibeWriteBusyIds((prev) => new Set(prev).add(poolTrackId));
       try {
         const result = await api.agreePoolVibe(setId, poolTrackId);
         setVibes(buildVibeMap(result.tracks));
         setVibesLoaded(true);
         setToast('Vibe upvoted');
+        return true;
       } catch (err) {
         setToast(err instanceof ApiError ? err.message : 'Vibe upvote failed');
+        return false;
       } finally {
-        setVibeWriteBusyId(null);
+        setVibeWriteBusyIds((prev) => {
+          const next = new Set(prev);
+          next.delete(poolTrackId);
+          return next;
+        });
       }
     },
     [setId],
@@ -285,16 +291,22 @@ export default function PoolPanel({
 
   const saveVibeOverride = useCallback(
     async (poolTrackId: number, payload: PoolVibeOverrideIn) => {
-      setVibeWriteBusyId(poolTrackId);
+      setVibeWriteBusyIds((prev) => new Set(prev).add(poolTrackId));
       try {
         const result = await api.overridePoolVibe(setId, poolTrackId, payload);
         setVibes(buildVibeMap(result.tracks));
         setVibesLoaded(true);
         setToast('Vibe override saved');
+        return true;
       } catch (err) {
         setToast(err instanceof ApiError ? err.message : 'Vibe override failed');
+        return false;
       } finally {
-        setVibeWriteBusyId(null);
+        setVibeWriteBusyIds((prev) => {
+          const next = new Set(prev);
+          next.delete(poolTrackId);
+          return next;
+        });
       }
     },
     [setId],
@@ -528,7 +540,7 @@ export default function PoolPanel({
                 {vibe && (
                   <VibeTiers
                     state={vibe}
-                    busy={vibeWriteBusyId === t.id}
+                    busy={vibeWriteBusyIds.has(t.id)}
                     onAgree={() => agreeVibe(t.id)}
                     onSaveOverride={(payload) => saveVibeOverride(t.id, payload)}
                   />

--- a/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
@@ -12,6 +12,7 @@ import type {
   PoolImportResult,
   PoolSource,
   PoolState,
+  PoolVibeOverrideIn,
   SetDocumentSnapshot,
   TrackVibeState,
 } from '@/lib/api-types';
@@ -84,6 +85,7 @@ export default function PoolPanel({
   const [showVibes, setShowVibes] = useState(false);
   const [vibesLoaded, setVibesLoaded] = useState(false);
   const [vibesBusy, setVibesBusy] = useState(false);
+  const [vibeWriteBusyId, setVibeWriteBusyId] = useState<number | null>(null);
   const addMenuRef = useRef<HTMLSpanElement | null>(null);
   const contextMenuRef = useRef<HTMLDivElement | null>(null);
 
@@ -263,6 +265,40 @@ export default function PoolPanel({
       setVibesBusy(false);
     }
   }, [setId]);
+
+  const agreeVibe = useCallback(
+    async (poolTrackId: number) => {
+      setVibeWriteBusyId(poolTrackId);
+      try {
+        const result = await api.agreePoolVibe(setId, poolTrackId);
+        setVibes(buildVibeMap(result.tracks));
+        setVibesLoaded(true);
+        setToast('Vibe upvoted');
+      } catch (err) {
+        setToast(err instanceof ApiError ? err.message : 'Vibe upvote failed');
+      } finally {
+        setVibeWriteBusyId(null);
+      }
+    },
+    [setId],
+  );
+
+  const saveVibeOverride = useCallback(
+    async (poolTrackId: number, payload: PoolVibeOverrideIn) => {
+      setVibeWriteBusyId(poolTrackId);
+      try {
+        const result = await api.overridePoolVibe(setId, poolTrackId, payload);
+        setVibes(buildVibeMap(result.tracks));
+        setVibesLoaded(true);
+        setToast('Vibe override saved');
+      } catch (err) {
+        setToast(err instanceof ApiError ? err.message : 'Vibe override failed');
+      } finally {
+        setVibeWriteBusyId(null);
+      }
+    },
+    [setId],
+  );
 
   const toggleSelect = (id: number) => {
     setSelected((prev) => {
@@ -489,7 +525,14 @@ export default function PoolPanel({
                     </span>
                   )}
                 </div>
-                {vibe && <VibeTiers state={vibe} />}
+                {vibe && (
+                  <VibeTiers
+                    state={vibe}
+                    busy={vibeWriteBusyId === t.id}
+                    onAgree={() => agreeVibe(t.id)}
+                    onSaveOverride={(payload) => saveVibeOverride(t.id, payload)}
+                  />
+                )}
               </div>
               <div
                 className={styles.poolTrackStripe}

--- a/dashboard/app/(dj)/setbuilder/components/VibeTiers.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/VibeTiers.tsx
@@ -2,14 +2,17 @@
 
 /**
  * Three-tier vibe display (issue #391) — DJ's own override, community
- * consensus, and globally-cached LLM guess, side by side. Read-only in v1
- * (write UX is v1.1). Low-confidence LLM guesses are flagged for review.
+ * consensus, and globally-cached LLM guess, side by side. Low-confidence
+ * LLM guesses are flagged for review. Optional callbacks expose the v1.1
+ * write controls without coupling this renderer to API calls.
  */
 
+import { useEffect, useState } from 'react';
 import type { TrackVibeState } from '@/lib/api-types';
 import styles from '../setbuilder.module.css';
 
 type TierSource = 'own' | 'community' | 'llm';
+type OverridePayload = { energy: number | null; mood: string | null };
 
 interface TierView {
   source: TierSource;
@@ -20,6 +23,18 @@ interface TierView {
   suffix: string | null;
   title: string | undefined;
   warn: boolean;
+}
+
+interface SourceIndicator {
+  label: string;
+  aria: string;
+}
+
+interface VibeTiersProps {
+  state: TrackVibeState;
+  busy?: boolean;
+  onAgree?: () => void;
+  onSaveOverride?: (payload: OverridePayload) => void;
 }
 
 function buildTiers(state: TrackVibeState): TierView[] {
@@ -63,6 +78,22 @@ function buildTiers(state: TrackVibeState): TierView[] {
   ];
 }
 
+function indicatorFor(state: TrackVibeState): SourceIndicator {
+  if (state.own) return { label: 'You', aria: 'Vibe source: your override' };
+  if (state.community) return { label: 'Crowd', aria: 'Vibe source: community consensus' };
+  if (state.llm) return { label: 'AI', aria: 'Vibe source: AI guess' };
+  return { label: 'None', aria: 'Vibe source: not set' };
+}
+
+function hasNonOwnVibe(state: TrackVibeState): boolean {
+  return Boolean(
+    state.community?.energy != null ||
+      state.community?.mood != null ||
+      state.llm?.energy != null ||
+      state.llm?.mood != null,
+  );
+}
+
 function chipAria(tier: TierView): string {
   const parts: string[] = [];
   if (tier.energy != null) parts.push(`energy ${tier.energy}`);
@@ -70,39 +101,131 @@ function chipAria(tier: TierView): string {
   return `${tier.ariaName}: ${parts.length ? parts.join(', ') : 'not set'}`;
 }
 
-export default function VibeTiers({ state }: { state: TrackVibeState }) {
+export default function VibeTiers({
+  state,
+  busy = false,
+  onAgree,
+  onSaveOverride,
+}: VibeTiersProps) {
+  const [editing, setEditing] = useState(false);
+  const [energy, setEnergy] = useState('');
+  const [mood, setMood] = useState('');
+  const indicator = indicatorFor(state);
+
+  useEffect(() => {
+    if (editing) return;
+    setEnergy(String(state.own?.energy ?? state.resolved.energy ?? ''));
+    setMood(state.own?.mood ?? state.resolved.mood ?? '');
+  }, [editing, state]);
+
+  const saveOverride = () => {
+    const trimmedEnergy = energy.trim();
+    const parsedEnergy = trimmedEnergy === '' ? null : Math.round(Number(trimmedEnergy));
+    onSaveOverride?.({
+      energy: Number.isFinite(parsedEnergy) ? parsedEnergy : null,
+      mood: mood.trim() || null,
+    });
+    setEditing(false);
+  };
+
   return (
-    <div className={styles.vibeTiers}>
-      {buildTiers(state).map((tier) => {
-        const empty = tier.energy == null && tier.mood == null;
-        // Per-field winner: a tier wins if it supplies the resolved energy OR mood.
-        const winner =
-          state.resolved.energy_source === tier.source ||
-          state.resolved.mood_source === tier.source;
-        const classes = [
-          styles.vibeChip,
-          empty ? styles.vibeEmpty : '',
-          tier.warn ? styles.vibeLow : '',
-          !empty && winner ? styles.vibeWinner : '',
-        ]
-          .filter(Boolean)
-          .join(' ');
-        return (
-          <span key={tier.source} className={classes} title={tier.title} aria-label={chipAria(tier)}>
-            {tier.warn && <span aria-hidden>⚠</span>}
-            <span className={styles.vibeChipLabel}>{tier.label}</span>
-            {empty ? (
-              <span>—</span>
-            ) : (
-              <>
-                {tier.energy != null && <span>E{tier.energy}</span>}
-                {tier.mood != null && <span>{tier.mood}</span>}
-                {tier.suffix && <span>{tier.suffix}</span>}
-              </>
+    <div className={styles.vibeBlock}>
+      <div className={styles.vibeTopRow}>
+        <span className={styles.vibeSource} aria-label={indicator.aria}>
+          {indicator.label}
+        </span>
+        <div className={styles.vibeTiers}>
+          {buildTiers(state).map((tier) => {
+            const empty = tier.energy == null && tier.mood == null;
+            // Per-field winner: a tier wins if it supplies the resolved energy OR mood.
+            const winner =
+              state.resolved.energy_source === tier.source ||
+              state.resolved.mood_source === tier.source;
+            const classes = [
+              styles.vibeChip,
+              empty ? styles.vibeEmpty : '',
+              tier.warn ? styles.vibeLow : '',
+              !empty && winner ? styles.vibeWinner : '',
+            ]
+              .filter(Boolean)
+              .join(' ');
+            return (
+              <span
+                key={tier.source}
+                className={classes}
+                title={tier.title}
+                aria-label={chipAria(tier)}
+              >
+                {tier.warn && <span aria-hidden>⚠</span>}
+                <span className={styles.vibeChipLabel}>{tier.label}</span>
+                {empty ? (
+                  <span>—</span>
+                ) : (
+                  <>
+                    {tier.energy != null && <span>E{tier.energy}</span>}
+                    {tier.mood != null && <span>{tier.mood}</span>}
+                    {tier.suffix && <span>{tier.suffix}</span>}
+                  </>
+                )}
+              </span>
+            );
+          })}
+        </div>
+        {(onAgree || onSaveOverride) && (
+          <span className={styles.vibeActions}>
+            {onAgree && (
+              <button
+                type="button"
+                className={styles.vibeActionBtn}
+                onClick={onAgree}
+                disabled={busy || !hasNonOwnVibe(state)}
+              >
+                Agree
+              </button>
+            )}
+            {onSaveOverride && (
+              <button
+                type="button"
+                className={styles.vibeActionBtn}
+                onClick={() => setEditing((open) => !open)}
+                disabled={busy}
+              >
+                Tweak
+              </button>
             )}
           </span>
-        );
-      })}
+        )}
+      </div>
+      {editing && onSaveOverride && (
+        <div className={styles.vibeEditForm}>
+          <label className={styles.vibeEditLabel}>
+            <span>Energy</span>
+            <input
+              className={styles.vibeNumber}
+              type="number"
+              min="0"
+              max="10"
+              value={energy}
+              onChange={(e) => setEnergy(e.target.value)}
+            />
+          </label>
+          <label className={styles.vibeEditLabel}>
+            <span>Mood</span>
+            <input
+              className={styles.vibeMood}
+              maxLength={50}
+              value={mood}
+              onChange={(e) => setMood(e.target.value)}
+            />
+          </label>
+          <button type="button" className={styles.vibeActionBtn} onClick={saveOverride}>
+            Save
+          </button>
+          <button type="button" className={styles.vibeActionBtn} onClick={() => setEditing(false)}>
+            Cancel
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/dashboard/app/(dj)/setbuilder/components/VibeTiers.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/VibeTiers.tsx
@@ -34,7 +34,7 @@ interface VibeTiersProps {
   state: TrackVibeState;
   busy?: boolean;
   onAgree?: () => void;
-  onSaveOverride?: (payload: OverridePayload) => void;
+  onSaveOverride?: (payload: OverridePayload) => boolean | Promise<boolean>;
 }
 
 function buildTiers(state: TrackVibeState): TierView[] {
@@ -118,14 +118,16 @@ export default function VibeTiers({
     setMood(state.own?.mood ?? state.resolved.mood ?? '');
   }, [editing, state]);
 
-  const saveOverride = () => {
+  const saveOverride = async () => {
     const trimmedEnergy = energy.trim();
     const parsedEnergy = trimmedEnergy === '' ? null : Math.round(Number(trimmedEnergy));
-    onSaveOverride?.({
+    const payload = {
       energy: Number.isFinite(parsedEnergy) ? parsedEnergy : null,
       mood: mood.trim() || null,
-    });
-    setEditing(false);
+    };
+    if (payload.energy == null && payload.mood == null) return;
+    const ok = (await onSaveOverride?.(payload)) ?? true;
+    if (ok) setEditing(false);
   };
 
   return (
@@ -218,7 +220,7 @@ export default function VibeTiers({
               onChange={(e) => setMood(e.target.value)}
             />
           </label>
-          <button type="button" className={styles.vibeActionBtn} onClick={saveOverride}>
+          <button type="button" className={styles.vibeActionBtn} onClick={saveOverride} disabled={busy}>
             Save
           </button>
           <button type="button" className={styles.vibeActionBtn} onClick={() => setEditing(false)}>

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
@@ -25,6 +25,8 @@ const mockApi = vi.hoisted(() => ({
   search: vi.fn(),
   getPoolVibes: vi.fn(),
   enrichPoolVibes: vi.fn(),
+  agreePoolVibe: vi.fn(),
+  overridePoolVibe: vi.fn(),
 }));
 
 vi.mock('@/lib/api', async (importOriginal) => {
@@ -103,6 +105,13 @@ const VIBE_STATE: TrackVibeState = {
 
 const POOL_VIBES: PoolVibesState = { tracks: [VIBE_STATE] };
 
+const COMMUNITY_VIBE_STATE: TrackVibeState = {
+  ...VIBE_STATE,
+  own: null,
+  community: { energy: 7, mood: 'dark', sample_size: 3 },
+  resolved: { energy: 7, energy_source: 'community', mood: 'dark', mood_source: 'community' },
+};
+
 const ENRICHED_VIBE_STATE: TrackVibeState = {
   ...VIBE_STATE,
   llm: {
@@ -126,6 +135,12 @@ const ENRICH_RESULT: VibeEnrichmentResult = {
   failed: 0,
   llm_calls: 2,
   vibes: { tracks: [ENRICHED_VIBE_STATE] },
+};
+
+const OVERRIDDEN_VIBE_STATE: TrackVibeState = {
+  ...COMMUNITY_VIBE_STATE,
+  own: { energy: 8, mood: 'gritty' },
+  resolved: { energy: 8, energy_source: 'own', mood: 'gritty', mood_source: 'own' },
 };
 
 beforeEach(() => {
@@ -339,6 +354,34 @@ describe('PoolPanel', () => {
     expect(await screen.findByText(/2 analyzed · 0 cached · 0 failed/)).toBeTruthy();
     // chips updated from the enrichment result — AI tier now populated
     expect(screen.getByLabelText('AI vibe: energy 5, mood happy')).toBeTruthy();
+  });
+
+  it('vibe controls agree and tweak pool-row ratings through the API', async () => {
+    mockApi.getPoolVibes.mockResolvedValue({ tracks: [COMMUNITY_VIBE_STATE] });
+    mockApi.agreePoolVibe.mockResolvedValue({ tracks: [COMMUNITY_VIBE_STATE] });
+    mockApi.overridePoolVibe.mockResolvedValue({ tracks: [OVERRIDDEN_VIBE_STATE] });
+    render(<PoolPanel setId={1} />);
+    await screen.findByText('Event Song');
+
+    fireEvent.click(screen.getByText('Vibes'));
+    expect(await screen.findByLabelText('Vibe source: community consensus')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Agree' }));
+    await waitFor(() => expect(mockApi.agreePoolVibe).toHaveBeenCalledWith(1, 11));
+    expect(await screen.findByText('Vibe upvoted')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tweak' }));
+    fireEvent.change(screen.getByLabelText('Energy'), { target: { value: '8' } });
+    fireEvent.change(screen.getByLabelText('Mood'), { target: { value: 'gritty' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(mockApi.overridePoolVibe).toHaveBeenCalledWith(1, 11, {
+        energy: 8,
+        mood: 'gritty',
+      })
+    );
+    expect(await screen.findByLabelText('Your vibe: energy 8, mood gritty')).toBeTruthy();
   });
 
   it('analyze failure surfaces ApiError 400 message, generic text otherwise', async () => {

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { act, render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { ApiError } from '@/lib/api';
 import type {
   PoolState,
@@ -142,6 +142,16 @@ const OVERRIDDEN_VIBE_STATE: TrackVibeState = {
   own: { energy: 8, mood: 'gritty' },
   resolved: { energy: 8, energy_source: 'own', mood: 'gritty', mood_source: 'own' },
 };
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -382,6 +392,70 @@ describe('PoolPanel', () => {
       })
     );
     expect(await screen.findByLabelText('Your vibe: energy 8, mood gritty')).toBeTruthy();
+  });
+
+  it('tracks overlapping vibe writes per pool track', async () => {
+    const secondCommunityVibe: TrackVibeState = {
+      ...COMMUNITY_VIBE_STATE,
+      pool_track_id: 12,
+      vibe_key: 'tidal artist|tidal song',
+    };
+    const firstWrite = deferred<PoolVibesState>();
+    const secondWrite = deferred<PoolVibesState>();
+    mockApi.getPoolVibes.mockResolvedValue({
+      tracks: [COMMUNITY_VIBE_STATE, secondCommunityVibe],
+    });
+    mockApi.agreePoolVibe
+      .mockReturnValueOnce(firstWrite.promise)
+      .mockReturnValueOnce(secondWrite.promise);
+    render(<PoolPanel setId={1} />);
+    await screen.findByText('Event Song');
+
+    fireEvent.click(screen.getByText('Vibes'));
+    const eventRow = await screen.findByTestId('pool-track-11');
+    const tidalRow = screen.getByTestId('pool-track-12');
+    const eventAgree = within(eventRow).getByRole('button', { name: 'Agree' });
+    const tidalAgree = within(tidalRow).getByRole('button', { name: 'Agree' });
+
+    fireEvent.click(eventAgree);
+    await waitFor(() => expect((eventAgree as HTMLButtonElement).disabled).toBe(true));
+    fireEvent.click(tidalAgree);
+
+    await waitFor(() => expect((tidalAgree as HTMLButtonElement).disabled).toBe(true));
+    expect((eventAgree as HTMLButtonElement).disabled).toBe(true);
+
+    await act(async () => {
+      firstWrite.resolve({ tracks: [COMMUNITY_VIBE_STATE, secondCommunityVibe] });
+      await firstWrite.promise;
+    });
+
+    await waitFor(() => expect((eventAgree as HTMLButtonElement).disabled).toBe(false));
+    expect((tidalAgree as HTMLButtonElement).disabled).toBe(true);
+
+    await act(async () => {
+      secondWrite.resolve({ tracks: [COMMUNITY_VIBE_STATE, secondCommunityVibe] });
+      await secondWrite.promise;
+    });
+    await waitFor(() => expect((tidalAgree as HTMLButtonElement).disabled).toBe(false));
+  });
+
+  it('keeps the tweak form open when override save fails', async () => {
+    mockApi.getPoolVibes.mockResolvedValue({ tracks: [COMMUNITY_VIBE_STATE] });
+    mockApi.overridePoolVibe.mockRejectedValueOnce(new ApiError('Invalid vibe override', 422));
+    render(<PoolPanel setId={1} />);
+    await screen.findByText('Event Song');
+
+    fireEvent.click(screen.getByText('Vibes'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Tweak' }));
+    fireEvent.change(screen.getByLabelText('Energy'), { target: { value: '8' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mockApi.overridePoolVibe).toHaveBeenCalledWith(1, 11, {
+      energy: 8,
+      mood: 'dark',
+    }));
+    expect(await screen.findByText('Invalid vibe override')).toBeTruthy();
+    expect(screen.getByLabelText('Energy')).toBeTruthy();
   });
 
   it('analyze failure surfaces ApiError 400 message, generic text otherwise', async () => {

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/VibeTiers.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/VibeTiers.test.tsx
@@ -4,8 +4,8 @@
  * and winner highlight from the resolved precedence.
  */
 
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import type { TrackVibeState } from '@/lib/api-types';
 import styles from '../../setbuilder.module.css';
 import VibeTiers from '../VibeTiers';
@@ -44,7 +44,7 @@ describe('VibeTiers', () => {
   it('renders all three tiers side-by-side with their values', () => {
     render(<VibeTiers state={makeState()} />);
     // labels
-    expect(screen.getByText('You')).toBeTruthy();
+    expect(screen.getAllByText('You').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('Crowd')).toBeTruthy();
     expect(screen.getByText('AI')).toBeTruthy();
     // own: E9 (no mood)
@@ -106,5 +106,46 @@ describe('VibeTiers', () => {
     expect(crowd.className).toContain(styles.vibeWinner);
     const ai = screen.getByLabelText('AI vibe: energy 5, mood happy');
     expect(ai.className).not.toContain(styles.vibeWinner);
+  });
+
+  it('shows the highest-priority row source indicator', () => {
+    const { rerender } = render(<VibeTiers state={makeState()} />);
+    expect(screen.getByLabelText('Vibe source: your override').textContent).toBe('You');
+
+    rerender(<VibeTiers state={makeState({ own: null })} />);
+    expect(screen.getByLabelText('Vibe source: community consensus').textContent).toBe('Crowd');
+
+    rerender(
+      <VibeTiers
+        state={makeState({
+          own: null,
+          community: null,
+          resolved: { energy: 5, energy_source: 'llm', mood: 'happy', mood_source: 'llm' },
+        })}
+      />
+    );
+    expect(screen.getByLabelText('Vibe source: AI guess').textContent).toBe('AI');
+  });
+
+  it('offers agree and tweak controls when callbacks are provided', () => {
+    const onAgree = vi.fn();
+    const onSaveOverride = vi.fn();
+    render(
+      <VibeTiers
+        state={makeState({ own: null })}
+        onAgree={onAgree}
+        onSaveOverride={onSaveOverride}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Agree' }));
+    expect(onAgree).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tweak' }));
+    fireEvent.change(screen.getByLabelText('Energy'), { target: { value: '8' } });
+    fireEvent.change(screen.getByLabelText('Mood'), { target: { value: 'gritty' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSaveOverride).toHaveBeenCalledWith({ energy: 8, mood: 'gritty' });
   });
 });

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/VibeTiers.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/VibeTiers.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { TrackVibeState } from '@/lib/api-types';
 import styles from '../../setbuilder.module.css';
 import VibeTiers from '../VibeTiers';
@@ -147,5 +147,39 @@ describe('VibeTiers', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(onSaveOverride).toHaveBeenCalledWith({ energy: 8, mood: 'gritty' });
+  });
+
+  it('keeps the tweak form open when the save callback reports failure', async () => {
+    const onSaveOverride = vi.fn().mockResolvedValue(false);
+    render(<VibeTiers state={makeState({ own: null })} onSaveOverride={onSaveOverride} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tweak' }));
+    fireEvent.change(screen.getByLabelText('Energy'), { target: { value: '8' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onSaveOverride).toHaveBeenCalledWith({ energy: 8, mood: 'dark' }));
+    expect(screen.getByLabelText('Energy')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy();
+  });
+
+  it('does not submit an empty tweak payload', () => {
+    const onSaveOverride = vi.fn();
+    render(
+      <VibeTiers
+        state={makeState({
+          own: null,
+          community: null,
+          llm: null,
+          resolved: { energy: null, energy_source: null, mood: null, mood_source: null },
+        })}
+        onSaveOverride={onSaveOverride}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tweak' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSaveOverride).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Energy')).toBeTruthy();
   });
 });

--- a/dashboard/app/(dj)/setbuilder/setbuilder.module.css
+++ b/dashboard/app/(dj)/setbuilder/setbuilder.module.css
@@ -2141,10 +2141,36 @@
 
 /* Three-tier vibe chips (issue #391) */
 
+.vibeBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.vibeTopRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.vibeSource {
+  display: inline-flex;
+  align-items: center;
+  min-height: 18px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  border: 1px solid #4b5563;
+  color: #d1d5db;
+  font-size: 10px;
+  font-weight: 700;
+}
+
 .vibeTiers {
   display: flex;
   gap: 6px;
-  margin-top: 4px;
+  flex-wrap: wrap;
 }
 
 .vibeChip {
@@ -2175,6 +2201,68 @@
 
 .vibeWinner {
   border-color: var(--color-primary, #8b5cf6);
+}
+
+.vibeActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.vibeActionBtn {
+  min-height: 20px;
+  padding: 1px 7px;
+  border-radius: 4px;
+  border: 1px solid var(--border, #3a3a3a);
+  background: #202020;
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+.vibeActionBtn:hover:not(:disabled) {
+  border-color: #6b7280;
+  color: var(--text-primary, #ededed);
+}
+
+.vibeActionBtn:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.vibeEditForm {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.vibeEditLabel {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  color: var(--text-secondary);
+  font-size: 10px;
+}
+
+.vibeNumber,
+.vibeMood {
+  min-height: 24px;
+  border: 1px solid var(--border, #3a3a3a);
+  border-radius: 4px;
+  background: #111;
+  color: var(--text-primary, #ededed);
+  font-size: 12px;
+  padding: 2px 6px;
+}
+
+.vibeNumber {
+  width: 54px;
+}
+
+.vibeMood {
+  width: 110px;
 }
 
 @media (max-width: 980px) {

--- a/dashboard/app/(dj)/setbuilder/setbuilder.module.css
+++ b/dashboard/app/(dj)/setbuilder/setbuilder.module.css
@@ -2161,8 +2161,8 @@
   min-height: 18px;
   padding: 1px 6px;
   border-radius: 4px;
-  border: 1px solid #4b5563;
-  color: #d1d5db;
+  border: 1px solid var(--border);
+  color: var(--text);
   font-size: 10px;
   font-weight: 700;
 }
@@ -2180,7 +2180,7 @@
   font-size: 10px;
   padding: 1px 6px;
   border-radius: 4px;
-  border: 1px solid var(--border, #3a3a3a);
+  border: 1px solid var(--border);
   color: var(--text-secondary);
 }
 
@@ -2194,13 +2194,13 @@
 }
 
 .vibeLow {
-  border-color: #f59e0b;
+  border-color: var(--color-warning);
   border-style: dashed;
-  color: #f59e0b;
+  color: var(--color-warning);
 }
 
 .vibeWinner {
-  border-color: var(--color-primary, #8b5cf6);
+  border-color: var(--color-primary);
 }
 
 .vibeActions {
@@ -2213,8 +2213,8 @@
   min-height: 20px;
   padding: 1px 7px;
   border-radius: 4px;
-  border: 1px solid var(--border, #3a3a3a);
-  background: #202020;
+  border: 1px solid var(--border);
+  background: var(--card);
   color: var(--text-secondary);
   font-size: 10px;
   line-height: 1.2;
@@ -2222,8 +2222,8 @@
 }
 
 .vibeActionBtn:hover:not(:disabled) {
-  border-color: #6b7280;
-  color: var(--text-primary, #ededed);
+  border-color: var(--text-tertiary);
+  color: var(--text);
 }
 
 .vibeActionBtn:disabled {
@@ -2249,10 +2249,10 @@
 .vibeNumber,
 .vibeMood {
   min-height: 24px;
-  border: 1px solid var(--border, #3a3a3a);
+  border: 1px solid var(--border);
   border-radius: 4px;
-  background: #111;
-  color: var(--text-primary, #ededed);
+  background: var(--bg);
+  color: var(--text);
   font-size: 12px;
   padding: 2px 6px;
 }

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -5757,7 +5757,17 @@ export interface components {
             energy?: number | null;
             /** Mood */
             mood?: string | null;
-        };
+        } & ({
+            /** Energy */
+            energy: number | null;
+            /** Mood */
+            mood?: string | null;
+        } | {
+            /** Energy */
+            energy?: number | null;
+            /** Mood */
+            mood: string | null;
+        });
         /**
          * PoolVibesState
          * @description Vibe state for every track in a set's pool.
@@ -12681,6 +12691,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["PoolVibesState"];
                 };
+            };
+            /** @description No non-own vibe signal available for this pool track. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -3098,6 +3098,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/setbuilder/sets/{set_id}/pool/vibes/{pool_track_id}/agree": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Agree Pool Vibe
+         * @description Upvote the best non-own vibe signal for one pool track without creating an own tier.
+         */
+        post: operations["agree_pool_vibe_api_setbuilder_sets__set_id__pool_vibes__pool_track_id__agree_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/pool/vibes/{pool_track_id}/override": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Override Pool Vibe
+         * @description Write an explicit DJ vibe edit, preserving omitted fields from their latest vote.
+         */
+        patch: operations["override_pool_vibe_api_setbuilder_sets__set_id__pool_vibes__pool_track_id__override_patch"];
+        trace?: never;
+    };
     "/api/setbuilder/sets/{set_id}/share": {
         parameters: {
             query?: never;
@@ -5707,6 +5747,16 @@ export interface components {
             supported: boolean;
             /** Track Count */
             track_count: number | null;
+        };
+        /**
+         * PoolVibeOverrideIn
+         * @description Explicit DJ edit for one pool track's vibe fields.
+         */
+        PoolVibeOverrideIn: {
+            /** Energy */
+            energy?: number | null;
+            /** Mood */
+            mood?: string | null;
         };
         /**
          * PoolVibesState
@@ -12599,6 +12649,74 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    agree_pool_vibe_api_setbuilder_sets__set_id__pool_vibes__pool_track_id__agree_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+                pool_track_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PoolVibesState"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    override_pool_vibe_api_setbuilder_sets__set_id__pool_vibes__pool_track_id__override_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+                pool_track_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PoolVibeOverrideIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PoolVibesState"];
+                };
             };
             /** @description Validation Error */
             422: {

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -247,6 +247,7 @@ export type BuilderPlaylists = Schemas['BuilderPlaylistsOut'];
 export type PoolVibesState = Schemas['PoolVibesState'];
 export type TrackVibeState = Schemas['TrackVibeStateOut'];
 export type VibeEnrichmentResult = Schemas['VibeEnrichmentResult'];
+export type PoolVibeOverrideIn = Schemas['PoolVibeOverrideIn'];
 
 // WrzDJSet sharing + duplication (issue #398)
 export interface ShareTokenOut {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -61,6 +61,7 @@ import type {
   PoolMutationResult,
   PoolState,
   PoolUrlPreview,
+  PoolVibeOverrideIn,
   PoolVibesState,
   PublicEvent,
   RecommendationResponse,
@@ -852,6 +853,21 @@ class ApiClient {
   }
   async enrichPoolVibes(setId: number): Promise<VibeEnrichmentResult> {
     return this.fetch(`/api/setbuilder/sets/${setId}/pool/vibes/enrich`, { method: 'POST' });
+  }
+  async agreePoolVibe(setId: number, poolTrackId: number): Promise<PoolVibesState> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pool/vibes/${poolTrackId}/agree`, {
+      method: 'POST',
+    });
+  }
+  async overridePoolVibe(
+    setId: number,
+    poolTrackId: number,
+    payload: PoolVibeOverrideIn
+  ): Promise<PoolVibesState> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/pool/vibes/${poolTrackId}/override`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    });
   }
   async getBuilderPlaylists(): Promise<BuilderPlaylists> {
     return this.fetch('/api/setbuilder/playlists');

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -1110,10 +1110,10 @@ def _pool_vibe_state_for_track(
     set_obj: Set,
     pool_track_id: int,
 ) -> vibe_resolver.TrackVibeState:
-    for state in vibe_resolver.build_pool_vibe_states(db, actor, set_obj):
-        if state.pool_track_id == pool_track_id:
-            return state
-    raise HTTPException(status_code=404, detail="Pool track not found")
+    state = vibe_resolver.build_pool_vibe_state(db, actor, set_obj, pool_track_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="Pool track not found")
+    return state
 
 
 def _agree_values(state: vibe_resolver.TrackVibeState) -> tuple[int | None, str | None]:
@@ -1185,7 +1185,11 @@ def get_pool_vibes(
     return _pool_vibes_state(db, current_user, set_obj)
 
 
-@router.post("/sets/{set_id}/pool/vibes/{pool_track_id}/agree", response_model=PoolVibesState)
+@router.post(
+    "/sets/{set_id}/pool/vibes/{pool_track_id}/agree",
+    response_model=PoolVibesState,
+    responses={400: {"description": "No non-own vibe signal available for this pool track."}},
+)
 @limiter.limit("30/minute")
 def agree_pool_vibe(
     set_id: int,

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -15,6 +15,11 @@ from app.api.deps import get_current_active_user, get_db
 from app.core.rate_limit import limiter
 from app.models.set import Set
 from app.models.set_pool import SetPoolTrack
+from app.models.track_vibe import (
+    TRACK_VIBE_SOURCE_EXPLICIT_EDIT,
+    TRACK_VIBE_SOURCE_UPVOTE,
+    TrackVibeOverride,
+)
 from app.models.user import User
 from app.schemas.setbuilder import (
     AgentChatIn,
@@ -54,6 +59,7 @@ from app.schemas.setbuilder import (
     PoolState,
     PoolTrackOut,
     PoolUrlPreview,
+    PoolVibeOverrideIn,
     PoolVibesState,
     ResolvedVibeOut,
     SetCreate,
@@ -1098,6 +1104,74 @@ def _pool_vibes_state(db: Session, actor: User, set_obj: Set) -> PoolVibesState:
     return PoolVibesState(tracks=out)
 
 
+def _pool_vibe_state_for_track(
+    db: Session,
+    actor: User,
+    set_obj: Set,
+    pool_track_id: int,
+) -> vibe_resolver.TrackVibeState:
+    for state in vibe_resolver.build_pool_vibe_states(db, actor, set_obj):
+        if state.pool_track_id == pool_track_id:
+            return state
+    raise HTTPException(status_code=404, detail="Pool track not found")
+
+
+def _agree_values(state: vibe_resolver.TrackVibeState) -> tuple[int | None, str | None]:
+    energy = (
+        state.community.energy
+        if state.community and state.community.energy is not None
+        else state.llm.energy
+        if state.llm
+        else None
+    )
+    mood = (
+        state.community.mood
+        if state.community and state.community.mood is not None
+        else state.llm.mood
+        if state.llm
+        else None
+    )
+    if energy is None and mood is None:
+        raise HTTPException(status_code=400, detail="No vibe available to agree with")
+    return energy, mood
+
+
+def _overridden_from_vibe_id(state: vibe_resolver.TrackVibeState) -> int | None:
+    if state.llm is None:
+        return None
+    if "llm" in {state.resolved.energy_source, state.resolved.mood_source}:
+        return state.llm.id
+    return None
+
+
+def _write_vibe_override(
+    db: Session,
+    actor: User,
+    state: vibe_resolver.TrackVibeState,
+    *,
+    energy: int | None,
+    mood: str | None,
+    source: str,
+    energy_was: int | None = None,
+    mood_was: str | None = None,
+    overridden_from_vibe_id: int | None = None,
+) -> TrackVibeOverride:
+    row = TrackVibeOverride(
+        track_id=state.vibe_key,
+        user_id=actor.id,
+        energy_override=energy,
+        mood_override=mood,
+        overridden_from_vibe_id=overridden_from_vibe_id,
+        energy_was=energy_was,
+        mood_was=mood_was,
+        source=source,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
 @router.get("/sets/{set_id}/pool/vibes", response_model=PoolVibesState)
 @limiter.limit("60/minute")
 def get_pool_vibes(
@@ -1108,6 +1182,72 @@ def get_pool_vibes(
 ) -> PoolVibesState:
     """Three-tier vibe state (own / community / LLM) for the set's pool."""
     set_obj = _get_owned_or_404(db, set_id, current_user)
+    return _pool_vibes_state(db, current_user, set_obj)
+
+
+@router.post("/sets/{set_id}/pool/vibes/{pool_track_id}/agree", response_model=PoolVibesState)
+@limiter.limit("30/minute")
+def agree_pool_vibe(
+    set_id: int,
+    pool_track_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PoolVibesState:
+    """Upvote the best non-own vibe signal for one pool track without creating an own tier."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    state = _pool_vibe_state_for_track(db, current_user, set_obj, pool_track_id)
+    energy, mood = _agree_values(state)
+    _write_vibe_override(
+        db,
+        current_user,
+        state,
+        energy=energy,
+        mood=mood,
+        source=TRACK_VIBE_SOURCE_UPVOTE,
+    )
+    return _pool_vibes_state(db, current_user, set_obj)
+
+
+@router.patch("/sets/{set_id}/pool/vibes/{pool_track_id}/override", response_model=PoolVibesState)
+@limiter.limit("30/minute")
+def override_pool_vibe(
+    set_id: int,
+    pool_track_id: int,
+    payload: PoolVibeOverrideIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> PoolVibesState:
+    """Write an explicit DJ vibe edit, preserving omitted fields from their latest vote."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    state = _pool_vibe_state_for_track(db, current_user, set_obj, pool_track_id)
+    latest = vibe_resolver.latest_override_row(db, current_user.id, state.vibe_key)
+    energy = (
+        payload.energy
+        if "energy" in payload.model_fields_set
+        else latest.energy_override
+        if latest
+        else None
+    )
+    mood = (
+        payload.mood
+        if "mood" in payload.model_fields_set
+        else latest.mood_override
+        if latest
+        else None
+    )
+    _write_vibe_override(
+        db,
+        current_user,
+        state,
+        energy=energy,
+        mood=mood,
+        source=TRACK_VIBE_SOURCE_EXPLICIT_EDIT,
+        energy_was=state.resolved.energy,
+        mood_was=state.resolved.mood,
+        overridden_from_vibe_id=_overridden_from_vibe_id(state),
+    )
     return _pool_vibes_state(db, current_user, set_obj)
 
 

--- a/server/app/models/track_vibe.py
+++ b/server/app/models/track_vibe.py
@@ -24,6 +24,10 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app.core.time import utcnow
 from app.models.base import Base
 
+TRACK_VIBE_SOURCE_EXPLICIT_EDIT = "explicit_edit"
+TRACK_VIBE_SOURCE_UPVOTE = "upvote"
+TRACK_VIBE_SOURCE_DOWNVOTE_IMPLICIT = "downvote_implicit"
+
 
 class TrackVibe(Base):
     """Global LLM vibe cache. One row per track+provider+model+prompt+schema."""

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -767,6 +767,27 @@ class PoolVibesState(BaseModel):
     tracks: list[TrackVibeStateOut]
 
 
+class PoolVibeOverrideIn(BaseModel):
+    """Explicit DJ edit for one pool track's vibe fields."""
+
+    energy: int | None = Field(default=None, ge=0, le=10)
+    mood: str | None = Field(default=None, max_length=50)
+
+    @field_validator("mood")
+    @classmethod
+    def _normalize_mood(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        trimmed = value.strip()
+        return trimmed or None
+
+    @model_validator(mode="after")
+    def _requires_touched_field(self) -> "PoolVibeOverrideIn":
+        if not {"energy", "mood"} & self.model_fields_set:
+            raise ValueError("energy or mood is required")
+        return self
+
+
 class VibeEnrichmentResult(BaseModel):
     """Result of an enrichment run, plus the refreshed vibe state."""
 

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -770,6 +770,58 @@ class PoolVibesState(BaseModel):
 class PoolVibeOverrideIn(BaseModel):
     """Explicit DJ edit for one pool track's vibe fields."""
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "allOf": [
+                {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "energy": {
+                                    "anyOf": [
+                                        {"maximum": 10.0, "minimum": 0.0, "type": "integer"},
+                                        {"type": "null"},
+                                    ],
+                                    "title": "Energy",
+                                },
+                                "mood": {
+                                    "anyOf": [
+                                        {"maxLength": 50, "type": "string"},
+                                        {"type": "null"},
+                                    ],
+                                    "title": "Mood",
+                                },
+                            },
+                            "required": ["energy"],
+                            "type": "object",
+                        },
+                        {
+                            "properties": {
+                                "energy": {
+                                    "anyOf": [
+                                        {"maximum": 10.0, "minimum": 0.0, "type": "integer"},
+                                        {"type": "null"},
+                                    ],
+                                    "title": "Energy",
+                                },
+                                "mood": {
+                                    "anyOf": [
+                                        {"maxLength": 50, "type": "string"},
+                                        {"type": "null"},
+                                    ],
+                                    "title": "Mood",
+                                },
+                            },
+                            "required": ["mood"],
+                            "type": "object",
+                        },
+                    ]
+                }
+            ],
+            "minProperties": 1,
+        }
+    )
+
     energy: int | None = Field(default=None, ge=0, le=10)
     mood: str | None = Field(default=None, max_length=50)
 

--- a/server/app/services/setbuilder/vibe_resolver.py
+++ b/server/app/services/setbuilder/vibe_resolver.py
@@ -161,3 +161,40 @@ def build_pool_vibe_states(db: Session, actor: User, set_obj: Set) -> list[Track
         )
         for track, key in zip(tracks, keys, strict=True)
     ]
+
+
+def build_pool_vibe_state(
+    db: Session,
+    actor: User,
+    set_obj: Set,
+    pool_track_id: int,
+) -> TrackVibeState | None:
+    """Targeted TrackVibeState lookup for write paths."""
+    track = (
+        db.query(SetPoolTrack)
+        .filter(SetPoolTrack.set_id == set_obj.id, SetPoolTrack.id == pool_track_id)
+        .first()
+    )
+    if track is None:
+        return None
+
+    key = vibe_key(track)
+    settings = get_system_settings(db)
+    own = _own_overrides(db, actor.id, [key]).get(key)
+    community = community_consensus(
+        db,
+        [key],
+        min_sample=settings.vibe_consensus_min_sample,
+        max_stddev=settings.vibe_consensus_max_stddev,
+        exclude_user_id=actor.id,
+    ).get(key)
+    llm = _llm_vibes(db, [key]).get(key)
+
+    return TrackVibeState(
+        pool_track_id=track.id,
+        vibe_key=key,
+        own=own,
+        community=community,
+        llm=llm,
+        resolved=resolve_vibe(own, community, llm),
+    )

--- a/server/app/services/setbuilder/vibe_resolver.py
+++ b/server/app/services/setbuilder/vibe_resolver.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 
 from app.models.set import Set
 from app.models.set_pool import SetPoolTrack
-from app.models.track_vibe import TrackVibe, TrackVibeOverride
+from app.models.track_vibe import TRACK_VIBE_SOURCE_EXPLICIT_EDIT, TrackVibe, TrackVibeOverride
 from app.models.user import User
 from app.services.setbuilder.community_vibe import CommunityVibe, community_consensus
 from app.services.setbuilder.vibe_enrichment import PROMPT_VERSION, SCHEMA_VERSION, vibe_key
@@ -79,7 +79,7 @@ class TrackVibeState:
 
 
 def _own_overrides(db: Session, user_id: int, keys: list[str]) -> dict[str, OwnVibe]:
-    """Latest override per track for one user; rows with both fields null count as no override."""
+    """Latest explicit edit per track; upvotes are community votes, not own overrides."""
     unique_keys = list(dict.fromkeys(keys))
     rows = (
         db.query(TrackVibeOverride)
@@ -93,8 +93,19 @@ def _own_overrides(db: Session, user_id: int, keys: list[str]) -> dict[str, OwnV
     return {
         key: OwnVibe(energy=row.energy_override, mood=row.mood_override)
         for key, row in latest.items()
-        if row.energy_override is not None or row.mood_override is not None
+        if row.source == TRACK_VIBE_SOURCE_EXPLICIT_EDIT
+        and (row.energy_override is not None or row.mood_override is not None)
     }
+
+
+def latest_override_row(db: Session, user_id: int, track_id: str) -> TrackVibeOverride | None:
+    """Latest vote snapshot for one user+track, regardless of source."""
+    return (
+        db.query(TrackVibeOverride)
+        .filter(TrackVibeOverride.user_id == user_id, TrackVibeOverride.track_id == track_id)
+        .order_by(TrackVibeOverride.id.desc())
+        .first()
+    )
 
 
 def _llm_vibes(db: Session, keys: list[str]) -> dict[str, TrackVibe]:

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -6427,7 +6427,80 @@
         "type": "object"
       },
       "PoolVibeOverrideIn": {
+        "allOf": [
+          {
+            "anyOf": [
+              {
+                "properties": {
+                  "energy": {
+                    "anyOf": [
+                      {
+                        "maximum": 10.0,
+                        "minimum": 0.0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "title": "Energy"
+                  },
+                  "mood": {
+                    "anyOf": [
+                      {
+                        "maxLength": 50,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "title": "Mood"
+                  }
+                },
+                "required": [
+                  "energy"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "energy": {
+                    "anyOf": [
+                      {
+                        "maximum": 10.0,
+                        "minimum": 0.0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "title": "Energy"
+                  },
+                  "mood": {
+                    "anyOf": [
+                      {
+                        "maxLength": 50,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "title": "Mood"
+                  }
+                },
+                "required": [
+                  "mood"
+                ],
+                "type": "object"
+              }
+            ]
+          }
+        ],
         "description": "Explicit DJ edit for one pool track's vibe fields.",
+        "minProperties": 1,
         "properties": {
           "energy": {
             "anyOf": [
@@ -18998,6 +19071,9 @@
               }
             },
             "description": "Successful Response"
+          },
+          "400": {
+            "description": "No non-own vibe signal available for this pool track."
           },
           "422": {
             "content": {

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -6426,6 +6426,38 @@
         "title": "PoolUrlPreview",
         "type": "object"
       },
+      "PoolVibeOverrideIn": {
+        "description": "Explicit DJ edit for one pool track's vibe fields.",
+        "properties": {
+          "energy": {
+            "anyOf": [
+              {
+                "maximum": 10.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Energy"
+          },
+          "mood": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mood"
+          }
+        },
+        "title": "PoolVibeOverrideIn",
+        "type": "object"
+      },
       "PoolVibesState": {
         "description": "Vibe state for every track in a set's pool.",
         "properties": {
@@ -18927,6 +18959,130 @@
           }
         ],
         "summary": "Enrich Pool Vibes",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/pool/vibes/{pool_track_id}/agree": {
+      "post": {
+        "description": "Upvote the best non-own vibe signal for one pool track without creating an own tier.",
+        "operationId": "agree_pool_vibe_api_setbuilder_sets__set_id__pool_vibes__pool_track_id__agree_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pool_track_id",
+            "required": true,
+            "schema": {
+              "title": "Pool Track Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PoolVibesState"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Agree Pool Vibe",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/pool/vibes/{pool_track_id}/override": {
+      "patch": {
+        "description": "Write an explicit DJ vibe edit, preserving omitted fields from their latest vote.",
+        "operationId": "override_pool_vibe_api_setbuilder_sets__set_id__pool_vibes__pool_track_id__override_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pool_track_id",
+            "required": true,
+            "schema": {
+              "title": "Pool Track Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PoolVibeOverrideIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PoolVibesState"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Override Pool Vibe",
         "tags": [
           "setbuilder"
         ]

--- a/server/scripts/export_openapi.py
+++ b/server/scripts/export_openapi.py
@@ -23,10 +23,13 @@ Request-body schemas (EventCreate, EventUpdate, etc.) keep their original
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
-from app.main import app
+SERVER_ROOT = Path(__file__).resolve().parent.parent
+if str(SERVER_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVER_ROOT))
 
 
 def _collect_refs(node: Any) -> set[str]:
@@ -83,7 +86,9 @@ def _promote_response_fields_to_required(spec: dict[str, Any]) -> None:
 
 
 def export() -> Path:
-    output = Path(__file__).resolve().parent.parent / "openapi.json"
+    from app.main import app
+
+    output = SERVER_ROOT / "openapi.json"
     # Force fresh generation — FastAPI caches the schema on `app.openapi_schema`,
     # which can hide newly-added routes when this script is invoked from a
     # long-running process.

--- a/server/tests/test_setbuilder_vibes.py
+++ b/server/tests/test_setbuilder_vibes.py
@@ -382,13 +382,14 @@ def _vote(
     *,
     energy: int | None = None,
     mood: str | None = None,
+    source: str = "explicit_edit",
 ) -> TrackVibeOverride:
     row = TrackVibeOverride(
         track_id=track_id,
         user_id=user_id,
         energy_override=energy,
         mood_override=mood,
-        source="explicit_edit",
+        source=source,
     )
     db.add(row)
     db.commit()
@@ -424,6 +425,17 @@ class TestCommunityConsensus:
         _vote(db, "tidal:1", users[2].id, energy=8)
         result = community_consensus(db, ["tidal:1"], min_sample=3, max_stddev=1.5)
         assert result["tidal:1"].energy == 8
+        assert result["tidal:1"].sample_size == 3
+
+    def test_upvote_source_counts_as_community_vote(self, db):
+        users = _make_users(db, 3)
+        for user in users:
+            _vote(db, "tidal:1", user.id, energy=8, mood="dark", source="upvote")
+
+        result = community_consensus(db, ["tidal:1"], min_sample=3, max_stddev=1.5)
+
+        assert result["tidal:1"].energy == 8
+        assert result["tidal:1"].mood == "dark"
         assert result["tidal:1"].sample_size == 3
 
     def test_mood_majority(self, db):
@@ -519,6 +531,27 @@ class TestVibeResolver:
         resolved = resolve_vibe(own, community, llm)
         assert (resolved.energy, resolved.energy_source) == (9, "own")
         assert (resolved.mood, resolved.mood_source) == ("gritty", "own")
+
+    def test_upvote_does_not_become_own_override(self, db, test_user):
+        s = _seed_pool(db, test_user.id, 1)
+        _vote(db, "tidal:0", test_user.id, energy=8, mood="dark", source="upvote")
+
+        states = build_pool_vibe_states(db, test_user, s)
+
+        assert len(states) == 1
+        assert states[0].own is None
+        assert states[0].community is None
+        assert states[0].resolved == ResolvedVibe(None, None, None, None)
+
+    def test_latest_upvote_retracts_prior_explicit_own_tier(self, db, test_user):
+        s = _seed_pool(db, test_user.id, 1)
+        _vote(db, "tidal:0", test_user.id, energy=9, mood="gritty", source="explicit_edit")
+        _vote(db, "tidal:0", test_user.id, energy=7, mood="dark", source="upvote")
+
+        states = build_pool_vibe_states(db, test_user, s)
+
+        assert states[0].own is None
+        assert states[0].resolved == ResolvedVibe(None, None, None, None)
 
     def test_community_beats_llm(self):
         community = CommunityVibe(energy=5, mood="dark", sample_size=4)

--- a/server/tests/test_setbuilder_vibes_api.py
+++ b/server/tests/test_setbuilder_vibes_api.py
@@ -11,6 +11,7 @@ from app.models.track_vibe import TrackVibe, TrackVibeOverride
 from app.models.user import User
 from app.services.llm.base import ChatResponse, ToolCall
 from app.services.llm.exceptions import NoLlmConfigured, ProviderUnavailable
+from app.services.setbuilder import vibe_resolver
 from app.services.setbuilder.vibe_enrichment import PROMPT_VERSION, SCHEMA_VERSION
 
 DISPATCH_TARGET = "app.services.setbuilder.vibe_enrichment.Gateway.dispatch"
@@ -212,6 +213,23 @@ class TestGetPoolVibes:
 
 
 class TestWritePoolVibes:
+    def test_openapi_documents_pool_vibe_write_contract(self, client):
+        schema = client.app.openapi()
+        override = schema["components"]["schemas"]["PoolVibeOverrideIn"]
+
+        assert override["minProperties"] == 1
+        any_of = override.get("anyOf") or override.get("allOf", [{}])[0].get("anyOf", [])
+        required_sets = {tuple(item["required"]) for item in any_of}
+        assert ("energy",) in required_sets
+        assert ("mood",) in required_sets
+
+        responses = schema["paths"][
+            "/api/setbuilder/sets/{set_id}/pool/vibes/{pool_track_id}/agree"
+        ]["post"]["responses"]
+        assert responses["400"]["description"] == (
+            "No non-own vibe signal available for this pool track."
+        )
+
     def test_agree_upvotes_consensus_without_own_override(
         self, client, db, auth_headers, set_id, test_user
     ):
@@ -250,6 +268,26 @@ class TestWritePoolVibes:
         assert row.mood_override == "dark"
         assert row.energy_was is None
         assert row.mood_was is None
+
+    def test_agree_uses_targeted_pre_write_lookup(
+        self, client, db, auth_headers, set_id, test_user
+    ):
+        _seed_pool_tracks(db, set_id, 3)
+        pool_track_id = _pool_track_id(db, set_id)
+        for voter in _make_voters(db, 3):
+            _vote(db, "tidal:0", voter.id, energy=7, mood="dark")
+
+        with patch(
+            "app.api.setbuilder.vibe_resolver.build_pool_vibe_states",
+            wraps=vibe_resolver.build_pool_vibe_states,
+        ) as build_states:
+            resp = client.post(
+                f"/api/setbuilder/sets/{set_id}/pool/vibes/{pool_track_id}/agree",
+                headers=auth_headers,
+            )
+
+        assert resp.status_code == 200
+        assert build_states.call_count == 1
 
     def test_agree_rejects_track_with_no_vibe_to_upvote(self, client, db, auth_headers, set_id):
         _seed_pool_tracks(db, set_id, 1)

--- a/server/tests/test_setbuilder_vibes_api.py
+++ b/server/tests/test_setbuilder_vibes_api.py
@@ -56,6 +56,49 @@ def _seed_pool_tracks(db: Session, set_id: int, n: int) -> None:
     db.commit()
 
 
+def _pool_track_id(db: Session, set_id: int, track_id: str = "tidal:0") -> int:
+    row = (
+        db.query(SetPoolTrack)
+        .filter(SetPoolTrack.set_id == set_id, SetPoolTrack.track_id == track_id)
+        .one()
+    )
+    return row.id
+
+
+def _make_voters(db: Session, n: int) -> list[User]:
+    from app.services.auth import get_password_hash
+
+    pw = get_password_hash("password123")
+    users = [User(username=f"vibe-voter-{i}", password_hash=pw, role="dj") for i in range(n)]
+    db.add_all(users)
+    db.commit()
+    for user in users:
+        db.refresh(user)
+    return users
+
+
+def _vote(
+    db: Session,
+    track_id: str,
+    user_id: int,
+    *,
+    energy: int | None = None,
+    mood: str | None = None,
+    source: str = "explicit_edit",
+) -> TrackVibeOverride:
+    row = TrackVibeOverride(
+        track_id=track_id,
+        user_id=user_id,
+        energy_override=energy,
+        mood_override=mood,
+        source=source,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
 def _llm_vibe_row(track_id: str = "tidal:0", *, energy: int = 5, confidence: float = 0.8):
     return TrackVibe(
         track_id=track_id,
@@ -166,6 +209,131 @@ class TestGetPoolVibes:
         assert llm["low_confidence"] is False
         assert llm["llm_provider"] == "anthropic_apikey"
         assert llm["llm_model"] == "claude-haiku-4-5"
+
+
+class TestWritePoolVibes:
+    def test_agree_upvotes_consensus_without_own_override(
+        self, client, db, auth_headers, set_id, test_user
+    ):
+        _seed_pool_tracks(db, set_id, 1)
+        pool_track_id = _pool_track_id(db, set_id)
+        for voter in _make_voters(db, 3):
+            _vote(db, "tidal:0", voter.id, energy=7, mood="dark")
+
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/vibes/{pool_track_id}/agree",
+            headers=auth_headers,
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        (track,) = body["tracks"]
+        assert track["own"] is None
+        assert track["community"] == {"energy": 7, "mood": "dark", "sample_size": 3}
+        assert track["resolved"] == {
+            "energy": 7,
+            "energy_source": "community",
+            "mood": "dark",
+            "mood_source": "community",
+        }
+
+        row = (
+            db.query(TrackVibeOverride)
+            .filter(
+                TrackVibeOverride.user_id == test_user.id,
+                TrackVibeOverride.track_id == "tidal:0",
+            )
+            .one()
+        )
+        assert row.source == "upvote"
+        assert row.energy_override == 7
+        assert row.mood_override == "dark"
+        assert row.energy_was is None
+        assert row.mood_was is None
+
+    def test_agree_rejects_track_with_no_vibe_to_upvote(self, client, db, auth_headers, set_id):
+        _seed_pool_tracks(db, set_id, 1)
+        pool_track_id = _pool_track_id(db, set_id)
+
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/vibes/{pool_track_id}/agree",
+            headers=auth_headers,
+        )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "No vibe available to agree with"
+        assert db.query(TrackVibeOverride).count() == 0
+
+    def test_tweak_writes_explicit_override_with_previous_resolved_capture(
+        self, client, db, auth_headers, set_id, test_user
+    ):
+        _seed_pool_tracks(db, set_id, 1)
+        pool_track_id = _pool_track_id(db, set_id)
+        llm = _llm_vibe_row("tidal:0", energy=5, confidence=0.8)
+        db.add(llm)
+        db.commit()
+        db.refresh(llm)
+
+        resp = client.patch(
+            f"/api/setbuilder/sets/{set_id}/pool/vibes/{pool_track_id}/override",
+            json={"energy": 8, "mood": "dark"},
+            headers=auth_headers,
+        )
+
+        assert resp.status_code == 200
+        (track,) = resp.json()["tracks"]
+        assert track["own"] == {"energy": 8, "mood": "dark"}
+        assert track["resolved"] == {
+            "energy": 8,
+            "energy_source": "own",
+            "mood": "dark",
+            "mood_source": "own",
+        }
+
+        row = (
+            db.query(TrackVibeOverride)
+            .filter(
+                TrackVibeOverride.user_id == test_user.id,
+                TrackVibeOverride.track_id == "tidal:0",
+            )
+            .one()
+        )
+        assert row.source == "explicit_edit"
+        assert row.energy_override == 8
+        assert row.mood_override == "dark"
+        assert row.energy_was == 5
+        assert row.mood_was == "happy"
+        assert row.overridden_from_vibe_id == llm.id
+
+    def test_tweak_carries_forward_omitted_fields_from_latest_vote(
+        self, client, db, auth_headers, set_id, test_user
+    ):
+        _seed_pool_tracks(db, set_id, 1)
+        pool_track_id = _pool_track_id(db, set_id)
+        _vote(db, "tidal:0", test_user.id, energy=6, mood="dark", source="explicit_edit")
+
+        resp = client.patch(
+            f"/api/setbuilder/sets/{set_id}/pool/vibes/{pool_track_id}/override",
+            json={"energy": 9},
+            headers=auth_headers,
+        )
+
+        assert resp.status_code == 200
+        rows = (
+            db.query(TrackVibeOverride)
+            .filter(
+                TrackVibeOverride.user_id == test_user.id,
+                TrackVibeOverride.track_id == "tidal:0",
+            )
+            .order_by(TrackVibeOverride.id)
+            .all()
+        )
+        assert len(rows) == 2
+        assert rows[-1].source == "explicit_edit"
+        assert rows[-1].energy_override == 9
+        assert rows[-1].mood_override == "dark"
+        assert rows[-1].energy_was == 6
+        assert rows[-1].mood_was == "dark"
 
 
 class TestEnrichPoolVibes:


### PR DESCRIPTION
## Summary
- Add auth-gated setbuilder pool vibe agree and explicit override endpoints.
- Keep upvotes out of the DJ own-override tier while still feeding community consensus.
- Add pool-row Agree/Tweak controls, source indicators, API wiring, generated OpenAPI/types, and regression tests.

## Design decisions
- `source="upvote"` rows are stored as community votes and intentionally do not render as the user's own override tier.
- The Tweak form writes `source="explicit_edit"` and captures the previous resolved energy/mood for future taste-profile training.
- The UI stays silent on DJ-vs-community disagreement; it only shows the active precedence source indicator.

## Tests
- server: ruff check .
- server: ruff format --check .
- server: bandit -r app -c pyproject.toml -q
- server: pytest --tb=short -q (2854 passed, coverage 87.99%)
- server: alembic upgrade head && alembic check (run against local WrzDJ Postgres on 5433 because 5432 is occupied by another project)
- dashboard: npm run lint
- dashboard: npx tsc --noEmit
- dashboard: npm test -- --run (89 files, 1211 tests)

Closes #399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added “Agree” actions for pool tracks to register community or AI-generated vibe consensus.
- Added per-track “Tweak/Save override” editing for energy and mood, including clear source indicators for the resulting vibe values.

**Improved UX**
- Vibe controls now disable independently per track while a write is in progress, preventing cross-track interference.
- Better error handling keeps the edit form open when a save fails.

**Styling & Tests**
- Refined vibe editor/chip styling and expanded UI and API test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->