### PR TITLE
feat(setbuilder): explain_transition agent tool — the why behind a transition warning

### DIFF
--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -17,6 +17,7 @@ from app.services.llm.exceptions import NoLlmConfigured
 from app.services.llm.gateway import Gateway
 from app.services.setbuilder import curve
 from app.services.setbuilder.pass1_deterministic import (
+    TrackMeta,
     TransitionScore,
     recompute_transition_scores,
     transition_score,
@@ -259,6 +260,7 @@ def apply_tool_call(
         "set_peak_at": _tool_set_peak_at,
         "bump_energy": _tool_bump_energy,
         "analyze_transition": _tool_analyze_transition,
+        "explain_transition": _tool_explain_transition,
         "critique_set": _tool_static_critique,
     }
     handler = handlers.get(name)
@@ -406,6 +408,80 @@ def _tool_analyze_transition(
         raise AgentToolError("slot has no pool metadata")
     score, warnings = transition_score(prev, curr, set_obj.key_strictness)
     return {"position": position, "score": score, "warnings": warnings}, set()
+
+
+def _tool_explain_transition(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Read-only: turn a transition's terse warning codes into grounded sentences."""
+    position = int(payload["position"])
+    slots = _ordered_slots(db, set_obj.id)
+    if position <= 0 or position >= len(slots):
+        raise AgentToolError("position must identify a transition destination")
+    tracks = {
+        _pass1_track_meta(t).slot_track_id: _pass1_track_meta(t)
+        for t in _pool_tracks(db, set_obj.id)
+    }
+    prev = tracks.get(slots[position - 1].track_id or "")
+    curr = tracks.get(slots[position].track_id or "")
+    if curr is None:
+        raise AgentToolError("slot has no pool metadata")
+    score, warnings = transition_score(prev, curr, set_obj.key_strictness)
+    explanations = [
+        {"code": code, "detail": _explain_warning(code, prev, curr)} for code in warnings
+    ]
+    return {
+        "position": position,
+        "score": score,
+        "explanations": explanations,
+        "prev": _track_summary(prev),
+        "curr": _track_summary(curr),
+    }, set()
+
+
+def _track_summary(meta: TrackMeta | None) -> dict[str, Any] | None:
+    """Compact prev/curr summary of the fields that drive transition scoring."""
+    if meta is None:
+        return None
+    return {
+        "title": meta.title,
+        "artist": meta.artist,
+        "bpm": meta.bpm,
+        "key": meta.key,
+        "energy": meta.energy,
+    }
+
+
+def _explain_warning(code: str, prev: TrackMeta | None, curr: TrackMeta) -> str:
+    """Build one human-readable sentence for a warning, grounded in real fields."""
+    if code == "bpm_jump":
+        prev_bpm = _fmt_number(prev.bpm) if prev else "unknown"
+        return (
+            f"Big tempo gap: {prev_bpm} BPM into {_fmt_number(curr.bpm)} BPM — "
+            "too far to ride the same groove."
+        )
+    if code == "key_clash":
+        prev_key = (prev.key if prev and prev.key else "unknown") if prev else "unknown"
+        return (
+            f"Keys clash: {prev_key} into {curr.key or 'unknown'} are not "
+            "harmonically adjacent on the Camelot wheel."
+        )
+    if code == "mood_shift":
+        prev_mood = (prev.mood if prev and prev.mood else "unknown") if prev else "unknown"
+        return (
+            f"Mood swings from {prev_mood} to {curr.mood or 'unknown'} — "
+            "the emotional energy lurches."
+        )
+    if code == "repeat_artist":
+        artist = curr.artist or (prev.artist if prev else None) or "the same artist"
+        return f"Back-to-back {artist}: repeating an artist can stall the set's variety."
+    return code.replace("_", " ")
+
+
+def _fmt_number(value: float | None) -> str:
+    if value is None:
+        return "unknown"
+    return f"{value:g}"
 
 
 def _tool_static_critique(
@@ -661,6 +737,13 @@ def _tool_display_summary(
             readable = ", ".join(str(warning).replace("_", " ") for warning in warnings)
             return f"{base} Warnings: {readable}."
         return base
+    if name == "explain_transition":
+        base = f"Explained transition into {_position_label(int(result['position']))}."
+        explanations = result.get("explanations") or []
+        if explanations:
+            details = " ".join(str(item.get("detail") or "") for item in explanations)
+            return f"{base} {details}".strip()
+        return f"{base} No transition issues."
     if name == "critique_set":
         grade = result.get("overall_grade")
         if grade:
@@ -684,6 +767,15 @@ def _agent_tools() -> list[ToolSpec]:
         ToolSpec(
             name="analyze_transition",
             description="Analyze one transition by destination slot position.",
+            input_schema={
+                "type": "object",
+                "properties": {"position": {"type": "integer"}},
+                "required": ["position"],
+            },
+        ),
+        ToolSpec(
+            name="explain_transition",
+            description="Explain why a transition is flagged, grounded in the two tracks' fields.",
             input_schema={
                 "type": "object",
                 "properties": {"position": {"type": "integer"}},

--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -461,13 +461,16 @@ def _explain_warning(code: str, prev: TrackMeta | None, curr: TrackMeta) -> str:
             "too far to ride the same groove."
         )
     if code == "key_clash":
-        prev_key = (prev.key if prev and prev.key else "unknown") if prev else "unknown"
+        prev_key = prev.key if (prev and prev.key) else "unknown"
         return (
             f"Keys clash: {prev_key} into {curr.key or 'unknown'} are not "
             "harmonically adjacent on the Camelot wheel."
         )
     if code == "mood_shift":
-        prev_mood = (prev.mood if prev and prev.mood else "unknown") if prev else "unknown"
+        # Forward-looking: transition_score may emit mood_shift, but the current
+        # pool→TrackMeta path never populates mood (SetPoolTrack has no mood column),
+        # so this branch is defensive and only exercised directly by unit tests today.
+        prev_mood = prev.mood if (prev and prev.mood) else "unknown"
         return (
             f"Mood swings from {prev_mood} to {curr.mood or 'unknown'} — "
             "the emotional energy lurches."

--- a/server/tests/test_setbuilder_pass2.py
+++ b/server/tests/test_setbuilder_pass2.py
@@ -10,9 +10,13 @@ from app.models.user import User
 from app.services.llm.base import ChatResponse, ToolCall
 from app.services.llm.exceptions import NoLlmConfigured
 from app.services.setbuilder import agent_history
+from app.services.setbuilder.pass1_deterministic import TrackMeta
 from app.services.setbuilder.pass2_agent import (
     AgentToolError,
+    _explain_warning,
     _tool_display_summary,
+    _track_summary,
+    apply_tool_call,
     chat_with_agent,
     critique_set,
 )
@@ -447,3 +451,180 @@ def test_tool_display_summary_transition_omits_empty_warnings():
     )
 
     assert summary == "Analyzed transition into slot 2: 90."
+
+
+def _meta(**overrides) -> TrackMeta:
+    base = dict(
+        pool_id=1,
+        slot_track_id="tidal:x",
+        title="T",
+        artist="A",
+        bpm=124.0,
+        key="8A",
+        energy=6,
+    )
+    base.update(overrides)
+    return TrackMeta(**base)
+
+
+def test_explain_warning_key_clash_cites_both_keys():
+    prev = _meta(key="8A")
+    curr = _meta(key="2A")
+    detail = _explain_warning("key_clash", prev, curr)
+    assert "8A" in detail and "2A" in detail
+
+
+def test_explain_warning_mood_shift_cites_both_moods():
+    prev = _meta(mood="dark")
+    curr = _meta(mood="euphoric")
+    detail = _explain_warning("mood_shift", prev, curr)
+    assert "dark" in detail and "euphoric" in detail
+
+
+def test_explain_warning_handles_missing_prev_and_fields():
+    detail = _explain_warning("bpm_jump", None, _meta(bpm=None))
+    assert "unknown" in detail
+    # Unknown codes fall back to a readable phrase.
+    assert _explain_warning("some_new_code", None, _meta()) == "some new code"
+
+
+def test_track_summary_handles_none():
+    assert _track_summary(None) is None
+    assert _track_summary(_meta(title="Hi"))["title"] == "Hi"
+
+
+def test_tool_display_summary_explain_transition_lists_details():
+    summary = _tool_display_summary(
+        "explain_transition",
+        {},
+        {
+            "position": 2,
+            "score": 60.0,
+            "explanations": [{"code": "bpm_jump", "detail": "Big tempo gap: 124 into 150."}],
+        },
+        {},
+        {},
+    )
+
+    assert "slot 3" in summary
+    assert "Big tempo gap" in summary
+
+
+def test_tool_display_summary_explain_transition_clean():
+    summary = _tool_display_summary(
+        "explain_transition",
+        {},
+        {"position": 1, "score": 92.0, "explanations": []},
+        {},
+        {},
+    )
+
+    assert summary == "Explained transition into slot 2. No transition issues."
+
+
+def _mk_set_with_warned_transition(db: Session, user: User) -> Set:
+    """A two-slot set whose transition trips bpm_jump + repeat_artist warnings."""
+    set_obj = Set(owner_id=user.id, name="Warned Set", key_strictness=1.0)
+    db.add(set_obj)
+    db.flush()
+    source = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(source)
+    db.flush()
+    db.add_all(
+        [
+            SetPoolTrack(
+                set_id=set_obj.id,
+                source_id=source.id,
+                track_id="tidal:a",
+                title="Opener",
+                artist="DJ Same",
+                bpm=124,
+                key="8A",
+                camelot="8A",
+                energy=8,
+                duration_sec=210,
+                dedupe_sig="sig-a",
+            ),
+            SetPoolTrack(
+                set_id=set_obj.id,
+                source_id=source.id,
+                track_id="tidal:b",
+                title="Follower",
+                artist="DJ Same",
+                bpm=150,
+                key="2A",
+                camelot="2A",
+                energy=3,
+                duration_sec=210,
+                dedupe_sig="sig-b",
+            ),
+        ]
+    )
+    db.flush()
+    db.add_all(
+        [
+            SetSlot(set_id=set_obj.id, position=0, track_id="tidal:a"),
+            SetSlot(set_id=set_obj.id, position=1, track_id="tidal:b"),
+        ]
+    )
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def test_explain_transition_returns_grounded_explanations(db: Session, test_user: User):
+    set_obj = _mk_set_with_warned_transition(db, test_user)
+
+    result, positions = apply_tool_call(db, set_obj, "explain_transition", {"position": 1})
+
+    assert positions == set()
+    assert result["position"] == 1
+    assert isinstance(result["score"], float)
+    codes = {item["code"] for item in result["explanations"]}
+    assert "bpm_jump" in codes
+    assert "repeat_artist" in codes
+    by_code = {item["code"]: item["detail"] for item in result["explanations"]}
+    # bpm_jump explanation cites both real BPM values.
+    assert "124" in by_code["bpm_jump"]
+    assert "150" in by_code["bpm_jump"]
+    # repeat_artist explanation names the shared artist.
+    assert "DJ Same" in by_code["repeat_artist"]
+    # Compact prev/curr summary carries the two tracks' real fields.
+    assert result["prev"]["title"] == "Opener"
+    assert result["curr"]["title"] == "Follower"
+    assert result["prev"]["bpm"] == 124
+    assert result["curr"]["bpm"] == 150
+
+
+def test_explain_transition_clean_transition_has_no_issues(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+
+    result, positions = apply_tool_call(db, set_obj, "explain_transition", {"position": 1})
+
+    assert positions == set()
+    assert result["explanations"] == []
+    assert result["prev"]["title"] == "Track 0"
+    assert result["curr"]["title"] == "Track 1"
+
+
+def test_explain_transition_rejects_out_of_range_position(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+
+    with pytest.raises(AgentToolError):
+        apply_tool_call(db, set_obj, "explain_transition", {"position": 0})
+    with pytest.raises(AgentToolError):
+        apply_tool_call(db, set_obj, "explain_transition", {"position": 99})
+
+
+def test_explain_transition_leaves_event_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set_with_warned_transition(db, test_user)
+    before_count = db.query(Request).count()
+    before_title = test_request.song_title
+
+    apply_tool_call(db, set_obj, "explain_transition", {"position": 1})
+
+    db.refresh(test_request)
+    assert db.query(Request).count() == before_count
+    assert test_request.song_title == before_title


### PR DESCRIPTION
## Why

Part of #442 (Family 1 — read-only sensing). `analyze_transition` already returns a transition score plus terse warning codes; `explain_transition` turns those codes into the **why** — a per-warning, human-readable sentence grounded in the two tracks' actual BPM / key / artist / mood — so the agent can teach the DJ rather than just flag.

## What

A single **read-only** agent tool `explain_transition` in `server/app/services/setbuilder/pass2_agent.py`:

- Validates `position` exactly like `_tool_analyze_transition` (`> 0` and `< len(slots)`).
- Resolves prev/curr `TrackMeta` via the same helpers and calls `transition_score(prev, curr, set_obj.key_strictness)` to get `(score, warnings)` — **no refactor** of `analyze_transition`.
- Maps each warning code to a concrete sentence built from real fields, and returns a compact prev/curr summary.
- Writes to **no table** and returns `(result, set())`. Not in `MUTATION_TOOLS`; no `rationale`.
- Wired additively in exactly the 3 spots (handlers dict, `_agent_tools()` bare ToolSpec, result-summary chain).

## Design decisions

**Which warning codes are explained.** The issue's `energy_dip` / `vibe_clash` / `era_jump` are illustrative `CritiqueFlagType` codes from the LLM critique pass. The deterministic `transition_score()` this tool consumes actually emits **`bpm_jump`, `key_clash`, `mood_shift`, `repeat_artist`** — so those are the codes given grounded explanations. An unknown code falls back to a humanized phrase (`code.replace("_", " ")`), so the tool stays correct if `transition_score` grows new codes.

**Explanation sentence templates** (grounded in the two tracks' real fields):
- `bpm_jump` → `"Big tempo gap: {prev_bpm} BPM into {curr_bpm} BPM — too far to ride the same groove."`
- `key_clash` → `"Keys clash: {prev_key} into {curr_key} are not harmonically adjacent on the Camelot wheel."`
- `mood_shift` → `"Mood swings from {prev_mood} to {curr_mood} — the emotional energy lurches."`
- `repeat_artist` → `"Back-to-back {artist}: repeating an artist can stall the set's variety."`

Missing fields render as `"unknown"` rather than throwing.

**prev/curr summary shape:** a compact `{title, artist, bpm, key, energy}` per track — the fields that drive transition scoring — so the frontend's default `ToolCard` render is informative without an extra round-trip. `prev` is `null` when the previous slot has no pool metadata.

**Return shape:** `{position, score, explanations: [{code, detail}], prev, curr}`. Clean transition → `explanations: []`.

**Frontend:** untouched — the issue's optional frontend tweak is unnecessary; the default `ToolCard` `display_summary` render is sufficient, and the new result-summary clause produces a readable one-liner.

## Testing
- [x] Unit tests pass (`tests/test_setbuilder_pass2.py`): warned transition asserts grounded explanations; clean transition → empty explanations; out-of-range position raises `AgentToolError`; `requests`-table-untouched regression; pure-helper tests for `key_clash` / `mood_shift` / missing-field / `null`-prev paths
- [x] Full backend suite green: 2916 passed, coverage 87.83% (gate 85%)
- [x] `ruff check` / `ruff format --check` / `bandit` clean
- [ ] CI green
- [ ] Manual verification: call `explain_transition` via the setbuilder chat agent and confirm per-warning sentences render

🤖 Co-authored by Claude Opus 4.8. Closes #458.