### PR TITLE
feat(collect): paginate + sort pending-review (#478 · 3/4)

### DIFF
--- a/dashboard/app/(dj)/events/[code]/components/PreEventVotingTab.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/PreEventVotingTab.tsx
@@ -2,7 +2,18 @@
 
 import { useEffect, useState } from 'react';
 import { z } from 'zod';
-import { apiClient, PendingReviewRow } from '@/lib/api';
+import { apiClient, PendingReviewRow, PUBLIC_PAGE_MAX } from '@/lib/api';
+import type { SortDirection } from '@/lib/api-types';
+import {
+  PENDING_REVIEW_DEFAULT_DIRECTION,
+  PENDING_REVIEW_SORT_FIELDS,
+  REVIEW_ORDER,
+  toPendingReviewParams,
+  type PendingReviewSort,
+} from '@/lib/pending-review-sort';
+
+/** First page size; the growing window grows by this on each "Load More". */
+const PAGE_SIZE = 100;
 
 interface EventShape {
   code: string;
@@ -82,6 +93,11 @@ export default function PreEventVotingTab({
   onEventChange,
 }: Props) {
   const [pending, setPending] = useState<PendingReviewRow[]>([]);
+  const [pendingTotal, setPendingTotal] = useState(0);
+  const [displayLimit, setDisplayLimit] = useState(PAGE_SIZE);
+  const [sortField, setSortField] = useState<PendingReviewSort>(REVIEW_ORDER);
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [loadingMore, setLoadingMore] = useState(false);
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [confirming, setConfirming] = useState<ConfirmAction | null>(null);
   const [topN, setTopN] = useState(20);
@@ -102,14 +118,54 @@ export default function PreEventVotingTab({
   const [syncResult, setSyncResult] = useState<{ queued: number } | null>(null);
   const [syncError, setSyncError] = useState<string | null>(null);
 
+  // Re-fetch whenever the event, sort, or direction changes — each resets the
+  // growing window back to the first page. "Load More" drives its own fetch
+  // (loadMore) so its loading state stays meaningful. The effect intentionally
+  // re-runs only on the inputs below, mirroring the original code.code effect.
   useEffect(() => {
-    refresh();
+    setDisplayLimit(PAGE_SIZE);
+    fetchPage(PAGE_SIZE);
 
-  }, [event.code]);
+  }, [event.code, sortField, sortDirection]);
 
-  async function refresh() {
-    const resp = await apiClient.getPendingReview(event.code);
+  // Fetch the pending-review window from offset=0 up to `limit`. Every refresh
+  // re-fetches the whole current window so sort/paging stay consistent.
+  async function fetchPage(limit: number) {
+    const resp = await apiClient.getPendingReview(event.code, {
+      ...toPendingReviewParams(sortField, sortDirection),
+      limit,
+      offset: 0,
+    });
     setPending(resp.requests);
+    setPendingTotal(resp.total);
+  }
+
+  /** Re-fetch the current window (used after bulk actions). */
+  function refresh() {
+    return fetchPage(displayLimit);
+  }
+
+  function handleSortFieldChange(next: PendingReviewSort) {
+    setSortField(next);
+    // Snap direction to the field's natural default; Review order has none.
+    if (next !== REVIEW_ORDER) {
+      setSortDirection(PENDING_REVIEW_DEFAULT_DIRECTION[next]);
+    }
+  }
+
+  function handleSortDirectionToggle() {
+    setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+  }
+
+  async function loadMore() {
+    const next = Math.min(displayLimit + PAGE_SIZE, PUBLIC_PAGE_MAX);
+    setLoadingMore(true);
+    try {
+      await fetchPage(next);
+      setDisplayLimit(next);
+    } finally {
+      setLoadingMore(false);
+    }
   }
 
   async function applyOverride(value: 'force_collection' | 'force_live' | null) {
@@ -256,7 +312,7 @@ export default function PreEventVotingTab({
         </div>
         <div className="pre-event-stat">
           <div className="pre-event-stat-label">Pending review</div>
-          <div className="pre-event-stat-value">{pending.length}</div>
+          <div className="pre-event-stat-value">{pendingTotal}</div>
         </div>
         <div className="pre-event-stat">
           <div className="pre-event-stat-label">Pick cap / guest</div>
@@ -433,8 +489,50 @@ export default function PreEventVotingTab({
 
       <div className="card">
         <h3 style={{ marginBottom: '0.75rem', fontSize: '1rem' }}>
-          Pending review ({pending.length})
+          Pending review ({pendingTotal})
         </h3>
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.375rem',
+            marginBottom: '0.75rem',
+          }}
+        >
+          <label
+            htmlFor="pending-sort-field"
+            style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}
+          >
+            Sort
+          </label>
+          <select
+            id="pending-sort-field"
+            className="input"
+            aria-label="Sort pending review by"
+            value={sortField}
+            onChange={(e) => handleSortFieldChange(e.target.value as PendingReviewSort)}
+            style={{ width: 'auto', padding: '0.25rem 0.5rem', fontSize: '0.75rem' }}
+          >
+            {PENDING_REVIEW_SORT_FIELDS.map((f) => (
+              <option key={f.value} value={f.value}>
+                {f.label}
+              </option>
+            ))}
+          </select>
+          {sortField !== REVIEW_ORDER && (
+            <button
+              type="button"
+              className="btn btn-sm"
+              style={{ background: 'var(--surface-raised)', fontSize: '0.75rem', minWidth: '2rem' }}
+              onClick={handleSortDirectionToggle}
+              aria-label={`Sort direction: ${sortDirection === 'asc' ? 'ascending' : 'descending'}`}
+              title={sortDirection === 'asc' ? 'Ascending' : 'Descending'}
+            >
+              {sortDirection === 'asc' ? '↑' : '↓'}
+            </button>
+          )}
+        </div>
 
         <div className="pre-event-review-controls">
           <label>
@@ -471,8 +569,9 @@ export default function PreEventVotingTab({
             type="button"
             className="btn btn-sm btn-danger"
             onClick={() => bulk('reject_remaining')}
+            title="Rejects every still-pending request server-side — not just the rows loaded below."
           >
-            Reject remaining
+            Reject all remaining
           </button>
         </div>
 
@@ -526,6 +625,32 @@ export default function PreEventVotingTab({
               ))}
             </tbody>
           </table>
+        )}
+
+        {pending.length > 0 && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.75rem',
+              marginTop: '0.75rem',
+            }}
+          >
+            <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
+              Showing {pending.length} of {pendingTotal}
+            </span>
+            {pending.length < pendingTotal && pending.length < PUBLIC_PAGE_MAX && (
+              <button
+                type="button"
+                className="btn btn-sm"
+                style={{ background: 'var(--surface-raised)' }}
+                disabled={loadingMore}
+                onClick={loadMore}
+              >
+                {loadingMore ? 'Loading…' : 'Load More'}
+              </button>
+            )}
+          </div>
         )}
 
         {selected.size > 0 && (

--- a/dashboard/app/(dj)/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/__tests__/PreEventVotingTab.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import PreEventVotingTab from "../PreEventVotingTab";
-import { apiClient } from "@/lib/api";
+import { apiClient, PUBLIC_PAGE_MAX, type PendingReviewRow } from "@/lib/api";
 
 const baseEvent = {
   code: "ABC",
@@ -16,25 +16,68 @@ const baseEvent = {
   tidal_collection_bidirectional: false,
 };
 
-vi.mock("@/lib/api", () => ({
-  apiClient: {
-    patchCollectionSettings: vi.fn().mockResolvedValue({
-      code: "ABC",
-      name: "Wedding",
-      collection_opens_at: "2026-04-21T12:00:00Z",
-      live_starts_at: "2026-04-22T20:00:00Z",
-      submission_cap_per_guest: 15,
-      collection_phase_override: "force_live",
-      phase: "live",
-      tidal_sync_enabled: false,
-      tidal_collection_playlist_id: null,
-      tidal_collection_bidirectional: false,
-    }),
-    getPendingReview: vi.fn().mockResolvedValue({ requests: [], total: 0 }),
-    bulkReview: vi.fn().mockResolvedValue({ accepted: 0, rejected: 0, unchanged: 0 }),
-    syncCollectionToTidal: vi.fn().mockResolvedValue({ queued: 3 }),
-  },
-}));
+// A full PendingReviewRow literal — every required key present (#478).
+function makeRow(id: number): PendingReviewRow {
+  return {
+    id,
+    song_title: `Song ${id}`,
+    artist: `Artist ${id}`,
+    artwork_url: null,
+    vote_count: id,
+    nickname: null,
+    created_at: "2026-04-21T12:00:00Z",
+    note: null,
+    status: "new",
+  };
+}
+
+// Pending-review envelope (#478): requests + total (+ pagination/sort echo).
+function envelope(rows: PendingReviewRow[], total: number) {
+  return { requests: rows, total, limit: 100, offset: 0, sort: null, direction: null };
+}
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    apiClient: {
+      patchCollectionSettings: vi.fn().mockResolvedValue({
+        code: "ABC",
+        name: "Wedding",
+        collection_opens_at: "2026-04-21T12:00:00Z",
+        live_starts_at: "2026-04-22T20:00:00Z",
+        submission_cap_per_guest: 15,
+        collection_phase_override: "force_live",
+        phase: "live",
+        tidal_sync_enabled: false,
+        tidal_collection_playlist_id: null,
+        tidal_collection_bidirectional: false,
+      }),
+      getPendingReview: vi.fn().mockResolvedValue({
+        requests: [],
+        total: 0,
+        limit: 100,
+        offset: 0,
+        sort: null,
+        direction: null,
+      }),
+      bulkReview: vi.fn().mockResolvedValue({ accepted: 0, rejected: 0, unchanged: 0 }),
+      syncCollectionToTidal: vi.fn().mockResolvedValue({ queued: 3 }),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(apiClient.getPendingReview).mockReset();
+  vi.mocked(apiClient.getPendingReview).mockResolvedValue({
+    requests: [],
+    total: 0,
+    limit: 100,
+    offset: 0,
+    sort: null,
+    direction: null,
+  });
+});
 
 describe("PreEventVotingTab", () => {
   it("renders phase and share link", () => {
@@ -149,5 +192,179 @@ describe("PreEventVotingTab", () => {
         tidal_collection_bidirectional: true,
       });
     });
+  });
+
+  // ---- Pagination + sort (issue #478) ----
+
+  it("fetches the first page in default Review order (no sort param)", async () => {
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={vi.fn()}
+      />
+    );
+    await waitFor(() => {
+      expect(apiClient.getPendingReview).toHaveBeenCalledWith("ABC", {
+        limit: 100,
+        offset: 0,
+      });
+    });
+  });
+
+  it("re-fetches with sort + direction when the Sort select changes", async () => {
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={vi.fn()}
+      />
+    );
+    await waitFor(() => expect(apiClient.getPendingReview).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText(/sort pending review by/i), {
+      target: { value: "upvotes" },
+    });
+
+    await waitFor(() => {
+      expect(apiClient.getPendingReview).toHaveBeenCalledWith("ABC", {
+        sort: "upvotes",
+        direction: "desc",
+        limit: 100,
+        offset: 0,
+      });
+    });
+  });
+
+  it("snaps direction to the field default and toggles it", async () => {
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={vi.fn()}
+      />
+    );
+    await waitFor(() => expect(apiClient.getPendingReview).toHaveBeenCalled());
+
+    // Title defaults to ascending; the toggle then flips it to descending.
+    fireEvent.change(screen.getByLabelText(/sort pending review by/i), {
+      target: { value: "title" },
+    });
+    await waitFor(() => {
+      expect(apiClient.getPendingReview).toHaveBeenCalledWith("ABC", {
+        sort: "title",
+        direction: "asc",
+        limit: 100,
+        offset: 0,
+      });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /sort direction/i }));
+    await waitFor(() => {
+      expect(apiClient.getPendingReview).toHaveBeenCalledWith("ABC", {
+        sort: "title",
+        direction: "desc",
+        limit: 100,
+        offset: 0,
+      });
+    });
+  });
+
+  it("has no direction toggle in Review order", async () => {
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={vi.fn()}
+      />
+    );
+    await waitFor(() => expect(apiClient.getPendingReview).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: /sort direction/i })).not.toBeInTheDocument();
+  });
+
+  it("shows 'Showing X of N' from the envelope total and Load More grows the window", async () => {
+    vi.mocked(apiClient.getPendingReview)
+      .mockResolvedValueOnce(envelope([makeRow(1), makeRow(2)], 250))
+      .mockResolvedValueOnce(envelope([makeRow(1), makeRow(2), makeRow(3)], 250));
+
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText(/showing 2 of 250/i)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /load more/i }));
+
+    // Second call asks for the grown window (limit 200) from offset 0.
+    await waitFor(() => {
+      expect(apiClient.getPendingReview).toHaveBeenLastCalledWith("ABC", {
+        limit: 200,
+        offset: 0,
+      });
+    });
+  });
+
+  it("hides Load More once the loaded count reaches the envelope total", async () => {
+    vi.mocked(apiClient.getPendingReview).mockResolvedValue(
+      envelope([makeRow(1), makeRow(2)], 2)
+    );
+
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText(/showing 2 of 2/i)).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+  });
+
+  it("clamps the growing window to PUBLIC_PAGE_MAX on Load More", async () => {
+    // Enough total to keep Load More alive; we click until the requested limit
+    // would exceed the cap and assert it is clamped to PUBLIC_PAGE_MAX. The
+    // mock always echoes the requested limit's worth of (one) row so the loaded
+    // count never trips the row-length gate — isolating the limit clamp.
+    vi.mocked(apiClient.getPendingReview).mockImplementation(async (_code, opts) => ({
+      requests: [makeRow(1)],
+      total: 100_000,
+      limit: opts?.limit ?? 100,
+      offset: 0,
+      sort: null,
+      direction: null,
+    }));
+
+    render(
+      <PreEventVotingTab
+        event={baseEvent}
+        tidalConnected={false}
+        tidalIntegrationEnabled={false}
+        onEventChange={vi.fn()}
+      />
+    );
+    await waitFor(() => expect(screen.getByRole("button", { name: /load more/i })).toBeInTheDocument());
+
+    // Click Load More many times; the requested limit grows by 100 but clamps.
+    for (let i = 0; i < 10; i++) {
+      fireEvent.click(screen.getByRole("button", { name: /load more/i }));
+      // Let the awaited fetch settle before the next click.
+      await waitFor(() => expect(apiClient.getPendingReview).toHaveBeenCalled());
+    }
+
+    const requestedLimits = vi
+      .mocked(apiClient.getPendingReview)
+      .mock.calls.map(([, opts]) => opts?.limit ?? 0);
+    expect(Math.max(...requestedLimits)).toBeLessThanOrEqual(PUBLIC_PAGE_MAX);
   });
 });

