### PR TITLE
feat(setbuilder): make agent chat mutations undoable

### DIFF
--- a/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/[setId]/page.tsx
@@ -468,6 +468,7 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
               onToggle={() => setChatOpen((open) => !open)}
               refreshToken={refreshToken}
               onMutationApplied={() => setRefreshToken((v) => v + 1)}
+              commit={historyEnabled ? history.commit : undefined}
             />
           </div>
         )}
@@ -477,6 +478,7 @@ export default function BuilderPage({ params }: { params: Promise<{ setId: strin
           setId={Number(setId)}
           refreshToken={refreshToken}
           onMutationApplied={() => setRefreshToken((v) => v + 1)}
+          commit={historyEnabled ? history.commit : undefined}
         />
       )}
       {toast && (

--- a/dashboard/app/(dj)/setbuilder/components/ChatSidebar.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/ChatSidebar.tsx
@@ -2,6 +2,7 @@
 
 import ChatPanelBody, { PersonaToggle } from './ChatPanelBody';
 import { useAgentChat } from './useAgentChat';
+import type { BuilderCommit } from './useSetDocumentHistory';
 import styles from '../setbuilder.module.css';
 
 /**
@@ -15,14 +16,16 @@ export default function ChatSidebar({
   onToggle,
   refreshToken = 0,
   onMutationApplied,
+  commit,
 }: {
   setId: number;
   open: boolean;
   onToggle: () => void;
   refreshToken?: number;
   onMutationApplied: () => void;
+  commit?: BuilderCommit;
 }) {
-  const chat = useAgentChat(setId, { open, refreshToken, onMutationApplied });
+  const chat = useAgentChat(setId, { open, refreshToken, onMutationApplied, commit });
 
   if (!open) {
     return (

--- a/dashboard/app/(dj)/setbuilder/components/MobileAgentOverlay.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/MobileAgentOverlay.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import ChatPanelBody, { PersonaToggle } from './ChatPanelBody';
 import { useAgentChat } from './useAgentChat';
+import type { BuilderCommit } from './useSetDocumentHistory';
 import styles from '../setbuilder.module.css';
 
 /**
@@ -16,16 +17,18 @@ export default function MobileAgentOverlay({
   setId,
   refreshToken = 0,
   onMutationApplied,
+  commit,
 }: {
   setId: number;
   refreshToken?: number;
   onMutationApplied: () => void;
+  commit?: BuilderCommit;
 }) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const closeRef = useRef<HTMLButtonElement>(null);
   const wasOpenRef = useRef(false);
-  const chat = useAgentChat(setId, { open, refreshToken, onMutationApplied });
+  const chat = useAgentChat(setId, { open, refreshToken, onMutationApplied, commit });
   const grade = chat.critique?.overall_grade;
 
   // Dialog focus lifecycle: move focus into the overlay on open, close on Escape,

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/ChatSidebar.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/ChatSidebar.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ChatSidebar from '../ChatSidebar';
+import type { BuilderCommit } from '../useSetDocumentHistory';
 
 const mockApi = vi.hoisted(() => ({
   critiqueSet: vi.fn(),
@@ -82,6 +83,30 @@ describe('ChatSidebar', () => {
     expect(screen.getByText('B+')).toBeInTheDocument();
     expect(screen.getByText(/energy dip/i)).toBeInTheDocument();
     expect(mockApi.critiqueSet).toHaveBeenCalledWith(9);
+  });
+
+  it('routes sends through the provided commit instead of onMutationApplied', async () => {
+    const commit = vi.fn((...args: unknown[]) => (args[1] as () => Promise<unknown>)());
+    const onMutationApplied = vi.fn();
+    render(
+      <ChatSidebar
+        setId={5}
+        open
+        onToggle={vi.fn()}
+        onMutationApplied={onMutationApplied}
+        commit={commit as unknown as BuilderCommit}
+      />,
+    );
+    await waitFor(() => expect(mockApi.getSetAgentHistory).toHaveBeenCalledWith(5));
+
+    fireEvent.change(screen.getByPlaceholderText(/tell the agent/i), {
+      target: { value: 'swap the opener' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() => expect(commit).toHaveBeenCalledTimes(1));
+    expect(commit.mock.calls[0][0]).toBe('Agent · swap the opener');
+    expect(onMutationApplied).not.toHaveBeenCalled();
   });
 
   it('loads persisted history without rendering raw tool JSON', async () => {

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/MobileAgentOverlay.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/MobileAgentOverlay.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import MobileAgentOverlay from '../MobileAgentOverlay';
+import type { BuilderCommit } from '../useSetDocumentHistory';
 
 const mockApi = vi.hoisted(() => ({
   critiqueSet: vi.fn(),
@@ -73,6 +74,29 @@ describe('MobileAgentOverlay', () => {
     await waitFor(() =>
       expect(mockApi.chatWithSetAgent).toHaveBeenCalledWith(9, { message: 'swap the opener' }),
     );
+  });
+
+  it('routes overlay sends through the provided commit instead of onMutationApplied', async () => {
+    const commit = vi.fn((...args: unknown[]) => (args[1] as () => Promise<unknown>)());
+    const onMutationApplied = vi.fn();
+    render(
+      <MobileAgentOverlay
+        setId={5}
+        onMutationApplied={onMutationApplied}
+        commit={commit as unknown as BuilderCommit}
+      />,
+    );
+    fireEvent.click(await screen.findByRole('button', { name: /open agent/i }));
+    await waitFor(() => expect(mockApi.getSetAgentHistory).toHaveBeenCalledWith(5));
+
+    fireEvent.change(screen.getByPlaceholderText(/tell the agent/i), {
+      target: { value: 'swap the opener' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() => expect(commit).toHaveBeenCalledTimes(1));
+    expect(commit.mock.calls[0][0]).toBe('Agent · swap the opener');
+    expect(onMutationApplied).not.toHaveBeenCalled();
   });
 
   it('closes the overlay with the close affordance', async () => {

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/useAgentChat.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/useAgentChat.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { formatAgentError, useAgentChat } from '../useAgentChat';
+import type { BuilderCommit } from '../useSetDocumentHistory';
 
 const mockApi = vi.hoisted(() => ({
   critiqueSet: vi.fn(),
@@ -48,6 +49,71 @@ describe('useAgentChat', () => {
       slots: [],
       affected_transition_scores: [],
     });
+  });
+
+  function mutatingResult() {
+    return {
+      message: 'Rebuilt.',
+      assistant_message: assistantMessage({
+        tool_calls: [
+          {
+            id: 'a1',
+            name: 'autobuild',
+            args: {},
+            rationale: 'Rebuild from pool',
+            result: {},
+            mutating: true,
+            display_summary: 'Rebuilt the set.',
+          },
+        ],
+      }),
+      tool_calls: [],
+      slots: [],
+      affected_transition_scores: [],
+    };
+  }
+
+  it('routes a mutating turn through commit as one labeled undo entry', async () => {
+    mockApi.chatWithSetAgent.mockResolvedValue(mutatingResult());
+    const commit = vi.fn((...args: unknown[]) => (args[1] as () => Promise<unknown>)());
+    const onMutationApplied = vi.fn();
+
+    const { result } = renderHook(() =>
+      useAgentChat(9, {
+        open: true,
+        onMutationApplied,
+        commit: commit as unknown as BuilderCommit,
+      }),
+    );
+    await act(async () => {
+      await result.current.send('rebuild the set');
+    });
+
+    expect(commit).toHaveBeenCalledTimes(1);
+    expect(commit.mock.calls[0][0]).toBe('Agent · rebuild the set');
+    const shouldRecord = commit.mock.calls[0][2] as unknown as (r: {
+      tool_calls: { mutating: boolean }[];
+      assistant_message: { tool_calls: { mutating: boolean }[] };
+    }) => boolean;
+    expect(
+      shouldRecord({ tool_calls: [], assistant_message: { tool_calls: [{ mutating: true }] } }),
+    ).toBe(true);
+    expect(
+      shouldRecord({ tool_calls: [], assistant_message: { tool_calls: [{ mutating: false }] } }),
+    ).toBe(false);
+    expect(onMutationApplied).not.toHaveBeenCalled();
+  });
+
+  it('falls back to onMutationApplied when no commit is provided', async () => {
+    mockApi.chatWithSetAgent.mockResolvedValue(mutatingResult());
+    const onMutationApplied = vi.fn();
+
+    const { result } = renderHook(() => useAgentChat(9, { open: true, onMutationApplied }));
+    await act(async () => {
+      await result.current.send('rebuild the set');
+    });
+
+    expect(onMutationApplied).toHaveBeenCalledTimes(1);
   });
 
   it('loads the critique on mount', async () => {

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/useSetDocumentHistory.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/useSetDocumentHistory.test.tsx
@@ -57,6 +57,9 @@ function Harness({ mutate, enabled = true }: { mutate: () => Promise<void>; enab
       <div data-testid="redo-label">{history.nextRedoLabel ?? ''}</div>
       <div data-testid="slot-target">{history.snapshot?.slots[0]?.target_energy ?? 'none'}</div>
       <button onClick={() => void history.commit('Retarget slot 1', mutate)}>commit</button>
+      <button onClick={() => void history.commit('No-record', mutate, () => false)}>
+        commit-norecord
+      </button>
       <button onClick={() => void history.undo()}>undo</button>
       <button onClick={() => void history.redo()}>redo</button>
       <button onClick={() => void history.saveNow()}>save</button>
@@ -105,6 +108,48 @@ describe('useSetDocumentHistory', () => {
     fireEvent.click(screen.getByText('redo'));
     await waitFor(() => expect(screen.getByTestId('slot-target')).toHaveTextContent('8.5'));
     expect(mockApi.putSetDocument).toHaveBeenLastCalledWith(5, snapshot(8.5));
+  });
+
+  it('publishes the new snapshot but records no undo entry when shouldRecord is false', async () => {
+    let serverDoc = snapshot(null);
+    mockApi.getSetDocument.mockImplementation(() => Promise.resolve(clone(serverDoc)));
+    mockApi.putSetDocument.mockImplementation((_setId: number, doc: SetDocumentSnapshot) => {
+      serverDoc = clone(doc);
+      return Promise.resolve(clone(serverDoc));
+    });
+
+    render(
+      <Harness mutate={() => Promise.resolve().then(() => void (serverDoc = snapshot(8.5)))} />,
+    );
+    await waitFor(() => expect(screen.getByTestId('slot-target')).toHaveTextContent('none'));
+
+    fireEvent.click(screen.getByText('commit-norecord'));
+
+    await waitFor(() => expect(screen.getByTestId('slot-target')).toHaveTextContent('8.5'));
+    expect(screen.getByTestId('undo-depth')).toHaveTextContent('0');
+  });
+
+  it('leaves the redo stack intact when a non-recording commit runs', async () => {
+    let serverDoc = snapshot(null);
+    mockApi.getSetDocument.mockImplementation(() => Promise.resolve(clone(serverDoc)));
+    mockApi.putSetDocument.mockImplementation((_setId: number, doc: SetDocumentSnapshot) => {
+      serverDoc = clone(doc);
+      return Promise.resolve(clone(serverDoc));
+    });
+
+    render(
+      <Harness mutate={() => Promise.resolve().then(() => void (serverDoc = snapshot(8.5)))} />,
+    );
+    await waitFor(() => expect(screen.getByTestId('slot-target')).toHaveTextContent('none'));
+
+    fireEvent.click(screen.getByText('commit'));
+    await waitFor(() => expect(screen.getByTestId('undo-depth')).toHaveTextContent('1'));
+    fireEvent.click(screen.getByText('undo'));
+    await waitFor(() => expect(screen.getByTestId('redo-depth')).toHaveTextContent('1'));
+
+    fireEvent.click(screen.getByText('commit-norecord'));
+    await waitFor(() => expect(screen.getByTestId('slot-target')).toHaveTextContent('8.5'));
+    expect(screen.getByTestId('redo-depth')).toHaveTextContent('1');
   });
 
   it('manual save writes the current snapshot without adding history depth', async () => {

--- a/dashboard/app/(dj)/setbuilder/components/useAgentChat.ts
+++ b/dashboard/app/(dj)/setbuilder/components/useAgentChat.ts
@@ -2,7 +2,8 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { api, ApiError } from '@/lib/api';
-import type { AgentChatMessage, SetCritique } from '@/lib/api-types';
+import type { AgentChatMessage, AgentChatOut, SetCritique } from '@/lib/api-types';
+import type { BuilderCommit } from './useSetDocumentHistory';
 
 export type Persona = 'peer' | 'pro';
 
@@ -67,7 +68,13 @@ export function useAgentChat(
     open,
     refreshToken = 0,
     onMutationApplied,
-  }: { open: boolean; refreshToken?: number; onMutationApplied: () => void },
+    commit,
+  }: {
+    open: boolean;
+    refreshToken?: number;
+    onMutationApplied: () => void;
+    commit?: BuilderCommit;
+  },
 ): AgentChatController {
   const [persona, setPersona] = useState<Persona>('peer');
   const [critique, setCritique] = useState<SetCritique | null>(null);
@@ -158,7 +165,11 @@ export function useAgentChat(
     setBusy(true);
     setError(null);
     try {
-      const result = await api.chatWithSetAgent(setId, { message });
+      const didMutate = (res: AgentChatOut) =>
+        [...res.tool_calls, ...res.assistant_message.tool_calls].some((tool) => tool.mutating);
+      const label = `Agent · ${message.slice(0, 40)}`;
+      const action = () => api.chatWithSetAgent(setId, { message });
+      const result = commit ? await commit(label, action, didMutate) : await action();
       setEntries((prev) => [
         ...prev.filter((entry) => entry.id !== pendingEntry.id),
         {
@@ -171,8 +182,9 @@ export function useAgentChat(
         },
         result.assistant_message,
       ]);
-      const mutatingTools = [...result.tool_calls, ...result.assistant_message.tool_calls];
-      if (mutatingTools.some((tool) => tool.mutating)) onMutationApplied();
+      // With commit, the published snapshot bumps snapshotVersion and the
+      // workspace reloads; only the no-history fallback needs the manual refresh.
+      if (!commit && didMutate(result)) onMutationApplied();
     } catch (err) {
       setEntries((prev) => prev.filter((entry) => entry.id !== pendingEntry.id));
       setError(formatAgentError(err));

--- a/dashboard/app/(dj)/setbuilder/components/useSetDocumentHistory.ts
+++ b/dashboard/app/(dj)/setbuilder/components/useSetDocumentHistory.ts
@@ -6,7 +6,11 @@ import type { SetDocumentSnapshot } from '@/lib/api-types';
 
 const AUTOSAVE_KEY = 'wrzdj.setbuilder.autosave';
 
-export type BuilderCommit = <T>(label: string, action: () => Promise<T> | T) => Promise<T>;
+export type BuilderCommit = <T>(
+  label: string,
+  action: () => Promise<T> | T,
+  shouldRecord?: (result: T) => boolean,
+) => Promise<T>;
 
 interface HistoryEntry {
   label: string;
@@ -127,7 +131,7 @@ export function useSetDocumentHistory(
   }, [enabled, publishSnapshot, setId]);
 
   const commit: BuilderCommit = useCallback(
-    async (label, action) => {
+    async (label, action, shouldRecord = () => true) => {
       if (!beginOperation()) {
         throw new Error('Another document history operation is already in progress');
       }
@@ -138,8 +142,10 @@ export function useSetDocumentHistory(
         setSaveError(null);
         const result = await action();
         const after = await api.getSetDocument(setId);
-        setUndoStack((prev) => [...prev, { label, snapshot: before }].slice(-50));
-        setRedoStack([]);
+        if (shouldRecord(result)) {
+          setUndoStack((prev) => [...prev, { label, snapshot: before }].slice(-50));
+          setRedoStack([]);
+        }
         publishSnapshot(after);
         setLastSavedAt(new Date());
         setIsDirty(false);

--- a/docs/superpowers/plans/2026-06-18-agent-undo.md
+++ b/docs/superpowers/plans/2026-06-18-agent-undo.md
@@ -1,0 +1,465 @@
+# Agent-action Undo Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make WrzDJSet agent chat mutations undoable by routing them through the dashboard's existing document-history stack, so `Ctrl+Z` / ↶ reverts an agent edit exactly like a manual one.
+
+**Architecture:** Frontend-only. Extend `useSetDocumentHistory.commit` with an optional `shouldRecord(result)` predicate (backward-compatible), then wrap `useAgentChat.send`'s chat call in `commit` so a mutating turn becomes one undo entry. The `after`-snapshot publish drives the existing `snapshotVersion` reload, replacing the agent path's `onMutationApplied`/`refreshToken` refresh. No backend change — `build_snapshot`/`restore_snapshot` + `GET`/`PUT /sets/{id}/document` already exist.
+
+**Tech Stack:** Next.js / React 19, TypeScript (strict), Vitest + @testing-library/react. Spec: `docs/superpowers/specs/2026-06-18-agent-undo-design.md`. Issue: #493.
+
+## Global Constraints
+
+- **No backend changes.** Only `dashboard/` files.
+- **Backward-compatible `commit`.** Existing two-arg callers (manual edits in `page.tsx`, `BuilderWorkspace`, `PoolPanel`) must keep identical behavior; the new third parameter is optional and defaults to "always record".
+- **Frontend CI must pass between tasks:** from `dashboard/`, `npm run lint`, `npx tsc --noEmit`, and `npm test -- --run` all green (vitest coverage gate: 68% branches / 65% functions / 78% lines / 77% statements).
+- **Vanilla CSS / inline styles only** — no Tailwind, no UI framework (no new UI is added here regardless).
+- **All paths are relative to the repo root** `/home/adam/github/WrzDJ`. Run `npm` commands from `dashboard/`.
+
+---
+
+### Task 1: Add `shouldRecord` predicate to `commit`
+
+**Files:**
+- Modify: `dashboard/app/(dj)/setbuilder/components/useSetDocumentHistory.ts` (type at line 9; `commit` at lines 129-156)
+- Test: `dashboard/app/(dj)/setbuilder/components/__tests__/useSetDocumentHistory.test.tsx`
+
+**Interfaces:**
+- Produces: `BuilderCommit = <T>(label: string, action: () => Promise<T> | T, shouldRecord?: (result: T) => boolean) => Promise<T>`. When `shouldRecord(result)` is false, `commit` publishes the new snapshot but adds no undo entry and leaves the redo stack intact. Default predicate is `() => true` (unchanged behavior).
+
+- [ ] **Step 1: Add the failing tests**
+
+In `__tests__/useSetDocumentHistory.test.tsx`, add a no-record button to `Harness` (inside the `<div>`, after the existing `commit` button on line 59):
+
+```tsx
+      <button onClick={() => void history.commit('No-record', mutate, () => false)}>
+        commit-norecord
+      </button>
+```
+
+Then add these two tests inside the `describe('useSetDocumentHistory', ...)` block:
+
+```tsx
+  it('publishes the new snapshot but records no undo entry when shouldRecord is false', async () => {
+    let serverDoc = snapshot(null);
+    mockApi.getSetDocument.mockImplementation(() => Promise.resolve(clone(serverDoc)));
+    mockApi.putSetDocument.mockImplementation((_setId: number, doc: SetDocumentSnapshot) => {
+      serverDoc = clone(doc);
+      return Promise.resolve(clone(serverDoc));
+    });
+
+    render(
+      <Harness mutate={() => Promise.resolve().then(() => void (serverDoc = snapshot(8.5)))} />,
+    );
+    await waitFor(() => expect(screen.getByTestId('slot-target')).toHaveTextContent('none'));
+
+    fireEvent.click(screen.getByText('commit-norecord'));
+
+    await waitFor(() => expect(screen.getByTestId('slot-target')).toHaveTextContent('8.5'));
+    expect(screen.getByTestId('undo-depth')).toHaveTextContent('0');
+  });
+
+  it('leaves the redo stack intact when a non-recording commit runs', async () => {
+    let serverDoc = snapshot(null);
+    mockApi.getSetDocument.mockImplementation(() => Promise.resolve(clone(serverDoc)));
+    mockApi.putSetDocument.mockImplementation((_setId: number, doc: SetDocumentSnapshot) => {
+      serverDoc = clone(doc);
+      return Promise.resolve(clone(serverDoc));
+    });
+
+    render(
+      <Harness mutate={() => Promise.resolve().then(() => void (serverDoc = snapshot(8.5)))} />,
+    );
+    await waitFor(() => expect(screen.getByTestId('slot-target')).toHaveTextContent('none'));
+
+    fireEvent.click(screen.getByText('commit')); // records, target -> 8.5
+    await waitFor(() => expect(screen.getByTestId('undo-depth')).toHaveTextContent('1'));
+    fireEvent.click(screen.getByText('undo')); // redo-depth -> 1
+    await waitFor(() => expect(screen.getByTestId('redo-depth')).toHaveTextContent('1'));
+
+    fireEvent.click(screen.getByText('commit-norecord')); // must not clear redo
+    await waitFor(() => expect(screen.getByTestId('slot-target')).toHaveTextContent('8.5'));
+    expect(screen.getByTestId('redo-depth')).toHaveTextContent('1');
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run (from `dashboard/`): `npm test -- --run useSetDocumentHistory`
+Expected: the two new tests FAIL — the current `commit` ignores the third arg and always records / clears redo, so `undo-depth` becomes `1` and `redo-depth` becomes `0`.
+
+- [ ] **Step 3: Implement the predicate**
+
+In `useSetDocumentHistory.ts`, change the `BuilderCommit` type (line 9) to:
+
+```ts
+export type BuilderCommit = <T>(
+  label: string,
+  action: () => Promise<T> | T,
+  shouldRecord?: (result: T) => boolean,
+) => Promise<T>;
+```
+
+Replace the `commit` callback body (lines 129-156) with (only the signature default and the `if (shouldRecord(result))` guard change):
+
+```ts
+  const commit: BuilderCommit = useCallback(
+    async (label, action, shouldRecord = () => true) => {
+      if (!beginOperation()) {
+        throw new Error('Another document history operation is already in progress');
+      }
+      try {
+        const before = await fetchCurrent();
+        setIsSaving(true);
+        setIsDirty(true);
+        setSaveError(null);
+        const result = await action();
+        const after = await api.getSetDocument(setId);
+        if (shouldRecord(result)) {
+          setUndoStack((prev) => [...prev, { label, snapshot: before }].slice(-50));
+          setRedoStack([]);
+        }
+        publishSnapshot(after);
+        setLastSavedAt(new Date());
+        setIsDirty(false);
+        return result;
+      } catch (error) {
+        setSaveError(error instanceof Error ? error.message : 'Save failed');
+        throw error;
+      } finally {
+        setIsSaving(false);
+        finishOperation();
+      }
+    },
+    [beginOperation, fetchCurrent, finishOperation, publishSnapshot, setId],
+  );
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run (from `dashboard/`): `npm test -- --run useSetDocumentHistory`
+Expected: PASS — including the pre-existing record/undo/redo and autosave tests (backward compatibility).
+
+- [ ] **Step 5: Type-check and commit**
+
+```bash
+cd dashboard && npx tsc --noEmit && npm run lint
+git add "dashboard/app/(dj)/setbuilder/components/useSetDocumentHistory.ts" \
+        "dashboard/app/(dj)/setbuilder/components/__tests__/useSetDocumentHistory.test.tsx"
+git commit -m "feat(setbuilder): add shouldRecord predicate to history commit (#493)"
+```
+
+---
+
+### Task 2: Bridge `useAgentChat.send` through `commit`
+
+**Files:**
+- Modify: `dashboard/app/(dj)/setbuilder/components/useAgentChat.ts` (options at lines 64-71; `send` at lines 142-183)
+- Test: `dashboard/app/(dj)/setbuilder/components/__tests__/useAgentChat.test.tsx`
+
+**Interfaces:**
+- Consumes: `BuilderCommit` from Task 1.
+- Produces: `useAgentChat(setId, { open, refreshToken?, onMutationApplied, commit? })`. When `commit` is provided, a send wraps the chat call in `commit('Agent · <message>', action, didMutate)` and does NOT call `onMutationApplied`. When `commit` is absent, behavior is unchanged (calls `onMutationApplied` on a mutating turn). `didMutate(res) = [...res.tool_calls, ...res.assistant_message.tool_calls].some(t => t.mutating)`.
+
+- [ ] **Step 1: Add the failing tests**
+
+In `__tests__/useAgentChat.test.tsx`, add these tests inside the `describe('useAgentChat', ...)` block. (Helper `assistantMessage` and `mockApi` already exist in the file.)
+
+```tsx
+  function mutatingResult() {
+    return {
+      message: 'Rebuilt.',
+      assistant_message: assistantMessage({
+        tool_calls: [
+          {
+            id: 'a1',
+            name: 'autobuild',
+            args: {},
+            rationale: 'Rebuild from pool',
+            result: {},
+            mutating: true,
+            display_summary: 'Rebuilt the set.',
+          },
+        ],
+      }),
+      tool_calls: [],
+      slots: [],
+      affected_transition_scores: [],
+    };
+  }
+
+  it('routes a mutating turn through commit as one labeled undo entry', async () => {
+    mockApi.chatWithSetAgent.mockResolvedValue(mutatingResult());
+    const commit = vi.fn((_label: string, action: () => Promise<unknown>) => action());
+    const onMutationApplied = vi.fn();
+
+    const { result } = renderHook(() =>
+      useAgentChat(9, { open: true, onMutationApplied, commit }),
+    );
+    await act(async () => {
+      await result.current.send('rebuild the set');
+    });
+
+    expect(commit).toHaveBeenCalledTimes(1);
+    const [label, , shouldRecord] = commit.mock.calls[0] as [
+      string,
+      unknown,
+      (r: { tool_calls: { mutating: boolean }[]; assistant_message: { tool_calls: { mutating: boolean }[] } }) => boolean,
+    ];
+    expect(label).toBe('Agent · rebuild the set');
+    expect(shouldRecord({ tool_calls: [], assistant_message: { tool_calls: [{ mutating: true }] } })).toBe(true);
+    expect(shouldRecord({ tool_calls: [], assistant_message: { tool_calls: [{ mutating: false }] } })).toBe(false);
+    expect(onMutationApplied).not.toHaveBeenCalled();
+  });
+
+  it('falls back to onMutationApplied when no commit is provided', async () => {
+    mockApi.chatWithSetAgent.mockResolvedValue(mutatingResult());
+    const onMutationApplied = vi.fn();
+
+    const { result } = renderHook(() => useAgentChat(9, { open: true, onMutationApplied }));
+    await act(async () => {
+      await result.current.send('rebuild the set');
+    });
+
+    expect(onMutationApplied).toHaveBeenCalledTimes(1);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run (from `dashboard/`): `npm test -- --run useAgentChat`
+Expected: the "routes through commit" test FAILS — `useAgentChat` does not yet accept or call `commit` (so `commit` is never invoked). The fallback test passes already (current behavior).
+
+- [ ] **Step 3: Implement the bridge**
+
+In `useAgentChat.ts`, add imports near the top (after line 5):
+
+```ts
+import type { AgentChatOut } from '@/lib/api-types';
+import type { BuilderCommit } from './useSetDocumentHistory';
+```
+
+Change the options destructuring + type (lines 66-70) to include `commit`:
+
+```ts
+  {
+    open,
+    refreshToken = 0,
+    onMutationApplied,
+    commit,
+  }: {
+    open: boolean;
+    refreshToken?: number;
+    onMutationApplied: () => void;
+    commit?: BuilderCommit;
+  },
+```
+
+Replace the body of the `try` block in `send` (lines 160-175) with:
+
+```ts
+    try {
+      const didMutate = (res: AgentChatOut) =>
+        [...res.tool_calls, ...res.assistant_message.tool_calls].some((tool) => tool.mutating);
+      const label = `Agent · ${message.slice(0, 40)}`;
+      const action = () => api.chatWithSetAgent(setId, { message });
+      const result = commit ? await commit(label, action, didMutate) : await action();
+      setEntries((prev) => [
+        ...prev.filter((entry) => entry.id !== pendingEntry.id),
+        {
+          id: pendingEntry.id,
+          role: 'user',
+          content: message,
+          display_summary: null,
+          tool_calls: [],
+          affected_transition_scores: [],
+        },
+        result.assistant_message,
+      ]);
+      // With commit, the published snapshot bumps snapshotVersion and the
+      // workspace reloads; only the no-history fallback needs the manual refresh.
+      if (!commit && didMutate(result)) onMutationApplied();
+    } catch (err) {
+```
+
+(The `catch`/`finally` blocks on lines 176-182 are unchanged.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run (from `dashboard/`): `npm test -- --run useAgentChat`
+Expected: PASS — both new tests and all existing `useAgentChat` tests.
+
+- [ ] **Step 5: Type-check and commit**
+
+```bash
+cd dashboard && npx tsc --noEmit && npm run lint
+git add "dashboard/app/(dj)/setbuilder/components/useAgentChat.ts" \
+        "dashboard/app/(dj)/setbuilder/components/__tests__/useAgentChat.test.tsx"
+git commit -m "feat(setbuilder): bridge agent chat turns into the undo stack (#493)"
+```
+
+---
+
+### Task 3: Thread `commit` through the chat surfaces and the page
+
+**Files:**
+- Modify: `dashboard/app/(dj)/setbuilder/components/ChatSidebar.tsx` (props lines 12-25)
+- Modify: `dashboard/app/(dj)/setbuilder/components/MobileAgentOverlay.tsx` (props lines 15-28)
+- Modify: `dashboard/app/(dj)/setbuilder/[setId]/page.tsx` (ChatSidebar mount lines 465-471; MobileAgentOverlay mount lines 476-480)
+- Test: `dashboard/app/(dj)/setbuilder/components/__tests__/ChatSidebar.test.tsx`
+
+**Interfaces:**
+- Consumes: `useAgentChat`'s `commit?` option (Task 2), `history.commit: BuilderCommit` (already mounted in `page.tsx` line 93).
+
+- [ ] **Step 1: Add the failing test**
+
+In `__tests__/ChatSidebar.test.tsx`, add this test inside the `describe('ChatSidebar', ...)` block. It mounts the sidebar with a fake `commit` and asserts the bridge is used. (The file already mocks `api` with `critiqueSet`, `chatWithSetAgent`, `getSetAgentHistory` and sets `chatWithSetAgent` to a mutating `swap_slots` result in `beforeEach`.)
+
+```tsx
+  it('routes sends through the provided commit instead of onMutationApplied', async () => {
+    const commit = vi.fn((_label: string, action: () => Promise<unknown>) => action());
+    const onMutationApplied = vi.fn();
+    render(
+      <ChatSidebar
+        setId={5}
+        open
+        onToggle={() => {}}
+        onMutationApplied={onMutationApplied}
+        commit={commit}
+      />,
+    );
+    await waitFor(() => expect(mockApi.getSetAgentHistory).toHaveBeenCalledWith(5));
+
+    fireEvent.change(screen.getByPlaceholderText(/tell the agent/i), {
+      target: { value: 'swap the opener' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() => expect(commit).toHaveBeenCalledTimes(1));
+    expect(commit.mock.calls[0][0]).toBe('Agent · swap the opener');
+    expect(onMutationApplied).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (from `dashboard/`): `npm test -- --run ChatSidebar`
+Expected: FAIL — `ChatSidebar` does not yet accept a `commit` prop, so `commit` is never called (and tsc would reject the prop).
+
+- [ ] **Step 3: Add the `commit` prop to both chat surfaces**
+
+In `ChatSidebar.tsx`, add the import (after line 4):
+
+```ts
+import type { BuilderCommit } from './useSetDocumentHistory';
+```
+
+Change the props (lines 12-25) to add `commit` and pass it through:
+
+```tsx
+export default function ChatSidebar({
+  setId,
+  open,
+  onToggle,
+  refreshToken = 0,
+  onMutationApplied,
+  commit,
+}: {
+  setId: number;
+  open: boolean;
+  onToggle: () => void;
+  refreshToken?: number;
+  onMutationApplied: () => void;
+  commit?: BuilderCommit;
+}) {
+  const chat = useAgentChat(setId, { open, refreshToken, onMutationApplied, commit });
+```
+
+In `MobileAgentOverlay.tsx`, add the same import (after line 5) and change the props (lines 15-28):
+
+```tsx
+export default function MobileAgentOverlay({
+  setId,
+  refreshToken = 0,
+  onMutationApplied,
+  commit,
+}: {
+  setId: number;
+  refreshToken?: number;
+  onMutationApplied: () => void;
+  commit?: BuilderCommit;
+}) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const wasOpenRef = useRef(false);
+  const chat = useAgentChat(setId, { open, refreshToken, onMutationApplied, commit });
+```
+
+- [ ] **Step 4: Pass `history.commit` from the page**
+
+`commit` is gated on `historyEnabled` (page.tsx line 92: `!isLoading && isAuthenticated && role !== 'pending'`). When history is disabled, `history.commit` throws on use (`fetchCurrent` rejects with "Document history is not ready"), so pass `undefined` in that case and `useAgentChat` falls back to `onMutationApplied`.
+
+In `[setId]/page.tsx`, add `commit={historyEnabled ? history.commit : undefined}` to the `<ChatSidebar>` mount (after line 470):
+
+```tsx
+            <ChatSidebar
+              setId={Number(setId)}
+              open={chatOpen}
+              onToggle={() => setChatOpen((open) => !open)}
+              refreshToken={refreshToken}
+              onMutationApplied={() => setRefreshToken((v) => v + 1)}
+              commit={historyEnabled ? history.commit : undefined}
+            />
+```
+
+And to the `<MobileAgentOverlay>` mount (after line 479):
+
+```tsx
+        <MobileAgentOverlay
+          setId={Number(setId)}
+          refreshToken={refreshToken}
+          onMutationApplied={() => setRefreshToken((v) => v + 1)}
+          commit={historyEnabled ? history.commit : undefined}
+        />
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run (from `dashboard/`): `npm test -- --run ChatSidebar`
+Expected: PASS — the new test and all existing `ChatSidebar` tests (which omit `commit` and exercise the unchanged fallback path).
+
+- [ ] **Step 6: Full frontend CI**
+
+Run (from `dashboard/`):
+
+```bash
+npm run lint
+npx tsc --noEmit
+npm test -- --run
+```
+
+Expected: all green, coverage gate met. If `page.test.tsx` mocks `ChatSidebar`/`MobileAgentOverlay`, it is unaffected by the new optional prop; if it renders them, the optional `commit` defaults to `undefined` (fallback) and tests stay green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add "dashboard/app/(dj)/setbuilder/components/ChatSidebar.tsx" \
+        "dashboard/app/(dj)/setbuilder/components/MobileAgentOverlay.tsx" \
+        "dashboard/app/(dj)/setbuilder/[setId]/page.tsx" \
+        "dashboard/app/(dj)/setbuilder/components/__tests__/ChatSidebar.test.tsx"
+git commit -m "feat(setbuilder): wire history.commit into the agent chat surfaces (#493)"
+```
+
+---
+
+## Manual verification (after Task 3)
+
+1. Start the app, open a set in the builder, open the agent chat.
+2. Ask the agent to make a change (e.g. "swap the first two tracks"). Confirm the timeline updates.
+3. Press `Ctrl+Z` (or click ↶). Confirm the change reverts and the ↶ tooltip read `Agent · swap the first two tracks` before the undo.
+4. Ask the agent a non-mutating question (e.g. "why is transition 2 flagged?"). Confirm no new undo entry appears (↶ depth unchanged).
+
+## What this unblocks
+
+Once merged, every agent mutation — including the destructive Family 3 tools (`autobuild`/`run_pass1`, `fill_to_duration`, #491) and Family 4 imports — is undoable for free, because the captured snapshot is the whole document. This satisfies the #491 "Task 0" gate; those tools then need only their standard tool implementation, no per-tool undo wiring.

--- a/docs/superpowers/specs/2026-06-18-agent-undo-design.md
+++ b/docs/superpowers/specs/2026-06-18-agent-undo-design.md
@@ -1,0 +1,146 @@
+# Agent-action undo — design spec
+
+**Issue:** #493 · **Gates:** #491 (Family 3 destructive tools), #442 Family 4 (imports)
+**Date:** 2026-06-18 · **Status:** approved (brainstorm)
+
+## Problem
+
+WrzDJSet agent chat mutations bypass the dashboard's existing undo system. A DJ
+can `Ctrl+Z` a manual drag-reorder but **cannot** undo an agent edit. The
+destructive Family 3 tools (`autobuild`/`run_pass1`, `fill_to_duration`) and
+Family 4 imports rewrite or mass-mutate the set, and have no recovery path — so
+they are blocked until undo covers agent actions.
+
+## Key finding: undo already exists
+
+The dashboard already ships a complete undo/redo system in
+`dashboard/app/(dj)/setbuilder/components/useSetDocumentHistory.ts`:
+
+- A client-side 50-deep snapshot stack (`undoStack`/`redoStack`), each entry
+  `{ label, SetDocumentSnapshot }`.
+- `Ctrl/Cmd+Z` / `Shift+Z` / `Ctrl+Y` shortcuts + a `HistoryControls` ↶/↷ toolbar
+  with depth badges and next-action labels.
+- A `commit(label, action)` pattern: manual edits wrap their API call so a
+  before-snapshot is captured and pushed for undo.
+- Restore via the existing `PUT /sets/{id}/document` → `document_snapshot.restore_snapshot`
+  (full delete-and-recreate of slots/pool/curve with `pool:` id remapping).
+
+The **only** gap: agent chat mutations (`useAgentChat.send`) do not go through
+`commit()`. They bump a `refreshToken` to reload slots, so agent changes never
+enter the undo stack.
+
+This work is therefore a **bridge into the existing stack**, not a new undo
+system. No backend change is required — `build_snapshot`/`restore_snapshot` and
+`GET`/`PUT /sets/{id}/document` (issue #395) already suffice.
+
+## Decisions (locked)
+
+1. **Unified global undo.** A mutating agent turn pushes one entry onto the same
+   stack manual edits use; `Ctrl+Z` / ↶ undoes it identically. No separate
+   per-message undo concept.
+2. **Frontend bridge via `commit()`.** The pre-mutation snapshot is captured
+   client-side by the existing `commit` path. No backend change, no new response
+   field.
+3. **Granularity: one undo entry per mutating agent turn** (the chat turn is the
+   DJ's unit of action), not per tool.
+4. **Scope: every mutating agent turn is undoable** (consistent with manual
+   edits), not destructive-tools-only. The `shouldRecord` predicate makes this
+   the simplest implementation as well as the most consistent UX.
+
+## Design
+
+### Change A — extend `commit` with a `shouldRecord` predicate
+
+`useSetDocumentHistory.commit` currently always pushes an undo entry. Add an
+optional predicate so a wrapped call records only when it actually mutated:
+
+```ts
+type BuilderCommit = <T>(
+  label: string,
+  action: () => Promise<T> | T,
+  shouldRecord?: (result: T) => boolean, // default: () => true
+) => Promise<T>;
+```
+
+Inside `commit`, after `const result = await action()` and capturing `after`,
+push `{ label, snapshot: before }` to `undoStack` **only if**
+`shouldRecord(result)`; always `publishSnapshot(after)`, clear redo, and reset
+dirty/save state as today. Existing two-arg callers are unaffected (predicate
+defaults to always-record). This is the single behavioral change in the hook.
+
+### Change B — bridge `useAgentChat.send`
+
+Thread the page-level `commit` (and `enabled` flag) down to the chat surface
+(`ChatSidebar` / `MobileAgentOverlay` → `useAgentChat`), replacing the current
+`onMutationApplied` refresh callback. In `send`, wrap the chat call:
+
+```ts
+const mutated = (res: AgentChatOut) =>
+  [...res.tool_calls, ...res.assistant_message.tool_calls].some((t) => t.mutating);
+
+const result = await commit(
+  `Agent · ${truncate(message, 40)}`,
+  () => api.chatWithSetAgent(setId, { message }),
+  mutated,
+);
+```
+
+A mutating turn → one undo entry labeled e.g. `Agent · rebuild the set`,
+undoable with the same `Ctrl+Z` / ↶ as a manual drag. A pure-conversation turn →
+no entry. The `after` publish bumps `snapshotVersion`, which already drives the
+`BuilderWorkspace` reload — so the agent path's separate `onMutationApplied` /
+`refreshToken` refresh is **removed** (a single refresh path, not two).
+
+### Why this covers Family 3 and Family 4 for free
+
+`SetDocumentSnapshot` is the whole document — settings, slots, curve points, and
+**pool**. So:
+
+- `autobuild` / `fill_to_duration` rewrite slots → undo restores the prior order.
+- `import_from_event` / `import_from_tidal` add pool tracks → undo restores the
+  pre-import pool (`restore_snapshot` deletes and recreates the pool).
+
+No per-tool undo wiring is ever needed. Any current or future agent mutation is
+undoable the moment it ships. This satisfies the #491 "Task 0" gate.
+
+## Edge cases & error handling
+
+- **Lock during LLM latency.** `commit` holds the single-operation lock for the
+  whole turn, so manual undo/edit is blocked while the agent runs. Acceptable —
+  chat input is already disabled while `busy`. Deliberate, not worked around.
+- **History disabled / not loaded.** If `commit` is unavailable (history hook
+  `enabled === false`, or the document has not loaded yet), `send` falls back to
+  today's behavior (send + reload, no undo entry) rather than throwing.
+- **Failed turn.** `commit` already routes errors to `saveError` and pushes
+  nothing; the agent error surfaces exactly as today, with no phantom undo entry.
+- **Label.** `Agent · <first ~40 chars of the message>` — known up front, reads
+  well in the ↶ tooltip and the undo toast (`Undid Agent · …`).
+
+## Testing (frontend, vitest — no backend change)
+
+- `commit` with `shouldRecord` returning `false`: publishes `after`, pushes **no**
+  undo entry; returning `true`: pushes exactly one. Existing two-arg callers
+  still record.
+- `useAgentChat.send` with a mutating response → exactly one undo entry with the
+  expected label; with a non-mutating response → zero entries.
+- Undo after an agent turn calls `PUT /sets/{id}/document` with the captured
+  `before` snapshot (i.e. the turn is reversible end to end).
+- History-disabled fallback: `send` does not throw and still posts the chat.
+
+## Scope boundary (YAGNI)
+
+Not building: per-tool undo buttons, a server-side undo log, agent-specific redo
+affordances, or multi-turn batching. The unified stack already provides redo,
+keyboard shortcuts, depth labels, and autosave.
+
+## Acceptance criteria
+
+- [ ] `commit` accepts an optional `shouldRecord` predicate; two-arg callers
+  unchanged.
+- [ ] A mutating agent turn produces one undo entry; a non-mutating turn produces
+  none.
+- [ ] `Ctrl+Z` / ↶ after an agent edit restores the exact pre-turn document.
+- [ ] The redundant agent `onMutationApplied`/`refreshToken` refresh is removed;
+  the workspace reloads via `snapshotVersion`.
+- [ ] Graceful fallback when history is disabled.
+- [ ] Frontend test suite green at the configured coverage gate; `tsc`/lint clean.


### PR DESCRIPTION
## Why
WrzDJSet agent chat mutations bypassed the dashboard's existing undo system, so a DJ could `Ctrl+Z` a manual drag but **not** an agent edit. This blocks the destructive Family 3 tools (`autobuild`/`fill_to_duration`, #491) and Family 4 imports, which need a recovery path before they can ship.

## What
Bridges agent chat turns into the **existing** 50-deep document-history stack (`useSetDocumentHistory`) — unified global undo, so a mutating turn becomes an ordinary undo entry reverted by the same `Ctrl+Z` / ↶ as a manual edit. **Frontend-only, no backend change** — it rides the `build_snapshot`/`restore_snapshot` + `GET`/`PUT /document` surface (#395) that already exists.

Three small changes:
1. `commit` gains an optional `shouldRecord(result)` predicate (backward-compatible) — record an undo entry only when the turn mutated.
2. `useAgentChat.send` wraps the chat call in `commit` with a `didMutate` predicate; falls back to the old refresh when history is unavailable.
3. `history.commit` is threaded through `ChatSidebar`/`MobileAgentOverlay` (gated on `historyEnabled`).

Because the captured snapshot is the **whole document** (slots + curve + pool), every current and future agent mutation — including the unbuilt Family 3/4 destructive tools — is undoable for free. This satisfies the #491 undo gate.

Design + plan: `docs/superpowers/specs/2026-06-18-agent-undo-design.md`, `docs/superpowers/plans/2026-06-18-agent-undo.md`.

## Testing
- [x] Unit tests pass (5 new across the 3 changes; full suite 1345)
- [x] Coverage gate met (Branch 69.94% ≥ 68, Funcs 72.84% ≥ 65, Lines 81.48% ≥ 78, Stmts 79.1% ≥ 77)
- [x] `tsc --noEmit` + eslint clean
- [ ] Manual: ask the agent to edit a set, press Ctrl+Z, confirm it reverts; ask a non-mutating question, confirm no undo entry
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #493. Unblocks #491 + #442 Family 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled undo/redo for agent-driven set mutations by routing mutating chat turns through the existing document history stack when history is available.
  * Mutations now create a single labeled undo entry per mutating agent turn (and skip history-free mutation handling when history is disabled).
* **Tests**
  * Added/updated unit tests to verify commit-based undo routing and non-recording mutation behavior (including redo preservation).
* **Documentation**
  * Added an end-to-end implementation plan and a design specification for the agent undo integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->