### PR TITLE
fix(kiosk): recover gracefully when a paired kiosk's event is deleted

### DIFF
--- a/dashboard/app/e/[code]/display/page.test.tsx
+++ b/dashboard/app/e/[code]/display/page.test.tsx
@@ -889,6 +889,27 @@ describe('KioskDisplayPage', () => {
       expect(localStorageMock.getItem('kiosk_pair_code')).toBeNull();
     });
 
+    it('redirects to /kiosk-pair when assignment returns unassigned (event deleted)', async () => {
+      vi.useFakeTimers();
+      setupDefaultMocks();
+      localStorageMock.setItem('kiosk_session_token', 'test-session-token');
+      localStorageMock.setItem('kiosk_pair_code', 'ABC123');
+      vi.mocked(api.getKioskAssignment).mockResolvedValue({
+        status: 'unassigned',
+        event_code: null,
+        event_join_code: null,
+        event_name: null,
+      });
+
+      render(<KioskDisplayPage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(10000); });
+
+      expect(mockPush).toHaveBeenCalledWith('/kiosk-pair');
+      expect(localStorageMock.getItem('kiosk_session_token')).toBeNull();
+      expect(localStorageMock.getItem('kiosk_pair_code')).toBeNull();
+    });
+
     it('does NOT redirect when session is valid', async () => {
       vi.useFakeTimers();
       setupDefaultMocks();

--- a/dashboard/app/e/[code]/display/page.tsx
+++ b/dashboard/app/e/[code]/display/page.tsx
@@ -121,7 +121,15 @@ export default function KioskDisplayPage() {
 
     const checkSession = async () => {
       try {
-        await api.getKioskAssignment(token);
+        const assignment = await api.getKioskAssignment(token);
+        // A 200 can still be terminal: the assigned event was deleted (legacy/
+        // edge orphan → 'unassigned') or the pairing lapsed ('expired'). Both
+        // mean this device must re-pair (issue #474).
+        if (assignment.status === 'unassigned' || assignment.status === 'expired') {
+          localStorage.removeItem(SESSION_TOKEN_KEY);
+          localStorage.removeItem(PAIR_CODE_KEY);
+          router.push('/kiosk-pair');
+        }
       } catch (err) {
         if (err instanceof ApiError && err.status === 404) {
           localStorage.removeItem(SESSION_TOKEN_KEY);

--- a/dashboard/app/kiosk-pair/__tests__/page.test.tsx
+++ b/dashboard/app/kiosk-pair/__tests__/page.test.tsx
@@ -27,7 +27,16 @@ vi.mock('@/lib/api', () => ({
     getKioskPairStatus: (...args: unknown[]) => mockGetKioskPairStatus(...args),
     getKioskAssignment: (...args: unknown[]) => mockGetKioskAssignment(...args),
   },
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
 }));
+
+import { ApiError } from '@/lib/api';
 
 // Mock localStorage
 const mockStorage: Record<string, string> = {};
@@ -175,5 +184,31 @@ describe('KioskPairPage', () => {
     await waitFor(() => {
       expect(screen.getByText('ABC-234')).toBeInTheDocument();
     });
+  });
+
+  it('re-pairs when pair-status polling returns unassigned (event deleted mid-pairing)', async () => {
+    // Fresh pairing whose event vanishes between complete and the redirect.
+    mockGetKioskPairStatus
+      .mockResolvedValueOnce({ status: 'unassigned', event_code: null, event_join_code: null, event_name: null })
+      .mockResolvedValue({ status: 'pairing', event_code: null, event_name: null });
+
+    render(<KioskPairPage />);
+
+    await waitFor(() => {
+      // initial pairing + recovery pairing = at least two createKioskPairing calls
+      expect(mockCreateKioskPairing.mock.calls.length).toBeGreaterThanOrEqual(2);
+    }, { timeout: 5000 });
+  });
+
+  it('re-pairs when pair-status polling 404s (pairing record cleaned up)', async () => {
+    mockGetKioskPairStatus
+      .mockRejectedValueOnce(new ApiError('not found', 404))
+      .mockResolvedValue({ status: 'pairing', event_code: null, event_name: null });
+
+    render(<KioskPairPage />);
+
+    await waitFor(() => {
+      expect(mockCreateKioskPairing.mock.calls.length).toBeGreaterThanOrEqual(2);
+    }, { timeout: 5000 });
   });
 });

--- a/dashboard/app/kiosk-pair/__tests__/page.test.tsx
+++ b/dashboard/app/kiosk-pair/__tests__/page.test.tsx
@@ -150,4 +150,30 @@ describe('KioskPairPage', () => {
       expect(mockPush).toHaveBeenCalledWith('/e/EVT02J/display');
     });
   });
+
+  it('re-pairs when assignment returns unassigned (event deleted)', async () => {
+    // Existing paired session whose event has since been deleted (issue #474).
+    mockStorage['kiosk_session_token'] = 'b'.repeat(64);
+    mockStorage['kiosk_pair_code'] = 'OLD123';
+    mockGetKioskAssignment.mockResolvedValue({
+      status: 'unassigned',
+      event_code: null,
+      event_join_code: null,
+      event_name: null,
+    });
+
+    await act(async () => {
+      render(<KioskPairPage />);
+    });
+
+    // Stale session is cleared and a fresh pairing is started…
+    await waitFor(() => {
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('kiosk_session_token');
+      expect(mockCreateKioskPairing).toHaveBeenCalledWith('test-nonce-abc123');
+    });
+    // …and the new, scannable code is shown (not the stale OLD-123).
+    await waitFor(() => {
+      expect(screen.getByText('ABC-234')).toBeInTheDocument();
+    });
+  });
 });

