### PR TITLE
feat(setbuilder): replace_slot agent tool — atomic track swap

### DIFF
--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -41,6 +41,7 @@ MUTATION_TOOLS = {
     "reorder_slot",
     "swap_slots",
     "remove_slot",
+    "replace_slot",
     "insert_from_pool",
     "search_and_insert",
     "add_slow_window",
@@ -267,6 +268,7 @@ def apply_tool_call(
         "reorder_slot": _tool_reorder_slot,
         "swap_slots": _tool_swap_slots,
         "remove_slot": _tool_remove_slot,
+        "replace_slot": _tool_replace_slot,
         "insert_from_pool": _tool_insert_from_pool,
         "search_and_insert": _tool_search_and_insert,
         "add_slow_window": _tool_add_slow_window,
@@ -337,6 +339,24 @@ def _tool_remove_slot(
             row.position -= 1
     db.flush()
     return {"removed_slot_id": slot.id}, {position}
+
+
+def _tool_replace_slot(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Atomic track swap: keep the slot's position, point it at a new pool track.
+
+    A single op that replaces remove+insert, so the timeline never passes through
+    a transient invalid state and no positions shift. Mirrors ``_tool_remove_slot``
+    for the locked check and the insert tools for the namespaced id derivation.
+    """
+    slot = _slot_or_error(db, set_obj.id, int(payload["slot_id"]))
+    if slot.locked:
+        raise AgentToolError("Locked slots cannot be replaced")
+    track = _pool_track_or_error(db, set_obj.id, int(payload["pool_track_id"]))
+    slot.track_id = _pass1_track_meta(track).slot_track_id
+    db.flush()
+    return {"slot_id": slot.id, "pool_track_id": track.id}, {slot.position}
 
 
 def _tool_insert_from_pool(
@@ -891,6 +911,15 @@ def _tool_display_summary(
         removed = before.get(int(payload["slot_id"]))
         if removed:
             return f"Removed {removed['label']} from {_position_label(removed['position'])}."
+    if name == "replace_slot":
+        slot_id = int(result["slot_id"])
+        old = before.get(slot_id)
+        new = after.get(slot_id)
+        if old and new:
+            return (
+                f"Replaced {old['label']} with {new['label']} at "
+                f"{_position_label(new['position'])}."
+            )
     if name in {"insert_from_pool", "search_and_insert"}:
         position = int(result["position"])
         inserted = next((s for s in after.values() if s["position"] == position), None)
@@ -984,6 +1013,7 @@ def _agent_tools() -> list[ToolSpec]:
         _tool("reorder_slot", {"slot_id": "integer", "position": "integer"}),
         _tool("swap_slots", {"slot_a_id": "integer", "slot_b_id": "integer"}),
         _tool("remove_slot", {"slot_id": "integer"}),
+        _tool("replace_slot", {"slot_id": "integer", "pool_track_id": "integer"}),
         _tool("insert_from_pool", {"pool_track_id": "integer", "position": "integer"}),
         _tool("search_and_insert", {"query": "string", "position": "integer"}),
         _tool("add_slow_window", {"t0_sec": "integer", "t1_sec": "integer", "label": "string"}),

--- a/server/tests/test_setbuilder_pass2.py
+++ b/server/tests/test_setbuilder_pass2.py
@@ -1031,3 +1031,160 @@ def test_explain_transition_leaves_event_requests_untouched(
     db.refresh(test_request)
     assert db.query(Request).count() == before_count
     assert test_request.song_title == before_title
+
+
+def test_tool_display_summary_replace_slot():
+    summary = _tool_display_summary(
+        "replace_slot",
+        {"slot_id": 1, "pool_track_id": 9},
+        {"slot_id": 1, "pool_track_id": 9},
+        {1: {"position": 0, "label": "Old - A"}},
+        {1: {"position": 0, "label": "New - B"}},
+    )
+
+    assert summary == "Replaced Old - A with New - B at slot 1."
+
+
+def _pool_track_by_track_id(set_obj: Set, track_id: str) -> SetPoolTrack:
+    return next(t for t in set_obj.pool_tracks if t.track_id == track_id)
+
+
+def test_replace_slot_swaps_track_in_place(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    opener = sorted(set_obj.slots, key=lambda s: s.position)[0]
+    second = sorted(set_obj.slots, key=lambda s: s.position)[1]
+    # tidal:2 is in the pool but not yet placed in any slot.
+    replacement = _pool_track_by_track_id(set_obj, "tidal:2")
+
+    result, positions = apply_tool_call(
+        db,
+        set_obj,
+        "replace_slot",
+        {
+            "slot_id": opener.id,
+            "pool_track_id": replacement.id,
+            "rationale": "Open with a stronger track.",
+        },
+    )
+
+    db.refresh(opener)
+    db.refresh(second)
+    assert result == {"slot_id": opener.id, "pool_track_id": replacement.id}
+    assert positions == {0}
+    # Same position, new track id derived the way the insert tools derive it.
+    assert opener.position == 0
+    assert opener.track_id == "tidal:2"
+    # The other slot is untouched.
+    assert second.position == 1
+    assert second.track_id == "tidal:1"
+
+
+def test_replace_slot_rejects_locked_slot(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    opener = sorted(set_obj.slots, key=lambda s: s.position)[0]
+    opener.locked = True
+    db.commit()
+    replacement = _pool_track_by_track_id(set_obj, "tidal:2")
+    before_track_id = opener.track_id
+
+    with pytest.raises(AgentToolError, match="[Ll]ocked"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "replace_slot",
+            {
+                "slot_id": opener.id,
+                "pool_track_id": replacement.id,
+                "rationale": "Try to replace a pinned track.",
+            },
+        )
+
+    db.refresh(opener)
+    assert opener.track_id == before_track_id
+
+
+def test_replace_slot_rejects_foreign_pool_track(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    other = _mk_set_with_tracks(db, test_user)
+    opener = sorted(set_obj.slots, key=lambda s: s.position)[0]
+    foreign = _pool_track_by_track_id(other, "tidal:2")
+
+    with pytest.raises(AgentToolError, match="Pool track not found"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "replace_slot",
+            {
+                "slot_id": opener.id,
+                "pool_track_id": foreign.id,
+                "rationale": "Pull a track from another set.",
+            },
+        )
+
+
+def test_replace_slot_rejects_foreign_slot(db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    other = _mk_set_with_tracks(db, test_user)
+    foreign_slot = sorted(other.slots, key=lambda s: s.position)[0]
+    replacement = _pool_track_by_track_id(set_obj, "tidal:2")
+
+    with pytest.raises(AgentToolError, match="Slot not found"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "replace_slot",
+            {
+                "slot_id": foreign_slot.id,
+                "pool_track_id": replacement.id,
+                "rationale": "Replace a slot from another set.",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_replace_slot_requires_rationale(monkeypatch, db: Session, test_user: User):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    opener = sorted(set_obj.slots, key=lambda s: s.position)[0]
+    replacement = _pool_track_by_track_id(set_obj, "tidal:2")
+
+    async def fake_dispatch(*args, **kwargs):
+        return ChatResponse(
+            stop_reason="tool_use",
+            tool_calls=[
+                ToolCall(
+                    id="replace-1",
+                    name="replace_slot",
+                    input={"slot_id": opener.id, "pool_track_id": replacement.id},
+                )
+            ],
+        )
+
+    monkeypatch.setattr("app.services.setbuilder.pass2_agent.Gateway.dispatch", fake_dispatch)
+
+    with pytest.raises(AgentToolError, match="rationale"):
+        await chat_with_agent(db, test_user, set_obj, message="Replace the opener")
+
+
+def test_replace_slot_leaves_event_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set_with_tracks(db, test_user)
+    opener = sorted(set_obj.slots, key=lambda s: s.position)[0]
+    replacement = _pool_track_by_track_id(set_obj, "tidal:2")
+    before_count = db.query(Request).count()
+    before_title = test_request.song_title
+
+    apply_tool_call(
+        db,
+        set_obj,
+        "replace_slot",
+        {
+            "slot_id": opener.id,
+            "pool_track_id": replacement.id,
+            "rationale": "Swap the opener; the request queue must stay untouched.",
+        },
+    )
+
+    db.refresh(test_request)
+    assert db.query(Request).count() == before_count
+    assert test_request.song_title == before_title


### PR DESCRIPTION
## Why

Part of #442 (Family 2 — safe mutations). Swapping the track in a slot today means remove + insert: two ops with a transient invalid state and shifting positions. `replace_slot` does it atomically — same position, new track.

## What

Adds a single mutation tool `replace_slot` to the WrzDJSet pass-2 agent (`server/app/services/setbuilder/pass2_agent.py`):

- `_tool_replace_slot(db, set_obj, payload)` resolves the slot via `_slot_or_error`, **refuses locked slots** (`AgentToolError`, mirroring `_tool_remove_slot`), resolves the replacement via `_pool_track_or_error`, then writes **only** the slot's `track_id` — keeping its `position`. `db.flush()`; returns `({"slot_id", "pool_track_id"}, {slot.position})`.
- Wired into the 4 existing additive spots, mirroring the sibling mutation tools: `MUTATION_TOOLS`, the `handlers` allowlist in `apply_tool_call`, the `_agent_tools()` schema (`_tool("replace_slot", {"slot_id": "integer", "pool_track_id": "integer"})` — auto-adds `rationale`), and a one-sentence `replace_slot` clause in `_tool_display_summary`.

### Slot ↔ pool-track id derivation (design decision)

The new `track_id` is derived with `_pass1_track_meta(track).slot_track_id`, the exact helper the insert tools route through. It resolves to `track.track_id or f"pool:{track.id}"` (`pass1_deterministic.py`), identical to what `_insert_track_at` builds inline — so the namespacing rule stays in one place rather than being re-derived.

## Security invariants (from #442)

- **Owner-scoped**: both slot and pool track resolved against `set_obj.id`.
- **Respects `locked`**: a locked slot cannot be replaced.
- **Requires a `rationale`** (enforced by `MUTATION_TOOLS`).
- Dispatched only through `apply_tool_call`'s closed allowlist.
- Writes **only** the slot's `track_id`; **never** the `requests` table (regression test asserts unchanged).
- No new REST endpoints, no DB migrations, no openapi/type regen.

## Testing

- [x] Unit tests in `server/tests/test_setbuilder_pass2.py`: replace happy path (position preserved, other slot untouched), locked rejection, foreign pool track, foreign slot, missing-rationale, `requests`-untouched regression, display-summary.
- [x] Backend ruff check / ruff format --check / bandit: clean
- [x] Backend pytest: 2939 passed, coverage 87.92% (gate 85%)
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #467.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added track replacement operation to swap tracks in set slots while preserving their positions
  * AI agent now integrates track replacement support with built-in validation and error handling for various edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->