### PR TITLE
fix(repo): untrack dashboard/node_modules symlink leaked via worktree merges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,9 @@ dist/
 build/
 
 # Node
-node_modules/
+# No trailing slash: also ignores a `node_modules` symlink/file, not just a directory
+# (worktree setups symlink node_modules; the dir-only pattern let one leak into git once).
+node_modules
 .next/
 out/
 .turbo/

--- a/dashboard/node_modules
+++ b/dashboard/node_modules
@@ -1,1 +1,0 @@
-/home/adam/github/WrzDJ/dashboard/node_modules


### PR DESCRIPTION
## Why
A worktree's `dashboard/node_modules` **symlink** (pointing at the absolute local path `/home/adam/github/WrzDJ/dashboard/node_modules`) slipped past `.gitignore`'s `node_modules/` pattern — a trailing slash matches directories only, not a symlink *file* — and `git add -A` during the #455–#458 cascade merge resolution staged it onto `main` (introduced in `1b44630`, PR #460).

A committed symlink to a machine-local absolute path breaks CI checkouts and every other clone.

## What
- `git rm --cached dashboard/node_modules` — untrack the leaked symlink (mode `120000`).
- Drop the trailing slash in `.gitignore` (`node_modules/` → `node_modules`) so the pattern also ignores a `node_modules` symlink/file, preventing recurrence in worktree setups.

## Testing
- [x] `git check-ignore dashboard/node_modules` now matches
- [x] Only `.gitignore` + the symlink removal in the diff (no source churn)
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` configuration to properly exclude node_modules files and symlinks from version control. This ensures dependencies are not accidentally committed to the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->