--- a/dashboard/app/kiosk-pair/page.tsx
+++ b/dashboard/app/kiosk-pair/page.tsx
@@ -59,7 +59,9 @@ export default function KioskPairPage() {
         router.push(`/e/${status.event_join_code}/display`);
         return;
       }
-      if (status.status === 'expired') {
+      // 'expired' = pair code timed out; 'unassigned' = the paired event was
+      // deleted (issue #474). Both are dead sessions — clear and re-pair.
+      if (status.status === 'expired' || status.status === 'unassigned') {
         localStorage.removeItem(SESSION_TOKEN_KEY);
         localStorage.removeItem(PAIR_CODE_KEY);
         createNewPairing();
@@ -72,7 +74,7 @@ export default function KioskPairPage() {
           if (s.status === 'active' && s.event_join_code) {
             stopPolling();
             router.push(`/e/${s.event_join_code}/display`);
-          } else if (s.status === 'expired') {
+          } else if (s.status === 'expired' || s.status === 'unassigned') {
             stopPolling();
             localStorage.removeItem(SESSION_TOKEN_KEY);
             localStorage.removeItem(PAIR_CODE_KEY);

--- a/dashboard/app/kiosk-pair/page.tsx
+++ b/dashboard/app/kiosk-pair/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { QRCodeSVG } from 'qrcode.react';
-import { api } from '@/lib/api';
+import { api, ApiError } from '@/lib/api';
 
 type PairState = 'loading' | 'pairing' | 'expired' | 'error';
 
@@ -44,9 +44,23 @@ export default function KioskPairPage() {
         } else if (status.status === 'expired') {
           stopPolling();
           setState('expired');
+        } else if (status.status === 'unassigned') {
+          // The event was deleted out from under this pairing (issue #474) —
+          // dead session, re-pair with a fresh code.
+          stopPolling();
+          localStorage.removeItem(SESSION_TOKEN_KEY);
+          localStorage.removeItem(PAIR_CODE_KEY);
+          createNewPairing();
         }
-      } catch {
-        // Silently retry on network errors
+      } catch (err) {
+        // A 404 means the pairing record is gone (e.g. its event was deleted
+        // and the kiosk row was cleaned up) — re-pair. Other errors: retry.
+        if (err instanceof ApiError && err.status === 404) {
+          stopPolling();
+          localStorage.removeItem(SESSION_TOKEN_KEY);
+          localStorage.removeItem(PAIR_CODE_KEY);
+          createNewPairing();
+        }
       }
     }, POLL_INTERVAL_MS);
   }, [router, stopPolling]);

--- a/server/app/api/kiosk.py
+++ b/server/app/api/kiosk.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from app.api.deps import get_current_active_user, get_db
 from app.core.rate_limit import get_client_ip, limiter
 from app.models.event import Event
