### PR TITLE
chore(deps): bump FastAPI 0.137.1 + starlette 1.3.1 (clears 5 starlette CVEs)

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "WrzDJ API Server"
 requires-python = ">=3.11"
 dependencies = [
-    "fastapi>=0.109.0",
+    "fastapi>=0.133.0",  # first release to drop starlette<1.0.0 cap (allows starlette 1.x)
     "uvicorn[standard]>=0.27.0",
     "sqlalchemy>=2.0.0",
     "alembic>=1.13.0",
@@ -35,6 +35,7 @@ dependencies = [
     "resend>=2.0.0",
     "better-profanity>=0.7.0",
     "sse-starlette>=2.0.0",
+    "starlette>=1.3.1",      # GHSA cluster (form-limit DoS, Host-header poisoning, SSRF via UNC) — needs fastapi>=0.133.0
     "python-json-logger>=3.0",
     "coolname==5.0.0",
 ]

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -766,7 +766,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.128.3"
+version = "0.137.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -775,9 +775,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/93/6f8464c39697dfad67c0c37cb1d23f784096b08707506b559b36ef1ddf87/fastapi-0.128.3.tar.gz", hash = "sha256:ed99383fd96063447597d5aa2a9ec3973be198e3b4fc10c55f15c62efdb21c60", size = 377310, upload-time = "2026-02-06T16:47:19.456Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/b1/e5b92c59d2c37817e77c1a8c2fc1f79cdcc04c68253e5406b43e3204cba7/fastapi-0.137.1.tar.gz", hash = "sha256:822360704230d9533d8d9475399613525968aa2f0b5bd2a3ccc9f18c88fd541c", size = 408293, upload-time = "2026-06-15T11:28:20.79Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/fb/6e46514575f7c4689d5aec223f47e847e77faada658da4d674c7e34a018f/fastapi-0.128.3-py3-none-any.whl", hash = "sha256:c8cdf7c2182c9a06bf9cfa3329819913c189dc86389b90d5709892053582db29", size = 105145, upload-time = "2026-02-06T16:47:22.365Z" },
+    { url = "https://files.pythonhosted.org/packages/da/35/380b9a5922f4340e51c309cde09e5bd32e62f02302971bee30dc15aa0624/fastapi-0.137.1-py3-none-any.whl", hash = "sha256:64f6983c59e45c4b9fdc44e57cb8035c2451ee91ea8e8ec042aca37de7cf6b69", size = 121877, upload-time = "2026-06-15T11:28:19.523Z" },
 ]
 
 [[package]]
@@ -2358,15 +2358,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -2800,6 +2800,7 @@ dependencies = [
     { name = "spotipy" },
     { name = "sqlalchemy" },
     { name = "sse-starlette" },
+    { name = "starlette" },
     { name = "tidalapi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
@@ -2829,7 +2830,7 @@ requires-dist = [
     { name = "better-profanity", specifier = ">=0.7.0" },
     { name = "coolname", specifier = "==5.0.0" },
     { name = "cryptography", specifier = ">=48.0.1" },
-    { name = "fastapi", specifier = ">=0.109.0" },
+    { name = "fastapi", specifier = ">=0.133.0" },
     { name = "freezegun", marker = "extra == 'dev'", specifier = ">=1.2.0" },
     { name = "httpx", specifier = ">=0.26.0" },
     { name = "idna", specifier = ">=3.15" },
@@ -2857,6 +2858,7 @@ requires-dist = [
     { name = "spotipy", specifier = ">=2.23.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "sse-starlette", specifier = ">=2.0.0" },
+    { name = "starlette", specifier = ">=1.3.1" },
     { name = "tidalapi", specifier = ">=0.7.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0" },


### PR DESCRIPTION
> **Stacked on #445.** Base is `chore/dependabot-security-bumps`; review/merge #445 first, then this retargets to `main`.

## Why

The final 5 Dependabot alerts are all **starlette**, and their fixes only exist on the starlette **1.x** line:
- form-limit silently ignored → DoS (**high**)
- SSRF + NTLM credential theft via UNC paths in StaticFiles (**high**)
- arbitrary HTTP method dispatched to HTTPEndpoint via getattr (medium)
- Host-header validation gaps poisoning `request.url` (medium ×2)

FastAPI 0.128.3 pins `starlette<1.0.0`, so starlette can't move alone. This bumps FastAPI past that cap.

## What

- `fastapi` 0.128.3 → **0.137.1**  (0.133.0 was the first to drop the `<1.0.0` cap; pinned latest)
- `starlette` 0.52.1 → **1.3.1**  (added as an explicit `>=1.3.1` security floor — 1.3.1 is the only release clearing the high-severity form-limit alert)

**Zero application code changes.** A starlette *major* bump (0.52→1.3) typically breaks middleware/request internals, but the app rides high enough on FastAPI's abstractions that nothing needed touching — proven by the suite below.

### Version choice
0.137.1 chosen over the more-soaked 0.136.3 (~24 days) for cleaner scanner optics — 0.136.3 carried a *withdrawn* Amazon-Inspector false-positive malware flag. Both passed the full suite identically. Both provenance-verified (maintainer `tiangolo`, monotonic release history, absent from all Shai-Hulud / supply-chain victim lists; no compromise found).

## Testing
- [x] Backend: **2869 pytest passed**, coverage **87.96%** (≥85% gate) under fastapi 0.137.1 + starlette 1.3.1
- [x] **pip-audit: zero remaining advisories** (starlette cluster cleared)
- [x] ruff check + ruff format clean
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #444.