### PR TITLE
feat(setbuilder): Engine DJ + Lexicon exports via Rekordbox XML (#401)

### DIFF
--- a/dashboard/app/(dj)/setbuilder/components/ExportModal.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/ExportModal.tsx
@@ -41,11 +41,27 @@ const PLATFORMS = [
     sub: 'Universal playlist / plaintext',
     available: true,
   },
-  { id: 'enginedj' as const, label: 'Engine DJ XML', sub: '', available: false },
+  {
+    id: 'enginedj' as const,
+    label: 'Engine DJ XML',
+    sub: 'Imports via Rekordbox XML — relink on import',
+    available: true,
+  },
+  {
+    id: 'lexicon' as const,
+    label: 'Lexicon',
+    sub: 'Imports via Rekordbox XML — relink on import',
+    available: true,
+  },
   { id: 'serato' as const, label: 'Serato .crate', sub: '', available: false },
   { id: 'spotify' as const, label: 'Spotify', sub: '', available: false },
   { id: 'applemusic' as const, label: 'Apple Music', sub: '', available: false },
 ];
+
+// Targets that emit the Rekordbox DJ_PLAYLISTS XML. Engine DJ and Lexicon have
+// no proprietary import format — both ingest this XML — so they share one
+// download path with rekordbox.
+const XML_PLATFORMS = ['rekordbox', 'enginedj', 'lexicon'] as const;
 
 // ---------------------------------------------------------------------------
 // Props
