### PR TITLE
feat(setbuilder): move_range agent tool — relocate a contiguous slot block

### DIFF
--- a/server/app/services/setbuilder/agent_common.py
+++ b/server/app/services/setbuilder/agent_common.py
@@ -14,6 +14,7 @@ from app.models.set_pool import SetPoolTrack
 
 MUTATION_TOOLS = {
     "reorder_slot",
+    "move_range",
     "swap_slots",
     "remove_slot",
     "replace_slot",

--- a/server/app/services/setbuilder/agent_display.py
+++ b/server/app/services/setbuilder/agent_display.py
@@ -35,6 +35,15 @@ def _tool_display_summary(
                 f"Moved {slot['label']} from {_position_label(slot['position'])} to "
                 f"{_position_label(int(result['position']))}."
             )
+    if name == "move_range":
+        start = int(result["start_position"])
+        end = int(result["end_position"])
+        span = (
+            _position_label(start)
+            if int(result["moved_count"]) == 1
+            else f"slots {start + 1}–{end + 1}"
+        )
+        return f"Moved {span} to {_position_label(int(result['to_position']))}."
     if name == "remove_slot":
         removed = before.get(int(payload["slot_id"]))
         if removed:

--- a/server/app/services/setbuilder/agent_tool_specs.py
+++ b/server/app/services/setbuilder/agent_tool_specs.py
@@ -50,6 +50,10 @@ def _critique_tool() -> ToolSpec:
 def _agent_tools() -> list[ToolSpec]:
     return [
         _tool("reorder_slot", {"slot_id": "integer", "position": "integer"}),
+        _tool(
+            "move_range",
+            {"start_position": "integer", "end_position": "integer", "to_position": "integer"},
+        ),
         _tool("swap_slots", {"slot_a_id": "integer", "slot_b_id": "integer"}),
         _tool("remove_slot", {"slot_id": "integer"}),
         _tool("replace_slot", {"slot_id": "integer", "pool_track_id": "integer"}),

--- a/server/app/services/setbuilder/agent_tools_mutations.py
+++ b/server/app/services/setbuilder/agent_tools_mutations.py
@@ -52,6 +52,44 @@ def _tool_reorder_slot(
     return {"slot_id": slot.id, "position": new_position}, set(range(low, high + 1))
 
 
+def _tool_move_range(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Relocate the contiguous slot block ``[start_position, end_position]`` so it
+    begins at ``to_position`` (clamped to a valid insertion index).
+
+    The span analogue of ``_tool_reorder_slot``: a locked slot may never change
+    position (neither dragged inside the block nor displaced by the shift), and
+    the handler returns the touched position window for the orchestrator to
+    rescore — it does not rescore itself.
+    """
+    slots = _ordered_slots(db, set_obj.id)
+    count = len(slots)
+    start = int(payload["start_position"])
+    end = int(payload["end_position"])
+    if not 0 <= start <= end < count:
+        raise AgentToolError("start_position and end_position must be a valid slot range")
+    block = slots[start : end + 1]
+    if any(slot.locked for slot in block):
+        raise AgentToolError("Cannot move a locked slot")
+    remaining = slots[:start] + slots[end + 1 :]
+    to_position = max(0, min(len(remaining), int(payload["to_position"])))
+    new_order = remaining[:to_position] + block + remaining[to_position:]
+    if any(slot.locked and slot.position != idx for idx, slot in enumerate(new_order)):
+        raise AgentToolError("Move would displace a locked slot")
+    for idx, slot in enumerate(new_order):
+        slot.position = idx
+    db.flush()
+    block_len = len(block)
+    affected = set(range(min(start, to_position), max(end, to_position + block_len - 1) + 1))
+    return {
+        "start_position": start,
+        "end_position": end,
+        "to_position": to_position,
+        "moved_count": block_len,
+    }, affected
+
+
 def _tool_swap_slots(
     db: Session, set_obj: Set, payload: dict[str, Any]
 ) -> tuple[dict[str, Any], set[int]]:

--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -35,6 +35,7 @@ from app.services.setbuilder.agent_tools_mutations import (
     _tool_bump_energy,
     _tool_insert_from_pool,
     _tool_lock_slot,
+    _tool_move_range,
     _tool_remove_curve_point,
     _tool_remove_slot,
     _tool_reorder_slot,
@@ -301,6 +302,7 @@ def apply_tool_call(
         raise AgentToolError(f"{name} requires a rationale")
     handlers = {
         "reorder_slot": _tool_reorder_slot,
+        "move_range": _tool_move_range,
         "swap_slots": _tool_swap_slots,
         "remove_slot": _tool_remove_slot,
         "replace_slot": _tool_replace_slot,

--- a/server/tests/test_setbuilder_pass2.py
+++ b/server/tests/test_setbuilder_pass2.py
@@ -1975,3 +1975,214 @@ def test_set_curve_point_schema_keeps_label_optional():
     assert required == {"position_sec", "energy", "rationale"}
     assert "label" not in required
     assert "label" in spec.input_schema["properties"]
+
+
+# move_range (#442, Family 3) — relocate a contiguous block of slots
+# ---------------------------------------------------------------------------
+
+
+def _ordered_track_ids(db: Session, set_id: int) -> list[str | None]:
+    """Slot track_ids in position order — the visible timeline sequence."""
+    rows = db.query(SetSlot).filter(SetSlot.set_id == set_id).order_by(SetSlot.position.asc()).all()
+    return [row.track_id for row in rows]
+
+
+def test_move_range_relocates_contiguous_block(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user, slot_count=5)
+
+    result, affected = apply_tool_call(
+        db,
+        set_obj,
+        "move_range",
+        {
+            "start_position": 1,
+            "end_position": 2,
+            "to_position": 3,
+            "rationale": "Group the mid-set builders together before the peak.",
+        },
+    )
+
+    # remaining = [0, 3, 4]; insert block [1, 2] at index 3 -> [0, 3, 4, 1, 2]
+    assert _ordered_track_ids(db, set_obj.id) == [
+        "tidal:0",
+        "tidal:3",
+        "tidal:4",
+        "tidal:1",
+        "tidal:2",
+    ]
+    assert result == {
+        "start_position": 1,
+        "end_position": 2,
+        "to_position": 3,
+        "moved_count": 2,
+    }
+    # Everything from the block's old start (1) to its new end (4) is touched.
+    assert affected == {1, 2, 3, 4}
+
+
+def test_move_range_to_front(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user, slot_count=5)
+
+    apply_tool_call(
+        db,
+        set_obj,
+        "move_range",
+        {
+            "start_position": 2,
+            "end_position": 3,
+            "to_position": 0,
+            "rationale": "Open with the two anthems.",
+        },
+    )
+
+    assert _ordered_track_ids(db, set_obj.id) == [
+        "tidal:2",
+        "tidal:3",
+        "tidal:0",
+        "tidal:1",
+        "tidal:4",
+    ]
+
+
+def test_move_range_clamps_to_position_past_end(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user, slot_count=4)
+
+    result, _ = apply_tool_call(
+        db,
+        set_obj,
+        "move_range",
+        {
+            "start_position": 0,
+            "end_position": 0,
+            "to_position": 99,
+            "rationale": "Send the opener to the very end.",
+        },
+    )
+
+    assert _ordered_track_ids(db, set_obj.id) == [
+        "tidal:1",
+        "tidal:2",
+        "tidal:3",
+        "tidal:0",
+    ]
+    assert result["to_position"] == 3  # clamped to len(remaining)
+
+
+def test_move_range_requires_rationale(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user, slot_count=4)
+
+    with pytest.raises(AgentToolError, match="rationale"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "move_range",
+            {"start_position": 0, "end_position": 1, "to_position": 2},
+        )
+
+
+def test_move_range_rejects_invalid_span(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user, slot_count=4)
+
+    with pytest.raises(AgentToolError, match="start_position"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "move_range",
+            {
+                "start_position": 2,
+                "end_position": 1,
+                "to_position": 0,
+                "rationale": "Inverted span should be rejected.",
+            },
+        )
+
+
+def test_move_range_rejects_locked_slot_in_block(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user, slot_count=5)
+    slots = sorted(set_obj.slots, key=lambda s: s.position)
+    slots[2].locked = True
+    db.commit()
+
+    with pytest.raises(AgentToolError, match="locked"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "move_range",
+            {
+                "start_position": 1,
+                "end_position": 2,
+                "to_position": 4,
+                "rationale": "Tried to drag a pinned slot inside the block.",
+            },
+        )
+
+
+def test_move_range_rejects_displacing_locked_slot(db: Session, test_user: User):
+    set_obj = _mk_set_for_curve(db, test_user, slot_count=5)
+    slots = sorted(set_obj.slots, key=lambda s: s.position)
+    slots[0].locked = True  # pinned opener
+    db.commit()
+
+    with pytest.raises(AgentToolError, match="locked"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "move_range",
+            {
+                "start_position": 3,
+                "end_position": 4,
+                "to_position": 0,
+                "rationale": "Moving the closers to the front would shove the pinned opener.",
+            },
+        )
+
+
+def test_move_range_leaves_event_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set_for_curve(db, test_user, slot_count=4)
+    before_count = db.query(Request).count()
+    before_title = test_request.song_title
+
+    apply_tool_call(
+        db,
+        set_obj,
+        "move_range",
+        {
+            "start_position": 0,
+            "end_position": 1,
+            "to_position": 2,
+            "rationale": "Reorder must never touch the request queue.",
+        },
+    )
+
+    db.refresh(test_request)
+    assert db.query(Request).count() == before_count
+    assert test_request.song_title == before_title
+
+
+def test_move_range_registered_as_mutation_tool():
+    from app.services.setbuilder.pass2_agent import MUTATION_TOOLS
+
+    assert "move_range" in MUTATION_TOOLS
+    assert "move_range" in {tool.name for tool in _agent_tools()}
+
+
+def test_tool_display_summary_move_range():
+    summary = _tool_display_summary(
+        "move_range",
+        {},
+        {"start_position": 1, "end_position": 2, "to_position": 3, "moved_count": 2},
+        {},
+        {},
+    )
+    assert summary == "Moved slots 2–3 to slot 4."
+
+    single = _tool_display_summary(
+        "move_range",
+        {},
+        {"start_position": 0, "end_position": 0, "to_position": 3, "moved_count": 1},
+        {},
+        {},
+    )
+    assert single == "Moved slot 1 to slot 4."


### PR DESCRIPTION
> **Stacked on #483** (the pass2_agent.py split). Review/merge that first; this PR's diff is clean once #483 lands and this rebases onto main.

## Why
The agent can reorder one slot at a time, but moving a contiguous block ("pull slots 4–6 to the front") takes N single reorders. #442 Family 3 calls for a single atomic block move.

## What
`move_range` relocates the contiguous block `[start_position, end_position]` so it begins at `to_position` (clamped). The span analogue of `reorder_slot`: it reuses the **locked-anchor invariant** (a locked slot may never change position — neither dragged inside the block nor displaced by the shift) and returns the touched position window for the orchestrator to rescore, rather than calling `apply_slot_order` (which eagerly rescores everything and would break the handler contract).

Owner-scoped, requires `rationale`, renders in ToolCard, and a regression test asserts the `requests` table is untouched.

## Testing
- [x] Unit tests pass (10 new; full suite 3002)
- [x] Coverage 88.49% (gate 85%)
- [x] ruff + bandit clean
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #481. Part of #442 (Family 3).