### PR TITLE
feat(requests): paginated DJ request list + sort controls (#478 · 2/4)

### DIFF
--- a/dashboard/app/(dj)/events/[code]/__tests__/event-help.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/__tests__/event-help.test.tsx
@@ -73,6 +73,7 @@ vi.mock('@/lib/api', () => ({
     }),
     getRequests: vi.fn().mockResolvedValue({
       requests: [], total: 0, limit: 100, offset: 0, sort: 'date_requested', direction: 'desc',
+      status_counts: { all: 0, new: 0, accepted: 0, playing: 0, played: 0, rejected: 0 },
     }),
     getPlayHistory: vi.fn().mockResolvedValue({ items: [], total: 0 }),
     getDisplaySettings: vi.fn().mockResolvedValue({

--- a/dashboard/app/(dj)/events/[code]/__tests__/event-help.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/__tests__/event-help.test.tsx
@@ -71,7 +71,9 @@ vi.mock('@/lib/api', () => ({
       expires_at: '2026-12-31T00:00:00Z', is_active: true,
       tidal_sync_enabled: false, beatport_sync_enabled: false,
     }),
-    getRequests: vi.fn().mockResolvedValue([]),
+    getRequests: vi.fn().mockResolvedValue({
+      requests: [], total: 0, limit: 100, offset: 0, sort: 'date_requested', direction: 'desc',
+    }),
     getPlayHistory: vi.fn().mockResolvedValue({ items: [], total: 0 }),
     getDisplaySettings: vi.fn().mockResolvedValue({
       now_playing_hidden: false, now_playing_auto_hide_minutes: 10,

--- a/dashboard/app/(dj)/events/[code]/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/__tests__/page.test.tsx
@@ -223,6 +223,7 @@ function mockRequestList(
     offset: 0,
     sort: 'date_requested',
     direction: 'desc',
+    status_counts: { all: requests.length, new: 0, accepted: 0, playing: 0, played: 0, rejected: 0 },
     ...overrides,
   };
 }
@@ -1104,6 +1105,105 @@ describe('EventQueuePage', () => {
 
       const backLink = screen.getByText(/Back to Dashboard/);
       expect(backLink.closest('a')).toHaveAttribute('href', '/dashboard');
+    });
+  });
+
+  describe('Server-side status filter + status counts (issue #478, Bugs 1 & 2)', () => {
+    it('passes server status_counts through to SongTab', async () => {
+      setupDefaultMocks();
+      vi.mocked(api.getRequests).mockResolvedValue(
+        mockRequestList([mockRequest()], {
+          status_counts: { all: 120, new: 80, accepted: 25, playing: 2, played: 10, rejected: 3 },
+        }),
+      );
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      expect(capturedSongTabProps.statusCounts).toEqual({
+        all: 120, new: 80, accepted: 25, playing: 2, played: 10, rejected: 3,
+      });
+    });
+
+    it('refetches with the chosen status server-side when the filter changes', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+      vi.mocked(api.getRequests).mockClear();
+
+      const onFilterChange = capturedSongTabProps.onFilterChange as (f: string) => void;
+      await act(async () => { onFilterChange('accepted'); });
+
+      // First fetch after a filter change must carry status: 'accepted', offset 0.
+      expect(api.getRequests).toHaveBeenCalledWith(
+        'TEST',
+        expect.objectContaining({ status: 'accepted', offset: 0 }),
+      );
+    });
+
+    it("omits status (undefined) when the filter is 'all'", async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      const onFilterChange = capturedSongTabProps.onFilterChange as (f: string) => void;
+      // Move off 'all' then back to 'all'.
+      await act(async () => { onFilterChange('accepted'); });
+      vi.mocked(api.getRequests).mockClear();
+      await act(async () => { onFilterChange('all'); });
+
+      expect(api.getRequests).toHaveBeenCalledWith(
+        'TEST',
+        expect.objectContaining({ status: undefined, offset: 0 }),
+      );
+    });
+  });
+
+  describe('Immediate reload on sort change (issue #478, Bug 3)', () => {
+    it('refetches immediately when the sort field changes (not waiting for poll)', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+      vi.mocked(api.getRequests).mockClear();
+
+      const onSortFieldChange = capturedSongTabProps.onSortFieldChange as (f: string) => void;
+      await act(async () => { onSortFieldChange('upvotes'); });
+
+      expect(api.getRequests).toHaveBeenCalledWith(
+        'TEST',
+        expect.objectContaining({ sort: 'upvotes', offset: 0 }),
+      );
+    });
+
+    it('refetches immediately when the sort direction toggles', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+      vi.mocked(api.getRequests).mockClear();
+
+      const onSortDirectionToggle = capturedSongTabProps.onSortDirectionToggle as () => void;
+      await act(async () => { onSortDirectionToggle(); });
+
+      // Default field date_requested defaults desc → toggling yields asc.
+      expect(api.getRequests).toHaveBeenCalledWith(
+        'TEST',
+        expect.objectContaining({ direction: 'asc', offset: 0 }),
+      );
+    });
+
+    it('does not double-fetch on the initial mount (effect skips first render)', async () => {
+      vi.useFakeTimers();
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+
+      // Exactly one initial load — the sort-change effect must skip mount.
+      expect(api.getRequests).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/dashboard/app/(dj)/events/[code]/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/__tests__/page.test.tsx
@@ -179,7 +179,7 @@ vi.mock('@/lib/api', () => ({
 }));
 
 import { api, ApiError } from '@/lib/api';
-import type { SongRequest } from '@/lib/api';
+import type { SongRequest, RequestListResponse } from '@/lib/api';
 import EventQueuePage from '../page';
 
 function mockEvent(overrides = {}) {
@@ -211,9 +211,25 @@ function mockRequest(overrides: Partial<SongRequest> = {}): SongRequest {
   };
 }
 
+/** Wrap request rows in the #478 paginated envelope returned by getRequests. */
+function mockRequestList(
+  requests: SongRequest[] = [],
+  overrides: Partial<RequestListResponse> = {},
+): RequestListResponse {
+  return {
+    requests,
+    total: requests.length,
+    limit: 100,
+    offset: 0,
+    sort: 'date_requested',
+    direction: 'desc',
+    ...overrides,
+  };
+}
+
 function setupDefaultMocks() {
   vi.mocked(api.getEvent).mockResolvedValue(mockEvent());
-  vi.mocked(api.getRequests).mockResolvedValue([]);
+  vi.mocked(api.getRequests).mockResolvedValue(mockRequestList([]));
   vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
   vi.mocked(api.getDisplaySettings).mockResolvedValue({
     status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
@@ -358,7 +374,7 @@ describe('EventQueuePage', () => {
 
     it('shows expired state on 410 with archived data', async () => {
       vi.mocked(api.getEvent).mockRejectedValue(new ApiError('Expired', 410));
-      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.getRequests).mockResolvedValue(mockRequestList([mockRequest()]));
       vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
       vi.mocked(api.getDisplaySettings).mockResolvedValue({
         status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
@@ -385,7 +401,7 @@ describe('EventQueuePage', () => {
 
     it('shows error card on 410 without archived match', async () => {
       vi.mocked(api.getEvent).mockRejectedValue(new ApiError('Expired', 410));
-      vi.mocked(api.getRequests).mockResolvedValue([]);
+      vi.mocked(api.getRequests).mockResolvedValue(mockRequestList([]));
       vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
       vi.mocked(api.getDisplaySettings).mockResolvedValue({
         status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
@@ -427,7 +443,7 @@ describe('EventQueuePage', () => {
     it('stops on 404', async () => {
       vi.useFakeTimers();
       vi.mocked(api.getEvent).mockRejectedValue(new ApiError('Not found', 404));
-      vi.mocked(api.getRequests).mockResolvedValue([]);
+      vi.mocked(api.getRequests).mockResolvedValue(mockRequestList([]));
       vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
       vi.mocked(api.getDisplaySettings).mockResolvedValue({
         status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
@@ -529,7 +545,7 @@ describe('EventQueuePage', () => {
     it('auto-dismisses after 5s', async () => {
       vi.useFakeTimers();
       setupDefaultMocks();
-      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.getRequests).mockResolvedValue(mockRequestList([mockRequest()]));
       vi.mocked(api.updateRequestStatus).mockRejectedValue(new ApiError('Status error', 400));
 
       render(<EventQueuePage />);
@@ -559,7 +575,7 @@ describe('EventQueuePage', () => {
 
     it('calls updateRequestStatus via handler', async () => {
       setupDefaultMocks();
-      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.getRequests).mockResolvedValue(mockRequestList([mockRequest()]));
       vi.mocked(api.updateRequestStatus).mockResolvedValue(mockRequest({ status: 'accepted' }));
 
       render(<EventQueuePage />);
@@ -573,7 +589,7 @@ describe('EventQueuePage', () => {
 
     it('shows error on status update failure', async () => {
       setupDefaultMocks();
-      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.getRequests).mockResolvedValue(mockRequestList([mockRequest()]));
       vi.mocked(api.updateRequestStatus).mockRejectedValue(new ApiError('Invalid transition', 400));
 
       render(<EventQueuePage />);
@@ -590,7 +606,7 @@ describe('EventQueuePage', () => {
     it('calls acceptAllRequests', async () => {
       setupDefaultMocks();
       vi.mocked(api.acceptAllRequests).mockResolvedValue({ status: 'ok', accepted_count: 1 });
-      vi.mocked(api.getRequests).mockResolvedValue([mockRequest({ status: 'accepted' })]);
+      vi.mocked(api.getRequests).mockResolvedValue(mockRequestList([mockRequest({ status: 'accepted' })]));
 
       render(<EventQueuePage />);
       await screen.findByText('Test Event');
@@ -715,7 +731,7 @@ describe('EventQueuePage', () => {
       vi.mocked(api.getArchivedEvents).mockResolvedValue([{
         ...mockEvent(), status: 'expired' as const, request_count: 1, archived_at: null,
       }]);
-      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.getRequests).mockResolvedValue(mockRequestList([mockRequest()]));
       vi.mocked(api.exportEventCsv).mockResolvedValue(undefined);
 
       render(<EventQueuePage />);
@@ -949,7 +965,7 @@ describe('EventQueuePage', () => {
       vi.mocked(api.getArchivedEvents).mockResolvedValue([{
         ...mockEvent(), status: 'expired' as const, request_count: 0, archived_at: null,
       }]);
-      vi.mocked(api.getRequests).mockResolvedValue([]);
+      vi.mocked(api.getRequests).mockResolvedValue(mockRequestList([]));
       vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
       vi.mocked(api.getDisplaySettings).mockResolvedValue({
         status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
@@ -980,7 +996,7 @@ describe('EventQueuePage', () => {
       vi.mocked(api.getArchivedEvents).mockResolvedValue([{
         ...mockEvent(), status: 'expired' as const, request_count: 1, archived_at: null,
       }]);
-      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.getRequests).mockResolvedValue(mockRequestList([mockRequest()]));
       vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
       vi.mocked(api.getDisplaySettings).mockResolvedValue({
         status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
@@ -1008,7 +1024,7 @@ describe('EventQueuePage', () => {
       vi.mocked(api.getArchivedEvents).mockResolvedValue([{
         ...mockEvent(), status: 'expired' as const, request_count: 0, archived_at: null,
       }]);
-      vi.mocked(api.getRequests).mockResolvedValue([]);
+      vi.mocked(api.getRequests).mockResolvedValue(mockRequestList([]));
       vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
       vi.mocked(api.getDisplaySettings).mockResolvedValue({
         status: 'ok', now_playing_hidden: false, now_playing_auto_hide_minutes: 10,
@@ -1032,7 +1048,7 @@ describe('EventQueuePage', () => {
   describe('Delete request', () => {
     it('calls deleteRequest via handler', async () => {
       setupDefaultMocks();
-      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.getRequests).mockResolvedValue(mockRequestList([mockRequest()]));
       vi.mocked(api.deleteRequest).mockResolvedValue(undefined);
 
       render(<EventQueuePage />);
@@ -1048,7 +1064,7 @@ describe('EventQueuePage', () => {
   describe('Refresh metadata', () => {
     it('calls refreshRequestMetadata via handler', async () => {
       setupDefaultMocks();
-      vi.mocked(api.getRequests).mockResolvedValue([mockRequest()]);
+      vi.mocked(api.getRequests).mockResolvedValue(mockRequestList([mockRequest()]));
       vi.mocked(api.refreshRequestMetadata).mockResolvedValue(
         mockRequest({ genre: 'Electronic', bpm: 128 }),
       );
@@ -1067,7 +1083,7 @@ describe('EventQueuePage', () => {
     it('calls rejectAllRequests via handler', async () => {
       setupDefaultMocks();
       vi.mocked(api.rejectAllRequests).mockResolvedValue({ status: 'ok', count: 0 });
-      vi.mocked(api.getRequests).mockResolvedValue([]);
+      vi.mocked(api.getRequests).mockResolvedValue(mockRequestList([]));
 
       render(<EventQueuePage />);
       await screen.findByText('Test Event');

--- a/dashboard/app/(dj)/events/[code]/components/PreEventVotingTab.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/PreEventVotingTab.tsx
@@ -2,7 +2,18 @@
 
 import { useEffect, useState } from 'react';
 import { z } from 'zod';
-import { apiClient, PendingReviewRow } from '@/lib/api';
+import { apiClient, PendingReviewRow, PUBLIC_PAGE_MAX } from '@/lib/api';
+import type { SortDirection } from '@/lib/api-types';
+import {
+  PENDING_REVIEW_DEFAULT_DIRECTION,
+  PENDING_REVIEW_SORT_FIELDS,
+  REVIEW_ORDER,
+  toPendingReviewParams,
+  type PendingReviewSort,
+} from '@/lib/pending-review-sort';
+
+/** First page size; the growing window grows by this on each "Load More". */
+const PAGE_SIZE = 100;
 
 interface EventShape {
   code: string;
@@ -82,6 +93,11 @@ export default function PreEventVotingTab({
   onEventChange,
 }: Props) {
   const [pending, setPending] = useState<PendingReviewRow[]>([]);
+  const [pendingTotal, setPendingTotal] = useState(0);
+  const [displayLimit, setDisplayLimit] = useState(PAGE_SIZE);
+  const [sortField, setSortField] = useState<PendingReviewSort>(REVIEW_ORDER);
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [loadingMore, setLoadingMore] = useState(false);
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [confirming, setConfirming] = useState<ConfirmAction | null>(null);
   const [topN, setTopN] = useState(20);
@@ -102,14 +118,54 @@ export default function PreEventVotingTab({
   const [syncResult, setSyncResult] = useState<{ queued: number } | null>(null);
   const [syncError, setSyncError] = useState<string | null>(null);
 
+  // Re-fetch whenever the event, sort, or direction changes — each resets the
+  // growing window back to the first page. "Load More" drives its own fetch
+  // (loadMore) so its loading state stays meaningful. The effect intentionally
+  // re-runs only on the inputs below, mirroring the original code.code effect.
   useEffect(() => {
-    refresh();
+    setDisplayLimit(PAGE_SIZE);
+    fetchPage(PAGE_SIZE);
 
-  }, [event.code]);
+  }, [event.code, sortField, sortDirection]);
 
-  async function refresh() {
-    const resp = await apiClient.getPendingReview(event.code);
+  // Fetch the pending-review window from offset=0 up to `limit`. Every refresh
+  // re-fetches the whole current window so sort/paging stay consistent.
+  async function fetchPage(limit: number) {
+    const resp = await apiClient.getPendingReview(event.code, {
+      ...toPendingReviewParams(sortField, sortDirection),
+      limit,
+      offset: 0,
+    });
     setPending(resp.requests);
+    setPendingTotal(resp.total);
+  }
+
+  /** Re-fetch the current window (used after bulk actions). */
+  function refresh() {
+    return fetchPage(displayLimit);
+  }
+
+  function handleSortFieldChange(next: PendingReviewSort) {
+    setSortField(next);
+    // Snap direction to the field's natural default; Review order has none.
+    if (next !== REVIEW_ORDER) {
+      setSortDirection(PENDING_REVIEW_DEFAULT_DIRECTION[next]);
+    }
+  }
+
+  function handleSortDirectionToggle() {
+    setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+  }
+
+  async function loadMore() {
+    const next = Math.min(displayLimit + PAGE_SIZE, PUBLIC_PAGE_MAX);
+    setLoadingMore(true);
+    try {
+      await fetchPage(next);
+      setDisplayLimit(next);
+    } finally {
+      setLoadingMore(false);
+    }
   }
 
   async function applyOverride(value: 'force_collection' | 'force_live' | null) {
@@ -256,7 +312,7 @@ export default function PreEventVotingTab({
         </div>
         <div className="pre-event-stat">
           <div className="pre-event-stat-label">Pending review</div>
-          <div className="pre-event-stat-value">{pending.length}</div>
+          <div className="pre-event-stat-value">{pendingTotal}</div>
         </div>
         <div className="pre-event-stat">
           <div className="pre-event-stat-label">Pick cap / guest</div>
@@ -433,8 +489,50 @@ export default function PreEventVotingTab({
 
       <div className="card">
         <h3 style={{ marginBottom: '0.75rem', fontSize: '1rem' }}>
-          Pending review ({pending.length})
+          Pending review ({pendingTotal})
         </h3>
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.375rem',
+            marginBottom: '0.75rem',
+          }}
+        >
+          <label
+            htmlFor="pending-sort-field"
+            style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}
+          >
+            Sort
+          </label>
+          <select
+            id="pending-sort-field"
+            className="input"
+            aria-label="Sort pending review by"
+            value={sortField}
+            onChange={(e) => handleSortFieldChange(e.target.value as PendingReviewSort)}
+            style={{ width: 'auto', padding: '0.25rem 0.5rem', fontSize: '0.75rem' }}
+          >
+            {PENDING_REVIEW_SORT_FIELDS.map((f) => (
+              <option key={f.value} value={f.value}>
+                {f.label}
+              </option>
+            ))}
+          </select>
+          {sortField !== REVIEW_ORDER && (
+            <button
+              type="button"
+              className="btn btn-sm"
+              style={{ background: 'var(--surface-raised)', fontSize: '0.75rem', minWidth: '2rem' }}
+              onClick={handleSortDirectionToggle}
+              aria-label={`Sort direction: ${sortDirection === 'asc' ? 'ascending' : 'descending'}`}
+              title={sortDirection === 'asc' ? 'Ascending' : 'Descending'}
+            >
+              {sortDirection === 'asc' ? '↑' : '↓'}
+            </button>
+          )}
+        </div>
 
         <div className="pre-event-review-controls">
           <label>
@@ -471,8 +569,9 @@ export default function PreEventVotingTab({
             type="button"
             className="btn btn-sm btn-danger"
             onClick={() => bulk('reject_remaining')}
+            title="Rejects every still-pending request server-side — not just the rows loaded below."
           >
-            Reject remaining
+            Reject all remaining
           </button>
         </div>
 
@@ -526,6 +625,32 @@ export default function PreEventVotingTab({
               ))}
             </tbody>
           </table>
+        )}
+
+        {pending.length > 0 && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.75rem',
+              marginTop: '0.75rem',
+            }}
+          >
+            <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
+              Showing {pending.length} of {pendingTotal}
+            </span>
+            {pending.length < pendingTotal && pending.length < PUBLIC_PAGE_MAX && (
+              <button
+                type="button"
+                className="btn btn-sm"
+                style={{ background: 'var(--surface-raised)' }}
+                disabled={loadingMore}
+                onClick={loadMore}
+              >
+                {loadingMore ? 'Loading…' : 'Load More'}
+              </button>
+            )}
+          </div>
         )}
 
         {selected.size > 0 && (

--- a/dashboard/app/(dj)/events/[code]/components/RequestQueueSection.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/RequestQueueSection.tsx
@@ -38,13 +38,19 @@ interface RequestQueueSectionProps {
   deletingRequest?: number | null;
   refreshingRequest?: number | null;
   // Sort + growing-window pagination (issue #478). The server sorts
-  // authoritatively by field+direction; the list here only filters by status.
+  // authoritatively by field+direction and filters by status; this component is
+  // fully controlled — `requests` is the server-filtered page rendered as-is.
   sortField: RequestSort;
   sortDirection: SortDirection;
   onSortFieldChange: (field: RequestSort) => void;
   onSortDirectionToggle: () => void;
   total: number;
   onLoadMore: (status?: string) => Promise<void>;
+  // Active status filter (lifted to the page so the poll re-fetches with it) and
+  // true per-status totals for the tabs (independent of the loaded window).
+  filter: StatusFilter;
+  onFilterChange: (filter: StatusFilter) => void;
+  statusCounts: Record<StatusFilter, number>;
 }
 
 export function RequestQueueSection({
@@ -74,22 +80,15 @@ export function RequestQueueSection({
   onSortDirectionToggle,
   total,
   onLoadMore,
+  filter,
+  onFilterChange,
+  statusCounts,
 }: RequestQueueSectionProps) {
-  const [filter, setFilter] = useState<StatusFilter>('all');
   const [advancedMode, setAdvancedMode] = useState(false);
   const [deletingAll, setDeletingAll] = useState(false);
   const [refreshingAll, setRefreshingAll] = useState(false);
   const [enrichingAll, setEnrichingAll] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
-
-  const statusCounts = useMemo(() => {
-    const counts = { all: requests.length, new: 0, accepted: 0, playing: 0, played: 0, rejected: 0 };
-    for (const r of requests) {
-      const s = r.status as keyof typeof counts;
-      if (s in counts) counts[s]++;
-    }
-    return counts;
-  }, [requests]);
 
   // Compute BPM context from the DJ's active set (accepted + playing)
   // so badges show proximity relative to the current musical direction
@@ -101,15 +100,12 @@ export function RequestQueueSection({
     return computeBpmContext(activeBpms);
   }, [requests]);
 
-  // The server returns rows already sorted by the chosen field+direction
-  // (issue #478), so the list only filters by status — never reorders.
-  const filteredRequests = useMemo(
-    () => requests.filter((r) => (filter === 'all' ? true : r.status === filter)),
-    [requests, filter],
-  );
-
+  // The server returns rows already sorted AND filtered by status (issue #478),
+  // so this component renders `requests` as-is — never reordering or filtering.
   const handleDeleteAll = async () => {
-    const count = filteredRequests.length;
+    // Bulk delete targets the whole server-side filtered set (true count), not
+    // just the loaded window. "all" deletes every status.
+    const count = filter === 'all' ? statusCounts.all : statusCounts[filter];
     if (count === 0) return;
     if (!window.confirm(`Delete all ${count} ${filter === 'all' ? '' : filter + ' '}request${count === 1 ? '' : 's'}? This cannot be undone.`)) return;
     setDeletingAll(true);
@@ -121,10 +117,10 @@ export function RequestQueueSection({
   };
 
   const handleRefreshAll = async () => {
-    if (filteredRequests.length === 0) return;
+    if (requests.length === 0) return;
     setRefreshingAll(true);
     try {
-      const ids = filteredRequests.map((r) => r.id);
+      const ids = requests.map((r) => r.id);
       for (const id of ids) {
         await onRefreshMetadata?.(id);
       }
@@ -141,7 +137,7 @@ export function RequestQueueSection({
             <button
               key={status}
               className={`tab ${filter === status ? 'active' : ''}`}
-              onClick={() => setFilter(status)}
+              onClick={() => onFilterChange(status)}
             >
               {status.charAt(0).toUpperCase() + status.slice(1)} ({statusCounts[status]})
             </button>
@@ -242,7 +238,7 @@ export function RequestQueueSection({
                   className="btn btn-sm"
                   style={{ background: 'var(--surface-raised)', fontSize: '0.7rem' }}
                   onClick={handleRefreshAll}
-                  disabled={refreshingAll || filteredRequests.length === 0}
+                  disabled={refreshingAll || requests.length === 0}
                 >
                   {refreshingAll ? 'Refreshing...' : 'Refresh All'}
                 </button>
@@ -250,7 +246,7 @@ export function RequestQueueSection({
                   className="btn btn-sm"
                   style={{ background: 'var(--color-danger-subtle)', fontSize: '0.7rem' }}
                   onClick={handleDeleteAll}
-                  disabled={deletingAll || filteredRequests.length === 0}
+                  disabled={deletingAll || (filter === 'all' ? statusCounts.all : statusCounts[filter]) === 0}
                 >
                   {deletingAll ? 'Deleting...' : 'Delete All'}
                 </button>
@@ -260,7 +256,7 @@ export function RequestQueueSection({
         )}
       </div>
 
-      {filteredRequests.length === 0 ? (
+      {requests.length === 0 ? (
         <div className="card" style={{ textAlign: 'center' }}>
           <p style={{ color: 'var(--text-secondary)' }}>
             {filter === 'all'
@@ -270,7 +266,7 @@ export function RequestQueueSection({
         </div>
       ) : (
         <div className="request-list scrollable-list" style={{ marginBottom: '1rem' }}>
-          {filteredRequests.map((request) => (
+          {requests.map((request) => (
             <div
               key={request.id}
               id={`request-${request.id}`}
@@ -492,9 +488,9 @@ export function RequestQueueSection({
       )}
 
       {(() => {
-        // Growing window applies to the full fetched set (`requests`), not the
-        // status-filtered view, so the count reflects what's loaded vs the
-        // server's true total. Hide once everything is loaded or we hit the cap.
+        // `requests` is the server's filtered page and `total` is that filter's
+        // true count, so "Showing X of Y" is honest per-filter. Hide once
+        // everything is loaded or we hit the cap.
         const loaded = requests.length;
         const hasMore = loaded < total && loaded < PUBLIC_PAGE_MAX;
         if (loaded === 0) return null;

--- a/dashboard/app/(dj)/events/[code]/components/RequestQueueSection.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/RequestQueueSection.tsx
@@ -12,7 +12,9 @@ import { getRequestEmphasisStyle } from '@/lib/request-emphasis';
 import { safeExternalUrl } from '@/lib/safe-url';
 import { getVoteHeatStyle } from '@/lib/vote-heat';
 import { formatPriorityScore, getPriorityScoreColor } from '@/lib/priority-score';
-import type { SortMode } from '@/lib/priority-score';
+import { PUBLIC_PAGE_MAX } from '@/lib/api';
+import { SORT_FIELDS } from '@/lib/request-sort';
+import type { RequestSort, SortDirection } from '@/lib/api-types';
 
 interface RequestQueueSectionProps {
   requests: SongRequest[];
@@ -35,8 +37,14 @@ interface RequestQueueSectionProps {
   rejectingAll?: boolean;
   deletingRequest?: number | null;
   refreshingRequest?: number | null;
-  sortMode: SortMode;
-  onSortModeChange: (mode: SortMode) => void;
+  // Sort + growing-window pagination (issue #478). The server sorts
+  // authoritatively by field+direction; the list here only filters by status.
+  sortField: RequestSort;
+  sortDirection: SortDirection;
+  onSortFieldChange: (field: RequestSort) => void;
+  onSortDirectionToggle: () => void;
+  total: number;
+  onLoadMore: (status?: string) => Promise<void>;
 }
 
 export function RequestQueueSection({
@@ -60,14 +68,19 @@ export function RequestQueueSection({
   rejectingAll,
   deletingRequest,
   refreshingRequest,
-  sortMode,
-  onSortModeChange,
+  sortField,
+  sortDirection,
+  onSortFieldChange,
+  onSortDirectionToggle,
+  total,
+  onLoadMore,
 }: RequestQueueSectionProps) {
   const [filter, setFilter] = useState<StatusFilter>('all');
   const [advancedMode, setAdvancedMode] = useState(false);
   const [deletingAll, setDeletingAll] = useState(false);
   const [refreshingAll, setRefreshingAll] = useState(false);
   const [enrichingAll, setEnrichingAll] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
 
   const statusCounts = useMemo(() => {
     const counts = { all: requests.length, new: 0, accepted: 0, playing: 0, played: 0, rejected: 0 };
@@ -88,19 +101,12 @@ export function RequestQueueSection({
     return computeBpmContext(activeBpms);
   }, [requests]);
 
-  const filteredRequests = useMemo(() => {
-    const filtered = requests.filter((r) => (filter === 'all' ? true : r.status === filter));
-    // In priority mode, API returns pre-sorted results — preserve that order
-    if (sortMode === 'priority') return filtered;
-    if (filter === 'all') {
-      return [...filtered].sort((a, b) => {
-        const aBottom = a.status === 'played' ? 1 : 0;
-        const bBottom = b.status === 'played' ? 1 : 0;
-        return aBottom - bBottom;
-      });
-    }
-    return filtered;
-  }, [requests, filter, sortMode]);
+  // The server returns rows already sorted by the chosen field+direction
+  // (issue #478), so the list only filters by status — never reorders.
+  const filteredRequests = useMemo(
+    () => requests.filter((r) => (filter === 'all' ? true : r.status === filter)),
+    [requests, filter],
+  );
 
   const handleDeleteAll = async () => {
     const count = filteredRequests.length;
@@ -141,17 +147,40 @@ export function RequestQueueSection({
             </button>
           ))}
         </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.375rem', marginLeft: 'auto' }}>
+          <label
+            htmlFor="request-sort-field"
+            style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}
+          >
+            Sort
+          </label>
+          <select
+            id="request-sort-field"
+            className="input"
+            aria-label="Sort requests by"
+            value={sortField}
+            onChange={(e) => onSortFieldChange(e.target.value as RequestSort)}
+            style={{ width: 'auto', padding: '0.25rem 0.5rem', fontSize: '0.75rem' }}
+          >
+            {SORT_FIELDS.map((f) => (
+              <option key={f.value} value={f.value}>
+                {f.label}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            className="btn btn-sm"
+            style={{ background: 'var(--surface-raised)', fontSize: '0.75rem', minWidth: '2rem' }}
+            onClick={onSortDirectionToggle}
+            aria-label={`Sort direction: ${sortDirection === 'asc' ? 'ascending' : 'descending'}`}
+            title={sortDirection === 'asc' ? 'Ascending' : 'Descending'}
+          >
+            {sortDirection === 'asc' ? '↑' : '↓'}
+          </button>
+        </div>
         {!isExpiredOrArchived && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginLeft: 'auto' }}>
-            <label style={{ display: 'flex', alignItems: 'center', gap: '0.375rem', fontSize: '0.75rem', color: sortMode === 'priority' ? 'var(--color-success)' : 'var(--text-secondary)', cursor: 'pointer' }}>
-              <input
-                type="checkbox"
-                checked={sortMode === 'priority'}
-                onChange={(e) => onSortModeChange(e.target.checked ? 'priority' : 'chronological')}
-                style={{ accentColor: 'var(--color-success)' }}
-              />
-              Best Match
-            </label>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
             <label style={{ display: 'flex', alignItems: 'center', gap: '0.375rem', fontSize: '0.75rem', color: 'var(--text-secondary)', cursor: 'pointer' }}>
               <input
                 type="checkbox"
@@ -350,7 +379,7 @@ export function RequestQueueSection({
                       {request.vote_count} {request.vote_count === 1 ? 'vote' : 'votes'}
                     </span>
                   )}
-                  {sortMode === 'priority' && request.priority_score != null && (
+                  {sortField === 'best_match' && request.priority_score != null && (
                     <Tooltip description="Combines votes, wait time, harmonic compatibility, and BPM energy match" delay={100}>
                       <span
                         style={{
@@ -461,6 +490,40 @@ export function RequestQueueSection({
           ))}
         </div>
       )}
+
+      {(() => {
+        // Growing window applies to the full fetched set (`requests`), not the
+        // status-filtered view, so the count reflects what's loaded vs the
+        // server's true total. Hide once everything is loaded or we hit the cap.
+        const loaded = requests.length;
+        const hasMore = loaded < total && loaded < PUBLIC_PAGE_MAX;
+        if (loaded === 0) return null;
+        return (
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '1rem' }}>
+            <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
+              Showing {loaded} of {total}
+            </span>
+            {hasMore && (
+              <button
+                type="button"
+                className="btn btn-sm"
+                style={{ background: 'var(--surface-raised)' }}
+                disabled={loadingMore}
+                onClick={async () => {
+                  setLoadingMore(true);
+                  try {
+                    await onLoadMore(filter === 'all' ? undefined : filter);
+                  } finally {
+                    setLoadingMore(false);
+                  }
+                }}
+              >
+                {loadingMore ? 'Loading…' : 'Load More'}
+              </button>
+            )}
+          </div>
+        );
+      })()}
     </>
   );
 }

--- a/dashboard/app/(dj)/events/[code]/components/SongManagementTab.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/SongManagementTab.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import type { SongRequest, PlayHistoryItem, RecommendedTrack } from '@/lib/api-types';
-import type { SortMode } from '@/lib/priority-score';
+import type { SongRequest, PlayHistoryItem, RecommendedTrack, RequestSort, SortDirection } from '@/lib/api-types';
 import { RequestQueueSection } from './RequestQueueSection';
 import { SyncReportPanel } from './SyncReportPanel';
 import { PlayHistorySection } from './PlayHistorySection';
@@ -45,8 +44,12 @@ interface SongManagementTabProps {
   rejectingAll?: boolean;
   deletingRequest?: number | null;
   refreshingRequest?: number | null;
-  sortMode: SortMode;
-  onSortModeChange: (mode: SortMode) => void;
+  sortField: RequestSort;
+  sortDirection: SortDirection;
+  onSortFieldChange: (field: RequestSort) => void;
+  onSortDirectionToggle: () => void;
+  total: number;
+  onLoadMore: (status?: string) => Promise<void>;
 }
 
 export function SongManagementTab(props: SongManagementTabProps) {
@@ -89,8 +92,12 @@ export function SongManagementTab(props: SongManagementTabProps) {
         rejectingAll={props.rejectingAll}
         deletingRequest={props.deletingRequest}
         refreshingRequest={props.refreshingRequest}
-        sortMode={props.sortMode}
-        onSortModeChange={props.onSortModeChange}
+        sortField={props.sortField}
+        sortDirection={props.sortDirection}
+        onSortFieldChange={props.onSortFieldChange}
+        onSortDirectionToggle={props.onSortDirectionToggle}
+        total={props.total}
+        onLoadMore={props.onLoadMore}
       />
       </HelpSpot>
 

--- a/dashboard/app/(dj)/events/[code]/components/SongManagementTab.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/SongManagementTab.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import type { SongRequest, PlayHistoryItem, RecommendedTrack, RequestSort, SortDirection } from '@/lib/api-types';
 import { RequestQueueSection } from './RequestQueueSection';
+import type { StatusFilter } from './types';
 import { SyncReportPanel } from './SyncReportPanel';
 import { PlayHistorySection } from './PlayHistorySection';
 import { RecommendationsCard } from './RecommendationsCard';
@@ -50,6 +51,9 @@ interface SongManagementTabProps {
   onSortDirectionToggle: () => void;
   total: number;
   onLoadMore: (status?: string) => Promise<void>;
+  filter: StatusFilter;
+  onFilterChange: (filter: StatusFilter) => void;
+  statusCounts: Record<StatusFilter, number>;
 }
 
 export function SongManagementTab(props: SongManagementTabProps) {
@@ -98,6 +102,9 @@ export function SongManagementTab(props: SongManagementTabProps) {
         onSortDirectionToggle={props.onSortDirectionToggle}
         total={props.total}
         onLoadMore={props.onLoadMore}
+        filter={props.filter}
+        onFilterChange={props.onFilterChange}
+        statusCounts={props.statusCounts}
       />
       </HelpSpot>
 

--- a/dashboard/app/(dj)/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import PreEventVotingTab from "../PreEventVotingTab";
-import { apiClient } from "@/lib/api";
+import { apiClient, PUBLIC_PAGE_MAX, type PendingReviewRow } from "@/lib/api";
 
 const baseEvent = {
   code: "ABC",
@@ -16,25 +16,68 @@ const baseEvent = {
   tidal_collection_bidirectional: false,
 };
 
-vi.mock("@/lib/api", () => ({
-  apiClient: {
-    patchCollectionSettings: vi.fn().mockResolvedValue({
-      code: "ABC",
-      name: "Wedding",
-      collection_opens_at: "2026-04-21T12:00:00Z",
-      live_starts_at: "2026-04-22T20:00:00Z",
-      submission_cap_per_guest: 15,
-      collection_phase_override: "force_live",
-      phase: "live",
-      tidal_sync_enabled: false,
-      tidal_collection_playlist_id: null,
-      tidal_collection_bidirectional: false,
-    }),
-    getPendingReview: vi.fn().mockResolvedValue({ requests: [], total: 0 }),
-    bulkReview: vi.fn().mockResolvedValue({ accepted: 0, rejected: 0, unchanged: 0 }),
-    syncCollectionToTidal: vi.fn().mockResolvedValue({ queued: 3 }),
-  },
-}));
+// A full PendingReviewRow literal — every required key present (#478).
+function makeRow(id: number): PendingReviewRow {
+  return {
+    id,
+    song_title: `Song ${id}`,
+    artist: `Artist ${id}`,
+    artwork_url: null,
+    vote_count: id,
+    nickname: null,
+    created_at: "2026-04-21T12:00:00Z",
+    note: null,
+    status: "new",
+  };
+}
+
+// Pending-review envelope (#478): requests + total (+ pagination/sort echo).
+function envelope(rows: PendingReviewRow[], total: number) {
+  return { requests: rows, total, limit: 100, offset: 0, sort: null, direction: null };
+}
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    apiClient: {
+      patchCollectionSettings: vi.fn().mockResolvedValue({
+        code: "ABC",
+        name: "Wedding",
+        collection_opens_at: "2026-04-21T12:00:00Z",
+        live_starts_at: "2026-04-22T20:00:00Z",
+        submission_cap_per_guest: 15,
+        collection_phase_override: "force_live",
+        phase: "live",
+        tidal_sync_enabled: false,
+        tidal_collection_playlist_id: null,
+        tidal_collection_bidirectional: false,
+      }),
+      getPendingReview: vi.fn().mockResolvedValue({
+        requests: [],
+        total: 0,
+        limit: 100,
+        offset: 0,
+        sort: null,
+        direction: null,
+      }),
+      bulkReview: vi.fn().mockResolvedValue({ accepted: 0, rejected: 0, unchanged: 0 }),
+      syncCollectionToTidal: vi.fn().mockResolvedValue({ queued: 3 }),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(apiClient.getPendingReview).mockReset();
+  vi.mocked(apiClient.getPendingReview).mockResolvedValue({
+    requests: [],
+    total: 0,
+    limit: 100,
+    offset: 0,
+    sort: null,
+    direction: null,
+  });
+});
 
 describe("PreEventVotingTab", () => {
   it("renders phase and share link", () => {
@@ -149,5 +192,179 @@ describe("PreEventVotingTab", () => {
         tidal_collection_bidirectional: true,
       });
     });
+  });
+
+  // ---- Pagination + sort (issue #478) ----
+
+  it("fetches the first page in default Review order (no sort param)", async () => {
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={vi.fn()}
+      />
+    );
+    await waitFor(() => {
+      expect(apiClient.getPendingReview).toHaveBeenCalledWith("ABC", {
+        limit: 100,
+        offset: 0,
+      });
+    });
+  });
+
+  it("re-fetches with sort + direction when the Sort select changes", async () => {
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={vi.fn()}
+      />
+    );
+    await waitFor(() => expect(apiClient.getPendingReview).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText(/sort pending review by/i), {
+      target: { value: "upvotes" },
+    });
+
+    await waitFor(() => {
+      expect(apiClient.getPendingReview).toHaveBeenCalledWith("ABC", {
+        sort: "upvotes",
+        direction: "desc",
+        limit: 100,
+        offset: 0,
+      });
+    });
+  });
+
+  it("snaps direction to the field default and toggles it", async () => {
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={vi.fn()}
+      />
+    );
+    await waitFor(() => expect(apiClient.getPendingReview).toHaveBeenCalled());
+
+    // Title defaults to ascending; the toggle then flips it to descending.
+    fireEvent.change(screen.getByLabelText(/sort pending review by/i), {
+      target: { value: "title" },
+    });
+    await waitFor(() => {
+      expect(apiClient.getPendingReview).toHaveBeenCalledWith("ABC", {
+        sort: "title",
+        direction: "asc",
+        limit: 100,
+        offset: 0,
+      });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /sort direction/i }));
+    await waitFor(() => {
+      expect(apiClient.getPendingReview).toHaveBeenCalledWith("ABC", {
+        sort: "title",
+        direction: "desc",
+        limit: 100,
+        offset: 0,
+      });
+    });
+  });
+
+  it("has no direction toggle in Review order", async () => {
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={vi.fn()}
+      />
+    );
+    await waitFor(() => expect(apiClient.getPendingReview).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: /sort direction/i })).not.toBeInTheDocument();
+  });
+
+  it("shows 'Showing X of N' from the envelope total and Load More grows the window", async () => {
+    vi.mocked(apiClient.getPendingReview)
+      .mockResolvedValueOnce(envelope([makeRow(1), makeRow(2)], 250))
+      .mockResolvedValueOnce(envelope([makeRow(1), makeRow(2), makeRow(3)], 250));
+
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText(/showing 2 of 250/i)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /load more/i }));
+
+    // Second call asks for the grown window (limit 200) from offset 0.
+    await waitFor(() => {
+      expect(apiClient.getPendingReview).toHaveBeenLastCalledWith("ABC", {
+        limit: 200,
+        offset: 0,
+      });
+    });
+  });
+
+  it("hides Load More once the loaded count reaches the envelope total", async () => {
+    vi.mocked(apiClient.getPendingReview).mockResolvedValue(
+      envelope([makeRow(1), makeRow(2)], 2)
+    );
+
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText(/showing 2 of 2/i)).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+  });
+
+  it("clamps the growing window to PUBLIC_PAGE_MAX on Load More", async () => {
+    // Enough total to keep Load More alive; we click until the requested limit
+    // would exceed the cap and assert it is clamped to PUBLIC_PAGE_MAX. The
+    // mock always echoes the requested limit's worth of (one) row so the loaded
+    // count never trips the row-length gate — isolating the limit clamp.
+    vi.mocked(apiClient.getPendingReview).mockImplementation(async (_code, opts) => ({
+      requests: [makeRow(1)],
+      total: 100_000,
+      limit: opts?.limit ?? 100,
+      offset: 0,
+      sort: null,
+      direction: null,
+    }));
+
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={vi.fn()}
+      />
+    );
+    await waitFor(() => expect(screen.getByRole("button", { name: /load more/i })).toBeInTheDocument());
+
+    // Click Load More many times; the requested limit grows by 100 but clamps.
+    for (let i = 0; i < 10; i++) {
+      fireEvent.click(screen.getByRole("button", { name: /load more/i }));
+      // Let the awaited fetch settle before the next click.
+      await waitFor(() => expect(apiClient.getPendingReview).toHaveBeenCalled());
+    }
+
+    const requestedLimits = vi
+      .mocked(apiClient.getPendingReview)
+      .mock.calls.map(([, opts]) => opts?.limit ?? 0);
+    expect(Math.max(...requestedLimits)).toBeLessThanOrEqual(PUBLIC_PAGE_MAX);
   });
 });

--- a/dashboard/app/(dj)/events/[code]/components/__tests__/RequestQueueSection.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/__tests__/RequestQueueSection.test.tsx
@@ -63,6 +63,9 @@ function baseProps(overrides: Record<string, unknown> = {}) {
     onSortDirectionToggle: vi.fn(),
     total: 1,
     onLoadMore: vi.fn().mockResolvedValue(undefined),
+    filter: 'all' as const,
+    onFilterChange: vi.fn(),
+    statusCounts: { all: 1, new: 1, accepted: 0, playing: 0, played: 0, rejected: 0 },
     ...overrides,
   };
 }
@@ -95,6 +98,71 @@ describe('RequestQueueSection sort controls', () => {
     expect(screen.getByLabelText('Sort direction: ascending')).toHaveTextContent('↑');
     rerender(<RequestQueueSection {...baseProps({ sortDirection: 'desc' })} />);
     expect(screen.getByLabelText('Sort direction: descending')).toHaveTextContent('↓');
+  });
+});
+
+describe('RequestQueueSection status tabs (server-side, issue #478)', () => {
+  it('renders tab counts from statusCounts, not the loaded requests window', () => {
+    // Only a 2-row window is loaded, but the true event totals are larger.
+    const reqs = [makeRequest({ id: 1, status: 'accepted' }), makeRequest({ id: 2, status: 'accepted' })];
+    render(
+      <RequestQueueSection
+        {...baseProps({
+          requests: reqs,
+          filter: 'accepted',
+          total: 25,
+          statusCounts: { all: 120, new: 80, accepted: 25, playing: 2, played: 10, rejected: 3 },
+        })}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'All (120)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'New (80)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Accepted (25)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Playing (2)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Played (10)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Rejected (3)' })).toBeInTheDocument();
+  });
+
+  it('calls onFilterChange when a status tab is selected (server-side filter)', () => {
+    const onFilterChange = vi.fn();
+    render(<RequestQueueSection {...baseProps({ onFilterChange })} />);
+    fireEvent.click(screen.getByRole('button', { name: /^Accepted/ }));
+    expect(onFilterChange).toHaveBeenCalledWith('accepted');
+  });
+
+  it('renders the server-returned requests as-is without client-side status filtering', () => {
+    // filter='accepted' but the server already returned the correct rows. The
+    // component must NOT drop rows whose status differs (no client filter).
+    const reqs = [
+      makeRequest({ id: 1, status: 'accepted', song_title: 'Keep Me' }),
+      makeRequest({ id: 2, status: 'accepted', song_title: 'And Me' }),
+    ];
+    render(
+      <RequestQueueSection
+        {...baseProps({
+          requests: reqs,
+          filter: 'accepted',
+          total: 2,
+          statusCounts: { all: 2, new: 0, accepted: 2, playing: 0, played: 0, rejected: 0 },
+        })}
+      />,
+    );
+    expect(screen.getByText('Keep Me')).toBeInTheDocument();
+    expect(screen.getByText('And Me')).toBeInTheDocument();
+  });
+
+  it('uses statusCounts.new for the Accept All button label', () => {
+    render(
+      <RequestQueueSection
+        {...baseProps({
+          requests: [makeRequest({ id: 1, status: 'accepted' })],
+          filter: 'accepted',
+          statusCounts: { all: 50, new: 42, accepted: 8, playing: 0, played: 0, rejected: 0 },
+        })}
+      />,
+    );
+    // Honest count even when no "new" rows are in the loaded window.
+    expect(screen.getByRole('button', { name: 'Accept All (42)' })).toBeInTheDocument();
   });
 });
 

--- a/dashboard/app/(dj)/events/[code]/components/__tests__/RequestQueueSection.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/__tests__/RequestQueueSection.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { SongRequest } from '@/lib/api-types';
+
+// Keep the unit isolated from the heavy api client + UI children.
+// A small cap keeps the "hits PUBLIC_PAGE_MAX" test from rendering 500 rows.
+vi.mock('@/lib/api', () => ({ PUBLIC_PAGE_MAX: 3 }));
+vi.mock('@/components/Tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../SyncStatusBadges', () => ({ SyncStatusBadges: () => null }));
+vi.mock('@/components/MusicBadges', () => ({
+  KeyBadge: () => null,
+  BpmBadge: () => null,
+  GenreBadge: () => null,
+}));
+vi.mock('@/components/PreviewPlayer', () => ({ PreviewPlayer: () => null }));
+
+import { RequestQueueSection } from '../RequestQueueSection';
+
+function makeRequest(overrides: Partial<SongRequest> = {}): SongRequest {
+  return {
+    id: 1,
+    event_id: 1,
+    song_title: 'Test Song',
+    artist: 'Test Artist',
+    source: 'spotify',
+    source_url: null,
+    artwork_url: null,
+    note: null,
+    nickname: null,
+    status: 'new',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    accepted_at: null,
+    is_duplicate: false,
+    raw_search_query: null,
+    sync_results_json: null,
+    vote_count: 0,
+    priority_score: null,
+    genre: null,
+    bpm: null,
+    musical_key: null,
+    ...overrides,
+  };
+}
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+  return {
+    requests: [makeRequest()],
+    isExpiredOrArchived: false,
+    connectedServices: [],
+    updating: null,
+    acceptingAll: false,
+    syncingRequest: null,
+    onUpdateStatus: vi.fn(),
+    onAcceptAll: vi.fn(),
+    onSyncToTidal: vi.fn(),
+    onOpenTidalPicker: vi.fn(),
+    sortField: 'date_requested' as const,
+    sortDirection: 'desc' as const,
+    onSortFieldChange: vi.fn(),
+    onSortDirectionToggle: vi.fn(),
+    total: 1,
+    onLoadMore: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('RequestQueueSection sort controls', () => {
+  it('renders the sort select reflecting the current field', () => {
+    render(<RequestQueueSection {...baseProps({ sortField: 'best_match' })} />);
+    const select = screen.getByLabelText('Sort requests by') as HTMLSelectElement;
+    expect(select.value).toBe('best_match');
+  });
+
+  it('calls onSortFieldChange when a new field is picked', () => {
+    const onSortFieldChange = vi.fn();
+    render(<RequestQueueSection {...baseProps({ onSortFieldChange })} />);
+    fireEvent.change(screen.getByLabelText('Sort requests by'), {
+      target: { value: 'upvotes' },
+    });
+    expect(onSortFieldChange).toHaveBeenCalledWith('upvotes');
+  });
+
+  it('calls onSortDirectionToggle when the direction button is clicked', () => {
+    const onSortDirectionToggle = vi.fn();
+    render(<RequestQueueSection {...baseProps({ onSortDirectionToggle, sortDirection: 'asc' })} />);
+    fireEvent.click(screen.getByLabelText(/Sort direction/));
+    expect(onSortDirectionToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows ↑ for asc and ↓ for desc', () => {
+    const { rerender } = render(<RequestQueueSection {...baseProps({ sortDirection: 'asc' })} />);
+    expect(screen.getByLabelText('Sort direction: ascending')).toHaveTextContent('↑');
+    rerender(<RequestQueueSection {...baseProps({ sortDirection: 'desc' })} />);
+    expect(screen.getByLabelText('Sort direction: descending')).toHaveTextContent('↓');
+  });
+});
+
+describe('RequestQueueSection Load More', () => {
+  it('shows "Showing X of N" and a Load More button when more rows exist', () => {
+    render(<RequestQueueSection {...baseProps({ requests: [makeRequest()], total: 5 })} />);
+    expect(screen.getByText('Showing 1 of 5')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Load More' })).toBeInTheDocument();
+  });
+
+  it('hides the Load More button once everything is loaded', () => {
+    const reqs = [makeRequest({ id: 1 }), makeRequest({ id: 2 })];
+    render(<RequestQueueSection {...baseProps({ requests: reqs, total: 2 })} />);
+    expect(screen.getByText('Showing 2 of 2')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Load More' })).toBeNull();
+  });
+
+  it('hides Load More at the PUBLIC_PAGE_MAX cap even if total is larger', () => {
+    // PUBLIC_PAGE_MAX is mocked to 3 above, so 3 loaded rows hits the cap.
+    const reqs = Array.from({ length: 3 }, (_, i) => makeRequest({ id: i + 1 }));
+    render(<RequestQueueSection {...baseProps({ requests: reqs, total: 900 })} />);
+    expect(screen.getByText('Showing 3 of 900')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Load More' })).toBeNull();
+  });
+
+  it('invokes onLoadMore with the active status filter', async () => {
+    const onLoadMore = vi.fn().mockResolvedValue(undefined);
+    render(<RequestQueueSection {...baseProps({ onLoadMore, total: 5 })} />);
+    // Default filter is "all" → status omitted (undefined).
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Load More' }));
+    });
+    expect(onLoadMore).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/dashboard/app/(dj)/events/[code]/components/__tests__/SongManagementTab.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/__tests__/SongManagementTab.test.tsx
@@ -66,6 +66,9 @@ const baseProps = {
   onSortDirectionToggle: vi.fn(),
   total: 1,
   onLoadMore: vi.fn(),
+  filter: 'all' as const,
+  onFilterChange: vi.fn(),
+  statusCounts: { all: 1, new: 0, accepted: 1, playing: 0, played: 0, rejected: 0 },
 };
 
 describe('SongManagementTab', () => {

--- a/dashboard/app/(dj)/events/[code]/components/__tests__/SongManagementTab.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/__tests__/SongManagementTab.test.tsx
@@ -60,8 +60,12 @@ const baseProps = {
   beatportLinked: false,
   onAcceptTrack: vi.fn(),
   onRefreshRequests: vi.fn(),
-  sortMode: 'chronological' as const,
-  onSortModeChange: vi.fn(),
+  sortField: 'date_requested' as const,
+  sortDirection: 'desc' as const,
+  onSortFieldChange: vi.fn(),
+  onSortDirectionToggle: vi.fn(),
+  total: 1,
+  onLoadMore: vi.fn(),
 };
 
 describe('SongManagementTab', () => {

--- a/dashboard/app/(dj)/events/[code]/page.tsx
+++ b/dashboard/app/(dj)/events/[code]/page.tsx
@@ -5,11 +5,11 @@ import { useRouter, useParams } from 'next/navigation';
 import Link from 'next/link';
 import { QRCodeSVG } from 'qrcode.react';
 import { useAuth } from '@/lib/auth';
-import { api, ApiError, Event, ArchivedEvent, SongRequest, PlayHistoryItem, TidalStatus, TidalSearchResult, BeatportStatus, CollectionSettingsResponse } from '@/lib/api';
+import { api, ApiError, Event, ArchivedEvent, SongRequest, PlayHistoryItem, TidalStatus, TidalSearchResult, BeatportStatus, CollectionSettingsResponse, PUBLIC_PAGE_MAX } from '@/lib/api';
 import { useEventStream } from '@/lib/use-event-stream';
 import { usePollingLoop } from '@/lib/usePollingLoop';
-import type { BeatportSearchResult, NowPlayingInfo } from '@/lib/api-types';
-import type { SortMode } from '@/lib/priority-score';
+import type { BeatportSearchResult, NowPlayingInfo, RequestSort, SortDirection } from '@/lib/api-types';
+import { SORT_FIELD_DEFAULT_DIRECTION, isRequestSort, migrateLegacySort } from '@/lib/request-sort';
 import { useHelp } from '@/lib/help/HelpContext';
 import { HelpSpot } from '@/components/help/HelpSpot';
 import { HelpButton } from '@/components/help/HelpButton';
@@ -33,6 +33,18 @@ function toLocalDateTimeString(date: Date): string {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }
 
+/** Read the persisted sort field for an event, falling back to the legacy
+ *  toggle then the default. Returns a valid {@link RequestSort}. */
+function readStoredSortField(code: string): RequestSort {
+  try {
+    const storedField = localStorage.getItem(`wrzdj-sortfield-${code}`);
+    if (storedField && isRequestSort(storedField)) return storedField;
+    return migrateLegacySort(localStorage.getItem(`wrzdj-sort-${code}`));
+  } catch {
+    return migrateLegacySort(null);
+  }
+}
+
 export default function EventQueuePage() {
   const { isAuthenticated, isLoading } = useAuth();
   const router = useRouter();
@@ -41,6 +53,10 @@ export default function EventQueuePage() {
 
   const [event, setEvent] = useState<Event | ArchivedEvent | null>(null);
   const [requests, setRequests] = useState<SongRequest[]>([]);
+  // Growing-window pagination (issue #478): every refresh re-fetches
+  // [0, displayLimit) so live vote/status changes never drift the offset.
+  const [displayLimit, setDisplayLimit] = useState(100);
+  const [requestTotal, setRequestTotal] = useState(0);
   const [playHistory, setPlayHistory] = useState<PlayHistoryItem[]>([]);
   const [playHistoryTotal, setPlayHistoryTotal] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -136,28 +152,72 @@ export default function EventQueuePage() {
     }
   });
 
-  // Sort mode (persisted in localStorage per event)
-  const [sortMode, setSortMode] = useState<SortMode>(() => {
+  // Sort field + direction (persisted in localStorage per event, issue #478).
+  // Migrates the legacy single `wrzdj-sort-${code}` toggle: 'priority' →
+  // best_match, anything else → date_requested.
+  const [sortField, setSortField] = useState<RequestSort>(() => readStoredSortField(code));
+  const [sortDirection, setSortDirection] = useState<SortDirection>(() => {
     try {
-      const stored = localStorage.getItem(`wrzdj-sort-${code}`);
-      return stored === 'priority' ? 'priority' : 'chronological';
+      const storedDir = localStorage.getItem(`wrzdj-sortdir-${code}`);
+      if (storedDir === 'asc' || storedDir === 'desc') return storedDir;
     } catch {
-      return 'chronological';
+      // localStorage unavailable
     }
+    return SORT_FIELD_DEFAULT_DIRECTION[readStoredSortField(code)];
   });
 
-  const handleSortModeChange = useCallback((mode: SortMode) => {
-    setSortMode(mode);
+  // Changing the field snaps direction to that field's default (a separate
+  // toggle then flips it). Persist both for next session.
+  const handleSortFieldChange = useCallback((field: RequestSort) => {
+    const direction = SORT_FIELD_DEFAULT_DIRECTION[field];
+    setSortField(field);
+    setSortDirection(direction);
     try {
-      localStorage.setItem(`wrzdj-sort-${code}`, mode);
+      localStorage.setItem(`wrzdj-sortfield-${code}`, field);
+      localStorage.setItem(`wrzdj-sortdir-${code}`, direction);
     } catch {
       // localStorage unavailable
     }
   }, [code]);
 
-  // Ref so loadData/callbacks always use current sort mode
-  const sortModeRef = useRef(sortMode);
-  sortModeRef.current = sortMode;
+  const handleSortDirectionToggle = useCallback(() => {
+    setSortDirection((prev) => {
+      const next: SortDirection = prev === 'asc' ? 'desc' : 'asc';
+      try {
+        localStorage.setItem(`wrzdj-sortdir-${code}`, next);
+      } catch {
+        // localStorage unavailable
+      }
+      return next;
+    });
+  }, [code]);
+
+  // Refs so polling/SSE/mutation callbacks always read the current values.
+  const sortFieldRef = useRef(sortField);
+  sortFieldRef.current = sortField;
+  const sortDirectionRef = useRef(sortDirection);
+  sortDirectionRef.current = sortDirection;
+  const displayLimitRef = useRef(displayLimit);
+  displayLimitRef.current = displayLimit;
+
+  // Single growing-window fetch: always [0, displayLimit) with the current
+  // sort field/direction so live reorders never drift the offset (issue #478).
+  // Reads refs so polling/SSE/mutation callbacks pick up current values.
+  const reloadRequests = useCallback(
+    async (status?: string): Promise<SongRequest[]> => {
+      const resp = await api.getRequests(code, {
+        status,
+        sort: sortFieldRef.current,
+        direction: sortDirectionRef.current,
+        limit: displayLimitRef.current,
+        offset: 0,
+      });
+      setRequests(resp.requests);
+      setRequestTotal(resp.total);
+      return resp.requests;
+    },
+    [code],
+  );
 
   const toggleCompactMode = useCallback(() => {
     setCompactMode((prev) => {
@@ -253,7 +313,12 @@ export default function EventQueuePage() {
     try {
       const [eventData, requestsData, historyData, displaySettings, tidalStatusData, beatportStatusData, nowPlayingData, bridgeStatusData] = await Promise.all([
         api.getEvent(code),
-        api.getRequests(code, { sort: sortModeRef.current }),
+        api.getRequests(code, {
+          sort: sortFieldRef.current,
+          direction: sortDirectionRef.current,
+          limit: displayLimitRef.current,
+          offset: 0,
+        }),
         api.getPlayHistory(code).catch((): undefined => undefined),
         api.getDisplaySettings(code).catch(() => ({ now_playing_hidden: false, now_playing_auto_hide_minutes: 10, requests_open: true, kiosk_display_only: false })),
         api.getTidalStatus().catch(() => ({ linked: false, user_id: null, expires_at: null, integration_enabled: true })),
@@ -262,7 +327,8 @@ export default function EventQueuePage() {
         api.getBridgeStatus(code).catch(() => ({ connected: false, device_name: null, last_seen: null, circuit_breaker_state: null, buffer_size: null, plugin_id: null, deck_count: null, uptime_seconds: null })),
       ]);
       setEvent(eventData);
-      setRequests(requestsData);
+      setRequests(requestsData.requests);
+      setRequestTotal(requestsData.total);
       if (historyData !== undefined) {
         setPlayHistory(historyData.items);
         setPlayHistoryTotal(historyData.total);
@@ -301,12 +367,18 @@ export default function EventQueuePage() {
         try {
           const [archivedEvents, requestsData] = await Promise.all([
             api.getArchivedEvents(),
-            api.getRequests(code, { sort: sortModeRef.current }), // Still works for owners
+            api.getRequests(code, {
+              sort: sortFieldRef.current,
+              direction: sortDirectionRef.current,
+              limit: displayLimitRef.current,
+              offset: 0,
+            }), // Still works for owners
           ]);
           const archivedEvent = archivedEvents.find((e) => e.code === code);
           if (archivedEvent) {
             setEvent(archivedEvent);
-            setRequests(requestsData);
+            setRequests(requestsData.requests);
+            setRequestTotal(requestsData.total);
             setEventStatus(archivedEvent.status);
             setError(null);
             return false; // Stop polling - event is expired
@@ -374,8 +446,7 @@ export default function EventQueuePage() {
     setAcceptingAll(true);
     try {
       await api.acceptAllRequests(code);
-      const updatedRequests = await api.getRequests(code, { sort: sortModeRef.current });
-      setRequests(updatedRequests);
+      await reloadRequests();
     } catch (err) {
       setActionError(err instanceof ApiError ? err.message : 'Failed to accept all requests');
     } finally {
@@ -566,8 +637,7 @@ export default function EventQueuePage() {
         )
       );
       // Refresh to get updated sync_results_json from server
-      const updatedRequests = await api.getRequests(code, { sort: sortModeRef.current });
-      setRequests(updatedRequests);
+      await reloadRequests();
     } catch (err) {
       setActionError(err instanceof ApiError ? err.message : 'Failed to sync to Tidal');
     } finally {
@@ -601,8 +671,7 @@ export default function EventQueuePage() {
     setLinkingTrack(true);
     try {
       await api.linkTidalTrack(requestId, tidalTrackId);
-      const updatedRequests = await api.getRequests(code, { sort: sortModeRef.current });
-      setRequests(updatedRequests);
+      await reloadRequests();
       setShowTidalPicker(null);
     } catch (err) {
       setActionError(err instanceof ApiError ? err.message : 'Failed to link Tidal track');
@@ -638,8 +707,7 @@ export default function EventQueuePage() {
     try {
       await api.linkBeatportTrack(requestId, beatportTrackId);
       // Reload requests to get updated sync_results_json
-      const updatedRequests = await api.getRequests(code, { sort: sortModeRef.current });
-      setRequests(updatedRequests);
+      await reloadRequests();
       setShowBeatportPicker(null);
     } catch (err) {
       setActionError(err instanceof ApiError ? err.message : 'Failed to link Beatport track');
@@ -766,8 +834,7 @@ export default function EventQueuePage() {
     setRejectingAll(true);
     try {
       await api.rejectAllRequests(code);
-      const updatedRequests = await api.getRequests(code, { sort: sortModeRef.current });
-      setRequests(updatedRequests);
+      await reloadRequests();
     } catch (err) {
       setActionError(err instanceof ApiError ? err.message : 'Failed to reject all requests');
     } finally {
@@ -778,8 +845,7 @@ export default function EventQueuePage() {
   const handleBulkDelete = async (status?: string) => {
     try {
       await api.bulkDeleteRequests(code, status);
-      const updatedRequests = await api.getRequests(code, { sort: sortModeRef.current });
-      setRequests(updatedRequests);
+      await reloadRequests();
     } catch (err) {
       setActionError(err instanceof ApiError ? err.message : 'Failed to bulk delete requests');
     }
@@ -802,14 +868,22 @@ export default function EventQueuePage() {
       },
     );
     // Refresh request list
-    const updatedRequests = await api.getRequests(code, { sort: sortModeRef.current });
-    setRequests(updatedRequests);
+    await reloadRequests();
   };
 
   const handleRefreshRequests = useCallback(async () => {
-    const updatedRequests = await api.getRequests(code, { sort: sortModeRef.current });
-    setRequests(updatedRequests);
-  }, [code]);
+    await reloadRequests();
+  }, [reloadRequests]);
+
+  // Grow the window by a page and re-fetch. When a status filter is active the
+  // caller passes it so `total` stays honest per-filter (issue #478).
+  const handleLoadMore = useCallback(async (status?: string) => {
+    const next = Math.min(displayLimitRef.current + 100, PUBLIC_PAGE_MAX);
+    if (next === displayLimitRef.current) return;
+    displayLimitRef.current = next;
+    setDisplayLimit(next);
+    await reloadRequests(status);
+  }, [reloadRequests]);
 
   if (isLoading || !isAuthenticated) {
     return (
@@ -994,8 +1068,12 @@ export default function EventQueuePage() {
             onSyncToTidal={handleSyncToTidal}
             onOpenTidalPicker={handleOpenTidalPicker}
             onScrollToSyncReport={handleScrollToSyncReport}
-            sortMode={sortMode}
-            onSortModeChange={handleSortModeChange}
+            sortField={sortField}
+            sortDirection={sortDirection}
+            onSortFieldChange={handleSortFieldChange}
+            onSortDirectionToggle={handleSortDirectionToggle}
+            total={requestTotal}
+            onLoadMore={handleLoadMore}
           />
           <PlayHistorySection
             items={playHistory}
@@ -1072,8 +1150,12 @@ export default function EventQueuePage() {
               rejectingAll={rejectingAll}
               deletingRequest={deletingRequest}
               refreshingRequest={refreshingRequest}
-              sortMode={sortMode}
-              onSortModeChange={handleSortModeChange}
+              sortField={sortField}
+              sortDirection={sortDirection}
+              onSortFieldChange={handleSortFieldChange}
+              onSortDirectionToggle={handleSortDirectionToggle}
+              total={requestTotal}
+              onLoadMore={handleLoadMore}
             />
           </div>
 

--- a/dashboard/app/(dj)/events/[code]/page.tsx
+++ b/dashboard/app/(dj)/events/[code]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import Link from 'next/link';
 import { QRCodeSVG } from 'qrcode.react';
@@ -22,6 +22,7 @@ import { TidalLoginModal } from './components/TidalLoginModal';
 import { BeatportLoginModal } from './components/BeatportLoginModal';
 import { ServiceTrackPickerModal } from './components/ServiceTrackPickerModal';
 import { RequestQueueSection } from './components/RequestQueueSection';
+import type { StatusFilter } from './components/types';
 import { PlayHistorySection } from './components/PlayHistorySection';
 import { SongManagementTab } from './components/SongManagementTab';
 import { EventManagementTab } from './components/EventManagementTab';
@@ -31,6 +32,23 @@ import type { RecommendedTrack } from '@/lib/api-types';
 function toLocalDateTimeString(date: Date): string {
   const pad = (n: number) => n.toString().padStart(2, '0');
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+/** Coerce the server's open `status_counts` dict into the strict per-tab shape,
+ *  defaulting any absent status to 0 (issue #478). The backend always returns
+ *  all six keys, but this keeps the type honest at the boundary. */
+function normalizeStatusCounts(
+  counts: Record<string, number> | null | undefined,
+): Record<StatusFilter, number> {
+  const c = counts ?? {};
+  return {
+    all: c.all ?? 0,
+    new: c.new ?? 0,
+    accepted: c.accepted ?? 0,
+    playing: c.playing ?? 0,
+    played: c.played ?? 0,
+    rejected: c.rejected ?? 0,
+  };
 }
 
 /** Read the persisted sort field for an event, falling back to the legacy
@@ -55,8 +73,16 @@ export default function EventQueuePage() {
   const [requests, setRequests] = useState<SongRequest[]>([]);
   // Growing-window pagination (issue #478): every refresh re-fetches
   // [0, displayLimit) so live vote/status changes never drift the offset.
-  const [displayLimit, setDisplayLimit] = useState(100);
+  const INITIAL_DISPLAY_LIMIT = 100;
+  const [displayLimit, setDisplayLimit] = useState(INITIAL_DISPLAY_LIMIT);
   const [requestTotal, setRequestTotal] = useState(0);
+  // Status filtering is server-side (issue #478): the active filter is lifted
+  // here so the 5s poll AND manual reloads fetch with it, and the tab counts
+  // come from the server's true per-status totals (not the loaded window).
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [statusCounts, setStatusCounts] = useState<Record<StatusFilter, number>>({
+    all: 0, new: 0, accepted: 0, playing: 0, played: 0, rejected: 0,
+  });
   const [playHistory, setPlayHistory] = useState<PlayHistoryItem[]>([]);
   const [playHistoryTotal, setPlayHistoryTotal] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -199,14 +225,22 @@ export default function EventQueuePage() {
   sortDirectionRef.current = sortDirection;
   const displayLimitRef = useRef(displayLimit);
   displayLimitRef.current = displayLimit;
+  const statusFilterRef = useRef(statusFilter);
+  statusFilterRef.current = statusFilter;
 
-  // Single growing-window fetch: always [0, displayLimit) with the current
-  // sort field/direction so live reorders never drift the offset (issue #478).
-  // Reads refs so polling/SSE/mutation callbacks pick up current values.
+  // Map the tab filter to the API's `status` param: 'all' → undefined.
+  const filterToStatus = (filter: StatusFilter): string | undefined =>
+    filter === 'all' ? undefined : filter;
+
+  // Single growing-window fetch: always [0, displayLimit) with the current sort
+  // field/direction AND active status filter so the server returns a complete,
+  // honestly-totaled page (issue #478). Reads refs so polling/SSE/mutation
+  // callbacks pick up current values; callers may pass an explicit status to
+  // override the active filter (e.g. right after toggling it).
   const reloadRequests = useCallback(
     async (status?: string): Promise<SongRequest[]> => {
       const resp = await api.getRequests(code, {
-        status,
+        status: status ?? filterToStatus(statusFilterRef.current),
         sort: sortFieldRef.current,
         direction: sortDirectionRef.current,
         limit: displayLimitRef.current,
@@ -214,9 +248,24 @@ export default function EventQueuePage() {
       });
       setRequests(resp.requests);
       setRequestTotal(resp.total);
+      setStatusCounts(normalizeStatusCounts(resp.status_counts));
       return resp.requests;
     },
     [code],
+  );
+
+  // Switching status tabs re-fetches server-side at offset 0 (issue #478),
+  // resetting the growing window so the new filter's total is honest. We pass
+  // the new status explicitly because the ref hasn't flushed this render yet.
+  const handleFilterChange = useCallback(
+    (filter: StatusFilter) => {
+      setStatusFilter(filter);
+      statusFilterRef.current = filter;
+      setDisplayLimit(INITIAL_DISPLAY_LIMIT);
+      displayLimitRef.current = INITIAL_DISPLAY_LIMIT;
+      reloadRequests(filterToStatus(filter));
+    },
+    [reloadRequests],
   );
 
   const toggleCompactMode = useCallback(() => {
@@ -240,12 +289,10 @@ export default function EventQueuePage() {
   // Beatport login modal state
   const [showBeatportLogin, setShowBeatportLogin] = useState(false);
 
-  // Tab title badge: show "(N) Event - WrzDJ" when backgrounded
-  const newRequestCount = useMemo(
-    () => requests.filter((r) => r.status === 'new').length,
-    [requests]
-  );
-  useTabTitle(event?.name ?? null, newRequestCount);
+  // Tab title badge: show "(N) Event - WrzDJ" when backgrounded. Uses the true
+  // server-side new count so it stays correct when a non-'new' filter is active
+  // (the loaded `requests` window no longer contains every new row, issue #478).
+  useTabTitle(event?.name ?? null, statusCounts.new);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -314,6 +361,7 @@ export default function EventQueuePage() {
       const [eventData, requestsData, historyData, displaySettings, tidalStatusData, beatportStatusData, nowPlayingData, bridgeStatusData] = await Promise.all([
         api.getEvent(code),
         api.getRequests(code, {
+          status: filterToStatus(statusFilterRef.current),
           sort: sortFieldRef.current,
           direction: sortDirectionRef.current,
           limit: displayLimitRef.current,
@@ -329,6 +377,7 @@ export default function EventQueuePage() {
       setEvent(eventData);
       setRequests(requestsData.requests);
       setRequestTotal(requestsData.total);
+      setStatusCounts(normalizeStatusCounts(requestsData.status_counts));
       if (historyData !== undefined) {
         setPlayHistory(historyData.items);
         setPlayHistoryTotal(historyData.total);
@@ -368,6 +417,7 @@ export default function EventQueuePage() {
           const [archivedEvents, requestsData] = await Promise.all([
             api.getArchivedEvents(),
             api.getRequests(code, {
+              status: filterToStatus(statusFilterRef.current),
               sort: sortFieldRef.current,
               direction: sortDirectionRef.current,
               limit: displayLimitRef.current,
@@ -379,6 +429,7 @@ export default function EventQueuePage() {
             setEvent(archivedEvent);
             setRequests(requestsData.requests);
             setRequestTotal(requestsData.total);
+            setStatusCounts(normalizeStatusCounts(requestsData.status_counts));
             setEventStatus(archivedEvent.status);
             setError(null);
             return false; // Stop polling - event is expired
@@ -408,6 +459,20 @@ export default function EventQueuePage() {
 
   // Poll every 5 seconds unless stopped (SSE handles real-time updates).
   usePollingLoop(isAuthenticated, loadData, 5_000);
+
+  // Immediate re-fetch when the sort field/direction changes (issue #478, Bug 3)
+  // — otherwise the new order only appears on the next 5s poll. Skip the first
+  // render so we don't double-fetch alongside the initial load.
+  const sortChangeMountRef = useRef(true);
+  useEffect(() => {
+    if (sortChangeMountRef.current) {
+      sortChangeMountRef.current = false;
+      return;
+    }
+    setDisplayLimit(INITIAL_DISPLAY_LIMIT);
+    displayLimitRef.current = INITIAL_DISPLAY_LIMIT;
+    reloadRequests();
+  }, [sortField, sortDirection, reloadRequests]);
 
   // SSE: trigger immediate refresh on real-time events (new requests, bridge updates)
   const loadDataRef = useRef(loadData);
@@ -1074,6 +1139,9 @@ export default function EventQueuePage() {
             onSortDirectionToggle={handleSortDirectionToggle}
             total={requestTotal}
             onLoadMore={handleLoadMore}
+            filter={statusFilter}
+            onFilterChange={handleFilterChange}
+            statusCounts={statusCounts}
           />
           <PlayHistorySection
             items={playHistory}
@@ -1156,6 +1224,9 @@ export default function EventQueuePage() {
               onSortDirectionToggle={handleSortDirectionToggle}
               total={requestTotal}
               onLoadMore={handleLoadMore}
+              filter={statusFilter}
+              onFilterChange={handleFilterChange}
+              statusCounts={statusCounts}
             />
           </div>
 

--- a/dashboard/app/e/[code]/display/__tests__/no-identify.test.tsx
+++ b/dashboard/app/e/[code]/display/__tests__/no-identify.test.tsx
@@ -46,6 +46,7 @@ vi.mock('@/lib/api', () => ({
       event: { code: 'TEST01', name: 'Test' },
       qr_join_url: 'http://x',
       accepted_queue: [],
+      accepted_queue_total: 0,
       now_playing: null,
       now_playing_hidden: false,
       requests_open: true,
@@ -60,6 +61,7 @@ vi.mock('@/lib/api', () => ({
     getKioskAssignment: vi.fn(),
   },
   ApiError: class extends Error { status = 0; },
+  PUBLIC_PAGE_MAX: 500,
 }));
 
 describe('KioskDisplayPage (F4)', () => {

--- a/dashboard/app/e/[code]/display/page.test.tsx
+++ b/dashboard/app/e/[code]/display/page.test.tsx
@@ -44,6 +44,7 @@ const mockKioskDisplay = {
     { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false },
     { id: 2, title: 'Song 2', artist: 'Artist 2', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false },
   ],
+  accepted_queue_total: 2,
   now_playing: null,
   now_playing_hidden: false,
   requests_open: true,
@@ -91,6 +92,7 @@ vi.mock('@/lib/api', () => ({
       this.status = status;
     }
   },
+  PUBLIC_PAGE_MAX: 500,
 }));
 
 import { api, ApiError } from '@/lib/api';
@@ -297,6 +299,7 @@ describe('KioskDisplayPage', () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
         accepted_queue: [],
+        accepted_queue_total: 0,
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(mockNowPlaying);
       vi.mocked(api.getPlayHistory).mockResolvedValue(mockPlayHistory);
@@ -415,6 +418,88 @@ describe('KioskDisplayPage', () => {
       // Should still poll after error
       await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
       expect(api.getKioskDisplay).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('Accepted-queue pagination (growing window)', () => {
+    it('fetches the initial page with limit 100 and offset 0', async () => {
+      setupDefaultMocks();
+
+      render(<KioskDisplayPage />);
+      await screen.findByText('Test Event');
+
+      expect(api.getKioskDisplay).toHaveBeenCalledWith('TEST123', { limit: 100, offset: 0 });
+    });
+
+    it('uses accepted_queue_total for the headline count and a "of" indicator', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        accepted_queue_total: 250, // far more than the 2 loaded items
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+      await screen.findByText('Test Event');
+
+      // Headline QUEUE stat shows the true total, not the loaded page length
+      expect(screen.getByText('250')).toBeInTheDocument();
+      // Compact "showing X of Y" indicator (loaded 2 of 250)
+      expect(screen.getByText('2 OF 250 TRACKS')).toBeInTheDocument();
+    });
+
+    it('shows the plain total when the whole queue is loaded', async () => {
+      setupDefaultMocks(); // 2 items, accepted_queue_total: 2
+
+      render(<KioskDisplayPage />);
+      await screen.findByText('Test Event');
+
+      expect(screen.getByText('2 TRACKS')).toBeInTheDocument();
+    });
+
+    it('grows displayLimit toward PUBLIC_PAGE_MAX when total exceeds the loaded page', async () => {
+      vi.useFakeTimers();
+      // Every response reports far more accepted requests than the loaded page,
+      // so each refresh should bump the requested limit by 100, clamped at 500.
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        accepted_queue_total: 999,
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(1, 'TEST123', { limit: 100, offset: 0 });
+
+      // Each subsequent poll should request the next 100-larger window.
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(2, 'TEST123', { limit: 200, offset: 0 });
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(3, 'TEST123', { limit: 300, offset: 0 });
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(4, 'TEST123', { limit: 400, offset: 0 });
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(5, 'TEST123', { limit: 500, offset: 0 });
+
+      // Clamped at PUBLIC_PAGE_MAX (500) — does not keep growing.
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(6, 'TEST123', { limit: 500, offset: 0 });
+    });
+
+    it('does not grow the window when the whole queue is already loaded', async () => {
+      vi.useFakeTimers();
+      setupDefaultMocks(); // total 2, loaded 2
+
+      render(<KioskDisplayPage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      // Limit stays at the initial 100 — nothing more to load.
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(2, 'TEST123', { limit: 100, offset: 0 });
     });
   });
 

--- a/dashboard/app/e/[code]/display/page.tsx
+++ b/dashboard/app/e/[code]/display/page.tsx
@@ -640,6 +640,10 @@ export default function KioskDisplayPage() {
           align-items: center;
           gap: 14px;
           overflow: hidden;
+          /* Keep natural row height so a long accepted queue scrolls instead of
+             squishing: overflow:hidden zeroes the flex auto min-height, so without
+             flex-shrink:0 the column crushes every row to fit (issue #478). */
+          flex-shrink: 0;
         }
         .queue-item-top1 {
           border-color: var(--banner-accent-50, rgba(255,255,255,0.1));

--- a/dashboard/app/e/[code]/display/page.tsx
+++ b/dashboard/app/e/[code]/display/page.tsx
@@ -3,11 +3,14 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { QRCodeSVG } from 'qrcode.react';
-import { api, ApiError, KioskDisplay, NowPlayingInfo, PlayHistoryItem } from '@/lib/api';
+import { api, ApiError, KioskDisplay, NowPlayingInfo, PlayHistoryItem, PUBLIC_PAGE_MAX } from '@/lib/api';
 import { useEventStream } from '@/lib/use-event-stream';
 import { usePollingLoop } from '@/lib/usePollingLoop';
 import { RequestModal } from './components/RequestModal';
 const AUTO_SCROLL_INTERVAL = 5000; // 5 seconds between auto-scrolls
+// Accepted-queue growing-window: start at 100 and grow by this step each refresh
+// (clamped to PUBLIC_PAGE_MAX) when the server reports more accepted requests.
+const PUBLIC_PAGE_MAX_INITIAL = 100;
 const SESSION_CHECK_INTERVAL = 10_000; // 10 seconds between kiosk session checks
 const SESSION_TOKEN_KEY = 'kiosk_session_token';
 const PAIR_CODE_KEY = 'kiosk_pair_code';
@@ -59,15 +62,32 @@ export default function KioskDisplayPage() {
   // Track whether initial load succeeded (ref avoids stale closure in useCallback)
   const hasLoadedRef = useRef(false);
 
+  // Automatic growing window for the accepted queue (#411 model): always fetch
+  // offset=0 with the current limit, and grow the limit gradually across refreshes
+  // when the server reports more accepted requests than we've loaded. The ref keeps
+  // the polling/SSE callbacks reading the current value without re-creating loadDisplay.
+  const [displayLimit, setDisplayLimit] = useState(PUBLIC_PAGE_MAX_INITIAL);
+  const displayLimitRef = useRef(displayLimit);
+  displayLimitRef.current = displayLimit;
+
   // Load kiosk display data and StageLinQ data
   const loadDisplay = useCallback(async (): Promise<boolean> => {
     try {
+      const limit = displayLimitRef.current;
       const [kioskData, nowPlayingData, historyData] = await Promise.all([
-        api.getKioskDisplay(code),
+        api.getKioskDisplay(code, { limit, offset: 0 }),
         api.getNowPlaying(code).catch((): undefined => undefined),
         api.getPlayHistory(code).catch((): undefined => undefined),
       ]);
       setDisplay(kioskData);
+      // Grow the window for the NEXT refresh if the server has more accepted
+      // requests than the page we just loaded (clamped to PUBLIC_PAGE_MAX).
+      if (
+        kioskData.accepted_queue_total > kioskData.accepted_queue.length &&
+        limit < PUBLIC_PAGE_MAX
+      ) {
+        setDisplayLimit(Math.min(limit + PUBLIC_PAGE_MAX_INITIAL, PUBLIC_PAGE_MAX));
+      }
       // Only update stagelinq now-playing when the fetch succeeded;
       // on transient network errors (undefined), preserve the previous value
       if (nowPlayingData !== undefined) {
@@ -264,6 +284,10 @@ export default function KioskDisplayPage() {
 
   const bannerAccent = safeColor(display.banner_colors?.[0], '#3b82f6');
   const queue = display.accepted_queue;
+  // True accepted-queue size (before pagination). `queue` is only the loaded
+  // page, so use this for the headline count and a "showing X of Y" indicator.
+  const acceptedTotal = display.accepted_queue_total;
+  const hasMoreThanShown = acceptedTotal > queue.length;
   const maxVotes = Math.max(1, ...queue.map((r) => r.vote_count));
   const totalVotes = queue.reduce((s, r) => s + r.vote_count, 0);
 
@@ -1106,7 +1130,7 @@ export default function KioskDisplayPage() {
             <h1 className="kiosk-event-name">{display.event.name}</h1>
             <div className="kiosk-stats">
               <div className="kiosk-stat">
-                <span className="kiosk-stat-value">{queue.length}</span>
+                <span className="kiosk-stat-value">{acceptedTotal}</span>
                 <span className="kiosk-stat-label">QUEUE</span>
               </div>
               <div className="kiosk-stat">
@@ -1190,7 +1214,11 @@ export default function KioskDisplayPage() {
                 QUEUE
               </div>
               <div style={{ flex: 1 }} />
-              <span className="queue-track-count">{queue.length} TRACKS</span>
+              <span className="queue-track-count">
+                {hasMoreThanShown
+                  ? `${queue.length} OF ${acceptedTotal} TRACKS`
+                  : `${acceptedTotal} TRACKS`}
+              </span>
             </div>
             {queue.length > 0 ? (
               <div className="queue-list" ref={queueListRef}>

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -1527,6 +1527,85 @@ describe('ApiClient', () => {
     });
   });
 
+  describe('getPendingReview', () => {
+    // #478: pending-review now returns a paginated envelope, not a bare array.
+    const envelope = (overrides: Record<string, unknown> = {}) => ({
+      requests: [],
+      total: 0,
+      limit: 100,
+      offset: 0,
+      sort: null,
+      direction: null,
+      ...overrides,
+    });
+
+    it('returns the paginated envelope with the true total', async () => {
+      api.setToken('test-token');
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          envelope({
+            requests: [
+              {
+                id: 1,
+                song_title: 'S',
+                artist: 'A',
+                artwork_url: null,
+                vote_count: 5,
+                nickname: null,
+                created_at: '2026-04-21T12:00:00Z',
+                note: null,
+                status: 'new',
+              },
+            ],
+            total: 250,
+          }),
+      });
+
+      const resp = await api.getPendingReview('ABC123');
+      expect(resp.requests).toHaveLength(1);
+      expect(resp.total).toBe(250);
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/events/ABC123/pending-review');
+    });
+
+    it('omits sort/direction/limit/offset by default (Review order)', async () => {
+      api.setToken('test-token');
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => envelope() });
+
+      await api.getPendingReview('ABC123');
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).not.toContain('sort=');
+      expect(url).not.toContain('direction=');
+      expect(url).not.toContain('limit=');
+      expect(url).not.toContain('offset=');
+    });
+
+    it('appends sort + direction params when specified', async () => {
+      api.setToken('test-token');
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => envelope() });
+
+      await api.getPendingReview('ABC123', { sort: 'upvotes', direction: 'desc' });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('sort=upvotes');
+      expect(url).toContain('direction=desc');
+    });
+
+    it('appends limit + offset params, sending offset=0 even though falsy', async () => {
+      api.setToken('test-token');
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => envelope() });
+
+      await api.getPendingReview('ABC123', { limit: 200, offset: 0 });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('limit=200');
+      expect(url).toContain('offset=0');
+    });
+  });
+
   describe('acceptAllRequests', () => {
     it('accepts all pending requests', async () => {
       api.setToken('test-token');

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -1438,18 +1438,33 @@ describe('ApiClient', () => {
   // ========== Request Management ==========
 
   describe('getRequests', () => {
-    it('fetches all requests for an event', async () => {
+    // #478: the endpoint now returns a paginated envelope, not a bare array.
+    const envelope = (overrides: Record<string, unknown> = {}) => ({
+      requests: [],
+      total: 0,
+      limit: 100,
+      offset: 0,
+      sort: 'date_requested',
+      direction: 'desc',
+      ...overrides,
+    });
+
+    it('returns the paginated envelope for an event', async () => {
       api.setToken('test-token');
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => [
-          { id: 1, artist: 'A', song_title: 'S', status: 'new' },
-          { id: 2, artist: 'B', song_title: 'T', status: 'accepted' },
-        ],
+        json: async () => envelope({
+          requests: [
+            { id: 1, artist: 'A', song_title: 'S', status: 'new' },
+            { id: 2, artist: 'B', song_title: 'T', status: 'accepted' },
+          ],
+          total: 2,
+        }),
       });
 
-      const requests = await api.getRequests('ABC123');
-      expect(requests).toHaveLength(2);
+      const resp = await api.getRequests('ABC123');
+      expect(resp.requests).toHaveLength(2);
+      expect(resp.total).toBe(2);
 
       const [url] = mockFetch.mock.calls[0];
       expect(url).toContain('/api/events/ABC123/requests');
@@ -1458,10 +1473,7 @@ describe('ApiClient', () => {
 
     it('filters requests by status', async () => {
       api.setToken('test-token');
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => [{ id: 1, status: 'new' }],
-      });
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => envelope() });
 
       await api.getRequests('ABC123', { status: 'new' });
 
@@ -1469,30 +1481,49 @@ describe('ApiClient', () => {
       expect(url).toContain('status=new');
     });
 
-    it('appends sort parameter when specified', async () => {
+    it('appends sort + direction params when specified', async () => {
       api.setToken('test-token');
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => [{ id: 1, status: 'new', priority_score: 0.85 }],
-      });
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => envelope() });
 
-      await api.getRequests('ABC123', { sort: 'priority' });
+      await api.getRequests('ABC123', { sort: 'best_match', direction: 'desc' });
 
       const [url] = mockFetch.mock.calls[0];
-      expect(url).toContain('sort=priority');
+      expect(url).toContain('sort=best_match');
+      expect(url).toContain('direction=desc');
     });
 
-    it('omits sort parameter by default', async () => {
+    it('appends limit + offset params when specified', async () => {
       api.setToken('test-token');
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => [],
-      });
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => envelope() });
+
+      await api.getRequests('ABC123', { limit: 200, offset: 0 });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('limit=200');
+      expect(url).toContain('offset=0');
+    });
+
+    it('sends offset=0 even though it is falsy (growing-window contract)', async () => {
+      api.setToken('test-token');
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => envelope() });
+
+      await api.getRequests('ABC123', { limit: 100, offset: 0 });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('offset=0');
+    });
+
+    it('omits sort/direction/limit/offset by default', async () => {
+      api.setToken('test-token');
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => envelope() });
 
       await api.getRequests('ABC123');
 
       const [url] = mockFetch.mock.calls[0];
       expect(url).not.toContain('sort=');
+      expect(url).not.toContain('direction=');
+      expect(url).not.toContain('limit=');
+      expect(url).not.toContain('offset=');
     });
   });
 

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -1752,29 +1752,41 @@ describe('ApiClient', () => {
   });
 
   describe('getKioskDisplay', () => {
+    const kioskDisplayBody = {
+      event: { code: 'FRI001', name: 'Friday Night' },
+      qr_join_url: 'https://example.com/join/FRI001',
+      accepted_queue: [],
+      accepted_queue_total: 0,
+      now_playing: null,
+      now_playing_hidden: false,
+      requests_open: true,
+      kiosk_display_only: false,
+      updated_at: '2026-01-01T00:00:00Z',
+      banner_url: null,
+      banner_kiosk_url: null,
+      banner_colors: null,
+    };
+
     it('fetches kiosk display data', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          event: { code: 'FRI001', name: 'Friday Night' },
-          qr_join_url: 'https://example.com/join/FRI001',
-          accepted_queue: [],
-          now_playing: null,
-          now_playing_hidden: false,
-          requests_open: true,
-          kiosk_display_only: false,
-          updated_at: '2026-01-01T00:00:00Z',
-          banner_url: null,
-          banner_kiosk_url: null,
-          banner_colors: null,
-        }),
-      });
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => kioskDisplayBody });
 
       const result = await api.getKioskDisplay('FRI001');
       expect(result.event.name).toBe('Friday Night');
+      expect(result.accepted_queue_total).toBe(0);
 
       const [url] = mockFetch.mock.calls[0];
       expect(url).toContain('/api/public/events/FRI001/display');
+      expect(url).not.toContain('?');
+    });
+
+    it('appends limit and offset when provided', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => kioskDisplayBody });
+
+      await api.getKioskDisplay('FRI001', { limit: 200, offset: 100 });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('limit=200');
+      expect(url).toContain('offset=100');
     });
   });
 

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -6176,6 +6176,10 @@ export interface components {
             /** Requests */
             requests: components["schemas"]["RequestOut"][];
             sort: components["schemas"]["RequestSort"];
+            /** Status Counts */
+            status_counts: {
+                [key: string]: number;
+            };
             /** Total */
             total: number;
         };

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -1316,7 +1316,13 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get Event Requests */
+        /**
+         * Get Event Requests
+         * @description Paginated, sorted request list. Owner sees requests regardless of status.
+         *
+         *     ``total`` is computed before pagination so the dashboard shows a truthful
+         *     count rather than inferring it from the returned page length (issue #478).
+         */
         get: operations["get_event_requests_api_events__code__requests_get"];
         put?: never;
         /** Submit Request */
@@ -6154,6 +6160,25 @@ export interface components {
              */
             new_email: string;
         };
+        /**
+         * RequestListResponse
+         * @description Paginated DJ request list.
+         *
+         *     ``total`` is the true row count before pagination, so the dashboard never
+         *     infers the count from the returned page length (the #411 failure mode).
+         */
+        RequestListResponse: {
+            direction: components["schemas"]["SortDirection"];
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
+            /** Requests */
+            requests: components["schemas"]["RequestOut"][];
+            sort: components["schemas"]["RequestSort"];
+            /** Total */
+            total: number;
+        };
         /** RequestOut */
         RequestOut: {
             /** Accepted At */
@@ -6205,6 +6230,12 @@ export interface components {
              */
             vote_count: number;
         };
+        /**
+         * RequestSort
+         * @description DJ-facing sort fields for the request list (issue #478).
+         * @enum {string}
+         */
+        RequestSort: "date_requested" | "date_accepted" | "upvotes" | "bpm" | "key" | "title" | "artist" | "best_match";
         /**
          * RequestSource
          * @enum {string}
@@ -6711,6 +6742,11 @@ export interface components {
             /** Target Energy */
             target_energy?: number | null;
         };
+        /**
+         * SortDirection
+         * @enum {string}
+         */
+        SortDirection: "asc" | "desc";
         /** StatusMessageResponse */
         StatusMessageResponse: {
             /** Message */
@@ -9661,7 +9697,9 @@ export interface operations {
                 status?: components["schemas"]["RequestStatus"] | null;
                 since?: string | null;
                 limit?: number;
-                sort?: "chronological" | "priority";
+                offset?: number;
+                sort?: components["schemas"]["RequestSort"];
+                direction?: components["schemas"]["SortDirection"] | null;
             };
             header?: never;
             path: {
@@ -9677,7 +9715,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["RequestOut"][];
+                    "application/json": components["schemas"]["RequestListResponse"];
                 };
             };
             /** @description Validation Error */

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -1218,7 +1218,12 @@ export interface paths {
         };
         /**
          * Pending Review
-         * @description Get pending review data source for DJ bulk-review.
+         * @description Paginated pending-review source for DJ bulk-review (issue #478).
+         *
+         *     ``total`` is the true count of pending rows before pagination, so the
+         *     Pre-Event tab never shows a capped page length as the queue size. Default
+         *     ordering stays the vote-ranked review order; bulk actions still operate
+         *     server-side against the full filtered set, not the loaded page.
          */
         get: operations["pending_review_api_events__code__pending_review_get"];
         put?: never;
@@ -5628,8 +5633,14 @@ export interface components {
         };
         /** PendingReviewResponse */
         PendingReviewResponse: {
+            direction: components["schemas"]["SortDirection"] | null;
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
             /** Requests */
             requests: components["schemas"]["PendingReviewRow"][];
+            sort: components["schemas"]["RequestSort"] | null;
             /** Total */
             total: number;
         };
@@ -9534,7 +9545,12 @@ export interface operations {
     };
     pending_review_api_events__code__pending_review_get: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+                offset?: number;
+                sort?: components["schemas"]["RequestSort"] | null;
+                direction?: components["schemas"]["SortDirection"] | null;
+            };
             header?: never;
             path: {
                 code: string;

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -5302,6 +5302,8 @@ export interface components {
         KioskDisplayResponse: {
             /** Accepted Queue */
             accepted_queue: components["schemas"]["PublicRequestInfo"][];
+            /** Accepted Queue Total */
+            accepted_queue_total: number;
             /** Banner Colors */
             banner_colors: string[] | null;
             /** Banner Kiosk Url */
@@ -11092,7 +11094,10 @@ export interface operations {
     };
     get_kiosk_display_api_public_events__code__display_get: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+                offset?: number;
+            };
             header?: never;
             path: {
                 code: string;

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -23,6 +23,10 @@ type Schemas = components['schemas'];
 export type Event = Schemas['EventOut'];
 export type PublicEvent = Schemas['PublicEventResponse'];
 export type SongRequest = Schemas['RequestOut'];
+// DJ request list pagination + sort envelope (issue #478)
+export type RequestListResponse = Schemas['RequestListResponse'];
+export type RequestSort = Schemas['RequestSort'];
+export type SortDirection = Schemas['SortDirection'];
 export type PublicRequestInfo = Schemas['PublicRequestInfo'] & { requester_verified?: boolean };
 export type GuestRequestInfo = Schemas['GuestRequestInfo'] & { requester_verified?: boolean };
 export type GuestNowPlaying = Schemas['GuestNowPlaying'];

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -27,6 +27,9 @@ export type SongRequest = Schemas['RequestOut'];
 export type RequestListResponse = Schemas['RequestListResponse'];
 export type RequestSort = Schemas['RequestSort'];
 export type SortDirection = Schemas['SortDirection'];
+// Pre-event pending-review pagination + sort envelope (issue #478)
+export type PendingReviewResponse = Schemas['PendingReviewResponse'];
+export type PendingReviewRow = Schemas['PendingReviewRow'];
 export type PublicRequestInfo = Schemas['PublicRequestInfo'] & { requester_verified?: boolean };
 export type GuestRequestInfo = Schemas['GuestRequestInfo'] & { requester_verified?: boolean };
 export type GuestNowPlaying = Schemas['GuestNowPlaying'];

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -78,6 +78,9 @@ import type {
   ShareTokenOut,
   SlotTargetOut,
   SongRequest,
+  RequestListResponse,
+  RequestSort,
+  SortDirection,
   SystemSettings,
   SystemStats,
   TidalEventSettings,
@@ -185,6 +188,9 @@ export type {
   SharedSlotView,
   ShareTokenOut,
   SongRequest,
+  RequestListResponse,
+  RequestSort,
+  SortDirection,
   SyncResultEntry,
   SystemSettings,
   SystemStats,
@@ -1015,13 +1021,30 @@ class ApiClient {
     });
   }
 
+  /**
+   * DJ request list (issue #478). Returns the paginated envelope
+   * (`requests`/`total`/`limit`/`offset`/`sort`/`direction`) so the dashboard
+   * never infers the row count from a page length.
+   *
+   * `limit` clamps to {@link PUBLIC_PAGE_MAX} (mirrors backend MAX_PAGE_SIZE);
+   * sending a larger value returns HTTP 422.
+   */
   async getRequests(
     code: string,
-    options?: { status?: string; sort?: 'chronological' | 'priority' },
-  ): Promise<SongRequest[]> {
+    options?: {
+      status?: string;
+      sort?: RequestSort;
+      direction?: SortDirection;
+      limit?: number;
+      offset?: number;
+    },
+  ): Promise<RequestListResponse> {
     const params = new URLSearchParams();
     if (options?.status) params.set('status', options.status);
     if (options?.sort) params.set('sort', options.sort);
+    if (options?.direction) params.set('direction', options.direction);
+    if (options?.limit !== undefined) params.set('limit', String(options.limit));
+    if (options?.offset !== undefined) params.set('offset', String(options.offset));
     const qs = params.toString();
     return this.fetch(`/api/events/${code}/requests${qs ? `?${qs}` : ''}`);
   }

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1231,8 +1231,15 @@ class ApiClient {
     return this.publicFetch(`${getApiUrl()}/api/public/events/${code}`);
   }
 
-  async getKioskDisplay(code: string): Promise<KioskDisplay> {
-    return this.publicFetch(`${getApiUrl()}/api/public/events/${code}/display`);
+  async getKioskDisplay(
+    code: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<KioskDisplay> {
+    const qs = new URLSearchParams();
+    if (options?.limit !== undefined) qs.set('limit', String(options.limit));
+    if (options?.offset !== undefined) qs.set('offset', String(options.offset));
+    const suffix = qs.toString() ? `?${qs}` : '';
+    return this.publicFetch(`${getApiUrl()}/api/public/events/${code}/display${suffix}`);
   }
 
   /**

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -78,6 +78,7 @@ import type {
   ShareTokenOut,
   SlotTargetOut,
   SongRequest,
+  PendingReviewResponse,
   RequestListResponse,
   RequestSort,
   SortDirection,
@@ -188,6 +189,8 @@ export type {
   SharedSlotView,
   ShareTokenOut,
   SongRequest,
+  PendingReviewResponse,
+  PendingReviewRow,
   RequestListResponse,
   RequestSort,
   SortDirection,
@@ -300,22 +303,9 @@ export interface CollectionSyncResponse {
   queued: number;
 }
 
-export interface PendingReviewRow {
-  id: number;
-  song_title: string;
-  artist: string;
-  artwork_url: string | null;
-  vote_count: number;
-  nickname: string | null;
-  created_at: string;
-  note: string | null;
-  status: 'new' | 'accepted' | 'playing' | 'played' | 'rejected';
-}
-
-export interface PendingReviewResponse {
-  requests: PendingReviewRow[];
-  total: number;
-}
+// Pre-event pending-review row + pagination envelope (issue #478) are
+// re-exported below from the generated OpenAPI surface (`PendingReviewRow` /
+// `PendingReviewResponse`), so the envelope stays in lockstep with the backend.
 
 export interface BulkReviewResponse {
   accepted: number;
@@ -2195,8 +2185,28 @@ class ApiClient {
     return this.fetch(`/api/events/${code}/collection/sync-tidal`, { method: 'POST' });
   }
 
-  async getPendingReview(code: string): Promise<PendingReviewResponse> {
-    return this.fetch(`/api/events/${code}/pending-review`);
+  /**
+   * Pre-event pending-review list (issue #478). Returns the paginated envelope
+   * (`requests`/`total`/`limit`/`offset`/`sort`/`direction`). Omitting `sort`
+   * yields the default vote-ranked "Review order" (votes desc, age asc); pass a
+   * `RequestSort` value to override. `limit` clamps to {@link PUBLIC_PAGE_MAX}.
+   */
+  async getPendingReview(
+    code: string,
+    options?: {
+      sort?: RequestSort;
+      direction?: SortDirection;
+      limit?: number;
+      offset?: number;
+    },
+  ): Promise<PendingReviewResponse> {
+    const params = new URLSearchParams();
+    if (options?.sort) params.set('sort', options.sort);
+    if (options?.direction) params.set('direction', options.direction);
+    if (options?.limit !== undefined) params.set('limit', String(options.limit));
+    if (options?.offset !== undefined) params.set('offset', String(options.offset));
+    const qs = params.toString();
+    return this.fetch(`/api/events/${code}/pending-review${qs ? `?${qs}` : ''}`);
   }
 
   async bulkReview(

--- a/dashboard/lib/pending-review-sort.ts
+++ b/dashboard/lib/pending-review-sort.ts
@@ -1,0 +1,58 @@
+/**
+ * Pre-event pending-review sort metadata (issue #478).
+ *
+ * The pending-review list is a focused subset of the DJ request-sort surface:
+ * every row is `status="new"`, so bpm/key/date_accepted/best_match aren't
+ * meaningful or displayed. We offer only the five options below.
+ *
+ * "Review order" is the backend default (vote-ranked: votes desc, age asc) and
+ * is requested by sending NO `sort` param — so it has no direction toggle. The
+ * remaining options map 1:1 onto `RequestSort` field values with per-field
+ * default directions mirrored from the backend.
+ */
+
+import type { RequestSort, SortDirection } from './api-types';
+
+/** Sentinel for the default vote-ranked order (sends no `sort` param). */
+export const REVIEW_ORDER = 'review_order' as const;
+
+/** A pending-review sort selection: either the sentinel or a real field. */
+export type PendingReviewSort = typeof REVIEW_ORDER | RequestSort;
+
+/** Sort options in display order. Review order leads (the backend default). */
+export const PENDING_REVIEW_SORT_FIELDS: readonly {
+  value: PendingReviewSort;
+  label: string;
+}[] = [
+  { value: REVIEW_ORDER, label: 'Review order' },
+  { value: 'upvotes', label: 'Upvotes' },
+  { value: 'date_requested', label: 'Date requested' },
+  { value: 'title', label: 'Title' },
+  { value: 'artist', label: 'Artist' },
+] as const;
+
+/** Per-field default direction (mirrors the backend's per-field defaults). */
+export const PENDING_REVIEW_DEFAULT_DIRECTION: Record<RequestSort, SortDirection> = {
+  upvotes: 'desc',
+  date_requested: 'desc',
+  title: 'asc',
+  artist: 'asc',
+  // Unused by the pending-review UI, but kept exhaustive for the union.
+  date_accepted: 'desc',
+  bpm: 'asc',
+  key: 'asc',
+  best_match: 'desc',
+};
+
+/**
+ * Resolve a pending-review selection into the `getPendingReview` query params.
+ * "Review order" sends nothing (the backend default); a real field sends both
+ * `sort` and `direction`.
+ */
+export function toPendingReviewParams(
+  sort: PendingReviewSort,
+  direction: SortDirection,
+): { sort?: RequestSort; direction?: SortDirection } {
+  if (sort === REVIEW_ORDER) return {};
+  return { sort, direction };
+}

--- a/dashboard/lib/priority-score.ts
+++ b/dashboard/lib/priority-score.ts
@@ -2,10 +2,8 @@
  * Priority score formatting and display utilities.
  *
  * Used by the DJ dashboard to render priority score badges
- * on request cards when sort=priority is active.
+ * on request cards when sort=best_match is active (issue #478).
  */
-
-export type SortMode = 'chronological' | 'priority';
 
 /**
  * Format a priority score (0.0-1.0) as a percentage string.

--- a/dashboard/lib/request-sort.ts
+++ b/dashboard/lib/request-sort.ts
@@ -1,0 +1,52 @@
+/**
+ * DJ request-list sort metadata (issue #478).
+ *
+ * The backend exposes 8 sort fields with per-field default directions. The
+ * dashboard mirrors those defaults so that changing the sort field snaps the
+ * direction toggle to the field's natural default; a separate toggle flips it.
+ *
+ * Keep `SORT_FIELDS` / `SORT_FIELD_DEFAULT_DIRECTION` in sync with
+ * server/app/schemas (RequestSort + per-field defaults).
+ */
+
+import type { RequestSort, SortDirection } from './api-types';
+
+/** Sort options in dashboard display order. Best Match leads (former "priority"). */
+export const SORT_FIELDS: readonly { value: RequestSort; label: string }[] = [
+  { value: 'best_match', label: 'Best Match' },
+  { value: 'date_requested', label: 'Date requested' },
+  { value: 'date_accepted', label: 'Date accepted' },
+  { value: 'upvotes', label: 'Upvotes' },
+  { value: 'bpm', label: 'BPM' },
+  { value: 'key', label: 'Key' },
+  { value: 'title', label: 'Title' },
+  { value: 'artist', label: 'Artist' },
+] as const;
+
+/** Per-field default direction (mirrors the backend's per-field defaults). */
+export const SORT_FIELD_DEFAULT_DIRECTION: Record<RequestSort, SortDirection> = {
+  date_requested: 'desc',
+  date_accepted: 'desc',
+  upvotes: 'desc',
+  bpm: 'asc',
+  key: 'asc',
+  title: 'asc',
+  artist: 'asc',
+  best_match: 'desc',
+};
+
+/** Default sort field when no preference is stored. */
+export const DEFAULT_SORT_FIELD: RequestSort = 'date_requested';
+
+/** Type guard: is this string one of the known sort fields? */
+export function isRequestSort(value: string): value is RequestSort {
+  return SORT_FIELDS.some((f) => f.value === value);
+}
+
+/**
+ * Migrate a legacy `wrzdj-sort-${code}` value (the #468 toggle) to a sort field.
+ * `'priority'` → `best_match`; anything else falls back to `date_requested`.
+ */
+export function migrateLegacySort(legacy: string | null): RequestSort {
+  return legacy === 'priority' ? 'best_match' : DEFAULT_SORT_FIELD;
+}

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -105,6 +105,7 @@ from app.services.request_sort import (
     DEFAULT_SORT_DIRECTION,
     filtered_requests_query,
     get_sorted_requests,
+    status_counts,
 )
 from app.services.sync.orchestrator import enrich_request_metadata, sync_requests_batch
 from app.services.sync.registry import get_connected_adapters
@@ -810,6 +811,7 @@ def get_event_requests(
         offset=offset,
         sort=sort,
         direction=resolved,
+        status_counts=status_counts(db, event),
     )
 
 

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -64,7 +64,7 @@ from app.schemas.search import SearchResult
 from app.services.collect import (
     collection_settings_payload,
     execute_bulk_review,
-    get_pending_review_rows,
+    get_sorted_pending_review,
     update_collection_settings,
 )
 from app.services.event import (
@@ -1161,11 +1161,24 @@ def sync_collection_to_tidal(
 
 @router.get("/{code}/pending-review", response_model=PendingReviewResponse)
 def pending_review(
+    limit: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    offset: int = Query(default=0, ge=0),
+    sort: RequestSort | None = None,
+    direction: SortDirection | None = None,
     event: Event = Depends(get_event_for_dj_or_admin),
     db: Session = Depends(get_db),
 ):
-    """Get pending review data source for DJ bulk-review."""
-    rows = get_pending_review_rows(db, event.id)
+    """Paginated pending-review source for DJ bulk-review (issue #478).
+
+    ``total`` is the true count of pending rows before pagination, so the
+    Pre-Event tab never shows a capped page length as the queue size. Default
+    ordering stays the vote-ranked review order; bulk actions still operate
+    server-side against the full filtered set, not the loaded page.
+    """
+    rows, total = get_sorted_pending_review(
+        db, event.id, sort=sort, direction=direction, limit=limit, offset=offset
+    )
+    resolved = direction or (DEFAULT_SORT_DIRECTION[sort] if sort else None)
     return PendingReviewResponse(
         requests=[
             PendingReviewRow(
@@ -1181,7 +1194,11 @@ def pending_review(
             )
             for r in rows
         ],
-        total=len(rows),
+        total=total,
+        limit=limit,
+        offset=offset,
+        sort=sort,
+        direction=resolved,
     )
 
 

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -1,6 +1,5 @@
 import json
 from datetime import UTC, datetime
-from typing import Literal
 from urllib.parse import quote
 
 from fastapi import (
@@ -25,6 +24,7 @@ from app.api.deps import (
     require_verified_human_soft,
 )
 from app.core.config import get_settings
+from app.core.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from app.core.rate_limit import get_guest_id, limiter
 from app.models.event import Event
 from app.models.request import RequestStatus
@@ -53,7 +53,13 @@ from app.schemas.recommendation import (
     RecommendedTrack,
     TemplatePlaylistRequest,
 )
-from app.schemas.request import RequestCreate, RequestOut
+from app.schemas.request import (
+    RequestCreate,
+    RequestListResponse,
+    RequestOut,
+    RequestSort,
+    SortDirection,
+)
 from app.schemas.search import SearchResult
 from app.services.collect import (
     collection_settings_payload,
@@ -94,6 +100,11 @@ from app.services.request import (
     create_request,
     get_requests_for_event,
     reject_all_new_requests,
+)
+from app.services.request_sort import (
+    DEFAULT_SORT_DIRECTION,
+    filtered_requests_query,
+    get_sorted_requests,
 )
 from app.services.sync.orchestrator import enrich_request_metadata, sync_requests_batch
 from app.services.sync.registry import get_connected_adapters
@@ -757,24 +768,68 @@ def bulk_delete_requests_endpoint(
     return BulkActionResponse(status="ok", count=count)
 
 
-@router.get("/{code}/requests", response_model=list[RequestOut])
+@router.get("/{code}/requests", response_model=RequestListResponse)
 @limiter.limit("60/minute")
 def get_event_requests(
     request: Request,
     status: RequestStatus | None = None,
     since: datetime | None = None,
-    limit: int = Query(default=100, ge=1, le=500),
-    sort: Literal["chronological", "priority"] = "chronological",
+    limit: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    offset: int = Query(default=0, ge=0),
+    sort: RequestSort = RequestSort.DATE_REQUESTED,
+    direction: SortDirection | None = None,
     event: Event = Depends(get_owned_event),
     db: Session = Depends(get_db),
-) -> list[RequestOut]:
-    # Owner can view requests regardless of event status
-    requests = get_requests_for_event(db, event, status, since, limit)
+) -> RequestListResponse:
+    """Paginated, sorted request list. Owner sees requests regardless of status.
 
-    if sort == "priority":
-        return _apply_priority_sort(requests, event, db)
+    ``total`` is computed before pagination so the dashboard shows a truthful
+    count rather than inferring it from the returned page length (issue #478).
+    """
+    resolved = direction or DEFAULT_SORT_DIRECTION[sort]
 
-    return [_request_to_out(r) for r in requests]
+    if sort == RequestSort.BEST_MATCH:
+        requests, total = _best_match_page(db, event, status, since, limit, offset)
+    else:
+        rows, total = get_sorted_requests(
+            db,
+            event,
+            status=status,
+            since=since,
+            sort=sort,
+            direction=resolved,
+            limit=limit,
+            offset=offset,
+        )
+        requests = [_request_to_out(r) for r in rows]
+
+    return RequestListResponse(
+        requests=requests,
+        total=total,
+        limit=limit,
+        offset=offset,
+        sort=sort,
+        direction=resolved,
+    )
+
+
+def _best_match_page(
+    db: Session,
+    event: "Event",
+    status: RequestStatus | None,
+    since: datetime | None,
+    limit: int,
+    offset: int,
+) -> tuple[list[RequestOut], int]:
+    """Best Match (priority) sort with a true total, then paginate.
+
+    Priority scoring needs now-playing context and runs over the whole filtered
+    set, so we score everything, then slice the requested window.
+    """
+    base = filtered_requests_query(db, event, status, since)
+    total = base.count()
+    ordered = _apply_priority_sort(base.all(), event, db)
+    return ordered[offset : offset + limit], total
 
 
 def _apply_priority_sort(

--- a/server/app/api/public.py
+++ b/server/app/api/public.py
@@ -125,6 +125,9 @@ class KioskDisplayResponse(BaseModel):
     event: PublicEventInfo
     qr_join_url: str
     accepted_queue: list[PublicRequestInfo]
+    # True count of accepted requests before pagination — the kiosk shows this
+    # rather than the visible page length so the queue count is honest (#478).
+    accepted_queue_total: int
     now_playing: PublicRequestInfo | None
     now_playing_hidden: bool
     requests_open: bool = True
@@ -140,6 +143,8 @@ class KioskDisplayResponse(BaseModel):
 def get_kiosk_display(
     code: str,
     request: Request,
+    limit: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    offset: int = Query(default=0, ge=0),
     db: Session = Depends(get_db),
 ) -> KioskDisplayResponse:
     """Get public kiosk display data for an event."""
@@ -161,9 +166,25 @@ def get_kiosk_display(
         base_url = str(request.base_url).rstrip("/")
     qr_join_url = f"{base_url}/join/{event.join_code}"
 
-    # Get accepted requests (status = 'accepted') sorted by vote_count desc, then updated_at asc
-    accepted_requests = [r for r in event.requests if r.status == RequestStatus.ACCEPTED.value]
-    accepted_requests.sort(key=lambda r: (-r.vote_count, r.updated_at))
+    # Accepted queue: count + sort + paginate in SQL with a true total before
+    # the page, rather than materializing event.requests and sorting in Python.
+    # Order preserves the prior display rule (votes desc, updated_at asc) plus a
+    # deterministic id tie-breaker so the growing window never skips/dupes (#478).
+    accepted_q = db.query(SongRequest).filter(
+        SongRequest.event_id == event.id,
+        SongRequest.status == RequestStatus.ACCEPTED.value,
+    )
+    accepted_queue_total = accepted_q.count()
+    accepted_requests = (
+        accepted_q.order_by(
+            SongRequest.vote_count.desc(),
+            SongRequest.updated_at.asc(),
+            SongRequest.id.desc(),
+        )
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
 
     accepted_queue = [
         PublicRequestInfo(
@@ -208,6 +229,7 @@ def get_kiosk_display(
         event=PublicEventInfo(code=event.join_code, name=event.name),
         qr_join_url=qr_join_url,
         accepted_queue=accepted_queue,
+        accepted_queue_total=accepted_queue_total,
         now_playing=now_playing,
         now_playing_hidden=now_playing_is_hidden,
         requests_open=event.requests_open,

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -6,6 +6,7 @@ from typing import Annotated, Literal
 from pydantic import AfterValidator, BaseModel, Field, StringConstraints
 
 from app.core.validation import contains_profanity
+from app.schemas.request import RequestSort, SortDirection
 
 
 def _check_nickname_profanity(v: str) -> str:
@@ -177,6 +178,10 @@ class PendingReviewRow(BaseModel):
 class PendingReviewResponse(BaseModel):
     requests: list[PendingReviewRow]
     total: int
+    limit: int
+    offset: int
+    sort: RequestSort | None
+    direction: SortDirection | None
 
 
 class BulkReviewRequest(BaseModel):

--- a/server/app/schemas/request.py
+++ b/server/app/schemas/request.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field, field_validator
@@ -96,5 +97,38 @@ class RequestOut(BaseSchema):
     sync_results_json: str | None = None
     # Voting
     vote_count: int = 0
-    # Priority scoring (populated only when sort=priority)
+    # Priority scoring (populated only when sort=best_match)
     priority_score: float | None = None
+
+
+class RequestSort(str, Enum):
+    """DJ-facing sort fields for the request list (issue #478)."""
+
+    DATE_REQUESTED = "date_requested"
+    DATE_ACCEPTED = "date_accepted"
+    UPVOTES = "upvotes"
+    BPM = "bpm"
+    KEY = "key"
+    TITLE = "title"
+    ARTIST = "artist"
+    BEST_MATCH = "best_match"
+
+
+class SortDirection(str, Enum):
+    ASC = "asc"
+    DESC = "desc"
+
+
+class RequestListResponse(BaseSchema):
+    """Paginated DJ request list.
+
+    ``total`` is the true row count before pagination, so the dashboard never
+    infers the count from the returned page length (the #411 failure mode).
+    """
+
+    requests: list[RequestOut]
+    total: int
+    limit: int
+    offset: int
+    sort: RequestSort
+    direction: SortDirection

--- a/server/app/schemas/request.py
+++ b/server/app/schemas/request.py
@@ -132,3 +132,8 @@ class RequestListResponse(BaseSchema):
     offset: int
     sort: RequestSort
     direction: SortDirection
+    # True per-status counts for the whole event, computed before pagination and
+    # independent of the active status/since/limit/offset (issue #478). Keys:
+    # all, new, accepted, playing, played, rejected (0 when absent). ``all`` is
+    # the cross-status total; ``total`` stays the active filter's count.
+    status_counts: dict[str, int]

--- a/server/app/services/collect.py
+++ b/server/app/services/collect.py
@@ -6,13 +6,16 @@ from fastapi import HTTPException
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from app.core.pagination import DEFAULT_PAGE_SIZE
 from app.core.time import utcnow
 from app.models.event import Event
 from app.models.guest import Guest
 from app.models.guest_profile import GuestProfile
 from app.models.request import Request as SongRequest
 from app.schemas.collect import BulkReviewRequest, UpdateCollectionSettings
+from app.schemas.request import RequestSort, SortDirection
 from app.services.request import mark_accepted
+from app.services.request_sort import DEFAULT_SORT_DIRECTION, apply_field_sort, key_sorted
 
 
 class NicknameConflictError(Exception):
@@ -81,17 +84,50 @@ def update_collection_settings(
     return event
 
 
-def get_pending_review_rows(db: Session, event_id: int, limit: int = 200) -> list[SongRequest]:
-    """Collection-phase requests awaiting DJ review, ranked by votes then age."""
-    return (
+def get_sorted_pending_review(
+    db: Session,
+    event_id: int,
+    *,
+    sort: RequestSort | None = None,
+    direction: SortDirection | None = None,
+    limit: int = DEFAULT_PAGE_SIZE,
+    offset: int = 0,
+) -> tuple[list[SongRequest], int]:
+    """Collection-phase requests awaiting DJ review: ``(page_rows, true_total)``.
+
+    ``total`` is counted before pagination so the Pre-Event tab shows a truthful
+    count rather than a silently capped page length (issue #478). The default
+    (``sort=None``) preserves the vote-ranked review order; ``best_match`` falls
+    back to it because priority scoring is meaningless pre-event (no now-playing).
+    """
+    base = (
         db.query(SongRequest)
         .filter(SongRequest.event_id == event_id)
         .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
         .filter(SongRequest.status == "new")
-        .order_by(SongRequest.vote_count.desc(), SongRequest.created_at.asc())
-        .limit(limit)
-        .all()
     )
+    total = base.count()
+
+    if sort is None or sort == RequestSort.BEST_MATCH:
+        page = (
+            base.order_by(
+                SongRequest.vote_count.desc(),
+                SongRequest.created_at.asc(),
+                SongRequest.id.desc(),
+            )
+            .offset(offset)
+            .limit(limit)
+            .all()
+        )
+        return page, total
+
+    resolved = direction or DEFAULT_SORT_DIRECTION[sort]
+    if sort == RequestSort.KEY:
+        ordered = key_sorted(base.all(), resolved)
+        return ordered[offset : offset + limit], total
+
+    page = apply_field_sort(base, sort, resolved).offset(offset).limit(limit).all()
+    return page, total
 
 
 def execute_bulk_review(

--- a/server/app/services/request_sort.py
+++ b/server/app/services/request_sort.py
@@ -89,7 +89,7 @@ def _camelot_ordinal(musical_key: str | None) -> int | None:
     return pos.number * 2 + (1 if pos.letter == "B" else 0)
 
 
-def _key_sorted(rows: list[Request], direction: SortDirection) -> list[Request]:
+def key_sorted(rows: list[Request], direction: SortDirection) -> list[Request]:
     """Sort by harmonic key in Python; null/unparseable keys always last."""
     desc = direction == SortDirection.DESC
 
@@ -108,6 +108,20 @@ def _key_sorted(rows: list[Request], direction: SortDirection) -> list[Request]:
     return sorted(rows, key=key_fn)
 
 
+def apply_field_sort(query: Query, sort: RequestSort, direction: SortDirection) -> Query:
+    """Apply ``ORDER BY`` for a SQL-expressible field sort.
+
+    Adds nulls-last for nullable columns and a deterministic ``id DESC``
+    tie-breaker. Not valid for ``KEY`` (harmonic, Python-sorted via
+    :func:`key_sorted`) or ``BEST_MATCH`` (priority-scored in the endpoint).
+    """
+    column = _SORT_COLUMNS[sort]
+    ordering = column.asc() if direction == SortDirection.ASC else column.desc()
+    if sort in _NULLABLE_SORTS:
+        ordering = nullslast(ordering)
+    return query.order_by(ordering, Request.id.desc())
+
+
 def get_sorted_requests(
     db: Session,
     event: Event,
@@ -124,12 +138,8 @@ def get_sorted_requests(
     total = base.count()
 
     if sort == RequestSort.KEY:
-        ordered = _key_sorted(base.all(), direction)
+        ordered = key_sorted(base.all(), direction)
         return ordered[offset : offset + limit], total
 
-    column = _SORT_COLUMNS[sort]
-    ordering = column.asc() if direction == SortDirection.ASC else column.desc()
-    if sort in _NULLABLE_SORTS:
-        ordering = nullslast(ordering)
-    page = base.order_by(ordering, Request.id.desc()).offset(offset).limit(limit).all()
+    page = apply_field_sort(base, sort, direction).offset(offset).limit(limit).all()
     return page, total

--- a/server/app/services/request_sort.py
+++ b/server/app/services/request_sort.py
@@ -60,6 +60,27 @@ def filtered_requests_query(
     return query
 
 
+def status_counts(db: Session, event: Event) -> dict[str, int]:
+    """True per-status counts for an event, independent of pagination/filters.
+
+    Backs the dashboard status-filter tabs (issue #478): a single
+    ``GROUP BY status`` over the whole event, always returning all six keys
+    (``all`` plus each status, 0 when absent). ``all`` is the cross-status total.
+    """
+    counts = {"all": 0, "new": 0, "accepted": 0, "playing": 0, "played": 0, "rejected": 0}
+    rows = (
+        db.query(Request.status, func.count(Request.id))
+        .filter(Request.event_id == event.id)
+        .group_by(Request.status)
+        .all()
+    )
+    for status, count in rows:
+        if status in counts:
+            counts[status] = count
+        counts["all"] += count
+    return counts
+
+
 def _camelot_ordinal(musical_key: str | None) -> int | None:
     """Map a key to a sortable harmonic ordinal (1A=2, 1B=3, ... 12B=25)."""
     pos = parse_key(musical_key)

--- a/server/app/services/request_sort.py
+++ b/server/app/services/request_sort.py
@@ -1,0 +1,114 @@
+"""Sorting + pagination for the authenticated DJ request list (issue #478).
+
+Field sorts the database can express (date/upvotes/bpm/title/artist) run as
+efficient ``ORDER BY ... LIMIT/OFFSET`` with a true ``COUNT``. Sorts needing
+domain logic the DB can't express run in Python: ``key`` (harmonic Camelot
+order) here, and ``best_match`` (priority scoring) in the endpoint. Every sort
+ends with a deterministic ``id DESC`` tie-breaker so pages never duplicate or
+skip rows as values reorder between polls.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import nullslast
+from sqlalchemy.orm import Query, Session
+from sqlalchemy.sql import func
+
+from app.models.event import Event
+from app.models.request import Request, RequestStatus
+from app.schemas.request import RequestSort, SortDirection
+from app.services.recommendation.camelot import parse_key
+
+# Default direction per field when the client does not pass one explicitly.
+DEFAULT_SORT_DIRECTION: dict[RequestSort, SortDirection] = {
+    RequestSort.DATE_REQUESTED: SortDirection.DESC,
+    RequestSort.DATE_ACCEPTED: SortDirection.DESC,
+    RequestSort.UPVOTES: SortDirection.DESC,
+    RequestSort.BPM: SortDirection.ASC,
+    RequestSort.KEY: SortDirection.ASC,
+    RequestSort.TITLE: SortDirection.ASC,
+    RequestSort.ARTIST: SortDirection.ASC,
+    RequestSort.BEST_MATCH: SortDirection.DESC,
+}
+
+# SQL columns for field sorts the database can order directly.
+_SORT_COLUMNS = {
+    RequestSort.DATE_REQUESTED: Request.created_at,
+    RequestSort.DATE_ACCEPTED: Request.accepted_at,
+    RequestSort.UPVOTES: Request.vote_count,
+    RequestSort.BPM: Request.bpm,
+    RequestSort.TITLE: func.lower(Request.song_title),
+    RequestSort.ARTIST: func.lower(Request.artist),
+}
+
+# Sorts whose column is nullable — nulls always sort last, both directions.
+_NULLABLE_SORTS = {RequestSort.DATE_ACCEPTED, RequestSort.BPM}
+
+
+def filtered_requests_query(
+    db: Session,
+    event: Event,
+    status: RequestStatus | None,
+    since: datetime | None,
+) -> Query:
+    """Base query for an event's requests with the existing status/since filters."""
+    query = db.query(Request).filter(Request.event_id == event.id)
+    if status:
+        query = query.filter(Request.status == status.value)
+    if since:
+        query = query.filter(Request.created_at > since)
+    return query
+
+
+def _camelot_ordinal(musical_key: str | None) -> int | None:
+    """Map a key to a sortable harmonic ordinal (1A=2, 1B=3, ... 12B=25)."""
+    pos = parse_key(musical_key)
+    if pos is None:
+        return None
+    return pos.number * 2 + (1 if pos.letter == "B" else 0)
+
+
+def _key_sorted(rows: list[Request], direction: SortDirection) -> list[Request]:
+    """Sort by harmonic key in Python; null/unparseable keys always last."""
+    desc = direction == SortDirection.DESC
+
+    def key_fn(r: Request) -> tuple:
+        ordinal = _camelot_ordinal(r.musical_key)
+        is_null = ordinal is None
+        primary = (-ordinal if desc else ordinal) if ordinal is not None else 0
+        return (
+            is_null,
+            primary,
+            (r.song_title or "").lower(),
+            (r.artist or "").lower(),
+            -r.id,
+        )
+
+    return sorted(rows, key=key_fn)
+
+
+def get_sorted_requests(
+    db: Session,
+    event: Event,
+    *,
+    status: RequestStatus | None,
+    since: datetime | None,
+    sort: RequestSort,
+    direction: SortDirection,
+    limit: int,
+    offset: int,
+) -> tuple[list[Request], int]:
+    """Return ``(page_rows, true_total)`` for a field sort (not best_match)."""
+    base = filtered_requests_query(db, event, status, since)
+    total = base.count()
+
+    if sort == RequestSort.KEY:
+        ordered = _key_sorted(base.all(), direction)
+        return ordered[offset : offset + limit], total
+
+    column = _SORT_COLUMNS[sort]
+    ordering = column.asc() if direction == SortDirection.ASC else column.desc()
+    if sort in _NULLABLE_SORTS:
+        ordering = nullslast(ordering)
+    page = base.order_by(ordering, Request.id.desc()).offset(offset).limit(limit).all()
+    return page, total

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -4725,6 +4725,10 @@
             "title": "Accepted Queue",
             "type": "array"
           },
+          "accepted_queue_total": {
+            "title": "Accepted Queue Total",
+            "type": "integer"
+          },
           "banner_colors": {
             "anyOf": [
               {
@@ -4800,6 +4804,7 @@
         },
         "required": [
           "accepted_queue",
+          "accepted_queue_total",
           "banner_colors",
           "banner_kiosk_url",
           "banner_url",
@@ -16874,6 +16879,29 @@
             "schema": {
               "title": "Code",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
             }
           }
         ],

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -7457,6 +7457,13 @@
           "sort": {
             "$ref": "#/components/schemas/RequestSort"
           },
+          "status_counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Status Counts",
+            "type": "object"
+          },
           "total": {
             "title": "Total",
             "type": "integer"
@@ -7468,6 +7475,7 @@
           "offset",
           "requests",
           "sort",
+          "status_counts",
           "total"
         ],
         "title": "RequestListResponse",

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -7433,6 +7433,46 @@
         "title": "RequestEmailChangeRequest",
         "type": "object"
       },
+      "RequestListResponse": {
+        "description": "Paginated DJ request list.\n\n``total`` is the true row count before pagination, so the dashboard never\ninfers the count from the returned page length (the #411 failure mode).",
+        "properties": {
+          "direction": {
+            "$ref": "#/components/schemas/SortDirection"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "requests": {
+            "items": {
+              "$ref": "#/components/schemas/RequestOut"
+            },
+            "title": "Requests",
+            "type": "array"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/RequestSort"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "direction",
+          "limit",
+          "offset",
+          "requests",
+          "sort",
+          "total"
+        ],
+        "title": "RequestListResponse",
+        "type": "object"
+      },
       "RequestOut": {
         "properties": {
           "accepted_at": {
@@ -7624,6 +7664,21 @@
         ],
         "title": "RequestOut",
         "type": "object"
+      },
+      "RequestSort": {
+        "description": "DJ-facing sort fields for the request list (issue #478).",
+        "enum": [
+          "date_requested",
+          "date_accepted",
+          "upvotes",
+          "bpm",
+          "key",
+          "title",
+          "artist",
+          "best_match"
+        ],
+        "title": "RequestSort",
+        "type": "string"
       },
       "RequestSource": {
         "enum": [
@@ -9245,6 +9300,14 @@
         },
         "title": "SlotTargetUpdate",
         "type": "object"
+      },
+      "SortDirection": {
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "title": "SortDirection",
+        "type": "string"
       },
       "StatusMessageResponse": {
         "properties": {
@@ -14583,6 +14646,7 @@
     },
     "/api/events/{code}/requests": {
       "get": {
+        "description": "Paginated, sorted request list. Owner sees requests regardless of status.\n\n``total`` is computed before pagination so the dashboard shows a truthful\ncount rather than inferring it from the returned page length (issue #478).",
         "operationId": "get_event_requests_api_events__code__requests_get",
         "parameters": [
           {
@@ -14641,16 +14705,38 @@
           },
           {
             "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
             "name": "sort",
             "required": false,
             "schema": {
-              "default": "chronological",
-              "enum": [
-                "chronological",
-                "priority"
+              "$ref": "#/components/schemas/RequestSort",
+              "default": "date_requested"
+            }
+          },
+          {
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/SortDirection"
+                },
+                {
+                  "type": "null"
+                }
               ],
-              "title": "Sort",
-              "type": "string"
+              "title": "Direction"
             }
           }
         ],
@@ -14659,11 +14745,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/RequestOut"
-                  },
-                  "title": "Response Get Event Requests Api Events  Code  Requests Get",
-                  "type": "array"
+                  "$ref": "#/components/schemas/RequestListResponse"
                 }
               }
             },

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -5735,6 +5735,24 @@
       },
       "PendingReviewResponse": {
         "properties": {
+          "direction": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SortDirection"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
           "requests": {
             "items": {
               "$ref": "#/components/schemas/PendingReviewRow"
@@ -5742,13 +5760,27 @@
             "title": "Requests",
             "type": "array"
           },
+          "sort": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RequestSort"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "total": {
             "title": "Total",
             "type": "integer"
           }
         },
         "required": [
+          "direction",
+          "limit",
+          "offset",
           "requests",
+          "sort",
           "total"
         ],
         "title": "PendingReviewResponse",
@@ -14398,7 +14430,7 @@
     },
     "/api/events/{code}/pending-review": {
       "get": {
-        "description": "Get pending review data source for DJ bulk-review.",
+        "description": "Paginated pending-review source for DJ bulk-review (issue #478).\n\n``total`` is the true count of pending rows before pagination, so the\nPre-Event tab never shows a capped page length as the queue size. Default\nordering stays the vote-ranked review order; bulk actions still operate\nserver-side against the full filtered set, not the loaded page.",
         "operationId": "pending_review_api_events__code__pending_review_get",
         "parameters": [
           {
@@ -14408,6 +14440,61 @@
             "schema": {
               "title": "Code",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/RequestSort"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Sort"
+            }
+          },
+          {
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/SortDirection"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Direction"
             }
           }
         ],

--- a/server/tests/test_accepted_at.py
+++ b/server/tests/test_accepted_at.py
@@ -117,5 +117,5 @@ def test_request_out_exposes_accepted_at(db, client, test_event, auth_headers):
     resp = client.get(f"/api/events/{test_event.code}/requests", headers=auth_headers)
 
     assert resp.status_code == 200
-    match = next(item for item in resp.json() if item["id"] == r.id)
+    match = next(item for item in resp.json()["requests"] if item["id"] == r.id)
     assert match["accepted_at"] is not None

--- a/server/tests/test_api_contracts.py
+++ b/server/tests/test_api_contracts.py
@@ -119,7 +119,15 @@ REQUEST_OUT_KEYS = {
 }
 
 # Paginated DJ request-list envelope (issue #478).
-REQUEST_LIST_RESPONSE_KEYS = {"requests", "total", "limit", "offset", "sort", "direction"}
+REQUEST_LIST_RESPONSE_KEYS = {
+    "requests",
+    "total",
+    "limit",
+    "offset",
+    "sort",
+    "direction",
+    "status_counts",
+}
 
 ADMIN_USER_OUT_KEYS = {"id", "username", "is_active", "role", "created_at", "event_count"}
 

--- a/server/tests/test_api_contracts.py
+++ b/server/tests/test_api_contracts.py
@@ -118,6 +118,9 @@ REQUEST_OUT_KEYS = {
     "musical_key",
 }
 
+# Paginated DJ request-list envelope (issue #478).
+REQUEST_LIST_RESPONSE_KEYS = {"requests", "total", "limit", "offset", "sort", "direction"}
+
 ADMIN_USER_OUT_KEYS = {"id", "username", "is_active", "role", "created_at", "event_count"}
 
 ADMIN_EVENT_OUT_KEYS = {
@@ -294,9 +297,11 @@ class TestRequestContracts:
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert isinstance(data, list)
-        if data:
-            _assert_keys(data[0], REQUEST_OUT_KEYS, "GET /api/events/{code}/requests[0]")
+        _assert_keys(data, REQUEST_LIST_RESPONSE_KEYS, "GET /api/events/{code}/requests")
+        if data["requests"]:
+            _assert_keys(
+                data["requests"][0], REQUEST_OUT_KEYS, "GET /api/events/{code}/requests[0]"
+            )
 
     def test_update_request_shape(
         self, client: TestClient, auth_headers: dict, test_request: Request

--- a/server/tests/test_api_contracts.py
+++ b/server/tests/test_api_contracts.py
@@ -173,6 +173,7 @@ KIOSK_DISPLAY_KEYS = {
     "event",
     "qr_join_url",
     "accepted_queue",
+    "accepted_queue_total",
     "now_playing",
     "now_playing_hidden",
     "requests_open",

--- a/server/tests/test_integration_multi_sync.py
+++ b/server/tests/test_integration_multi_sync.py
@@ -161,7 +161,7 @@ def test_sync_results_exposed_in_api_response(client, auth_headers, test_request
     response = client.get(f"/api/events/{event.code}/requests", headers=auth_headers)
     assert response.status_code == 200
 
-    data = response.json()
+    data = response.json()["requests"]
     assert len(data) > 0
     req = next(r for r in data if r["id"] == test_request.id)
     assert req["sync_results_json"] is not None

--- a/server/tests/test_kiosk_display_pagination.py
+++ b/server/tests/test_kiosk_display_pagination.py
@@ -1,0 +1,77 @@
+"""Kiosk display pagination (issue #478, PR 4/4).
+
+GET /api/public/events/{join_code}/display previously returned every accepted
+row (sorted in Python over event.requests) with no true total. Add limit/offset
++ accepted_queue_total so the kiosk can grow its window and show a truthful
+queue count instead of treating the visible page as the whole queue.
+"""
+
+from app.models.event import Event
+from app.models.request import Request, RequestStatus
+
+
+def _accepted(db, event: Event, *, title="Song", votes=0, dedupe=None) -> Request:
+    r = Request(
+        event_id=event.id,
+        song_title=title,
+        artist="Artist",
+        source="manual",
+        status=RequestStatus.ACCEPTED.value,
+        vote_count=votes,
+        dedupe_key=dedupe or f"kd_{title}",
+    )
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+def _get(client, event: Event, **params):
+    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    url = f"/api/public/events/{event.join_code}/display" + (f"?{qs}" if qs else "")
+    return client.get(url)
+
+
+def test_kiosk_display_reports_true_accepted_total(db, client, test_event):
+    for i in range(5):
+        _accepted(db, test_event, title=f"S{i}", dedupe=f"d{i}")
+
+    body = _get(client, test_event, limit=2, offset=0).json()
+
+    assert body["accepted_queue_total"] == 5
+    assert len(body["accepted_queue"]) == 2
+
+
+def test_kiosk_display_offset_pages_cover_all(db, client, test_event):
+    for i in range(4):
+        _accepted(db, test_event, title=f"S{i}", votes=10 - i, dedupe=f"d{i}")
+
+    p1 = _get(client, test_event, limit=2, offset=0).json()["accepted_queue"]
+    p2 = _get(client, test_event, limit=2, offset=2).json()["accepted_queue"]
+
+    ids = [r["id"] for r in p1 + p2]
+    assert len(ids) == 4
+    assert len(set(ids)) == 4
+
+
+def test_kiosk_display_order_votes_desc(db, client, test_event):
+    low = _accepted(db, test_event, title="low", votes=1, dedupe="a")
+    high = _accepted(db, test_event, title="high", votes=9, dedupe="b")
+
+    body = _get(client, test_event).json()
+
+    assert [r["id"] for r in body["accepted_queue"]] == [high.id, low.id]
+
+
+def test_kiosk_display_total_counts_all_not_page(db, client, test_event):
+    for i in range(30):
+        _accepted(db, test_event, title=f"S{i}", dedupe=f"d{i}")
+
+    body = _get(client, test_event, limit=10).json()
+
+    assert body["accepted_queue_total"] == 30
+    assert len(body["accepted_queue"]) == 10
+
+
+def test_kiosk_display_oversized_limit_422(db, client, test_event):
+    assert _get(client, test_event, limit=501).status_code == 422

--- a/server/tests/test_pending_review_pagination.py
+++ b/server/tests/test_pending_review_pagination.py
@@ -1,0 +1,101 @@
+"""Pre-Event Voting pending-review pagination + sort (issue #478, PR 3/4).
+
+Removes the silent 200-row cap, returns a true total computed before pagination,
+and adds the shared sort contract. The default ordering stays the vote-ranked
+review order (votes desc, age asc) so existing DJ muscle memory is preserved.
+"""
+
+from app.models.event import Event
+from app.models.request import Request, RequestStatus
+
+
+def _pending(db, event: Event, *, title="Song", votes=0, dedupe=None) -> Request:
+    r = Request(
+        event_id=event.id,
+        song_title=title,
+        artist="Artist",
+        source="manual",
+        status=RequestStatus.NEW.value,
+        vote_count=votes,
+        submitted_during_collection=True,
+        dedupe_key=dedupe or f"pr_{title}",
+    )
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+def _get(client, event, headers, **params):
+    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    url = f"/api/events/{event.code}/pending-review" + (f"?{qs}" if qs else "")
+    return client.get(url, headers=headers)
+
+
+def test_pending_review_envelope_true_total(db, client, test_event, auth_headers):
+    for i in range(5):
+        _pending(db, test_event, title=f"S{i}", dedupe=f"d{i}")
+
+    body = _get(client, test_event, auth_headers, limit=2, offset=0).json()
+
+    assert body["total"] == 5
+    assert len(body["requests"]) == 2
+    assert body["limit"] == 2
+    assert body["offset"] == 0
+
+
+def test_pending_review_offset_pages_cover_all(db, client, test_event, auth_headers):
+    for i in range(5):
+        _pending(db, test_event, title=f"S{i}", votes=i, dedupe=f"d{i}")
+
+    p1 = _get(client, test_event, auth_headers, limit=2, offset=0).json()["requests"]
+    p2 = _get(client, test_event, auth_headers, limit=2, offset=2).json()["requests"]
+    p3 = _get(client, test_event, auth_headers, limit=2, offset=4).json()["requests"]
+
+    ids = [r["id"] for r in p1 + p2 + p3]
+    assert len(ids) == 5
+    assert len(set(ids)) == 5
+
+
+def test_pending_review_no_silent_cap(db, client, test_event, auth_headers):
+    """Old code capped at 200 with total=len(rows); total must be the real count."""
+    for i in range(50):
+        _pending(db, test_event, title=f"S{i}", dedupe=f"d{i}")
+
+    body = _get(client, test_event, auth_headers).json()  # default limit 100
+
+    assert body["total"] == 50
+    assert len(body["requests"]) == 50
+
+
+def test_pending_review_default_is_review_order(db, client, test_event, auth_headers):
+    low = _pending(db, test_event, title="low", votes=1, dedupe="a")
+    high = _pending(db, test_event, title="high", votes=9, dedupe="b")
+
+    body = _get(client, test_event, auth_headers).json()
+
+    assert [r["id"] for r in body["requests"]] == [high.id, low.id]
+
+
+def test_pending_review_oversized_limit_422(db, client, test_event, auth_headers):
+    assert _get(client, test_event, auth_headers, limit=501).status_code == 422
+
+
+def test_pending_review_sort_title_asc(db, client, test_event, auth_headers):
+    z = _pending(db, test_event, title="Zoo", dedupe="a")
+    a = _pending(db, test_event, title="Apple", dedupe="b")
+
+    body = _get(client, test_event, auth_headers, sort="title").json()
+
+    assert body["sort"] == "title"
+    assert [r["id"] for r in body["requests"]] == [a.id, z.id]
+
+
+def test_pending_review_sort_upvotes_asc_override(db, client, test_event, auth_headers):
+    low = _pending(db, test_event, title="low", votes=1, dedupe="a")
+    high = _pending(db, test_event, title="high", votes=9, dedupe="b")
+
+    body = _get(client, test_event, auth_headers, sort="upvotes", direction="asc").json()
+
+    assert body["direction"] == "asc"
+    assert [r["id"] for r in body["requests"]] == [low.id, high.id]

--- a/server/tests/test_priority_sort_api.py
+++ b/server/tests/test_priority_sort_api.py
@@ -1,6 +1,6 @@
 """Integration tests for priority sort on the request list endpoint.
 
-TDD Phase 2: RED — tests for GET /api/events/{code}/requests?sort=priority.
+TDD Phase 2: RED — tests for GET /api/events/{code}/requests?sort=best_match.
 """
 
 from datetime import timedelta
@@ -71,7 +71,7 @@ class TestPrioritySortEndpoint:
             headers=auth_headers,
         )
         assert resp.status_code == 200
-        data = resp.json()
+        data = resp.json()["requests"]
         assert len(data) == 3
         # Newest first (Third, then Second, then First)
         assert data[0]["song_title"] == "Third"
@@ -113,11 +113,11 @@ class TestPrioritySortEndpoint:
         )
 
         resp = client.get(
-            f"/api/events/{test_event.code}/requests?sort=priority",
+            f"/api/events/{test_event.code}/requests?sort=best_match",
             headers=auth_headers,
         )
         assert resp.status_code == 200
-        data = resp.json()
+        data = resp.json()["requests"]
         assert len(data) == 3
 
         # All should have priority_score
@@ -177,11 +177,11 @@ class TestPrioritySortEndpoint:
         )
 
         resp = client.get(
-            f"/api/events/{test_event.code}/requests?sort=priority&status=new",
+            f"/api/events/{test_event.code}/requests?sort=best_match&status=new",
             headers=auth_headers,
         )
         assert resp.status_code == 200
-        data = resp.json()
+        data = resp.json()["requests"]
         new_requests = [d for d in data if d["status"] == "new"]
         assert len(new_requests) == 2
         # Compatible should rank higher
@@ -211,11 +211,11 @@ class TestPrioritySortEndpoint:
         )
 
         resp = client.get(
-            f"/api/events/{test_event.code}/requests?sort=priority",
+            f"/api/events/{test_event.code}/requests?sort=best_match",
             headers=auth_headers,
         )
         assert resp.status_code == 200
-        data = resp.json()
+        data = resp.json()["requests"]
         assert len(data) == 2
         # Popular should be first even without harmonic context
         assert data[0]["song_title"] == "Popular"
@@ -237,7 +237,7 @@ class TestPrioritySortEndpoint:
             headers=auth_headers,
         )
         assert resp.status_code == 200
-        data = resp.json()
+        data = resp.json()["requests"]
         assert data[0]["priority_score"] is None
 
     def test_sort_param_validation(
@@ -279,11 +279,11 @@ class TestPrioritySortEndpoint:
         )
 
         resp = client.get(
-            f"/api/events/{test_event.code}/requests?sort=priority&status=new",
+            f"/api/events/{test_event.code}/requests?sort=best_match&status=new",
             headers=auth_headers,
         )
         assert resp.status_code == 200
-        data = resp.json()
+        data = resp.json()["requests"]
         # Only NEW requests
         assert len(data) == 1
         assert data[0]["song_title"] == "New Song"
@@ -296,6 +296,6 @@ class TestPrioritySortEndpoint:
     ):
         """Unauthenticated request should fail."""
         resp = client.get(
-            f"/api/events/{test_event.code}/requests?sort=priority",
+            f"/api/events/{test_event.code}/requests?sort=best_match",
         )
         assert resp.status_code == 401

--- a/server/tests/test_request_sort.py
+++ b/server/tests/test_request_sort.py
@@ -199,3 +199,102 @@ def test_deterministic_tiebreaker_id_desc(db, client, test_event, auth_headers):
 
     # equal votes -> newest id first
     assert [r["id"] for r in body["requests"]] == [b.id, a.id]
+
+
+def test_status_counts_independent_of_limit_status_offset(db, client, test_event, auth_headers):
+    """status_counts is the true per-status total for the whole event, not the
+    paginated/filtered window (issue #478, Bugs 1 & 2)."""
+    for i in range(5):
+        _mk(db, test_event, title=f"new{i}", status=RequestStatus.NEW.value, dedupe=f"n{i}")
+    for i in range(3):
+        _mk(
+            db,
+            test_event,
+            title=f"acc{i}",
+            status=RequestStatus.ACCEPTED.value,
+            accepted_at=utcnow(),
+            dedupe=f"a{i}",
+        )
+
+    # Fetch a tiny window of the accepted filter — counts must ignore it.
+    body = _get(client, test_event, auth_headers, status="accepted", limit=2, offset=0).json()
+
+    assert body["total"] == 3  # active filter total is unchanged
+    assert len(body["requests"]) == 2  # window honored
+    assert body["status_counts"] == {
+        "all": 8,
+        "new": 5,
+        "accepted": 3,
+        "playing": 0,
+        "played": 0,
+        "rejected": 0,
+    }
+
+
+def test_status_counts_always_returns_all_six_keys_when_empty(db, client, test_event, auth_headers):
+    """All six keys are present (0 when absent) so the dashboard never crashes."""
+    body = _get(client, test_event, auth_headers).json()
+
+    assert body["status_counts"] == {
+        "all": 0,
+        "new": 0,
+        "accepted": 0,
+        "playing": 0,
+        "played": 0,
+        "rejected": 0,
+    }
+
+
+def test_status_counts_present_for_best_match(db, client, test_event, auth_headers):
+    """The best_match branch must include status_counts too (issue #478)."""
+    _mk(db, test_event, title="n0", status=RequestStatus.NEW.value, dedupe="n0")
+    _mk(db, test_event, title="n1", status=RequestStatus.NEW.value, dedupe="n1")
+    _mk(
+        db,
+        test_event,
+        title="p0",
+        status=RequestStatus.PLAYED.value,
+        dedupe="p0",
+    )
+
+    body = _get(client, test_event, auth_headers, sort="best_match").json()
+
+    assert body["sort"] == "best_match"
+    assert body["status_counts"] == {
+        "all": 3,
+        "new": 2,
+        "accepted": 0,
+        "playing": 0,
+        "played": 1,
+        "rejected": 0,
+    }
+
+
+def test_status_counts_ignores_since_filter(db, client, test_event, auth_headers):
+    """status_counts is independent of the `since` incremental filter."""
+    now = utcnow()
+    _mk(
+        db,
+        test_event,
+        title="old",
+        status=RequestStatus.NEW.value,
+        created_at=now - timedelta(hours=2),
+        dedupe="old",
+    )
+    _mk(
+        db,
+        test_event,
+        title="recent",
+        status=RequestStatus.ACCEPTED.value,
+        accepted_at=now,
+        created_at=now,
+        dedupe="recent",
+    )
+
+    since = (now - timedelta(minutes=30)).isoformat()
+    body = _get(client, test_event, auth_headers, since=since).json()
+
+    # `since` filters the page (only "recent" is newer), but counts see both.
+    assert body["status_counts"]["all"] == 2
+    assert body["status_counts"]["new"] == 1
+    assert body["status_counts"]["accepted"] == 1

--- a/server/tests/test_request_sort.py
+++ b/server/tests/test_request_sort.py
@@ -1,0 +1,201 @@
+"""DJ request-list pagination + sort contract (issue #478, PR 2/4).
+
+GET /api/events/{code}/requests returns a paginated envelope with a true total
+(independent of page length) and supports deterministic sorting across the seven
+DJ-facing fields plus Best Match. Mirrors the #411 growing-window model already
+used by /collect and /join.
+"""
+
+from datetime import timedelta
+
+from app.core.time import utcnow
+from app.models.event import Event
+from app.models.request import Request, RequestStatus
+
+
+def _mk(
+    db,
+    event: Event,
+    *,
+    title="Song",
+    artist="Artist",
+    status=RequestStatus.NEW.value,
+    votes=0,
+    bpm=None,
+    key=None,
+    accepted_at=None,
+    created_at=None,
+    dedupe=None,
+) -> Request:
+    r = Request(
+        event_id=event.id,
+        song_title=title,
+        artist=artist,
+        source="manual",
+        status=status,
+        vote_count=votes,
+        bpm=bpm,
+        musical_key=key,
+        accepted_at=accepted_at,
+        created_at=created_at or utcnow(),
+        dedupe_key=dedupe or f"dk_{title}_{artist}",
+    )
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+def _get(client, event, headers, **params):
+    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    url = f"/api/events/{event.code}/requests"
+    if qs:
+        url += f"?{qs}"
+    resp = client.get(url, headers=headers)
+    return resp
+
+
+def test_list_returns_paginated_envelope_with_true_total(db, client, test_event, auth_headers):
+    for i in range(3):
+        _mk(db, test_event, title=f"S{i}", dedupe=f"d{i}")
+
+    resp = _get(client, test_event, auth_headers, limit=2, offset=0)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 3
+    assert len(body["requests"]) == 2
+    assert body["limit"] == 2
+    assert body["offset"] == 0
+    assert "sort" in body and "direction" in body
+
+
+def test_offset_pages_cover_all_rows_without_dup_or_skip(db, client, test_event, auth_headers):
+    for i in range(5):
+        _mk(db, test_event, title=f"S{i}", dedupe=f"d{i}")
+
+    page1 = _get(client, test_event, auth_headers, limit=2, offset=0).json()["requests"]
+    page2 = _get(client, test_event, auth_headers, limit=2, offset=2).json()["requests"]
+    page3 = _get(client, test_event, auth_headers, limit=2, offset=4).json()["requests"]
+
+    ids = [r["id"] for r in page1 + page2 + page3]
+    assert len(ids) == 5
+    assert len(set(ids)) == 5
+
+
+def test_oversized_limit_rejected_422(db, client, test_event, auth_headers):
+    resp = _get(client, test_event, auth_headers, limit=501)
+    assert resp.status_code == 422
+
+
+def test_default_sort_is_date_requested_desc(db, client, test_event, auth_headers):
+    now = utcnow()
+    old = _mk(db, test_event, title="old", created_at=now - timedelta(hours=2), dedupe="a")
+    new = _mk(db, test_event, title="new", created_at=now, dedupe="b")
+
+    body = _get(client, test_event, auth_headers).json()
+
+    assert body["sort"] == "date_requested"
+    assert body["direction"] == "desc"
+    assert [r["id"] for r in body["requests"]] == [new.id, old.id]
+
+
+def test_sort_upvotes_desc(db, client, test_event, auth_headers):
+    low = _mk(db, test_event, title="low", votes=1, dedupe="a")
+    high = _mk(db, test_event, title="high", votes=9, dedupe="b")
+
+    body = _get(client, test_event, auth_headers, sort="upvotes").json()
+
+    assert [r["id"] for r in body["requests"]] == [high.id, low.id]
+
+
+def test_sort_title_asc(db, client, test_event, auth_headers):
+    z = _mk(db, test_event, title="Zoo", dedupe="a")
+    a = _mk(db, test_event, title="Apple", dedupe="b")
+
+    body = _get(client, test_event, auth_headers, sort="title").json()
+
+    assert [r["id"] for r in body["requests"]] == [a.id, z.id]
+
+
+def test_sort_bpm_asc_nulls_last(db, client, test_event, auth_headers):
+    fast = _mk(db, test_event, title="fast", bpm=140.0, dedupe="a")
+    slow = _mk(db, test_event, title="slow", bpm=90.0, dedupe="b")
+    unknown = _mk(db, test_event, title="unknown", bpm=None, dedupe="c")
+
+    body = _get(client, test_event, auth_headers, sort="bpm").json()
+
+    assert [r["id"] for r in body["requests"]] == [slow.id, fast.id, unknown.id]
+
+
+def test_sort_key_camelot_order_nulls_last(db, client, test_event, auth_headers):
+    # Camelot ordinals: 1A=2, 5A=10, 8B=17 -> ascending; null last
+    k8b = _mk(db, test_event, title="k8b", key="8B", dedupe="a")
+    k1a = _mk(db, test_event, title="k1a", key="1A", dedupe="b")
+    k5a = _mk(db, test_event, title="k5a", key="5A", dedupe="c")
+    knull = _mk(db, test_event, title="knull", key=None, dedupe="d")
+
+    body = _get(client, test_event, auth_headers, sort="key").json()
+
+    assert [r["id"] for r in body["requests"]] == [k1a.id, k5a.id, k8b.id, knull.id]
+
+
+def test_sort_date_accepted_stable_after_later_updated_at(db, client, test_event, auth_headers):
+    """date_accepted must not reorder when updated_at later moves (issue #478)."""
+    now = utcnow()
+    first = _mk(
+        db,
+        test_event,
+        title="first",
+        status=RequestStatus.ACCEPTED.value,
+        accepted_at=now - timedelta(minutes=10),
+        dedupe="a",
+    )
+    second = _mk(
+        db,
+        test_event,
+        title="second",
+        status=RequestStatus.ACCEPTED.value,
+        accepted_at=now,
+        dedupe="b",
+    )
+
+    # Simulate a later metadata refresh bumping `first`'s updated_at past `second`.
+    first.updated_at = now + timedelta(minutes=5)
+    db.commit()
+
+    body = _get(client, test_event, auth_headers, sort="date_accepted").json()
+
+    # desc by accepted_at -> second (newer accept) before first, unaffected by updated_at
+    assert [r["id"] for r in body["requests"]] == [second.id, first.id]
+
+
+def test_sort_best_match_attaches_scores_and_total(db, client, test_event, auth_headers):
+    for i in range(3):
+        _mk(db, test_event, title=f"S{i}", votes=i, dedupe=f"d{i}")
+
+    body = _get(client, test_event, auth_headers, sort="best_match").json()
+
+    assert body["sort"] == "best_match"
+    assert body["total"] == 3
+    assert all("priority_score" in r for r in body["requests"])
+
+
+def test_direction_override(db, client, test_event, auth_headers):
+    low = _mk(db, test_event, title="low", votes=1, dedupe="a")
+    high = _mk(db, test_event, title="high", votes=9, dedupe="b")
+
+    body = _get(client, test_event, auth_headers, sort="upvotes", direction="asc").json()
+
+    assert body["direction"] == "asc"
+    assert [r["id"] for r in body["requests"]] == [low.id, high.id]
+
+
+def test_deterministic_tiebreaker_id_desc(db, client, test_event, auth_headers):
+    a = _mk(db, test_event, title="tie", votes=5, dedupe="a")
+    b = _mk(db, test_event, title="tie", votes=5, dedupe="b")
+
+    body = _get(client, test_event, auth_headers, sort="upvotes").json()
+
+    # equal votes -> newest id first
+    assert [r["id"] for r in body["requests"]] == [b.id, a.id]

--- a/server/tests/test_requests.py
+++ b/server/tests/test_requests.py
@@ -181,8 +181,9 @@ class TestListRequests:
         )
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 1
-        assert data[0]["id"] == test_request.id
+        assert data["total"] == 1
+        assert len(data["requests"]) == 1
+        assert data["requests"][0]["id"] == test_request.id
 
     def test_list_requests_filter_by_status(
         self, client: TestClient, auth_headers: dict, test_event: Event, test_request: Request
@@ -194,14 +195,15 @@ class TestListRequests:
         )
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 1
+        assert data["total"] == 1
+        assert len(data["requests"]) == 1
 
         response = client.get(
             f"/api/events/{test_event.code}/requests?status=played",
             headers=auth_headers,
         )
         assert response.status_code == 200
-        assert len(response.json()) == 0
+        assert response.json()["total"] == 0
 
     def test_list_requests_no_auth(self, client: TestClient, test_event: Event):
         """Test listing requests without auth fails."""
@@ -563,7 +565,7 @@ class TestMarkPlayingSingleActive:
             f"/api/events/{test_event.code}/requests?status=played",
             headers=auth_headers,
         )
-        played_ids = [r["id"] for r in resp_check.json()]
+        played_ids = [r["id"] for r in resp_check.json()["requests"]]
         assert req1 in played_ids
 
     def test_mark_playing_updates_now_playing_table(

--- a/server/tests/test_sync_results_exposure.py
+++ b/server/tests/test_sync_results_exposure.py
@@ -55,7 +55,7 @@ class TestGetEventRequestsIncludesSyncFields:
             headers=auth_headers,
         )
         assert response.status_code == 200
-        data = response.json()
+        data = response.json()["requests"]
         assert len(data) == 1
 
         req = data[0]
@@ -86,7 +86,7 @@ class TestGetEventRequestsIncludesSyncFields:
             headers=auth_headers,
         )
         assert response.status_code == 200
-        req = response.json()[0]
+        req = response.json()["requests"][0]
         assert req["sync_results_json"] is None
         assert req["raw_search_query"] is None
 

--- a/server/tests/test_voting.py
+++ b/server/tests/test_voting.py
@@ -270,7 +270,7 @@ class TestVoteCountInResponses:
             headers=auth_headers,
         )
         assert response.status_code == 200
-        data = response.json()
+        data = response.json()["requests"]
         assert len(data) == 1
         assert "vote_count" in data[0]
         assert data[0]["vote_count"] == 0


### PR DESCRIPTION
## Why

Issue #478, PR 2 of 4. The DJ Song Management list returned a bare array capped at 100 with no true total and only a chronological/priority toggle — the #411 failure mode (a capped page length masquerading as the whole queue) and no way to sort by the fields a DJ actually cares about.

**Stacked on #479 (PR1, `accepted_at`).** Review/merge that first.

## What

**Backend** — `GET /api/events/{code}/requests` now returns a paginated envelope `{ requests, total, limit, offset, sort, direction }`:
- True `total` computed before pagination (never inferred from page length).
- Eight sort fields: `date_requested`, `date_accepted`, `upvotes`, `bpm`, `key` (harmonic Camelot order), `title`, `artist`, `best_match` (the former priority sort). Per-field default directions; `direction` overridable.
- SQL-expressible sorts → `ORDER BY … NULLS LAST, id DESC` + `LIMIT/OFFSET`. `key`/`best_match` sort in Python over the full filtered set. Every sort ends with an `id DESC` tie-breaker so pages never duplicate or skip rows between polls.
- New `app/services/request_sort.py`; `RequestListResponse`/`RequestSort`/`SortDirection` schemas; regenerated OpenAPI + TS types.

**Frontend** — DJ list adopts the #411 growing-window model:
- Unified **Sort** selector (Best Match + the seven fields) with a direction toggle — Best Match replaces the old priority checkbox (no two conflicting sort controls).
- `displayLimit` grows on **Load More** up to `PUBLIC_PAGE_MAX`; truthful "showing X of Y" from the real total; every poll/SSE refresh re-fetches from `offset=0` to avoid drift when rows reorder.
- `getRequests` returns the envelope; new `lib/request-sort.ts` mirrors the backend's per-field defaults.

## Testing

- [x] Backend: new `test_request_sort.py` (12 tests — envelope, true total, offset slicing, 422 guard, every sort incl. null-last bpm/key + Camelot order, `date_accepted` stable after a later `updated_at`, tie-breakers); full suite **3013 passed, coverage 88.49%** (≥85% gate)
- [x] Backend `ruff` clean
- [x] Frontend: new `RequestQueueSection.test.tsx` + api-client param tests + Load-More clamp tests; `tsc` clean, `eslint` clean, **1308 vitest pass**, coverage gate holds
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Part of #478 (PR 2/4). Builds on #479 and #411.