### PR TITLE
chore(bridge): update alphatheta-connect and sibling deps

### DIFF
--- a/bridge/package-lock.json
+++ b/bridge/package-lock.json
@@ -8,7 +8,9 @@
       "name": "wrzdj-bridge",
       "version": "0.1.0",
       "dependencies": {
-        "alphatheta-connect": "0.15.0",
+        "alphatheta-connect": "0.21.1",
+        "metadata-connect": "1.1.10",
+        "onelibrary-connect": "1.1.1",
         "stagelinq": "3.0.4"
       },
       "devDependencies": {
@@ -1157,9 +1159,9 @@
       }
     },
     "node_modules/alphatheta-connect": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/alphatheta-connect/-/alphatheta-connect-0.15.0.tgz",
-      "integrity": "sha512-10ndVfRoFPzowpKdW32Y63mQMMSoRrXD/Vcln22DcrKTcqZG2cDbtsl5seVX32fDlAVSk7PC3exsnNV6CmT+tQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/alphatheta-connect/-/alphatheta-connect-0.21.1.tgz",
+      "integrity": "sha512-rqidl1KG+eNifxKs6uiPneEYZYALFuLQ/OKKPVs2RimDSx8xzFcJ45pdifb7WigdjyGsBmISBp3igurwl/b2+Q==",
       "license": "MIT",
       "dependencies": {
         "@types/better-sqlite3": "^7.6.13",
@@ -1176,6 +1178,8 @@
         "kaitai-struct": "^0.11.0",
         "lodash": "^4.17.21",
         "lru_map": "^0.4.1",
+        "metadata-connect": "file:../metadata-connect",
+        "onelibrary-connect": "file:../onelibrary-connect",
         "promise-readable": "^6.0.0",
         "promise-retry": "^2.0.1",
         "promise-socket": "^7.0.0",
@@ -1228,6 +1232,14 @@
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
       "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
       "license": "MIT"
+    },
+    "node_modules/alphatheta-connect/node_modules/metadata-connect": {
+      "resolved": "node_modules/metadata-connect",
+      "link": true
+    },
+    "node_modules/alphatheta-connect/node_modules/onelibrary-connect": {
+      "resolved": "node_modules/onelibrary-connect",
+      "link": true
     },
     "node_modules/alphatheta-connect/node_modules/undici-types": {
       "version": "6.21.0",
@@ -2156,6 +2168,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/metadata-connect": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/metadata-connect/-/metadata-connect-1.1.10.tgz",
+      "integrity": "sha512-retx7VI/I0AdEUcAfB5lwJ0AlmS/XDhy51Me4SWeUuK2d4rMu782zLsp15odfk982+M9sexkU2Z2mXYiZL+dyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -2245,6 +2266,18 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onelibrary-connect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/onelibrary-connect/-/onelibrary-connect-1.1.1.tgz",
+      "integrity": "sha512-vtwOdeG2/EZm3EYrq1zyh1tLJ42GYfWpVMLKs/4Rh/ahgOJl058FuKYz3fS9tS8+hHC0qq7LJbwJ2d3uFU2NNw==",
+      "license": "MIT",
+      "dependencies": {
+        "better-sqlite3-multiple-ciphers": "^12.5.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/pathe": {

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -13,7 +13,9 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "alphatheta-connect": "0.15.0",
+    "alphatheta-connect": "0.21.1",
+    "metadata-connect": "1.1.10",
+    "onelibrary-connect": "1.1.1",
     "stagelinq": "3.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Update the bridge `alphatheta-connect` pin from `0.15.0` to `0.21.1`.
- Add exact `metadata-connect@1.1.10` and `onelibrary-connect@1.1.1` runtime dependencies so the published `alphatheta-connect@0.21.1` bundle can resolve its sibling package imports.
- Leave `stagelinq` pinned at `3.0.4` per the separate #385 dependency-drift task.

## Design decisions

- `alphatheta-connect@0.21.1` publishes `metadata-connect` and `onelibrary-connect` as `file:../...` dependencies. A clean bridge install did not fetch those packages from npm, and the real contract import failed with `Cannot find module 'onelibrary-connect'`. I added the two published sibling packages as exact direct bridge dependencies rather than patching bridge source or changing the AlphaTheta version target.
- Verification was run under Node 22 via an ephemeral `node@22` runner because the repo requires Node 22+ and the host default Node 26 cannot build the native sqlite dependency used by this package family.
- I did not run `npm audit fix` or change `stagelinq`; `npm audit --omit=dev` reports the existing `stagelinq` path advisories (`file-type`, `ip`), which belong to #385 or a dedicated security follow-up.

## Verification

- `cd bridge && npx -y -p node@22 -p npm@11 npm ci`
- `cd bridge && npx -y -p node@22 -c 'node --version && ./node_modules/.bin/vitest run "contracts"'` (2 files, 9 tests)
- `cd bridge && npx -y -p node@22 -c 'node --version && ./node_modules/.bin/tsc --noEmit'`
- `cd bridge && npx -y -p node@22 -c 'node --version && ./node_modules/.bin/vitest run'` (15 files, 343 tests)

Closes #417


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->