--- a/dashboard/app/e/[code]/display/__tests__/no-identify.test.tsx
+++ b/dashboard/app/e/[code]/display/__tests__/no-identify.test.tsx
@@ -46,6 +46,7 @@ vi.mock('@/lib/api', () => ({
       event: { code: 'TEST01', name: 'Test' },
       qr_join_url: 'http://x',
       accepted_queue: [],
+      accepted_queue_total: 0,
       now_playing: null,
       now_playing_hidden: false,
       requests_open: true,
@@ -60,6 +61,7 @@ vi.mock('@/lib/api', () => ({
     getKioskAssignment: vi.fn(),
   },
   ApiError: class extends Error { status = 0; },
+  PUBLIC_PAGE_MAX: 500,
 }));
 
 describe('KioskDisplayPage (F4)', () => {

--- a/dashboard/app/e/[code]/display/page.test.tsx
+++ b/dashboard/app/e/[code]/display/page.test.tsx
@@ -44,6 +44,7 @@ const mockKioskDisplay = {
     { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false },
     { id: 2, title: 'Song 2', artist: 'Artist 2', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false },
   ],
+  accepted_queue_total: 2,
   now_playing: null,
   now_playing_hidden: false,
   requests_open: true,
@@ -91,6 +92,7 @@ vi.mock('@/lib/api', () => ({
       this.status = status;
     }
   },
+  PUBLIC_PAGE_MAX: 500,
 }));
 
 import { api, ApiError } from '@/lib/api';
@@ -297,6 +299,7 @@ describe('KioskDisplayPage', () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
         accepted_queue: [],
+        accepted_queue_total: 0,
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(mockNowPlaying);
       vi.mocked(api.getPlayHistory).mockResolvedValue(mockPlayHistory);
@@ -415,6 +418,88 @@ describe('KioskDisplayPage', () => {
       // Should still poll after error
       await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
       expect(api.getKioskDisplay).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('Accepted-queue pagination (growing window)', () => {
+    it('fetches the initial page with limit 100 and offset 0', async () => {
+      setupDefaultMocks();
+
+      render(<KioskDisplayPage />);
+      await screen.findByText('Test Event');
+
+      expect(api.getKioskDisplay).toHaveBeenCalledWith('TEST123', { limit: 100, offset: 0 });
+    });
+
+    it('uses accepted_queue_total for the headline count and a "of" indicator', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        accepted_queue_total: 250, // far more than the 2 loaded items
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+      await screen.findByText('Test Event');
+
+      // Headline QUEUE stat shows the true total, not the loaded page length
+      expect(screen.getByText('250')).toBeInTheDocument();
+      // Compact "showing X of Y" indicator (loaded 2 of 250)
+      expect(screen.getByText('2 OF 250 TRACKS')).toBeInTheDocument();
+    });
+
+    it('shows the plain total when the whole queue is loaded', async () => {
+      setupDefaultMocks(); // 2 items, accepted_queue_total: 2
+
+      render(<KioskDisplayPage />);
+      await screen.findByText('Test Event');
+
+      expect(screen.getByText('2 TRACKS')).toBeInTheDocument();
+    });
+
+    it('grows displayLimit toward PUBLIC_PAGE_MAX when total exceeds the loaded page', async () => {
+      vi.useFakeTimers();
+      // Every response reports far more accepted requests than the loaded page,
+      // so each refresh should bump the requested limit by 100, clamped at 500.
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        accepted_queue_total: 999,
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(1, 'TEST123', { limit: 100, offset: 0 });
+
+      // Each subsequent poll should request the next 100-larger window.
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(2, 'TEST123', { limit: 200, offset: 0 });
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(3, 'TEST123', { limit: 300, offset: 0 });
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(4, 'TEST123', { limit: 400, offset: 0 });
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(5, 'TEST123', { limit: 500, offset: 0 });
+
+      // Clamped at PUBLIC_PAGE_MAX (500) — does not keep growing.
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(6, 'TEST123', { limit: 500, offset: 0 });
+    });
+
+    it('does not grow the window when the whole queue is already loaded', async () => {
+      vi.useFakeTimers();
+      setupDefaultMocks(); // total 2, loaded 2
+
+      render(<KioskDisplayPage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      // Limit stays at the initial 100 — nothing more to load.
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(2, 'TEST123', { limit: 100, offset: 0 });
     });
   });
 

--- a/dashboard/app/e/[code]/display/page.tsx
+++ b/dashboard/app/e/[code]/display/page.tsx
@@ -640,6 +640,10 @@ export default function KioskDisplayPage() {
           align-items: center;
           gap: 14px;
           overflow: hidden;
+          /* Keep natural row height so a long accepted queue scrolls instead of
+             squishing: overflow:hidden zeroes the flex auto min-height, so without
+             flex-shrink:0 the column crushes every row to fit (issue #478). */
+          flex-shrink: 0;
         }
         .queue-item-top1 {
           border-color: var(--banner-accent-50, rgba(255,255,255,0.1));

--- a/dashboard/app/e/[code]/display/page.tsx
+++ b/dashboard/app/e/[code]/display/page.tsx
@@ -3,11 +3,14 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { QRCodeSVG } from 'qrcode.react';
-import { api, ApiError, KioskDisplay, NowPlayingInfo, PlayHistoryItem } from '@/lib/api';
+import { api, ApiError, KioskDisplay, NowPlayingInfo, PlayHistoryItem, PUBLIC_PAGE_MAX } from '@/lib/api';
 import { useEventStream } from '@/lib/use-event-stream';
 import { usePollingLoop } from '@/lib/usePollingLoop';
 import { RequestModal } from './components/RequestModal';
 const AUTO_SCROLL_INTERVAL = 5000; // 5 seconds between auto-scrolls
+// Accepted-queue growing-window: start at 100 and grow by this step each refresh
+// (clamped to PUBLIC_PAGE_MAX) when the server reports more accepted requests.
+const PUBLIC_PAGE_MAX_INITIAL = 100;
 const SESSION_CHECK_INTERVAL = 10_000; // 10 seconds between kiosk session checks
 const SESSION_TOKEN_KEY = 'kiosk_session_token';
 const PAIR_CODE_KEY = 'kiosk_pair_code';
@@ -59,15 +62,32 @@ export default function KioskDisplayPage() {
   // Track whether initial load succeeded (ref avoids stale closure in useCallback)
   const hasLoadedRef = useRef(false);
 
+  // Automatic growing window for the accepted queue (#411 model): always fetch
+  // offset=0 with the current limit, and grow the limit gradually across refreshes
+  // when the server reports more accepted requests than we've loaded. The ref keeps
+  // the polling/SSE callbacks reading the current value without re-creating loadDisplay.
+  const [displayLimit, setDisplayLimit] = useState(PUBLIC_PAGE_MAX_INITIAL);
+  const displayLimitRef = useRef(displayLimit);
+  displayLimitRef.current = displayLimit;
+
   // Load kiosk display data and StageLinQ data
   const loadDisplay = useCallback(async (): Promise<boolean> => {
     try {
+      const limit = displayLimitRef.current;
       const [kioskData, nowPlayingData, historyData] = await Promise.all([
-        api.getKioskDisplay(code),
+        api.getKioskDisplay(code, { limit, offset: 0 }),
         api.getNowPlaying(code).catch((): undefined => undefined),
         api.getPlayHistory(code).catch((): undefined => undefined),
       ]);
       setDisplay(kioskData);
+      // Grow the window for the NEXT refresh if the server has more accepted
+      // requests than the page we just loaded (clamped to PUBLIC_PAGE_MAX).
+      if (
+        kioskData.accepted_queue_total > kioskData.accepted_queue.length &&
+        limit < PUBLIC_PAGE_MAX
+      ) {
+        setDisplayLimit(Math.min(limit + PUBLIC_PAGE_MAX_INITIAL, PUBLIC_PAGE_MAX));
+      }
       // Only update stagelinq now-playing when the fetch succeeded;
       // on transient network errors (undefined), preserve the previous value
       if (nowPlayingData !== undefined) {
@@ -264,6 +284,10 @@ export default function KioskDisplayPage() {
 
   const bannerAccent = safeColor(display.banner_colors?.[0], '#3b82f6');
   const queue = display.accepted_queue;
+  // True accepted-queue size (before pagination). `queue` is only the loaded
+  // page, so use this for the headline count and a "showing X of Y" indicator.
+  const acceptedTotal = display.accepted_queue_total;
+  const hasMoreThanShown = acceptedTotal > queue.length;
   const maxVotes = Math.max(1, ...queue.map((r) => r.vote_count));
   const totalVotes = queue.reduce((s, r) => s + r.vote_count, 0);
 
@@ -1106,7 +1130,7 @@ export default function KioskDisplayPage() {
             <h1 className="kiosk-event-name">{display.event.name}</h1>
             <div className="kiosk-stats">
               <div className="kiosk-stat">
-                <span className="kiosk-stat-value">{queue.length}</span>
+                <span className="kiosk-stat-value">{acceptedTotal}</span>
                 <span className="kiosk-stat-label">QUEUE</span>
               </div>
               <div className="kiosk-stat">
@@ -1190,7 +1214,11 @@ export default function KioskDisplayPage() {
                 QUEUE
               </div>
               <div style={{ flex: 1 }} />
-              <span className="queue-track-count">{queue.length} TRACKS</span>
+              <span className="queue-track-count">
+                {hasMoreThanShown
+                  ? `${queue.length} OF ${acceptedTotal} TRACKS`
+                  : `${acceptedTotal} TRACKS`}
+              </span>
             </div>
             {queue.length > 0 ? (
               <div className="queue-list" ref={queueListRef}>

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -1527,6 +1527,85 @@ describe('ApiClient', () => {
     });
   });
 
+  describe('getPendingReview', () => {
+    // #478: pending-review now returns a paginated envelope, not a bare array.
+    const envelope = (overrides: Record<string, unknown> = {}) => ({
+      requests: [],
+      total: 0,
+      limit: 100,
+      offset: 0,
+      sort: null,
+      direction: null,
+      ...overrides,
+    });
+
+    it('returns the paginated envelope with the true total', async () => {
+      api.setToken('test-token');
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          envelope({
+            requests: [
+              {
+                id: 1,
+                song_title: 'S',
+                artist: 'A',
+                artwork_url: null,
+                vote_count: 5,
+                nickname: null,
+                created_at: '2026-04-21T12:00:00Z',
+                note: null,
+                status: 'new',
+              },
+            ],
+            total: 250,
+          }),
+      });
+
+      const resp = await api.getPendingReview('ABC123');
+      expect(resp.requests).toHaveLength(1);
+      expect(resp.total).toBe(250);
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/events/ABC123/pending-review');
+    });
+
+    it('omits sort/direction/limit/offset by default (Review order)', async () => {
+      api.setToken('test-token');
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => envelope() });
+
+      await api.getPendingReview('ABC123');
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).not.toContain('sort=');
+      expect(url).not.toContain('direction=');
+      expect(url).not.toContain('limit=');
+      expect(url).not.toContain('offset=');
+    });
+
+    it('appends sort + direction params when specified', async () => {
+      api.setToken('test-token');
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => envelope() });
+
+      await api.getPendingReview('ABC123', { sort: 'upvotes', direction: 'desc' });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('sort=upvotes');
+      expect(url).toContain('direction=desc');
+    });
+
+    it('appends limit + offset params, sending offset=0 even though falsy', async () => {
+      api.setToken('test-token');
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => envelope() });
+
+      await api.getPendingReview('ABC123', { limit: 200, offset: 0 });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('limit=200');
+      expect(url).toContain('offset=0');
+    });
+  });
+
   describe('acceptAllRequests', () => {
     it('accepts all pending requests', async () => {
       api.setToken('test-token');

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -1752,29 +1752,41 @@ describe('ApiClient', () => {
   });
 
   describe('getKioskDisplay', () => {
+    const kioskDisplayBody = {
+      event: { code: 'FRI001', name: 'Friday Night' },
+      qr_join_url: 'https://example.com/join/FRI001',
+      accepted_queue: [],
+      accepted_queue_total: 0,
+      now_playing: null,
+      now_playing_hidden: false,
+      requests_open: true,
+      kiosk_display_only: false,
+      updated_at: '2026-01-01T00:00:00Z',
+      banner_url: null,
+      banner_kiosk_url: null,
+      banner_colors: null,
+    };
+
     it('fetches kiosk display data', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          event: { code: 'FRI001', name: 'Friday Night' },
-          qr_join_url: 'https://example.com/join/FRI001',
-          accepted_queue: [],
-          now_playing: null,
-          now_playing_hidden: false,
-          requests_open: true,
-          kiosk_display_only: false,
-          updated_at: '2026-01-01T00:00:00Z',
-          banner_url: null,
-          banner_kiosk_url: null,
-          banner_colors: null,
-        }),
-      });
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => kioskDisplayBody });
 
       const result = await api.getKioskDisplay('FRI001');
       expect(result.event.name).toBe('Friday Night');
+      expect(result.accepted_queue_total).toBe(0);
 
       const [url] = mockFetch.mock.calls[0];
       expect(url).toContain('/api/public/events/FRI001/display');
+      expect(url).not.toContain('?');
+    });
+
+    it('appends limit and offset when provided', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => kioskDisplayBody });
+
+      await api.getKioskDisplay('FRI001', { limit: 200, offset: 100 });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('limit=200');
+      expect(url).toContain('offset=100');
     });
   });
 

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -1218,7 +1218,12 @@ export interface paths {
         };
         /**
          * Pending Review
-         * @description Get pending review data source for DJ bulk-review.
+         * @description Paginated pending-review source for DJ bulk-review (issue #478).
+         *
+         *     ``total`` is the true count of pending rows before pagination, so the
+         *     Pre-Event tab never shows a capped page length as the queue size. Default
+         *     ordering stays the vote-ranked review order; bulk actions still operate
+         *     server-side against the full filtered set, not the loaded page.
          */
         get: operations["pending_review_api_events__code__pending_review_get"];
         put?: never;
