### PR TITLE
ci: re-add Docker Build Smoke Test check, drop slow multi-arch builds from PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,9 +219,13 @@ jobs:
   docker-build:
     name: Docker Build Smoke Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,3 +216,37 @@ jobs:
       - name: Run tests
         run: python -m pytest test_portal.py -q
 
+  docker-build:
+    name: Docker Build Smoke Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      # amd64-only, no push: verifies both images build on every PR/push without
+      # paying for the multi-arch (arm64-under-QEMU) publish, which now runs only
+      # on main/tag pushes in docker-publish.yml. The job NAME must stay exactly
+      # "Docker Build Smoke Test" — main's branch protection requires that check.
+      - name: Build backend image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./server
+          platforms: linux/amd64
+          push: false
+          load: false
+          cache-from: type=gha,scope=ci-api
+          cache-to: type=gha,mode=max,scope=ci-api
+
+      - name: Build frontend image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./dashboard
+          build-args: |
+            NEXT_PUBLIC_API_URL=http://localhost:8000
+          platforms: linux/amd64
+          push: false
+          load: false
+          cache-from: type=gha,scope=ci-web
+          cache-to: type=gha,mode=max,scope=ci-web

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,11 +1,12 @@
 name: Docker Publish
 
+# PR-time image validation lives in ci.yml's "Docker Build Smoke Test" (amd64,
+# no push). This workflow only runs on main/tag pushes, where it does the full
+# multi-arch build+push to GHCR — keeping the slow arm64-under-QEMU build off PRs.
 on:
   push:
     branches: [main]
     tags: ['v*']
-  pull_request:
-    branches: [main]
 
 env:
   REGISTRY: ghcr.io
@@ -26,7 +27,6 @@ jobs:
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -52,7 +52,7 @@ jobs:
         with:
           context: ./server
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -71,7 +71,6 @@ jobs:
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -99,7 +98,7 @@ jobs:
           build-args: |
             NEXT_PUBLIC_API_URL=__WRZDJ_API_URL__
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -40,7 +40,6 @@ jobs:
           images: ${{ env.API_IMAGE }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -65,7 +64,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -84,7 +83,6 @@ jobs:
           images: ${{ env.WEB_IMAGE }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
## Why

`main`'s branch protection requires a status check named **`Docker Build Smoke Test`** that **no workflow has emitted** since Docker building moved out of `ci.yml` into the dedicated `docker-publish.yml` (#318). GitHub matches required checks by *name*, so it waits forever for a check that never reports — every PR shows `BLOCKED` + `REVIEW_REQUIRED`, and only `--admin` merges get through. That silently defeats branch protection.

Separately, `docker-publish.yml` ran a full `linux/amd64,linux/arm64` build on every PR (arm64 under QEMU emulation — the slow part) **without** being a required check: it cost a lot of PR wall-clock while gating nothing.

## What

- **`ci.yml`** — re-introduce a job named exactly **`Docker Build Smoke Test`** that builds both images **amd64-only, no push**, with GHA layer caching. Because the job name matches the existing required check, branch protection is satisfied by a real, fast build — **no repo-config/API change needed**, the fix ships entirely in version-controlled YAML.
- **`docker-publish.yml`** — drop the `pull_request` trigger so the heavy multi-arch build+push to GHCR runs **only on `main`/tag pushes**, and remove the now-dead `!= 'pull_request'` conditionals (`push:` is now unconditionally `true`).

Net effect: PRs get a fast Docker build signal that actually gates merges; the slow arm64/QEMU build no longer runs on PRs; release publishing on `main`/tags is unchanged.

## Testing
- [x] Both workflows parse as valid YAML
- [x] Backend image builds locally (amd64): `docker build ./server` → OK
- [x] Frontend image builds locally (amd64): `docker build --build-arg NEXT_PUBLIC_API_URL=… ./dashboard` → OK
- [x] CI green on this PR — and the `Docker Build Smoke Test` check now **reports** (this PR is itself the proof: it should become mergeable without `--admin`)
- [ ] After merge: confirm `main`/tag push still publishes multi-arch images to GHCR (no regression in the release path)

🤖 Co-authored by Claude Opus 4.8. Closes #476.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Docker build smoke tests to validate container image builds on pull requests
  * Updated Docker image publishing workflow to publish only on main branch pushes and version tag releases
  * Optimized Docker build caching configuration for backend and frontend services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->