### PR TITLE
feat(kiosk): paginate the accepted queue with a true total (#478 · 4/4)

### DIFF
--- a/dashboard/app/e/[code]/display/__tests__/no-identify.test.tsx
+++ b/dashboard/app/e/[code]/display/__tests__/no-identify.test.tsx
@@ -46,6 +46,7 @@ vi.mock('@/lib/api', () => ({
       event: { code: 'TEST01', name: 'Test' },
       qr_join_url: 'http://x',
       accepted_queue: [],
+      accepted_queue_total: 0,
       now_playing: null,
       now_playing_hidden: false,
       requests_open: true,
@@ -60,6 +61,7 @@ vi.mock('@/lib/api', () => ({
     getKioskAssignment: vi.fn(),
   },
   ApiError: class extends Error { status = 0; },
+  PUBLIC_PAGE_MAX: 500,
 }));
 
 describe('KioskDisplayPage (F4)', () => {

--- a/dashboard/app/e/[code]/display/page.test.tsx
+++ b/dashboard/app/e/[code]/display/page.test.tsx
@@ -44,6 +44,7 @@ const mockKioskDisplay = {
     { id: 1, title: 'Song 1', artist: 'Artist 1', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false },
     { id: 2, title: 'Song 2', artist: 'Artist 2', artwork_url: null, nickname: null, vote_count: 0, bpm: null, musical_key: null, genre: null, requester_verified: false },
   ],
+  accepted_queue_total: 2,
   now_playing: null,
   now_playing_hidden: false,
   requests_open: true,
@@ -91,6 +92,7 @@ vi.mock('@/lib/api', () => ({
       this.status = status;
     }
   },
+  PUBLIC_PAGE_MAX: 500,
 }));
 
 import { api, ApiError } from '@/lib/api';
@@ -297,6 +299,7 @@ describe('KioskDisplayPage', () => {
       vi.mocked(api.getKioskDisplay).mockResolvedValue({
         ...mockKioskDisplay,
         accepted_queue: [],
+        accepted_queue_total: 0,
       });
       vi.mocked(api.getNowPlaying).mockResolvedValue(mockNowPlaying);
       vi.mocked(api.getPlayHistory).mockResolvedValue(mockPlayHistory);
@@ -415,6 +418,88 @@ describe('KioskDisplayPage', () => {
       // Should still poll after error
       await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
       expect(api.getKioskDisplay).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('Accepted-queue pagination (growing window)', () => {
+    it('fetches the initial page with limit 100 and offset 0', async () => {
+      setupDefaultMocks();
+
+      render(<KioskDisplayPage />);
+      await screen.findByText('Test Event');
+
+      expect(api.getKioskDisplay).toHaveBeenCalledWith('TEST123', { limit: 100, offset: 0 });
+    });
+
+    it('uses accepted_queue_total for the headline count and a "of" indicator', async () => {
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        accepted_queue_total: 250, // far more than the 2 loaded items
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+      await screen.findByText('Test Event');
+
+      // Headline QUEUE stat shows the true total, not the loaded page length
+      expect(screen.getByText('250')).toBeInTheDocument();
+      // Compact "showing X of Y" indicator (loaded 2 of 250)
+      expect(screen.getByText('2 OF 250 TRACKS')).toBeInTheDocument();
+    });
+
+    it('shows the plain total when the whole queue is loaded', async () => {
+      setupDefaultMocks(); // 2 items, accepted_queue_total: 2
+
+      render(<KioskDisplayPage />);
+      await screen.findByText('Test Event');
+
+      expect(screen.getByText('2 TRACKS')).toBeInTheDocument();
+    });
+
+    it('grows displayLimit toward PUBLIC_PAGE_MAX when total exceeds the loaded page', async () => {
+      vi.useFakeTimers();
+      // Every response reports far more accepted requests than the loaded page,
+      // so each refresh should bump the requested limit by 100, clamped at 500.
+      vi.mocked(api.getKioskDisplay).mockResolvedValue({
+        ...mockKioskDisplay,
+        accepted_queue_total: 999,
+      });
+      vi.mocked(api.getNowPlaying).mockResolvedValue(null);
+      vi.mocked(api.getPlayHistory).mockResolvedValue({ items: [], total: 0 });
+
+      render(<KioskDisplayPage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(1, 'TEST123', { limit: 100, offset: 0 });
+
+      // Each subsequent poll should request the next 100-larger window.
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(2, 'TEST123', { limit: 200, offset: 0 });
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(3, 'TEST123', { limit: 300, offset: 0 });
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(4, 'TEST123', { limit: 400, offset: 0 });
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(5, 'TEST123', { limit: 500, offset: 0 });
+
+      // Clamped at PUBLIC_PAGE_MAX (500) — does not keep growing.
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(6, 'TEST123', { limit: 500, offset: 0 });
+    });
+
+    it('does not grow the window when the whole queue is already loaded', async () => {
+      vi.useFakeTimers();
+      setupDefaultMocks(); // total 2, loaded 2
+
+      render(<KioskDisplayPage />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      // Limit stays at the initial 100 — nothing more to load.
+      expect(api.getKioskDisplay).toHaveBeenNthCalledWith(2, 'TEST123', { limit: 100, offset: 0 });
     });
   });
 

--- a/dashboard/app/e/[code]/display/page.tsx
+++ b/dashboard/app/e/[code]/display/page.tsx
@@ -640,6 +640,10 @@ export default function KioskDisplayPage() {
           align-items: center;
           gap: 14px;
           overflow: hidden;
+          /* Keep natural row height so a long accepted queue scrolls instead of
+             squishing: overflow:hidden zeroes the flex auto min-height, so without
+             flex-shrink:0 the column crushes every row to fit (issue #478). */
+          flex-shrink: 0;
         }
         .queue-item-top1 {
           border-color: var(--banner-accent-50, rgba(255,255,255,0.1));

--- a/dashboard/app/e/[code]/display/page.tsx
+++ b/dashboard/app/e/[code]/display/page.tsx
@@ -3,11 +3,14 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { QRCodeSVG } from 'qrcode.react';
-import { api, ApiError, KioskDisplay, NowPlayingInfo, PlayHistoryItem } from '@/lib/api';
+import { api, ApiError, KioskDisplay, NowPlayingInfo, PlayHistoryItem, PUBLIC_PAGE_MAX } from '@/lib/api';
 import { useEventStream } from '@/lib/use-event-stream';
 import { usePollingLoop } from '@/lib/usePollingLoop';
 import { RequestModal } from './components/RequestModal';
 const AUTO_SCROLL_INTERVAL = 5000; // 5 seconds between auto-scrolls
+// Accepted-queue growing-window: start at 100 and grow by this step each refresh
+// (clamped to PUBLIC_PAGE_MAX) when the server reports more accepted requests.
+const PUBLIC_PAGE_MAX_INITIAL = 100;
 const SESSION_CHECK_INTERVAL = 10_000; // 10 seconds between kiosk session checks
 const SESSION_TOKEN_KEY = 'kiosk_session_token';
 const PAIR_CODE_KEY = 'kiosk_pair_code';
@@ -59,15 +62,32 @@ export default function KioskDisplayPage() {
   // Track whether initial load succeeded (ref avoids stale closure in useCallback)
   const hasLoadedRef = useRef(false);
 
+  // Automatic growing window for the accepted queue (#411 model): always fetch
+  // offset=0 with the current limit, and grow the limit gradually across refreshes
+  // when the server reports more accepted requests than we've loaded. The ref keeps
+  // the polling/SSE callbacks reading the current value without re-creating loadDisplay.
+  const [displayLimit, setDisplayLimit] = useState(PUBLIC_PAGE_MAX_INITIAL);
+  const displayLimitRef = useRef(displayLimit);
+  displayLimitRef.current = displayLimit;
+
   // Load kiosk display data and StageLinQ data
   const loadDisplay = useCallback(async (): Promise<boolean> => {
     try {
+      const limit = displayLimitRef.current;
       const [kioskData, nowPlayingData, historyData] = await Promise.all([
-        api.getKioskDisplay(code),
+        api.getKioskDisplay(code, { limit, offset: 0 }),
         api.getNowPlaying(code).catch((): undefined => undefined),
         api.getPlayHistory(code).catch((): undefined => undefined),
       ]);
       setDisplay(kioskData);
+      // Grow the window for the NEXT refresh if the server has more accepted
+      // requests than the page we just loaded (clamped to PUBLIC_PAGE_MAX).
+      if (
+        kioskData.accepted_queue_total > kioskData.accepted_queue.length &&
+        limit < PUBLIC_PAGE_MAX
+      ) {
+        setDisplayLimit(Math.min(limit + PUBLIC_PAGE_MAX_INITIAL, PUBLIC_PAGE_MAX));
+      }
       // Only update stagelinq now-playing when the fetch succeeded;
       // on transient network errors (undefined), preserve the previous value
       if (nowPlayingData !== undefined) {
@@ -264,6 +284,10 @@ export default function KioskDisplayPage() {
 
   const bannerAccent = safeColor(display.banner_colors?.[0], '#3b82f6');
   const queue = display.accepted_queue;
+  // True accepted-queue size (before pagination). `queue` is only the loaded
+  // page, so use this for the headline count and a "showing X of Y" indicator.
+  const acceptedTotal = display.accepted_queue_total;
+  const hasMoreThanShown = acceptedTotal > queue.length;
   const maxVotes = Math.max(1, ...queue.map((r) => r.vote_count));
   const totalVotes = queue.reduce((s, r) => s + r.vote_count, 0);
 
@@ -1106,7 +1130,7 @@ export default function KioskDisplayPage() {
             <h1 className="kiosk-event-name">{display.event.name}</h1>
             <div className="kiosk-stats">
               <div className="kiosk-stat">
-                <span className="kiosk-stat-value">{queue.length}</span>
+                <span className="kiosk-stat-value">{acceptedTotal}</span>
                 <span className="kiosk-stat-label">QUEUE</span>
               </div>
               <div className="kiosk-stat">
@@ -1190,7 +1214,11 @@ export default function KioskDisplayPage() {
                 QUEUE
               </div>
               <div style={{ flex: 1 }} />
-              <span className="queue-track-count">{queue.length} TRACKS</span>
+              <span className="queue-track-count">
+                {hasMoreThanShown
+                  ? `${queue.length} OF ${acceptedTotal} TRACKS`
+                  : `${acceptedTotal} TRACKS`}
+              </span>
             </div>
             {queue.length > 0 ? (
               <div className="queue-list" ref={queueListRef}>

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -1752,29 +1752,41 @@ describe('ApiClient', () => {
   });
 
   describe('getKioskDisplay', () => {
+    const kioskDisplayBody = {
+      event: { code: 'FRI001', name: 'Friday Night' },
+      qr_join_url: 'https://example.com/join/FRI001',
+      accepted_queue: [],
+      accepted_queue_total: 0,
+      now_playing: null,
+      now_playing_hidden: false,
+      requests_open: true,
+      kiosk_display_only: false,
+      updated_at: '2026-01-01T00:00:00Z',
+      banner_url: null,
+      banner_kiosk_url: null,
+      banner_colors: null,
+    };
+
     it('fetches kiosk display data', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          event: { code: 'FRI001', name: 'Friday Night' },
-          qr_join_url: 'https://example.com/join/FRI001',
-          accepted_queue: [],
-          now_playing: null,
-          now_playing_hidden: false,
-          requests_open: true,
-          kiosk_display_only: false,
-          updated_at: '2026-01-01T00:00:00Z',
-          banner_url: null,
-          banner_kiosk_url: null,
-          banner_colors: null,
-        }),
-      });
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => kioskDisplayBody });
 
       const result = await api.getKioskDisplay('FRI001');
       expect(result.event.name).toBe('Friday Night');
+      expect(result.accepted_queue_total).toBe(0);
 
       const [url] = mockFetch.mock.calls[0];
       expect(url).toContain('/api/public/events/FRI001/display');
+      expect(url).not.toContain('?');
+    });
+
+    it('appends limit and offset when provided', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => kioskDisplayBody });
+
+      await api.getKioskDisplay('FRI001', { limit: 200, offset: 100 });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('limit=200');
+      expect(url).toContain('offset=100');
     });
   });
 

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -5302,6 +5302,8 @@ export interface components {
         KioskDisplayResponse: {
             /** Accepted Queue */
             accepted_queue: components["schemas"]["PublicRequestInfo"][];
+            /** Accepted Queue Total */
+            accepted_queue_total: number;
             /** Banner Colors */
             banner_colors: string[] | null;
             /** Banner Kiosk Url */
@@ -11092,7 +11094,10 @@ export interface operations {
     };
     get_kiosk_display_api_public_events__code__display_get: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+                offset?: number;
+            };
             header?: never;
             path: {
                 code: string;

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1231,8 +1231,15 @@ class ApiClient {
     return this.publicFetch(`${getApiUrl()}/api/public/events/${code}`);
   }
 
-  async getKioskDisplay(code: string): Promise<KioskDisplay> {
-    return this.publicFetch(`${getApiUrl()}/api/public/events/${code}/display`);
+  async getKioskDisplay(
+    code: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<KioskDisplay> {
+    const qs = new URLSearchParams();
+    if (options?.limit !== undefined) qs.set('limit', String(options.limit));
+    if (options?.offset !== undefined) qs.set('offset', String(options.offset));
+    const suffix = qs.toString() ? `?${qs}` : '';
+    return this.publicFetch(`${getApiUrl()}/api/public/events/${code}/display${suffix}`);
   }
 
   /**

--- a/server/app/api/public.py
+++ b/server/app/api/public.py
@@ -125,6 +125,9 @@ class KioskDisplayResponse(BaseModel):
     event: PublicEventInfo
     qr_join_url: str
     accepted_queue: list[PublicRequestInfo]
+    # True count of accepted requests before pagination — the kiosk shows this
+    # rather than the visible page length so the queue count is honest (#478).
+    accepted_queue_total: int
     now_playing: PublicRequestInfo | None
     now_playing_hidden: bool
     requests_open: bool = True
@@ -140,6 +143,8 @@ class KioskDisplayResponse(BaseModel):
 def get_kiosk_display(
     code: str,
     request: Request,
+    limit: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    offset: int = Query(default=0, ge=0),
     db: Session = Depends(get_db),
 ) -> KioskDisplayResponse:
     """Get public kiosk display data for an event."""
@@ -161,9 +166,25 @@ def get_kiosk_display(
         base_url = str(request.base_url).rstrip("/")
     qr_join_url = f"{base_url}/join/{event.join_code}"
 
-    # Get accepted requests (status = 'accepted') sorted by vote_count desc, then updated_at asc
-    accepted_requests = [r for r in event.requests if r.status == RequestStatus.ACCEPTED.value]
-    accepted_requests.sort(key=lambda r: (-r.vote_count, r.updated_at))
+    # Accepted queue: count + sort + paginate in SQL with a true total before
+    # the page, rather than materializing event.requests and sorting in Python.
+    # Order preserves the prior display rule (votes desc, updated_at asc) plus a
+    # deterministic id tie-breaker so the growing window never skips/dupes (#478).
+    accepted_q = db.query(SongRequest).filter(
+        SongRequest.event_id == event.id,
+        SongRequest.status == RequestStatus.ACCEPTED.value,
+    )
+    accepted_queue_total = accepted_q.count()
+    accepted_requests = (
+        accepted_q.order_by(
+            SongRequest.vote_count.desc(),
+            SongRequest.updated_at.asc(),
+            SongRequest.id.desc(),
+        )
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
 
     accepted_queue = [
         PublicRequestInfo(
@@ -208,6 +229,7 @@ def get_kiosk_display(
         event=PublicEventInfo(code=event.join_code, name=event.name),
         qr_join_url=qr_join_url,
         accepted_queue=accepted_queue,
+        accepted_queue_total=accepted_queue_total,
         now_playing=now_playing,
         now_playing_hidden=now_playing_is_hidden,
         requests_open=event.requests_open,

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -4725,6 +4725,10 @@
             "title": "Accepted Queue",
             "type": "array"
           },
+          "accepted_queue_total": {
+            "title": "Accepted Queue Total",
+            "type": "integer"
+          },
           "banner_colors": {
             "anyOf": [
               {
@@ -4800,6 +4804,7 @@
         },
         "required": [
           "accepted_queue",
+          "accepted_queue_total",
           "banner_colors",
           "banner_kiosk_url",
           "banner_url",
@@ -16874,6 +16879,29 @@
             "schema": {
               "title": "Code",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
             }
           }
         ],

--- a/server/tests/test_api_contracts.py
+++ b/server/tests/test_api_contracts.py
@@ -173,6 +173,7 @@ KIOSK_DISPLAY_KEYS = {
     "event",
     "qr_join_url",
     "accepted_queue",
+    "accepted_queue_total",
     "now_playing",
     "now_playing_hidden",
     "requests_open",

--- a/server/tests/test_kiosk_display_pagination.py
+++ b/server/tests/test_kiosk_display_pagination.py
@@ -1,0 +1,77 @@
+"""Kiosk display pagination (issue #478, PR 4/4).
+
+GET /api/public/events/{join_code}/display previously returned every accepted
+row (sorted in Python over event.requests) with no true total. Add limit/offset
++ accepted_queue_total so the kiosk can grow its window and show a truthful
+queue count instead of treating the visible page as the whole queue.
+"""
+
+from app.models.event import Event
+from app.models.request import Request, RequestStatus
+
+
+def _accepted(db, event: Event, *, title="Song", votes=0, dedupe=None) -> Request:
+    r = Request(
+        event_id=event.id,
+        song_title=title,
+        artist="Artist",
+        source="manual",
+        status=RequestStatus.ACCEPTED.value,
+        vote_count=votes,
+        dedupe_key=dedupe or f"kd_{title}",
+    )
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+def _get(client, event: Event, **params):
+    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    url = f"/api/public/events/{event.join_code}/display" + (f"?{qs}" if qs else "")
+    return client.get(url)
+
+
+def test_kiosk_display_reports_true_accepted_total(db, client, test_event):
+    for i in range(5):
+        _accepted(db, test_event, title=f"S{i}", dedupe=f"d{i}")
+
+    body = _get(client, test_event, limit=2, offset=0).json()
+
+    assert body["accepted_queue_total"] == 5
+    assert len(body["accepted_queue"]) == 2
+
+
+def test_kiosk_display_offset_pages_cover_all(db, client, test_event):
+    for i in range(4):
+        _accepted(db, test_event, title=f"S{i}", votes=10 - i, dedupe=f"d{i}")
+
+    p1 = _get(client, test_event, limit=2, offset=0).json()["accepted_queue"]
+    p2 = _get(client, test_event, limit=2, offset=2).json()["accepted_queue"]
+
+    ids = [r["id"] for r in p1 + p2]
+    assert len(ids) == 4
+    assert len(set(ids)) == 4
+
+
+def test_kiosk_display_order_votes_desc(db, client, test_event):
+    low = _accepted(db, test_event, title="low", votes=1, dedupe="a")
+    high = _accepted(db, test_event, title="high", votes=9, dedupe="b")
+
+    body = _get(client, test_event).json()
+
+    assert [r["id"] for r in body["accepted_queue"]] == [high.id, low.id]
+
+
+def test_kiosk_display_total_counts_all_not_page(db, client, test_event):
+    for i in range(30):
+        _accepted(db, test_event, title=f"S{i}", dedupe=f"d{i}")
+
+    body = _get(client, test_event, limit=10).json()
+
+    assert body["accepted_queue_total"] == 30
+    assert len(body["accepted_queue"]) == 10
+
+
+def test_kiosk_display_oversized_limit_422(db, client, test_event):
+    assert _get(client, test_event, limit=501).status_code == 422


### PR DESCRIPTION
## Why

Issue #478, PR 4 of 4 (final). `GET /api/public/events/{join_code}/display` materialized `event.requests` and sorted the entire accepted list in Python, with no true total — so the kiosk's queue count was just the visible list length, the #411 failure mode on the projector display.

**Stacked on #487 (PR3).** Review/merge the stack bottom-up (#479 → #486 → #487 → this).

## What

**Backend** — `GET .../display`:
- New `limit`/`offset` query params (shared 100/500 bounds) and a real `accepted_queue_total` counted in SQL before pagination.
- Accepted queue now sorted + sliced in SQL (votes desc, `updated_at` asc, `id` desc) instead of Python over `event.requests`. Public `join_code` routing unchanged (#324/#328).

**Frontend** — the kiosk is unattended, so there's **no manual Load More**. Instead an **automatic growing window**: `displayLimit` starts at 100 and grows by 100 (clamped to `PUBLIC_PAGE_MAX`) on the next refresh whenever the server reports more accepted rows than the loaded page; every refresh fetches `offset=0`. The headline **QUEUE** count uses `accepted_queue_total` and renders "X OF Y TRACKS" while the window catches up, so the kiosk never implies the visible page is the whole queue.

## Testing

- [x] Backend: new `test_kiosk_display_pagination.py` (5 tests — true total, offset slicing, vote order, total-counts-all-not-page, 422 guard); full suite **3025 passed, coverage 88.49%** (≥85% gate); `ruff` clean; `KIOSK_DISPLAY_KEYS` contract updated
- [x] Frontend: growing-window + count tests on the display page + api-client param test; `tsc` clean, `eslint` clean, **1325 vitest pass**
- [ ] CI green

## Acceptance criteria (#478) — closed by this stack

- No song-request list (dashboard / kiosk / join / collect) hides rows behind an undocumented cap — all expose a true `total`.
- Live/polling frontends use the #411 growing-window pattern.
- DJ dashboard sorts by date requested, **date accepted**, upvotes, BPM, key, title, artist (+ Best Match).
- `date_accepted` is backed by a real `accepted_at` timestamp (PR1), not ambiguous `updated_at`.
- Sort order deterministic across pages (id tie-breakers).
- Regression tests reference #411 and #478.

🤖 Co-authored by Claude Opus 4.8. Closes #478. Final of 4 stacked PRs (#479/#486/#487/this).