### PR TITLE
feat(setbuilder): set_curve_point/remove_curve_point agent tools (#468)

### DIFF
--- a/server/app/services/setbuilder/curve.py
+++ b/server/app/services/setbuilder/curve.py
@@ -287,3 +287,87 @@ def replace_vibe_windows(
     else:
         db.flush()
     return get_vibe_windows(db, set_obj.id)
+
+
+# ---------------------------------------------------------------------------
+# Standalone curve points (non-window SetCurvePoint rows, #468)
+# ---------------------------------------------------------------------------
+#
+# Standalone points are individual energy markers the agent places or removes
+# at a time offset. They are the *complement* of the paired vibe-window rows:
+# every standalone point has both window flags ``False``, so these helpers
+# filter on that and never touch ``add_slow_window``'s paired rows.
+
+
+def _standalone_points_filter(set_id: int):
+    """Owner-scoped filter for non-window points (both window flags False)."""
+    return (
+        SetCurvePoint.set_id == set_id,
+        SetCurvePoint.is_slow_window_start == False,  # noqa: E712
+        SetCurvePoint.is_slow_window_end == False,  # noqa: E712
+    )
+
+
+def get_standalone_point(db: Session, set_id: int, position_sec: int) -> SetCurvePoint | None:
+    """The non-window point at ``position_sec`` for the set, or None."""
+    return (
+        db.query(SetCurvePoint)
+        .filter(*_standalone_points_filter(set_id), SetCurvePoint.position_sec == position_sec)
+        .one_or_none()
+    )
+
+
+def upsert_curve_point(
+    db: Session,
+    set_obj: Set,
+    position_sec: int,
+    energy: int,
+    label: str | None = None,
+    *,
+    commit: bool = True,
+) -> SetCurvePoint:
+    """Insert or update a standalone (non-window) curve point at ``position_sec``.
+
+    Matches the existing non-window point at the same ``position_sec`` and
+    updates its ``energy``/``label``; otherwise inserts a new one. Window flags
+    are always ``False`` so paired vibe-window rows are never disturbed.
+    """
+    point = get_standalone_point(db, set_obj.id, position_sec)
+    if point is None:
+        point = SetCurvePoint(
+            set_id=set_obj.id,
+            position_sec=position_sec,
+            energy=energy,
+            label=label,
+            is_slow_window_start=False,
+            is_slow_window_end=False,
+        )
+        db.add(point)
+    else:
+        point.energy = energy
+        point.label = label
+    if commit:
+        db.commit()
+        db.refresh(point)
+    else:
+        db.flush()
+    return point
+
+
+def remove_curve_point(
+    db: Session, set_obj: Set, position_sec: int, *, commit: bool = True
+) -> bool:
+    """Delete the standalone (non-window) point at ``position_sec``.
+
+    Returns True when a point was removed, False when none existed. Window rows
+    are never matched, so vibe-window pairs are left intact.
+    """
+    point = get_standalone_point(db, set_obj.id, position_sec)
+    if point is None:
+        return False
+    db.delete(point)
+    if commit:
+        db.commit()
+    else:
+        db.flush()
+    return True

--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -1043,7 +1043,8 @@ def _agent_tools() -> list[ToolSpec]:
         _tool("bump_energy", {"amount": "number", "slot_id": "integer"}),
         _tool(
             "set_curve_point",
-            {"position_sec": "integer", "energy": "integer", "label": "string"},
+            {"position_sec": "integer", "energy": "integer"},
+            optional_fields={"label": "string"},
         ),
         _tool("remove_curve_point", {"position_sec": "integer"}),
         ToolSpec(
@@ -1090,8 +1091,20 @@ def _agent_tools() -> list[ToolSpec]:
     ]
 
 
-def _tool(name: str, fields: dict[str, str]) -> ToolSpec:
+def _tool(
+    name: str,
+    fields: dict[str, str],
+    *,
+    optional_fields: dict[str, str] | None = None,
+) -> ToolSpec:
+    """Build a mutation tool schema.
+
+    ``fields`` are required; ``optional_fields`` appear in the schema but are
+    not required. ``rationale`` is always added and required (mutation tools
+    must justify themselves — see ``MUTATION_TOOLS``).
+    """
     properties = {key: {"type": value} for key, value in fields.items()}
+    properties.update({key: {"type": value} for key, value in (optional_fields or {}).items()})
     properties["rationale"] = {"type": "string"}
     return ToolSpec(
         name=name,

--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -46,6 +46,8 @@ MUTATION_TOOLS = {
     "add_slow_window",
     "set_peak_at",
     "bump_energy",
+    "set_curve_point",
+    "remove_curve_point",
 }
 ALLOWED_FLAG_TYPES = {
     "energy_dip",
@@ -272,6 +274,8 @@ def apply_tool_call(
         "add_slow_window": _tool_add_slow_window,
         "set_peak_at": _tool_set_peak_at,
         "bump_energy": _tool_bump_energy,
+        "set_curve_point": _tool_set_curve_point,
+        "remove_curve_point": _tool_remove_curve_point,
         "analyze_transition": _tool_analyze_transition,
         "explain_transition": _tool_explain_transition,
         "get_track_vibes": _tool_get_track_vibes,
@@ -405,6 +409,45 @@ def _tool_bump_energy(
         slot.target_energy = round(max(0.0, min(10.0, base + amount)), 1)
     db.flush()
     return {"updated": len(slots)}, {s.position for s in slots}
+
+
+def _tool_set_curve_point(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Upsert a standalone (non-window) curve point at ``position_sec``.
+
+    Curve points are time-offset markers, not slot positions, so no slot
+    positions are affected — returns ``set()`` like ``add_slow_window``.
+    """
+    position_sec = int(payload["position_sec"])
+    energy = int(payload["energy"])
+    if not 0 <= energy <= 10:
+        raise AgentToolError("energy must be between 0 and 10")
+    label = payload.get("label")
+    label = str(label)[:50] if label is not None else None
+    point = curve.upsert_curve_point(db, set_obj, position_sec, energy, label, commit=False)
+    return {
+        "point_id": point.id,
+        "position_sec": point.position_sec,
+        "energy": point.energy,
+        "label": point.label,
+    }, set()
+
+
+def _tool_remove_curve_point(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Remove the standalone (non-window) curve point at ``position_sec``.
+
+    Keyed by ``position_sec`` (the agent works from the time-offset curve, not
+    DB row ids). Raises ``AgentToolError`` if no non-window point is there, so
+    the agent gets a clear signal instead of a silent no-op.
+    """
+    position_sec = int(payload["position_sec"])
+    removed = curve.remove_curve_point(db, set_obj, position_sec, commit=False)
+    if not removed:
+        raise AgentToolError("No curve point at that position_sec")
+    return {"removed_position_sec": position_sec}, set()
 
 
 def _tool_analyze_transition(
@@ -917,6 +960,15 @@ def _tool_display_summary(
         return (
             f"Added slow window {label} from {int(result['t0_sec'])}s to {int(result['t1_sec'])}s."
         )
+    if name == "set_curve_point":
+        label = result.get("label")
+        suffix = f" ({label})" if label else ""
+        return (
+            f"Set curve point at {int(result['position_sec'])}s to energy "
+            f"{int(result['energy'])}{suffix}."
+        )
+    if name == "remove_curve_point":
+        return f"Removed curve point at {int(result['removed_position_sec'])}s."
     if name == "analyze_transition":
         base = (
             f"Analyzed transition into {_position_label(int(result['position']))}: "
@@ -989,6 +1041,11 @@ def _agent_tools() -> list[ToolSpec]:
         _tool("add_slow_window", {"t0_sec": "integer", "t1_sec": "integer", "label": "string"}),
         _tool("set_peak_at", {"position": "integer", "energy": "number"}),
         _tool("bump_energy", {"amount": "number", "slot_id": "integer"}),
+        _tool(
+            "set_curve_point",
+            {"position_sec": "integer", "energy": "integer", "label": "string"},
+        ),
+        _tool("remove_curve_point", {"position_sec": "integer"}),
         ToolSpec(
             name="analyze_transition",
             description="Analyze one transition by destination slot position.",

--- a/server/tests/test_setbuilder_pass2.py
+++ b/server/tests/test_setbuilder_pass2.py
@@ -18,6 +18,7 @@ from app.services.setbuilder import agent_history, curve
 from app.services.setbuilder.pass1_deterministic import TrackMeta
 from app.services.setbuilder.pass2_agent import (
     AgentToolError,
+    _agent_tools,
     _explain_warning,
     _tool_display_summary,
     _track_summary,
@@ -1263,3 +1264,12 @@ def test_remove_curve_point_display_summary_is_human_readable():
         {},
     )
     assert summary == "Removed curve point at 120s."
+
+
+def test_set_curve_point_schema_keeps_label_optional():
+    """label is optional; position_sec/energy/rationale stay required."""
+    spec = next(t for t in _agent_tools() if t.name == "set_curve_point")
+    required = set(spec.input_schema["required"])
+    assert required == {"position_sec", "energy", "rationale"}
+    assert "label" not in required
+    assert "label" in spec.input_schema["properties"]

--- a/server/tests/test_setbuilder_pass2.py
+++ b/server/tests/test_setbuilder_pass2.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from app.models.request import Request
-from app.models.set import Set, SetSlot
+from app.models.set import Set, SetCurvePoint, SetSlot
 from app.models.set_pool import SetPoolSource, SetPoolTrack
 from app.models.track_vibe import (
     TRACK_VIBE_SOURCE_EXPLICIT_EDIT,
@@ -14,7 +14,7 @@ from app.models.track_vibe import (
 from app.models.user import User
 from app.services.llm.base import ChatResponse, ToolCall
 from app.services.llm.exceptions import NoLlmConfigured
-from app.services.setbuilder import agent_history
+from app.services.setbuilder import agent_history, curve
 from app.services.setbuilder.pass1_deterministic import TrackMeta
 from app.services.setbuilder.pass2_agent import (
     AgentToolError,
@@ -1031,3 +1031,235 @@ def test_explain_transition_leaves_event_requests_untouched(
     db.refresh(test_request)
     assert db.query(Request).count() == before_count
     assert test_request.song_title == before_title
+
+
+# ---------------------------------------------------------------------------
+# set_curve_point / remove_curve_point (#468)
+# ---------------------------------------------------------------------------
+
+
+def _standalone_points(db: Session, set_id: int) -> list[SetCurvePoint]:
+    """Non-window curve points for a set, ordered by time offset."""
+    return (
+        db.query(SetCurvePoint)
+        .filter(
+            SetCurvePoint.set_id == set_id,
+            SetCurvePoint.is_slow_window_start == False,  # noqa: E712
+            SetCurvePoint.is_slow_window_end == False,  # noqa: E712
+        )
+        .order_by(SetCurvePoint.position_sec.asc())
+        .all()
+    )
+
+
+def test_set_curve_point_inserts_non_window_point(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+
+    result, affected = apply_tool_call(
+        db,
+        set_obj,
+        "set_curve_point",
+        {"position_sec": 120, "energy": 7, "label": "Lift", "rationale": "build the room"},
+    )
+    db.commit()
+
+    assert affected == set()
+    assert result["position_sec"] == 120
+    assert result["energy"] == 7
+    assert result["label"] == "Lift"
+    points = _standalone_points(db, set_obj.id)
+    assert len(points) == 1
+    assert points[0].is_slow_window_start is False
+    assert points[0].is_slow_window_end is False
+
+
+def test_set_curve_point_upserts_at_same_position(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    apply_tool_call(
+        db,
+        set_obj,
+        "set_curve_point",
+        {"position_sec": 90, "energy": 4, "label": "Warm", "rationale": "warm-up"},
+    )
+    db.commit()
+
+    result, _ = apply_tool_call(
+        db,
+        set_obj,
+        "set_curve_point",
+        {"position_sec": 90, "energy": 9, "label": "Peak", "rationale": "raise it"},
+    )
+    db.commit()
+
+    points = _standalone_points(db, set_obj.id)
+    assert len(points) == 1  # updated, not duplicated
+    assert points[0].energy == 9
+    assert points[0].label == "Peak"
+    assert result["point_id"] == points[0].id
+
+
+def test_remove_curve_point_removes_non_window_point(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    apply_tool_call(
+        db,
+        set_obj,
+        "set_curve_point",
+        {"position_sec": 150, "energy": 6, "rationale": "marker"},
+    )
+    db.commit()
+
+    result, affected = apply_tool_call(
+        db,
+        set_obj,
+        "remove_curve_point",
+        {"position_sec": 150, "rationale": "no longer needed"},
+    )
+    db.commit()
+
+    assert affected == set()
+    assert result["removed_position_sec"] == 150
+    assert _standalone_points(db, set_obj.id) == []
+
+
+def test_curve_point_tools_never_touch_slow_window_rows(db: Session, test_user: User):
+    """Upsert + remove must leave paired vibe-window rows completely intact."""
+    set_obj = _mk_set_with_tracks(db, test_user)
+    curve.replace_vibe_windows(
+        db,
+        set_obj,
+        [{"t0_sec": 100, "t1_sec": 200, "label": "Slow set"}],
+        commit=True,
+    )
+    window_before = curve.get_vibe_windows(db, set_obj.id)
+    assert window_before == [{"t0_sec": 100, "t1_sec": 200, "label": "Slow set"}]
+
+    # A standalone point sharing a window boundary's position_sec must NOT
+    # match the window row — it inserts a distinct non-window row.
+    apply_tool_call(
+        db,
+        set_obj,
+        "set_curve_point",
+        {"position_sec": 100, "energy": 8, "rationale": "overlap boundary"},
+    )
+    db.commit()
+    apply_tool_call(
+        db,
+        set_obj,
+        "remove_curve_point",
+        {"position_sec": 100, "rationale": "remove standalone"},
+    )
+    db.commit()
+
+    # Windows survive both operations untouched.
+    assert curve.get_vibe_windows(db, set_obj.id) == window_before
+    window_rows = (
+        db.query(SetCurvePoint)
+        .filter(
+            SetCurvePoint.set_id == set_obj.id,
+            (SetCurvePoint.is_slow_window_start == True)  # noqa: E712
+            | (SetCurvePoint.is_slow_window_end == True),  # noqa: E712
+        )
+        .count()
+    )
+    assert window_rows == 2
+
+
+def test_remove_curve_point_does_not_remove_window_row(db: Session, test_user: User):
+    """remove_curve_point keyed at a window boundary errors, leaving the pair."""
+    set_obj = _mk_set_with_tracks(db, test_user)
+    curve.replace_vibe_windows(
+        db, set_obj, [{"t0_sec": 100, "t1_sec": 200, "label": "Slow"}], commit=True
+    )
+
+    with pytest.raises(AgentToolError, match="No curve point"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "remove_curve_point",
+            {"position_sec": 100, "rationale": "try to nuke window"},
+        )
+
+    assert curve.get_vibe_windows(db, set_obj.id) == [
+        {"t0_sec": 100, "t1_sec": 200, "label": "Slow"}
+    ]
+
+
+def test_set_curve_point_rejects_out_of_range_energy(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    for bad in (-1, 11):
+        with pytest.raises(AgentToolError, match="energy must be between 0 and 10"):
+            apply_tool_call(
+                db,
+                set_obj,
+                "set_curve_point",
+                {"position_sec": 60, "energy": bad, "rationale": "bad energy"},
+            )
+
+
+def test_curve_point_tools_require_rationale(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    with pytest.raises(AgentToolError, match="requires a rationale"):
+        apply_tool_call(db, set_obj, "set_curve_point", {"position_sec": 60, "energy": 5})
+    with pytest.raises(AgentToolError, match="requires a rationale"):
+        apply_tool_call(db, set_obj, "remove_curve_point", {"position_sec": 60})
+
+
+def test_remove_curve_point_missing_raises(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    with pytest.raises(AgentToolError, match="No curve point"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "remove_curve_point",
+            {"position_sec": 999, "rationale": "nothing here"},
+        )
+
+
+def test_curve_point_tools_leave_event_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    before_count = db.query(Request).count()
+    before_title = test_request.song_title
+
+    apply_tool_call(
+        db,
+        set_obj,
+        "set_curve_point",
+        {"position_sec": 80, "energy": 6, "rationale": "marker"},
+    )
+    apply_tool_call(
+        db,
+        set_obj,
+        "remove_curve_point",
+        {"position_sec": 80, "rationale": "cleanup"},
+    )
+    db.commit()
+
+    db.refresh(test_request)
+    assert db.query(Request).count() == before_count
+    assert test_request.song_title == before_title
+
+
+def test_set_curve_point_display_summary_is_human_readable():
+    summary = _tool_display_summary(
+        "set_curve_point",
+        {},
+        {"point_id": 1, "position_sec": 120, "energy": 7, "label": "Lift"},
+        {},
+        {},
+    )
+    assert "120s" in summary
+    assert "energy 7" in summary
+    assert "Lift" in summary
+
+
+def test_remove_curve_point_display_summary_is_human_readable():
+    summary = _tool_display_summary(
+        "remove_curve_point",
+        {},
+        {"removed_position_sec": 120},
+        {},
+        {},
+    )
+    assert summary == "Removed curve point at 120s."


### PR DESCRIPTION
## Why

Part of #442 (Family 2 — safe mutations). Beyond `add_slow_window`/`set_peak_at`, the WrzDJSet pass-2 agent needs precise curve editing: place or remove an individual energy point at a time offset. These two tools manage standalone `SetCurvePoint` rows.

## What

Two new mutation tools on the pass-2 agent:

- **`set_curve_point`** — upsert a non-window energy point at `position_sec` (energy validated 0–10, optional `label`).
- **`remove_curve_point`** — remove a non-window point at `position_sec`.

New service helpers in `curve.py` (`upsert_curve_point`, `remove_curve_point`, `get_standalone_point`) keep `pass2_agent.py` thin and match how the curve domain already lives there. Both helpers filter to **non-window** points (both window flags `False`), so `add_slow_window`'s paired vibe-window rows are never touched.

Wiring mirrors the existing mutation tools: both registered in `MUTATION_TOOLS`, the `apply_tool_call` allowlist, the `_agent_tools()` schema list (via `_tool(...)`, which auto-adds the required `rationale`), and the display-summary chain. The frontend `ToolCard` renders the new tools through its existing generic `display_summary` path — no frontend change needed.

## Design decisions

- **Remove key — `position_sec` (not `point_id`).** The agent reasons about the curve in time offsets and never sees DB row ids, so keying both tools by `position_sec` is symmetric and matches the upsert match rule.
- **Upsert match rule.** A non-window point (`is_slow_window_start == False AND is_slow_window_end == False`) at the exact same `position_sec`: same `position_sec` → update `energy` + `label`; otherwise insert. A standalone point may share a `position_sec` with a window boundary without colliding — the standalone filter makes window rows invisible to the upsert/remove queries.
- **Not-found behavior — `AgentToolError`.** `remove_curve_point` on a missing (or window-only) `position_sec` raises rather than silently no-opping, giving the agent a clear signal. This is also what protects window rows: removing at a window boundary errors instead of deleting the paired row.

## Security invariants (#442)

- Owner-scoped: every `SetCurvePoint` query filters `set_id == set_obj.id`.
- Never corrupts slow-window pairs (only touches points with both window flags `False`).
- Requires a `rationale` (enforced by `MUTATION_TOOLS`).
- Dispatched only through `apply_tool_call`'s closed allowlist.
- Writes only to `set_curve_points`; a regression test asserts the `requests` table is unchanged.
- No new REST endpoints, no DB migrations (model already exists), no openapi/type regen.

## Testing
- [x] Unit tests added (`server/tests/test_setbuilder_pass2.py`): insert, upsert-update, remove, slow-window-rows-untouched, remove-at-window-boundary-errors, energy validation, missing-rationale, missing-point, requests-untouched regression, display-summary readability
- [x] `ruff check` / `ruff format --check` clean
- [x] `bandit -r app -c pyproject.toml` clean
- [x] `pytest` green: 2943 passed, coverage 87.89% (gate 85%)
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #468.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standalone (non-window) curve point management to create, upsert, and remove curve markers by position.
  * Exposed new AI agent tools to edit curve points automatically, including optional labeling.
  * Enforced validation and safety rules so edits won’t affect slow-window curve pairs.

* **Tests**
  * Added end-to-end coverage for inserting, updating, removing, validation errors, missing-point handling, non-modification of slow-window rows, and tool display/schema behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->