### PR TITLE
feat(setbuilder): get_track_vibes agent tool — surface TrackVibe tags (#457)

### DIFF
--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -22,6 +22,7 @@ from app.services.setbuilder.pass1_deterministic import (
     transition_score,
 )
 from app.services.setbuilder.pass1_deterministic import _track_meta as _pass1_track_meta
+from app.services.setbuilder.vibe_resolver import TrackVibeState, build_pool_vibe_state
 
 logger = logging.getLogger(__name__)
 
@@ -259,6 +260,7 @@ def apply_tool_call(
         "set_peak_at": _tool_set_peak_at,
         "bump_energy": _tool_bump_energy,
         "analyze_transition": _tool_analyze_transition,
+        "get_track_vibes": _tool_get_track_vibes,
         "critique_set": _tool_static_critique,
     }
     handler = handlers.get(name)
@@ -406,6 +408,54 @@ def _tool_analyze_transition(
         raise AgentToolError("slot has no pool metadata")
     score, warnings = transition_score(prev, curr, set_obj.key_strictness)
     return {"position": position, "score": score, "warnings": warnings}, set()
+
+
+def _tool_get_track_vibes(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Read-only: surface a slot track's resolved TrackVibe tags (#457).
+
+    Resolves the slot -> its pool track -> the owner-merged vibe state via
+    ``vibe_resolver``. No vibe data yields an explicit empty result, never an
+    error. Writes to no table; returns ``set()`` (no affected positions).
+    """
+    slot = _slot_or_error(db, set_obj.id, int(payload["slot_id"]))
+    owner = db.get(User, set_obj.owner_id)
+    if owner is None:
+        raise AgentToolError("Set owner not found")
+    pool_track = _slot_pool_track(db, set_obj.id, slot.track_id)
+    state = (
+        build_pool_vibe_state(db, owner, set_obj, pool_track.id) if pool_track is not None else None
+    )
+    return _vibe_state_result(slot, pool_track, state), set()
+
+
+def _slot_pool_track(db: Session, set_id: int, slot_track_id: str | None) -> SetPoolTrack | None:
+    """Map a slot's namespaced track_id back to its pool track row, if any."""
+    for track in _pool_tracks(db, set_id):
+        if _pass1_track_meta(track).slot_track_id == (slot_track_id or ""):
+            return track
+    return None
+
+
+def _vibe_state_result(
+    slot: SetSlot, pool_track: SetPoolTrack | None, state: TrackVibeState | None
+) -> dict[str, Any]:
+    """Shape a TrackVibeState into the agent-facing vibe result payload."""
+    resolved = state.resolved if state else None
+    has_vibe = resolved is not None and (resolved.energy is not None or resolved.mood is not None)
+    return {
+        "slot_id": slot.id,
+        "position": slot.position,
+        "pool_track_id": pool_track.id if pool_track else None,
+        "has_vibe": has_vibe,
+        "resolved": {
+            "energy": resolved.energy if resolved else None,
+            "energy_source": resolved.energy_source if resolved else None,
+            "mood": resolved.mood if resolved else None,
+            "mood_source": resolved.mood_source if resolved else None,
+        },
+    }
 
 
 def _tool_static_critique(
@@ -661,6 +711,17 @@ def _tool_display_summary(
             readable = ", ".join(str(warning).replace("_", " ") for warning in warnings)
             return f"{base} Warnings: {readable}."
         return base
+    if name == "get_track_vibes":
+        where = _position_label(int(result["position"]))
+        if not result.get("has_vibe"):
+            return f"No vibe tags on record for {where}."
+        resolved = result.get("resolved") or {}
+        parts = []
+        if resolved.get("energy") is not None:
+            parts.append(f"energy {resolved['energy']} ({resolved.get('energy_source')})")
+        if resolved.get("mood"):
+            parts.append(f"mood {resolved['mood']} ({resolved.get('mood_source')})")
+        return f"Vibe tags for {where}: {', '.join(parts)}."
     if name == "critique_set":
         grade = result.get("overall_grade")
         if grade:
@@ -688,6 +749,15 @@ def _agent_tools() -> list[ToolSpec]:
                 "type": "object",
                 "properties": {"position": {"type": "integer"}},
                 "required": ["position"],
+            },
+        ),
+        ToolSpec(
+            name="get_track_vibes",
+            description="Read the resolved vibe tags (energy, mood, source) for one slot's track.",
+            input_schema={
+                "type": "object",
+                "properties": {"slot_id": {"type": "integer"}},
+                "required": ["slot_id"],
             },
         ),
         _critique_tool(),

--- a/server/tests/test_setbuilder_pass2.py
+++ b/server/tests/test_setbuilder_pass2.py
@@ -6,6 +6,11 @@ from sqlalchemy.orm import Session
 from app.models.request import Request
 from app.models.set import Set, SetSlot
 from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.models.track_vibe import (
+    TRACK_VIBE_SOURCE_EXPLICIT_EDIT,
+    TrackVibe,
+    TrackVibeOverride,
+)
 from app.models.user import User
 from app.services.llm.base import ChatResponse, ToolCall
 from app.services.llm.exceptions import NoLlmConfigured
@@ -13,9 +18,11 @@ from app.services.setbuilder import agent_history
 from app.services.setbuilder.pass2_agent import (
     AgentToolError,
     _tool_display_summary,
+    apply_tool_call,
     chat_with_agent,
     critique_set,
 )
+from app.services.setbuilder.vibe_enrichment import PROMPT_VERSION, SCHEMA_VERSION
 
 
 def _chat_then_critique(chat_calls, critique_input, counter=None):
@@ -447,3 +454,130 @@ def test_tool_display_summary_transition_omits_empty_warnings():
     )
 
     assert summary == "Analyzed transition into slot 2: 90."
+
+
+def _seed_llm_vibe(db: Session, track_key: str, **fields) -> TrackVibe:
+    """Insert a current-version global LLM vibe row the resolver will trust."""
+    vibe = TrackVibe(
+        track_id=track_key,
+        llm_provider="anthropic",
+        llm_model="claude-test",
+        prompt_version=PROMPT_VERSION,
+        schema_version=SCHEMA_VERSION,
+        **fields,
+    )
+    db.add(vibe)
+    db.flush()
+    return vibe
+
+
+def test_get_track_vibes_resolves_owner_merged_tags(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    opener = sorted(set_obj.slots, key=lambda s: s.position)[0]
+    _seed_llm_vibe(db, "tidal:0", energy=8, mood="dark", confidence=0.9)
+    db.add(
+        TrackVibeOverride(
+            track_id="tidal:0",
+            user_id=test_user.id,
+            energy_override=6,
+            source=TRACK_VIBE_SOURCE_EXPLICIT_EDIT,
+        )
+    )
+    db.commit()
+
+    result, positions = apply_tool_call(db, set_obj, "get_track_vibes", {"slot_id": opener.id})
+
+    assert positions == set()
+    assert result["slot_id"] == opener.id
+    assert result["has_vibe"] is True
+    # Per-field cascade: the DJ's own edit wins energy, LLM cache supplies mood.
+    assert result["resolved"] == {
+        "energy": 6,
+        "energy_source": "own",
+        "mood": "dark",
+        "mood_source": "llm",
+    }
+
+
+def test_get_track_vibes_empty_when_no_vibe_data(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    opener = sorted(set_obj.slots, key=lambda s: s.position)[0]
+
+    result, positions = apply_tool_call(db, set_obj, "get_track_vibes", {"slot_id": opener.id})
+
+    assert positions == set()
+    assert result["has_vibe"] is False
+    assert result["resolved"] == {
+        "energy": None,
+        "energy_source": None,
+        "mood": None,
+        "mood_source": None,
+    }
+
+
+def test_get_track_vibes_rejects_foreign_slot(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    other = _mk_set_with_tracks(db, test_user)
+    foreign_slot = sorted(other.slots, key=lambda s: s.position)[0]
+
+    with pytest.raises(AgentToolError, match="Slot not found"):
+        apply_tool_call(db, set_obj, "get_track_vibes", {"slot_id": foreign_slot.id})
+
+
+def test_tool_display_summary_get_track_vibes_with_tags():
+    summary = _tool_display_summary(
+        "get_track_vibes",
+        {},
+        {
+            "position": 0,
+            "has_vibe": True,
+            "resolved": {
+                "energy": 6,
+                "energy_source": "own",
+                "mood": "dark",
+                "mood_source": "llm",
+            },
+        },
+        {},
+        {},
+    )
+
+    assert summary == "Vibe tags for slot 1: energy 6 (own), mood dark (llm)."
+
+
+def test_tool_display_summary_get_track_vibes_empty():
+    summary = _tool_display_summary(
+        "get_track_vibes",
+        {},
+        {
+            "position": 2,
+            "has_vibe": False,
+            "resolved": {
+                "energy": None,
+                "energy_source": None,
+                "mood": None,
+                "mood_source": None,
+            },
+        },
+        {},
+        {},
+    )
+
+    assert summary == "No vibe tags on record for slot 3."
+
+
+def test_get_track_vibes_leaves_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    opener = sorted(set_obj.slots, key=lambda s: s.position)[0]
+    _seed_llm_vibe(db, "tidal:0", energy=7, mood="warm")
+    db.commit()
+    before_count = db.query(Request).count()
+    before_title = test_request.song_title
+
+    apply_tool_call(db, set_obj, "get_track_vibes", {"slot_id": opener.id})
+
+    db.refresh(test_request)
+    assert db.query(Request).count() == before_count
+    assert test_request.song_title == before_title


### PR DESCRIPTION
## Why

Part of #442 (Family 1 — read-only sensing). The WrzDJSet pass-2 agent flags "vibe clashes" but couldn't see the underlying vibe tags that justify the call. `get_track_vibes` surfaces a track's resolved `TrackVibe` tags so the agent can explain *why* two tracks clash instead of asserting it.

## What

Adds a single **read-only** agent tool `get_track_vibes` to `server/app/services/setbuilder/pass2_agent.py`:

- `_tool_get_track_vibes(db, set_obj, payload)` resolves the slot → its pool track → the owner-merged `TrackVibeState` via the existing `vibe_resolver.build_pool_vibe_state` (three-tier own → community → LLM cascade), reusing the resolver's merge instead of re-querying raw rows.
- Wired into the three additive spots only: the `handlers` dict in `apply_tool_call`, a bare `ToolSpec` in `_agent_tools()`, and one clause in the result-summary chain. **Not** in `MUTATION_TOOLS`; no `rationale`; returns `(result, set())`.
- A track with no vibe data returns an explicit empty result (`has_vibe: false`, all-`null` resolved), never an error.
- No frontend change: the issue states the default `ToolCard` `display_summary` render is sufficient.

## Design decisions

- **Input identifier — `slot_id` (not slot position).** The per-slot mutation tools (`reorder_slot`, `remove_slot`, `swap_slots`) all key on `slot_id`; only `analyze_transition` uses `position` because it identifies a *transition between two* slots. Since this tool targets one specific track, `slot_id` is the precise, consistent choice and reuses the existing `_slot_or_error(db, set_obj.id, slot_id)` ownership guard (foreign/invalid slot → `AgentToolError`).
- **Actor for the owner-merge = the set owner.** `apply_tool_call(db, set_obj, name, payload)` carries no `actor`, and three sibling Family-1 tools are editing that signature's call sites in parallel, so I derive the owner from `set_obj.owner_id` (`db.get(User, …)`) inside the handler rather than widening the signature. The set is owner-private, so the owner is exactly whose own/community/LLM tiers the resolver should merge.
- **Result shape.** `{ slot_id, position, pool_track_id, has_vibe, resolved: { energy, energy_source, mood, mood_source } }`. `resolved` mirrors the resolver's `ResolvedVibe` (per-field value + provenance tier: `own` | `community` | `llm` | `null`); `has_vibe` is true iff energy or mood resolved to a value. The display-summary renders e.g. `Vibe tags for slot 1: energy 6 (own), mood dark (llm).` or `No vibe tags on record for slot 3.`

## Security invariants

- **Read-only**: writes to no table (regression test asserts the `requests` table — count and a row's title — is unchanged after the call).
- **Owner-scoped**: the slot must belong to `set_obj`; a slot from another set raises `AgentToolError`. Never reads beyond the resolver's owner-merge behavior.
- Dispatched only through `apply_tool_call`'s closed allowlist; unknown name still raises `AgentToolError`.

## Testing

- [x] `apply_tool_call("get_track_vibes", …)` resolves owner-merged tags (own energy + LLM mood) for a slot with vibe data
- [x] Track without vibe data → explicit empty result, no exception
- [x] Foreign/invalid slot → `AgentToolError`
- [x] `requests` table unchanged after the call (read-only regression)
- [x] `_tool_display_summary` renders both the has-vibe and no-vibe chat summaries
- [x] Backend CI green locally: ruff check, ruff format --check, bandit, pytest (2912 passed, 87.78% coverage ≥ 85% gate)
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #457. Part of #442.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added track vibe querying capability to the set builder agent, enabling retrieval of resolved energy and mood values for specific set slots with support for owner customizations.

* **Tests**
  * Added comprehensive test coverage for track vibe queries, including owner override merging, empty state handling, and display formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->