### PR TITLE
feat(setbuilder): apply_curve_template agent tool (#466)

### DIFF
--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -46,6 +46,7 @@ MUTATION_TOOLS = {
     "add_slow_window",
     "set_peak_at",
     "bump_energy",
+    "apply_curve_template",
 }
 ALLOWED_FLAG_TYPES = {
     "energy_dip",
@@ -272,6 +273,7 @@ def apply_tool_call(
         "add_slow_window": _tool_add_slow_window,
         "set_peak_at": _tool_set_peak_at,
         "bump_energy": _tool_bump_energy,
+        "apply_curve_template": _tool_apply_curve_template,
         "analyze_transition": _tool_analyze_transition,
         "explain_transition": _tool_explain_transition,
         "get_track_vibes": _tool_get_track_vibes,
@@ -405,6 +407,60 @@ def _tool_bump_energy(
         slot.target_energy = round(max(0.0, min(10.0, base + amount)), 1)
     db.flush()
     return {"updated": len(slots)}, {s.position for s in slots}
+
+
+def _tool_apply_curve_template(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Re-target every (unlocked) slot from a built-in or owned template shape.
+
+    Reuses the curve service the REST endpoint uses. ``locked`` slots are
+    protected: ``apply_points_to_slots`` re-targets every slot uniformly, so we
+    snapshot the locked slots' ``target_energy`` first and restore it after,
+    leaving their DJ-chosen energy untouched. Their positions are excluded from
+    the affected set and from the returned targets.
+    """
+    points = _curve_template_points(db, set_obj, payload)
+    # apply_points_to_slots re-targets EVERY slot, so snapshot locked targets
+    # first to restore them afterward; its return value is ignored because we
+    # rebuild the locked-aware targets from the slots below.
+    locked_before = {
+        slot.id: slot.target_energy for slot in _ordered_slots(db, set_obj.id) if slot.locked
+    }
+    try:
+        curve.apply_points_to_slots(db, set_obj, points, None)
+    except ValueError as exc:
+        raise AgentToolError(str(exc)) from exc
+
+    targets: list[dict[str, Any]] = []
+    affected: set[int] = set()
+    for slot in _ordered_slots(db, set_obj.id):
+        if slot.id in locked_before:
+            slot.target_energy = locked_before[slot.id]
+            continue
+        targets.append({"slot_id": slot.id, "target_energy": slot.target_energy})
+        affected.add(slot.position)
+    if locked_before:
+        db.flush()
+
+    return {"targets": targets, "windows": curve.windows_from_points(points)}, affected
+
+
+def _curve_template_points(db: Session, set_obj: Set, payload: dict[str, Any]) -> list[dict]:
+    """Resolve the template (built-in name XOR owned id) to its point list."""
+    builtin = payload.get("builtin")
+    template_id = payload.get("template_id")
+    if builtin is not None:
+        points = curve.BUILTIN_TEMPLATES.get(str(builtin))
+        if points is None:
+            raise AgentToolError("Template not found")
+        return points
+    if template_id is not None:
+        tpl = curve.get_owned_template(db, int(template_id), set_obj.owner_id)
+        if tpl is None:
+            raise AgentToolError("Template not found")
+        return curve.template_points(tpl)
+    raise AgentToolError("apply_curve_template requires builtin or template_id")
 
 
 def _tool_analyze_transition(
@@ -917,6 +973,10 @@ def _tool_display_summary(
         return (
             f"Added slow window {label} from {int(result['t0_sec'])}s to {int(result['t1_sec'])}s."
         )
+    if name == "apply_curve_template":
+        shape = str(payload.get("builtin") or "saved template")
+        count = len(result.get("targets") or [])
+        return f"Applied curve template {shape} to {count} slot{'s' if count != 1 else ''}."
     if name == "analyze_transition":
         base = (
             f"Analyzed transition into {_position_label(int(result['position']))}: "
@@ -989,6 +1049,26 @@ def _agent_tools() -> list[ToolSpec]:
         _tool("add_slow_window", {"t0_sec": "integer", "t1_sec": "integer", "label": "string"}),
         _tool("set_peak_at", {"position": "integer", "energy": "number"}),
         _tool("bump_energy", {"amount": "number", "slot_id": "integer"}),
+        ToolSpec(
+            name="apply_curve_template",
+            description=(
+                "Re-target every unlocked slot's energy from an energy-curve "
+                "template shape. Provide exactly one of builtin (a preset name) "
+                "or template_id (one of the DJ's saved templates)."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "builtin": {
+                        "type": "string",
+                        "enum": sorted(curve.BUILTIN_TEMPLATES.keys()),
+                    },
+                    "template_id": {"type": "integer"},
+                    "rationale": {"type": "string"},
+                },
+                "required": ["rationale"],
+            },
+        ),
         ToolSpec(
             name="analyze_transition",
             description="Analyze one transition by destination slot position.",

--- a/server/tests/test_setbuilder_pass2.py
+++ b/server/tests/test_setbuilder_pass2.py
@@ -3,6 +3,7 @@
 import pytest
 from sqlalchemy.orm import Session
 
+from app.models.curve_template import SetCurveTemplate
 from app.models.request import Request
 from app.models.set import Set, SetSlot
 from app.models.set_pool import SetPoolSource, SetPoolTrack
@@ -14,7 +15,7 @@ from app.models.track_vibe import (
 from app.models.user import User
 from app.services.llm.base import ChatResponse, ToolCall
 from app.services.llm.exceptions import NoLlmConfigured
-from app.services.setbuilder import agent_history
+from app.services.setbuilder import agent_history, curve
 from app.services.setbuilder.pass1_deterministic import TrackMeta
 from app.services.setbuilder.pass2_agent import (
     AgentToolError,
@@ -1031,3 +1032,209 @@ def test_explain_transition_leaves_event_requests_untouched(
     db.refresh(test_request)
     assert db.query(Request).count() == before_count
     assert test_request.song_title == before_title
+
+
+# --- apply_curve_template (#466) -------------------------------------------
+
+
+def _mk_set_for_curve(db: Session, user: User, slot_count: int = 4) -> Set:
+    """Set with ``slot_count`` slots seeded to a flat baseline target_energy."""
+    set_obj = Set(owner_id=user.id, name="Curve Set", target_duration_sec=30 * 60)
+    db.add(set_obj)
+    db.flush()
+    db.add_all(
+        [
+            SetSlot(set_id=set_obj.id, position=idx, track_id=f"tidal:{idx}", target_energy=5.0)
+            for idx in range(slot_count)
+        ]
+    )
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def _save_template(db: Session, user: User, points: list[dict]) -> SetCurveTemplate:
+    return curve.create_template(db, user.id, "My Curve", points)
+
+
+def test_apply_curve_template_applies_builtin(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user)
+
+    result, positions = apply_tool_call(
+        db,
+        set_obj,
+        "apply_curve_template",
+        {"builtin": "Club Peak", "rationale": "Reshape into a club peak arc."},
+    )
+
+    slots = sorted(set_obj.slots, key=lambda s: s.position)
+    targets = [s.target_energy for s in slots]
+    # Club Peak rises to a peak then cools — not the flat 5.0 baseline.
+    assert targets != [5.0, 5.0, 5.0, 5.0]
+    assert positions == {0, 1, 2, 3}
+    assert [row["slot_id"] for row in result["targets"]] == [s.id for s in slots]
+    assert all(0.0 <= row["target_energy"] <= 10.0 for row in result["targets"])
+
+
+def test_apply_curve_template_emits_windows_from_builtin(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user)
+
+    result, _ = apply_tool_call(
+        db,
+        set_obj,
+        "apply_curve_template",
+        {"builtin": "Wedding", "rationale": "Wedding-night energy shape."},
+    )
+
+    # Wedding carries a paired slow_start/slow_end → exactly one window.
+    assert result["windows"] == [{"t0": 0.7, "t1": 0.78}]
+
+
+def test_apply_curve_template_applies_owned_template(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user)
+    tpl = _save_template(
+        db,
+        test_user,
+        [{"t": 0, "e": 2, "label": "Low"}, {"t": 1, "e": 9, "label": "High"}],
+    )
+
+    result, positions = apply_tool_call(
+        db,
+        set_obj,
+        "apply_curve_template",
+        {"template_id": tpl.id, "rationale": "Ramp from low to high."},
+    )
+
+    slots = sorted(set_obj.slots, key=lambda s: s.position)
+    targets = [s.target_energy for s in slots]
+    # A monotonic 2->9 ramp interpolated at uniform midpoints is strictly rising.
+    assert targets == sorted(targets)
+    assert targets[0] < targets[-1]
+    assert positions == {0, 1, 2, 3}
+    assert result["windows"] == []
+
+
+def test_apply_curve_template_unknown_builtin_raises(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user)
+
+    with pytest.raises(AgentToolError, match="Template not found"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "apply_curve_template",
+            {"builtin": "Does Not Exist", "rationale": "x"},
+        )
+
+
+def test_apply_curve_template_rejects_foreign_template(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user)
+    other = User(username="other-dj", password_hash="x", is_active=True)
+    db.add(other)
+    db.commit()
+    foreign = curve.create_template(db, other.id, "Theirs", [{"t": 0, "e": 5}])
+
+    with pytest.raises(AgentToolError, match="Template not found"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "apply_curve_template",
+            {"template_id": foreign.id, "rationale": "Steal their curve."},
+        )
+
+
+def test_apply_curve_template_missing_template_id_raises(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user)
+
+    with pytest.raises(AgentToolError, match="Template not found"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "apply_curve_template",
+            {"template_id": 999999, "rationale": "Nope."},
+        )
+
+
+def test_apply_curve_template_requires_input(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user)
+
+    with pytest.raises(AgentToolError, match="builtin or template_id"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "apply_curve_template",
+            {"rationale": "No shape given."},
+        )
+
+
+def test_apply_curve_template_requires_rationale(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user)
+
+    with pytest.raises(AgentToolError, match="rationale"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "apply_curve_template",
+            {"builtin": "Club Peak"},
+        )
+
+
+def test_apply_curve_template_skips_locked_slot_energy(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user)
+    slots = sorted(set_obj.slots, key=lambda s: s.position)
+    locked = slots[1]
+    locked.locked = True
+    locked.target_energy = 3.3
+    db.commit()
+
+    result, positions = apply_tool_call(
+        db,
+        set_obj,
+        "apply_curve_template",
+        {"builtin": "Club Peak", "rationale": "Reshape but respect the lock."},
+    )
+
+    db.refresh(locked)
+    # The locked slot keeps its DJ-chosen energy; its position is not reported.
+    assert locked.target_energy == 3.3
+    assert locked.position not in positions
+    reported = {row["slot_id"]: row["target_energy"] for row in result["targets"]}
+    assert locked.id not in reported
+    # Unlocked slots were still re-targeted.
+    assert positions == {0, 2, 3}
+
+
+def test_apply_curve_template_leaves_event_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set_for_curve(db, test_user)
+    before_count = db.query(Request).count()
+    before_title = test_request.song_title
+
+    apply_tool_call(
+        db,
+        set_obj,
+        "apply_curve_template",
+        {"builtin": "Open-Format", "rationale": "Standard open-format arc."},
+    )
+
+    db.refresh(test_request)
+    assert db.query(Request).count() == before_count
+    assert test_request.song_title == before_title
+
+
+def test_apply_curve_template_in_mutation_tools():
+    from app.services.setbuilder.pass2_agent import MUTATION_TOOLS
+
+    assert "apply_curve_template" in MUTATION_TOOLS
+
+
+def test_tool_display_summary_apply_curve_template():
+    summary = _tool_display_summary(
+        "apply_curve_template",
+        {"builtin": "Club Peak"},
+        {"targets": [{"slot_id": 1, "target_energy": 7.0}], "windows": []},
+        {},
+        {},
+    )
+
+    assert summary == "Applied curve template Club Peak to 1 slot."


### PR DESCRIPTION
## Why

Part of #442 (Family 2 — safe mutations). The pass-2 agent can nudge energy point-by-point but couldn't reshape the whole curve at once. `apply_curve_template` reuses the existing curve service so the agent can re-target every slot from a built-in or saved template shape.

## What

Adds a single mutation tool `apply_curve_template` to the WrzDJSet pass-2 agent (`server/app/services/setbuilder/pass2_agent.py`):

- Input is `builtin` (a name in `curve.BUILTIN_TEMPLATES`) **or** `template_id` (an owned `SetCurveTemplate`).
- Resolves the point list via the existing curve service, re-targets slots with `curve.apply_points_to_slots(...)`, and returns `{targets, windows}` (windows from `curve.windows_from_points`).
- Wired into the four additive spots: `MUTATION_TOOLS`, the `handlers` dispatch dict, the `_agent_tools()` schema (builtin enum XOR `template_id`, forced `rationale`), and the result-summary chain. No edits to `curve.py`.

## Design decisions

### Locked slots → energy is skipped (lock respected)
`curve.apply_points_to_slots` re-targets **every** slot's energy uniformly and has no concept of `locked`; `locked` nominally protects slot *order*. The epic says mutators respect locks, and the user-facing intent of locking a slot is "leave this one alone." Re-targeting a locked slot's energy out from under the DJ violates that intent, so this tool **skips locked slots' energy**: it snapshots each locked slot's `target_energy` before the apply and restores it after. Locked slots are also excluded from the affected-positions set and from the returned `targets`. A regression test (`test_apply_curve_template_skips_locked_slot_energy`) pins this. Reviewer: flag if you'd rather energy re-targeting ignore the order-lock — it's a deliberate call, not an oversight.

### Reuse over reinvention
The logic mirrors the thin REST endpoint at `app/api/setbuilder.py:828` exactly (same service calls, same owner-scoping intent). Owner scope for the template is `set_obj.owner_id` (the chat flow only loads sets the actor owns), keeping the tool signature `(db, set_obj, payload)` consistent with every sibling tool. The curve service's `ValueError` is caught and re-raised as `AgentToolError`.

## Security invariants (from #442)
- Owner-scoped: the set is loaded owned; the `SetCurveTemplate` must belong to the same owner (foreign/missing → `AgentToolError`).
- Requires a `rationale` (enforced by `MUTATION_TOOLS`).
- Allowlist-dispatched through `apply_tool_call`.
- Writes only this set's slot targets/curve; **never** the `requests` table — `test_apply_curve_template_leaves_event_requests_untouched` asserts request count + content unchanged.
- No new REST endpoints, no DB migrations, no openapi/type regen.

## Testing
- [x] Unit tests pass — 12 new tests in `server/tests/test_setbuilder_pass2.py` (builtin apply, windows-from-builtin, owned-template apply, unknown builtin, foreign `template_id`, missing `template_id`, missing input, missing rationale, locked-slot skip, requests-untouched regression, MUTATION_TOOLS membership, display summary).
- [x] Full backend suite green: 2944 passed.
- [x] Coverage gate met: 87.97% (threshold 85%).
- [x] ruff check / ruff format --check / bandit clean.
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #466.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a curve template tool for the setbuilder agent, enabling automatic re-targeting of slot energy values using built-in or custom saved templates while protecting locked slot configurations.

* **Tests**
  * Added comprehensive test coverage for curve template functionality, including built-in and custom templates, locked slot handling, validation, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->