### PR TITLE
feat(setbuilder): suggest_pairings/add_pairing/remove_pairing agent tools

### DIFF
--- a/server/app/services/setbuilder/agent_common.py
+++ b/server/app/services/setbuilder/agent_common.py
@@ -29,6 +29,8 @@ MUTATION_TOOLS = {
     "set_target",
     "lock_slot",
     "unlock_slot",
+    "add_pairing",
+    "remove_pairing",
 }
 
 

--- a/server/app/services/setbuilder/agent_display.py
+++ b/server/app/services/setbuilder/agent_display.py
@@ -148,6 +148,16 @@ def _tool_display_summary(
             head = f"Critique grade {grade}."
             return f"{head} {summary}" if summary else head
         return "Recomputed critique context."
+    if name == "suggest_pairings":
+        total = len(result.get("transitions") or [])
+        pinned = int(result.get("pinned_count") or 0)
+        return f"Reviewed {total} transition{'s' if total != 1 else ''}; {pinned} already pinned."
+    if name == "add_pairing":
+        transition = f"{result.get('from_label')} → {result.get('into_label')}"
+        verb = "Pinned the transition" if result.get("created") else "Updated the pinned transition"
+        return f"{verb} {transition}."
+    if name == "remove_pairing":
+        return f"Unpinned the transition {result.get('from_label')} → {result.get('into_label')}."
     return name.replace("_", " ").capitalize() + "."
 
 

--- a/server/app/services/setbuilder/agent_tool_specs.py
+++ b/server/app/services/setbuilder/agent_tool_specs.py
@@ -70,6 +70,15 @@ def _agent_tools() -> list[ToolSpec]:
         _tool("remove_curve_point", {"position_sec": "integer"}),
         _tool("lock_slot", {"slot_id": "integer"}),
         _tool("unlock_slot", {"slot_id": "integer"}),
+        _tool(
+            "add_pairing",
+            {"from_pool_track_id": "integer", "into_pool_track_id": "integer"},
+            optional_fields={"note": "string", "tags": "array"},
+        ),
+        _tool(
+            "remove_pairing",
+            {"from_pool_track_id": "integer", "into_pool_track_id": "integer"},
+        ),
         ToolSpec(
             name="set_target",
             description=(
@@ -150,6 +159,15 @@ def _agent_tools() -> list[ToolSpec]:
         ToolSpec(
             name="analyze_pool_gaps",
             description=("Report pool coverage holes: missing Camelot keys and sparse BPM bands."),
+            input_schema={"type": "object", "properties": {}},
+        ),
+        ToolSpec(
+            name="suggest_pairings",
+            description=(
+                "Read-only: the set's consecutive transitions with their score and "
+                "whether each is already pinned as a DJ pairing, plus each endpoint's "
+                "pool_track_id so strong unpinned ones can be pinned with add_pairing."
+            ),
             input_schema={"type": "object", "properties": {}},
         ),
         _critique_tool(),

--- a/server/app/services/setbuilder/agent_tools_mutations.py
+++ b/server/app/services/setbuilder/agent_tools_mutations.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 
 from app.models.set import Set, SetSlot
 from app.models.set_pool import SetPoolTrack
-from app.services.setbuilder import curve
+from app.services.setbuilder import curve, pairings
 from app.services.setbuilder.agent_common import (
     AgentToolError,
     _ordered_slots,
@@ -413,3 +413,82 @@ def _insert_track_at(
     db.add(SetSlot(set_id=set_obj.id, position=position, track_id=slot_track_id))
     db.flush()
     return {"pool_track_id": track.id, "position": position}, set(range(position, len(slots) + 1))
+
+
+def _tool_add_pairing(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Pin a transition as a DJ pairing (#442): the from->into pair gets a +20
+    pass-1 ordering boost. Owner-scoped via the pool tracks; writes only the
+    set's pairings, never the requests table.
+
+    Affects no slot positions or stored scores (the boost steers future pass-1
+    candidate ordering, not the current adjacency), so the affected set is empty.
+    The service runs with ``commit=False`` so the agent turn commits/rolls back
+    as one unit.
+    """
+    from_track_id, from_track = _pairing_endpoint(db, set_obj, payload, "from_pool_track_id")
+    into_track_id, into_track = _pairing_endpoint(db, set_obj, payload, "into_pool_track_id")
+    if from_track_id == into_track_id:
+        raise AgentToolError("A pairing needs two different tracks")
+    note = payload.get("note")
+    tags = payload.get("tags") or []
+    if not isinstance(tags, list):
+        raise AgentToolError("tags must be a list of strings")
+    try:
+        pairing, created = pairings.upsert_pairing(
+            db,
+            set_obj,
+            from_track_id=from_track_id,
+            into_track_id=into_track_id,
+            cue_in_sec=None,
+            note=str(note)[:500] if note is not None else None,
+            tags=[str(tag) for tag in tags],
+            commit=False,
+        )
+    except ValueError as exc:
+        raise AgentToolError(str(exc)) from exc
+    return {
+        "pairing_id": pairing.id,
+        "from_track_id": from_track_id,
+        "into_track_id": into_track_id,
+        "from_label": from_track.title,
+        "into_label": into_track.title,
+        "created": created,
+    }, set()
+
+
+def _tool_remove_pairing(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Unpin a saved transition pairing (#442), keyed by its two pool tracks.
+
+    Symmetric with ``_tool_add_pairing``; raises when no pairing exists so the
+    agent gets a clear signal instead of a silent no-op. Commit deferred to the
+    turn.
+    """
+    from_track_id, from_track = _pairing_endpoint(db, set_obj, payload, "from_pool_track_id")
+    into_track_id, into_track = _pairing_endpoint(db, set_obj, payload, "into_pool_track_id")
+    pairing = pairings.find_pairing(db, set_obj.id, from_track_id, into_track_id)
+    if pairing is None:
+        raise AgentToolError("No saved pairing for that transition")
+    pairings.delete_pairing(db, pairing, commit=False)
+    return {
+        "removed": True,
+        "from_track_id": from_track_id,
+        "into_track_id": into_track_id,
+        "from_label": from_track.title,
+        "into_label": into_track.title,
+    }, set()
+
+
+def _pairing_endpoint(
+    db: Session, set_obj: Set, payload: dict[str, Any], field_name: str
+) -> tuple[str, SetPoolTrack]:
+    """Resolve a pool-track id from ``payload`` to its (namespaced track_id, row).
+
+    The pairing key must be the same namespaced id slots use, so derive it via
+    the Pass-1 track meta — keeping pairings, slots, and the boost lookup aligned.
+    """
+    track = _pool_track_or_error(db, set_obj.id, int(payload[field_name]))
+    return _pass1_track_meta(track).slot_track_id, track

--- a/server/app/services/setbuilder/agent_tools_sensing.py
+++ b/server/app/services/setbuilder/agent_tools_sensing.py
@@ -22,6 +22,7 @@ from app.services.setbuilder.agent_common import (
     _pool_tracks,
     _slot_or_error,
 )
+from app.services.setbuilder.pairing_scoring import load_pairing_index
 from app.services.setbuilder.pass1_deterministic import TrackMeta, transition_score
 from app.services.setbuilder.pass1_deterministic import _track_meta as _pass1_track_meta
 from app.services.setbuilder.vibe_resolver import TrackVibeState, build_pool_vibe_state
@@ -316,3 +317,55 @@ def _tool_static_critique(
     scores = [s.transition_score for s in slots[1:] if s.transition_score is not None]
     avg = round(sum(scores) / len(scores), 1) if scores else None
     return {"average_transition_score": avg, "slot_count": len(slots)}, set()
+
+
+def _tool_suggest_pairings(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Read-only: the set's consecutive transitions with score + whether each is
+    already a saved (pinned) pairing (#442).
+
+    The score is the raw ``transition_score`` — the +20 DJ-pairing boost steers
+    pass-1 candidate ordering, not an existing adjacency's stored score, so this
+    reports the honest transition quality alongside an ``is_pinned`` flag and the
+    endpoints' ``pool_track_id`` so the agent can act with ``add_pairing``.
+    """
+    del payload
+    slots = _ordered_slots(db, set_obj.id)
+    by_track_id = {
+        _pass1_track_meta(track).slot_track_id: track for track in _pool_tracks(db, set_obj.id)
+    }
+    pinned = load_pairing_index(db, set_obj.id)
+    transitions: list[dict[str, Any]] = []
+    for position in range(1, len(slots)):
+        prev_track_id = slots[position - 1].track_id or ""
+        curr_track_id = slots[position].track_id or ""
+        prev_track = by_track_id.get(prev_track_id)
+        curr_track = by_track_id.get(curr_track_id)
+        if curr_track is None:
+            continue
+        prev_meta = _pass1_track_meta(prev_track) if prev_track is not None else None
+        score, warnings = transition_score(
+            prev_meta, _pass1_track_meta(curr_track), set_obj.key_strictness
+        )
+        pairing = pinned.get((prev_track_id, curr_track_id))
+        transitions.append(
+            {
+                "position": position,
+                "score": score,
+                "warnings": warnings,
+                "is_pinned": pairing is not None,
+                "pairing_id": pairing.id if pairing is not None else None,
+                "from": _pairing_endpoint(prev_track),
+                "into": _pairing_endpoint(curr_track),
+            }
+        )
+    pinned_count = sum(1 for transition in transitions if transition["is_pinned"])
+    return {"transitions": transitions, "pinned_count": pinned_count}, set()
+
+
+def _pairing_endpoint(track: SetPoolTrack | None) -> dict[str, Any]:
+    """Compact pool-track reference the agent can feed back to add_pairing."""
+    if track is None:
+        return {"pool_track_id": None, "title": None, "artist": None}
+    return {"pool_track_id": track.id, "title": track.title, "artist": track.artist}

--- a/server/app/services/setbuilder/pairings.py
+++ b/server/app/services/setbuilder/pairings.py
@@ -50,6 +50,15 @@ def _tags_json(tags: list[str]) -> str:
     return json.dumps(normalize_tags(tags), separators=(",", ":"))
 
 
+def _persist(db: Session, pairing: SetPairing, commit: bool) -> None:
+    """Commit + refresh (REST callers) or just flush (inside an agent turn)."""
+    if commit:
+        db.commit()
+        db.refresh(pairing)
+    else:
+        db.flush()
+
+
 def get_pairing(db: Session, set_obj: Set, pairing_id: int) -> SetPairing | None:
     """Fetch a pairing scoped to the set."""
     return (
@@ -84,8 +93,14 @@ def upsert_pairing(
     note: str | None,
     tags: list[str],
     increment_use_count: bool = False,
+    commit: bool = True,
 ) -> tuple[SetPairing, bool]:
-    """Create or update a transition pairing. Returns (row, created)."""
+    """Create or update a transition pairing. Returns (row, created).
+
+    ``commit=False`` flushes instead of committing so the call can take part in a
+    larger transaction (e.g. one WrzDJSet agent turn that rolls back as a unit);
+    the IntegrityError reconcile path only applies when this call owns the commit.
+    """
     if from_track_id == into_track_id:
         raise ValueError("from_track_id and into_track_id must be different")
     existing = find_pairing(db, set_obj.id, from_track_id, into_track_id)
@@ -95,8 +110,7 @@ def upsert_pairing(
         existing.tags_json = _tags_json(tags)
         if increment_use_count:
             existing.use_count += 1
-        db.commit()
-        db.refresh(existing)
+        _persist(db, existing, commit)
         return existing, False
 
     pairing = SetPairing(
@@ -109,6 +123,11 @@ def upsert_pairing(
         use_count=1 if increment_use_count else 0,
     )
     db.add(pairing)
+    if not commit:
+        # Surface a unique-constraint violation to the caller's transaction
+        # rather than rolling back work the agent turn has not committed yet.
+        db.flush()
+        return pairing, True
     try:
         db.commit()
     except IntegrityError:
@@ -145,9 +164,12 @@ def update_pairing(
     return pairing
 
 
-def delete_pairing(db: Session, pairing: SetPairing) -> None:
+def delete_pairing(db: Session, pairing: SetPairing, *, commit: bool = True) -> None:
     db.delete(pairing)
-    db.commit()
+    if commit:
+        db.commit()
+    else:
+        db.flush()
 
 
 def pairing_view(db: Session, set_obj: Set, pairing: SetPairing) -> PairingView:

--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -30,6 +30,7 @@ from app.services.setbuilder.agent_common import (
 from app.services.setbuilder.agent_display import _tool_display_summary
 from app.services.setbuilder.agent_tool_specs import _agent_tools, _critique_tool
 from app.services.setbuilder.agent_tools_mutations import (
+    _tool_add_pairing,
     _tool_add_slow_window,
     _tool_apply_curve_template,
     _tool_bump_energy,
@@ -37,6 +38,7 @@ from app.services.setbuilder.agent_tools_mutations import (
     _tool_lock_slot,
     _tool_move_range,
     _tool_remove_curve_point,
+    _tool_remove_pairing,
     _tool_remove_slot,
     _tool_reorder_slot,
     _tool_replace_slot,
@@ -54,6 +56,7 @@ from app.services.setbuilder.agent_tools_sensing import (
     _tool_explain_transition,
     _tool_get_track_vibes,
     _tool_static_critique,
+    _tool_suggest_pairings,
     _tool_summarize_set,
     _track_summary,
 )
@@ -317,11 +320,14 @@ def apply_tool_call(
         "set_target": _tool_set_target,
         "lock_slot": _tool_lock_slot,
         "unlock_slot": _tool_unlock_slot,
+        "add_pairing": _tool_add_pairing,
+        "remove_pairing": _tool_remove_pairing,
         "analyze_transition": _tool_analyze_transition,
         "explain_transition": _tool_explain_transition,
         "get_track_vibes": _tool_get_track_vibes,
         "summarize_set": _tool_summarize_set,
         "analyze_pool_gaps": _tool_analyze_pool_gaps,
+        "suggest_pairings": _tool_suggest_pairings,
         "critique_set": _tool_static_critique,
     }
     handler = handlers.get(name)

--- a/server/tests/test_setbuilder_pass2.py
+++ b/server/tests/test_setbuilder_pass2.py
@@ -1,5 +1,7 @@
 """Tests for WrzDJSet agent toolkit (#390)."""
 
+import json
+
 import pytest
 from sqlalchemy.orm import Session
 
@@ -2186,3 +2188,296 @@ def test_tool_display_summary_move_range():
         {},
     )
     assert single == "Moved slot 1 to slot 4."
+
+
+# suggest_pairings / add_pairing / remove_pairing (#442, Family 3)
+# ---------------------------------------------------------------------------
+
+
+def _mk_set_with_three_slots(db: Session, user: User) -> Set:
+    """A set whose first three pool tracks (tidal:0/1/2) fill slots 0/1/2."""
+    set_obj = _mk_set_with_tracks(db, user)
+    db.add(SetSlot(set_id=set_obj.id, position=2, track_id="tidal:2"))
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def _pairing_rows(db: Session, set_id: int):
+    from app.models.set_pairing import SetPairing
+
+    return db.query(SetPairing).filter(SetPairing.set_id == set_id).all()
+
+
+def test_suggest_pairings_reports_transitions_and_pinned_flag(db: Session, test_user: User):
+    from app.services.setbuilder import pairings
+
+    set_obj = _mk_set_with_three_slots(db, test_user)
+    pairings.upsert_pairing(
+        db,
+        set_obj,
+        from_track_id="tidal:0",
+        into_track_id="tidal:1",
+        cue_in_sec=None,
+        note=None,
+        tags=[],
+    )
+
+    result, affected = apply_tool_call(db, set_obj, "suggest_pairings", {})
+
+    assert affected == set()
+    transitions = result["transitions"]
+    assert [t["position"] for t in transitions] == [1, 2]
+    first, second = transitions
+    assert first["is_pinned"] is True
+    assert first["pairing_id"] is not None
+    assert second["is_pinned"] is False
+    assert second["pairing_id"] is None
+    assert result["pinned_count"] == 1
+
+
+def test_suggest_pairings_includes_pool_track_ids(db: Session, test_user: User):
+    set_obj = _mk_set_with_three_slots(db, test_user)
+
+    result, _ = apply_tool_call(db, set_obj, "suggest_pairings", {})
+
+    first = result["transitions"][0]
+    t0 = _pool_track_by_track_id(set_obj, "tidal:0")
+    t1 = _pool_track_by_track_id(set_obj, "tidal:1")
+    assert first["from"]["pool_track_id"] == t0.id
+    assert first["into"]["pool_track_id"] == t1.id
+    assert first["from"]["title"] == t0.title
+
+
+def test_suggest_pairings_leaves_event_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set_with_three_slots(db, test_user)
+    before_count = db.query(Request).count()
+
+    apply_tool_call(db, set_obj, "suggest_pairings", {})
+
+    assert db.query(Request).count() == before_count
+
+
+def test_add_pairing_creates_pairing(db: Session, test_user: User):
+    set_obj = _mk_set_with_three_slots(db, test_user)
+    t0 = _pool_track_by_track_id(set_obj, "tidal:0")
+    t2 = _pool_track_by_track_id(set_obj, "tidal:2")
+
+    result, affected = apply_tool_call(
+        db,
+        set_obj,
+        "add_pairing",
+        {
+            "from_pool_track_id": t0.id,
+            "into_pool_track_id": t2.id,
+            "note": "Killer drop",
+            "tags": ["peak", "PEAK", " peak "],
+            "rationale": "These two always land together.",
+        },
+    )
+
+    assert affected == set()
+    assert result["created"] is True
+    assert result["from_track_id"] == "tidal:0"
+    assert result["into_track_id"] == "tidal:2"
+    rows = _pairing_rows(db, set_obj.id)
+    assert len(rows) == 1
+    assert (rows[0].from_track_id, rows[0].into_track_id) == ("tidal:0", "tidal:2")
+    assert json.loads(rows[0].tags_json) == ["peak"]  # normalized + de-duped
+
+
+def test_add_pairing_is_idempotent_update(db: Session, test_user: User):
+    set_obj = _mk_set_with_three_slots(db, test_user)
+    t0 = _pool_track_by_track_id(set_obj, "tidal:0")
+    t1 = _pool_track_by_track_id(set_obj, "tidal:1")
+    payload = {
+        "from_pool_track_id": t0.id,
+        "into_pool_track_id": t1.id,
+        "rationale": "Pin this transition.",
+    }
+
+    first, _ = apply_tool_call(db, set_obj, "add_pairing", payload)
+    second, _ = apply_tool_call(db, set_obj, "add_pairing", payload)
+
+    assert first["created"] is True
+    assert second["created"] is False
+    assert len(_pairing_rows(db, set_obj.id)) == 1
+
+
+def test_add_pairing_rejects_same_track(db: Session, test_user: User):
+    set_obj = _mk_set_with_three_slots(db, test_user)
+    t0 = _pool_track_by_track_id(set_obj, "tidal:0")
+
+    with pytest.raises(AgentToolError, match="different"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "add_pairing",
+            {
+                "from_pool_track_id": t0.id,
+                "into_pool_track_id": t0.id,
+                "rationale": "A track cannot pair with itself.",
+            },
+        )
+
+
+def test_add_pairing_rejects_foreign_pool_track(db: Session, test_user: User):
+    set_obj = _mk_set_with_three_slots(db, test_user)
+    other = _mk_set_with_three_slots(db, test_user)
+    home = _pool_track_by_track_id(set_obj, "tidal:0")
+    foreign = _pool_track_by_track_id(other, "tidal:2")
+
+    with pytest.raises(AgentToolError, match="Pool track not found"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "add_pairing",
+            {
+                "from_pool_track_id": home.id,
+                "into_pool_track_id": foreign.id,
+                "rationale": "Cross-set pairing must be rejected.",
+            },
+        )
+
+
+def test_add_pairing_requires_rationale(db: Session, test_user: User):
+    set_obj = _mk_set_with_three_slots(db, test_user)
+    t0 = _pool_track_by_track_id(set_obj, "tidal:0")
+    t1 = _pool_track_by_track_id(set_obj, "tidal:1")
+
+    with pytest.raises(AgentToolError, match="rationale"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "add_pairing",
+            {"from_pool_track_id": t0.id, "into_pool_track_id": t1.id},
+        )
+
+
+def test_add_pairing_defers_commit(db: Session, test_user: User):
+    """add_pairing flushes but does not commit, so the turn can still roll back."""
+    set_obj = _mk_set_with_three_slots(db, test_user)
+    t0 = _pool_track_by_track_id(set_obj, "tidal:0")
+    t1 = _pool_track_by_track_id(set_obj, "tidal:1")
+
+    apply_tool_call(
+        db,
+        set_obj,
+        "add_pairing",
+        {
+            "from_pool_track_id": t0.id,
+            "into_pool_track_id": t1.id,
+            "rationale": "Tentative pin inside a turn.",
+        },
+    )
+    db.rollback()
+
+    assert _pairing_rows(db, set_obj.id) == []
+
+
+def test_remove_pairing_deletes_pairing(db: Session, test_user: User):
+    set_obj = _mk_set_with_three_slots(db, test_user)
+    t0 = _pool_track_by_track_id(set_obj, "tidal:0")
+    t1 = _pool_track_by_track_id(set_obj, "tidal:1")
+    apply_tool_call(
+        db,
+        set_obj,
+        "add_pairing",
+        {"from_pool_track_id": t0.id, "into_pool_track_id": t1.id, "rationale": "pin"},
+    )
+    db.commit()
+
+    result, affected = apply_tool_call(
+        db,
+        set_obj,
+        "remove_pairing",
+        {"from_pool_track_id": t0.id, "into_pool_track_id": t1.id, "rationale": "unpin"},
+    )
+
+    assert affected == set()
+    assert result["removed"] is True
+    assert _pairing_rows(db, set_obj.id) == []
+
+
+def test_remove_pairing_missing_raises(db: Session, test_user: User):
+    set_obj = _mk_set_with_three_slots(db, test_user)
+    t0 = _pool_track_by_track_id(set_obj, "tidal:0")
+    t1 = _pool_track_by_track_id(set_obj, "tidal:1")
+
+    with pytest.raises(AgentToolError, match="No saved pairing"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "remove_pairing",
+            {"from_pool_track_id": t0.id, "into_pool_track_id": t1.id, "rationale": "x"},
+        )
+
+
+def test_add_pairing_leaves_event_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set_with_three_slots(db, test_user)
+    t0 = _pool_track_by_track_id(set_obj, "tidal:0")
+    t1 = _pool_track_by_track_id(set_obj, "tidal:1")
+    before_count = db.query(Request).count()
+    before_title = test_request.song_title
+
+    apply_tool_call(
+        db,
+        set_obj,
+        "add_pairing",
+        {"from_pool_track_id": t0.id, "into_pool_track_id": t1.id, "rationale": "pin"},
+    )
+
+    db.refresh(test_request)
+    assert db.query(Request).count() == before_count
+    assert test_request.song_title == before_title
+
+
+def test_pairing_tools_registered():
+    from app.services.setbuilder.pass2_agent import MUTATION_TOOLS
+
+    names = {tool.name for tool in _agent_tools()}
+    assert {"suggest_pairings", "add_pairing", "remove_pairing"} <= names
+    assert "suggest_pairings" not in MUTATION_TOOLS  # read-only
+    assert {"add_pairing", "remove_pairing"} <= MUTATION_TOOLS
+
+
+def test_tool_display_summary_pairings():
+    added = _tool_display_summary(
+        "add_pairing",
+        {},
+        {"created": True, "from_label": "A", "into_label": "B"},
+        {},
+        {},
+    )
+    assert added == "Pinned the transition A → B."
+
+    updated = _tool_display_summary(
+        "add_pairing",
+        {},
+        {"created": False, "from_label": "A", "into_label": "B"},
+        {},
+        {},
+    )
+    assert updated == "Updated the pinned transition A → B."
+
+    removed = _tool_display_summary(
+        "remove_pairing",
+        {},
+        {"removed": True, "from_label": "A", "into_label": "B"},
+        {},
+        {},
+    )
+    assert removed == "Unpinned the transition A → B."
+
+    suggested = _tool_display_summary(
+        "suggest_pairings",
+        {},
+        {"transitions": [{}, {}], "pinned_count": 1},
+        {},
+        {},
+    )
+    assert suggested == "Reviewed 2 transitions; 1 already pinned."


### PR DESCRIPTION
> **Stacked on #483 → move_range PR.** Merge those first; this PR's diff is clean once it rebases onto main.

## Why
A `SetPairing` is a DJ "this A→B transition is great" annotation that gives the pair a +20 boost during pass-1 candidate ordering. #442 Family 3 calls for managing these from chat.

## What
- `suggest_pairings` (read-only): walks the set's consecutive transitions, returning each with its **raw** transition score, whether it's already pinned, and both endpoints' `pool_track_id` so the agent can act. Score stays raw on purpose — the +20 boost steers future pass-1 ordering, not an existing adjacency's stored score.
- `add_pairing` / `remove_pairing` (mutations): keyed by a pool-track-id pair, resolved to the same namespaced track-id the slots and the boost lookup use.

Reuses the pairings service, extended with a `commit=False` path so a pairing edit takes part in the agent turn's single transaction and rolls back with it. **REST callers keep the `commit=True` default — zero blast radius.** Owner-scoped, mutations require rationale, all three render in ToolCard, regression test asserts `requests` is untouched.

## Testing
- [x] Unit tests pass (14 new; full suite 3016)
- [x] Coverage 88.52% (gate 85%)
- [x] ruff + bandit clean
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #482. Part of #442 (Family 3).