### PR TITLE
feat(setbuilder): hand-drag reordering of timeline slots (#437)

### DIFF
--- a/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
@@ -31,6 +31,28 @@ import {
 } from './transportMath';
 import sbStyles from '../setbuilder.module.css';
 
+/**
+ * Pure helper: given the current ordered slots, a slot id being dragged, and
+ * an insertion index, return the new ordered id array — or null if the move is
+ * a no-op, targets an unknown slot, or would displace a locked slot anchor.
+ */
+export function buildReorderedIds(
+  slots: SlotView[],
+  slotId: number,
+  insertIdx: number,
+): number[] | null {
+  const fromIdx = slots.findIndex((s) => s.id === slotId);
+  if (fromIdx < 0) return null;
+  const target = insertIdx > fromIdx ? insertIdx - 1 : insertIdx;
+  if (target === fromIdx) return null; // no-op
+  const ids = slots.map((s) => s.id);
+  const without = ids.filter((id) => id !== slotId);
+  without.splice(target, 0, slotId);
+  // Locked slots are immovable anchors — reject any move that shifts one.
+  if (slots.some((s, idx) => s.locked && without[idx] !== s.id)) return null;
+  return without;
+}
+
 const SCRUB_KEY = 'wrzdj.transport.scrubEnabled';
 
 function readScrubSetting(): boolean {
@@ -388,6 +410,22 @@ export default function BuilderWorkspace({
     [commit, loadSlots, setId, slots],
   );
 
+  const handleSlotReorder = useCallback(
+    async (slotId: number, insertIdx: number) => {
+      const orderedIds = buildReorderedIds(slots, slotId, insertIdx);
+      if (!orderedIds) return;
+      const save = async () => api.reorderSlots(setId, orderedIds);
+      try {
+        const run = commit ? commit('Reorder slot', save) : save();
+        await run;
+        await loadSlots();
+      } catch {
+        await loadSlots();
+      }
+    },
+    [commit, loadSlots, setId, slots],
+  );
+
   const handleSlotLockChange = useCallback(
     async (slotIds: number[], locked: boolean, label?: string) => {
       if (slotIds.length === 0) return;
@@ -488,6 +526,7 @@ export default function BuilderWorkspace({
           scrollRequest={scrollRequest}
           onPairingAction={handlePairingAction}
           onPoolTrackDrop={handlePoolTrackDrop}
+          onSlotReorder={handleSlotReorder}
           onSlotLockChange={handleSlotLockChange}
           onLockBeforePlayhead={handleLockBeforePlayhead}
         />

--- a/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
@@ -16,7 +16,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { readPoolTrackDragPayload } from './dnd';
+import { readPoolTrackDragPayload, readSlotReorderDragPayload, SLOT_REORDER_DND_TYPE } from './dnd';
 import TimelineRow, { type TimelineMenu } from './TimelineRow';
 import type { SlotView } from './types';
 import { useMeasuredVirtualList } from './useMeasuredVirtualList';
@@ -41,6 +41,7 @@ export interface TimelinePanelProps {
   onPoolTrackDrop?: (poolTrackId: number, insertIdx: number) => void | Promise<void>;
   onSlotLockChange?: (slotIds: number[], locked: boolean) => void | Promise<void>;
   onLockBeforePlayhead?: () => void | Promise<void>;
+  onSlotReorder?: (slotId: number, insertIdx: number) => void | Promise<void>;
 }
 
 const ESTIMATED_SLOT_GROUP_HEIGHT = 52;
@@ -71,10 +72,12 @@ export default function TimelinePanel({
   onPoolTrackDrop,
   onSlotLockChange,
   onLockBeforePlayhead,
+  onSlotReorder,
 }: TimelinePanelProps) {
   const listRef = useRef<HTMLDivElement>(null);
   const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
   const handledScrollRequestNRef = useRef<number | null>(null);
+  const reorderSourceRef = useRef<number | null>(null);
   const [menu, setMenu] = useState<TimelineMenu | null>(null);
   const [dropIdx, setDropIdx] = useState<number | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
@@ -203,6 +206,7 @@ export default function TimelinePanel({
 
     const rect = list.getBoundingClientRect();
     const pointerTop = event.clientY - rect.top + list.scrollTop;
+    if (!Number.isFinite(pointerTop)) return slots.length;
     const insertIdx =
       pointerTop >= totalHeight ? slots.length : indexFromScrollTop(pointerTop);
 
@@ -253,6 +257,55 @@ export default function TimelinePanel({
 
   const handlePoolTrackDropAtPointer = (event: DragEvent<HTMLElement>) => {
     handlePoolTrackDrop(event, insertIndexFromPointer(event));
+  };
+
+  const dragIsReorder = (event: DragEvent<HTMLElement>) =>
+    event.dataTransfer.types.includes(SLOT_REORDER_DND_TYPE);
+
+  const reorderWouldCrossLock = (fromIdx: number, insertIdx: number) => {
+    const target = insertIdx > fromIdx ? insertIdx - 1 : insertIdx;
+    const lo = Math.min(fromIdx, target);
+    const hi = Math.max(fromIdx, target);
+    return slots.some((s, i) => s.locked && i !== fromIdx && i >= lo && i <= hi);
+  };
+
+  const handleListDragStart = (event: DragEvent<HTMLElement>) => {
+    const payload = readSlotReorderDragPayload(event.dataTransfer);
+    reorderSourceRef.current = payload ? payload.slotId : null;
+  };
+
+  const clearReorderSource = () => {
+    reorderSourceRef.current = null;
+  };
+
+  const resolveReorder = (event: DragEvent<HTMLElement>) => {
+    const slotId = reorderSourceRef.current;
+    const fromIdx = slotId == null ? -1 : slots.findIndex((s) => s.id === slotId);
+    const insertIdx = insertIndexFromPointer(event);
+    const valid = fromIdx >= 0 && !reorderWouldCrossLock(fromIdx, insertIdx);
+    return { slotId, insertIdx, valid };
+  };
+
+  const markReorderDrop = (event: DragEvent<HTMLElement>) => {
+    event.preventDefault();
+    const { insertIdx, valid } = resolveReorder(event);
+    if (!valid) {
+      event.dataTransfer.dropEffect = 'none';
+      setDropIdx(null);
+      return;
+    }
+    event.dataTransfer.dropEffect = 'move';
+    setDropIdx(insertIdx);
+  };
+
+  const handleReorderDrop = (event: DragEvent<HTMLElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setDropIdx(null);
+    const { slotId, insertIdx, valid } = resolveReorder(event);
+    clearReorderSource();
+    if (!valid || slotId == null) return;
+    void onSlotReorder?.(slotId, insertIdx);
   };
 
   const clearDropIfLeaving = (event: DragEvent<HTMLElement>) => {
@@ -316,9 +369,15 @@ export default function TimelinePanel({
         data-testid="timeline-list"
         data-virtualized="true"
         onScroll={handleScroll}
-        onDragOver={markPoolTrackDropAtPointer}
+        onDragStart={handleListDragStart}
+        onDragEnd={clearReorderSource}
+        onDragOver={(event) =>
+          dragIsReorder(event) ? markReorderDrop(event) : markPoolTrackDropAtPointer(event)
+        }
         onDragLeave={clearDropIfLeaving}
-        onDrop={handlePoolTrackDropAtPointer}
+        onDrop={(event) =>
+          dragIsReorder(event) ? handleReorderDrop(event) : handlePoolTrackDropAtPointer(event)
+        }
       >
         <div style={{ height: beforeHeight }} aria-hidden="true" />
         {items.map(({ idx }) => {

--- a/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx
@@ -4,7 +4,8 @@
  * Minimal timeline list (#389) — ordered slot rows with BPM/key/energy
  * badges and bidirectional hover sync with the curve. Clicking a curve
  * block scrolls the matching row into view, including virtualized rows.
- * Full drag-reorder timeline lands with #390/#397.
+ * Hand-drag reorder (#437): unlocked rows are drag sources and the list
+ * accepts slot-reorder drops, blocking any move that crosses a locked slot.
  */
 
 import {
@@ -260,7 +261,7 @@ export default function TimelinePanel({
   };
 
   const dragIsReorder = (event: DragEvent<HTMLElement>) =>
-    event.dataTransfer.types.includes(SLOT_REORDER_DND_TYPE);
+    event.dataTransfer.types?.includes(SLOT_REORDER_DND_TYPE) ?? false;
 
   const reorderWouldCrossLock = (fromIdx: number, insertIdx: number) => {
     const target = insertIdx > fromIdx ? insertIdx - 1 : insertIdx;

--- a/dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx
@@ -2,7 +2,7 @@
 
 import { type Dispatch, type DragEvent, type SetStateAction, useCallback } from 'react';
 import { fmtTime } from './curveMath';
-import { readPoolTrackDragPayload } from './dnd';
+import { readPoolTrackDragPayload, writeSlotReorderDragPayload } from './dnd';
 import { localPositionSec } from './transportMath';
 import type { SlotView } from './types';
 import { effectiveTarget } from './types';
@@ -155,7 +155,14 @@ export default function TimelineRow({
           slot.locked ? styles.timelineRowLocked : ''
         }`}
         data-locked={slot.locked ? 'true' : 'false'}
-        draggable={false}
+        draggable={!slot.locked}
+        onDragStart={(event) => {
+          if (slot.locked) {
+            event.preventDefault();
+            return;
+          }
+          writeSlotReorderDragPayload(event.dataTransfer, slot.id);
+        }}
         onMouseEnter={() => onHover(idx)}
         onMouseLeave={() => onHover(null)}
         onDoubleClick={() => onRowDoubleClick?.(idx)}

--- a/dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx
@@ -2,7 +2,7 @@
 
 import { type Dispatch, type DragEvent, type SetStateAction, useCallback } from 'react';
 import { fmtTime } from './curveMath';
-import { readPoolTrackDragPayload, writeSlotReorderDragPayload } from './dnd';
+import { readPoolTrackDragPayload, SLOT_REORDER_DND_TYPE, writeSlotReorderDragPayload } from './dnd';
 import { localPositionSec } from './transportMath';
 import type { SlotView } from './types';
 import { effectiveTarget } from './types';
@@ -167,11 +167,17 @@ export default function TimelineRow({
         onMouseLeave={() => onHover(null)}
         onDoubleClick={() => onRowDoubleClick?.(idx)}
         onDragOver={(event) => {
+          // Let slot-reorder drags bubble to the list's reorder handler — do
+          // not consume them here (no stopPropagation, no preventDefault).
+          if (event.dataTransfer.types?.includes(SLOT_REORDER_DND_TYPE)) return;
           event.stopPropagation();
           markPoolTrackDrop(event, idx);
         }}
         onDragLeave={clearDropIfLeaving}
-        onDrop={(event) => handlePoolTrackDrop(event, idx)}
+        onDrop={(event) => {
+          if (event.dataTransfer.types?.includes(SLOT_REORDER_DND_TYPE)) return;
+          handlePoolTrackDrop(event, idx);
+        }}
         onContextMenu={(event) => {
           if (idx >= slots.length - 1) return;
           event.preventDefault();

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/TimelinePanel.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/TimelinePanel.test.tsx
@@ -59,6 +59,12 @@ function fireReorderDrop(el: Element, dataTransfer: DataTransfer, clientY: numbe
   fireEvent(el, event);
 }
 
+function fireReorderDragOver(el: Element, dataTransfer: DataTransfer, clientY: number) {
+  const event = createEvent.dragOver(el, { dataTransfer });
+  Object.defineProperty(event, 'clientY', { value: clientY });
+  fireEvent(el, event);
+}
+
 function renderPanel(slots: SlotView[], onSlotReorder = vi.fn()) {
   render(
     <TimelinePanel
@@ -104,5 +110,26 @@ describe('TimelinePanel reorder drop', () => {
     fireEvent.dragStart(screen.getByTestId('timeline-row-0'), { dataTransfer: dt });
     fireReorderDrop(list, dt, 999);
     expect(onSlotReorder).not.toHaveBeenCalled();
+  });
+
+  it('reorders when the drop lands on a row (bubbles past the row pool handler)', () => {
+    const slots = [slot(1), slot(2), slot(3)];
+    const onSlotReorder = renderPanel(slots);
+    const dt = reorderDataTransfer(1);
+    // Drop ON a row, not the list root — this is where real drops land. The
+    // row must let the reorder drag bubble to the list's reorder handler.
+    fireEvent.dragStart(screen.getByTestId('timeline-row-0'), { dataTransfer: dt });
+    fireReorderDrop(screen.getByTestId('timeline-row-2'), dt, 999);
+    expect(onSlotReorder).toHaveBeenCalledTimes(1);
+    expect(onSlotReorder).toHaveBeenCalledWith(1, 3);
+  });
+
+  it('reports a move dropEffect for a reorder dragover bubbled from a row', () => {
+    const slots = [slot(1), slot(2), slot(3)];
+    renderPanel(slots);
+    const dt = reorderDataTransfer(1);
+    fireEvent.dragStart(screen.getByTestId('timeline-row-0'), { dataTransfer: dt });
+    fireReorderDragOver(screen.getByTestId('timeline-row-1'), dt, 60);
+    expect(dt.dropEffect).toBe('move');
   });
 });

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/TimelinePanel.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/TimelinePanel.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, createEvent } from '@testing-library/react';
+import TimelinePanel from '../TimelinePanel';
+import type { SlotView } from '../types';
+import { writeSlotReorderDragPayload } from '../dnd';
+
+const ROW_HEIGHT = 52;
+
+// Give the virtualized list deterministic, non-zero geometry. Under jsdom the
+// real hook sees a zero-height viewport, so totalHeight collapses to 0 and the
+// pointer->index mapping can never be exercised. This mock renders every row
+// and maps pointerTop straight to an index, so clientY drives insertIdx.
+vi.mock('../useMeasuredVirtualList', () => ({
+  useMeasuredVirtualList: ({ itemCount }: { itemCount: number }) => ({
+    startIdx: 0,
+    endIdx: itemCount,
+    beforeHeight: 0,
+    afterHeight: 0,
+    totalHeight: itemCount * ROW_HEIGHT,
+    items: Array.from({ length: itemCount }, (_, idx) => ({
+      idx,
+      key: idx,
+      top: idx * ROW_HEIGHT,
+      height: ROW_HEIGHT,
+    })),
+    setMeasuredHeight: vi.fn(),
+    scrollTopForIndex: (idx: number) => idx * ROW_HEIGHT,
+    indexFromScrollTop: (top: number) =>
+      Math.max(0, Math.min(itemCount, Math.floor(top / ROW_HEIGHT))),
+  }),
+}));
+
+function slot(id: number, locked = false): SlotView {
+  return {
+    id, position: id, locked, targetEnergy: null, transitionScore: 50,
+    nextPairingId: null, nextIsDjPairing: false,
+    track: { id: `t${id}`, title: `T${id}`, artist: `A${id}`, durationSec: 210, energy: 5, bpm: 120, key: '8A' },
+  };
+}
+
+function reorderDataTransfer(slotId: number): DataTransfer {
+  const store: Record<string, string> = {};
+  const dt = {
+    effectAllowed: 'none', dropEffect: 'none',
+    setData: (t: string, v: string) => { store[t] = v; },
+    getData: (t: string) => store[t] ?? '',
+    get types() { return Object.keys(store); },
+  } as unknown as DataTransfer;
+  writeSlotReorderDragPayload(dt, slotId);
+  return dt;
+}
+
+// jsdom's DragEvent constructor drops the clientY from the init dict, so a plain
+// fireEvent.drop({ clientY }) arrives with clientY === undefined. Build the event
+// and force the coordinate on before dispatch so the pointer->index path runs.
+function fireReorderDrop(el: Element, dataTransfer: DataTransfer, clientY: number) {
+  const event = createEvent.drop(el, { dataTransfer });
+  Object.defineProperty(event, 'clientY', { value: clientY });
+  fireEvent(el, event);
+}
+
+function renderPanel(slots: SlotView[], onSlotReorder = vi.fn()) {
+  render(
+    <TimelinePanel
+      slots={slots} hoveredIdx={null} currentIdx={-1} positionSec={0}
+      playing={false} onHover={vi.fn()} scrollRequest={null}
+      onSlotReorder={onSlotReorder}
+    />,
+  );
+  return onSlotReorder;
+}
+
+describe('TimelinePanel reorder drop', () => {
+  it('calls onSlotReorder with the source slot id and resolved target index', () => {
+    const slots = [slot(1), slot(2), slot(3)];
+    const onSlotReorder = renderPanel(slots);
+    const dt = reorderDataTransfer(1);
+    const list = screen.getByTestId('timeline-list');
+    // clientY 60 -> pointerTop 60 -> floor(60/52) = insertIdx 1.
+    fireEvent.dragStart(screen.getByTestId('timeline-row-0'), { dataTransfer: dt });
+    fireReorderDrop(list, dt, 60);
+    expect(onSlotReorder).toHaveBeenCalledTimes(1);
+    expect(onSlotReorder).toHaveBeenCalledWith(1, 1);
+  });
+
+  it('reorders within a span that does not cross a locked slot', () => {
+    const slots = [slot(1), slot(2), slot(3, true)];
+    const onSlotReorder = renderPanel(slots);
+    const dt = reorderDataTransfer(1);
+    const list = screen.getByTestId('timeline-list');
+    // Drag idx 0 to insertIdx 1; the locked slot at idx 2 is outside the [0,1] span.
+    fireEvent.dragStart(screen.getByTestId('timeline-row-0'), { dataTransfer: dt });
+    fireReorderDrop(list, dt, 60);
+    expect(onSlotReorder).toHaveBeenCalledTimes(1);
+    expect(onSlotReorder).toHaveBeenCalledWith(1, 1);
+  });
+
+  it('does not reorder across a locked slot', () => {
+    const slots = [slot(1), slot(2, true), slot(3)];
+    const onSlotReorder = renderPanel(slots);
+    const dt = reorderDataTransfer(1);
+    const list = screen.getByTestId('timeline-list');
+    // Drag idx 0 to the end; the locked slot at idx 1 sits inside the span.
+    fireEvent.dragStart(screen.getByTestId('timeline-row-0'), { dataTransfer: dt });
+    fireReorderDrop(list, dt, 999);
+    expect(onSlotReorder).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/TimelineRow.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/TimelineRow.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TimelineRow from '../TimelineRow';
+import type { SlotView } from '../types';
+import { readSlotReorderDragPayload } from '../dnd';
+
+function slot(id: number, locked = false): SlotView {
+  return {
+    id, position: id, locked, targetEnergy: null, transitionScore: 50,
+    nextPairingId: null, nextIsDjPairing: false,
+    track: { id: `t${id}`, title: `T${id}`, artist: `A${id}`, durationSec: 210, energy: 5, bpm: 120, key: '8A' },
+  };
+}
+
+function renderRow(s: SlotView) {
+  const slots = [s];
+  return render(
+    <TimelineRow
+      slot={s} prevSlot={null} nextSlot={null} idx={0} slots={slots}
+      hoveredIdx={null} currentIdx={-1} positionSec={0} playing={false}
+      selected={false} dropIdx={null} setDropIdx={vi.fn()} onHover={vi.fn()}
+      onSelectedChange={vi.fn()} setMenu={vi.fn()}
+    />,
+  );
+}
+
+function fakeDataTransfer(): DataTransfer {
+  const store: Record<string, string> = {};
+  return {
+    effectAllowed: 'none',
+    setData: (t: string, v: string) => { store[t] = v; },
+    getData: (t: string) => store[t] ?? '',
+  } as unknown as DataTransfer;
+}
+
+describe('TimelineRow drag source', () => {
+  it('is draggable when the slot is unlocked', () => {
+    renderRow(slot(1, false));
+    expect(screen.getByTestId('timeline-row-0').getAttribute('draggable')).toBe('true');
+  });
+
+  it('is not draggable when the slot is locked', () => {
+    renderRow(slot(1, true));
+    expect(screen.getByTestId('timeline-row-0').getAttribute('draggable')).toBe('false');
+  });
+
+  it('writes the slot id on drag start', () => {
+    renderRow(slot(7, false));
+    const dt = fakeDataTransfer();
+    fireEvent.dragStart(screen.getByTestId('timeline-row-0'), { dataTransfer: dt });
+    expect(readSlotReorderDragPayload(dt)).toEqual({ slotId: 7 });
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/buildReorderedIds.test.ts
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/buildReorderedIds.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { buildReorderedIds } from '../BuilderWorkspace';
+import type { SlotView } from '../types';
+
+function slot(id: number, locked = false): SlotView {
+  return {
+    id, position: id, locked, targetEnergy: null, transitionScore: 50,
+    nextPairingId: null, nextIsDjPairing: false,
+    track: { id: `t${id}`, title: `T${id}`, artist: `A${id}`, durationSec: 210, energy: 5, bpm: 120, key: '8A' },
+  };
+}
+
+describe('buildReorderedIds', () => {
+  const slots = [slot(1), slot(2), slot(3)];
+
+  it('moves a slot forward (drag idx 0 to end)', () => {
+    // insertIdx === slots.length means "drop at the end"
+    expect(buildReorderedIds(slots, 1, 3)).toEqual([2, 3, 1]);
+  });
+
+  it('moves a slot backward (drag idx 2 to front)', () => {
+    expect(buildReorderedIds(slots, 3, 0)).toEqual([3, 1, 2]);
+  });
+
+  it('returns null for a no-op move', () => {
+    // dragging idx 1 to insertIdx 1 (or 2, which resolves to the same slot) is a no-op
+    expect(buildReorderedIds(slots, 2, 1)).toBeNull();
+  });
+
+  it('returns null for an unknown slot id', () => {
+    expect(buildReorderedIds(slots, 999, 0)).toBeNull();
+  });
+
+  it('returns the new order when the move does not cross a locked slot', () => {
+    const s = [slot(1), slot(2), slot(3, true)]; // lock at idx 2
+    expect(buildReorderedIds(s, 1, 2)).toEqual([2, 1, 3]); // locked id 3 stays at idx 2
+  });
+
+  it('returns null when the move would displace a locked slot', () => {
+    const s = [slot(1), slot(2, true), slot(3)]; // lock at idx 1
+    expect(buildReorderedIds(s, 1, 3)).toBeNull(); // dragging idx0 to end crosses the lock
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/dnd.test.ts
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/dnd.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SLOT_REORDER_DND_TYPE,
+  writeSlotReorderDragPayload,
+  readSlotReorderDragPayload,
+} from '../dnd';
+
+function fakeDataTransfer(): DataTransfer {
+  const store: Record<string, string> = {};
+  return {
+    effectAllowed: 'none',
+    dropEffect: 'none',
+    setData: (type: string, val: string) => {
+      store[type] = val;
+    },
+    getData: (type: string) => store[type] ?? '',
+  } as unknown as DataTransfer;
+}
+
+describe('slot reorder drag payload', () => {
+  it('round-trips a slot id', () => {
+    const dt = fakeDataTransfer();
+    writeSlotReorderDragPayload(dt, 42);
+    expect(dt.effectAllowed).toBe('move');
+    expect(readSlotReorderDragPayload(dt)).toEqual({ slotId: 42 });
+  });
+
+  it('returns null for a missing payload', () => {
+    expect(readSlotReorderDragPayload(fakeDataTransfer())).toBeNull();
+  });
+
+  it('returns null for a malformed payload', () => {
+    const dt = fakeDataTransfer();
+    dt.setData(SLOT_REORDER_DND_TYPE, '{"slotId":"nope"}');
+    expect(readSlotReorderDragPayload(dt)).toBeNull();
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/components/dnd.ts
+++ b/dashboard/app/(dj)/setbuilder/components/dnd.ts
@@ -22,3 +22,30 @@ export function readPoolTrackDragPayload(dataTransfer: DataTransfer): PoolTrackD
     return null;
   }
 }
+
+export const SLOT_REORDER_DND_TYPE = 'application/x-wrzdj-slot-reorder';
+
+export interface SlotReorderDragPayload {
+  slotId: number;
+}
+
+export function writeSlotReorderDragPayload(dataTransfer: DataTransfer, slotId: number): void {
+  dataTransfer.effectAllowed = 'move';
+  dataTransfer.setData(SLOT_REORDER_DND_TYPE, JSON.stringify({ slotId }));
+  dataTransfer.setData('text/plain', String(slotId));
+}
+
+export function readSlotReorderDragPayload(
+  dataTransfer: DataTransfer,
+): SlotReorderDragPayload | null {
+  const raw = dataTransfer.getData(SLOT_REORDER_DND_TYPE);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { slotId?: unknown };
+    return typeof parsed.slotId === 'number' && Number.isInteger(parsed.slotId)
+      ? { slotId: parsed.slotId }
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -12988,6 +12988,13 @@ export interface operations {
                     "application/json": components["schemas"]["TransitionScoreOut"][];
                 };
             };
+            /** @description Invalid reorder (not a permutation, or would move a locked slot) */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -3202,6 +3202,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/setbuilder/sets/{set_id}/slots/order": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Reorder Slots
+         * @description Reassign the set's slot order by hand and recompute transition scores (#437).
+         */
+        put: operations["reorder_slots_api_setbuilder_sets__set_id__slots_order_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/setbuilder/sets/{set_id}/slots/{slot_id}/target": {
         parameters: {
             query?: never;
@@ -4045,10 +4065,7 @@ export interface components {
         };
         /** Body_upload_banner_api_events__code__banner_post */
         Body_upload_banner_api_events__code__banner_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** BridgeApiKeyResponse */
@@ -6513,6 +6530,14 @@ export interface components {
             track_id: string | null;
             /** Transition Score */
             transition_score: number | null;
+        };
+        /**
+         * SlotOrderRequest
+         * @description Full desired slot order for a set (hand-drag reorder, #437).
+         */
+        SlotOrderRequest: {
+            /** Slot Ids */
+            slot_ids: number[];
         };
         /**
          * SlotOut
@@ -12926,6 +12951,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SlotOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reorder_slots_api_setbuilder_sets__set_id__slots_order_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SlotOrderRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TransitionScoreOut"][];
                 };
             };
             /** @description Validation Error */

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -82,6 +82,7 @@ import type {
   TidalSearchResult,
   TidalSyncResult,
   TidalStatus,
+  TransitionScore,
   TransportCommandIn,
   TransportCommandOut,
   TransportStatusOut,
@@ -713,6 +714,12 @@ class ApiClient {
     return this.fetch(`/api/setbuilder/sets/${setId}/document`, {
       method: 'PUT',
       body: JSON.stringify(snapshot),
+    });
+  }
+  async reorderSlots(setId: number, slotIds: number[]): Promise<TransitionScore[]> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/slots/order`, {
+      method: 'PUT',
+      body: JSON.stringify({ slot_ids: slotIds }),
     });
   }
   async renameSet(setId: number, name: string): Promise<SetDetail> {

--- a/docs/superpowers/plans/2026-06-17-issue-437-timeline-reorder.md
+++ b/docs/superpowers/plans/2026-06-17-issue-437-timeline-reorder.md
@@ -1,0 +1,1064 @@
+# Timeline Hand-Drag Reorder (#437) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let DJs reorder WrzDJSet timeline slots by hand-dragging rows, persisting the new order and recomputing transition scores, while respecting locked slots and undo/redo.
+
+**Architecture:** A reusable backend reorder engine — `apply_slot_order` service (permutation + locked-invariant validation, position reassignment, Pass-1 rescore) behind a `PUT /sets/{id}/slots/order` endpoint — plus a frontend slice that extends the existing native-HTML5-DnD pattern: draggable rows, a slot-reorder `dataTransfer` payload, the existing virtualization-aware `insertIndexFromPointer`, and the `useSetDocumentHistory.commit()` path (which gives undo/redo/autosave for free).
+
+**Tech Stack:** FastAPI + SQLAlchemy + Pydantic (backend); pytest. Next.js/React 19 + vanilla CSS (frontend); Vitest + Testing Library. OpenAPI→TS type generation via `openapi-typescript`.
+
+**Spec:** `docs/superpowers/specs/2026-06-17-issue-437-timeline-reorder-design.md`
+**Branch:** `feat/issue-437` (already created off `origin/main`).
+
+---
+
+## File Structure
+
+**Backend (`server/`)**
+- Create `app/services/setbuilder/reorder.py` — `ReorderError` + `apply_slot_order(db, set_obj, ordered_ids)`. Reuses `pass1_deterministic.recompute_transition_scores`.
+- Modify `app/schemas/setbuilder.py` — add `SlotOrderRequest`.
+- Modify `app/api/setbuilder.py` — add `PUT /sets/{set_id}/slots/order` (imports `reorder`, `SlotOrderRequest`).
+- Create `tests/test_setbuilder_reorder.py` — service unit tests.
+- Create `tests/test_setbuilder_reorder_api.py` — endpoint tests.
+
+**Frontend (`dashboard/`)**
+- Modify `app/(dj)/setbuilder/components/dnd.ts` — slot-reorder payload helpers.
+- Modify `lib/api.ts` — `reorderSlots`.
+- Regenerate `lib/api-types.generated.ts` (via `npm run types:export && npm run types:generate`).
+- Modify `app/(dj)/setbuilder/components/TimelineRow.tsx` — draggable-when-unlocked + dragstart payload.
+- Modify `app/(dj)/setbuilder/components/TimelinePanel.tsx` — reorder drop handling + cross-lock block + `onSlotReorder` prop.
+- Modify `app/(dj)/setbuilder/components/BuilderWorkspace.tsx` — `handleSlotReorder` via `commit()`.
+- Create `__tests__/dnd.test.ts`, `__tests__/TimelineRow.test.tsx`, `__tests__/TimelinePanel.test.tsx`, `__tests__/BuilderWorkspace.reorder.test.tsx`.
+
+**Optional (preferred DRY, last):**
+- Modify `app/services/setbuilder/pass2_agent.py` — `_tool_reorder_slot` delegates position-reassignment to `reorder.apply_slot_order`.
+
+---
+
+## Task 0: Backend — `apply_slot_order` service
+
+**Files:**
+- Create: `server/app/services/setbuilder/reorder.py`
+- Test: `server/tests/test_setbuilder_reorder.py`
+
+Run all backend commands from `server/` with the venv: `.venv/bin/pytest`, `.venv/bin/ruff`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `server/tests/test_setbuilder_reorder.py`:
+
+```python
+"""Tests for DJ-driven full-order slot reordering (#437)."""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.set import Set, SetSlot
+from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.models.user import User
+from app.services.setbuilder.reorder import ReorderError, apply_slot_order
+
+
+def _set_with_slots(db: Session, user: User, n: int, locked_idx: int | None = None) -> Set:
+    set_obj = Set(owner_id=user.id, name="Friday", target_duration_sec=14 * 60)
+    db.add(set_obj)
+    db.commit()
+    db.refresh(set_obj)
+    src = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(src)
+    db.commit()
+    db.refresh(src)
+    for i in range(n):
+        db.add(
+            SetPoolTrack(
+                set_id=set_obj.id, source_id=src.id, track_id=f"tidal:{i}",
+                title=f"T{i}", artist=f"A{i}", bpm=120.0 + i, key="8A", camelot="8A",
+                energy=5, duration_sec=210, dedupe_sig=f"sig-{i}",
+            )
+        )
+        db.add(
+            SetSlot(
+                set_id=set_obj.id, position=i, track_id=f"tidal:{i}",
+                locked=(i == locked_idx),
+            )
+        )
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def _ids_in_order(set_obj: Set) -> list[int]:
+    return [s.id for s in sorted(set_obj.slots, key=lambda s: s.position)]
+
+
+def test_apply_slot_order_reassigns_positions(db: Session, test_user: User):
+    set_obj = _set_with_slots(db, test_user, 3)
+    ids = _ids_in_order(set_obj)
+    new_order = [ids[2], ids[0], ids[1]]
+
+    apply_slot_order(db, set_obj, new_order)
+    db.refresh(set_obj)
+
+    assert _ids_in_order(set_obj) == new_order
+    assert sorted(s.position for s in set_obj.slots) == [0, 1, 2]
+
+
+def test_apply_slot_order_recomputes_transition_scores(db: Session, test_user: User):
+    set_obj = _set_with_slots(db, test_user, 3)
+    ids = _ids_in_order(set_obj)
+
+    scores = apply_slot_order(db, set_obj, [ids[2], ids[0], ids[1]])
+
+    # First slot in the new order scores 100; scores are keyed to new positions.
+    by_pos = {s.position: s for s in scores}
+    assert by_pos[0].score == 100.0
+    assert {s.slot_id for s in scores} == set(ids)
+
+
+def test_apply_slot_order_rejects_non_permutation(db: Session, test_user: User):
+    set_obj = _set_with_slots(db, test_user, 3)
+    ids = _ids_in_order(set_obj)
+    with pytest.raises(ReorderError, match="permutation"):
+        apply_slot_order(db, set_obj, [ids[0], ids[1]])  # missing one
+    with pytest.raises(ReorderError, match="permutation"):
+        apply_slot_order(db, set_obj, [ids[0], ids[1], 99999])  # unknown id
+
+
+def test_apply_slot_order_rejects_moving_locked_slot(db: Session, test_user: User):
+    set_obj = _set_with_slots(db, test_user, 3, locked_idx=1)
+    ids = _ids_in_order(set_obj)
+    # Moving the locked middle slot to the front must fail.
+    with pytest.raises(ReorderError, match="locked"):
+        apply_slot_order(db, set_obj, [ids[1], ids[0], ids[2]])
+
+
+def test_apply_slot_order_allows_reorder_that_keeps_locked_position(db: Session, test_user: User):
+    set_obj = _set_with_slots(db, test_user, 3, locked_idx=1)
+    ids = _ids_in_order(set_obj)
+    # Swapping the two unlocked ends keeps the locked slot at index 1 — allowed.
+    apply_slot_order(db, set_obj, [ids[2], ids[1], ids[0]])
+    db.refresh(set_obj)
+    assert _ids_in_order(set_obj) == [ids[2], ids[1], ids[0]]
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_setbuilder_reorder.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.services.setbuilder.reorder'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `server/app/services/setbuilder/reorder.py`:
+
+```python
+"""DJ-driven full-order slot reordering for WrzDJSet (#437).
+
+Reuses Pass-1 transition scoring so a hand-drag reorder scores identically to
+the agent's ``reorder_slot`` tool.
+"""
+
+from sqlalchemy.orm import Session
+
+from app.models.set import Set
+from app.services.setbuilder.pass1_deterministic import (
+    TransitionScore,
+    recompute_transition_scores,
+)
+
+
+class ReorderError(ValueError):
+    """Requested order is not a permutation, or would move a locked slot."""
+
+
+def apply_slot_order(
+    db: Session, set_obj: Set, ordered_ids: list[int], *, commit: bool = True
+) -> list[TransitionScore]:
+    """Reassign slot positions to match ``ordered_ids`` and rescore transitions.
+
+    * ``ordered_ids`` must be a permutation of the set's current slot ids.
+    * Every locked slot must keep its current position (immovable anchor).
+    """
+    slots = sorted(set_obj.slots, key=lambda s: s.position)
+    if sorted(ordered_ids) != sorted(s.id for s in slots):
+        raise ReorderError("slot_ids must be a permutation of the set's slots")
+
+    by_id = {s.id: s for s in slots}
+    for new_position, slot_id in enumerate(ordered_ids):
+        slot = by_id[slot_id]
+        if slot.locked and slot.position != new_position:
+            raise ReorderError("Reorder would move a locked slot")
+
+    reordered = [by_id[slot_id] for slot_id in ordered_ids]
+    for new_position, slot in enumerate(reordered):
+        slot.position = new_position
+    db.flush()
+    return recompute_transition_scores(db, set_obj, reordered, commit=commit)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_setbuilder_reorder.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd server
+.venv/bin/ruff check --fix app/services/setbuilder/reorder.py tests/test_setbuilder_reorder.py
+.venv/bin/ruff format app/services/setbuilder/reorder.py tests/test_setbuilder_reorder.py
+cd ..
+git add server/app/services/setbuilder/reorder.py server/tests/test_setbuilder_reorder.py
+git commit -m "feat(setbuilder): add apply_slot_order reorder+rescore service (#437)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 1: Backend — `SlotOrderRequest` schema + `PUT /slots/order` endpoint
+
+**Files:**
+- Modify: `server/app/schemas/setbuilder.py` (add `SlotOrderRequest` after `BuildSetResponse`, ~line 453)
+- Modify: `server/app/api/setbuilder.py` (add endpoint after `update_slot_target`, ~line 530; extend two imports)
+- Test: `server/tests/test_setbuilder_reorder_api.py`
+
+- [ ] **Step 1: Write the failing endpoint tests**
+
+Create `server/tests/test_setbuilder_reorder_api.py`:
+
+```python
+"""Endpoint tests for hand-drag slot reorder (#437)."""
+
+from sqlalchemy.orm import Session
+
+from app.models.set import Set, SetSlot
+from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.models.user import User
+
+
+def _make_set_with_slots(db: Session, owner: User, n: int, locked_idx: int | None = None) -> Set:
+    set_obj = Set(owner_id=owner.id, name="Friday", target_duration_sec=14 * 60)
+    db.add(set_obj)
+    db.commit()
+    db.refresh(set_obj)
+    src = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(src)
+    db.commit()
+    db.refresh(src)
+    for i in range(n):
+        db.add(
+            SetPoolTrack(
+                set_id=set_obj.id, source_id=src.id, track_id=f"tidal:{i}",
+                title=f"T{i}", artist=f"A{i}", bpm=120.0 + i, key="8A", camelot="8A",
+                energy=5, duration_sec=210, dedupe_sig=f"sig-{i}",
+            )
+        )
+        db.add(SetSlot(set_id=set_obj.id, position=i, track_id=f"tidal:{i}", locked=(i == locked_idx)))
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def _ordered_ids(client, set_id: int, headers) -> list[int]:
+    rows = client.get(f"/api/setbuilder/sets/{set_id}/slots", headers=headers).json()
+    return [r["id"] for r in sorted(rows, key=lambda r: r["position"])]
+
+
+def test_reorder_slots_persists_new_order(client, db: Session, test_user: User, auth_headers):
+    set_obj = _make_set_with_slots(db, test_user, 3)
+    ids = _ordered_ids(client, set_obj.id, auth_headers)
+    new_order = [ids[2], ids[0], ids[1]]
+
+    resp = client.put(
+        f"/api/setbuilder/sets/{set_obj.id}/slots/order",
+        json={"slot_ids": new_order},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200
+    assert _ordered_ids(client, set_obj.id, auth_headers) == new_order
+    # Response carries recomputed scores keyed to new positions.
+    scores = {s["position"]: s for s in resp.json()}
+    assert scores[0]["score"] == 100.0
+
+
+def test_reorder_rejects_non_permutation(client, db: Session, test_user: User, auth_headers):
+    set_obj = _make_set_with_slots(db, test_user, 3)
+    ids = _ordered_ids(client, set_obj.id, auth_headers)
+    resp = client.put(
+        f"/api/setbuilder/sets/{set_obj.id}/slots/order",
+        json={"slot_ids": ids[:2]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_reorder_rejects_moving_locked_slot(client, db: Session, test_user: User, auth_headers):
+    set_obj = _make_set_with_slots(db, test_user, 3, locked_idx=1)
+    ids = _ordered_ids(client, set_obj.id, auth_headers)
+    resp = client.put(
+        f"/api/setbuilder/sets/{set_obj.id}/slots/order",
+        json={"slot_ids": [ids[1], ids[0], ids[2]]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_reorder_other_djs_set_is_404(client, db: Session, admin_user: User, test_user: User, auth_headers):
+    # admin_user owns the set; test_user (auth_headers) must not reach it.
+    set_obj = _make_set_with_slots(db, admin_user, 3)
+    resp = client.put(
+        f"/api/setbuilder/sets/{set_obj.id}/slots/order",
+        json={"slot_ids": [s.id for s in set_obj.slots]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_reorder_requires_active_user(client, db: Session, test_user: User, pending_headers):
+    set_obj = _make_set_with_slots(db, test_user, 3)
+    resp = client.put(
+        f"/api/setbuilder/sets/{set_obj.id}/slots/order",
+        json={"slot_ids": [s.id for s in set_obj.slots]},
+        headers=pending_headers,
+    )
+    assert resp.status_code in (401, 403)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_setbuilder_reorder_api.py -v`
+Expected: FAIL — 404/422 because the route does not exist yet.
+
+- [ ] **Step 3: Add the schema**
+
+In `server/app/schemas/setbuilder.py`, after `class BuildSetResponse` (~line 453), add:
+
+```python
+class SlotOrderRequest(BaseModel):
+    """Full desired slot order for a set (hand-drag reorder, #437)."""
+
+    slot_ids: list[int] = Field(..., min_length=1, max_length=500)
+```
+
+- [ ] **Step 4: Add the endpoint**
+
+In `server/app/api/setbuilder.py`:
+
+1. Add `SlotOrderRequest` to the `from app.schemas.setbuilder import (...)` block (line 24).
+2. Add `reorder` to the `from app.services.setbuilder import (...)` block (line 93).
+3. Insert after `update_slot_target` (after line 529):
+
+```python
+@router.put("/sets/{set_id}/slots/order", response_model=list[TransitionScoreOut])
+@limiter.limit("30/minute")
+def reorder_slots(
+    set_id: int,
+    payload: SlotOrderRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> list[TransitionScoreOut]:
+    """Reassign the set's slot order by hand and recompute transition scores (#437)."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    try:
+        scores = reorder.apply_slot_order(db, set_obj, payload.slot_ids)
+    except reorder.ReorderError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _transition_scores_out(scores)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_setbuilder_reorder_api.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Full backend gate + commit**
+
+```bash
+cd server
+.venv/bin/ruff check --fix app tests && .venv/bin/ruff format app tests
+.venv/bin/bandit -r app -c pyproject.toml -q
+.venv/bin/pytest --tb=short -q
+.venv/bin/alembic upgrade head && .venv/bin/alembic check
+cd ..
+git add server/app/schemas/setbuilder.py server/app/api/setbuilder.py server/tests/test_setbuilder_reorder_api.py
+git commit -m "feat(setbuilder): add PUT /sets/{id}/slots/order reorder endpoint (#437)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+Expected: pytest passes with coverage ≥ 85%; `alembic check` reports no drift (no model change here).
+
+---
+
+## Task 2: Frontend — regenerate types + `api.reorderSlots`
+
+**Files:**
+- Regenerate: `dashboard/lib/api-types.generated.ts`
+- Modify: `dashboard/lib/api.ts` (add method near `putSetDocument`, ~line 717; ensure `TransitionScore` is imported)
+
+- [ ] **Step 1: Regenerate the OpenAPI types**
+
+```bash
+cd dashboard
+npm run types:export      # writes ../server/openapi.json from FastAPI
+npm run types:generate    # regenerates lib/api-types.generated.ts
+git checkout next-env.d.ts 2>/dev/null || true
+```
+
+Verify `SlotOrderRequest` now appears: `grep -n "SlotOrderRequest" lib/api-types.generated.ts` → expect a hit.
+
+- [ ] **Step 2: Add the api client method**
+
+In `dashboard/lib/api.ts`, confirm `TransitionScore` is imported from `@/lib/api-types` (add it to the import if missing). Add after `putSetDocument` (~line 717):
+
+```typescript
+  async reorderSlots(setId: number, slotIds: number[]): Promise<TransitionScore[]> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/slots/order`, {
+      method: 'PUT',
+      body: JSON.stringify({ slot_ids: slotIds }),
+    });
+  }
+```
+
+- [ ] **Step 3: Verify types + lint**
+
+```bash
+cd dashboard
+npx tsc --noEmit
+npm run lint
+```
+
+Expected: no errors; no api-types drift (the generated file is up to date with the backend).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dashboard/lib/api.ts dashboard/lib/api-types.generated.ts
+git commit -m "feat(setbuilder): add reorderSlots api client + regenerate types (#437)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Frontend — `dnd.ts` slot-reorder payload (TDD)
+
+**Files:**
+- Modify: `dashboard/app/(dj)/setbuilder/components/dnd.ts`
+- Test: Create `dashboard/app/(dj)/setbuilder/components/__tests__/dnd.test.ts`
+
+Run frontend tests from `dashboard/`: `npm test -- --run <path>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `dashboard/app/(dj)/setbuilder/components/__tests__/dnd.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import {
+  SLOT_REORDER_DND_TYPE,
+  writeSlotReorderDragPayload,
+  readSlotReorderDragPayload,
+} from '../dnd';
+
+function fakeDataTransfer(): DataTransfer {
+  const store: Record<string, string> = {};
+  return {
+    effectAllowed: 'none',
+    dropEffect: 'none',
+    setData: (type: string, val: string) => {
+      store[type] = val;
+    },
+    getData: (type: string) => store[type] ?? '',
+  } as unknown as DataTransfer;
+}
+
+describe('slot reorder drag payload', () => {
+  it('round-trips a slot id', () => {
+    const dt = fakeDataTransfer();
+    writeSlotReorderDragPayload(dt, 42);
+    expect(dt.effectAllowed).toBe('move');
+    expect(readSlotReorderDragPayload(dt)).toEqual({ slotId: 42 });
+  });
+
+  it('returns null for a missing payload', () => {
+    expect(readSlotReorderDragPayload(fakeDataTransfer())).toBeNull();
+  });
+
+  it('returns null for a malformed payload', () => {
+    const dt = fakeDataTransfer();
+    dt.setData(SLOT_REORDER_DND_TYPE, '{"slotId":"nope"}');
+    expect(readSlotReorderDragPayload(dt)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm test -- --run app/\(dj\)/setbuilder/components/__tests__/dnd.test.ts`
+Expected: FAIL — exports not defined.
+
+- [ ] **Step 3: Implement**
+
+Append to `dashboard/app/(dj)/setbuilder/components/dnd.ts`:
+
+```typescript
+export const SLOT_REORDER_DND_TYPE = 'application/x-wrzdj-slot-reorder';
+
+export interface SlotReorderDragPayload {
+  slotId: number;
+}
+
+export function writeSlotReorderDragPayload(dataTransfer: DataTransfer, slotId: number): void {
+  dataTransfer.effectAllowed = 'move';
+  dataTransfer.setData(SLOT_REORDER_DND_TYPE, JSON.stringify({ slotId }));
+  dataTransfer.setData('text/plain', String(slotId));
+}
+
+export function readSlotReorderDragPayload(
+  dataTransfer: DataTransfer,
+): SlotReorderDragPayload | null {
+  const raw = dataTransfer.getData(SLOT_REORDER_DND_TYPE);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { slotId?: unknown };
+    return typeof parsed.slotId === 'number' && Number.isInteger(parsed.slotId)
+      ? { slotId: parsed.slotId }
+      : null;
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm test -- --run app/\(dj\)/setbuilder/components/__tests__/dnd.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "dashboard/app/(dj)/setbuilder/components/dnd.ts" "dashboard/app/(dj)/setbuilder/components/__tests__/dnd.test.ts"
+git commit -m "feat(setbuilder): add slot-reorder drag payload helpers (#437)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Frontend — `TimelineRow` draggable when unlocked (TDD)
+
+**Files:**
+- Modify: `dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx` (the row `<div>` at line 150–174: `draggable={false}` → conditional; add `onDragStart`)
+- Test: Create `dashboard/app/(dj)/setbuilder/components/__tests__/TimelineRow.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `dashboard/app/(dj)/setbuilder/components/__tests__/TimelineRow.test.tsx`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TimelineRow from '../TimelineRow';
+import type { SlotView } from '../types';
+import { readSlotReorderDragPayload } from '../dnd';
+
+function slot(id: number, locked = false): SlotView {
+  return {
+    id, position: id, locked, targetEnergy: null, transitionScore: 50,
+    nextPairingId: null, nextIsDjPairing: false,
+    track: { id: `t${id}`, title: `T${id}`, artist: `A${id}`, durationSec: 210, energy: 5, bpm: 120, key: '8A' },
+  };
+}
+
+function renderRow(s: SlotView) {
+  const slots = [s];
+  return render(
+    <TimelineRow
+      slot={s} prevSlot={null} nextSlot={null} idx={0} slots={slots}
+      hoveredIdx={null} currentIdx={-1} positionSec={0} playing={false}
+      selected={false} dropIdx={null} setDropIdx={vi.fn()} onHover={vi.fn()}
+      onSelectedChange={vi.fn()} setMenu={vi.fn()}
+    />,
+  );
+}
+
+function fakeDataTransfer(): DataTransfer {
+  const store: Record<string, string> = {};
+  return {
+    effectAllowed: 'none',
+    setData: (t: string, v: string) => { store[t] = v; },
+    getData: (t: string) => store[t] ?? '',
+  } as unknown as DataTransfer;
+}
+
+describe('TimelineRow drag source', () => {
+  it('is draggable when the slot is unlocked', () => {
+    renderRow(slot(1, false));
+    expect(screen.getByTestId('timeline-row-0').getAttribute('draggable')).toBe('true');
+  });
+
+  it('is not draggable when the slot is locked', () => {
+    renderRow(slot(1, true));
+    expect(screen.getByTestId('timeline-row-0').getAttribute('draggable')).toBe('false');
+  });
+
+  it('writes the slot id on drag start', () => {
+    renderRow(slot(7, false));
+    const dt = fakeDataTransfer();
+    fireEvent.dragStart(screen.getByTestId('timeline-row-0'), { dataTransfer: dt });
+    expect(readSlotReorderDragPayload(dt)).toEqual({ slotId: 7 });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm test -- --run app/\(dj\)/setbuilder/components/__tests__/TimelineRow.test.tsx`
+Expected: FAIL — row is `draggable="false"` always; no dragstart payload.
+
+- [ ] **Step 3: Implement**
+
+In `TimelineRow.tsx`:
+1. Add to the imports from `./dnd` (line 5): `writeSlotReorderDragPayload`.
+2. On the row `<div>` (line 150), replace `draggable={false}` with:
+
+```tsx
+        draggable={!slot.locked}
+        onDragStart={(event) => {
+          if (slot.locked) {
+            event.preventDefault();
+            return;
+          }
+          writeSlotReorderDragPayload(event.dataTransfer, slot.id);
+        }}
+```
+
+(Leave the existing `onDragOver` / `onDragLeave` / `onDrop` pool-track handlers in place — they coexist.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm test -- --run app/\(dj\)/setbuilder/components/__tests__/TimelineRow.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "dashboard/app/(dj)/setbuilder/components/TimelineRow.tsx" "dashboard/app/(dj)/setbuilder/components/__tests__/TimelineRow.test.tsx"
+git commit -m "feat(setbuilder): make unlocked timeline rows drag sources (#437)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Frontend — `TimelinePanel` reorder drop + cross-lock block (TDD)
+
+**Files:**
+- Modify: `dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx`
+- Test: Create `dashboard/app/(dj)/setbuilder/components/__tests__/TimelinePanel.test.tsx`
+
+**Design notes for this task:**
+- Add prop `onSlotReorder?: (slotId: number, insertIdx: number) => void | Promise<void>` to `TimelinePanelProps`.
+- Track the dragged source via a ref set on the bubbling `onDragStart` of the list container (`dragstart` can read `dataTransfer`; `dragover` cannot read data, only types). Clear it on drop/dragend.
+- Cross-lock block uses the agent's range rule: with `from` = source index and `target` = resolved insert index, reject if any locked slot sits in `[min(from,target), max(from,target)]` (excluding the source itself). Index === position because `slots` is position-ordered.
+- Reuse `insertIndexFromPointer` for the insert index and the existing `dropIdx` indicator.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `dashboard/app/(dj)/setbuilder/components/__tests__/TimelinePanel.test.tsx`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TimelinePanel from '../TimelinePanel';
+import type { SlotView } from '../types';
+import { writeSlotReorderDragPayload, SLOT_REORDER_DND_TYPE } from '../dnd';
+
+function slot(id: number, locked = false): SlotView {
+  return {
+    id, position: id, locked, targetEnergy: null, transitionScore: 50,
+    nextPairingId: null, nextIsDjPairing: false,
+    track: { id: `t${id}`, title: `T${id}`, artist: `A${id}`, durationSec: 210, energy: 5, bpm: 120, key: '8A' },
+  };
+}
+
+function reorderDataTransfer(slotId: number): DataTransfer {
+  const store: Record<string, string> = {};
+  const dt = {
+    effectAllowed: 'none', dropEffect: 'none',
+    setData: (t: string, v: string) => { store[t] = v; },
+    getData: (t: string) => store[t] ?? '',
+    get types() { return Object.keys(store); },
+  } as unknown as DataTransfer;
+  writeSlotReorderDragPayload(dt, slotId);
+  return dt;
+}
+
+function renderPanel(slots: SlotView[], onSlotReorder = vi.fn()) {
+  render(
+    <TimelinePanel
+      slots={slots} hoveredIdx={null} currentIdx={-1} positionSec={0}
+      playing={false} onHover={vi.fn()} scrollRequest={null}
+      onSlotReorder={onSlotReorder}
+    />,
+  );
+  return onSlotReorder;
+}
+
+describe('TimelinePanel reorder drop', () => {
+  it('calls onSlotReorder with the source slot id and target index', () => {
+    const slots = [slot(1), slot(2), slot(3)];
+    const onSlotReorder = renderPanel(slots);
+    const dt = reorderDataTransfer(1);
+    const list = screen.getByTestId('timeline-list');
+    fireEvent.dragStart(screen.getByTestId('timeline-row-0'), { dataTransfer: dt });
+    fireEvent.dragOver(list, { dataTransfer: dt, clientY: 999 }); // far down → end
+    fireEvent.drop(list, { dataTransfer: dt, clientY: 999 });
+    expect(onSlotReorder).toHaveBeenCalledTimes(1);
+    expect(onSlotReorder.mock.calls[0][0]).toBe(1);
+  });
+
+  it('does not reorder across a locked slot', () => {
+    const slots = [slot(1), slot(2, true), slot(3)]; // slot 2 locked (index 1)
+    const onSlotReorder = renderPanel(slots);
+    const dt = reorderDataTransfer(1); // dragging index 0 to the end crosses the lock
+    const list = screen.getByTestId('timeline-list');
+    fireEvent.dragStart(screen.getByTestId('timeline-row-0'), { dataTransfer: dt });
+    fireEvent.drop(list, { dataTransfer: dt, clientY: 999 });
+    expect(onSlotReorder).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm test -- --run app/\(dj\)/setbuilder/components/__tests__/TimelinePanel.test.tsx`
+Expected: FAIL — `onSlotReorder` prop unknown / not called.
+
+- [ ] **Step 3: Implement**
+
+In `TimelinePanel.tsx`:
+
+1. Extend the `./dnd` import (line 19): add `readSlotReorderDragPayload, SLOT_REORDER_DND_TYPE`.
+2. Add to `TimelinePanelProps`:
+
+```tsx
+  onSlotReorder?: (slotId: number, insertIdx: number) => void | Promise<void>;
+```
+
+3. Destructure `onSlotReorder` in the component params.
+4. Add a source ref near the other refs (after line 77):
+
+```tsx
+  const reorderSourceRef = useRef<number | null>(null);
+```
+
+5. Add reorder handlers (place near the existing pool handlers, ~line 256):
+
+```tsx
+  const dragIsReorder = (event: DragEvent<HTMLElement>) =>
+    event.dataTransfer.types.includes(SLOT_REORDER_DND_TYPE);
+
+  const reorderWouldCrossLock = (fromIdx: number, insertIdx: number) => {
+    const target = insertIdx > fromIdx ? insertIdx - 1 : insertIdx;
+    const lo = Math.min(fromIdx, target);
+    const hi = Math.max(fromIdx, target);
+    return slots.some((s, i) => s.locked && i !== fromIdx && i >= lo && i <= hi);
+  };
+
+  const handleListDragStart = (event: DragEvent<HTMLElement>) => {
+    const payload = readSlotReorderDragPayload(event.dataTransfer);
+    reorderSourceRef.current = payload ? payload.slotId : null;
+  };
+
+  const clearReorderSource = () => {
+    reorderSourceRef.current = null;
+  };
+
+  const markReorderDrop = (event: DragEvent<HTMLElement>) => {
+    event.preventDefault();
+    const slotId = reorderSourceRef.current;
+    const fromIdx = slotId == null ? -1 : slots.findIndex((s) => s.id === slotId);
+    const insertIdx = insertIndexFromPointer(event);
+    if (fromIdx < 0 || reorderWouldCrossLock(fromIdx, insertIdx)) {
+      event.dataTransfer.dropEffect = 'none';
+      setDropIdx(null);
+      return;
+    }
+    event.dataTransfer.dropEffect = 'move';
+    setDropIdx(insertIdx);
+  };
+
+  const handleReorderDrop = (event: DragEvent<HTMLElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setDropIdx(null);
+    const slotId = reorderSourceRef.current;
+    clearReorderSource();
+    if (slotId == null) return;
+    const fromIdx = slots.findIndex((s) => s.id === slotId);
+    const insertIdx = insertIndexFromPointer(event);
+    if (fromIdx < 0 || reorderWouldCrossLock(fromIdx, insertIdx)) return;
+    void onSlotReorder?.(slotId, insertIdx);
+  };
+```
+
+6. Update the list `<div data-testid="timeline-list">` (line 313) to branch by payload type. Replace its `onDragOver` / `onDrop` and add `onDragStart` / `onDragEnd`:
+
+```tsx
+        onDragStart={handleListDragStart}
+        onDragEnd={clearReorderSource}
+        onDragOver={(event) =>
+          dragIsReorder(event) ? markReorderDrop(event) : markPoolTrackDropAtPointer(event)
+        }
+        onDragLeave={clearDropIfLeaving}
+        onDrop={(event) =>
+          dragIsReorder(event) ? handleReorderDrop(event) : handlePoolTrackDropAtPointer(event)
+        }
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm test -- --run app/\(dj\)/setbuilder/components/__tests__/TimelinePanel.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "dashboard/app/(dj)/setbuilder/components/TimelinePanel.tsx" "dashboard/app/(dj)/setbuilder/components/__tests__/TimelinePanel.test.tsx"
+git commit -m "feat(setbuilder): handle slot-reorder drops in TimelinePanel (#437)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Frontend — `BuilderWorkspace.handleSlotReorder` via `commit()` (TDD)
+
+**Files:**
+- Modify: `dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx` (add handler near `handlePoolTrackDrop` ~line 370; pass `onSlotReorder` to `<TimelinePanel>` ~line 480)
+- Test: Create `dashboard/app/(dj)/setbuilder/components/__tests__/BuilderWorkspace.reorder.test.tsx`
+
+The handler builds the new ordered-id array, applies the same client-side locked guard, commits through history, then reloads slots. Mirrors `handlePoolTrackDrop`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `dashboard/app/(dj)/setbuilder/components/__tests__/BuilderWorkspace.reorder.test.tsx`. Mock `@/lib/api` (mirror `PoolPanel.test.tsx`'s `vi.hoisted` + `vi.mock` pattern). Render `BuilderWorkspace`, drive a reorder through the timeline list, and assert `api.reorderSlots` is called with the rebuilt order.
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { writeSlotReorderDragPayload } from '../dnd';
+
+const mockApi = vi.hoisted(() => ({
+  getSetSlots: vi.fn(),
+  getSetDocument: vi.fn(),
+  putSetDocument: vi.fn(),
+  reorderSlots: vi.fn(),
+  getTransportStatus: vi.fn(),
+}));
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/lib/api')>();
+  return { api: mockApi, ApiError: original.ApiError };
+});
+
+// NOTE: implementer fills in the minimal BuilderWorkspace props + slot/document
+// fixtures (3 slots, none locked) following the component's current prop shape.
+// getSetSlots resolves the 3 slots; getSetDocument resolves a snapshot; reorderSlots resolves [].
+
+function reorderDataTransfer(slotId: number): DataTransfer {
+  const store: Record<string, string> = {};
+  const dt = {
+    effectAllowed: 'none', dropEffect: 'none',
+    setData: (t: string, v: string) => { store[t] = v; },
+    getData: (t: string) => store[t] ?? '',
+    get types() { return Object.keys(store); },
+  } as unknown as DataTransfer;
+  writeSlotReorderDragPayload(dt, slotId);
+  return dt;
+}
+
+describe('BuilderWorkspace slot reorder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.reorderSlots.mockResolvedValue([]);
+  });
+
+  it('commits a reorder via api.reorderSlots with the rebuilt order', async () => {
+    // ...render BuilderWorkspace with 3 slots [id1,id2,id3]...
+    const dt = reorderDataTransfer(/* id of first slot */ 1);
+    const list = await screen.findByTestId('timeline-list');
+    fireEvent.dragStart(screen.getByTestId('timeline-row-0'), { dataTransfer: dt });
+    fireEvent.drop(list, { dataTransfer: dt, clientY: 999 }); // move first slot to the end
+    await waitFor(() => expect(mockApi.reorderSlots).toHaveBeenCalledTimes(1));
+    const [, orderedIds] = mockApi.reorderSlots.mock.calls[0];
+    expect(orderedIds[orderedIds.length - 1]).toBe(1); // moved slot is now last
+  });
+});
+```
+
+> If wiring a full `BuilderWorkspace` render proves heavy, this behavior may instead be unit-tested by extracting the order-rebuild + guard into a tiny pure helper `buildReorderedIds(slots, slotId, insertIdx)` in `BuilderWorkspace.tsx` (exported) and testing that directly. Prefer the integration test; fall back to the helper test only if the render is intractable. Document the choice in the PR.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm test -- --run app/\(dj\)/setbuilder/components/__tests__/BuilderWorkspace.reorder.test.tsx`
+Expected: FAIL — `onSlotReorder` not wired / `reorderSlots` never called.
+
+- [ ] **Step 3: Implement**
+
+In `BuilderWorkspace.tsx`, add after `handlePoolTrackDrop` (~line 389):
+
+```tsx
+  const handleSlotReorder = useCallback(
+    async (slotId: number, insertIdx: number) => {
+      const fromIdx = slots.findIndex((slot) => slot.id === slotId);
+      if (fromIdx < 0) return;
+      const target = insertIdx > fromIdx ? insertIdx - 1 : insertIdx;
+      if (target === fromIdx) return;
+      const ids = slots.map((slot) => slot.id);
+      const without = ids.filter((id) => id !== slotId);
+      without.splice(target, 0, slotId);
+      // Client-side locked-anchor guard (the backend enforces this too).
+      if (slots.some((slot, idx) => slot.locked && without[idx] !== slot.id)) return;
+      const save = async () => api.reorderSlots(setId, without);
+      try {
+        const run = commit ? commit('Reorder slot', save) : save();
+        await run;
+        await loadSlots();
+      } catch {
+        await loadSlots();
+      }
+    },
+    [commit, loadSlots, setId, slots],
+  );
+```
+
+Then pass it to `<TimelinePanel>` (~line 480):
+
+```tsx
+          onSlotReorder={handleSlotReorder}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm test -- --run app/\(dj\)/setbuilder/components/__tests__/BuilderWorkspace.reorder.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx" "dashboard/app/(dj)/setbuilder/components/__tests__/BuilderWorkspace.reorder.test.tsx"
+git commit -m "feat(setbuilder): wire hand-drag reorder commit in BuilderWorkspace (#437)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7 (OPTIONAL, preferred DRY): `_tool_reorder_slot` delegates to `apply_slot_order`
+
+Honors the spec's preferred refactor. **Skip and revert this task if the agent test suite regresses** — the fallback (independent implementations sharing only `recompute_transition_scores`) is acceptable and already shipped in Tasks 0–1.
+
+**Files:**
+- Modify: `server/app/services/setbuilder/pass2_agent.py` (`_tool_reorder_slot`, lines 270–291)
+
+- [ ] **Step 1: Run the existing agent tests to capture the green baseline**
+
+Run: `.venv/bin/pytest tests/ -k "agent or pass2 or reorder" -q`
+Expected: PASS — record the count.
+
+- [ ] **Step 2: Refactor `_tool_reorder_slot` to compute the new order then delegate**
+
+Replace the position-reassignment tail of `_tool_reorder_slot` so it builds `ordered_ids` (move `slot` to `new_position`) and calls `reorder.apply_slot_order(db, set_obj, ordered_ids, commit=False)`, keeping the existing locked-slot guard and the `set(range(low, high + 1))` affected-positions return. Import `from app.services.setbuilder import reorder` (guard against a circular import; if one appears, import inside the function).
+
+- [ ] **Step 3: Run agent tests + new reorder tests**
+
+Run: `.venv/bin/pytest tests/ -k "agent or pass2 or reorder" -q`
+Expected: PASS — same count as Step 1 plus the reorder tests.
+
+- [ ] **Step 4: Decide**
+
+If green → commit:
+
+```bash
+git add server/app/services/setbuilder/pass2_agent.py
+git commit -m "refactor(setbuilder): share apply_slot_order between agent + DJ reorder (#437)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+If any agent test regresses → `git checkout server/app/services/setbuilder/pass2_agent.py` and note in the PR that the fallback path was kept.
+
+---
+
+## Final: Full local CI + PR
+
+- [ ] **Step 1: Run the full local gate**
+
+```bash
+# Backend
+cd server
+.venv/bin/ruff check . && .venv/bin/ruff format --check .
+.venv/bin/bandit -r app -c pyproject.toml -q
+.venv/bin/pytest --tb=short -q
+.venv/bin/alembic upgrade head && .venv/bin/alembic check
+# Frontend
+cd ../dashboard
+npm run lint && npx tsc --noEmit && npm test -- --run
+git checkout next-env.d.ts 2>/dev/null || true
+cd ..
+```
+
+Expected: all green; backend coverage ≥ 85%; no api-types drift.
+
+- [ ] **Step 2: Push + open PR**
+
+```bash
+git push -u origin feat/issue-437
+gh pr create --title "feat(setbuilder): hand-drag reordering of timeline slots (#437)" --body "$(cat <<'EOF'
+## Why
+DJs need direct manual control over set order — hand-arranging tracks to override
+the deterministic builder and the agent. The shipped timeline rendered rows as
+non-draggable.
+
+## What
+- Backend: `apply_slot_order` reorder engine (permutation + locked-anchor validation,
+  Pass-1 transition rescore) behind `PUT /sets/{id}/slots/order`.
+- Frontend: draggable unlocked rows, a slot-reorder drag payload, reorder drop handling
+  reusing the virtualization-aware `insertIndexFromPointer`, and a `commit()`-routed
+  reorder so undo/redo/autosave come for free.
+- Locked slots are immovable anchors (enforced client- and server-side).
+- [Note here whether Task 7's agent DRY refactor landed or the fallback was kept.]
+
+Foundation for #438 (mobile-reorder view).
+
+## Testing
+- [ ] Backend unit + endpoint tests pass (`pytest`, coverage ≥ 85%)
+- [ ] Frontend vitest passes (`dnd`, `TimelineRow`, `TimelinePanel`, `BuilderWorkspace`)
+- [ ] Manual: drag a slot to a new index; order persists across reload
+- [ ] Manual: locked slots cannot be moved or displaced
+- [ ] Manual: transition score chips update after a reorder
+- [ ] Manual: Cmd/Ctrl+Z undoes the reorder
+- [ ] Manual: reorder works on a large (virtualized) set
+- [ ] CI green
+
+🤖 Co-authored by Claude Opus 4.8. Closes #437.
+EOF
+)"
+```
+
+- [ ] **Step 3: Drive the PR to green** — CI + CodeRabbit via the `review-remote-pr` loop until all checks pass and threads resolve.
+
+---
+
+## Self-Review (completed against the spec)
+
+- **Spec coverage:** full-order PUT (Task 1) ✓; `apply_slot_order` permutation + locked-invariant + Pass-1 rescore (Task 0) ✓; DJ auth + ownership + rate limit (Task 1) ✓; native-DnD payload (Task 3) ✓; draggable-when-unlocked (Task 4) ✓; `insertIndexFromPointer` reuse + cross-lock block + `onSlotReorder` (Task 5) ✓; `commit()` path → undo/redo/autosave (Task 6) ✓; DRY refactor with documented fallback (Task 7) ✓; virtualization acceptance covered by reuse + manual PR check ✓; type regeneration (Task 2) ✓.
+- **Placeholders:** the only deliberately-open spot is Task 6's `BuilderWorkspace` fixture wiring, with an explicit pure-helper fallback and a rule to document the choice — not a silent TODO.
+- **Type/name consistency:** `apply_slot_order` / `ReorderError` / `SlotOrderRequest` / `reorderSlots` / `onSlotReorder` / `SLOT_REORDER_DND_TYPE` used identically across tasks; backend returns `list[TransitionScoreOut]`, frontend consumes `TransitionScore[]`.

--- a/docs/superpowers/specs/2026-06-17-issue-437-timeline-reorder-design.md
+++ b/docs/superpowers/specs/2026-06-17-issue-437-timeline-reorder-design.md
@@ -1,0 +1,157 @@
+# Design — #437 Hand-drag reordering of timeline slots
+
+**Issue:** #437 (`feat(setbuilder): hand-drag reordering of timeline slots`)
+**Phase:** v1.1 (Polish). Foundation for #438 (mobile-reorder view).
+**Date:** 2026-06-17
+**Branch:** `feat/issue-437`
+
+## Why
+
+The WrzDJSet mockup specifies that DJs can drag slot rows to reorder a set by hand. The shipped
+timeline renders rows with `draggable={false}` — today reordering only happens via the deterministic
+Pass-1 builder and the agent's mutation tools. DJs need direct manual control to override the
+algorithm and place tracks exactly where they want.
+
+This issue lands the **reusable reorder engine** (backend reorder+rescore endpoint, frontend reorder
+commit path, drag payload) plus the **desktop native-drag UI** on top. #438 (mobile-reorder view)
+then becomes a thin touch presentation that reuses this engine rather than forking it.
+
+## Key constraints discovered in the codebase
+
+- **DnD is native HTML5 drag.** Pool→timeline drops use `dataTransfer` with a custom MIME type via
+  `dnd.ts` (`writePoolTrackDragPayload` / `readPoolTrackDragPayload`). Reorder extends this pattern
+  with a second payload type rather than introducing a DnD library.
+- **The PUT `/document` endpoint does not rescore.** `document_snapshot.restore_snapshot` persists
+  `position`, `transition_score`, and `transition_warnings` from the payload verbatim. The insert
+  flow sets the new slot's `transition_score` to `null`. So reorder cannot get correct scores from a
+  document PUT — it must hit a path that recomputes them.
+- **The agent already reorders + rescores.** `pass2_agent._tool_reorder_slot` moves a slot (with
+  locked-slot guards), and `chat_with_agent` then calls
+  `pass1_deterministic.recompute_transition_scores(db, set_obj, slots)` ("honoring current order").
+  Reorder reuses `recompute_transition_scores` so DJ drags and agent moves score identically.
+- **Virtualization is already solved.** `TimelinePanel.insertIndexFromPointer` converts a pointer Y
+  into an insert index through the virtualized window (only visible rows mounted). Reorder reuses it
+  — no new drag math.
+- **Persistence/undo/redo/autosave is already solved.** `useSetDocumentHistory.commit(label, action)`
+  snapshots before/after, manages undo+redo stacks, autosave, and the `beforeunload` guard. Reorder
+  routes through `commit()` and inherits all of it.
+
+## Decisions (resolved during brainstorming)
+
+1. **Scope:** #437 ships the reusable engine + desktop drag UI in one PR. (Est. ~300–450 LOC.)
+2. **API granularity:** full-order PUT — the client submits the complete desired slot order.
+3. **Locked-slot semantics:** strict — locked slots are immovable anchors that keep their absolute
+   index and act as barriers, partitioning the timeline into independently-reorderable regions.
+
+## Architecture
+
+### Backend (`server/`)
+
+**Schema** — `app/schemas/setbuilder.py`
+- `SlotOrderRequest { slot_ids: list[int] }` — the complete desired order of the set's slots.
+- Response reuses the existing transition-score-out shape used by other setbuilder mutations.
+
+**Service** — `app/services/setbuilder/` (alongside `pass1_deterministic` / `pass2_agent`)
+- `apply_slot_order(db, set_obj, ordered_ids) -> list[TransitionScore]`:
+  1. Validate `ordered_ids` is a permutation of the set's current slot ids (same multiset). Else
+     raise a 400-mapped error.
+  2. Validate every **locked** slot's index in `ordered_ids` equals its current `position`. Else
+     raise "Reorder would move a locked slot" (400).
+  3. Reassign each slot's `position` per `ordered_ids`.
+  4. Call `recompute_transition_scores(db, set_obj, slots)` (reuse Pass-1; honors the new order).
+  5. `db.commit()`; return the recomputed scores.
+- **DRY refactor (preferred):** `_tool_reorder_slot` computes the target order list, then delegates
+  position-reassignment to a shared helper so both the agent move and the DJ full-order PUT share one
+  source of truth. **Fallback:** if the refactor proves invasive during TDD, share only
+  `recompute_transition_scores` and leave `_tool_reorder_slot` untouched. The PR notes which path was
+  taken.
+
+**Endpoint** — `app/api/setbuilder.py`, mirroring `put_document_snapshot`
+- `PUT /sets/{set_id}/slots/order`, `response_model` = transition-scores out.
+- `Depends(get_current_active_user)` (DJ auth — NOT `get_current_user`, which allows pending).
+- `_get_owned_or_404(db, set_id, current_user)` for ownership.
+- `@limiter.limit("30/minute")` (mutation rate limit, matching sibling endpoints).
+- Maps the service's permutation/locked errors to HTTP 400 with non-leaky messages.
+
+### Frontend (`dashboard/app/(dj)/setbuilder/`)
+
+**`components/dnd.ts`**
+- `SLOT_REORDER_DND_TYPE = 'application/x-wrzdj-slot-reorder'`.
+- `writeSlotReorderDragPayload(dataTransfer, { slotId })` — sets `effectAllowed='move'`.
+- `readSlotReorderDragPayload(dataTransfer)` — parses + validates (integer `slotId`), returns `null`
+  on malformed input (mirrors `readPoolTrackDragPayload`).
+
+**`components/TimelineRow.tsx`**
+- `draggable={!slot.locked}` (locked rows stay non-draggable).
+- `onDragStart` writes the reorder payload; drag-handle cursor affordance via existing CSS module.
+- Locked rows render unchanged.
+
+**`components/TimelinePanel.tsx`**
+- The existing `onDragOver` / `onDrop` handlers detect which payload type is present:
+  - Pool-track payload → existing copy-insert behavior (unchanged).
+  - Slot-reorder payload → compute target index via `insertIndexFromPointer`; reuse the `dropIdx`
+    indicator; block the drop (`dropEffect='none'`) if it would cross or displace a locked slot.
+- New prop `onSlotReorder(slotId: number, toIdx: number) => void | Promise<void>`.
+
+**`components/BuilderWorkspace.tsx`**
+- `handleSlotReorder(slotId, toIdx)`: build the new ordered-id array by moving `slotId` to `toIdx`
+  among the current `slots` (respecting locked anchors), guard client-side, then
+  `commit('Reorder slot', () => api.reorderSlots(setId, orderedIds))` followed by `loadSlots()`.
+  Mirrors the existing `handlePoolTrackDrop`.
+
+**`lib/api.ts`**
+- `reorderSlots(setId: number, slotIds: number[])` → `PUT /api/setbuilder/sets/${setId}/slots/order`.
+
+## Data flow
+
+```
+dragstart (write {slotId})
+  → dragover: insertIndexFromPointer → dropIdx indicator; block if it crosses a lock
+  → drop: handleSlotReorder(slotId, toIdx)
+      → build new ordered-id array
+      → commit('Reorder slot', () => api.reorderSlots(setId, orderedIds))
+          → PUT /slots/order → apply_slot_order: validate → reassign positions → recompute scores
+      → loadSlots()  (refresh timeline + curve view-models)
+```
+
+Undo/redo, autosave, and the unsaved-changes `beforeunload` guard are inherited from `commit()`.
+
+## Error handling
+
+- **Backend:** permutation mismatch and locked-slot displacement both return HTTP 400 with a clear,
+  non-leaky message. No stack traces leak (per SECURITY.md). Parameterized ORM only.
+- **Frontend:** `handleSlotReorder` wraps the commit in `try/catch`; on failure the visible timeline
+  is left unchanged and `loadSlots()` re-syncs (mirrors `handlePoolTrackDrop`). `commit()` already
+  surfaces `saveError`.
+
+## Testing (TDD — RED first)
+
+**Backend (`server/tests/`, pytest, ≥85% coverage gate):**
+- `apply_slot_order` rejects a non-permutation payload (400).
+- `apply_slot_order` rejects when a locked slot's index changes (400).
+- Positions are reassigned to match `slot_ids`.
+- Transition scores are recomputed for the **new** adjacencies — assert a concrete score change for a
+  reorder that alters neighbors.
+- Endpoint auth: pending user is rejected; another DJ's set returns 404.
+
+**Frontend (`dashboard/.../__tests__/`, vitest):**
+- `dnd.ts`: reorder payload round-trips; malformed input returns `null`.
+- `TimelineRow`: `draggable` is true iff the slot is unlocked; `onDragStart` writes the payload.
+- `TimelinePanel`: a reorder drop computes the correct target index; a drop that would cross a locked
+  slot is blocked.
+- `BuilderWorkspace`: a reorder commits via `api.reorderSlots` and refreshes; undo restores the prior
+  order.
+
+## Out of scope (tracked in #438)
+
+- Touch / long-press reorder.
+- Mobile single-column reorder view.
+- Multi-row / batch selection drag (the full-order PUT supports it server-side, but no UI ships here).
+
+## Acceptance criteria (from the issue)
+
+- [ ] Drag a slot to a new index; order persists across reload.
+- [ ] Locked slots cannot be moved or displaced.
+- [ ] Transition scores recompute after reorder.
+- [ ] Undo/redo restores prior order.
+- [ ] Works with a large (virtualized) set.

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -531,7 +531,13 @@ def update_slot_target(
     return SlotTargetOut(slot_id=slot.id, target_energy=slot.target_energy)
 
 
-@router.put("/sets/{set_id}/slots/order", response_model=list[TransitionScoreOut])
+@router.put(
+    "/sets/{set_id}/slots/order",
+    response_model=list[TransitionScoreOut],
+    responses={
+        400: {"description": "Invalid reorder (not a permutation, or would move a locked slot)"}
+    },
+)
 @limiter.limit("30/minute")
 def reorder_slots(
     set_id: int,

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -71,6 +71,7 @@ from app.schemas.setbuilder import (
     SetRename,
     SetSummary,
     SetTargetUpdate,
+    SlotOrderRequest,
     SlotOut,
     SlotTargetOut,
     SlotTargetUpdate,
@@ -101,6 +102,7 @@ from app.services.setbuilder import (
     pass1_deterministic,
     pass2_agent,
     pool,
+    reorder,
     set_service,
     vibe_enrichment,
     vibe_resolver,
@@ -527,6 +529,24 @@ def update_slot_target(
         raise HTTPException(status_code=404, detail="Slot not found")
     slot = curve.set_slot_target(db, slot, payload.target_energy)
     return SlotTargetOut(slot_id=slot.id, target_energy=slot.target_energy)
+
+
+@router.put("/sets/{set_id}/slots/order", response_model=list[TransitionScoreOut])
+@limiter.limit("30/minute")
+def reorder_slots(
+    set_id: int,
+    payload: SlotOrderRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> list[TransitionScoreOut]:
+    """Reassign the set's slot order by hand and recompute transition scores (#437)."""
+    set_obj = _get_owned_or_404(db, set_id, current_user)
+    try:
+        scores = reorder.apply_slot_order(db, set_obj, payload.slot_ids)
+    except reorder.ReorderError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _transition_scores_out(scores)
 
 
 @router.post(

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -452,6 +452,12 @@ class BuildSetResponse(BaseModel):
     transition_scores: list[TransitionScoreOut]
 
 
+class SlotOrderRequest(BaseModel):
+    """Full desired slot order for a set (hand-drag reorder, #437)."""
+
+    slot_ids: list[int] = Field(..., min_length=1, max_length=500)
+
+
 AgentCritiqueFlagType = Literal[
     "energy_dip",
     "vibe_clash",

--- a/server/app/services/setbuilder/reorder.py
+++ b/server/app/services/setbuilder/reorder.py
@@ -1,0 +1,41 @@
+"""DJ-driven full-order slot reordering for WrzDJSet (#437).
+
+Reuses Pass-1 transition scoring so a hand-drag reorder scores identically to
+the agent's ``reorder_slot`` tool.
+"""
+
+from sqlalchemy.orm import Session
+
+from app.models.set import Set
+from app.services.setbuilder.pass1_deterministic import (
+    TransitionScore,
+    recompute_transition_scores,
+)
+
+
+class ReorderError(ValueError):
+    """Requested order is not a permutation, or would move a locked slot."""
+
+
+def apply_slot_order(
+    db: Session, set_obj: Set, ordered_ids: list[int], *, commit: bool = True
+) -> list[TransitionScore]:
+    """Reassign slot positions to match ``ordered_ids`` and rescore transitions.
+
+    * ``ordered_ids`` must be a permutation of the set's current slot ids.
+    * Every locked slot must keep its current position (immovable anchor).
+    """
+    slots = sorted(set_obj.slots, key=lambda s: s.position)
+    if sorted(ordered_ids) != sorted(s.id for s in slots):
+        raise ReorderError("slot_ids must be a permutation of the set's slots")
+
+    by_id = {s.id: s for s in slots}
+    for new_position, slot_id in enumerate(ordered_ids):
+        slot = by_id[slot_id]
+        if slot.locked and slot.position != new_position:
+            raise ReorderError("Reorder would move a locked slot")
+
+    reordered = [by_id[slot_id] for slot_id in ordered_ids]
+    for new_position, slot in enumerate(reordered):
+        slot.position = new_position
+    return recompute_transition_scores(db, set_obj, reordered, commit=commit)

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -19534,6 +19534,9 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Invalid reorder (not a permutation, or would move a locked slot)"
+          },
           "422": {
             "content": {
               "application/json": {

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1390,7 +1390,7 @@
       "Body_upload_banner_api_events__code__banner_post": {
         "properties": {
           "file": {
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File",
             "type": "string"
           }
@@ -8769,6 +8769,25 @@
           "transition_score"
         ],
         "title": "SharedSlotView",
+        "type": "object"
+      },
+      "SlotOrderRequest": {
+        "description": "Full desired slot order for a set (hand-drag reorder, #437).",
+        "properties": {
+          "slot_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "maxItems": 500,
+            "minItems": 1,
+            "title": "Slot Ids",
+            "type": "array"
+          }
+        },
+        "required": [
+          "slot_ids"
+        ],
+        "title": "SlotOrderRequest",
         "type": "object"
       },
       "SlotOut": {
@@ -19470,6 +19489,68 @@
           }
         ],
         "summary": "List Set Slots",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/slots/order": {
+      "put": {
+        "description": "Reassign the set's slot order by hand and recompute transition scores (#437).",
+        "operationId": "reorder_slots_api_setbuilder_sets__set_id__slots_order_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SlotOrderRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/TransitionScoreOut"
+                  },
+                  "title": "Response Reorder Slots Api Setbuilder Sets  Set Id  Slots Order Put",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Reorder Slots",
         "tags": [
           "setbuilder"
         ]

--- a/server/tests/test_setbuilder_reorder.py
+++ b/server/tests/test_setbuilder_reorder.py
@@ -1,0 +1,100 @@
+"""Tests for DJ-driven full-order slot reordering (#437)."""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.set import Set, SetSlot
+from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.models.user import User
+from app.services.setbuilder.reorder import ReorderError, apply_slot_order
+
+
+def _set_with_slots(db: Session, user: User, n: int, locked_idx: int | None = None) -> Set:
+    set_obj = Set(owner_id=user.id, name="Friday", target_duration_sec=14 * 60)
+    db.add(set_obj)
+    db.commit()
+    db.refresh(set_obj)
+    src = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(src)
+    db.commit()
+    db.refresh(src)
+    for i in range(n):
+        db.add(
+            SetPoolTrack(
+                set_id=set_obj.id,
+                source_id=src.id,
+                track_id=f"tidal:{i}",
+                title=f"T{i}",
+                artist=f"A{i}",
+                bpm=120.0 + i,
+                key="8A",
+                camelot="8A",
+                energy=5,
+                duration_sec=210,
+                dedupe_sig=f"sig-{i}",
+            )
+        )
+        db.add(
+            SetSlot(
+                set_id=set_obj.id,
+                position=i,
+                track_id=f"tidal:{i}",
+                locked=(i == locked_idx),
+            )
+        )
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def _ids_in_order(set_obj: Set) -> list[int]:
+    return [s.id for s in sorted(set_obj.slots, key=lambda s: s.position)]
+
+
+def test_apply_slot_order_reassigns_positions(db: Session, test_user: User):
+    set_obj = _set_with_slots(db, test_user, 3)
+    ids = _ids_in_order(set_obj)
+    new_order = [ids[2], ids[0], ids[1]]
+
+    apply_slot_order(db, set_obj, new_order)
+    db.refresh(set_obj)
+
+    assert _ids_in_order(set_obj) == new_order
+    assert sorted(s.position for s in set_obj.slots) == [0, 1, 2]
+
+
+def test_apply_slot_order_recomputes_transition_scores(db: Session, test_user: User):
+    set_obj = _set_with_slots(db, test_user, 3)
+    ids = _ids_in_order(set_obj)
+
+    scores = apply_slot_order(db, set_obj, [ids[2], ids[0], ids[1]])
+
+    by_pos = {s.position: s for s in scores}
+    assert by_pos[0].score == 100.0
+    assert {s.slot_id for s in scores} == set(ids)
+
+
+def test_apply_slot_order_rejects_non_permutation(db: Session, test_user: User):
+    set_obj = _set_with_slots(db, test_user, 3)
+    ids = _ids_in_order(set_obj)
+    with pytest.raises(ReorderError, match="permutation"):
+        apply_slot_order(db, set_obj, [ids[0], ids[1]])
+    with pytest.raises(ReorderError, match="permutation"):
+        apply_slot_order(db, set_obj, [ids[0], ids[1], 99999])
+    with pytest.raises(ReorderError, match="permutation"):
+        apply_slot_order(db, set_obj, [ids[0], ids[0], ids[1]])
+
+
+def test_apply_slot_order_rejects_moving_locked_slot(db: Session, test_user: User):
+    set_obj = _set_with_slots(db, test_user, 3, locked_idx=1)
+    ids = _ids_in_order(set_obj)
+    with pytest.raises(ReorderError, match="locked"):
+        apply_slot_order(db, set_obj, [ids[1], ids[0], ids[2]])
+
+
+def test_apply_slot_order_allows_reorder_that_keeps_locked_position(db: Session, test_user: User):
+    set_obj = _set_with_slots(db, test_user, 3, locked_idx=1)
+    ids = _ids_in_order(set_obj)
+    apply_slot_order(db, set_obj, [ids[2], ids[1], ids[0]])
+    db.refresh(set_obj)
+    assert _ids_in_order(set_obj) == [ids[2], ids[1], ids[0]]

--- a/server/tests/test_setbuilder_reorder_api.py
+++ b/server/tests/test_setbuilder_reorder_api.py
@@ -1,0 +1,109 @@
+"""Endpoint tests for hand-drag slot reorder (#437)."""
+
+from sqlalchemy.orm import Session
+
+from app.models.set import Set, SetSlot
+from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.models.user import User
+
+
+def _make_set_with_slots(db: Session, owner: User, n: int, locked_idx: int | None = None) -> Set:
+    set_obj = Set(owner_id=owner.id, name="Friday", target_duration_sec=14 * 60)
+    db.add(set_obj)
+    db.commit()
+    db.refresh(set_obj)
+    src = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(src)
+    db.commit()
+    db.refresh(src)
+    for i in range(n):
+        db.add(
+            SetPoolTrack(
+                set_id=set_obj.id,
+                source_id=src.id,
+                track_id=f"tidal:{i}",
+                title=f"T{i}",
+                artist=f"A{i}",
+                bpm=120.0 + i,
+                key="8A",
+                camelot="8A",
+                energy=5,
+                duration_sec=210,
+                dedupe_sig=f"sig-{i}",
+            )
+        )
+        db.add(
+            SetSlot(set_id=set_obj.id, position=i, track_id=f"tidal:{i}", locked=(i == locked_idx))
+        )
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def _ordered_ids(client, set_id: int, headers) -> list[int]:
+    rows = client.get(f"/api/setbuilder/sets/{set_id}/slots", headers=headers).json()
+    return [r["id"] for r in sorted(rows, key=lambda r: r["position"])]
+
+
+def test_reorder_slots_persists_new_order(client, db: Session, test_user: User, auth_headers):
+    set_obj = _make_set_with_slots(db, test_user, 3)
+    ids = _ordered_ids(client, set_obj.id, auth_headers)
+    new_order = [ids[2], ids[0], ids[1]]
+
+    resp = client.put(
+        f"/api/setbuilder/sets/{set_obj.id}/slots/order",
+        json={"slot_ids": new_order},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200
+    assert _ordered_ids(client, set_obj.id, auth_headers) == new_order
+    scores = {s["position"]: s for s in resp.json()}
+    assert scores[0]["score"] == 100.0
+    assert sorted(scores) == [0, 1, 2]
+    assert isinstance(scores[1]["score"], (int, float))
+
+
+def test_reorder_rejects_non_permutation(client, db: Session, test_user: User, auth_headers):
+    set_obj = _make_set_with_slots(db, test_user, 3)
+    ids = _ordered_ids(client, set_obj.id, auth_headers)
+    resp = client.put(
+        f"/api/setbuilder/sets/{set_obj.id}/slots/order",
+        json={"slot_ids": ids[:2]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_reorder_rejects_moving_locked_slot(client, db: Session, test_user: User, auth_headers):
+    set_obj = _make_set_with_slots(db, test_user, 3, locked_idx=1)
+    ids = _ordered_ids(client, set_obj.id, auth_headers)
+    resp = client.put(
+        f"/api/setbuilder/sets/{set_obj.id}/slots/order",
+        json={"slot_ids": [ids[1], ids[0], ids[2]]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+    assert _ordered_ids(client, set_obj.id, auth_headers) == ids
+
+
+def test_reorder_other_djs_set_is_404(
+    client, db: Session, admin_user: User, test_user: User, auth_headers
+):
+    set_obj = _make_set_with_slots(db, admin_user, 3)
+    resp = client.put(
+        f"/api/setbuilder/sets/{set_obj.id}/slots/order",
+        json={"slot_ids": [s.id for s in set_obj.slots]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_reorder_requires_active_user(client, db: Session, test_user: User, pending_headers):
+    set_obj = _make_set_with_slots(db, test_user, 3)
+    resp = client.put(
+        f"/api/setbuilder/sets/{set_obj.id}/slots/order",
+        json={"slot_ids": [s.id for s in set_obj.slots]},
+        headers=pending_headers,
+    )
+    assert resp.status_code in (401, 403)


### PR DESCRIPTION
## Why
DJs need direct manual control over set order — hand-arranging tracks to override the deterministic Pass-1 builder and the agent. The shipped timeline rendered rows as non-draggable, so reordering was only possible through the algorithm or the agent's tools. This is the foundation for the #438 mobile-reorder view.

## What
A reusable reorder engine plus the desktop native-drag UI on top:

- **Backend** — `apply_slot_order` service (`server/app/services/setbuilder/reorder.py`) behind `PUT /sets/{id}/slots/order`. It validates the submitted order is a permutation of the set's slots, enforces the locked-slot invariant, reassigns positions, and reuses Pass-1 `recompute_transition_scores` so a hand-drag scores **identically** to the agent's `reorder_slot` tool. DJ auth + ownership 404 + rate limit + Pydantic-bounded input.
- **Frontend** — unlocked rows become native drag sources (`dnd.ts` slot-reorder payload, distinct MIME type from pool-track drops); `TimelinePanel` resolves the drop index through the existing virtualization-aware `insertIndexFromPointer`, blocks cross-lock moves, and routes the change through `useSetDocumentHistory.commit()` — so **undo/redo, autosave, and the unsaved-changes guard all come for free**.
- **Locked slots are immovable anchors**, enforced at all three layers (panel drop guard, `buildReorderedIds`, backend invariant).
- Full-order PUT (not single-move), so the API also supports future batch reorders.

### Design decisions / deviations
- **Agent DRY refactor intentionally skipped.** Both the DJ path and the agent's `_tool_reorder_slot` already share `recompute_transition_scores` (the valuable logic). Routing the agent's *single-move* tool through the *full-order* `apply_slot_order` would double-rescore per turn and lose its affected-positions optimization, so the remaining ~3-line position-reassignment duplication is left in place (house DRY rule: two clear functions beat one parameterized knot).
- A holistic review caught a real **integration bug** (row drop handlers swallowed reorder drops via `stopPropagation` before they bubbled to the list); fixed with `8e6de45` and pinned with a row-targeted regression test. A defensive `types?.includes` guard also hardens the handlers against a `DataTransfer` without `types`.

## Testing
- [x] Backend unit + endpoint tests pass — `pytest` **2885 passed, 88.06% coverage** (gate 85%); `reorder.py` 100%
- [x] Frontend tests pass — `vitest` **1247 passed (93 files)**; `eslint` + `tsc --noEmit` clean
- [x] Permutation / locked-invariant / ownership(404) / pending-auth(403) covered server-side
- [x] dnd payload, draggable-when-unlocked, panel drop index mapping + cross-lock block, `buildReorderedIds`, and row-bubbling drop covered client-side
- [x] Manual: drag a slot to a new index; order persists across reload
- [x] Manual: locked slots cannot be moved or displaced
- [x] Manual: transition score chips update after a reorder; Cmd/Ctrl+Z undoes it
- [x] Manual: reorder works on a large (virtualized) set
- [x] CI green

Design spec + implementation plan committed under `docs/superpowers/`.

🤖 Co-authored by Claude Opus 4.8. Closes #437.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Timeline slots can now be reordered via drag-and-drop, with targets computed from the current view.
  * Only unlocked slots can be dragged; reordering that would cross locked slots is blocked.
  * Slot order changes now persist and automatically update transition scores.
  * Reorders integrate with undo/redo history and resync the timeline after failures.
  * Manual reordering is now supported through a dedicated API endpoint for the set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->