### PR TITLE
feat(setbuilder): set_target agent tool — set duration/BPM/key targets

### DIFF
--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -46,6 +46,7 @@ MUTATION_TOOLS = {
     "add_slow_window",
     "set_peak_at",
     "bump_energy",
+    "set_target",
 }
 ALLOWED_FLAG_TYPES = {
     "energy_dip",
@@ -70,6 +71,11 @@ SPARSE_BAND_THRESHOLD = 2
 
 class AgentToolError(ValueError):
     """The model requested an invalid or unsafe setbuilder tool operation."""
+
+
+# Sentinel for set_target: distinguishes an omitted field (leave unchanged) from
+# an explicit null (clear a nullable target column).
+_UNSET = object()
 
 
 @dataclass(frozen=True)
@@ -272,6 +278,7 @@ def apply_tool_call(
         "add_slow_window": _tool_add_slow_window,
         "set_peak_at": _tool_set_peak_at,
         "bump_energy": _tool_bump_energy,
+        "set_target": _tool_set_target,
         "analyze_transition": _tool_analyze_transition,
         "explain_transition": _tool_explain_transition,
         "get_track_vibes": _tool_get_track_vibes,
@@ -405,6 +412,79 @@ def _tool_bump_energy(
         slot.target_energy = round(max(0.0, min(10.0, base + amount)), 1)
     db.flush()
     return {"updated": len(slots)}, {s.position for s in slots}
+
+
+def _tool_set_target(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Set whichever of the Set's targets are present in ``payload`` (#465).
+
+    Each field is OPTIONAL: an omitted key leaves the column untouched, while an
+    explicit ``null`` clears a nullable column. Writes only ``set_obj``'s target
+    columns — never the ``requests`` table. Targets shape future deterministic
+    passes but move no slots, so the affected-positions set is always empty.
+    """
+    updates = _resolve_target_updates(payload)
+    _validate_bpm_window(set_obj, updates)
+    for column, value in updates.items():
+        setattr(set_obj, column, value)
+    db.flush()
+    return updates, set()
+
+
+def _resolve_target_updates(payload: dict[str, Any]) -> dict[str, Any]:
+    """Pull, coerce, and range-check the target fields actually present in payload."""
+    updates: dict[str, Any] = {}
+    _set_nonneg_int(updates, payload, "target_duration_sec", nullable=True)
+    _set_optional_int(updates, payload, "bpm_floor")
+    _set_optional_int(updates, payload, "bpm_ceiling")
+    _set_key_strictness(updates, payload)
+    _set_nonneg_int(updates, payload, "avg_transition_overlap_sec", nullable=False)
+    return updates
+
+
+def _set_nonneg_int(
+    updates: dict[str, Any], payload: dict[str, Any], field_name: str, *, nullable: bool
+) -> None:
+    value = payload.get(field_name, _UNSET)
+    if value is _UNSET:
+        return
+    if value is None:
+        if not nullable:
+            raise AgentToolError(f"{field_name} cannot be null")
+        updates[field_name] = None
+        return
+    coerced = int(value)
+    if coerced < 0:
+        raise AgentToolError(f"{field_name} must be non-negative")
+    updates[field_name] = coerced
+
+
+def _set_optional_int(updates: dict[str, Any], payload: dict[str, Any], field_name: str) -> None:
+    value = payload.get(field_name, _UNSET)
+    if value is _UNSET:
+        return
+    updates[field_name] = None if value is None else int(value)
+
+
+def _set_key_strictness(updates: dict[str, Any], payload: dict[str, Any]) -> None:
+    value = payload.get("key_strictness", _UNSET)
+    if value is _UNSET:
+        return
+    if value is None:
+        raise AgentToolError("key_strictness cannot be null")
+    coerced = float(value)
+    if not 0.0 <= coerced <= 1.0:
+        raise AgentToolError("key_strictness must be between 0.0 and 1.0")
+    updates["key_strictness"] = coerced
+
+
+def _validate_bpm_window(set_obj: Set, updates: dict[str, Any]) -> None:
+    """Reject an inverted BPM window, considering both new and already-stored bounds."""
+    floor = updates["bpm_floor"] if "bpm_floor" in updates else set_obj.bpm_floor
+    ceiling = updates["bpm_ceiling"] if "bpm_ceiling" in updates else set_obj.bpm_ceiling
+    if floor is not None and ceiling is not None and floor > ceiling:
+        raise AgentToolError("bpm_floor must be <= bpm_ceiling")
 
 
 def _tool_analyze_transition(
@@ -945,6 +1025,8 @@ def _tool_display_summary(
         if resolved.get("mood"):
             parts.append(f"mood {resolved['mood']} ({resolved.get('mood_source')})")
         return f"Vibe tags for {where}: {', '.join(parts)}."
+    if name == "set_target":
+        return _set_target_summary(result)
     if name == "summarize_set":
         return _summarize_set_summary(result)
     if name == "analyze_pool_gaps":
@@ -963,6 +1045,39 @@ def _tool_display_summary(
             return f"{head} {summary}" if summary else head
         return "Recomputed critique context."
     return name.replace("_", " ").capitalize() + "."
+
+
+def _set_target_summary(result: dict[str, Any]) -> str:
+    """One human-readable sentence over only the target fields the call set."""
+    parts: list[str] = []
+    if "target_duration_sec" in result:
+        secs = result["target_duration_sec"]
+        if secs is None:
+            parts.append("cleared duration target")
+        else:
+            parts.append(f"duration {int(secs) // 60} min")
+    parts.extend(_bpm_window_summary_parts(result))
+    if "key_strictness" in result:
+        parts.append(f"key strictness {float(result['key_strictness']):g}")
+    if "avg_transition_overlap_sec" in result:
+        parts.append(f"transition overlap {int(result['avg_transition_overlap_sec'])}s")
+    if not parts:
+        return "Updated set targets."
+    return "Set targets: " + ", ".join(parts) + "."
+
+
+def _bpm_window_summary_parts(result: dict[str, Any]) -> list[str]:
+    """Render the BPM bounds the call set: combined as a window when both are present."""
+    floor, ceiling = result.get("bpm_floor"), result.get("bpm_ceiling")
+    has_floor, has_ceiling = "bpm_floor" in result, "bpm_ceiling" in result
+    if has_floor and has_ceiling and floor is not None and ceiling is not None:
+        return [f"BPM {int(floor)}-{int(ceiling)}"]
+    parts: list[str] = []
+    if has_floor:
+        parts.append("cleared BPM floor" if floor is None else f"BPM floor {int(floor)}")
+    if has_ceiling:
+        parts.append("cleared BPM ceiling" if ceiling is None else f"BPM ceiling {int(ceiling)}")
+    return parts
 
 
 def _summarize_set_summary(result: dict[str, Any]) -> str:
@@ -989,6 +1104,28 @@ def _agent_tools() -> list[ToolSpec]:
         _tool("add_slow_window", {"t0_sec": "integer", "t1_sec": "integer", "label": "string"}),
         _tool("set_peak_at", {"position": "integer", "energy": "number"}),
         _tool("bump_energy", {"amount": "number", "slot_id": "integer"}),
+        ToolSpec(
+            name="set_target",
+            description=(
+                "Set the set's goals: total duration, BPM window, key strictness, and "
+                "average transition overlap. All target fields are optional — set only "
+                "those you want to change; omit the rest. The _tool() helper marks every "
+                "field required, so this uses a bare ToolSpec to keep the targets optional "
+                "while still requiring rationale (enforced via MUTATION_TOOLS)."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "target_duration_sec": {"type": ["integer", "null"], "minimum": 0},
+                    "bpm_floor": {"type": ["integer", "null"]},
+                    "bpm_ceiling": {"type": ["integer", "null"]},
+                    "key_strictness": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+                    "avg_transition_overlap_sec": {"type": "integer", "minimum": 0},
+                    "rationale": {"type": "string"},
+                },
+                "required": ["rationale"],
+            },
+        ),
         ToolSpec(
             name="analyze_transition",
             description="Analyze one transition by destination slot position.",

--- a/server/tests/test_setbuilder_pass2.py
+++ b/server/tests/test_setbuilder_pass2.py
@@ -1031,3 +1031,214 @@ def test_explain_transition_leaves_event_requests_untouched(
     db.refresh(test_request)
     assert db.query(Request).count() == before_count
     assert test_request.song_title == before_title
+
+
+def test_set_target_sets_every_field(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+
+    result, positions = apply_tool_call(
+        db,
+        set_obj,
+        "set_target",
+        {
+            "target_duration_sec": 3600,
+            "bpm_floor": 120,
+            "bpm_ceiling": 130,
+            "key_strictness": 0.8,
+            "avg_transition_overlap_sec": 12,
+            "rationale": "Dial in a one-hour peak-time set.",
+        },
+    )
+
+    assert positions == set()
+    db.refresh(set_obj)
+    assert set_obj.target_duration_sec == 3600
+    assert set_obj.bpm_floor == 120
+    assert set_obj.bpm_ceiling == 130
+    assert set_obj.key_strictness == 0.8
+    assert set_obj.avg_transition_overlap_sec == 12
+    assert result == {
+        "target_duration_sec": 3600,
+        "bpm_floor": 120,
+        "bpm_ceiling": 130,
+        "key_strictness": 0.8,
+        "avg_transition_overlap_sec": 12,
+    }
+
+
+def test_set_target_partial_update_leaves_others_unchanged(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    set_obj.bpm_floor = 118
+    set_obj.bpm_ceiling = 128
+    set_obj.key_strictness = 0.3
+    db.commit()
+    original_overlap = set_obj.avg_transition_overlap_sec
+
+    result, _ = apply_tool_call(
+        db,
+        set_obj,
+        "set_target",
+        {"target_duration_sec": 5400, "rationale": "Stretch to 90 minutes."},
+    )
+
+    db.refresh(set_obj)
+    assert set_obj.target_duration_sec == 5400
+    # Omitted fields are untouched.
+    assert set_obj.bpm_floor == 118
+    assert set_obj.bpm_ceiling == 128
+    assert set_obj.key_strictness == 0.3
+    assert set_obj.avg_transition_overlap_sec == original_overlap
+    # The result echoes only the fields the call actually set.
+    assert result == {"target_duration_sec": 5400}
+
+
+def test_set_target_clears_nullable_field_with_explicit_none(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)  # seeded target_duration_sec=420
+    assert set_obj.target_duration_sec is not None
+
+    result, _ = apply_tool_call(
+        db,
+        set_obj,
+        "set_target",
+        {"target_duration_sec": None, "rationale": "Drop the hard duration target."},
+    )
+
+    db.refresh(set_obj)
+    assert set_obj.target_duration_sec is None
+    assert result == {"target_duration_sec": None}
+
+
+def test_set_target_rejects_inverted_bpm_window(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+
+    with pytest.raises(AgentToolError, match="bpm_floor"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "set_target",
+            {"bpm_floor": 130, "bpm_ceiling": 120, "rationale": "oops"},
+        )
+
+
+def test_set_target_rejects_out_of_range_key_strictness(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+
+    for bad in (-0.1, 1.5):
+        with pytest.raises(AgentToolError, match="key_strictness"):
+            apply_tool_call(
+                db,
+                set_obj,
+                "set_target",
+                {"key_strictness": bad, "rationale": "oops"},
+            )
+
+
+def test_set_target_rejects_negative_durations(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+
+    with pytest.raises(AgentToolError, match="target_duration_sec"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "set_target",
+            {"target_duration_sec": -1, "rationale": "oops"},
+        )
+    with pytest.raises(AgentToolError, match="avg_transition_overlap_sec"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "set_target",
+            {"avg_transition_overlap_sec": -5, "rationale": "oops"},
+        )
+
+
+def test_set_target_rejects_inverted_bpm_against_existing_floor(db: Session, test_user: User):
+    """A new ceiling below the already-stored floor must be rejected too."""
+    set_obj = _mk_set_with_tracks(db, test_user)
+    set_obj.bpm_floor = 125
+    db.commit()
+
+    with pytest.raises(AgentToolError, match="bpm_floor"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "set_target",
+            {"bpm_ceiling": 120, "rationale": "Lower the top end."},
+        )
+
+
+def test_set_target_requires_rationale(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+
+    with pytest.raises(AgentToolError, match="rationale"):
+        apply_tool_call(db, set_obj, "set_target", {"target_duration_sec": 3600})
+
+
+def test_set_target_leaves_event_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    before_count = db.query(Request).count()
+    before_title = test_request.song_title
+
+    apply_tool_call(
+        db,
+        set_obj,
+        "set_target",
+        {
+            "target_duration_sec": 3000,
+            "bpm_floor": 122,
+            "bpm_ceiling": 128,
+            "rationale": "Set the targets without touching anyone's requests.",
+        },
+    )
+
+    db.refresh(test_request)
+    assert db.query(Request).count() == before_count
+    assert test_request.song_title == before_title
+
+
+def test_set_target_display_summary_is_human_readable():
+    summary = _tool_display_summary(
+        "set_target",
+        {"rationale": "x"},
+        {
+            "target_duration_sec": 3600,
+            "bpm_floor": 120,
+            "bpm_ceiling": 130,
+            "key_strictness": 0.8,
+            "avg_transition_overlap_sec": 12,
+        },
+        {},
+        {},
+    )
+    assert "duration 60 min" in summary
+    assert "BPM 120-130" in summary
+    assert "key strictness 0.8" in summary
+    assert "transition overlap 12s" in summary
+
+
+def test_set_target_display_summary_handles_clears_and_single_bounds():
+    # Cleared nullable fields and a lone floor/ceiling render distinct phrasing.
+    cleared = _tool_display_summary(
+        "set_target",
+        {"rationale": "x"},
+        {"target_duration_sec": None, "bpm_floor": None},
+        {},
+        {},
+    )
+    assert "cleared duration target" in cleared
+    assert "cleared BPM floor" in cleared
+
+    floor_only = _tool_display_summary("set_target", {"rationale": "x"}, {"bpm_floor": 124}, {}, {})
+    assert floor_only == "Set targets: BPM floor 124."
+
+    ceiling_only = _tool_display_summary(
+        "set_target", {"rationale": "x"}, {"bpm_ceiling": None}, {}, {}
+    )
+    assert ceiling_only == "Set targets: cleared BPM ceiling."
+
+    # An empty result (no fields set) still yields a sentence, never a crash.
+    assert _tool_display_summary("set_target", {"rationale": "x"}, {}, {}, {}) == (
+        "Updated set targets."
+    )


### PR DESCRIPTION
## Why

Part of #442 (Family 2 — safe mutations). The pass-2 agent could shape energy but
could not set the **set's targets** — the goal inputs the deterministic passes
optimize against. `set_target` lets the agent dial total duration, the BPM window,
key strictness, and average transition overlap.

## What

A single mutation tool `set_target` in `server/app/services/setbuilder/pass2_agent.py`:

- `_tool_set_target(db, set_obj, payload)` sets whichever of `target_duration_sec`,
  `bpm_floor`, `bpm_ceiling`, `key_strictness`, `avg_transition_overlap_sec` are
  present in the payload (all already columns on the `Set` model), then `db.flush()`.
- Returns only the fields the call actually set; affected positions are always
  `set()` (targets shape future passes but move no slots).
- Writes **only** the Set's target columns — never the `requests` table (pinned by
  a regression test).

Wiring mirrors the existing mutation tools across the 4 additive spots:
allowlist in `apply_tool_call`, `MUTATION_TOOLS`, the `_agent_tools()` schema, and a
one-sentence clause in the result-summary chain.

No new REST endpoints, no DB migrations (columns already exist), no openapi/type regen.

## Design decisions

**Schema approach — bare `ToolSpec`, not the `_tool()` helper.** The shared `_tool()`
helper marks *every* listed field `required`. The `set_target` target fields are all
optional (set only what you want to change), so the tool registers a bare `ToolSpec`
whose schema lists the targets as `properties` with `required: ["rationale"]` only.
Rationale is still enforced at runtime: `set_target` is added to `MUTATION_TOOLS`, and
`apply_tool_call` rejects any mutation tool whose payload lacks a non-empty `rationale`
before dispatch. The JSON-schema `required` is belt-and-suspenders guidance to the model.

**Omitted vs. explicit-null.** Two nullable target columns (`target_duration_sec`,
`bpm_floor`, `bpm_ceiling`) can legitimately be *cleared*. A private `_UNSET` sentinel
plus `payload.get(key, _UNSET)` distinguishes "field absent → leave unchanged" from
"field present as null → clear the column", keeping the partial-update contract crisp.

**Validation ranges.**
- `target_duration_sec`: integer ≥ 0, nullable (explicit null clears it).
- `avg_transition_overlap_sec`: integer ≥ 0, non-nullable.
- `bpm_floor` / `bpm_ceiling`: integers, nullable. If both bounds end up set — whether
  newly provided or already stored — `bpm_floor <= bpm_ceiling` is enforced, so lowering
  a ceiling below the stored floor (or vice-versa) is rejected.
- `key_strictness`: float in `[0.0, 1.0]`, non-nullable.

Any violation raises `AgentToolError` with a field-named message.

## Testing
- [x] Unit tests in `server/tests/test_setbuilder_pass2.py`: every field set, partial
  update leaves others unchanged, explicit-null clears a nullable field, inverted BPM
  window (new and against stored floor), out-of-range `key_strictness`, negative
  durations, missing-rationale, and a requests-untouched regression; plus display-summary
  branch coverage (window, single bound, cleared, empty).
- [x] Backend CI green locally: `ruff check`, `ruff format --check`, `bandit`,
  `pytest --tb=short -q` (2942 passed, coverage 87.82% ≥ 85% gate).
- [ ] CI green on PR.

🤖 Co-authored by Claude Opus 4.8. Closes #465.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `set_target` tool for updating Set target configuration including BPM windows, key strictness, and duration parameters, with built-in validation and human-readable change summaries.

* **Tests**
  * Added comprehensive test coverage for the new tool, including field updates, partial modifications, validation of invalid configurations, and display formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->