### PR TITLE
feat(setbuilder): analyze_pool_gaps agent tool — missing keys + sparse BPM bands

### DIFF
--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -15,6 +15,7 @@ from app.models.user import User
 from app.services.llm.base import ChatRequest, Message, ToolSpec
 from app.services.llm.exceptions import NoLlmConfigured
 from app.services.llm.gateway import Gateway
+from app.services.recommendation.camelot import parse_key
 from app.services.setbuilder import curve
 from app.services.setbuilder.pass1_deterministic import (
     TransitionScore,
@@ -52,6 +53,17 @@ ALLOWED_FLAG_TYPES = {
     "banger_buried",
     "transition_brilliant",
 }
+
+# The 24 Camelot-wheel slots: numbers 1-12 on each of the A (minor) and B
+# (major) rings. Used by analyze_pool_gaps to report which slots the pool
+# leaves uncovered.
+ALL_CAMELOT_KEYS: tuple[str, ...] = tuple(
+    f"{number}{letter}" for number in range(1, 13) for letter in ("A", "B")
+)
+# analyze_pool_gaps bins pool BPMs into fixed-width bands; a band holding
+# fewer than SPARSE_BAND_THRESHOLD tracks is flagged as a coverage hole.
+BPM_BAND_WIDTH = 10
+SPARSE_BAND_THRESHOLD = 2
 
 
 class AgentToolError(ValueError):
@@ -259,6 +271,7 @@ def apply_tool_call(
         "set_peak_at": _tool_set_peak_at,
         "bump_energy": _tool_bump_energy,
         "analyze_transition": _tool_analyze_transition,
+        "analyze_pool_gaps": _tool_analyze_pool_gaps,
         "critique_set": _tool_static_critique,
     }
     handler = handlers.get(name)
@@ -406,6 +419,51 @@ def _tool_analyze_transition(
         raise AgentToolError("slot has no pool metadata")
     score, warnings = transition_score(prev, curr, set_obj.key_strictness)
     return {"position": position, "score": score, "warnings": warnings}, set()
+
+
+def _tool_analyze_pool_gaps(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Read-only coverage report over the set's pool (missing keys + BPM bands)."""
+    del payload
+    metas = [_pass1_track_meta(t) for t in _pool_tracks(db, set_obj.id)]
+    camelot_keys = [str(pos) for pos in (parse_key(m.key) for m in metas) if pos is not None]
+    bpms = [float(m.bpm) for m in metas if m.bpm is not None]
+    present = set(camelot_keys)
+    missing = [key for key in ALL_CAMELOT_KEYS if key not in present]
+    bands = _bpm_bands(set_obj, bpms)
+    return {
+        "pool_size": len(metas),
+        "keyed_track_count": len(camelot_keys),
+        "bpm_track_count": len(bpms),
+        "missing_camelot_keys": missing,
+        "bpm_bands": bands,
+        "sparse_bands": [b for b in bands if b["count"] < SPARSE_BAND_THRESHOLD],
+    }, set()
+
+
+def _bpm_bands(set_obj: Set, bpms: list[float]) -> list[dict[str, Any]]:
+    """Bucket pool BPMs into fixed-width bands across the set's target window.
+
+    The window is ``set_obj.bpm_floor``..``bpm_ceiling`` when set, else the
+    observed pool min/max. Returns one entry per band (empty bands included)
+    so the agent can see tempo holes, not just where tracks cluster.
+    """
+    if not bpms:
+        return []
+    floor = set_obj.bpm_floor if set_obj.bpm_floor is not None else int(min(bpms))
+    ceiling = set_obj.bpm_ceiling if set_obj.bpm_ceiling is not None else int(max(bpms))
+    low = min(floor, int(min(bpms)))
+    high = max(ceiling, int(max(bpms)))
+    start = (low // BPM_BAND_WIDTH) * BPM_BAND_WIDTH
+    bands: list[dict[str, Any]] = []
+    edge = start
+    while edge <= high:
+        band_end = edge + BPM_BAND_WIDTH
+        count = sum(1 for bpm in bpms if edge <= bpm < band_end)
+        bands.append({"label": f"{edge}-{band_end}", "min": edge, "max": band_end, "count": count})
+        edge = band_end
+    return bands
 
 
 def _tool_static_critique(
@@ -661,6 +719,14 @@ def _tool_display_summary(
             readable = ", ".join(str(warning).replace("_", " ") for warning in warnings)
             return f"{base} Warnings: {readable}."
         return base
+    if name == "analyze_pool_gaps":
+        missing = result.get("missing_camelot_keys") or []
+        sparse = result.get("sparse_bands") or []
+        return (
+            f"Analyzed pool gaps over {int(result.get('pool_size') or 0)} tracks: "
+            f"{len(missing)} missing Camelot key{'s' if len(missing) != 1 else ''}, "
+            f"{len(sparse)} sparse BPM band{'s' if len(sparse) != 1 else ''}."
+        )
     if name == "critique_set":
         grade = result.get("overall_grade")
         if grade:
@@ -689,6 +755,11 @@ def _agent_tools() -> list[ToolSpec]:
                 "properties": {"position": {"type": "integer"}},
                 "required": ["position"],
             },
+        ),
+        ToolSpec(
+            name="analyze_pool_gaps",
+            description=("Report pool coverage holes: missing Camelot keys and sparse BPM bands."),
+            input_schema={"type": "object", "properties": {}},
         ),
         _critique_tool(),
     ]

--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -432,6 +432,14 @@ def _tool_analyze_pool_gaps(
     present = set(camelot_keys)
     missing = [key for key in ALL_CAMELOT_KEYS if key not in present]
     bands = _bpm_bands(set_obj, bpms)
+    logger.debug(
+        "Set %s analyze_pool_gaps: pool=%d keyed=%d bpm=%d missing_keys=%d",
+        set_obj.id,
+        len(metas),
+        len(camelot_keys),
+        len(bpms),
+        len(missing),
+    )
     return {
         "pool_size": len(metas),
         "keyed_track_count": len(camelot_keys),
@@ -445,9 +453,13 @@ def _tool_analyze_pool_gaps(
 def _bpm_bands(set_obj: Set, bpms: list[float]) -> list[dict[str, Any]]:
     """Bucket pool BPMs into fixed-width bands across the set's target window.
 
-    The window is ``set_obj.bpm_floor``..``bpm_ceiling`` when set, else the
-    observed pool min/max. Returns one entry per band (empty bands included)
-    so the agent can see tempo holes, not just where tracks cluster.
+    Bands are anchored to ``set_obj.bpm_floor``..``bpm_ceiling`` (the declared
+    window) when set, else the observed pool min/max. The range is then widened
+    to also cover any track outside that window, so every BPM-tagged pool track
+    lands in exactly one band — ``sum(band counts) == bpm_track_count`` always
+    holds, and out-of-window tracks surface as their own bands rather than
+    silently vanishing. Empty bands are included so the agent sees tempo holes,
+    not just where tracks cluster.
     """
     if not bpms:
         return []

--- a/server/tests/test_setbuilder_pass2.py
+++ b/server/tests/test_setbuilder_pass2.py
@@ -536,6 +536,31 @@ def test_analyze_pool_gaps_empty_pool_is_everything_a_gap(db: Session, test_user
     assert gaps["sparse_bands"] == []
 
 
+def test_analyze_pool_gaps_bands_anchor_to_window_but_keep_every_track(
+    db: Session, test_user: User
+):
+    # Declared window is 120-130, but the pool has tracks below (118) and above
+    # (135) it. Bands anchor to the declared window yet widen to cover the
+    # outliers, so every BPM-tagged track still lands in a band:
+    # sum(band counts) must equal bpm_track_count (no silent drops).
+    set_obj = _mk_set_with_pool(
+        db,
+        test_user,
+        [
+            {"camelot": "8A", "bpm": 118, "bpm_floor": 120, "bpm_ceiling": 130},
+            {"camelot": "8A", "bpm": 124},
+            {"camelot": "9A", "bpm": 135},
+        ],
+    )
+
+    gaps, _ = apply_tool_call(db, set_obj, "analyze_pool_gaps", {})
+
+    assert gaps["bpm_track_count"] == 3
+    assert sum(b["count"] for b in gaps["bpm_bands"]) == 3
+    labels = {b["label"] for b in gaps["bpm_bands"]}
+    assert {"110-120", "120-130", "130-140"} <= labels
+
+
 def test_analyze_pool_gaps_leaves_event_requests_untouched(
     db: Session, test_user: User, test_request: Request
 ):

--- a/server/tests/test_setbuilder_pass2.py
+++ b/server/tests/test_setbuilder_pass2.py
@@ -13,6 +13,7 @@ from app.services.setbuilder import agent_history
 from app.services.setbuilder.pass2_agent import (
     AgentToolError,
     _tool_display_summary,
+    apply_tool_call,
     chat_with_agent,
     critique_set,
 )
@@ -447,3 +448,129 @@ def test_tool_display_summary_transition_omits_empty_warnings():
     )
 
     assert summary == "Analyzed transition into slot 2: 90."
+
+
+def _mk_set_with_pool(db: Session, user: User, tracks: list[dict]) -> Set:
+    """Build a set whose pool is described row-by-row (no slots needed).
+
+    Each ``tracks`` entry may carry ``bpm``/``key``/``camelot`` (any may be
+    omitted/None) so a test can target specific Camelot keys and BPM bands.
+    """
+    set_obj = Set(
+        owner_id=user.id,
+        name="Gap Set",
+        bpm_floor=tracks[0].get("bpm_floor") if tracks else None,
+        bpm_ceiling=tracks[0].get("bpm_ceiling") if tracks else None,
+    )
+    db.add(set_obj)
+    db.flush()
+    source = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(source)
+    db.flush()
+    db.add_all(
+        [
+            SetPoolTrack(
+                set_id=set_obj.id,
+                source_id=source.id,
+                track_id=f"manual:{idx}",
+                title=f"Track {idx}",
+                artist=f"Artist {idx}",
+                bpm=row.get("bpm"),
+                key=row.get("key"),
+                camelot=row.get("camelot"),
+                dedupe_sig=f"gap-sig-{idx}",
+            )
+            for idx, row in enumerate(tracks)
+        ]
+    )
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def test_analyze_pool_gaps_reports_missing_keys_and_sparse_bands(db: Session, test_user: User):
+    # Pool covers only 8A (124) and 9A (132); leaves the other 22 Camelot
+    # slots empty and concentrates BPM around two bands.
+    set_obj = _mk_set_with_pool(
+        db,
+        test_user,
+        [
+            {"camelot": "8A", "bpm": 124},
+            {"camelot": "8A", "bpm": 126},
+            {"camelot": "9A", "bpm": 132},
+            {"key": "F minor", "bpm": None},  # 4A, no BPM
+        ],
+    )
+
+    gaps, affected = apply_tool_call(db, set_obj, "analyze_pool_gaps", {})
+
+    assert affected == set()
+    assert gaps["pool_size"] == 4
+    assert gaps["keyed_track_count"] == 4
+    assert gaps["bpm_track_count"] == 3
+    # 8A, 9A, 4A are present → not missing; everything else is.
+    assert "8A" not in gaps["missing_camelot_keys"]
+    assert "9A" not in gaps["missing_camelot_keys"]
+    assert "4A" not in gaps["missing_camelot_keys"]
+    assert "1B" in gaps["missing_camelot_keys"]
+    assert len(gaps["missing_camelot_keys"]) == 21
+    # Bands cover the observed 124-132 span; the high band (132) has a single
+    # track → flagged sparse.
+    band_labels = {b["label"] for b in gaps["bpm_bands"]}
+    assert any(b["count"] >= 2 for b in gaps["bpm_bands"])
+    sparse = {b["label"] for b in gaps["sparse_bands"]}
+    assert sparse and sparse <= band_labels
+
+
+def test_analyze_pool_gaps_empty_pool_is_everything_a_gap(db: Session, test_user: User):
+    set_obj = _mk_set_with_pool(db, test_user, [])
+
+    gaps, affected = apply_tool_call(db, set_obj, "analyze_pool_gaps", {})
+
+    assert affected == set()
+    assert gaps["pool_size"] == 0
+    assert gaps["keyed_track_count"] == 0
+    assert gaps["bpm_track_count"] == 0
+    assert len(gaps["missing_camelot_keys"]) == 24
+    assert gaps["bpm_bands"] == []
+    assert gaps["sparse_bands"] == []
+
+
+def test_analyze_pool_gaps_leaves_event_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set_with_pool(
+        db,
+        test_user,
+        [{"camelot": "8A", "bpm": 124}, {"camelot": "9A", "bpm": 128}],
+    )
+    before_count = db.query(Request).count()
+    before_title = test_request.song_title
+
+    apply_tool_call(db, set_obj, "analyze_pool_gaps", {})
+
+    db.refresh(test_request)
+    assert db.query(Request).count() == before_count
+    assert test_request.song_title == before_title
+
+
+def test_analyze_pool_gaps_unknown_tool_still_raises():
+    # Guards the closed allowlist: an unknown sibling name must not slip through.
+    with pytest.raises(AgentToolError, match="Unknown tool"):
+        apply_tool_call(None, None, "totally_unknown_tool", {})
+
+
+def test_tool_display_summary_analyze_pool_gaps():
+    summary = _tool_display_summary(
+        "analyze_pool_gaps",
+        {},
+        {
+            "pool_size": 4,
+            "missing_camelot_keys": ["1A", "1B"],
+            "sparse_bands": [{"label": "130-140", "min": 130, "max": 140, "count": 1}],
+        },
+        {},
+        {},
+    )
+
+    assert summary == "Analyzed pool gaps over 4 tracks: 2 missing Camelot keys, 1 sparse BPM band."


### PR DESCRIPTION
## Why

Part of #442 (Family 1 — read-only sensing). To recommend what to add next, the WrzDJSet agent needs to *see* coverage holes in a set's pool. `analyze_pool_gaps` surfaces missing Camelot keys and sparse BPM bands over `SetPoolTrack` so the agent fills gaps instead of guessing.

## What

A single **read-only** pass-2 agent tool `analyze_pool_gaps` in `server/app/services/setbuilder/pass2_agent.py`. It reports, over the owner-scoped pool:

- `missing_camelot_keys` — which of the 24 Camelot wheel slots have zero pool tracks (each pool key resolved through `recommendation.camelot.parse_key`).
- `bpm_bands` — pool BPMs bucketed into fixed-width bands across the set's target window, each with a track `count`; empty bands are included so tempo holes are visible.
- `sparse_bands` — the subset of bands below the sparse threshold.
- `pool_size`, `keyed_track_count`, `bpm_track_count` counters.

It mirrors the existing read-only `analyze_transition` tool: returns `(result, set())`, no `rationale`, not in `MUTATION_TOOLS`. Wired in exactly the three additive spots — the `apply_tool_call` `handlers` dict, a bare `ToolSpec` in `_agent_tools()`, and a one-sentence clause in the result-summary chain. No new endpoints, no migrations, no openapi/type regen. Frontend `ToolCard` already renders the `display_summary` generically (same as `analyze_transition`), so no dashboard change was needed.

## Design decisions

- **BPM-band width = 10 BPM.** The issue suggests 10-BPM bins, and it matches the genre-standard mixing window (adjacent tracks typically within a few BPM), so a band represents a "mixable tempo neighborhood." Defined as `BPM_BAND_WIDTH`.
- **Band range source.** Prefer `set_obj.bpm_floor`/`bpm_ceiling` (the DJ's declared target window) so gaps are meaningful relative to *intent*; fall back to the observed pool min/max when either bound is null. Bands are anchored to a 10-BPM grid (`floor // 10 * 10`) and span the union of the declared window and the observed range, so a track outside the declared window still lands in a band.
- **Sparse threshold = fewer than 2 tracks.** A band with 0 or 1 tracks can't sustain a multi-track tempo run, so it's a coverage hole worth filling; 2+ is the minimum to "stay" at a tempo. Defined as `SPARSE_BAND_THRESHOLD`.
- **Empty pool → "everything is a gap."** All 24 Camelot keys reported missing, `bpm_bands`/`sparse_bands` empty, counters zero — no exception.
- **24-slot universe** is constructed directly as `{1..12} × {A,B}` (`ALL_CAMELOT_KEYS`) rather than reaching into the camelot module's private definitions, keeping the modules decoupled.

## Security invariants (#442)

- Owner-scoped: reads only `_pool_tracks(db, set_obj.id)` for the already-owner-loaded set; never queries across sets.
- **Read-only**: writes to no table; returns `(result, set())`; not in `MUTATION_TOOLS`.
- Dispatched only through `apply_tool_call`'s closed allowlist (unknown name still raises `AgentToolError`).
- Regression test asserts the `requests` table row count and a request's title are unchanged after the call.

## Testing

- [x] `analyze_pool_gaps` callable via `apply_tool_call`; unknown name still raises `AgentToolError`
- [x] Reports missing Camelot keys and sparse BPM bands for a populated pool
- [x] Empty pool → all 24 keys missing, empty bands, no exception
- [x] `requests`-untouched regression test
- [x] `display_summary` clause unit test
- [x] Backend CI green locally: ruff check, ruff format --check, bandit, pytest (2911 passed, coverage 87.82% ≥ 85% gate)
- [ ] CI green on PR

## Heads-up (parallel batch)

One of 4 Family-1 read-only tools landing in parallel; all touch the same 3 additive spots in `pass2_agent.py`. Additions here are purely additive and localized — a trivial "keep-both" rebase is expected.

🤖 Co-authored by Claude Opus 4.8. Closes #456.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pool coverage analysis feature to identify missing Camelot keys and sparse BPM bands in your music pools.

* **Tests**
  * New test suite added for pool analysis functionality, covering edge cases and validating data integrity throughout the analysis process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->