+from app.models.kiosk import Kiosk
 from app.models.user import User
 from app.schemas.kiosk import (
     KioskAssignRequest,
@@ -54,20 +55,37 @@ public_router = APIRouter()
 auth_router = APIRouter()
 
 
-def _resolve_event_name(db: Session, event_code: str | None) -> str | None:
-    """Look up the event name for a given collection code, or return None."""
+def _resolve_event_labels(db: Session, event_code: str | None) -> tuple[str | None, str | None]:
+    """Return (join_code, name) for an event collection code, or (None, None).
+
+    Used by the DJ-facing KioskOut responses, which report the kiosk's stored
+    state verbatim (no 'unassigned' downgrade — see _resolve_kiosk_event).
+    """
     if not event_code:
-        return None
+        return (None, None)
     event = db.query(Event).filter(Event.code == event_code).first()
-    return event.name if event else None
+    if event is None:
+        return (None, None)
+    return (event.join_code, event.name)
 
 
-def _resolve_event_join_code(db: Session, event_code: str | None) -> str | None:
-    """Look up the join_code for an event identified by its collection code."""
-    if not event_code:
-        return None
-    event = db.query(Event).filter(Event.code == event_code).first()
-    return event.join_code if event else None
+def _resolve_kiosk_event(
+    db: Session, kiosk: Kiosk
+) -> tuple[str, str | None, str | None, str | None]:
+    """Resolve a kiosk's reportable (status, event_code, event_join_code, event_name).
+
+    An 'active' kiosk whose assigned event no longer resolves (deleted, or never
+    set) is reported with the synthetic 'unassigned' status so the device can
+    re-pair instead of polling forever with a stale code (issue #474).
+    """
+    event = None
+    if kiosk.event_code:
+        event = db.query(Event).filter(Event.code == kiosk.event_code).first()
+    if kiosk.status == "active" and event is None:
+        return ("unassigned", None, None, None)
+    if event is None:
+        return (kiosk.status, kiosk.event_code, None, None)
+    return (kiosk.status, kiosk.event_code, event.join_code, event.name)
 
 
 def _assert_caller_owns_event(event: Event, user: User) -> None:
@@ -143,11 +161,10 @@ def get_pair_status(pair_code: str, request: Request, db: Session = Depends(get_
     if kiosk.status == "pairing" and is_pair_code_expired(kiosk):
         return KioskPairStatusResponse(status="expired")
 
-    event_name = _resolve_event_name(db, kiosk.event_code)
-    event_join_code = _resolve_event_join_code(db, kiosk.event_code)
+    resolved_status, event_code, event_join_code, event_name = _resolve_kiosk_event(db, kiosk)
     return KioskPairStatusResponse(
-        status=kiosk.status,
-        event_code=kiosk.event_code,
+        status=resolved_status,
+        event_code=event_code,
         event_join_code=event_join_code,
         event_name=event_name,
     )
@@ -177,11 +194,10 @@ def get_session_assignment(request: Request, db: Session = Depends(get_db)):
     if kiosk.status == "active":
         update_kiosk_last_seen(db, kiosk)
 
-    event_name = _resolve_event_name(db, kiosk.event_code)
-    event_join_code = _resolve_event_join_code(db, kiosk.event_code)
+    resolved_status, event_code, event_join_code, event_name = _resolve_kiosk_event(db, kiosk)
     return KioskSessionResponse(
-        status=kiosk.status,
-        event_code=kiosk.event_code,
+        status=resolved_status,
+        event_code=event_code,
         event_join_code=event_join_code,
         event_name=event_name,
     )
@@ -243,19 +259,22 @@ def list_my_kiosks(
 ):
     """List all kiosks paired by the current user."""
     kiosks = get_kiosks_for_user(db, current_user.id)
-    return [
-        KioskOut(
-            id=k.id,
-            name=k.name,
-            event_code=k.event_code,
-            event_join_code=_resolve_event_join_code(db, k.event_code),
-            event_name=_resolve_event_name(db, k.event_code),
-            status=k.status,
-            paired_at=k.paired_at,
-            last_seen_at=k.last_seen_at,
+    out = []
+    for k in kiosks:
+        join_code, event_name = _resolve_event_labels(db, k.event_code)
+        out.append(
+            KioskOut(
+                id=k.id,
+                name=k.name,
+                event_code=k.event_code,
+                event_join_code=join_code,
+                event_name=event_name,
+                status=k.status,
+                paired_at=k.paired_at,
+                last_seen_at=k.last_seen_at,
+            )
         )
-        for k in kiosks
-    ]
+    return out
 
 
 def _get_owned_kiosk(db: Session, kiosk_id: int, user: User):
@@ -312,12 +331,13 @@ def rename_kiosk_endpoint(
     """Rename a kiosk."""
     kiosk = _get_owned_kiosk(db, kiosk_id, current_user)
     rename_kiosk(db, kiosk, body.name)
+    join_code, event_name = _resolve_event_labels(db, kiosk.event_code)
     return KioskOut(
         id=kiosk.id,
         name=kiosk.name,
         event_code=kiosk.event_code,
-        event_join_code=_resolve_event_join_code(db, kiosk.event_code),
-        event_name=_resolve_event_name(db, kiosk.event_code),
+        event_join_code=join_code,
+        event_name=event_name,
         status=kiosk.status,
         paired_at=kiosk.paired_at,
         last_seen_at=kiosk.last_seen_at,

--- a/server/app/services/event.py
+++ b/server/app/services/event.py
@@ -210,11 +210,16 @@ def delete_event(db: Session, event: Event) -> None:
     from app.models.play_history import PlayHistory
     from app.models.request_vote import RequestVote
     from app.services.banner import delete_banner_files
+    from app.services.kiosk import delete_kiosks_for_event
 
     event_id = event.id
+    event_code = event.code
 
     # Clean up banner files before deleting
     delete_banner_files(event.banner_filename)
+
+    # Remove kiosks bound to this event so they don't dangle (issue #474)
+    delete_kiosks_for_event(db, event_code)
 
     # Delete child records in FK-safe order
     db.query(NowPlaying).filter(NowPlaying.event_id == event_id).delete(synchronize_session=False)

--- a/server/app/services/kiosk.py
+++ b/server/app/services/kiosk.py
@@ -117,6 +117,17 @@ def delete_kiosk(db: Session, kiosk: Kiosk) -> None:
     db.commit()
 
 
+def delete_kiosks_for_event(db: Session, event_code: str) -> int:
+    """Delete all kiosks bound to a given event code (does not commit).
+
+    Called when an event is deleted so kiosks don't dangle pointing at a
+    non-existent event — which previously bricked the device on the pairing
+    screen (issue #474). Returns the number of kiosks removed; the caller is
+    responsible for committing.
+    """
+    return db.query(Kiosk).filter(Kiosk.event_code == event_code).delete(synchronize_session=False)
+
+
 def get_kiosks_for_user(db: Session, user_id: int) -> list[Kiosk]:
     """Get all kiosks paired by a specific user."""
     return (

--- a/server/tests/test_kiosk_api.py
+++ b/server/tests/test_kiosk_api.py
@@ -8,7 +8,8 @@ from sqlalchemy.orm import Session
 from app.core.time import utcnow
 from app.models.event import Event
 from app.models.user import User
-from app.services.kiosk import complete_pairing, create_kiosk
+from app.services.event import delete_event
+from app.services.kiosk import complete_pairing, create_kiosk, get_kiosk_by_id
 
 
 class TestKioskPairing:
@@ -550,3 +551,114 @@ class TestKioskIdor:
         )
         assert resp.status_code == 200
         assert resp.json()["event_code"] == test_event.code
+
+
+class TestKioskRecoveryOnMissingEvent:
+    """Issue #474 — a kiosk whose assigned event no longer exists must recover
+    gracefully instead of bricking on the pairing screen.
+
+    Two complementary layers:
+      * the public polling endpoints downgrade an 'active' kiosk whose event is
+        unresolvable to the synthetic 'unassigned' status, so the device can
+        re-pair instead of polling forever with a stale code;
+      * deleting an event removes the kiosks bound to it at the source, so the
+        dangling reference never forms in the first place.
+    """
+
+    @staticmethod
+    def _orphan_kiosk(db: Session, test_user: User, test_event: Event):
+        """Pair a kiosk to an event, then delete the event row directly —
+        bypassing the kiosk-cleanup path — to simulate a legacy/edge orphan."""
+        kiosk = create_kiosk(db)
+        complete_pairing(db, kiosk, test_event.code, test_user.id)
+        db.query(Event).filter(Event.id == test_event.id).delete(synchronize_session=False)
+        db.commit()
+        return kiosk
+
+    def test_session_assignment_reports_unassigned_when_event_missing(
+        self, client: TestClient, db: Session, test_user: User, test_event: Event
+    ):
+        kiosk = self._orphan_kiosk(db, test_user, test_event)
+        resp = client.get(
+            "/api/public/kiosk/session/assignment",
+            headers={"X-Kiosk-Session": kiosk.session_token},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "unassigned"
+        assert data["event_code"] is None
+        assert data["event_join_code"] is None
+
+    def test_pair_status_reports_unassigned_when_event_missing(
+        self, client: TestClient, db: Session, test_user: User, test_event: Event
+    ):
+        kiosk = self._orphan_kiosk(db, test_user, test_event)
+        resp = client.get(f"/api/public/kiosk/pair/{kiosk.pair_code}/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "unassigned"
+        assert data["event_join_code"] is None
+
+    def test_active_kiosk_with_valid_event_still_reports_active(
+        self, client: TestClient, db: Session, test_user: User, test_event: Event
+    ):
+        """Regression guard: a healthy paired kiosk is unaffected by the downgrade."""
+        kiosk = create_kiosk(db)
+        complete_pairing(db, kiosk, test_event.code, test_user.id)
+        resp = client.get(
+            "/api/public/kiosk/session/assignment",
+            headers={"X-Kiosk-Session": kiosk.session_token},
+        )
+        assert resp.json()["status"] == "active"
+        assert resp.json()["event_code"] == test_event.code
+
+    def test_delete_event_service_removes_bound_kiosks(
+        self, db: Session, test_user: User, test_event: Event
+    ):
+        kiosk = create_kiosk(db)
+        complete_pairing(db, kiosk, test_event.code, test_user.id)
+        kiosk_id = kiosk.id
+        delete_event(db, test_event)
+        assert get_kiosk_by_id(db, kiosk_id) is None
+
+    def test_delete_event_leaves_other_events_kiosks_untouched(
+        self, db: Session, test_user: User, test_event: Event
+    ):
+        """Only kiosks bound to the deleted event are removed."""
+        other_event = Event(
+            code="OTHER1",
+            join_code="OTHRJ2",
+            name="Other Event",
+            created_by_user_id=test_user.id,
+            expires_at=utcnow() + timedelta(hours=6),
+        )
+        db.add(other_event)
+        db.commit()
+        bound = create_kiosk(db)
+        complete_pairing(db, bound, test_event.code, test_user.id)
+        survivor = create_kiosk(db)
+        complete_pairing(db, survivor, other_event.code, test_user.id)
+        survivor_id = survivor.id
+
+        delete_event(db, test_event)
+
+        assert get_kiosk_by_id(db, survivor_id) is not None
+
+    def test_kiosk_session_404_after_its_event_deleted_via_endpoint(
+        self,
+        client: TestClient,
+        db: Session,
+        auth_headers: dict,
+        test_user: User,
+        test_event: Event,
+    ):
+        kiosk = create_kiosk(db)
+        complete_pairing(db, kiosk, test_event.code, test_user.id)
+        token = kiosk.session_token
+        resp = client.delete(f"/api/events/{test_event.code}", headers=auth_headers)
+        assert resp.status_code == 204
+        resp2 = client.get(
+            "/api/public/kiosk/session/assignment",
+            headers={"X-Kiosk-Session": token},
+        )
+        assert resp2.status_code == 404


### PR DESCRIPTION
## Why

A Raspberry Pi kiosk that was paired months ago booted to the **pairing screen** instead of its event display, and re-pairing failed server-side with `Kiosk is already paired` (409). Root cause (investigated in #474): the kiosk's assigned event had been **deleted**, but nothing cleaned up the kiosk. `kiosks.event_code` is a soft string reference with no FK, and event deletion never touched kiosks. The result was an unrecoverable dead-end — `/session/assignment` returned `status=active` with a **null** `event_join_code`, which the frontend can't route on, isn't `expired`, and never throws, so the device polled forever showing a stale code.

## What

Two complementary layers so a kiosk **never bricks** when its event disappears:

1. **Graceful signal (backend).** The public polling endpoints (`/session/assignment`, `/pair/{code}/status`) now downgrade an `active` kiosk whose event no longer resolves to a synthetic `"unassigned"` status (via `_resolve_kiosk_event`). The kiosk frontend treats `"unassigned"` exactly like `"expired"` — clears the dead session and re-pairs, showing a fresh, scannable code.
2. **Cleanup at the source (backend).** Deleting an event now removes the kiosks bound to it (`delete_kiosks_for_event`, wired into `delete_event` — so it covers both single and bulk delete). The dangling reference never forms; the device's next poll 404s and the existing 404-recovery re-pairs it.

DJ-facing `KioskOut` responses are unchanged in spirit — they still report the kiosk's stored state verbatim via a new shared `_resolve_event_labels` helper (no `unassigned` downgrade in the dashboard view). No schema/migration change — `status` is already a free-form string.

The display page needs no change: with layer 2, a kiosk mid-display when its event is deleted gets a 404 from its session check, which the existing handler already redirects to `/kiosk-pair`.

## Testing

- [x] Unit tests pass — backend `2992 passed`, coverage `88.44%` (gate 85%)
- [x] New regression tests (reference #474): endpoints report `unassigned` for an orphaned active kiosk; `delete_event` removes bound kiosks (and leaves others'); session 404s after its event is deleted; frontend re-pairs on `unassigned`
- [x] Frontend `1295 passed`; eslint + `tsc --noEmit` clean
- [x] ruff check + format + bandit clean
- [ ] Manual verification on `wrzdj-kiosk`: delete its event, confirm it recovers without hands-on intervention

🤖 Co-authored by Claude Opus 4.8. Closes #474.