### PR TITLE
feat(setbuilder): lock_slot/unlock_slot agent tools

### DIFF
--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -46,6 +46,8 @@ MUTATION_TOOLS = {
     "add_slow_window",
     "set_peak_at",
     "bump_energy",
+    "lock_slot",
+    "unlock_slot",
 }
 ALLOWED_FLAG_TYPES = {
     "energy_dip",
@@ -272,6 +274,8 @@ def apply_tool_call(
         "add_slow_window": _tool_add_slow_window,
         "set_peak_at": _tool_set_peak_at,
         "bump_energy": _tool_bump_energy,
+        "lock_slot": _tool_lock_slot,
+        "unlock_slot": _tool_unlock_slot,
         "analyze_transition": _tool_analyze_transition,
         "explain_transition": _tool_explain_transition,
         "get_track_vibes": _tool_get_track_vibes,
@@ -405,6 +409,28 @@ def _tool_bump_energy(
         slot.target_energy = round(max(0.0, min(10.0, base + amount)), 1)
     db.flush()
     return {"updated": len(slots)}, {s.position for s in slots}
+
+
+def _tool_lock_slot(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    return _set_slot_locked(db, set_obj, payload, locked=True)
+
+
+def _tool_unlock_slot(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    return _set_slot_locked(db, set_obj, payload, locked=False)
+
+
+def _set_slot_locked(
+    db: Session, set_obj: Set, payload: dict[str, Any], *, locked: bool
+) -> tuple[dict[str, Any], set[int]]:
+    """Pin/unpin a slot: write only its ``locked`` column. Idempotent."""
+    slot = _slot_or_error(db, set_obj.id, int(payload["slot_id"]))
+    slot.locked = locked
+    db.flush()
+    return {"slot_id": slot.id, "locked": locked}, {slot.position}
 
 
 def _tool_analyze_transition(
@@ -891,6 +917,11 @@ def _tool_display_summary(
         removed = before.get(int(payload["slot_id"]))
         if removed:
             return f"Removed {removed['label']} from {_position_label(removed['position'])}."
+    if name in {"lock_slot", "unlock_slot"}:
+        slot = before.get(int(result["slot_id"]))
+        verb = "Locked" if result.get("locked") else "Unlocked"
+        where = _position_label(slot["position"]) if slot else f"slot {result['slot_id']}"
+        return f"{verb} {where}."
     if name in {"insert_from_pool", "search_and_insert"}:
         position = int(result["position"])
         inserted = next((s for s in after.values() if s["position"] == position), None)
@@ -989,6 +1020,8 @@ def _agent_tools() -> list[ToolSpec]:
         _tool("add_slow_window", {"t0_sec": "integer", "t1_sec": "integer", "label": "string"}),
         _tool("set_peak_at", {"position": "integer", "energy": "number"}),
         _tool("bump_energy", {"amount": "number", "slot_id": "integer"}),
+        _tool("lock_slot", {"slot_id": "integer"}),
+        _tool("unlock_slot", {"slot_id": "integer"}),
         ToolSpec(
             name="analyze_transition",
             description="Analyze one transition by destination slot position.",

--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -427,10 +427,14 @@ def _set_slot_locked(
     db: Session, set_obj: Set, payload: dict[str, Any], *, locked: bool
 ) -> tuple[dict[str, Any], set[int]]:
     """Pin/unpin a slot: write only its ``locked`` column. Idempotent."""
-    slot = _slot_or_error(db, set_obj.id, int(payload["slot_id"]))
+    try:
+        slot_id = int(payload["slot_id"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise AgentToolError("slot_id must be an integer") from exc
+    slot = _slot_or_error(db, set_obj.id, slot_id)
     slot.locked = locked
     db.flush()
-    return {"slot_id": slot.id, "locked": locked}, {slot.position}
+    return {"slot_id": slot.id, "locked": locked, "position": slot.position}, {slot.position}
 
 
 def _tool_analyze_transition(

--- a/server/tests/test_setbuilder_pass2.py
+++ b/server/tests/test_setbuilder_pass2.py
@@ -1044,7 +1044,7 @@ def test_lock_slot_sets_locked_true(db: Session, test_user: User):
 
     db.refresh(slot)
     assert slot.locked is True
-    assert result == {"slot_id": slot.id, "locked": True}
+    assert result == {"slot_id": slot.id, "locked": True, "position": slot.position}
     assert positions == {slot.position}
 
 
@@ -1075,7 +1075,7 @@ def test_unlock_slot_sets_locked_false(db: Session, test_user: User):
 
     db.refresh(slot)
     assert slot.locked is False
-    assert result == {"slot_id": slot.id, "locked": False}
+    assert result == {"slot_id": slot.id, "locked": False, "position": slot.position}
     assert positions == {slot.position}
 
 
@@ -1104,6 +1104,16 @@ def test_lock_slot_rejects_foreign_slot(db: Session, test_user: User):
         apply_tool_call(
             db, set_obj, "lock_slot", {"slot_id": foreign_slot.id, "rationale": "Pin it."}
         )
+
+
+@pytest.mark.parametrize("bad_payload", [{}, {"slot_id": None}, {"slot_id": "not-an-int"}])
+def test_lock_slot_normalizes_invalid_slot_id(db: Session, test_user: User, bad_payload):
+    """Malformed slot_id from the model must surface as AgentToolError, not a raw
+    KeyError/TypeError/ValueError that escapes the apply_tool_call contract."""
+    set_obj = _mk_set_with_tracks(db, test_user)
+
+    with pytest.raises(AgentToolError, match="slot_id must be an integer"):
+        apply_tool_call(db, set_obj, "lock_slot", {**bad_payload, "rationale": "Pin it."})
 
 
 def test_lock_slot_then_reorder_refuses_that_slot(db: Session, test_user: User):

--- a/server/tests/test_setbuilder_pass2.py
+++ b/server/tests/test_setbuilder_pass2.py
@@ -1031,3 +1031,121 @@ def test_explain_transition_leaves_event_requests_untouched(
     db.refresh(test_request)
     assert db.query(Request).count() == before_count
     assert test_request.song_title == before_title
+
+
+def test_lock_slot_sets_locked_true(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    slot = sorted(set_obj.slots, key=lambda s: s.position)[0]
+    assert slot.locked is False
+
+    result, positions = apply_tool_call(
+        db, set_obj, "lock_slot", {"slot_id": slot.id, "rationale": "Pin the opener."}
+    )
+
+    db.refresh(slot)
+    assert slot.locked is True
+    assert result == {"slot_id": slot.id, "locked": True}
+    assert positions == {slot.position}
+
+
+def test_lock_slot_is_idempotent(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    slot = sorted(set_obj.slots, key=lambda s: s.position)[0]
+    slot.locked = True
+    db.flush()
+
+    result, _ = apply_tool_call(
+        db, set_obj, "lock_slot", {"slot_id": slot.id, "rationale": "Keep it pinned."}
+    )
+
+    db.refresh(slot)
+    assert slot.locked is True
+    assert result["locked"] is True
+
+
+def test_unlock_slot_sets_locked_false(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    slot = sorted(set_obj.slots, key=lambda s: s.position)[0]
+    slot.locked = True
+    db.flush()
+
+    result, positions = apply_tool_call(
+        db, set_obj, "unlock_slot", {"slot_id": slot.id, "rationale": "Release the pin."}
+    )
+
+    db.refresh(slot)
+    assert slot.locked is False
+    assert result == {"slot_id": slot.id, "locked": False}
+    assert positions == {slot.position}
+
+
+def test_lock_slot_requires_rationale(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    slot = sorted(set_obj.slots, key=lambda s: s.position)[0]
+
+    with pytest.raises(AgentToolError, match="rationale"):
+        apply_tool_call(db, set_obj, "lock_slot", {"slot_id": slot.id})
+
+
+def test_unlock_slot_requires_rationale(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    slot = sorted(set_obj.slots, key=lambda s: s.position)[0]
+
+    with pytest.raises(AgentToolError, match="rationale"):
+        apply_tool_call(db, set_obj, "unlock_slot", {"slot_id": slot.id})
+
+
+def test_lock_slot_rejects_foreign_slot(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    other = _mk_set_with_tracks(db, test_user)
+    foreign_slot = sorted(other.slots, key=lambda s: s.position)[0]
+
+    with pytest.raises(AgentToolError, match="Slot not found"):
+        apply_tool_call(
+            db, set_obj, "lock_slot", {"slot_id": foreign_slot.id, "rationale": "Pin it."}
+        )
+
+
+def test_lock_slot_then_reorder_refuses_that_slot(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    slot = sorted(set_obj.slots, key=lambda s: s.position)[0]
+    apply_tool_call(db, set_obj, "lock_slot", {"slot_id": slot.id, "rationale": "Pin the opener."})
+
+    with pytest.raises(AgentToolError, match="Locked"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "reorder_slot",
+            {"slot_id": slot.id, "position": 1, "rationale": "Try to move it."},
+        )
+
+
+def test_lock_slot_leaves_event_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    slot = sorted(set_obj.slots, key=lambda s: s.position)[0]
+    before_count = db.query(Request).count()
+    before_title = test_request.song_title
+
+    apply_tool_call(db, set_obj, "lock_slot", {"slot_id": slot.id, "rationale": "Pin the opener."})
+
+    db.refresh(test_request)
+    assert db.query(Request).count() == before_count
+    assert test_request.song_title == before_title
+
+
+def test_tool_display_summary_lock_and_unlock():
+    locked = _tool_display_summary(
+        "lock_slot", {}, {"slot_id": 1, "locked": True}, {1: {"position": 0}}, {1: {"position": 0}}
+    )
+    unlocked = _tool_display_summary(
+        "unlock_slot",
+        {},
+        {"slot_id": 1, "locked": False},
+        {1: {"position": 2}},
+        {1: {"position": 2}},
+    )
+
+    assert locked == "Locked slot 1."
+    assert unlocked == "Unlocked slot 3."


### PR DESCRIPTION
## Why

Part of #442 (Family 2 — safe mutations). The WrzDJSet pass-2 agent already **respects** locked slots (reorder/remove/swap refuse to touch them) but had no way to **set** the lock. These two tools let the agent (or the DJ, through it) pin a slot it wants protected from further reordering/replacement, then release it.

## What

Adds two idempotent mutation tools to `server/app/services/setbuilder/pass2_agent.py`:

- `lock_slot` → sets `slot.locked = True`
- `unlock_slot` → sets `slot.locked = False`

Both write **only** the slot's `locked` column, are owner-scoped via `_slot_or_error` on `set_obj.id`, require a `rationale` (enforced by `MUTATION_TOOLS` membership), and are dispatched through `apply_tool_call`'s closed allowlist. The shared toggle lives in a small `_set_slot_locked(..., *, locked)` helper. Wiring is the four standard additive spots (handlers dict, `MUTATION_TOOLS`, `_agent_tools()` schema, result-summary chain) — kept minimal/localized for the parallel Family-2 batch.

No new REST endpoints, no DB migrations (the `locked` column already exists), no openapi/type regen. Default `ToolCard` render is sufficient — no frontend change.

## Testing
- [x] Unit tests pass (`tests/test_setbuilder_pass2.py`): lock sets True, unlock sets False, idempotent lock, missing-rationale → `AgentToolError`, foreign/invalid slot → `AgentToolError`, post-lock reorder still refuses the slot, requests-table-untouched regression, display-summary text
- [x] Backend CI green locally: ruff check, ruff format --check, bandit, pytest (2941 passed, coverage 87.92% ≥ 85% gate)
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #464.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new set slot actions to lock and unlock slots, preventing unintended changes.
  * Locked slots are now blocked from being reordered.
  * Tool results present clear “Locked/Unlocked” confirmations for better readability.

* **Tests**
  * Added unit tests covering locking/unlocking behavior, idempotency, validation (missing rationale), foreign-slot rejection, malformed input handling, and interaction with reorder restrictions.
  * Added coverage to ensure unrelated request records remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->