### PR TITLE
fix: resolve collection-code vs join_code mismatches (dashboard 404s, search 403, bridge-app self-stop)

### DIFF
--- a/bridge-app/src/main/__tests__/event-health-service.test.ts
+++ b/bridge-app/src/main/__tests__/event-health-service.test.ts
@@ -15,8 +15,12 @@ describe('checkEventHealth', () => {
     const result = await checkEventHealth('https://api.wrzdj.com', 'ABC123');
 
     expect(result).toBe('active');
+    // Must hit the dual-resolver public event endpoint, which accepts EITHER the
+    // collection code or the join_code. The bridge holds the collection code, and
+    // the join-code-only /api/public/e/{code}/nowplaying would 404 on it — which
+    // the health check would misread as 'not_found' and stop a live bridge.
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://api.wrzdj.com/api/public/e/ABC123/nowplaying',
+      'https://api.wrzdj.com/api/public/events/ABC123',
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
@@ -55,7 +59,7 @@ describe('checkEventHealth', () => {
     await checkEventHealth('https://api.wrzdj.com', 'A B/C');
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://api.wrzdj.com/api/public/e/A%20B%2FC/nowplaying',
+      'https://api.wrzdj.com/api/public/events/A%20B%2FC',
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });

--- a/bridge-app/src/main/event-health-service.ts
+++ b/bridge-app/src/main/event-health-service.ts
@@ -2,8 +2,7 @@
  * Event health check service.
  *
  * Validates that an event still exists via the public API endpoint.
- * No authentication required — uses the public nowplaying endpoint
- * which returns appropriate HTTP status codes.
+ * No authentication required — returns appropriate HTTP status codes.
  */
 
 export type EventHealthStatus = 'active' | 'not_found' | 'expired' | 'error';
@@ -11,8 +10,13 @@ export type EventHealthStatus = 'active' | 'not_found' | 'expired' | 'error';
 /**
  * Check whether an event still exists and is active.
  *
- * Uses GET /api/public/e/{code}/nowplaying:
- *   200 → active (event exists, may or may not have a track playing)
+ * Uses GET /api/public/events/{code} — the dual-resolver public event endpoint,
+ * which accepts EITHER the collection code or the join_code. The bridge is
+ * configured with the collection code; the join-code-only
+ * /api/public/e/{code}/nowplaying would 404 on it and the health check would
+ * misread that as 'not_found' and stop a perfectly live bridge.
+ *
+ *   200 → active (event exists and is live)
  *   404 → not_found (event was deleted)
  *   410 → expired (event expired or archived)
  *   other → error (network issue, server error — don't act on this)
@@ -29,7 +33,7 @@ export async function checkEventHealth(
 
     try {
       const response = await fetch(
-        `${apiUrl}/api/public/e/${encodeURIComponent(eventCode)}/nowplaying`,
+        `${apiUrl}/api/public/events/${encodeURIComponent(eventCode)}`,
         { signal: controller.signal },
       );
 

--- a/dashboard/app/(dj)/events/[code]/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/events/[code]/__tests__/page.test.tsx
@@ -1108,6 +1108,30 @@ describe('EventQueuePage', () => {
     });
   });
 
+  describe('Live-display polls use join_code, not collection code', () => {
+    it('polls now-playing / bridge-status / history by join_code', async () => {
+      setupDefaultMocks();
+
+      render(<EventQueuePage />);
+      await screen.findByText('Test Event');
+
+      // These three endpoints resolve strictly by join_code (post-#324/#328
+      // public-URL contract). This route is keyed on the collection code 'TEST',
+      // but the live polls must use the event's join_code 'TSETJO' or the API
+      // 404s in a polling loop. Regression for the production console-spam bug.
+      expect(api.getNowPlaying).toHaveBeenCalledWith('TSETJO');
+      expect(api.getBridgeStatus).toHaveBeenCalledWith('TSETJO');
+      expect(api.getPlayHistory).toHaveBeenCalledWith('TSETJO');
+      expect(api.getNowPlaying).not.toHaveBeenCalledWith('TEST');
+      expect(api.getBridgeStatus).not.toHaveBeenCalledWith('TEST');
+      expect(api.getPlayHistory).not.toHaveBeenCalledWith('TEST');
+
+      // DJ-owned endpoints still resolve by the collection code.
+      expect(api.getEvent).toHaveBeenCalledWith('TEST');
+      expect(api.getRequests).toHaveBeenCalledWith('TEST', expect.anything());
+    });
+  });
+
   describe('Server-side status filter + status counts (issue #478, Bugs 1 & 2)', () => {
     it('passes server status_counts through to SongTab', async () => {
       setupDefaultMocks();

--- a/dashboard/app/(dj)/events/[code]/page.tsx
+++ b/dashboard/app/(dj)/events/[code]/page.tsx
@@ -375,25 +375,13 @@ export default function EventQueuePage() {
         api.getTidalStatus().catch(() => ({ linked: false, user_id: null, expires_at: null, integration_enabled: true })),
         api.getBeatportStatus().catch(() => ({ linked: false, expires_at: null, configured: false, subscription: null, integration_enabled: true })),
       ]);
-      // The three live-display endpoints (now-playing / bridge-status / history)
-      // resolve strictly by join_code (post-#324/#328 public-URL contract), so they
-      // need event.join_code — passing the collection `code` this route is keyed on
-      // would 404 in a loop. Fire them once join_code is known; they're non-critical
-      // so the extra hop never blocks the queue/event data above.
-      const liveCode = eventData.join_code;
-      const [historyData, nowPlayingData, bridgeStatusData] = await Promise.all([
-        api.getPlayHistory(liveCode).catch((): undefined => undefined),
-        api.getNowPlaying(liveCode).catch((): undefined => undefined),
-        api.getBridgeStatus(liveCode).catch(() => ({ connected: false, device_name: null, last_seen: null, circuit_breaker_state: null, buffer_size: null, plugin_id: null, deck_count: null, uptime_seconds: null })),
-      ]);
+      // Commit the core queue/event + settings state immediately so the request
+      // queue (and the page itself — `loading` clears in `finally`) renders as soon
+      // as this data is in. It must never wait on the non-critical live-display hop.
       setEvent(eventData);
       setRequests(requestsData.requests);
       setRequestTotal(requestsData.total);
       setStatusCounts(normalizeStatusCounts(requestsData.status_counts));
-      if (historyData !== undefined) {
-        setPlayHistory(historyData.items);
-        setPlayHistoryTotal(historyData.total);
-      }
       setNowPlayingHidden(displaySettings.now_playing_hidden);
       setRequestsOpen(displaySettings.requests_open ?? true);
       setKioskDisplayOnly(displaySettings.kiosk_display_only ?? false);
@@ -407,20 +395,38 @@ export default function EventQueuePage() {
       setTidalSyncEnabled(eventData.tidal_sync_enabled ?? false);
       setBeatportStatus(beatportStatusData);
       setBeatportSyncEnabled(eventData.beatport_sync_enabled ?? false);
-      if (nowPlayingData !== undefined) {
-        setNowPlaying(nowPlayingData ?? null);
-      }
-      setBridgeConnected(bridgeStatusData.connected);
-      setBridgeDetails({
-        circuitBreakerState: bridgeStatusData.circuit_breaker_state,
-        bufferSize: bridgeStatusData.buffer_size,
-        pluginId: bridgeStatusData.plugin_id,
-        deckCount: bridgeStatusData.deck_count,
-        uptimeSeconds: bridgeStatusData.uptime_seconds,
-      });
       setEventStatus('active');
       setError(null);
       hasLoadedRef.current = true;
+
+      // The three live-display endpoints (now-playing / bridge-status / history)
+      // resolve strictly by join_code (post-#324/#328 public-URL contract), so they
+      // need event.join_code — passing the collection `code` this route is keyed on
+      // would 404 in a loop. Fire them once join_code is known and commit their
+      // results when they arrive; they're non-critical, so this extra hop runs in
+      // the background and never blocks the queue/event render committed above.
+      const liveCode = eventData.join_code;
+      void Promise.all([
+        api.getPlayHistory(liveCode).catch((): undefined => undefined),
+        api.getNowPlaying(liveCode).catch((): undefined => undefined),
+        api.getBridgeStatus(liveCode).catch(() => ({ connected: false, device_name: null, last_seen: null, circuit_breaker_state: null, buffer_size: null, plugin_id: null, deck_count: null, uptime_seconds: null })),
+      ]).then(([historyData, nowPlayingData, bridgeStatusData]) => {
+        if (historyData !== undefined) {
+          setPlayHistory(historyData.items);
+          setPlayHistoryTotal(historyData.total);
+        }
+        if (nowPlayingData !== undefined) {
+          setNowPlaying(nowPlayingData ?? null);
+        }
+        setBridgeConnected(bridgeStatusData.connected);
+        setBridgeDetails({
+          circuitBreakerState: bridgeStatusData.circuit_breaker_state,
+          bufferSize: bridgeStatusData.buffer_size,
+          pluginId: bridgeStatusData.plugin_id,
+          deckCount: bridgeStatusData.deck_count,
+          uptimeSeconds: bridgeStatusData.uptime_seconds,
+        });
+      });
       return true; // Continue polling
     } catch (err) {
       if (err instanceof ApiError && err.status === 410) {

--- a/dashboard/app/(dj)/events/[code]/page.tsx
+++ b/dashboard/app/(dj)/events/[code]/page.tsx
@@ -360,7 +360,9 @@ export default function EventQueuePage() {
 
   const loadData = useCallback(async (): Promise<boolean> => {
     try {
-      const [eventData, requestsData, historyData, displaySettings, tidalStatusData, beatportStatusData, nowPlayingData, bridgeStatusData] = await Promise.all([
+      // Fetch the event and the collection-code-keyed data together (one round-trip).
+      // getEvent stays in this batch so the request queue isn't delayed behind it.
+      const [eventData, requestsData, displaySettings, tidalStatusData, beatportStatusData] = await Promise.all([
         api.getEvent(code),
         api.getRequests(code, {
           status: filterToStatus(statusFilterRef.current),
@@ -369,12 +371,20 @@ export default function EventQueuePage() {
           limit: displayLimitRef.current,
           offset: 0,
         }),
-        api.getPlayHistory(code).catch((): undefined => undefined),
         api.getDisplaySettings(code).catch(() => ({ now_playing_hidden: false, now_playing_auto_hide_minutes: 10, requests_open: true, kiosk_display_only: false })),
         api.getTidalStatus().catch(() => ({ linked: false, user_id: null, expires_at: null, integration_enabled: true })),
         api.getBeatportStatus().catch(() => ({ linked: false, expires_at: null, configured: false, subscription: null, integration_enabled: true })),
-        api.getNowPlaying(code).catch((): undefined => undefined),
-        api.getBridgeStatus(code).catch(() => ({ connected: false, device_name: null, last_seen: null, circuit_breaker_state: null, buffer_size: null, plugin_id: null, deck_count: null, uptime_seconds: null })),
+      ]);
+      // The three live-display endpoints (now-playing / bridge-status / history)
+      // resolve strictly by join_code (post-#324/#328 public-URL contract), so they
+      // need event.join_code — passing the collection `code` this route is keyed on
+      // would 404 in a loop. Fire them once join_code is known; they're non-critical
+      // so the extra hop never blocks the queue/event data above.
+      const liveCode = eventData.join_code;
+      const [historyData, nowPlayingData, bridgeStatusData] = await Promise.all([
+        api.getPlayHistory(liveCode).catch((): undefined => undefined),
+        api.getNowPlaying(liveCode).catch((): undefined => undefined),
+        api.getBridgeStatus(liveCode).catch(() => ({ connected: false, device_name: null, last_seen: null, circuit_breaker_state: null, buffer_size: null, plugin_id: null, deck_count: null, uptime_seconds: null })),
       ]);
       setEvent(eventData);
       setRequests(requestsData.requests);

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1138,10 +1138,17 @@ class ApiClient {
     query: string,
     reverify?: () => Promise<void>,
   ): Promise<SearchResult[]> {
-    const doFetch = () =>
-      fetch(`${getApiUrl()}/api/events/${code}/search?q=${encodeURIComponent(query)}`, {
+    const doFetch = () => {
+      // Send the JWT when present: the authenticated event owner (DJ dashboard
+      // "Search for Song") bypasses the guest human-verification gate. Guests
+      // have no token and fall through to the cookie-based gate + reverify retry.
+      const headers: Record<string, string> = {};
+      if (this.token) headers['Authorization'] = `Bearer ${this.token}`;
+      return fetch(`${getApiUrl()}/api/events/${code}/search?q=${encodeURIComponent(query)}`, {
         credentials: 'include',
+        headers,
       });
+    };
     if (reverify) {
       return withHumanRetry<SearchResult[]>(doFetch, reverify);
     }

--- a/server/app/api/deps.py
+++ b/server/app/api/deps.py
@@ -12,6 +12,7 @@ from app.services.auth import decode_token, get_user_by_username
 from app.services.event import get_event_by_code_for_owner
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")
+oauth2_scheme_optional = OAuth2PasswordBearer(tokenUrl="/api/auth/login", auto_error=False)
 
 
 def get_db() -> Generator[Session, None, None]:
@@ -39,6 +40,31 @@ def get_current_user(db: Session = Depends(get_db), token: str = Depends(oauth2_
     # CRIT-2: reject tokens whose version doesn't match the user's current version
     if token_data.token_version != user.token_version:
         raise credentials_exception
+    return user
+
+
+def get_current_user_optional(
+    db: Session = Depends(get_db),
+    token: str | None = Depends(oauth2_scheme_optional),
+) -> User | None:
+    """Resolve the authenticated user if a valid bearer token is present, else None.
+
+    Unlike get_current_user, this NEVER raises — it is for endpoints that serve
+    both authenticated owners and anonymous guests (e.g. the public event search,
+    where a logged-in DJ should bypass the guest human-verification gate while an
+    anonymous guest still goes through it). An absent, malformed, expired, or
+    version-stale token all resolve to None rather than 401.
+    """
+    if not token:
+        return None
+    token_data = decode_token(token)
+    if token_data is None or token_data.username is None:
+        return None
+    user = get_user_by_username(db, token_data.username)
+    if user is None or not user.is_active:
+        return None
+    if token_data.token_version != user.token_version:
+        return None
     return user
 
 

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -10,6 +10,7 @@ from fastapi import (
     HTTPException,
     Query,
     Request,
+    Response,
     UploadFile,
     status,
 )
@@ -18,6 +19,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import (
     get_current_active_user,
+    get_current_user_optional,
     get_db,
     get_event_for_dj_or_admin,
     get_owned_event,
@@ -406,14 +408,21 @@ def get_event(
 def event_search(
     code: str,
     request: Request,
+    response: Response,
     q: str = Query(..., min_length=2, max_length=200),
     db: Session = Depends(get_db),
-    _human: int | None = Depends(require_verified_human_soft),
+    current_user: User | None = Depends(get_current_user_optional),
 ) -> list[SearchResult]:
     """Public search endpoint for event guests.
 
     Priority: Tidal (primary) → Spotify (fallback) → Beatport (event toggle).
     Results are filtered for junk, deduplicated by ISRC, and sorted by popularity.
+
+    Auth model: anonymous guests must pass the human-verification gate
+    (require_verified_human_soft). The authenticated event OWNER bypasses it —
+    the DJ dashboard "Search for Song" tool reuses this endpoint, and the DJ
+    holds a JWT but no guest wrzdj_human cookie, so without the bypass an
+    enforced gate would 403 them on their own event.
     """
     from app.services.beatport import search_beatport_tracks
     from app.services.intent_parser import parse_intent
@@ -429,6 +438,12 @@ def event_search(
 
     if lookup_result in (EventLookupResult.EXPIRED, EventLookupResult.ARCHIVED):
         raise HTTPException(status_code=410, detail="Event has expired")
+
+    # Owner (authenticated DJ) bypasses the guest human-verification gate;
+    # everyone else still passes through it (soft- or enforced-mode).
+    is_owner = current_user is not None and current_user.id == event_obj.created_by_user_id
+    if not is_owner:
+        require_verified_human_soft(request, response, db)
 
     sys_settings = get_system_settings(db)
     owner = event_obj.created_by

--- a/server/tests/test_events.py
+++ b/server/tests/test_events.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 from app.core.time import utcnow
 from app.models.event import Event
 from app.models.request import Request, RequestStatus
+from app.models.system_settings import SystemSettings
 from app.models.user import User
 from app.schemas.beatport import BeatportSearchResult
 from app.schemas.search import SearchResult
@@ -1636,3 +1637,68 @@ class TestEventSearch:
         data = response.json()
         assert len(data) == 1
         assert data[0]["source"] == "spotify"
+
+
+def _enforce_human_verification(db: Session) -> None:
+    """Flip human_verification_enforced=True (Phase 2+) for the test DB."""
+    sys_settings = db.query(SystemSettings).filter_by(id=1).first()
+    if sys_settings is None:
+        sys_settings = SystemSettings(id=1, human_verification_enforced=True)
+        db.add(sys_settings)
+    else:
+        sys_settings.human_verification_enforced = True
+    db.commit()
+
+
+class TestEventSearchOwnerBypass:
+    """GET /api/events/{code}/search: authenticated event owners bypass the
+    guest human-verification gate; everyone else is still gated when enforced.
+
+    Regression for the production 403 a DJ hit using the dashboard "Search for
+    Song" button: the DJ is JWT-authenticated but holds no guest wrzdj_human
+    cookie, so with human_verification_enforced=True the public search rejected
+    them with 403.
+    """
+
+    @patch("app.services.spotify.search_songs")
+    def test_owner_bypasses_human_gate_when_enforced(
+        self, mock_search, client: TestClient, db: Session, test_event: Event, auth_headers: dict
+    ):
+        """Event owner with a valid JWT searches successfully even with
+        enforcement on and no human cookie (was 403 before the fix)."""
+        _enforce_human_verification(db)
+        mock_search.return_value = [
+            SearchResult(title="Levels", artist="Avicii", popularity=85, spotify_id="sp_levels")
+        ]
+
+        response = client.get(
+            f"/api/events/{test_event.code}/search?q=levels", headers=auth_headers
+        )
+
+        assert response.status_code == 200
+        assert response.json()[0]["title"] == "Levels"
+
+    def test_anonymous_still_gated_when_enforced(
+        self, client: TestClient, db: Session, test_event: Event
+    ):
+        """A request with no JWT and no human cookie stays 403 when enforced."""
+        _enforce_human_verification(db)
+
+        response = client.get(f"/api/events/{test_event.code}/search?q=levels")
+
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "human_verification_required"
+
+    def test_non_owner_authenticated_still_gated_when_enforced(
+        self, client: TestClient, db: Session, test_event: Event, admin_headers: dict
+    ):
+        """A different authenticated user (not the event owner) is still gated:
+        the bypass is owner-only, not 'any logged-in user'."""
+        _enforce_human_verification(db)
+
+        response = client.get(
+            f"/api/events/{test_event.code}/search?q=levels", headers=admin_headers
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "human_verification_required"


### PR DESCRIPTION
## Why
After `Event.code` (collection code, DJ surfaces) and `Event.join_code` (live/QR public surfaces) became distinct values, several callers written when the two were identical kept passing the collection code into endpoints that resolve **strictly by `join_code`**. On production event `4GX43T` this surfaced as:

- The DJ dashboard spamming the console with repeating **404s** on `/api/public/e/{code}/nowplaying|bridge-status|history`.
- The **"Search for Song"** button returning **403** (the authenticated DJ has a JWT but no guest `wrzdj_human` cookie, and human-verification is enforced in prod).
- (found while auditing the bridge) the **bridge-app** silently stopping a live bridge — its health check hit the join-code-only `/nowplaying` with the collection code → 404 → `"Event was deleted"`.

The four join-code-only endpoints are a deliberate, test-locked contract (`test_collection_code_is_rejected`, post-#324/#328). So every fix corrects the **caller** — none loosen those endpoints.

## What
- **Dashboard** (`(dj)/events/[code]/page.tsx`): poll the three live-display endpoints by `event.join_code`, fetched in a second batch so the request queue isn't delayed behind `getEvent`.
- **Search owner-bypass** (`deps.py`, `events.py`, `lib/api.ts`): new non-raising `get_current_user_optional`; the authenticated event **owner** skips the human-verification gate while anonymous guests still go through it. The dashboard now sends its JWT on `eventSearch`.
- **bridge-app** (`event-health-service.ts`): health check now uses the dual-resolver `/api/public/events/{code}` (accepts either code; same 200/404/410 semantics). Bridge core + CLI were already correct.

A repo-wide audit (40+ code-bearing endpoints, all client surfaces incl. kiosk) found no other mismatches.

## Testing
- [x] Backend pytest + 85% coverage gate (3061 passed, 88.57%); ruff/format/bandit clean
- [x] Dashboard lint + tsc + vitest (1341 passed); bridge 343; bridge-app 73
- [x] New regression tests: owner-bypass (anon 403 / owner 200 under enforcement), dashboard join_code polls, bridge-app dual-resolver URL
- [x] Manual verification on a local deploy: live owner-bypass proof (403 vs 200), dashboard polls hit join_code, endpoint contracts intact
- [x] CI green

🤖 Co-authored by Claude Opus 4.8 (1M context).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Event health checks now query a more accurate public endpoint.
  * Live display data (now playing, play history, bridge status) now uses the correct event identifier.

* **New Features**
  * Authenticated event owners can search without human verification; guests and non-owners remain subject to verification.

* **Tests**
  * Added/updated coverage for live-display polling identifier usage.
  * Added/updated coverage for owner bypass vs guest/non-owner verification behavior in event search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->