### PR TITLE
fix(requests): event owner bypasses human-verification gate on POST /requests

### DIFF
--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -658,9 +658,10 @@ def submit_request(
     code: str,
     request_data: RequestCreate,
     request: Request,
+    response: Response,
     background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
-    _human: int | None = Depends(require_verified_human_soft),
+    current_user: User | None = Depends(get_current_user_optional),
 ) -> RequestOut:
     event, lookup_result = get_event_by_public_code_with_status(db, code)
 
@@ -672,6 +673,14 @@ def submit_request(
 
     if lookup_result == EventLookupResult.ARCHIVED:
         raise HTTPException(status_code=410, detail="Event has been archived")
+
+    # Owner (authenticated DJ) bypasses the guest human-verification gate; the DJ
+    # dashboard "Add" button in the song-search modal reuses this endpoint and the
+    # DJ holds a JWT but no guest wrzdj_human cookie, so an enforced gate would 403
+    # them on their own event. Everyone else still passes through it (soft/enforced).
+    is_owner = current_user is not None and current_user.id == event.created_by_user_id
+    if not is_owner:
+        require_verified_human_soft(request, response, db)
 
     if not event.requests_open:
         raise HTTPException(status_code=403, detail="Requests are closed for this event")

--- a/server/tests/test_events.py
+++ b/server/tests/test_events.py
@@ -1702,3 +1702,60 @@ class TestEventSearchOwnerBypass:
 
         assert response.status_code == 403
         assert response.json()["detail"]["code"] == "human_verification_required"
+
+
+class TestSubmitRequestOwnerBypass:
+    """POST /api/events/{code}/requests: authenticated event owners bypass the
+    guest human-verification gate; everyone else is still gated when enforced.
+
+    Regression for the production 403 a DJ hit using the dashboard "Add" button
+    in the song-search modal: the DJ is JWT-authenticated but holds no guest
+    wrzdj_human cookie, so with human_verification_enforced=True the public
+    submit endpoint rejected them with 403 on their own event.
+    """
+
+    def test_owner_bypasses_human_gate_when_enforced(
+        self, client: TestClient, db: Session, test_event: Event, auth_headers: dict
+    ):
+        """Event owner with a valid JWT submits a request even with enforcement
+        on and no human cookie (was 403 before the fix)."""
+        _enforce_human_verification(db)
+
+        response = client.post(
+            f"/api/events/{test_event.code}/requests",
+            json={"artist": "Avicii", "title": "Levels"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["song_title"] == "Levels"
+
+    def test_anonymous_still_gated_when_enforced(
+        self, client: TestClient, db: Session, test_event: Event
+    ):
+        """A request with no JWT and no human cookie stays 403 when enforced."""
+        _enforce_human_verification(db)
+
+        response = client.post(
+            f"/api/events/{test_event.code}/requests",
+            json={"artist": "Avicii", "title": "Levels"},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "human_verification_required"
+
+    def test_non_owner_authenticated_still_gated_when_enforced(
+        self, client: TestClient, db: Session, test_event: Event, admin_headers: dict
+    ):
+        """A different authenticated user (not the event owner) is still gated:
+        the bypass is owner-only, not 'any logged-in user'."""
+        _enforce_human_verification(db)
+
+        response = client.post(
+            f"/api/events/{test_event.code}/requests",
+            json={"artist": "Avicii", "title": "Levels"},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "human_verification_required"


### PR DESCRIPTION
## Why

On production event `4GX43T`, a DJ adding a track from the dashboard song-search modal hit **`POST /api/events/{code}/requests` → 403**. The track never got added.

`submit_request` hard-depended on `require_verified_human_soft`, which raises 403 when `human_verification_enforced=True` for any caller lacking a valid `wrzdj_human` guest cookie. The DJ is JWT-authenticated but — like a guest who hasn't passed Turnstile — holds no human cookie, so the enforced gate rejected them **on their own event**.

This is the same bug class fixed for `event_search` in #492 (the dashboard "Search for Song" button), which was given an owner-bypass. The fix wasn't applied to the sibling submit endpoint, so search worked but *adding* the result still 403'd.

## What

Mirror the `event_search` owner-bypass on `submit_request`:
- Swap the hard `require_verified_human_soft` dependency for an optional bearer (`get_current_user_optional`) plus `Response`.
- Compute `is_owner = current_user is not None and current_user.id == event.created_by_user_id`.
- Run `require_verified_human_soft(...)` **only for non-owners**, placed right after the 404/410 checks so the human gate remains the first 403 an unverified caller sees.

The owner path leaves `guest_id` as `None`; `create_request` already declares `guest_id: int | None = None` and guards votes behind `if guest_id:`, so the owner path is safe (no 500). The frontend already sends `Authorization: Bearer` on this call.

Security posture is unchanged for everyone else: anonymous and non-owner authenticated callers are still gated when enforcement is on.

## Testing
- [x] New regression `TestSubmitRequestOwnerBypass` (owner bypasses gate → 200; anonymous → 403 `human_verification_required`; non-owner authed → 403), mirroring `TestEventSearchOwnerBypass`
- [x] Full backend suite: **3064 passed**, coverage **88.57%** (≥85% gate)
- [x] ruff check + ruff format --check + bandit clean
- [ ] CI green
- [ ] Manual verification on production event `4GX43T`: DJ adds a track from the search modal → 201/200, request appears

🤖 Co-authored by Claude Opus 4.8 (1M context). Follow-up to #492.