@@ -109,12 +125,14 @@ export default function ExportModal({ set, onClose, onSetUpdated }: ExportModalP
     setFileDownloaded(null);
     setStage('checking');
 
-    const targetMap: Record<'tidal' | 'rekordbox' | 'm3u', ExportTarget> = {
+    const targetMap: Record<'tidal' | 'rekordbox' | 'm3u' | 'enginedj' | 'lexicon', ExportTarget> = {
       tidal: 'tidal',
       rekordbox: 'rekordbox',
       m3u: 'm3u',
+      enginedj: 'enginedj',
+      lexicon: 'lexicon',
     };
-    const target = targetMap[platform.id as 'tidal' | 'rekordbox' | 'm3u'];
+    const target = targetMap[platform.id as keyof typeof targetMap];
 
     try {
       const result = await api.exportPreflight(set.id, target);
@@ -158,6 +176,8 @@ export default function ExportModal({ set, onClose, onSetUpdated }: ExportModalP
       rekordbox: 'xml',
       m3u: 'm3u8',
       txt: 'txt',
+      enginedj: 'xml',
+      lexicon: 'xml',
     };
     const fallback = buildFallbackName(set.name, extMap[format]);
     try {
@@ -394,19 +414,34 @@ function ConfirmStage({
         </button>
       )}
 
-      {canExport && platformId === 'rekordbox' && (
-        <div style={{ marginTop: '0.5rem', display: 'flex', gap: '0.5rem' }}>
-          <button
-            className="btn btn-primary btn-sm"
-            disabled={exporting || downloading}
-            onClick={() => onFileExport('rekordbox')}
-          >
-            {downloading ? 'Preparing…' : 'Download .xml'}
-          </button>
-          {fileDownloaded && (
-            <span style={{ fontSize: '0.75rem', color: 'var(--color-success, #22c55e)', alignSelf: 'center' }}>
-              Downloaded ✓
-            </span>
+      {canExport && (XML_PLATFORMS as readonly string[]).includes(platformId) && (
+        <div style={{ marginTop: '0.5rem' }}>
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
+            <button
+              className="btn btn-primary btn-sm"
+              disabled={exporting || downloading}
+              onClick={() => onFileExport(platformId as ExportFileFormat)}
+            >
+              {downloading ? 'Preparing…' : 'Download .xml'}
+            </button>
+            {fileDownloaded && (
+              <span style={{ fontSize: '0.75rem', color: 'var(--color-success, #22c55e)', alignSelf: 'center' }}>
+                Downloaded ✓
+              </span>
+            )}
+          </div>
+          {platformId !== 'rekordbox' && (
+            <div
+              style={{
+                marginTop: '0.5rem',
+                fontSize: '0.6875rem',
+                color: 'var(--text-secondary)',
+                lineHeight: 1.4,
+              }}
+            >
+              Engine DJ and Lexicon both import this Rekordbox XML. Set the XML path in the
+              app, import the playlist, then relink tracks to your local audio files.
+            </div>
           )}
         </div>
       )}

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/ExportModal.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/ExportModal.test.tsx
@@ -116,27 +116,36 @@ beforeEach(() => {
 });
 
 // ============================================================
-// 1. Platform picker — all 7 rows, 4 disabled with "Coming soon"
+// 1. Platform picker — all 8 rows, 3 disabled with "Coming soon"
 // ============================================================
 
 describe('ExportModal — platform picker', () => {
-  it('renders all 7 platform rows with 4 disabled and showing "Coming soon"', () => {
+  it('renders all 8 platform rows with 3 disabled and showing "Coming soon"', () => {
     render(<ExportModal {...baseProps} />);
 
-    // Available platforms
+    // Available platforms (Engine DJ + Lexicon both ship via Rekordbox XML)
     expect(screen.getByText('Tidal')).toBeTruthy();
     expect(screen.getByText('Rekordbox XML')).toBeTruthy();
     expect(screen.getByText('M3U / .txt')).toBeTruthy();
+    expect(screen.getByText('Engine DJ XML')).toBeTruthy();
+    expect(screen.getByText('Lexicon')).toBeTruthy();
 
     // Unavailable platforms
-    expect(screen.getByText('Engine DJ XML')).toBeTruthy();
     expect(screen.getByText('Serato .crate')).toBeTruthy();
     expect(screen.getByText('Spotify')).toBeTruthy();
     expect(screen.getByText('Apple Music')).toBeTruthy();
 
-    // Exactly 4 "Coming soon" badges
+    // Exactly 3 "Coming soon" badges
     const comingSoonBadges = screen.getAllByText('Coming soon');
-    expect(comingSoonBadges).toHaveLength(4);
+    expect(comingSoonBadges).toHaveLength(3);
+  });
+
+  it('Engine DJ and Lexicon rows are enabled (not "Coming soon")', () => {
+    render(<ExportModal {...baseProps} />);
+    const engineBtn = screen.getByRole('button', { name: /engine dj xml/i });
+    const lexiconBtn = screen.getByRole('button', { name: /lexicon/i });
+    expect((engineBtn as HTMLButtonElement).disabled).toBe(false);
+    expect((lexiconBtn as HTMLButtonElement).disabled).toBe(false);
   });
 
   it('unavailable rows are disabled and clicking them does not call exportPreflight', () => {
@@ -396,6 +405,48 @@ describe('ExportModal — M3U dual-download', () => {
     fireEvent.click(screen.getByRole('button', { name: /download.*txt/i }));
     await waitFor(() => {
       expect(mockApi.exportSetFile).toHaveBeenCalledWith(42, 'txt', false, expect.any(String));
+    });
+  });
+});
+
+// ============================================================
+// 8. Engine DJ + Lexicon: preflight → Download .xml via Rekordbox XML
+// ============================================================
+
+describe('ExportModal — Engine DJ + Lexicon (Rekordbox XML)', () => {
+  it.each([
+    ['Engine DJ XML', 'enginedj'],
+    ['Lexicon', 'lexicon'],
+  ])('%s preflights as %s then downloads .xml', async (label, format) => {
+    mockApi.exportPreflight.mockResolvedValue(
+      makePreflightClean(format as ExportPreflight['target'])
+    );
+    const mockBlob = new Blob(['<DJ_PLAYLISTS/>'], { type: 'application/xml' });
+    mockApi.exportSetFile.mockResolvedValue({ blob: mockBlob, filename: `set.xml` });
+
+    render(<ExportModal {...baseProps} />);
+    fireEvent.click(screen.getByText(label));
+
+    await waitFor(() => {
+      expect(mockApi.exportPreflight).toHaveBeenCalledWith(42, format);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /download.*xml/i })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /download.*xml/i }));
+    await waitFor(() => {
+      expect(mockApi.exportSetFile).toHaveBeenCalledWith(42, format, false, expect.any(String));
+    });
+  });
+
+  it('shows the import-then-relink note for these targets', async () => {
+    mockApi.exportPreflight.mockResolvedValue(makePreflightClean('enginedj'));
+    render(<ExportModal {...baseProps} />);
+    fireEvent.click(screen.getByText('Engine DJ XML'));
+    await waitFor(() => {
+      expect(screen.getByText(/relink/i)).toBeTruthy();
     });
   });
 });

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/ExportModal.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/ExportModal.test.tsx
@@ -441,10 +441,15 @@ describe('ExportModal — Engine DJ + Lexicon (Rekordbox XML)', () => {
     });
   });
 
-  it('shows the import-then-relink note for these targets', async () => {
-    mockApi.exportPreflight.mockResolvedValue(makePreflightClean('enginedj'));
+  it.each([
+    ['Engine DJ XML', 'enginedj'],
+    ['Lexicon', 'lexicon'],
+  ])('%s shows the import-then-relink note', async (label, format) => {
+    mockApi.exportPreflight.mockResolvedValue(
+      makePreflightClean(format as ExportPreflight['target'])
+    );
     render(<ExportModal {...baseProps} />);
-    fireEvent.click(screen.getByText('Engine DJ XML'));
+    fireEvent.click(screen.getByText(label));
     await waitFor(() => {
       expect(screen.getByText(/relink/i)).toBeTruthy();
     });

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -4952,7 +4952,7 @@ export interface components {
              * Format
              * @enum {string}
              */
-            format: "rekordbox" | "m3u" | "txt";
+            format: "rekordbox" | "m3u" | "txt" | "enginedj" | "lexicon";
             /**
              * Skip Unresolved
              * @default false
@@ -4968,7 +4968,7 @@ export interface components {
              * Target
              * @enum {string}
              */
-            target: "tidal" | "rekordbox" | "m3u" | "txt";
+            target: "tidal" | "rekordbox" | "m3u" | "txt" | "enginedj" | "lexicon";
         };
         /**
          * ExportPreflightOut
@@ -4986,7 +4986,7 @@ export interface components {
              * Target
              * @enum {string}
              */
-            target: "tidal" | "rekordbox" | "m3u" | "txt";
+            target: "tidal" | "rekordbox" | "m3u" | "txt" | "enginedj" | "lexicon";
             /** Tidal Connected */
             tidal_connected: boolean | null;
             /** Total */

--- a/docs/superpowers/plans/2026-06-17-issue-401-engine-lexicon-export.md
+++ b/docs/superpowers/plans/2026-06-17-issue-401-engine-lexicon-export.md
@@ -1,0 +1,119 @@
+# Engine DJ + Lexicon Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose Engine DJ and Lexicon as first-class export targets that emit the existing Rekordbox `DJ_PLAYLISTS` XML, plus an ISRC fidelity fix in the shared renderer.
+
+**Architecture:** Neither platform has a proprietary import format — both ingest Rekordbox XML. So we register `enginedj` and `lexicon` as distinct format keys against the existing `render_rekordbox_xml`, widen the schema `Literal`s, regenerate the OpenAPI contract + generated TS types, and flip/add the two ExportModal options. The only renderer change is emitting `track.isrc` via the `Comments` TRACK attribute.
+
+**Tech Stack:** FastAPI + Pydantic (backend), Next.js/React 19 + vanilla CSS (frontend), pytest + vitest.
+
+## Global Constraints
+
+- Backend ruff: line-length 100; rules E, F, I, UP. Coverage gate enforced (`--cov-fail-under`); new code must not drop coverage.
+- Frontend: vanilla CSS + inline React styles — NO Tailwind/UI framework.
+- Immutability; validate at boundaries; keep existing control-char sanitization (`_clean`) in the XML renderer.
+- Commit format: Conventional Commits, body ends with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- Branch: `feat/issue-401`. Never commit to main.
+- `enginedj` / `lexicon` are DISTINCT format keys (not aliases) — both map to `(render_rekordbox_xml, "application/xml", "xml")`.
+- Honest UI copy: label "Engine DJ XML" / "Lexicon", sub describes "imports via Rekordbox XML — relink on import".
+
+---
+
+## File Structure
+
+- `server/app/services/setbuilder/export_files.py` — add ISRC → `Comments` line in `render_rekordbox_xml`. No new renderer functions.
+- `server/app/schemas/setbuilder.py` — widen `ExportTarget` + `ExportFileFormat` Literals.
+- `server/app/api/setbuilder.py` — add `enginedj` + `lexicon` keys to `_FILE_RENDERERS`.
+- `server/openapi.json` — regenerated from the schema change.
+- `server/tests/test_setbuilder_export_service.py` — ISRC renderer test.
+- `server/tests/test_setbuilder_export_api.py` — enginedj/lexicon routing + media-type/ext + no-mutation tests.
+- `dashboard/lib/api-types.generated.ts` — regenerated from `openapi.json`.
+- `dashboard/app/(dj)/setbuilder/components/ExportModal.tsx` — flip enginedj, add lexicon, wire download + relink note.
+- `dashboard/app/(dj)/setbuilder/components/__tests__/ExportModal.test.tsx` — update picker counts + new-option wiring.
+
+---
+
+### Task 1: ISRC fidelity in the Rekordbox XML renderer
+
+**Files:**
+- Modify: `server/app/services/setbuilder/export_files.py` (`render_rekordbox_xml`)
+- Test: `server/tests/test_setbuilder_export_service.py` (`TestRekordboxXml`)
+
+**Interfaces:**
+- Consumes: `ExportTrack.isrc: str | None` (already exists in `export_common.py`).
+- Produces: TRACK attribute `Comments="ISRC:<isrc>"` when `track.isrc` is truthy; sanitized via `_clean`; absent otherwise.
+
+- [ ] **Step 1: Write failing tests** — ISRC present emits `Comments="ISRC:..."`; ISRC absent omits `Comments`; control chars in ISRC sanitized.
+- [ ] **Step 2: Run → FAIL** (`KeyError: 'Comments'`).
+- [ ] **Step 3: Implement** — in `render_rekordbox_xml`, after the genre block: `if track.isrc: attrs["Comments"] = f"ISRC:{_clean(track.isrc)}"`.
+- [ ] **Step 4: Run → PASS**.
+- [ ] **Step 5: Commit** `feat(setbuilder): emit ISRC via Comments in Rekordbox XML export`.
+
+### Task 2: Widen export schema Literals
+
+**Files:**
+- Modify: `server/app/schemas/setbuilder.py` (`ExportTarget`, `ExportFileFormat`)
+
+**Interfaces:**
+- Produces: `ExportTarget = Literal["tidal","rekordbox","m3u","txt","enginedj","lexicon"]`; `ExportFileFormat = Literal["rekordbox","m3u","txt","enginedj","lexicon"]`.
+
+- [ ] **Step 1:** Widen both Literals.
+- [ ] **Step 2:** (covered by Task 3 API tests — schema alone has no direct test).
+- [ ] **Step 3: Commit** folded into Task 3.
+
+### Task 3: Register enginedj + lexicon renderers at the API boundary
+
+**Files:**
+- Modify: `server/app/api/setbuilder.py` (`_FILE_RENDERERS`)
+- Test: `server/tests/test_setbuilder_export_api.py` (`TestFileExport`)
+
+**Interfaces:**
+- Consumes: `export_files.render_rekordbox_xml`, widened `ExportFileFormat`.
+- Produces: `_FILE_RENDERERS["enginedj"]` and `["lexicon"]` → `(render_rekordbox_xml, "application/xml", "xml")`.
+
+- [ ] **Step 1: Write failing tests** — POST `/export/file` with format `enginedj` and `lexicon` returns 200, `content-type` starts `application/xml`, `filename="...xml"`, body contains `DJ_PLAYLISTS`; preflight `target=enginedj` returns 200; export does not mutate set status.
+- [ ] **Step 2: Run → FAIL** (422 on unknown enum / KeyError).
+- [ ] **Step 3: Implement** — add the two dict entries (Task 2 Literals make them valid enum values).
+- [ ] **Step 4: Run → PASS**.
+- [ ] **Step 5: Regenerate** `server/openapi.json` via `.venv/bin/python scripts/export_openapi.py`.
+- [ ] **Step 6: Commit** `feat(setbuilder): route Engine DJ + Lexicon exports to Rekordbox XML`.
+
+### Task 4: Regenerate frontend types
+
+**Files:**
+- Modify: `dashboard/lib/api-types.generated.ts`
+
+- [ ] **Step 1:** From `dashboard/`, `npm run types:generate` (reads `../server/openapi.json`).
+- [ ] **Step 2:** Verify `enginedj`/`lexicon` appear in the generated `ExportPreflightIn`/`ExportFileIn` enums.
+- [ ] **Step 3: Commit** folded into Task 5 (types + UI land together to keep tsc green at every commit).
+
+### Task 5: ExportModal — flip Engine DJ, add Lexicon
+
+**Files:**
+- Modify: `dashboard/app/(dj)/setbuilder/components/ExportModal.tsx`
+- Test: `dashboard/app/(dj)/setbuilder/components/__tests__/ExportModal.test.tsx`
+
+**Interfaces:**
+- Consumes: widened `ExportTarget`/`ExportFileFormat`, `api.exportPreflight`, `api.exportSetFile`.
+- Produces: 5 available rows (tidal, rekordbox, m3u, enginedj, lexicon), 3 "Coming soon" (serato, spotify, applemusic). enginedj/lexicon download `.xml` and show a relink note.
+
+- [ ] **Step 1: Update test** — picker now renders 8 rows, 3 "Coming soon"; Engine DJ + Lexicon are enabled; clicking each calls `exportPreflight(id, 'enginedj'|'lexicon')` then shows a Download .xml button that calls `exportSetFile(id, 'enginedj'|'lexicon', false, ...)`.
+- [ ] **Step 2: Run → FAIL**.
+- [ ] **Step 3: Implement** — flip `enginedj` to available with honest sub; add `lexicon` row; extend `targetMap`/`extMap`; unify the rekordbox/enginedj/lexicon download block (3 identical XML targets → one block keyed off a constant) + relink note for enginedj/lexicon.
+- [ ] **Step 4: Run → PASS**; `npm run lint && npx tsc --noEmit`.
+- [ ] **Step 5: Commit** `feat(setbuilder): ship Engine DJ + Lexicon export options in modal`.
+
+### Task 6: Full CI + finish
+
+- [ ] Backend: ruff check, ruff format --check, bandit, pytest (coverage gate), `alembic upgrade head && alembic check`.
+- [ ] Frontend: lint, tsc --noEmit, vitest. `git checkout next-env.d.ts` if modified.
+- [ ] Finish branch → Push + PR with `Closes #401`, Why/What/Testing, credit Claude Opus 4.8, manual-QA note.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** (1) enginedj/lexicon options → Tasks 2,3,5. (2) in-modal relink note → Task 5. (3) ISRC fix → Task 1. (4) fixture/schema tests → Tasks 1,3,5. ✓
+- **Placeholder scan:** none. ✓
+- **Type consistency:** `enginedj`/`lexicon` literal spelling identical across schema, `_FILE_RENDERERS`, `targetMap`, `extMap`, tests. ✓

--- a/docs/superpowers/specs/2026-06-17-issue-401-design.md
+++ b/docs/superpowers/specs/2026-06-17-issue-401-design.md
@@ -1,0 +1,95 @@
+# Issue #401 — WrzDJSet: Engine DJ XML + Lexicon exports
+
+**Date:** 2026-06-17
+**Issue:** #401 (`phase:v2`, milestone v2-Reach)
+**Status:** Approved design
+
+## Summary
+
+Expose **Engine DJ** and **Lexicon** as first-class export targets in the
+WrzDJSet export modal. Research (below) established that neither platform has a
+distinct importable "native" file format — **both ingest the Rekordbox
+`DJ_PLAYLISTS` XML that WrzDJ already generates.** So this issue ships *labeled
+presets* of the existing renderer plus a real fidelity improvement (ISRC), not
+two new serializers.
+
+## Research findings (cross-validated, 2026-06-17)
+
+- **Engine DJ (Denon/InMusic):** No separate "Engine DJ XML" import format
+  exists. Engine DJ 4.x imports the standard Rekordbox `DJ_PLAYLISTS` XML
+  directly (Database tab → set Rekordbox XML path → Import Collection / Import
+  as Playlist). Its only native store is the Engine Library SQLite DB, which
+  Denon explicitly warns third parties not to write and which is not a
+  server-side export target.
+- **Lexicon (uselexicon/lexicondj):** No proprietary export format. It is a
+  conversion hub that *imports* Rekordbox XML (and iTunes XML / M3U). Its only
+  "native" interface is a localhost, unauthenticated, read-mostly REST API with
+  no documented "create playlist from metadata" endpoint — unsuitable for a
+  server-side export.
+- **Consequence:** both requested paths collapse onto the existing
+  `render_rekordbox_xml`. The one concrete gap: **ISRC has no standard slot in
+  `DJ_PLAYLISTS`** and is silently dropped today.
+
+## Scope (approved)
+
+1. Engine DJ + Lexicon exposed as export options that emit the existing
+   Rekordbox XML, under honest labels ("via Rekordbox XML").
+2. In-modal note on the import-then-relink workflow (docs delivered as UI copy +
+   PR body — **no new `.md` file**, per repo doc hooks).
+3. ISRC fidelity fix in the shared renderer (benefits rekordbox/Engine/Lexicon).
+4. Fixture/schema tests in CI (no real-app round-trip in CI; manual QA noted in PR).
+
+## Design
+
+### Backend
+
+- **`server/app/services/setbuilder/export_files.py`** — extend
+  `render_rekordbox_xml` to emit ISRC via the `Comments` TRACK attribute
+  (`"ISRC:<isrc>"`) when `track.isrc` is present. Keep control-char
+  sanitization (`_clean`) on the value. No new renderer functions.
+- **`server/app/api/setbuilder.py`** — add `"enginedj"` and `"lexicon"` keys to
+  `_FILE_RENDERERS`, both mapping to
+  `(export_files.render_rekordbox_xml, "application/xml", "xml")`. Distinct keys
+  (not aliases) so the UI lists them separately and future per-platform tweaks
+  don't churn the contract.
+- **`server/app/schemas/setbuilder.py`** — widen `ExportFileFormat` and
+  `ExportTarget` `Literal`s with `"enginedj"` and `"lexicon"`.
+
+### Frontend (`dashboard/app/(dj)/setbuilder/components/ExportModal.tsx`)
+
+- Flip the existing `enginedj` option to `available: true`, label
+  "Engine DJ XML", sub "Imports via Rekordbox XML — relink files on import".
+- Add a `lexicon` option (`available: true`), same XML download path, honest sub
+  copy.
+- Wire both through `targetMap` / `extMap` / `handleFileExport` and the
+  per-platform download-button block (both download `.xml`).
+- Short in-modal note describing import → relink for these targets.
+
+### Tests
+
+- **Backend (pytest):** golden-fixture assertion that ISRC lands in `Comments`;
+  that `enginedj`/`lexicon` formats route to the XML renderer with correct
+  media-type/ext; XML validity + control-char sanitization preserved. Regression
+  test asserting the `requests` table is untouched by an export.
+- **Frontend (vitest):** `ExportModal.test.tsx` updated for the two new options
+  and their download wiring.
+
+## Out of scope (documented as non-viable)
+
+- Engine Library SQLite DB writes (Denon-discouraged; potential #405 territory).
+- Lexicon Local API integration (localhost / unauth / read-mostly).
+
+## Files touched
+
+- `server/app/services/setbuilder/export_files.py`
+- `server/app/api/setbuilder.py`
+- `server/app/schemas/setbuilder.py`
+- `dashboard/app/(dj)/setbuilder/components/ExportModal.tsx`
+- `dashboard/app/(dj)/setbuilder/components/__tests__/ExportModal.test.tsx`
+- backend export tests (existing setbuilder export test module)
+- `server/openapi.json` (regenerate after schema change)
+
+## Conflict isolation
+
+Touches the export subsystem only — disjoint from #402 (mobile chat UI) and
+#403 (play-history backend). Safe to parallelize.

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -1523,8 +1523,12 @@ def export_set_tidal(
     )
 
 
+# Engine DJ and Lexicon both import Rekordbox DJ_PLAYLISTS XML — no separate
+# native format exists — so they reuse the same renderer under distinct keys.
 _FILE_RENDERERS = {
     "rekordbox": (export_files.render_rekordbox_xml, "application/xml", "xml"),
+    "enginedj": (export_files.render_rekordbox_xml, "application/xml", "xml"),
+    "lexicon": (export_files.render_rekordbox_xml, "application/xml", "xml"),
     "m3u": (export_files.render_m3u, "audio/x-mpegurl", "m3u8"),
     "txt": (export_files.render_txt, "text/plain", "txt"),
 }

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -884,8 +884,11 @@ class VibeEnrichmentResult(BaseModel):
 # Export (issue #396)
 
 
-ExportTarget = Literal["tidal", "rekordbox", "m3u", "txt"]
-ExportFileFormat = Literal["rekordbox", "m3u", "txt"]
+# Engine DJ and Lexicon have no proprietary import format — both ingest the
+# Rekordbox DJ_PLAYLISTS XML — so they are distinct format keys that render the
+# same XML (kept distinct, not aliased, so the UI lists them separately).
+ExportTarget = Literal["tidal", "rekordbox", "m3u", "txt", "enginedj", "lexicon"]
+ExportFileFormat = Literal["rekordbox", "m3u", "txt", "enginedj", "lexicon"]
 
 
 class ExportPreflightIn(BaseModel):

--- a/server/app/services/setbuilder/export_files.py
+++ b/server/app/services/setbuilder/export_files.py
@@ -63,6 +63,10 @@ def render_rekordbox_xml(set_name: str, tracks: list[ExportTrack]) -> str:
             attrs["Album"] = _clean(track.album)
         if track.genre:
             attrs["Genre"] = _clean(track.genre)
+        if track.isrc:
+            # DJ_PLAYLISTS has no native ISRC slot; carry it in Comments so
+            # Engine DJ / Lexicon / rekordbox preserve the identifier on import.
+            attrs["Comments"] = f"ISRC:{_clean(track.isrc)}"
         if track.duration_sec:
             attrs["TotalTime"] = str(track.duration_sec)
         if track.bpm:

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -4011,7 +4011,9 @@
             "enum": [
               "rekordbox",
               "m3u",
-              "txt"
+              "txt",
+              "enginedj",
+              "lexicon"
             ],
             "title": "Format",
             "type": "string"
@@ -4036,7 +4038,9 @@
               "tidal",
               "rekordbox",
               "m3u",
-              "txt"
+              "txt",
+              "enginedj",
+              "lexicon"
             ],
             "title": "Target",
             "type": "string"
@@ -4068,7 +4072,9 @@
               "tidal",
               "rekordbox",
               "m3u",
-              "txt"
+              "txt",
+              "enginedj",
+              "lexicon"
             ],
             "title": "Target",
             "type": "string"

--- a/server/tests/test_setbuilder_export_api.py
+++ b/server/tests/test_setbuilder_export_api.py
@@ -282,11 +282,12 @@ class TestFileExport:
 
     def test_enginedj_export_does_not_mutate_status(self, client, auth_headers, db, set_id):
         _seed_pool(db, set_id)
-        client.post(
+        resp = client.post(
             f"/api/setbuilder/sets/{set_id}/export/file",
             json={"format": "enginedj", "skip_unresolved": False},
             headers=auth_headers,
         )
+        assert resp.status_code == 200
         db.expire_all()
         assert db.get(Set, set_id).status == "draft"
 

--- a/server/tests/test_setbuilder_export_api.py
+++ b/server/tests/test_setbuilder_export_api.py
@@ -100,6 +100,21 @@ class TestPreflight:
         assert body["unresolved"][0]["track_id"] == "spotify:gone"
         assert body["unresolved"][0]["reason"] == "missing_metadata"
 
+    def test_enginedj_and_lexicon_preflight_use_file_branch(self, client, auth_headers, db, set_id):
+        _seed_pool(db, set_id)
+        for target in ("enginedj", "lexicon"):
+            resp = client.post(
+                f"/api/setbuilder/sets/{set_id}/export/preflight",
+                json={"target": target},
+                headers=auth_headers,
+            )
+            assert resp.status_code == 200, target
+            body = resp.json()
+            assert body["source"] == "pool"
+            assert body["resolved_count"] == 2
+            # File targets never run Tidal matching, so tidal_connected stays null.
+            assert body["tidal_connected"] is None
+
     def test_tidal_target_not_connected(self, client, auth_headers, db, set_id):
         _seed_pool(db, set_id)
         resp = client.post(
@@ -251,6 +266,29 @@ class TestFileExport:
         assert resp.headers["content-type"].startswith("application/xml")
         assert 'filename="Export Set.xml"' in resp.headers["content-disposition"]
         assert "DJ_PLAYLISTS" in resp.text
+
+    def test_enginedj_and_lexicon_route_to_rekordbox_xml(self, client, auth_headers, db, set_id):
+        _seed_pool(db, set_id)
+        for fmt in ("enginedj", "lexicon"):
+            resp = client.post(
+                f"/api/setbuilder/sets/{set_id}/export/file",
+                json={"format": fmt, "skip_unresolved": False},
+                headers=auth_headers,
+            )
+            assert resp.status_code == 200, fmt
+            assert resp.headers["content-type"].startswith("application/xml")
+            assert 'filename="Export Set.xml"' in resp.headers["content-disposition"]
+            assert "DJ_PLAYLISTS" in resp.text
+
+    def test_enginedj_export_does_not_mutate_status(self, client, auth_headers, db, set_id):
+        _seed_pool(db, set_id)
+        client.post(
+            f"/api/setbuilder/sets/{set_id}/export/file",
+            json={"format": "enginedj", "skip_unresolved": False},
+            headers=auth_headers,
+        )
+        db.expire_all()
+        assert db.get(Set, set_id).status == "draft"
 
     def test_m3u_and_txt_downloads(self, client, auth_headers, db, set_id):
         _seed_pool(db, set_id)

--- a/server/tests/test_setbuilder_export_service.py
+++ b/server/tests/test_setbuilder_export_service.py
@@ -168,6 +168,25 @@ class TestRekordboxXml:
         root = ET.fromstring(xml)  # parse fails if escaping is broken
         assert root.find("COLLECTION/TRACK[2]").attrib["Name"] == 'Peak "Time"'
 
+    def test_isrc_emitted_in_comments(self):
+        """ISRC has no native DJ_PLAYLISTS slot; carry it in Comments (Engine/Lexicon fidelity)."""
+        track = ExportTrack(position=0, title="T", artist="A", isrc="USX9P1234567")
+        xml = render_rekordbox_xml("S", [track])
+        root = ET.fromstring(xml)
+        assert root.find("COLLECTION/TRACK").attrib["Comments"] == "ISRC:USX9P1234567"
+
+    def test_no_isrc_omits_comments(self):
+        track = ExportTrack(position=0, title="T", artist="A")
+        xml = render_rekordbox_xml("S", [track])
+        root = ET.fromstring(xml)
+        assert "Comments" not in root.find("COLLECTION/TRACK").attrib
+
+    def test_isrc_control_chars_sanitized(self):
+        track = ExportTrack(position=0, title="T", artist="A", isrc="US\x00X9P\x1f1234567")
+        xml = render_rekordbox_xml("S", [track])
+        root = ET.fromstring(xml)  # must parse; control chars stripped
+        assert root.find("COLLECTION/TRACK").attrib["Comments"] == "ISRC:US X9P 1234567"
+
 
 class TestM3u:
     def test_extm3u_with_extinf_metadata(self):


### PR DESCRIPTION
## Why

Issue #401 asks for Engine DJ and Lexicon as export targets. Research
(captured in the design doc) established that **neither platform has a
proprietary import format** — both ingest the Rekordbox `DJ_PLAYLISTS`
XML WrzDJ already generates. So the honest, low-risk shipping path is
*labeled presets* of the existing renderer, not two new serializers. The
one real gap surfaced along the way: **ISRC had no slot in `DJ_PLAYLISTS`
and was silently dropped** on every export.

## What

- **ISRC fidelity fix** (benefits rekordbox/Engine DJ/Lexicon alike): the
  Rekordbox XML renderer now emits `track.isrc` via the TRACK `Comments`
  attribute as `ISRC:<isrc>`, run through the existing control-char
  sanitizer. Absent ISRC omits `Comments`.
- **Engine DJ + Lexicon export targets**: widened the export schema
  `Literal`s with distinct `enginedj`/`lexicon` keys (not aliases — so the
  UI lists them separately and future per-platform tweaks don't churn the
  contract) and mapped both to `render_rekordbox_xml`
  (`application/xml`, `.xml`).
- **ExportModal**: Engine DJ flips from "coming soon" to shipped, Lexicon
  is added; both download the Rekordbox XML through one shared
  `XML_PLATFORMS` block, with an in-modal import-then-relink note.
- Regenerated `server/openapi.json` and `dashboard/lib/api-types.generated.ts`.

Out of scope (documented as non-viable in the design): Engine Library
SQLite DB writes (Denon-discouraged) and the Lexicon Local API
(localhost / unauth / read-mostly).

## Testing

- [x] Backend unit/integration tests pass (`pytest` — 2891 passed, coverage 88% ≥ 85% gate)
- [x] Renderer tests: ISRC → `Comments`, omitted when absent, control chars sanitized
- [x] API tests: `enginedj`/`lexicon` route to the XML renderer (200, `application/xml`, `.xml`); preflight uses the file branch; export does not mutate set status
- [x] Frontend tests pass (`vitest` — 1264 passed); ExportModal picker shows 8 rows / 3 "coming soon", Engine DJ + Lexicon download `.xml` and show the relink note
- [x] `ruff check` / `ruff format` / `bandit` clean; `npm run lint` / `tsc --noEmit` clean
- [x] `alembic upgrade head && alembic check` — no new migration, no drift
- [ ] Manual QA (out of CI): import the exported `.xml` into current Engine DJ (Database tab → set Rekordbox XML path → Import) and Lexicon (import Rekordbox XML), confirm the playlist + metadata land and tracks relink to local audio

🤖 Co-authored by Claude Opus 4.8. Closes #401.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled **Engine DJ** and **Lexicon** as direct export options in the export modal.
  * Exporting for these options now downloads **XML** using the existing Rekordbox XML workflow.
  * Added in-app guidance describing the **import → track relink** flow for these XML exports.
* **Bug Fixes**
  * Improved **ISRC** preservation in exported XML (including safe handling of special/control characters).
* **Documentation**
  * Published the design specification and implementation plan for the new export targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->