### PR TITLE
feat(setbuilder): summarize_set read-only agent tool (#455)

### DIFF
--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -15,6 +15,7 @@ from app.models.user import User
 from app.services.llm.base import ChatRequest, Message, ToolSpec
 from app.services.llm.exceptions import NoLlmConfigured
 from app.services.llm.gateway import Gateway
+from app.services.recommendation.camelot import parse_key
 from app.services.setbuilder import curve
 from app.services.setbuilder.pass1_deterministic import (
     TransitionScore,
@@ -259,6 +260,7 @@ def apply_tool_call(
         "set_peak_at": _tool_set_peak_at,
         "bump_energy": _tool_bump_energy,
         "analyze_transition": _tool_analyze_transition,
+        "summarize_set": _tool_summarize_set,
         "critique_set": _tool_static_critique,
     }
     handler = handlers.get(name)
@@ -406,6 +408,72 @@ def _tool_analyze_transition(
         raise AgentToolError("slot has no pool metadata")
     score, warnings = transition_score(prev, curr, set_obj.key_strictness)
     return {"position": position, "score": score, "warnings": warnings}, set()
+
+
+def _tool_summarize_set(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Read-only snapshot of the whole set: duration, BPM arc, key journey, energy.
+
+    Returns ``(summary, set())`` — no positions are affected because nothing is
+    mutated. Mirrors ``_tool_analyze_transition`` (read-only), not ``_tool``.
+    """
+    del payload  # no input args
+    slots = _ordered_slots(db, set_obj.id)
+    # One view per pool track: meta carries BPM + normalized key, the raw row
+    # carries duration_sec (which TrackMeta does not expose).
+    by_track_id = {
+        _pass1_track_meta(t).slot_track_id: (_pass1_track_meta(t), t)
+        for t in _pool_tracks(db, set_obj.id)
+    }
+
+    total_duration_sec = 0
+    bpms: list[float] = []
+    key_journey: list[str] = []
+    energy_values: list[float | None] = []
+    for slot in slots:
+        meta, track = by_track_id.get(slot.track_id or "", (None, None))
+        if track is not None and track.duration_sec:
+            total_duration_sec += int(track.duration_sec)
+        if meta is not None and meta.bpm is not None:
+            bpms.append(float(meta.bpm))
+        camelot = parse_key(meta.key) if meta is not None else None
+        if camelot is not None:
+            key_journey.append(str(camelot))
+        energy_values.append(slot.target_energy)
+
+    target_duration_sec = set_obj.target_duration_sec
+    return {
+        "slot_count": len(slots),
+        "total_duration_sec": total_duration_sec,
+        "target_duration_sec": target_duration_sec,
+        "duration_delta_sec": (
+            total_duration_sec - target_duration_sec if target_duration_sec is not None else None
+        ),
+        "bpm_arc": _bpm_arc(bpms),
+        "key_journey": key_journey,
+        "energy_profile": _energy_profile(energy_values),
+    }, set()
+
+
+def _bpm_arc(bpms: list[float]) -> dict[str, float] | None:
+    """Min/max/first/last/mean over slots that have a BPM; ``None`` if none do."""
+    if not bpms:
+        return None
+    return {
+        "min": min(bpms),
+        "max": max(bpms),
+        "first": bpms[0],
+        "last": bpms[-1],
+        "mean": round(sum(bpms) / len(bpms), 1),
+    }
+
+
+def _energy_profile(values: list[float | None]) -> dict[str, Any]:
+    """Ordered ``target_energy`` per slot plus the slot position of the peak."""
+    known = [(pos, val) for pos, val in enumerate(values) if val is not None]
+    peak_position = max(known, key=lambda pair: pair[1])[0] if known else None
+    return {"values": values, "peak_position": peak_position}
 
 
 def _tool_static_critique(
@@ -661,6 +729,8 @@ def _tool_display_summary(
             readable = ", ".join(str(warning).replace("_", " ") for warning in warnings)
             return f"{base} Warnings: {readable}."
         return base
+    if name == "summarize_set":
+        return _summarize_set_summary(result)
     if name == "critique_set":
         grade = result.get("overall_grade")
         if grade:
@@ -669,6 +739,20 @@ def _tool_display_summary(
             return f"{head} {summary}" if summary else head
         return "Recomputed critique context."
     return name.replace("_", " ").capitalize() + "."
+
+
+def _summarize_set_summary(result: dict[str, Any]) -> str:
+    count = int(result.get("slot_count") or 0)
+    total = int(result.get("total_duration_sec") or 0)
+    parts = [f"Set has {count} slot{'s' if count != 1 else ''}, {total // 60} min total"]
+    delta = result.get("duration_delta_sec")
+    if delta is not None and delta != 0:
+        over_under = "over" if delta > 0 else "under"
+        parts.append(f"{abs(int(delta)) // 60} min {over_under} target")
+    arc = result.get("bpm_arc")
+    if arc:
+        parts.append(f"BPM {arc['min']:g}-{arc['max']:g}")
+    return "; ".join(parts) + "."
 
 
 def _agent_tools() -> list[ToolSpec]:
@@ -689,6 +773,14 @@ def _agent_tools() -> list[ToolSpec]:
                 "properties": {"position": {"type": "integer"}},
                 "required": ["position"],
             },
+        ),
+        ToolSpec(
+            name="summarize_set",
+            description=(
+                "Read-only snapshot of the whole set: total vs target duration, "
+                "BPM arc, Camelot key journey, and energy profile."
+            ),
+            input_schema={"type": "object", "properties": {}, "required": []},
         ),
         _critique_tool(),
     ]

--- a/server/tests/test_setbuilder_pass2.py
+++ b/server/tests/test_setbuilder_pass2.py
@@ -13,6 +13,7 @@ from app.services.setbuilder import agent_history
 from app.services.setbuilder.pass2_agent import (
     AgentToolError,
     _tool_display_summary,
+    apply_tool_call,
     chat_with_agent,
     critique_set,
 )
@@ -435,6 +436,125 @@ def test_tool_display_summary_includes_transition_warnings():
     assert "68" in summary
     assert "bpm jump" in summary
     assert "key clash" in summary
+
+
+def _mk_set_for_summary(db: Session, user: User) -> Set:
+    """A set with varied BPM/key/energy so the summary has signal to report."""
+    set_obj = Set(owner_id=user.id, name="Summary Set", target_duration_sec=600)
+    db.add(set_obj)
+    db.flush()
+    source = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(source)
+    db.flush()
+    specs = [
+        # (bpm, camelot, key, duration_sec)
+        (120.0, "8A", "A minor", 200),
+        (124.0, "9A", "E minor", 220),
+        (128.0, None, None, 180),  # unknown key -> skipped in key_journey
+    ]
+    for idx, (bpm, camelot, key, duration) in enumerate(specs):
+        db.add(
+            SetPoolTrack(
+                set_id=set_obj.id,
+                source_id=source.id,
+                track_id=f"tidal:{idx}",
+                title=f"Track {idx}",
+                artist=f"Artist {idx}",
+                bpm=bpm,
+                key=key,
+                camelot=camelot,
+                energy=5,
+                duration_sec=duration,
+                dedupe_sig=f"sum-sig-{idx}",
+            )
+        )
+    db.flush()
+    db.add_all(
+        [
+            SetSlot(set_id=set_obj.id, position=0, track_id="tidal:0", target_energy=4.0),
+            SetSlot(set_id=set_obj.id, position=1, track_id="tidal:1", target_energy=9.0),
+            SetSlot(set_id=set_obj.id, position=2, track_id="tidal:2", target_energy=6.0),
+        ]
+    )
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def test_summarize_set_reports_duration_bpm_key_and_energy(db: Session, test_user: User):
+    set_obj = _mk_set_for_summary(db, test_user)
+
+    result, positions = apply_tool_call(db, set_obj, "summarize_set", {})
+
+    assert positions == set()  # read-only: no affected positions
+    assert result["slot_count"] == 3
+    assert result["total_duration_sec"] == 600  # 200 + 220 + 180
+    assert result["target_duration_sec"] == 600
+    assert result["duration_delta_sec"] == 0  # total - target
+    assert result["bpm_arc"] == {
+        "min": 120.0,
+        "max": 128.0,
+        "first": 120.0,
+        "last": 128.0,
+        "mean": 124.0,
+    }
+    # Unknown key on slot 3 is skipped, order preserved.
+    assert result["key_journey"] == ["8A", "9A"]
+    assert result["energy_profile"]["values"] == [4.0, 9.0, 6.0]
+    assert result["energy_profile"]["peak_position"] == 1  # the 9.0 slot
+
+
+def test_summarize_set_handles_empty_set(db: Session, test_user: User):
+    set_obj = Set(owner_id=test_user.id, name="Empty", target_duration_sec=300)
+    db.add(set_obj)
+    db.commit()
+    db.refresh(set_obj)
+
+    result, positions = apply_tool_call(db, set_obj, "summarize_set", {})
+
+    assert positions == set()
+    assert result["slot_count"] == 0
+    assert result["total_duration_sec"] == 0
+    assert result["target_duration_sec"] == 300
+    assert result["duration_delta_sec"] == -300
+    assert result["bpm_arc"] is None
+    assert result["key_journey"] == []
+    assert result["energy_profile"] == {"values": [], "peak_position": None}
+
+
+def test_summarize_set_leaves_event_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set_for_summary(db, test_user)
+    before_count = db.query(Request).count()
+    before_title = test_request.song_title
+
+    apply_tool_call(db, set_obj, "summarize_set", {})
+
+    db.refresh(test_request)
+    assert db.query(Request).count() == before_count
+    assert test_request.song_title == before_title
+
+
+def test_summarize_set_display_summary_is_human_readable():
+    summary = _tool_display_summary(
+        "summarize_set",
+        {},
+        {
+            "slot_count": 3,
+            "total_duration_sec": 600,
+            "target_duration_sec": 600,
+            "duration_delta_sec": 0,
+            "bpm_arc": {"min": 120.0, "max": 128.0, "first": 120.0, "last": 128.0, "mean": 124.0},
+            "key_journey": ["8A", "9A"],
+            "energy_profile": {"values": [4.0, 9.0, 6.0], "peak_position": 1},
+        },
+        {},
+        {},
+    )
+
+    assert "3 slots" in summary
+    assert "120" in summary and "128" in summary
 
 
 def test_tool_display_summary_transition_omits_empty_warnings():


### PR DESCRIPTION
## Why

Part of #442 (Family 1 — read-only sensing). The WrzDJSet chat agent could mutate the timeline but had no way to **describe** it. `summarize_set` gives the agent a one-call snapshot — duration vs target, BPM arc, Camelot key journey, energy profile — so it can reason about the whole set before acting and justify its suggestions. Prereq #441 (read-only tool surfacing in `ToolCard`) is merged, so the result renders via the default `ToolCard`.

## What

A single **read-only** `summarize_set` tool on the pass-2 agent (`server/app/services/setbuilder/pass2_agent.py`):

- `_tool_summarize_set(db, set_obj, payload) -> (summary, set())` — mirrors the read-only `analyze_transition` handler. Returns an empty affected-positions set, is **not** in `MUTATION_TOOLS`, and takes no input args (no `rationale`).
- Computes over the ordered slots + their pool metadata (reuses `_ordered_slots`, `_pool_tracks`, `_pass1_track_meta`, and `camelot.parse_key`): `total_duration_sec`, `target_duration_sec`, `duration_delta_sec`, `bpm_arc`, `key_journey`, `energy_profile`, `slot_count`.

Wired into the **three** additive spots only: the `handlers` dict in `apply_tool_call`, the `_agent_tools()` `ToolSpec` list (bare ToolSpec, empty input schema), and the result-summary chain in `_tool_display_summary`.

No frontend change: the default `ToolCard` renders the `display_summary` sentence (e.g. `"Set has 3 slots, 10 min total; BPM 120-128."`), which is sufficient per the issue.

## Design decisions

- **`bpm_arc`** → `{min, max, first, last, mean}` over only the slots whose pool track has a BPM, or **`null`** when none do. A dict-of-nulls would force every consumer to null-check each field; one top-level `null` is a cleaner "no signal" sentinel. `mean` is rounded to 1 decimal; the others are the raw float BPMs so `first`/`last` can be read as the literal opener/closer tempo.
- **`key_journey`** → an **ordered list of Camelot strings** (e.g. `["8A", "9A"]`) with unknown/unparseable keys **skipped** (not `null`-padded). It is a narrative of the harmonic path, so gaps add noise; positional alignment is the job of `energy_profile`, not this list. Keys are normalized through `camelot.parse_key` over the pool track's `camelot or key`.
- **`energy_profile`** → `{values: [...], peak_position: int|null}`. `values` is the per-slot `target_energy` (the curve-shaped value the agent actually edits — **not** the pool track's intrinsic energy), kept **positionally aligned** including `null` for slots with no explicit target. `peak_position` is the slot position of the max known target (first wins on ties), or `null` for an empty/all-null set.
- **`duration_delta_sec`** = `total - target` (positive = over-target, negative = under), or `null` when the set has no `target_duration_sec`. Duration is summed from the raw `SetPoolTrack.duration_sec` because `TrackMeta` does not expose it.
- **Empty set** → `slot_count: 0`, `total_duration_sec: 0`, `bpm_arc: null`, `key_journey: []`, `energy_profile: {values: [], peak_position: null}` — no exception.

## Testing

- [x] Unit: happy path asserts duration delta, full `bpm_arc`, `key_journey` (unknown key skipped, order preserved), `energy_profile` values + peak position
- [x] Unit: empty set → sensible zero/empty result, no exception
- [x] Regression: `requests` table row count + a request's title are **unchanged** after the call (read-only invariant)
- [x] Unit: `display_summary` is human-readable
- [x] Unknown tool name still raises `AgentToolError` (existing closed allowlist, unchanged)
- [x] Backend CI green locally: `ruff check`, `ruff format --check`, `bandit`, `pytest` (2910 passed, coverage 87.79% ≥ 85% gate)
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #455. Part of #442.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a read-only `summarize_set` tool that generates a human-readable snapshot of a DJ set, including slot count, duration delta vs target, BPM arc stats, Camelot key journey (skipping unknown keys), and an energy profile highlighting the peak slot position.

* **Tests**
  * Added coverage for populated and empty sets, verified correct arc/journey/profile outputs, ensured set data remains unchanged, and confirmed the tool’s display summary formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->