### PR TITLE
feat(dj): show date on request timestamps that span days (long collects)

### DIFF
--- a/dashboard/app/(dj)/events/[code]/components/RequestQueueSection.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/RequestQueueSection.tsx
@@ -11,6 +11,7 @@ import { computeBpmContext } from '@/lib/bpm-stats';
 import { getRequestEmphasisStyle } from '@/lib/request-emphasis';
 import { safeExternalUrl } from '@/lib/safe-url';
 import { getVoteHeatStyle } from '@/lib/vote-heat';
+import { formatRequestTimestamp } from '@/lib/format-time';
 import { formatPriorityScore, getPriorityScoreColor } from '@/lib/priority-score';
 import { PUBLIC_PAGE_MAX } from '@/lib/api';
 import { SORT_FIELDS } from '@/lib/request-sort';
@@ -359,7 +360,7 @@ export function RequestQueueSection({
                 }} />
                 <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.5rem' }}>
                   <p style={{ fontSize: '0.75rem', margin: 0 }}>
-                    {new Date(request.created_at).toLocaleTimeString()}
+                    {formatRequestTimestamp(request.created_at)}
                   </p>
                   {request.vote_count > 0 && (
                     <span

--- a/dashboard/lib/__tests__/format-time.test.ts
+++ b/dashboard/lib/__tests__/format-time.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { formatRequestTimestamp, ordinalSuffix } from '../format-time';
+
+describe('ordinalSuffix', () => {
+  it('uses st/nd/rd for 1/2/3 and th otherwise', () => {
+    expect(ordinalSuffix(1)).toBe('st');
+    expect(ordinalSuffix(2)).toBe('nd');
+    expect(ordinalSuffix(3)).toBe('rd');
+    expect(ordinalSuffix(4)).toBe('th');
+    expect(ordinalSuffix(21)).toBe('st');
+    expect(ordinalSuffix(22)).toBe('nd');
+    expect(ordinalSuffix(23)).toBe('rd');
+    expect(ordinalSuffix(31)).toBe('st');
+  });
+
+  it('treats 11/12/13 as th (teens exception)', () => {
+    expect(ordinalSuffix(11)).toBe('th');
+    expect(ordinalSuffix(12)).toBe('th');
+    expect(ordinalSuffix(13)).toBe('th');
+  });
+});
+
+describe('formatRequestTimestamp', () => {
+  const now = new Date('2026-06-18T20:00:00');
+
+  it('shows 24h time only for a same-day request', () => {
+    const r = new Date('2026-06-18T14:30:05');
+    expect(formatRequestTimestamp(r.toISOString(), now)).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('prefixes the ordinal month/day for an earlier day', () => {
+    const r = new Date('2026-06-17T09:12:44');
+    expect(formatRequestTimestamp(r.toISOString(), now)).toMatch(
+      /^June 17th, \d{2}:\d{2}:\d{2}$/,
+    );
+  });
+
+  it('uses st for the 1st and th for the 11th', () => {
+    expect(formatRequestTimestamp(new Date('2026-05-01T10:00:00').toISOString(), now)).toMatch(
+      /^May 1st, /,
+    );
+    expect(formatRequestTimestamp(new Date('2026-05-11T10:00:00').toISOString(), now)).toMatch(
+      /^May 11th, /,
+    );
+  });
+});

--- a/dashboard/lib/format-time.ts
+++ b/dashboard/lib/format-time.ts
@@ -1,0 +1,38 @@
+/** Day-of-month ordinal suffix: 1→st, 2→nd, 3→rd, 11–13→th, 21→st, … */
+export function ordinalSuffix(day: number): string {
+  const rem100 = day % 100;
+  if (rem100 >= 11 && rem100 <= 13) return 'th';
+  switch (day % 10) {
+    case 1:
+      return 'st';
+    case 2:
+      return 'nd';
+    case 3:
+      return 'rd';
+    default:
+      return 'th';
+  }
+}
+
+/**
+ * Format a request timestamp for the DJ queue, in the viewer's local time zone.
+ *
+ * Same calendar day as `now`: 24h time only (e.g. `14:30:05`) — compact for
+ * normal single-day/live events. Any earlier day (long-running collects span
+ * days): `Month DDth, HH:MM:SS` (e.g. `June 17th, 09:12:44`) so the date is
+ * surfaced exactly when the time alone is ambiguous.
+ */
+export function formatRequestTimestamp(iso: string, now: Date = new Date()): string {
+  const d = new Date(iso);
+  const time = d.toLocaleTimeString(undefined, {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  if (d.toDateString() === now.toDateString()) {
+    return time;
+  }
+  const month = d.toLocaleString(undefined, { month: 'long' });
+  return `${month} ${d.getDate()}${ordinalSuffix(d.getDate())}, ${time}`;
+}


### PR DESCRIPTION
## Why

During a **long-running collect** (collection phase spanning multiple days), each request in DJ Song Management showed **time only** (`toLocaleTimeString()` → `2:30:05 PM`). With requests accumulating across days, there was no way to tell *which day* a request came in.

## What

New `formatRequestTimestamp(iso, now?)` in `dashboard/lib/format-time.ts`, rendered in `RequestQueueSection`:

- **Same calendar day** as now → 24h time only: `14:30:05` (stays compact for normal single-day / live events).
- **Any earlier day** → `Month DDth, HH:MM:SS`: `June 17th, 09:12:44` — the date appears automatically exactly when the time alone is ambiguous.

All in the viewer's local time zone. Ordinal suffix (`st`/`nd`/`rd`/`th`, incl. the 11–13 teens exception) is a small pure helper.

## Testing

- [x] New `lib/__tests__/format-time.test.ts` — ordinal suffix (incl. 11th/21st/31st) + same-day-time-only vs earlier-day-with-date
- [x] `tsc` clean, `eslint` clean, full vitest **1340 pass** (101 files)
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8.