### PR TITLE
feat(setbuilder): mobile chat view via Agent FAB + full-viewport overlay (#402)

### DIFF
--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -10,6 +10,8 @@ import { ThemeToggle } from '@/components/ThemeToggle';
 import BuilderBrandMenu from '../components/BuilderBrandMenu';
 import BuilderWorkspace from '../components/BuilderWorkspace';
 import ChatSidebar from '../components/ChatSidebar';
+import MobileAgentOverlay from '../components/MobileAgentOverlay';
+import { useIsMobile } from '../components/useIsMobile';
 import PairingsOverlay from '../components/PairingsOverlay';
 import BuilderSettingsModal, { type BuilderSettings } from '../components/BuilderSettingsModal';
 import ConfirmActionDialog, { type ConfirmAction } from '../components/ConfirmActionDialog';
@@ -66,6 +68,7 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
   const numericSetId = Number(setId);
   const { isAuthenticated, isLoading, role } = useAuth();
   const router = useRouter();
+  const isMobile = useIsMobile();
   const [set, setSet] = useState<SetDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [chatOpen, setChatOpen] = useState(false);
@@ -426,16 +429,25 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
           onProjectionChange={handleProjectionChange}
         />
 
-        <div className={styles.panelChat}>
-          <ChatSidebar
-            setId={Number(setId)}
-            open={chatOpen}
-            onToggle={() => setChatOpen((open) => !open)}
-            refreshToken={refreshToken}
-            onMutationApplied={() => setRefreshToken((v) => v + 1)}
-          />
-        </div>
+        {!isMobile && (
+          <div className={styles.panelChat}>
+            <ChatSidebar
+              setId={Number(setId)}
+              open={chatOpen}
+              onToggle={() => setChatOpen((open) => !open)}
+              refreshToken={refreshToken}
+              onMutationApplied={() => setRefreshToken((v) => v + 1)}
+            />
+          </div>
+        )}
       </div>
+      {isMobile && (
+        <MobileAgentOverlay
+          setId={Number(setId)}
+          refreshToken={refreshToken}
+          onMutationApplied={() => setRefreshToken((v) => v + 1)}
+        />
+      )}
       {toast && (
         <div className={styles.poolToast} role="status" aria-live="polite">
           {toast}

--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -69,6 +69,11 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
   const { isAuthenticated, isLoading, role } = useAuth();
   const router = useRouter();
   const isMobile = useIsMobile();
+  // Defer mounting either chat surface until after hydration so a mobile client
+  // never briefly mounts the desktop sidebar (and its agent fetches) before
+  // `useIsMobile` resolves. The grid already reserves the chat column, so this
+  // adds no layout shift on desktop.
+  const [chatSurfaceReady, setChatSurfaceReady] = useState(false);
   const [set, setSet] = useState<SetDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [chatOpen, setChatOpen] = useState(false);
@@ -92,6 +97,10 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
   const [targetProjection, setTargetProjection] = useState<TargetProjection | null>(null);
   const [savingTarget, setSavingTarget] = useState(false);
   const [targetError, setTargetError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setChatSurfaceReady(true);
+  }, []);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -429,7 +438,7 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
           onProjectionChange={handleProjectionChange}
         />
 
-        {!isMobile && (
+        {chatSurfaceReady && !isMobile && (
           <div className={styles.panelChat}>
             <ChatSidebar
               setId={Number(setId)}
@@ -441,7 +450,7 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
           </div>
         )}
       </div>
-      {isMobile && (
+      {chatSurfaceReady && isMobile && (
         <MobileAgentOverlay
           setId={Number(setId)}
           refreshToken={refreshToken}

--- a/dashboard/app/(dj)/setbuilder/components/ChatPanelBody.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/ChatPanelBody.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { AppliedToolCall, SetCritique, TransitionScore } from '@/lib/api-types';
+import type { AgentChatController, Persona } from './useAgentChat';
+import styles from '../setbuilder.module.css';
+
+function flagTone(type: string): string {
+  if (type === 'transition_brilliant') return styles.flagBrilliant;
+  if (type === 'energy_dip' || type === 'banger_buried' || type === 'vibe_clash') {
+    return styles.flagDanger;
+  }
+  return styles.flagWarn;
+}
+
+function formatFlag(type: string): string {
+  return type.replaceAll('_', ' ');
+}
+
+function lockSkipReasons(tool: AppliedToolCall): string[] {
+  const result = tool.result;
+  if (!result || typeof result !== 'object') return [];
+  const data = result as Record<string, unknown>;
+  const skipped = data.skipped_slots ?? data.skippedSlots ?? data.skipped;
+  if (!Array.isArray(skipped)) return [];
+  return skipped
+    .map((item) => {
+      if (!item || typeof item !== 'object') return null;
+      const reason = 'reason' in item ? String(item.reason ?? '') : '';
+      if (!/lock/i.test(reason)) return null;
+      const slot =
+        'slot_position' in item && typeof item.slot_position === 'number'
+          ? `slot ${item.slot_position + 1}`
+          : 'a slot';
+      return `Skipped ${slot} because it is locked.`;
+    })
+    .filter((reason): reason is string => Boolean(reason));
+}
+
+function critiqueFlags(tool: AppliedToolCall): { type: string; slotPosition: number | null }[] {
+  if (tool.name !== 'critique_set') return [];
+  const result = tool.result;
+  if (!result || typeof result !== 'object') return [];
+  const flags = (result as Record<string, unknown>).flags;
+  if (!Array.isArray(flags)) return [];
+  return flags
+    .map((item) => {
+      if (!item || typeof item !== 'object' || !('type' in item)) return null;
+      const data = item as Record<string, unknown>;
+      const type = typeof data.type === 'string' ? data.type : '';
+      if (!type) return null;
+      const slotPosition = typeof data.slot_position === 'number' ? data.slot_position : null;
+      return { type, slotPosition };
+    })
+    .filter((flag): flag is { type: string; slotPosition: number | null } => Boolean(flag));
+}
+
+export function PersonaToggle({
+  persona,
+  onChange,
+}: {
+  persona: Persona;
+  onChange: (persona: Persona) => void;
+}) {
+  return (
+    <div className={styles.personaToggle} aria-label="Agent personality">
+      <button
+        className={persona === 'peer' ? styles.personaActive : ''}
+        onClick={() => onChange('peer')}
+      >
+        Peer
+      </button>
+      <button
+        className={persona === 'pro' ? styles.personaActive : ''}
+        onClick={() => onChange('pro')}
+      >
+        Pro
+      </button>
+    </div>
+  );
+}
+
+function ToolCard({ tool }: { tool: AppliedToolCall }) {
+  const toolName = tool.name.replaceAll('_', ' ');
+  const rationale = tool.rationale?.trim() ?? '';
+  const summary = tool.display_summary?.trim() || rationale || toolName;
+  const skippedLocks = lockSkipReasons(tool);
+  const flags = critiqueFlags(tool);
+  return (
+    <div className={styles.toolCallCard} data-testid="agent-tool-card">
+      <span className={styles.toolName}>{toolName}</span>
+      <div className={styles.toolBody}>
+        <div className={styles.toolSummary}>{summary}</div>
+        {rationale && rationale !== summary && (
+          <div className={styles.toolRationale}>{rationale}</div>
+        )}
+        {skippedLocks.map((reason) => (
+          <div key={reason} className={styles.toolRationale} data-testid="agent-lock-skip">
+            {reason}
+          </div>
+        ))}
+        {flags.length > 0 && (
+          <div className={styles.critiqueFlags}>
+            {flags.map((flag, i) => (
+              <span
+                key={`${flag.type}-${i}`}
+                className={`${styles.flagChip} ${flagTone(flag.type)}`}
+              >
+                {formatFlag(flag.type)}
+                {flag.slotPosition != null ? ` · ${flag.slotPosition + 1}` : ''}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CritiqueCard({ critique, persona }: { critique: SetCritique; persona: Persona }) {
+  return (
+    <div className={styles.critiqueCard} data-testid="critique-card">
+      <div className={styles.critiqueHeader}>
+        <div className={styles.critiqueGrade}>{critique.overall_grade}</div>
+        <div>
+          <div className={styles.critiqueTitle}>
+            {persona === 'peer' ? 'Vibe check' : 'Set Analysis'}
+          </div>
+          <div className={styles.critiqueSub}>
+            {persona === 'peer'
+              ? 'Quick read on the timeline'
+              : 'Computed against curve, pool, and transition scores'}
+          </div>
+        </div>
+      </div>
+      <div className={styles.critiqueSummary}>{critique.summary || 'No summary returned.'}</div>
+      <div className={styles.critiqueFlags}>
+        {critique.flags.length === 0 ? (
+          <span className={styles.flagChip}>no flags</span>
+        ) : (
+          critique.flags.map((flag, i) => (
+            <span key={`${flag.type}-${i}`} className={`${styles.flagChip} ${flagTone(flag.type)}`}>
+              {formatFlag(flag.type)}
+              {flag.slot_position != null ? ` · ${flag.slot_position + 1}` : ''}
+            </span>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Presentational chat body shared by the desktop sidebar and mobile overlay.
+ * Renders context meta, the critique card, errors, the scrolling message list
+ * (with tool cards and transition-score chips), and the composer. All state and
+ * actions come from {@link AgentChatController}.
+ */
+export default function ChatPanelBody({ chat }: { chat: AgentChatController }) {
+  const { persona, critique, entries, historyMeta, input, setInput, busy, error, suggestions } =
+    chat;
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [entries, busy]);
+
+  return (
+    <>
+      {historyMeta && (
+        <div className={styles.chatContextMeta}>
+          {historyMeta.usesCompactContext
+            ? `Uses compact context + last ${historyMeta.recentTurnLimit} turns`
+            : 'Uses recent turns'}
+        </div>
+      )}
+      {critique && <CritiqueCard critique={critique} persona={persona} />}
+      {error && (
+        <div className={styles.chatError} role="alert">
+          {error}
+        </div>
+      )}
+
+      <div className={styles.chatScroll} ref={scrollRef}>
+        {entries.length === 0 && (
+          <div className={styles.chatEmpty}>
+            Ask the agent to critique, explain, or edit the timeline.
+          </div>
+        )}
+        {entries.map((entry) => (
+          <div
+            key={entry.id}
+            className={`${styles.chatMessage} ${entry.role === 'user' ? styles.chatUser : styles.chatAgent}`}
+          >
+            <div className={styles.chatAuthor}>
+              {entry.role === 'user'
+                ? 'You'
+                : persona === 'peer'
+                  ? 'WrzDJ Agent'
+                  : 'WrzDJSet Assistant'}
+            </div>
+            <div className={styles.chatBubble}>{entry.display_summary || entry.content}</div>
+            {entry.tool_calls?.map((tool) => <ToolCard key={tool.id} tool={tool} />)}
+            {entry.affected_transition_scores && entry.affected_transition_scores.length > 0 && (
+              <div className={styles.scoreUpdate}>
+                {entry.affected_transition_scores.map((score: TransitionScore) => (
+                  <span key={score.slot_id}>
+                    slot {score.position + 1}: {Math.round(score.score)}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+        {busy && <div className={styles.chatEmpty}>Agent is thinking...</div>}
+      </div>
+
+      <div className={styles.chatComposer}>
+        <div className={styles.chatSuggestions}>
+          {suggestions.map((suggestion) => (
+            <button
+              key={suggestion}
+              className={styles.suggestionChip}
+              onClick={() => chat.send(suggestion)}
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
+        <div className={styles.chatInputWrap}>
+          <textarea
+            className={styles.chatInput}
+            value={input}
+            placeholder={
+              persona === 'peer' ? 'tell the agent what to fix...' : 'Issue an instruction...'
+            }
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                chat.send();
+              }
+            }}
+            rows={1}
+          />
+          <button
+            className={styles.chatSend}
+            disabled={!input.trim() || busy}
+            onClick={() => chat.send()}
+          >
+            Send
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/ChatSidebar.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/ChatSidebar.tsx
@@ -1,159 +1,14 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import { api, ApiError } from '@/lib/api';
-import type {
-  AgentChatMessage,
-  AppliedToolCall,
-  SetCritique,
-  TransitionScore,
-} from '@/lib/api-types';
+import ChatPanelBody, { PersonaToggle } from './ChatPanelBody';
+import { useAgentChat } from './useAgentChat';
 import styles from '../setbuilder.module.css';
 
-type Persona = 'peer' | 'pro';
-
-type ChatEntry = Pick<
-  AgentChatMessage,
-  'id' | 'role' | 'content' | 'display_summary' | 'tool_calls' | 'affected_transition_scores'
-> & { pending?: boolean };
-
-const PEER_SUGGESTIONS = [
-  'Why is the weakest transition flagged?',
-  'Make the slow window land softer',
-  'Find a better bridge from the pool',
-  'Cut one track with least damage',
-];
-
-const PRO_SUGGESTIONS = [
-  'Analyze transition 2',
-  'Recompute critique from current set',
-  'Bump the peak energy by 0.5',
-  'Surface risky BPM jumps',
-];
-
-function flagTone(type: string): string {
-  if (type === 'transition_brilliant') return styles.flagBrilliant;
-  if (type === 'energy_dip' || type === 'banger_buried' || type === 'vibe_clash') {
-    return styles.flagDanger;
-  }
-  return styles.flagWarn;
-}
-
-function formatFlag(type: string): string {
-  return type.replaceAll('_', ' ');
-}
-
-function formatAgentError(error: unknown): string {
-  const message = error instanceof Error ? error.message : 'Agent request failed';
-  if (/locked/i.test(message)) {
-    return 'Skipped because a locked slot would be changed. Unlock that slot before editing it.';
-  }
-  return message;
-}
-
-function lockSkipReasons(tool: AppliedToolCall): string[] {
-  const result = tool.result;
-  if (!result || typeof result !== 'object') return [];
-  const data = result as Record<string, unknown>;
-  const skipped = data.skipped_slots ?? data.skippedSlots ?? data.skipped;
-  if (!Array.isArray(skipped)) return [];
-  return skipped
-    .map((item) => {
-      if (!item || typeof item !== 'object') return null;
-      const reason = 'reason' in item ? String(item.reason ?? '') : '';
-      if (!/lock/i.test(reason)) return null;
-      const slot =
-        'slot_position' in item && typeof item.slot_position === 'number'
-          ? `slot ${item.slot_position + 1}`
-          : 'a slot';
-      return `Skipped ${slot} because it is locked.`;
-    })
-    .filter((reason): reason is string => Boolean(reason));
-}
-
-function critiqueFlags(tool: AppliedToolCall): { type: string; slotPosition: number | null }[] {
-  if (tool.name !== 'critique_set') return [];
-  const result = tool.result;
-  if (!result || typeof result !== 'object') return [];
-  const flags = (result as Record<string, unknown>).flags;
-  if (!Array.isArray(flags)) return [];
-  return flags
-    .map((item) => {
-      if (!item || typeof item !== 'object' || !('type' in item)) return null;
-      const data = item as Record<string, unknown>;
-      const type = typeof data.type === 'string' ? data.type : '';
-      if (!type) return null;
-      const slotPosition = typeof data.slot_position === 'number' ? data.slot_position : null;
-      return { type, slotPosition };
-    })
-    .filter((flag): flag is { type: string; slotPosition: number | null } => Boolean(flag));
-}
-
-function ToolCard({ tool }: { tool: AppliedToolCall }) {
-  const toolName = tool.name.replaceAll('_', ' ');
-  const rationale = tool.rationale?.trim() ?? '';
-  const summary = tool.display_summary?.trim() || rationale || toolName;
-  const skippedLocks = lockSkipReasons(tool);
-  const flags = critiqueFlags(tool);
-  return (
-    <div className={styles.toolCallCard} data-testid="agent-tool-card">
-      <span className={styles.toolName}>{toolName}</span>
-      <div className={styles.toolBody}>
-        <div className={styles.toolSummary}>{summary}</div>
-        {rationale && rationale !== summary && <div className={styles.toolRationale}>{rationale}</div>}
-        {skippedLocks.map((reason) => (
-          <div key={reason} className={styles.toolRationale} data-testid="agent-lock-skip">
-            {reason}
-          </div>
-        ))}
-        {flags.length > 0 && (
-          <div className={styles.critiqueFlags}>
-            {flags.map((flag, i) => (
-              <span key={`${flag.type}-${i}`} className={`${styles.flagChip} ${flagTone(flag.type)}`}>
-                {formatFlag(flag.type)}
-                {flag.slotPosition != null ? ` · ${flag.slotPosition + 1}` : ''}
-              </span>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function CritiqueCard({ critique, persona }: { critique: SetCritique; persona: Persona }) {
-  return (
-    <div className={styles.critiqueCard} data-testid="critique-card">
-      <div className={styles.critiqueHeader}>
-        <div className={styles.critiqueGrade}>{critique.overall_grade}</div>
-        <div>
-          <div className={styles.critiqueTitle}>
-            {persona === 'peer' ? 'Vibe check' : 'Set Analysis'}
-          </div>
-          <div className={styles.critiqueSub}>
-            {persona === 'peer'
-              ? 'Quick read on the timeline'
-              : 'Computed against curve, pool, and transition scores'}
-          </div>
-        </div>
-      </div>
-      <div className={styles.critiqueSummary}>{critique.summary || 'No summary returned.'}</div>
-      <div className={styles.critiqueFlags}>
-        {critique.flags.length === 0 ? (
-          <span className={styles.flagChip}>no flags</span>
-        ) : (
-          critique.flags.map((flag, i) => (
-            <span key={`${flag.type}-${i}`} className={`${styles.flagChip} ${flagTone(flag.type)}`}>
-              {formatFlag(flag.type)}
-              {flag.slot_position != null ? ` · ${flag.slot_position + 1}` : ''}
-            </span>
-          ))
-        )}
-      </div>
-    </div>
-  );
-}
-
+/**
+ * Desktop chat shell: occupies the `chat` grid column, toggles between a
+ * collapsed spine (showing the critique grade) and the full panel. All chat
+ * behavior lives in {@link useAgentChat}; rendering in {@link ChatPanelBody}.
+ */
 export default function ChatSidebar({
   setId,
   open,
@@ -167,124 +22,15 @@ export default function ChatSidebar({
   refreshToken?: number;
   onMutationApplied: () => void;
 }) {
-  const [persona, setPersona] = useState<Persona>('peer');
-  const [critique, setCritique] = useState<SetCritique | null>(null);
-  const [entries, setEntries] = useState<ChatEntry[]>([]);
-  const [historyMeta, setHistoryMeta] = useState<{
-    usesCompactContext: boolean;
-    recentTurnLimit: number;
-  } | null>(null);
-  const [input, setInput] = useState('');
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const historyRequestIdRef = useRef(0);
-  const historyErrorRef = useRef<string | null>(null);
-  const hasLocalTurnRef = useRef(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    setError(null);
-    api
-      .critiqueSet(setId)
-      .then((result) => {
-        if (!cancelled) setCritique(result);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        setCritique(null);
-        setError(err instanceof ApiError && err.status === 400 ? err.message : 'Critique unavailable');
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [setId, refreshToken]);
-
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    const requestId = historyRequestIdRef.current + 1;
-    historyRequestIdRef.current = requestId;
-    hasLocalTurnRef.current = false;
-
-    api
-      .getSetAgentHistory(setId)
-      .then((history) => {
-        if (cancelled || historyRequestIdRef.current !== requestId) return;
-        if (!hasLocalTurnRef.current) {
-          setEntries(history.messages);
-        }
-        setHistoryMeta({
-          usesCompactContext: history.uses_compact_context,
-          recentTurnLimit: history.recent_turn_limit,
-        });
-        const staleHistoryError = historyErrorRef.current;
-        setError((current) => (current === staleHistoryError ? null : current));
-        historyErrorRef.current = null;
-      })
-      .catch((err) => {
-        if (cancelled || historyRequestIdRef.current !== requestId) return;
-        const message = err instanceof Error ? err.message : 'Agent history unavailable';
-        historyErrorRef.current = message;
-        setError(message);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open, setId]);
-
-  useEffect(() => {
-    if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-  }, [entries, busy]);
-
-  const suggestions = persona === 'peer' ? PEER_SUGGESTIONS : PRO_SUGGESTIONS;
-
-  const send = async (override?: string) => {
-    const message = (override ?? input).trim();
-    if (!message || busy) return;
-    hasLocalTurnRef.current = true;
-    const pendingEntry: ChatEntry = {
-      id: -Date.now(),
-      role: 'user',
-      content: message,
-      display_summary: null,
-      tool_calls: [],
-      affected_transition_scores: [],
-      pending: true,
-    };
-    setEntries((prev) => [...prev, pendingEntry]);
-    setInput('');
-    setBusy(true);
-    setError(null);
-    try {
-      const result = await api.chatWithSetAgent(setId, { message });
-      setEntries((prev) => [
-        ...prev.filter((entry) => entry.id !== pendingEntry.id),
-        {
-          id: pendingEntry.id,
-          role: 'user',
-          content: message,
-          display_summary: null,
-          tool_calls: [],
-          affected_transition_scores: [],
-        },
-        result.assistant_message,
-      ]);
-      const mutatingTools = [...result.tool_calls, ...result.assistant_message.tool_calls];
-      if (mutatingTools.some((tool) => tool.mutating)) onMutationApplied();
-    } catch (err) {
-      setEntries((prev) => prev.filter((entry) => entry.id !== pendingEntry.id));
-      setError(formatAgentError(err));
-    } finally {
-      setBusy(false);
-    }
-  };
+  const chat = useAgentChat(setId, { open, refreshToken, onMutationApplied });
 
   if (!open) {
     return (
       <button className={`${styles.panel} ${styles.chatCollapsed}`} onClick={onToggle}>
         <span className={styles.chatCollapsedLabel}>Agent</span>
-        {critique?.overall_grade && <span className={styles.chatCollapsedGrade}>{critique.overall_grade}</span>}
+        {chat.critique?.overall_grade && (
+          <span className={styles.chatCollapsedGrade}>{chat.critique.overall_grade}</span>
+        )}
       </button>
     );
   }
@@ -293,98 +39,12 @@ export default function ChatSidebar({
     <section className={`${styles.panel} ${styles.chatSection}`} aria-label="Agent chat">
       <div className={styles.chatHeader}>
         <div className={styles.panelHeaderInline}>Agent</div>
-        <div className={styles.personaToggle} aria-label="Agent personality">
-          <button
-            className={persona === 'peer' ? styles.personaActive : ''}
-            onClick={() => setPersona('peer')}
-          >
-            Peer
-          </button>
-          <button
-            className={persona === 'pro' ? styles.personaActive : ''}
-            onClick={() => setPersona('pro')}
-          >
-            Pro
-          </button>
-        </div>
+        <PersonaToggle persona={chat.persona} onChange={chat.setPersona} />
         <button className="btn btn-sm" onClick={onToggle}>
           Collapse
         </button>
       </div>
-
-      {historyMeta && (
-        <div className={styles.chatContextMeta}>
-          {historyMeta.usesCompactContext
-            ? `Uses compact context + last ${historyMeta.recentTurnLimit} turns`
-            : 'Uses recent turns'}
-        </div>
-      )}
-      {critique && <CritiqueCard critique={critique} persona={persona} />}
-      {error && (
-        <div className={styles.chatError} role="alert">
-          {error}
-        </div>
-      )}
-
-      <div className={styles.chatScroll} ref={scrollRef}>
-        {entries.length === 0 && (
-          <div className={styles.chatEmpty}>Ask the agent to critique, explain, or edit the timeline.</div>
-        )}
-        {entries.map((entry) => (
-          <div
-            key={entry.id}
-            className={`${styles.chatMessage} ${entry.role === 'user' ? styles.chatUser : styles.chatAgent}`}
-          >
-            <div className={styles.chatAuthor}>
-              {entry.role === 'user'
-                ? 'You'
-                : persona === 'peer'
-                  ? 'WrzDJ Agent'
-                  : 'WrzDJSet Assistant'}
-            </div>
-            <div className={styles.chatBubble}>{entry.display_summary || entry.content}</div>
-            {entry.tool_calls?.map((tool) => <ToolCard key={tool.id} tool={tool} />)}
-            {entry.affected_transition_scores && entry.affected_transition_scores.length > 0 && (
-              <div className={styles.scoreUpdate}>
-                {entry.affected_transition_scores.map((score: TransitionScore) => (
-                  <span key={score.slot_id}>
-                    slot {score.position + 1}: {Math.round(score.score)}
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
-        ))}
-        {busy && <div className={styles.chatEmpty}>Agent is thinking...</div>}
-      </div>
-
-      <div className={styles.chatComposer}>
-        <div className={styles.chatSuggestions}>
-          {suggestions.map((suggestion) => (
-            <button key={suggestion} className={styles.suggestionChip} onClick={() => send(suggestion)}>
-              {suggestion}
-            </button>
-          ))}
-        </div>
-        <div className={styles.chatInputWrap}>
-          <textarea
-            className={styles.chatInput}
-            value={input}
-            placeholder={persona === 'peer' ? 'tell the agent what to fix...' : 'Issue an instruction...'}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault();
-                send();
-              }
-            }}
-            rows={1}
-          />
-          <button className={styles.chatSend} disabled={!input.trim() || busy} onClick={() => send()}>
-            Send
-          </button>
-        </div>
-      </div>
+      <ChatPanelBody chat={chat} />
     </section>
   );
 }

--- a/dashboard/app/(dj)/setbuilder/components/MobileAgentOverlay.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/MobileAgentOverlay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import ChatPanelBody, { PersonaToggle } from './ChatPanelBody';
 import { useAgentChat } from './useAgentChat';
 import styles from '../setbuilder.module.css';
@@ -22,12 +22,38 @@ export default function MobileAgentOverlay({
   onMutationApplied: () => void;
 }) {
   const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const wasOpenRef = useRef(false);
   const chat = useAgentChat(setId, { open, refreshToken, onMutationApplied });
   const grade = chat.critique?.overall_grade;
 
+  // Dialog focus lifecycle: move focus into the overlay on open, close on Escape,
+  // and restore focus to the FAB that opened it when it closes.
+  useEffect(() => {
+    if (open) {
+      wasOpenRef.current = true;
+      closeRef.current?.focus();
+      const onKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') setOpen(false);
+      };
+      window.addEventListener('keydown', onKeyDown);
+      return () => window.removeEventListener('keydown', onKeyDown);
+    }
+    if (wasOpenRef.current) {
+      wasOpenRef.current = false;
+      triggerRef.current?.focus();
+    }
+  }, [open]);
+
   if (!open) {
     return (
-      <button className={styles.agentFab} aria-label="Open agent chat" onClick={() => setOpen(true)}>
+      <button
+        ref={triggerRef}
+        className={styles.agentFab}
+        aria-label="Open agent chat"
+        onClick={() => setOpen(true)}
+      >
         <span className={styles.agentFabLabel}>Agent</span>
         {grade && (
           <span className={styles.agentFabGrade} data-testid="agent-fab-grade">
@@ -42,6 +68,7 @@ export default function MobileAgentOverlay({
     <div className={styles.agentOverlay} role="dialog" aria-modal="true" aria-label="Agent chat">
       <div className={styles.agentOverlayHeader}>
         <button
+          ref={closeRef}
           className={styles.agentOverlayBack}
           aria-label="Close agent chat"
           onClick={() => setOpen(false)}

--- a/dashboard/app/(dj)/setbuilder/components/MobileAgentOverlay.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/MobileAgentOverlay.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState } from 'react';
+import ChatPanelBody, { PersonaToggle } from './ChatPanelBody';
+import { useAgentChat } from './useAgentChat';
+import styles from '../setbuilder.module.css';
+
+/**
+ * Mobile agent surface: a floating "Agent" FAB (carrying the critique grade)
+ * that opens a full-viewport overlay with the complete chat experience. Shares
+ * {@link useAgentChat}/{@link ChatPanelBody} with the desktop sidebar; history
+ * loads only while the overlay is open. Rendered instead of (never alongside)
+ * the desktop sidebar on narrow viewports.
+ */
+export default function MobileAgentOverlay({
+  setId,
+  refreshToken = 0,
+  onMutationApplied,
+}: {
+  setId: number;
+  refreshToken?: number;
+  onMutationApplied: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const chat = useAgentChat(setId, { open, refreshToken, onMutationApplied });
+  const grade = chat.critique?.overall_grade;
+
+  if (!open) {
+    return (
+      <button className={styles.agentFab} aria-label="Open agent chat" onClick={() => setOpen(true)}>
+        <span className={styles.agentFabLabel}>Agent</span>
+        {grade && (
+          <span className={styles.agentFabGrade} data-testid="agent-fab-grade">
+            {grade}
+          </span>
+        )}
+      </button>
+    );
+  }
+
+  return (
+    <div className={styles.agentOverlay} role="dialog" aria-modal="true" aria-label="Agent chat">
+      <div className={styles.agentOverlayHeader}>
+        <button
+          className={styles.agentOverlayBack}
+          aria-label="Close agent chat"
+          onClick={() => setOpen(false)}
+        >
+          <span aria-hidden="true">←</span>
+        </button>
+        <div className={styles.panelHeaderInline}>Agent</div>
+        {grade && <span className={styles.chatCollapsedGrade}>{grade}</span>}
+        <PersonaToggle persona={chat.persona} onChange={chat.setPersona} />
+      </div>
+      <ChatPanelBody chat={chat} />
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/ChatPanelBody.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/ChatPanelBody.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ChatPanelBody from '../ChatPanelBody';
+import type { AgentChatController } from '../useAgentChat';
+
+function makeController(overrides: Partial<AgentChatController> = {}): AgentChatController {
+  return {
+    persona: 'peer',
+    setPersona: vi.fn(),
+    critique: {
+      overall_grade: 'B+',
+      summary: 'Strong opening, risky bridge.',
+      flags: [{ type: 'energy_dip', slot_position: 2, message: 'Bridge drops too hard.' }],
+    },
+    entries: [],
+    historyMeta: { usesCompactContext: true, recentTurnLimit: 12 },
+    input: '',
+    setInput: vi.fn(),
+    busy: false,
+    error: null,
+    suggestions: ['Make the slow window land softer'],
+    send: vi.fn(),
+    ...overrides,
+  } as AgentChatController;
+}
+
+describe('ChatPanelBody', () => {
+  it('renders the critique card with grade and flags', () => {
+    render(<ChatPanelBody chat={makeController()} />);
+    expect(screen.getByTestId('critique-card')).toBeInTheDocument();
+    expect(screen.getByText('B+')).toBeInTheDocument();
+    expect(screen.getByText(/energy dip/i)).toBeInTheDocument();
+  });
+
+  it('renders a persisted tool call without raw JSON', () => {
+    const chat = makeController({
+      entries: [
+        {
+          id: 2,
+          role: 'assistant',
+          content: 'Swapped slot 1 Track A with slot 2 Track B.',
+          display_summary: 'Swapped slot 1 Track A with slot 2 Track B.',
+          tool_calls: [
+            {
+              id: 'swap-1',
+              name: 'swap_slots',
+              args: { slot_a_id: 1, slot_b_id: 2 },
+              rationale: 'Better opener',
+              result: { slot_a_id: 1, slot_b_id: 2 },
+              mutating: true,
+              display_summary: 'Swapped slot 1 Track A with slot 2 Track B.',
+            },
+          ],
+          affected_transition_scores: [],
+        },
+      ],
+    });
+    render(<ChatPanelBody chat={chat} />);
+    expect(screen.getByTestId('agent-tool-card')).toHaveTextContent('swap slots');
+    expect(screen.queryByText(/"slot_a_id"/)).not.toBeInTheDocument();
+  });
+
+  it('sends a suggestion chip when tapped', () => {
+    const send = vi.fn();
+    render(<ChatPanelBody chat={makeController({ send })} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Make the slow window land softer' }));
+    expect(send).toHaveBeenCalledWith('Make the slow window land softer');
+  });
+
+  it('submits the typed message via the Send button', () => {
+    const send = vi.fn();
+    render(<ChatPanelBody chat={makeController({ input: 'swap the opener', send })} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/MobileAgentOverlay.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/MobileAgentOverlay.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import MobileAgentOverlay from '../MobileAgentOverlay';
+
+const mockApi = vi.hoisted(() => ({
+  critiqueSet: vi.fn(),
+  chatWithSetAgent: vi.fn(),
+  getSetAgentHistory: vi.fn(),
+}));
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/lib/api')>();
+  return { api: mockApi, ApiError: original.ApiError };
+});
+
+describe('MobileAgentOverlay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.critiqueSet.mockResolvedValue({
+      overall_grade: 'B+',
+      summary: 'Strong opening, risky bridge.',
+      flags: [{ type: 'energy_dip', slot_position: 2, message: 'Bridge drops too hard.' }],
+    });
+    mockApi.getSetAgentHistory.mockResolvedValue({
+      messages: [],
+      context_summary: null,
+      compacted_through_message_id: null,
+      uses_compact_context: true,
+      recent_turn_limit: 12,
+    });
+    mockApi.chatWithSetAgent.mockResolvedValue({
+      message: 'Swapped.',
+      assistant_message: {
+        id: 2,
+        role: 'assistant',
+        content: 'Swapped.',
+        display_summary: 'Swapped.',
+        tool_calls: [],
+        affected_transition_scores: [],
+        created_at: '2026-06-15T00:00:01Z',
+      },
+      tool_calls: [],
+      slots: [],
+      affected_transition_scores: [],
+    });
+  });
+
+  it('shows the critique grade on the FAB before opening', async () => {
+    render(<MobileAgentOverlay setId={9} onMutationApplied={vi.fn()} />);
+    expect(await screen.findByTestId('agent-fab-grade')).toHaveTextContent('B+');
+    // History is not fetched until the overlay opens.
+    expect(mockApi.getSetAgentHistory).not.toHaveBeenCalled();
+  });
+
+  it('opens the full overlay from the FAB and loads history', async () => {
+    render(<MobileAgentOverlay setId={9} onMutationApplied={vi.fn()} />);
+    fireEvent.click(await screen.findByRole('button', { name: /open agent/i }));
+
+    expect(await screen.findByTestId('critique-card')).toBeInTheDocument();
+    await waitFor(() => expect(mockApi.getSetAgentHistory).toHaveBeenCalledWith(9));
+  });
+
+  it('submits a message from the overlay composer', async () => {
+    render(<MobileAgentOverlay setId={9} onMutationApplied={vi.fn()} />);
+    fireEvent.click(await screen.findByRole('button', { name: /open agent/i }));
+    await screen.findByTestId('critique-card');
+
+    fireEvent.change(screen.getByPlaceholderText(/tell the agent/i), {
+      target: { value: 'swap the opener' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() =>
+      expect(mockApi.chatWithSetAgent).toHaveBeenCalledWith(9, { message: 'swap the opener' }),
+    );
+  });
+
+  it('closes the overlay with the close affordance', async () => {
+    render(<MobileAgentOverlay setId={9} onMutationApplied={vi.fn()} />);
+    fireEvent.click(await screen.findByRole('button', { name: /open agent/i }));
+    await screen.findByTestId('critique-card');
+
+    fireEvent.click(screen.getByRole('button', { name: /close agent/i }));
+
+    await waitFor(() => expect(screen.queryByTestId('critique-card')).not.toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /open agent/i })).toBeInTheDocument();
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/MobileAgentOverlay.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/MobileAgentOverlay.test.tsx
@@ -85,4 +85,51 @@ describe('MobileAgentOverlay', () => {
     await waitFor(() => expect(screen.queryByTestId('critique-card')).not.toBeInTheDocument());
     expect(screen.getByRole('button', { name: /open agent/i })).toBeInTheDocument();
   });
+
+  it('switches persona from the overlay header', async () => {
+    render(<MobileAgentOverlay setId={9} onMutationApplied={vi.fn()} />);
+    fireEvent.click(await screen.findByRole('button', { name: /open agent/i }));
+    await screen.findByTestId('critique-card');
+
+    // Peer persona renders the "Vibe check" critique title.
+    expect(screen.getByText('Vibe check')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Pro' }));
+
+    // Pro persona swaps the critique title and composer placeholder.
+    expect(screen.getByText('Set Analysis')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/issue an instruction/i)).toBeInTheDocument();
+  });
+
+  it('renders the error fallback when critique loading fails', async () => {
+    mockApi.critiqueSet.mockRejectedValue(new Error('boom'));
+    render(<MobileAgentOverlay setId={9} onMutationApplied={vi.fn()} />);
+    fireEvent.click(await screen.findByRole('button', { name: /open agent/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/critique unavailable/i);
+  });
+
+  it('moves focus to the close button on open and restores it to the FAB on close', async () => {
+    render(<MobileAgentOverlay setId={9} onMutationApplied={vi.fn()} />);
+    fireEvent.click(await screen.findByRole('button', { name: /open agent/i }));
+
+    const closeButton = await screen.findByRole('button', { name: /close agent/i });
+    await waitFor(() => expect(closeButton).toHaveFocus());
+
+    fireEvent.click(closeButton);
+
+    const fab = await screen.findByRole('button', { name: /open agent/i });
+    await waitFor(() => expect(fab).toHaveFocus());
+  });
+
+  it('closes the overlay when Escape is pressed', async () => {
+    render(<MobileAgentOverlay setId={9} onMutationApplied={vi.fn()} />);
+    fireEvent.click(await screen.findByRole('button', { name: /open agent/i }));
+    await screen.findByTestId('critique-card');
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    await waitFor(() => expect(screen.queryByTestId('critique-card')).not.toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /open agent/i })).toBeInTheDocument();
+  });
 });

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/useAgentChat.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/useAgentChat.test.tsx
@@ -1,0 +1,165 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { formatAgentError, useAgentChat } from '../useAgentChat';
+
+const mockApi = vi.hoisted(() => ({
+  critiqueSet: vi.fn(),
+  chatWithSetAgent: vi.fn(),
+  getSetAgentHistory: vi.fn(),
+}));
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/lib/api')>();
+  return { api: mockApi, ApiError: original.ApiError };
+});
+
+function assistantMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 2,
+    role: 'assistant',
+    content: 'Swapped.',
+    display_summary: 'Swapped.',
+    tool_calls: [],
+    affected_transition_scores: [],
+    created_at: '2026-06-15T00:00:01Z',
+    ...overrides,
+  };
+}
+
+describe('useAgentChat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.critiqueSet.mockResolvedValue({
+      overall_grade: 'B+',
+      summary: 'Strong opening, risky bridge.',
+      flags: [],
+    });
+    mockApi.getSetAgentHistory.mockResolvedValue({
+      messages: [],
+      context_summary: null,
+      compacted_through_message_id: null,
+      uses_compact_context: true,
+      recent_turn_limit: 12,
+    });
+    mockApi.chatWithSetAgent.mockResolvedValue({
+      message: 'Swapped.',
+      assistant_message: assistantMessage(),
+      tool_calls: [],
+      slots: [],
+      affected_transition_scores: [],
+    });
+  });
+
+  it('loads the critique on mount', async () => {
+    const { result } = renderHook(() => useAgentChat(9, { open: false, onMutationApplied: vi.fn() }));
+    await waitFor(() => expect(result.current.critique?.overall_grade).toBe('B+'));
+    expect(mockApi.critiqueSet).toHaveBeenCalledWith(9);
+  });
+
+  it('loads history only after the surface opens', async () => {
+    const { rerender } = renderHook(
+      ({ open }) => useAgentChat(9, { open, onMutationApplied: vi.fn() }),
+      { initialProps: { open: false } },
+    );
+    await waitFor(() => expect(mockApi.critiqueSet).toHaveBeenCalled());
+    expect(mockApi.getSetAgentHistory).not.toHaveBeenCalled();
+
+    rerender({ open: true });
+    await waitFor(() => expect(mockApi.getSetAgentHistory).toHaveBeenCalledWith(9));
+  });
+
+  it('optimistically appends, replaces the pending entry, and clears input on send', async () => {
+    const { result } = renderHook(() => useAgentChat(9, { open: true, onMutationApplied: vi.fn() }));
+    await waitFor(() => expect(mockApi.getSetAgentHistory).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.send('swap the opener');
+    });
+
+    expect(mockApi.chatWithSetAgent).toHaveBeenCalledWith(9, { message: 'swap the opener' });
+    expect(result.current.input).toBe('');
+    const roles = result.current.entries.map((entry) => entry.role);
+    expect(roles).toEqual(['user', 'assistant']);
+    expect(result.current.entries.every((entry) => !entry.pending)).toBe(true);
+  });
+
+  it('ignores a second send fired in the same tick (no duplicate request)', async () => {
+    const { result } = renderHook(() => useAgentChat(9, { open: true, onMutationApplied: vi.fn() }));
+    await waitFor(() => expect(mockApi.critiqueSet).toHaveBeenCalled());
+
+    await act(async () => {
+      await Promise.all([result.current.send('swap'), result.current.send('swap')]);
+    });
+
+    expect(mockApi.chatWithSetAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies the parent when a mutating tool runs', async () => {
+    const onMutationApplied = vi.fn();
+    mockApi.chatWithSetAgent.mockResolvedValue({
+      message: 'done',
+      assistant_message: assistantMessage({
+        tool_calls: [{ id: 1, name: 'reorder_slots', mutating: true }],
+      }),
+      tool_calls: [],
+      slots: [],
+      affected_transition_scores: [],
+    });
+    const { result } = renderHook(() => useAgentChat(9, { open: true, onMutationApplied }));
+    await waitFor(() => expect(mockApi.getSetAgentHistory).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.send('reorder');
+    });
+
+    expect(onMutationApplied).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify the parent for read-only tool calls', async () => {
+    const onMutationApplied = vi.fn();
+    mockApi.chatWithSetAgent.mockResolvedValue({
+      message: 'analysis',
+      assistant_message: assistantMessage({
+        tool_calls: [{ id: 1, name: 'critique_set', mutating: false }],
+      }),
+      tool_calls: [],
+      slots: [],
+      affected_transition_scores: [],
+    });
+    const { result } = renderHook(() => useAgentChat(9, { open: true, onMutationApplied }));
+    await waitFor(() => expect(mockApi.getSetAgentHistory).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.send('analyze');
+    });
+
+    expect(onMutationApplied).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a friendly error and drops the pending entry on send failure', async () => {
+    mockApi.chatWithSetAgent.mockRejectedValue(new Error('slot is locked'));
+    const { result } = renderHook(() => useAgentChat(9, { open: true, onMutationApplied: vi.fn() }));
+    await waitFor(() => expect(mockApi.getSetAgentHistory).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.send('edit a locked slot');
+    });
+
+    expect(result.current.error).toMatch(/unlock/i);
+    expect(result.current.entries).toHaveLength(0);
+  });
+});
+
+describe('formatAgentError', () => {
+  it('rewrites locked-slot failures into guidance', () => {
+    expect(formatAgentError(new Error('the slot is locked'))).toMatch(/unlock/i);
+  });
+
+  it('passes through other error messages', () => {
+    expect(formatAgentError(new Error('network down'))).toBe('network down');
+  });
+
+  it('falls back to a generic message for non-Error values', () => {
+    expect(formatAgentError('nope')).toBe('Agent request failed');
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/useIsMobile.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/useIsMobile.test.tsx
@@ -1,0 +1,67 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useIsMobile } from '../useIsMobile';
+
+type Listener = (event: { matches: boolean }) => void;
+
+function installMatchMedia(initialMatches: boolean) {
+  const listeners = new Set<Listener>();
+  let matches = initialMatches;
+  const mql = {
+    get matches() {
+      return matches;
+    },
+    media: '',
+    onchange: null,
+    addEventListener: (_: string, cb: Listener) => listeners.add(cb),
+    removeEventListener: (_: string, cb: Listener) => listeners.delete(cb),
+    addListener: (cb: Listener) => listeners.add(cb),
+    removeListener: (cb: Listener) => listeners.delete(cb),
+    dispatchEvent: () => true,
+  };
+  window.matchMedia = vi.fn().mockImplementation((query: string) => {
+    mql.media = query;
+    return mql as unknown as MediaQueryList;
+  });
+  return {
+    setMatches(next: boolean) {
+      matches = next;
+      listeners.forEach((cb) => cb({ matches: next }));
+    },
+  };
+}
+
+describe('useIsMobile', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    vi.restoreAllMocks();
+  });
+
+  it('reflects a matching media query after mount', () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when the query does not match', () => {
+    installMatchMedia(false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+
+  it('queries the provided breakpoint', () => {
+    installMatchMedia(true);
+    renderHook(() => useIsMobile(600));
+    expect(window.matchMedia).toHaveBeenCalledWith('(max-width: 600px)');
+  });
+
+  it('updates when the media query changes', () => {
+    const controller = installMatchMedia(false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+    act(() => controller.setMatches(true));
+    expect(result.current).toBe(true);
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/components/useAgentChat.ts
+++ b/dashboard/app/(dj)/setbuilder/components/useAgentChat.ts
@@ -1,0 +1,186 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { api, ApiError } from '@/lib/api';
+import type { AgentChatMessage, SetCritique } from '@/lib/api-types';
+
+export type Persona = 'peer' | 'pro';
+
+export type ChatEntry = Pick<
+  AgentChatMessage,
+  'id' | 'role' | 'content' | 'display_summary' | 'tool_calls' | 'affected_transition_scores'
+> & { pending?: boolean };
+
+export interface AgentChatController {
+  persona: Persona;
+  setPersona: (persona: Persona) => void;
+  critique: SetCritique | null;
+  entries: ChatEntry[];
+  historyMeta: { usesCompactContext: boolean; recentTurnLimit: number } | null;
+  input: string;
+  setInput: (value: string) => void;
+  busy: boolean;
+  error: string | null;
+  suggestions: string[];
+  send: (override?: string) => Promise<void>;
+}
+
+const PEER_SUGGESTIONS = [
+  'Why is the weakest transition flagged?',
+  'Make the slow window land softer',
+  'Find a better bridge from the pool',
+  'Cut one track with least damage',
+];
+
+const PRO_SUGGESTIONS = [
+  'Analyze transition 2',
+  'Recompute critique from current set',
+  'Bump the peak energy by 0.5',
+  'Surface risky BPM jumps',
+];
+
+export function formatAgentError(error: unknown): string {
+  const message = error instanceof Error ? error.message : 'Agent request failed';
+  if (/locked/i.test(message)) {
+    return 'Skipped because a locked slot would be changed. Unlock that slot before editing it.';
+  }
+  return message;
+}
+
+/**
+ * Owns all WrzDJSet agent-chat state and side effects (critique load, history
+ * load, message send). Shared by the desktop sidebar and the mobile overlay so
+ * exactly one instance mounts and fetches at a time.
+ */
+export function useAgentChat(
+  setId: number,
+  {
+    open,
+    refreshToken = 0,
+    onMutationApplied,
+  }: { open: boolean; refreshToken?: number; onMutationApplied: () => void },
+): AgentChatController {
+  const [persona, setPersona] = useState<Persona>('peer');
+  const [critique, setCritique] = useState<SetCritique | null>(null);
+  const [entries, setEntries] = useState<ChatEntry[]>([]);
+  const [historyMeta, setHistoryMeta] = useState<{
+    usesCompactContext: boolean;
+    recentTurnLimit: number;
+  } | null>(null);
+  const [input, setInput] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const historyRequestIdRef = useRef(0);
+  const historyErrorRef = useRef<string | null>(null);
+  const hasLocalTurnRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+    api
+      .critiqueSet(setId)
+      .then((result) => {
+        if (!cancelled) setCritique(result);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setCritique(null);
+        setError(
+          err instanceof ApiError && err.status === 400 ? err.message : 'Critique unavailable',
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [setId, refreshToken]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const requestId = historyRequestIdRef.current + 1;
+    historyRequestIdRef.current = requestId;
+    hasLocalTurnRef.current = false;
+
+    api
+      .getSetAgentHistory(setId)
+      .then((history) => {
+        if (cancelled || historyRequestIdRef.current !== requestId) return;
+        if (!hasLocalTurnRef.current) {
+          setEntries(history.messages);
+        }
+        setHistoryMeta({
+          usesCompactContext: history.uses_compact_context,
+          recentTurnLimit: history.recent_turn_limit,
+        });
+        const staleHistoryError = historyErrorRef.current;
+        setError((current) => (current === staleHistoryError ? null : current));
+        historyErrorRef.current = null;
+      })
+      .catch((err) => {
+        if (cancelled || historyRequestIdRef.current !== requestId) return;
+        const message = err instanceof Error ? err.message : 'Agent history unavailable';
+        historyErrorRef.current = message;
+        setError(message);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, setId]);
+
+  const suggestions = persona === 'peer' ? PEER_SUGGESTIONS : PRO_SUGGESTIONS;
+
+  const send = async (override?: string) => {
+    const message = (override ?? input).trim();
+    if (!message || busy) return;
+    hasLocalTurnRef.current = true;
+    const pendingEntry: ChatEntry = {
+      id: -Date.now(),
+      role: 'user',
+      content: message,
+      display_summary: null,
+      tool_calls: [],
+      affected_transition_scores: [],
+      pending: true,
+    };
+    setEntries((prev) => [...prev, pendingEntry]);
+    setInput('');
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await api.chatWithSetAgent(setId, { message });
+      setEntries((prev) => [
+        ...prev.filter((entry) => entry.id !== pendingEntry.id),
+        {
+          id: pendingEntry.id,
+          role: 'user',
+          content: message,
+          display_summary: null,
+          tool_calls: [],
+          affected_transition_scores: [],
+        },
+        result.assistant_message,
+      ]);
+      const mutatingTools = [...result.tool_calls, ...result.assistant_message.tool_calls];
+      if (mutatingTools.some((tool) => tool.mutating)) onMutationApplied();
+    } catch (err) {
+      setEntries((prev) => prev.filter((entry) => entry.id !== pendingEntry.id));
+      setError(formatAgentError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return {
+    persona,
+    setPersona,
+    critique,
+    entries,
+    historyMeta,
+    input,
+    setInput,
+    busy,
+    error,
+    suggestions,
+    send,
+  };
+}

--- a/dashboard/app/(dj)/setbuilder/components/useAgentChat.ts
+++ b/dashboard/app/(dj)/setbuilder/components/useAgentChat.ts
@@ -51,6 +51,15 @@ export function formatAgentError(error: unknown): string {
  * Owns all WrzDJSet agent-chat state and side effects (critique load, history
  * load, message send). Shared by the desktop sidebar and the mobile overlay so
  * exactly one instance mounts and fetches at a time.
+ *
+ * Capabilities & limitations:
+ * - Critique loads on mount and whenever `setId`/`refreshToken` change.
+ * - History loads only while `open` is true; stale responses are discarded via
+ *   a monotonic request id so a fast reopen never clobbers fresher state.
+ * - Sends are one-at-a-time: a synchronous in-flight guard rejects overlapping
+ *   `send()` calls, so the same tick can never fire duplicate requests.
+ * - No retry or streaming: a failed send surfaces a normalized error message and
+ *   removes its optimistic pending entry.
  */
 export function useAgentChat(
   setId: number,
@@ -73,6 +82,7 @@ export function useAgentChat(
   const historyRequestIdRef = useRef(0);
   const historyErrorRef = useRef<string | null>(null);
   const hasLocalTurnRef = useRef(false);
+  const sendInFlightRef = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -131,7 +141,8 @@ export function useAgentChat(
 
   const send = async (override?: string) => {
     const message = (override ?? input).trim();
-    if (!message || busy) return;
+    if (!message || busy || sendInFlightRef.current) return;
+    sendInFlightRef.current = true;
     hasLocalTurnRef.current = true;
     const pendingEntry: ChatEntry = {
       id: -Date.now(),
@@ -167,6 +178,7 @@ export function useAgentChat(
       setError(formatAgentError(err));
     } finally {
       setBusy(false);
+      sendInFlightRef.current = false;
     }
   };
 

--- a/dashboard/app/(dj)/setbuilder/components/useIsMobile.ts
+++ b/dashboard/app/(dj)/setbuilder/components/useIsMobile.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Tracks whether the viewport is at or below a mobile breakpoint.
+ *
+ * Hydration-safe: starts as `false` (desktop) so the server render and the
+ * first client render agree, then updates after mount and on every change.
+ */
+export function useIsMobile(maxWidthPx = 720): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const query = window.matchMedia(`(max-width: ${maxWidthPx}px)`);
+    const update = () => setIsMobile(query.matches);
+    update();
+    query.addEventListener('change', update);
+    return () => query.removeEventListener('change', update);
+  }, [maxWidthPx]);
+
+  return isMobile;
+}

--- a/dashboard/app/(dj)/setbuilder/setbuilder.module.css
+++ b/dashboard/app/(dj)/setbuilder/setbuilder.module.css
@@ -961,6 +961,104 @@
   cursor: not-allowed;
 }
 
+/* ------------------------------------------------------------------ */
+/* Mobile agent chat: FAB + full-viewport overlay (#402)               */
+/* Rendered only on narrow viewports (useIsMobile); the desktop layout */
+/* is untouched. Touch-target bumps are scoped to .agentOverlay so the */
+/* shared composer/chips stay compact on desktop.                      */
+
+.agentFab {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 80;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 44px;
+  padding: 0 1.1rem;
+  border: 1px solid rgba(183, 139, 255, 0.4);
+  border-radius: 999px;
+  background: #b78bff;
+  color: #fff;
+  font-family: var(--font-display), sans-serif;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+
+.agentFabLabel {
+  line-height: 1;
+}
+
+.agentFabGrade {
+  padding: 0.12rem 0.42rem;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.22);
+  font-size: 0.75rem;
+  line-height: 1;
+}
+
+.agentOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+.agentOverlayHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+  padding: 0.5rem 0.65rem;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--card);
+}
+
+.agentOverlayBack {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--surface-raised, rgba(255, 255, 255, 0.06));
+  color: var(--text);
+  font-size: 1.2rem;
+}
+
+/* Comfortable touch targets and zoom-safe input, overlay-only. */
+.agentOverlay .personaToggle button {
+  min-height: 44px;
+  padding: 0 0.85rem;
+}
+
+.agentOverlay .suggestionChip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 0.8rem;
+  font-size: 0.8125rem;
+}
+
+.agentOverlay .chatInput {
+  font-size: 1rem;
+}
+
+.agentOverlay .chatSend {
+  min-height: 44px;
+  padding: 0 0.9rem;
+}
+
 .confirmWrap {
   position: fixed;
   inset: 0;
@@ -2306,6 +2404,19 @@
 }
 
 @media (max-width: 720px) {
+  /* #402 — chat moves to the FAB + overlay, so drop the desktop chat column.
+     The pool/timeline workspace itself is intentionally not yet responsive
+     (documented known gap). */
+  .workspace,
+  .workspace.chatOpen,
+  .workspace.chatClosed {
+    grid-template-columns: 320px 1fr;
+    grid-template-areas:
+      'pool curve'
+      'pool transport'
+      'pool timeline';
+  }
+
   .topbarPairingsBtn {
     padding: 0 0.5rem;
     font-size: 0;

--- a/docs/superpowers/plans/2026-06-17-issue-402-mobile-chat.md
+++ b/docs/superpowers/plans/2026-06-17-issue-402-mobile-chat.md
@@ -1,0 +1,149 @@
+# Issue #402 — Mobile Chat View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the WrzDJSet agent chat a usable mobile surface — a floating "Agent" FAB
+(carrying the critique grade) that opens a full-viewport overlay with the complete agent
+experience — without making the desktop 3-column workspace responsive.
+
+**Architecture:** Extract `ChatSidebar`'s chat logic into a `useAgentChat` hook and a
+presentational `ChatPanelBody`. The desktop `ChatSidebar` and a new `MobileAgentOverlay`
+both wrap `ChatPanelBody`. A `useIsMobile` hook (matchMedia 720px, hydration-guarded) lets
+`page.tsx` render EITHER the desktop sidebar OR the mobile overlay — never both — so only
+one `useAgentChat` mounts and fetches.
+
+**Tech Stack:** Next.js / React 19, TypeScript (strict), vanilla CSS modules
+(`setbuilder.module.css`), Vitest + Testing Library (jsdom).
+
+## Global Constraints
+
+- Frontend only. No backend/API changes.
+- Vanilla CSS + inline React styles — NO Tailwind, NO UI framework. Dark theme
+  (bg `#0a0a0a`, cards `#1a1a1a`, text `#ededed`), mobile-first.
+- ≥44px touch targets; single-column stacking on mobile (consistent with #438).
+- Desktop layout (≥721px) must remain byte-for-byte unchanged.
+- Existing `ChatSidebar.test.tsx` must stay green (it is the desktop regression guard).
+- Honor vitest coverage gates: branches 68 / functions 65 / lines 78 / statements 77.
+- Commit format: `feat(setbuilder): …` ending with
+  `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+- `components/useIsMobile.ts` (new) — matchMedia hook, hydration-guarded.
+- `components/useAgentChat.ts` (new) — all chat state + actions + `formatAgentError`.
+- `components/ChatPanelBody.tsx` (new) — presentational body (context meta, critique card,
+  error, message list w/ tool cards + score updates, composer w/ suggestion chips + input).
+  Houses `ToolCard`, `CritiqueCard`, `PersonaToggle` and the pure render helpers
+  (`flagTone`, `formatFlag`, `lockSkipReasons`, `critiqueFlags`).
+- `components/MobileAgentOverlay.tsx` (new) — FAB + full-viewport overlay wrapping the body.
+- `components/ChatSidebar.tsx` (modify) — thin desktop shell wrapping the body.
+- `[setId]/page.tsx` (modify) — pick sidebar OR overlay via `useIsMobile`.
+- `setbuilder.module.css` (modify) — FAB, overlay, mobile legibility, hide desktop chat col.
+- `components/__tests__/useIsMobile.test.tsx` (new)
+- `components/__tests__/ChatPanelBody.test.tsx` (new)
+- `components/__tests__/MobileAgentOverlay.test.tsx` (new)
+
+---
+
+## Task 1: `useIsMobile` hook
+
+**Files:**
+- Create: `dashboard/app/(dj)/setbuilder/components/useIsMobile.ts`
+- Test: `dashboard/app/(dj)/setbuilder/components/__tests__/useIsMobile.test.tsx`
+
+**Interfaces:**
+- Produces: `useIsMobile(maxWidthPx?: number = 720): boolean` — `false` on first render
+  (SSR-safe), reflects `matchMedia('(max-width: {n}px)').matches` after mount, updates on
+  `change`.
+
+- [ ] Step 1: Write failing test (default false, true when match, reacts to change event).
+- [ ] Step 2: Run — expect FAIL (module missing).
+- [ ] Step 3: Implement hook: `useState(false)` + `useEffect` subscribing to the MediaQueryList.
+- [ ] Step 4: Run — expect PASS.
+- [ ] Step 5: Commit.
+
+## Task 2: `useAgentChat` hook + `ChatPanelBody`, refactor `ChatSidebar`
+
+**Files:**
+- Create: `components/useAgentChat.ts`, `components/ChatPanelBody.tsx`
+- Modify: `components/ChatSidebar.tsx`
+- Create: `components/__tests__/ChatPanelBody.test.tsx`
+- Guard: `components/__tests__/ChatSidebar.test.tsx` (must stay green, unchanged)
+
+**Interfaces:**
+- Produces: `useAgentChat(setId: number, opts: { open: boolean; refreshToken?: number;
+  onMutationApplied: () => void }): AgentChatController` where `AgentChatController = {
+  persona, setPersona, critique, entries, historyMeta, input, setInput, busy, error,
+  suggestions, send }`.
+- Produces: `ChatPanelBody({ chat: AgentChatController })` — presentational; owns scrollRef +
+  autoscroll; renders meta/critique/error/messages/composer.
+- Produces: `PersonaToggle({ persona, onChange })` exported from `ChatPanelBody.tsx`.
+- Consumes (ChatSidebar): `useAgentChat`, `ChatPanelBody`, `PersonaToggle`.
+
+- [ ] Step 1: Add `ChatPanelBody.test.tsx` — render with a stub controller (no API): asserts
+  critique-card, a tool card, suggestion chip click → `send(chip)`, Send button → `send()`.
+- [ ] Step 2: Run — expect FAIL (module missing).
+- [ ] Step 3: Extract `useAgentChat.ts` (move state/effects/send + `formatAgentError`).
+- [ ] Step 4: Create `ChatPanelBody.tsx` (move ToolCard/CritiqueCard/PersonaToggle + render
+  helpers + body JSX + scrollRef/autoscroll).
+- [ ] Step 5: Rewrite `ChatSidebar.tsx` to a thin shell (collapsed button + header w/
+  PersonaToggle + Collapse) wrapping `ChatPanelBody`, driven by `useAgentChat`.
+- [ ] Step 6: Run `ChatPanelBody.test.tsx` AND `ChatSidebar.test.tsx` — expect PASS (both).
+- [ ] Step 7: Commit.
+
+## Task 3: `MobileAgentOverlay`
+
+**Files:**
+- Create: `components/MobileAgentOverlay.tsx`
+- Create: `components/__tests__/MobileAgentOverlay.test.tsx`
+
+**Interfaces:**
+- Consumes: `useAgentChat`, `ChatPanelBody`, `PersonaToggle`.
+- Produces: `MobileAgentOverlay({ setId, refreshToken?, onMutationApplied })` — renders a FAB
+  (grade badge from critique) that toggles a full-viewport overlay; overlay header has a
+  back/close affordance + grade + PersonaToggle; body is `ChatPanelBody`. History loads only
+  while the overlay is open.
+
+- [ ] Step 1: Write failing test (mock `@/lib/api` like ChatSidebar.test): FAB shows grade
+  after critique resolves; click FAB → overlay (critique-card) appears; type + Send →
+  `chatWithSetAgent` called; close affordance hides the overlay.
+- [ ] Step 2: Run — expect FAIL (module missing).
+- [ ] Step 3: Implement the overlay.
+- [ ] Step 4: Run — expect PASS.
+- [ ] Step 5: Commit.
+
+## Task 4: Wire `page.tsx` + CSS
+
+**Files:**
+- Modify: `[setId]/page.tsx`
+- Modify: `setbuilder.module.css`
+
+**Interfaces:**
+- Consumes: `useIsMobile`, `MobileAgentOverlay`, existing `ChatSidebar`.
+
+- [ ] Step 1: In `page.tsx`, compute `isMobile = useIsMobile()`. Render the `.panelChat`
+  `<ChatSidebar>` only when `!isMobile`; render `<MobileAgentOverlay>` (outside the grid)
+  only when `isMobile`. Single `useAgentChat` mount either way.
+- [ ] Step 2: CSS — at `max-width:720px`: hide `.panelChat`, collapse `.workspace` grid to a
+  single column (pool/transport/timeline stack), style `.agentFab` (≥44px, fixed
+  bottom-right, grade badge) and `.agentOverlay` (fixed inset:0 full-viewport, header w/ back +
+  grade + persona, scrollable body, sticky composer); ensure tool cards / critique / chips are
+  legible (single-column, ≥44px taps).
+- [ ] Step 3: Run full FE CI (`npm run lint && npx tsc --noEmit && npm test -- --run`) — PASS,
+  coverage gates met. `git checkout next-env.d.ts` if the build touched it.
+- [ ] Step 4: Commit.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** mobile chat surface (overlay) ✓; tool cards legible (Task 4 CSS) ✓;
+  suggestion chips touch-usable (≥44px, Task 4) ✓; critique card adapted (single-column) ✓;
+  single fetch (Task 4 single-mount) ✓; desktop unchanged (PersonaToggle keeps header
+  identical; CSS changes gated behind 720px) ✓.
+- **Placeholder scan:** none — each task names exact files, interfaces, and test intent.
+- **Type consistency:** `AgentChatController` shape and `useAgentChat`/`ChatPanelBody`/
+  `PersonaToggle`/`MobileAgentOverlay` signatures are consistent across Tasks 1-4.

--- a/docs/superpowers/specs/2026-06-17-issue-402-design.md
+++ b/docs/superpowers/specs/2026-06-17-issue-402-design.md
@@ -1,0 +1,88 @@
+# Issue #402 — WrzDJSet: Mobile chat view
+
+**Date:** 2026-06-17
+**Issue:** #402 (`phase:v2`, milestone v2-Reach)
+**Status:** Approved design
+
+## Summary
+
+Give the WrzDJSet agent chat a usable mobile surface: on narrow viewports,
+replace the desktop chat column with a floating "Agent" FAB (carrying the
+critique grade) that opens a **full-viewport overlay** with the complete agent
+experience (critique, tool cards, suggestion chips, composer). Desktop layout is
+unchanged.
+
+## Context / finding
+
+The builder `.workspace` is a hard 3-column CSS grid
+(`pool 320px | timeline 1fr | chat 360px`) with **no mobile treatment** — the
+only `@media` rules (980px / 720px) restyle the PairingsOverlay modal. So the
+issue's "sheet within the responsive builder" assumes a responsive builder that
+does not exist. Scope decision (approved): build a **self-contained** mobile chat
+surface reachable independent of the desktop grid; do **not** make the whole
+workspace responsive in this issue. The full responsive-workspace gap is a
+documented known limitation, not filed as a follow-up.
+
+## Design
+
+### Component refactor (avoids duplicating ~390 LOC of chat logic)
+
+- **`useAgentChat(setId, { refreshToken, onMutationApplied })`** — new hook
+  holding all chat state + actions currently inside `ChatSidebar` (load history,
+  send message, critique, persona, suggestions, error handling).
+- **`ChatPanelBody`** — new presentational component rendering the message list,
+  tool cards, critique card, suggestion chips, persona toggle, and composer from
+  the hook's output.
+- **`ChatSidebar`** — becomes the thin desktop shell (collapse toggle +
+  `grid-area: chat` positioning) wrapping `ChatPanelBody`.
+- **`MobileAgentOverlay`** — new FAB + full-viewport panel, also wrapping
+  `ChatPanelBody`; the FAB surfaces the critique grade badge.
+
+### Single-mount strategy (no double fetch)
+
+- **`useIsMobile`** — new hook over `matchMedia('(max-width: 720px)')`, guarded
+  for hydration (defaults to desktop on first render, updates after mount).
+- `[setId]/page.tsx` renders **either** `<ChatSidebar>` **or**
+  `<MobileAgentOverlay>` based on `useIsMobile` — never both — so only one
+  `useAgentChat` instance is mounted and fetching.
+
+### CSS (`setbuilder.module.css`)
+
+- Reuse the existing 720px breakpoint. Hide the desktop chat column on mobile.
+- Style the FAB and the full-viewport overlay panel (header with back affordance
+  + grade, scrollable body, sticky composer).
+- Ensure tool cards / critique card / suggestion chips are legible at mobile
+  widths: **≥44px touch targets**, single-column stacking (consistent with the
+  #438 mobile-reorder work).
+
+### Tests (vitest)
+
+- `ChatPanelBody`: renders messages, tool cards, critique, suggestion chips
+  (migrate the existing `ChatSidebar.test.tsx` content coverage).
+- `MobileAgentOverlay`: FAB opens/closes the overlay, shows the grade badge,
+  renders the body, composer submits a message.
+- `useIsMobile`: behavior via mocked `matchMedia`.
+- Desktop `ChatSidebar` path remains green.
+
+## Out of scope
+
+Full responsive workspace (mobile timeline/pool/curve editing). Documented
+limitation only.
+
+## Files touched
+
+- `dashboard/app/(dj)/setbuilder/components/ChatSidebar.tsx`
+- `dashboard/app/(dj)/setbuilder/components/useAgentChat.ts` (new)
+- `dashboard/app/(dj)/setbuilder/components/ChatPanelBody.tsx` (new)
+- `dashboard/app/(dj)/setbuilder/components/MobileAgentOverlay.tsx` (new)
+- `dashboard/app/(dj)/setbuilder/components/useIsMobile.ts` (new)
+- `dashboard/app/(dj)/setbuilder/setbuilder.module.css`
+- `dashboard/app/(dj)/setbuilder/[setId]/page.tsx`
+- `dashboard/app/(dj)/setbuilder/components/__tests__/` (new + updated)
+
+## Conflict isolation
+
+Frontend-only, scoped to the setbuilder chat components + CSS + page layout.
+Disjoint from #401 (export backend/modal) and #403 (play-history backend). Safe
+to parallelize. Note: #401 also edits `ExportModal.tsx` in the same components
+dir but a different file — no overlap with the chat components above.


### PR DESCRIPTION
## Why

The WrzDJSet builder is a hard 3-column desktop grid (`pool | timeline | chat`)
with no mobile treatment, so the agent chat column is unusable on a phone. This
gives the agent a first-class mobile surface without attempting to make the
whole workspace responsive (a larger, separate effort).

## What

On viewports ≤720px the desktop chat column is replaced by a floating **Agent**
FAB — carrying the live critique grade — that opens a **full-viewport overlay**
with the complete agent experience (critique card, tool-call cards, suggestion
chips, persona toggle, composer).

To avoid duplicating ~390 LOC of chat logic, `ChatSidebar` was refactored:

- **`useAgentChat`** — hook holding all chat state + actions (critique/history
  load, send, persona, error handling).
- **`ChatPanelBody`** — presentational body (messages, tool cards, critique,
  suggestion chips, composer) plus a shared `PersonaToggle`.
- **`ChatSidebar`** — now a thin desktop shell wrapping `ChatPanelBody`.
- **`MobileAgentOverlay`** — the FAB + overlay, also wrapping `ChatPanelBody`.
- **`useIsMobile`** — hydration-guarded `matchMedia(720px)` hook so `page.tsx`
  renders **either** the desktop sidebar **or** the mobile overlay — never both,
  so only one `useAgentChat` mounts and fetches.

Touch targets are ≥44px and the overlay stacks single-column (consistent with
the #438 mobile-reorder work); the bumps are scoped to `.agentOverlay` so the
desktop composer is byte-for-byte unchanged.

**Out of scope (documented known gap):** the pool/timeline/curve workspace
itself is still not responsive.

## Testing
- [x] Unit tests pass (`npm test -- --run` → 1272 passed)
- [x] Coverage gates pass (`npm test -- --run --coverage` → exit 0; 78.75% stmts
      / 69.89% branch / 72.75% funcs / 81.13% lines)
- [x] Lint clean (`npm run lint`) + TypeScript strict (`npx tsc --noEmit`)
- [x] Desktop `ChatSidebar.test.tsx` (11 tests) stays green as the
      behavior-preservation guard
- [ ] Manual verification: load a set on a ≤720px viewport → Agent FAB shows
      grade → tap opens overlay → critique/tool cards/chips legible → send works
      → close returns to the builder; desktop sidebar unchanged
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #402.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mobile-optimized chat experience: users can now access the agent chat via a floating "Agent" button on smaller screens, which opens a full-viewport overlay for seamless conversations
  * Desktop users remain unaffected; the existing sidebar chat experience is unchanged

* **Documentation**
  * Added implementation and design documentation for the mobile chat feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->