@@ -5628,8 +5633,14 @@ export interface components {
         };
         /** PendingReviewResponse */
         PendingReviewResponse: {
+            direction: components["schemas"]["SortDirection"] | null;
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
             /** Requests */
             requests: components["schemas"]["PendingReviewRow"][];
+            sort: components["schemas"]["RequestSort"] | null;
             /** Total */
             total: number;
         };
@@ -9534,7 +9545,12 @@ export interface operations {
     };
     pending_review_api_events__code__pending_review_get: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+                offset?: number;
+                sort?: components["schemas"]["RequestSort"] | null;
+                direction?: components["schemas"]["SortDirection"] | null;
+            };
             header?: never;
             path: {
                 code: string;

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -5302,6 +5302,8 @@ export interface components {
         KioskDisplayResponse: {
             /** Accepted Queue */
             accepted_queue: components["schemas"]["PublicRequestInfo"][];
+            /** Accepted Queue Total */
+            accepted_queue_total: number;
             /** Banner Colors */
             banner_colors: string[] | null;
             /** Banner Kiosk Url */
@@ -11092,7 +11094,10 @@ export interface operations {
     };
     get_kiosk_display_api_public_events__code__display_get: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+                offset?: number;
+            };
             header?: never;
             path: {
                 code: string;

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -27,6 +27,9 @@ export type SongRequest = Schemas['RequestOut'];
 export type RequestListResponse = Schemas['RequestListResponse'];
 export type RequestSort = Schemas['RequestSort'];
 export type SortDirection = Schemas['SortDirection'];
+// Pre-event pending-review pagination + sort envelope (issue #478)
+export type PendingReviewResponse = Schemas['PendingReviewResponse'];
+export type PendingReviewRow = Schemas['PendingReviewRow'];
 export type PublicRequestInfo = Schemas['PublicRequestInfo'] & { requester_verified?: boolean };
 export type GuestRequestInfo = Schemas['GuestRequestInfo'] & { requester_verified?: boolean };
 export type GuestNowPlaying = Schemas['GuestNowPlaying'];

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1231,8 +1231,15 @@ class ApiClient {
     return this.publicFetch(`${getApiUrl()}/api/public/events/${code}`);
   }
 
-  async getKioskDisplay(code: string): Promise<KioskDisplay> {
-    return this.publicFetch(`${getApiUrl()}/api/public/events/${code}/display`);
+  async getKioskDisplay(
+    code: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<KioskDisplay> {
+    const qs = new URLSearchParams();
+    if (options?.limit !== undefined) qs.set('limit', String(options.limit));
+    if (options?.offset !== undefined) qs.set('offset', String(options.offset));
+    const suffix = qs.toString() ? `?${qs}` : '';
+    return this.publicFetch(`${getApiUrl()}/api/public/events/${code}/display${suffix}`);
   }
 
   /**

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -78,6 +78,7 @@ import type {
   ShareTokenOut,
   SlotTargetOut,
   SongRequest,
+  PendingReviewResponse,
   RequestListResponse,
   RequestSort,
   SortDirection,
@@ -188,6 +189,8 @@ export type {
   SharedSlotView,
   ShareTokenOut,
   SongRequest,
+  PendingReviewResponse,
+  PendingReviewRow,
   RequestListResponse,
   RequestSort,
   SortDirection,
@@ -300,22 +303,9 @@ export interface CollectionSyncResponse {
   queued: number;
 }
 
-export interface PendingReviewRow {
-  id: number;
-  song_title: string;
-  artist: string;
-  artwork_url: string | null;
-  vote_count: number;
-  nickname: string | null;
-  created_at: string;
-  note: string | null;
-  status: 'new' | 'accepted' | 'playing' | 'played' | 'rejected';
-}
-
-export interface PendingReviewResponse {
-  requests: PendingReviewRow[];
-  total: number;
-}
+// Pre-event pending-review row + pagination envelope (issue #478) are
+// re-exported below from the generated OpenAPI surface (`PendingReviewRow` /
+// `PendingReviewResponse`), so the envelope stays in lockstep with the backend.
 
 export interface BulkReviewResponse {
   accepted: number;
@@ -2195,8 +2185,28 @@ class ApiClient {
     return this.fetch(`/api/events/${code}/collection/sync-tidal`, { method: 'POST' });
   }
 
-  async getPendingReview(code: string): Promise<PendingReviewResponse> {
-    return this.fetch(`/api/events/${code}/pending-review`);
+  /**
+   * Pre-event pending-review list (issue #478). Returns the paginated envelope
+   * (`requests`/`total`/`limit`/`offset`/`sort`/`direction`). Omitting `sort`
+   * yields the default vote-ranked "Review order" (votes desc, age asc); pass a
+   * `RequestSort` value to override. `limit` clamps to {@link PUBLIC_PAGE_MAX}.
+   */
+  async getPendingReview(
+    code: string,
+    options?: {
+      sort?: RequestSort;
+      direction?: SortDirection;
+      limit?: number;
+      offset?: number;
+    },
+  ): Promise<PendingReviewResponse> {
+    const params = new URLSearchParams();
+    if (options?.sort) params.set('sort', options.sort);
+    if (options?.direction) params.set('direction', options.direction);
+    if (options?.limit !== undefined) params.set('limit', String(options.limit));
+    if (options?.offset !== undefined) params.set('offset', String(options.offset));
+    const qs = params.toString();
+    return this.fetch(`/api/events/${code}/pending-review${qs ? `?${qs}` : ''}`);
   }
 
   async bulkReview(

--- a/dashboard/lib/pending-review-sort.ts
+++ b/dashboard/lib/pending-review-sort.ts
@@ -1,0 +1,58 @@
+/**
+ * Pre-event pending-review sort metadata (issue #478).
+ *
+ * The pending-review list is a focused subset of the DJ request-sort surface:
+ * every row is `status="new"`, so bpm/key/date_accepted/best_match aren't
+ * meaningful or displayed. We offer only the five options below.
+ *
+ * "Review order" is the backend default (vote-ranked: votes desc, age asc) and
+ * is requested by sending NO `sort` param — so it has no direction toggle. The
+ * remaining options map 1:1 onto `RequestSort` field values with per-field
+ * default directions mirrored from the backend.
+ */
+
+import type { RequestSort, SortDirection } from './api-types';
+
+/** Sentinel for the default vote-ranked order (sends no `sort` param). */
+export const REVIEW_ORDER = 'review_order' as const;
+
+/** A pending-review sort selection: either the sentinel or a real field. */
+export type PendingReviewSort = typeof REVIEW_ORDER | RequestSort;
+
+/** Sort options in display order. Review order leads (the backend default). */
+export const PENDING_REVIEW_SORT_FIELDS: readonly {
+  value: PendingReviewSort;
+  label: string;
+}[] = [
+  { value: REVIEW_ORDER, label: 'Review order' },
+  { value: 'upvotes', label: 'Upvotes' },
+  { value: 'date_requested', label: 'Date requested' },
+  { value: 'title', label: 'Title' },
+  { value: 'artist', label: 'Artist' },
+] as const;
+
+/** Per-field default direction (mirrors the backend's per-field defaults). */
+export const PENDING_REVIEW_DEFAULT_DIRECTION: Record<RequestSort, SortDirection> = {
+  upvotes: 'desc',
+  date_requested: 'desc',
+  title: 'asc',
+  artist: 'asc',
+  // Unused by the pending-review UI, but kept exhaustive for the union.
+  date_accepted: 'desc',
+  bpm: 'asc',
+  key: 'asc',
+  best_match: 'desc',
+};
+
+/**
+ * Resolve a pending-review selection into the `getPendingReview` query params.
+ * "Review order" sends nothing (the backend default); a real field sends both
+ * `sort` and `direction`.
+ */
+export function toPendingReviewParams(
+  sort: PendingReviewSort,
+  direction: SortDirection,
+): { sort?: RequestSort; direction?: SortDirection } {
+  if (sort === REVIEW_ORDER) return {};
+  return { sort, direction };
+}

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -64,7 +64,7 @@ from app.schemas.search import SearchResult
 from app.services.collect import (
     collection_settings_payload,
     execute_bulk_review,
-    get_pending_review_rows,
+    get_sorted_pending_review,
     update_collection_settings,
 )
 from app.services.event import (
@@ -1161,11 +1161,24 @@ def sync_collection_to_tidal(
 
 @router.get("/{code}/pending-review", response_model=PendingReviewResponse)
 def pending_review(
+    limit: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    offset: int = Query(default=0, ge=0),
+    sort: RequestSort | None = None,
+    direction: SortDirection | None = None,
     event: Event = Depends(get_event_for_dj_or_admin),
     db: Session = Depends(get_db),
 ):
-    """Get pending review data source for DJ bulk-review."""
-    rows = get_pending_review_rows(db, event.id)
+    """Paginated pending-review source for DJ bulk-review (issue #478).
+
+    ``total`` is the true count of pending rows before pagination, so the
+    Pre-Event tab never shows a capped page length as the queue size. Default
+    ordering stays the vote-ranked review order; bulk actions still operate
+    server-side against the full filtered set, not the loaded page.
+    """
+    rows, total = get_sorted_pending_review(
+        db, event.id, sort=sort, direction=direction, limit=limit, offset=offset
+    )
+    resolved = direction or (DEFAULT_SORT_DIRECTION[sort] if sort else None)
     return PendingReviewResponse(
         requests=[
             PendingReviewRow(
@@ -1181,7 +1194,11 @@ def pending_review(
             )
             for r in rows
         ],
-        total=len(rows),
+        total=total,
+        limit=limit,
+        offset=offset,
+        sort=sort,
+        direction=resolved,
     )
 
 

--- a/server/app/api/public.py
+++ b/server/app/api/public.py
@@ -125,6 +125,9 @@ class KioskDisplayResponse(BaseModel):
     event: PublicEventInfo
     qr_join_url: str
     accepted_queue: list[PublicRequestInfo]
+    # True count of accepted requests before pagination — the kiosk shows this
+    # rather than the visible page length so the queue count is honest (#478).
+    accepted_queue_total: int
     now_playing: PublicRequestInfo | None
     now_playing_hidden: bool
     requests_open: bool = True
@@ -140,6 +143,8 @@ class KioskDisplayResponse(BaseModel):
 def get_kiosk_display(
     code: str,
     request: Request,
+    limit: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    offset: int = Query(default=0, ge=0),
     db: Session = Depends(get_db),
 ) -> KioskDisplayResponse:
     """Get public kiosk display data for an event."""
@@ -161,9 +166,25 @@ def get_kiosk_display(
         base_url = str(request.base_url).rstrip("/")
     qr_join_url = f"{base_url}/join/{event.join_code}"
 
-    # Get accepted requests (status = 'accepted') sorted by vote_count desc, then updated_at asc
-    accepted_requests = [r for r in event.requests if r.status == RequestStatus.ACCEPTED.value]
-    accepted_requests.sort(key=lambda r: (-r.vote_count, r.updated_at))
+    # Accepted queue: count + sort + paginate in SQL with a true total before
+    # the page, rather than materializing event.requests and sorting in Python.
+    # Order preserves the prior display rule (votes desc, updated_at asc) plus a
+    # deterministic id tie-breaker so the growing window never skips/dupes (#478).
+    accepted_q = db.query(SongRequest).filter(
+        SongRequest.event_id == event.id,
+        SongRequest.status == RequestStatus.ACCEPTED.value,
+    )
+    accepted_queue_total = accepted_q.count()
+    accepted_requests = (
+        accepted_q.order_by(
+            SongRequest.vote_count.desc(),
+            SongRequest.updated_at.asc(),
+            SongRequest.id.desc(),
+        )
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
 
     accepted_queue = [
         PublicRequestInfo(
@@ -208,6 +229,7 @@ def get_kiosk_display(
         event=PublicEventInfo(code=event.join_code, name=event.name),
         qr_join_url=qr_join_url,
         accepted_queue=accepted_queue,
+        accepted_queue_total=accepted_queue_total,
         now_playing=now_playing,
         now_playing_hidden=now_playing_is_hidden,
         requests_open=event.requests_open,

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -6,6 +6,7 @@ from typing import Annotated, Literal
 from pydantic import AfterValidator, BaseModel, Field, StringConstraints
 
 from app.core.validation import contains_profanity
+from app.schemas.request import RequestSort, SortDirection
 
 
 def _check_nickname_profanity(v: str) -> str:
@@ -177,6 +178,10 @@ class PendingReviewRow(BaseModel):
 class PendingReviewResponse(BaseModel):
     requests: list[PendingReviewRow]
     total: int
+    limit: int
+    offset: int
+    sort: RequestSort | None
+    direction: SortDirection | None
 
 
 class BulkReviewRequest(BaseModel):

--- a/server/app/services/collect.py
+++ b/server/app/services/collect.py
@@ -6,13 +6,16 @@ from fastapi import HTTPException
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from app.core.pagination import DEFAULT_PAGE_SIZE
 from app.core.time import utcnow
 from app.models.event import Event
 from app.models.guest import Guest
 from app.models.guest_profile import GuestProfile
 from app.models.request import Request as SongRequest
 from app.schemas.collect import BulkReviewRequest, UpdateCollectionSettings
+from app.schemas.request import RequestSort, SortDirection
 from app.services.request import mark_accepted
+from app.services.request_sort import DEFAULT_SORT_DIRECTION, apply_field_sort, key_sorted
 
 
 class NicknameConflictError(Exception):
@@ -81,17 +84,50 @@ def update_collection_settings(
     return event
 
 
-def get_pending_review_rows(db: Session, event_id: int, limit: int = 200) -> list[SongRequest]:
-    """Collection-phase requests awaiting DJ review, ranked by votes then age."""
-    return (
+def get_sorted_pending_review(
+    db: Session,
+    event_id: int,
+    *,
+    sort: RequestSort | None = None,
+    direction: SortDirection | None = None,
+    limit: int = DEFAULT_PAGE_SIZE,
+    offset: int = 0,
+) -> tuple[list[SongRequest], int]:
+    """Collection-phase requests awaiting DJ review: ``(page_rows, true_total)``.
+
+    ``total`` is counted before pagination so the Pre-Event tab shows a truthful
+    count rather than a silently capped page length (issue #478). The default
+    (``sort=None``) preserves the vote-ranked review order; ``best_match`` falls
+    back to it because priority scoring is meaningless pre-event (no now-playing).
+    """
+    base = (
         db.query(SongRequest)
         .filter(SongRequest.event_id == event_id)
         .filter(SongRequest.submitted_during_collection == True)  # noqa: E712
         .filter(SongRequest.status == "new")
-        .order_by(SongRequest.vote_count.desc(), SongRequest.created_at.asc())
-        .limit(limit)
-        .all()
     )
+    total = base.count()
+
+    if sort is None or sort == RequestSort.BEST_MATCH:
+        page = (
+            base.order_by(
+                SongRequest.vote_count.desc(),
+                SongRequest.created_at.asc(),
+                SongRequest.id.desc(),
+            )
+            .offset(offset)
+            .limit(limit)
+            .all()
+        )
+        return page, total
+
+    resolved = direction or DEFAULT_SORT_DIRECTION[sort]
+    if sort == RequestSort.KEY:
+        ordered = key_sorted(base.all(), resolved)
+        return ordered[offset : offset + limit], total
+
+    page = apply_field_sort(base, sort, resolved).offset(offset).limit(limit).all()
+    return page, total
 
 
 def execute_bulk_review(

--- a/server/app/services/request_sort.py
+++ b/server/app/services/request_sort.py
@@ -89,7 +89,7 @@ def _camelot_ordinal(musical_key: str | None) -> int | None:
     return pos.number * 2 + (1 if pos.letter == "B" else 0)
 
 
-def _key_sorted(rows: list[Request], direction: SortDirection) -> list[Request]:
+def key_sorted(rows: list[Request], direction: SortDirection) -> list[Request]:
     """Sort by harmonic key in Python; null/unparseable keys always last."""
     desc = direction == SortDirection.DESC
 
@@ -108,6 +108,20 @@ def _key_sorted(rows: list[Request], direction: SortDirection) -> list[Request]:
     return sorted(rows, key=key_fn)
 
 
+def apply_field_sort(query: Query, sort: RequestSort, direction: SortDirection) -> Query:
+    """Apply ``ORDER BY`` for a SQL-expressible field sort.
+
+    Adds nulls-last for nullable columns and a deterministic ``id DESC``
+    tie-breaker. Not valid for ``KEY`` (harmonic, Python-sorted via
+    :func:`key_sorted`) or ``BEST_MATCH`` (priority-scored in the endpoint).
+    """
+    column = _SORT_COLUMNS[sort]
+    ordering = column.asc() if direction == SortDirection.ASC else column.desc()
+    if sort in _NULLABLE_SORTS:
+        ordering = nullslast(ordering)
+    return query.order_by(ordering, Request.id.desc())
+
+
 def get_sorted_requests(
     db: Session,
     event: Event,
@@ -124,12 +138,8 @@ def get_sorted_requests(
     total = base.count()
 
     if sort == RequestSort.KEY:
-        ordered = _key_sorted(base.all(), direction)
+        ordered = key_sorted(base.all(), direction)
         return ordered[offset : offset + limit], total
 
-    column = _SORT_COLUMNS[sort]
-    ordering = column.asc() if direction == SortDirection.ASC else column.desc()
-    if sort in _NULLABLE_SORTS:
-        ordering = nullslast(ordering)
-    page = base.order_by(ordering, Request.id.desc()).offset(offset).limit(limit).all()
+    page = apply_field_sort(base, sort, direction).offset(offset).limit(limit).all()
     return page, total

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -4725,6 +4725,10 @@
             "title": "Accepted Queue",
             "type": "array"
           },
+          "accepted_queue_total": {
+            "title": "Accepted Queue Total",
+            "type": "integer"
+          },
           "banner_colors": {
             "anyOf": [
               {
@@ -4800,6 +4804,7 @@
         },
         "required": [
           "accepted_queue",
+          "accepted_queue_total",
           "banner_colors",
           "banner_kiosk_url",
           "banner_url",
@@ -16874,6 +16879,29 @@
             "schema": {
               "title": "Code",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
             }
           }
         ],

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -5735,6 +5735,24 @@
       },
       "PendingReviewResponse": {
         "properties": {
+          "direction": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SortDirection"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
           "requests": {
             "items": {
               "$ref": "#/components/schemas/PendingReviewRow"
@@ -5742,13 +5760,27 @@
             "title": "Requests",
             "type": "array"
           },
+          "sort": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RequestSort"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "total": {
             "title": "Total",
             "type": "integer"
           }
         },
         "required": [
+          "direction",
+          "limit",
+          "offset",
           "requests",
+          "sort",
           "total"
         ],
         "title": "PendingReviewResponse",
@@ -14398,7 +14430,7 @@
     },
     "/api/events/{code}/pending-review": {
       "get": {
-        "description": "Get pending review data source for DJ bulk-review.",
+        "description": "Paginated pending-review source for DJ bulk-review (issue #478).\n\n``total`` is the true count of pending rows before pagination, so the\nPre-Event tab never shows a capped page length as the queue size. Default\nordering stays the vote-ranked review order; bulk actions still operate\nserver-side against the full filtered set, not the loaded page.",
         "operationId": "pending_review_api_events__code__pending_review_get",
         "parameters": [
           {
@@ -14408,6 +14440,61 @@
             "schema": {
               "title": "Code",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/RequestSort"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Sort"
+            }
+          },
+          {
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/SortDirection"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Direction"
             }
           }
         ],

--- a/server/tests/test_api_contracts.py
+++ b/server/tests/test_api_contracts.py
@@ -173,6 +173,7 @@ KIOSK_DISPLAY_KEYS = {
     "event",
     "qr_join_url",
     "accepted_queue",
+    "accepted_queue_total",
     "now_playing",
     "now_playing_hidden",
     "requests_open",

--- a/server/tests/test_kiosk_display_pagination.py
+++ b/server/tests/test_kiosk_display_pagination.py
@@ -1,0 +1,77 @@
+"""Kiosk display pagination (issue #478, PR 4/4).
+
+GET /api/public/events/{join_code}/display previously returned every accepted
+row (sorted in Python over event.requests) with no true total. Add limit/offset
++ accepted_queue_total so the kiosk can grow its window and show a truthful
+queue count instead of treating the visible page as the whole queue.
+"""
+
+from app.models.event import Event
+from app.models.request import Request, RequestStatus
+
+
+def _accepted(db, event: Event, *, title="Song", votes=0, dedupe=None) -> Request:
+    r = Request(
+        event_id=event.id,
+        song_title=title,
+        artist="Artist",
+        source="manual",
+        status=RequestStatus.ACCEPTED.value,
+        vote_count=votes,
+        dedupe_key=dedupe or f"kd_{title}",
+    )
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+def _get(client, event: Event, **params):
+    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    url = f"/api/public/events/{event.join_code}/display" + (f"?{qs}" if qs else "")
+    return client.get(url)
+
+
+def test_kiosk_display_reports_true_accepted_total(db, client, test_event):
+    for i in range(5):
+        _accepted(db, test_event, title=f"S{i}", dedupe=f"d{i}")
+
+    body = _get(client, test_event, limit=2, offset=0).json()
+
+    assert body["accepted_queue_total"] == 5
+    assert len(body["accepted_queue"]) == 2
+
+
+def test_kiosk_display_offset_pages_cover_all(db, client, test_event):
+    for i in range(4):
+        _accepted(db, test_event, title=f"S{i}", votes=10 - i, dedupe=f"d{i}")
+
+    p1 = _get(client, test_event, limit=2, offset=0).json()["accepted_queue"]
+    p2 = _get(client, test_event, limit=2, offset=2).json()["accepted_queue"]
+
+    ids = [r["id"] for r in p1 + p2]
+    assert len(ids) == 4
+    assert len(set(ids)) == 4
+
+
+def test_kiosk_display_order_votes_desc(db, client, test_event):
+    low = _accepted(db, test_event, title="low", votes=1, dedupe="a")
+    high = _accepted(db, test_event, title="high", votes=9, dedupe="b")
+
+    body = _get(client, test_event).json()
+
+    assert [r["id"] for r in body["accepted_queue"]] == [high.id, low.id]
+
+
+def test_kiosk_display_total_counts_all_not_page(db, client, test_event):
+    for i in range(30):
+        _accepted(db, test_event, title=f"S{i}", dedupe=f"d{i}")
+
+    body = _get(client, test_event, limit=10).json()
+
+    assert body["accepted_queue_total"] == 30
+    assert len(body["accepted_queue"]) == 10
+
+
+def test_kiosk_display_oversized_limit_422(db, client, test_event):
+    assert _get(client, test_event, limit=501).status_code == 422

--- a/server/tests/test_pending_review_pagination.py
+++ b/server/tests/test_pending_review_pagination.py
@@ -1,0 +1,101 @@
+"""Pre-Event Voting pending-review pagination + sort (issue #478, PR 3/4).
+
+Removes the silent 200-row cap, returns a true total computed before pagination,
+and adds the shared sort contract. The default ordering stays the vote-ranked
+review order (votes desc, age asc) so existing DJ muscle memory is preserved.
+"""
+
+from app.models.event import Event
+from app.models.request import Request, RequestStatus
+
+
+def _pending(db, event: Event, *, title="Song", votes=0, dedupe=None) -> Request:
+    r = Request(
+        event_id=event.id,
+        song_title=title,
+        artist="Artist",
+        source="manual",
+        status=RequestStatus.NEW.value,
+        vote_count=votes,
+        submitted_during_collection=True,
+        dedupe_key=dedupe or f"pr_{title}",
+    )
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+def _get(client, event, headers, **params):
+    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    url = f"/api/events/{event.code}/pending-review" + (f"?{qs}" if qs else "")
+    return client.get(url, headers=headers)
+
+
+def test_pending_review_envelope_true_total(db, client, test_event, auth_headers):
+    for i in range(5):
+        _pending(db, test_event, title=f"S{i}", dedupe=f"d{i}")
+
+    body = _get(client, test_event, auth_headers, limit=2, offset=0).json()
+
+    assert body["total"] == 5
+    assert len(body["requests"]) == 2
+    assert body["limit"] == 2
+    assert body["offset"] == 0
+
+
+def test_pending_review_offset_pages_cover_all(db, client, test_event, auth_headers):
+    for i in range(5):
+        _pending(db, test_event, title=f"S{i}", votes=i, dedupe=f"d{i}")
+
+    p1 = _get(client, test_event, auth_headers, limit=2, offset=0).json()["requests"]
+    p2 = _get(client, test_event, auth_headers, limit=2, offset=2).json()["requests"]
+    p3 = _get(client, test_event, auth_headers, limit=2, offset=4).json()["requests"]
+
+    ids = [r["id"] for r in p1 + p2 + p3]
+    assert len(ids) == 5
+    assert len(set(ids)) == 5
+
+
+def test_pending_review_no_silent_cap(db, client, test_event, auth_headers):
+    """Old code capped at 200 with total=len(rows); total must be the real count."""
+    for i in range(50):
+        _pending(db, test_event, title=f"S{i}", dedupe=f"d{i}")
+
+    body = _get(client, test_event, auth_headers).json()  # default limit 100
+
+    assert body["total"] == 50
+    assert len(body["requests"]) == 50
+
+
+def test_pending_review_default_is_review_order(db, client, test_event, auth_headers):
+    low = _pending(db, test_event, title="low", votes=1, dedupe="a")
+    high = _pending(db, test_event, title="high", votes=9, dedupe="b")
+
+    body = _get(client, test_event, auth_headers).json()
+
+    assert [r["id"] for r in body["requests"]] == [high.id, low.id]
+
+
+def test_pending_review_oversized_limit_422(db, client, test_event, auth_headers):
+    assert _get(client, test_event, auth_headers, limit=501).status_code == 422
+
+
+def test_pending_review_sort_title_asc(db, client, test_event, auth_headers):
+    z = _pending(db, test_event, title="Zoo", dedupe="a")
+    a = _pending(db, test_event, title="Apple", dedupe="b")
+
+    body = _get(client, test_event, auth_headers, sort="title").json()
+
+    assert body["sort"] == "title"
+    assert [r["id"] for r in body["requests"]] == [a.id, z.id]
+
+
+def test_pending_review_sort_upvotes_asc_override(db, client, test_event, auth_headers):
+    low = _pending(db, test_event, title="low", votes=1, dedupe="a")
+    high = _pending(db, test_event, title="high", votes=9, dedupe="b")
+
+    body = _get(client, test_event, auth_headers, sort="upvotes", direction="asc").json()
+
+    assert body["direction"] == "asc"
+    assert [r["id"] for r in body["requests"]] == [low.id, high.id]


### PR DESCRIPTION
## Why

Issue #478, PR 3 of 4. `GET /api/events/{code}/pending-review` returned `total = len(rows)` after an **undocumented 200-row cap** — the #411 failure mode applied to the Pre-Event Voting tab: a capped page length presented as the true pending count, silently hiding rows past 200.

**Stacked on #486 (PR2).** Review/merge that first.

## What

**Backend** — pending-review now returns the paginated envelope `{ requests, total, limit, offset, sort, direction }`:
- True `total` counted before pagination; `limit`/`offset` drive a #411 growing window.
- Reuses PR2's sort machinery — `apply_field_sort` extracted and `key_sorted` made public in `request_sort.py`, so pending-review and the DJ list share one `ORDER BY … NULLS LAST, id DESC` + Camelot implementation.
- Default (no `sort`) preserves the vote-ranked **review order** (votes desc, age asc, id desc); `best_match` falls back to it (priority scoring is meaningless pre-event).
- Retired the capped `get_pending_review_rows`.

**Frontend** — Pre-Event Voting tab:
- Focused **Sort** selector: Review order (default) + Upvotes / Date requested / Title / Artist, with a direction toggle for the field sorts.
- Growing window: `displayLimit` grows on **Load More** to `PUBLIC_PAGE_MAX`; "showing X of Y" from the real `total`; refresh re-fetches `offset=0`.
- Bulk actions (Accept top N / Accept threshold / Reject remaining) unchanged — still server-side against the full filtered set, not the loaded page ("Reject remaining" relabeled "Reject all remaining" for clarity).

## Testing

- [x] Backend: new `test_pending_review_pagination.py` (7 tests — true total, offset slicing, no silent cap, default review order, 422 guard, field sorts); full suite **3020 passed, coverage 88.49%** (≥85% gate); `ruff` clean
- [x] Frontend: new `pending-review-sort.ts` + PreEventVotingTab sort/Load-More tests + api-client param tests; `tsc` clean, `eslint` clean, **1319 vitest pass**
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Part of #478 (PR 3/4). Builds on #486.