### PR TITLE
fix(nginx): allow 'unsafe-eval' in production CSP for guest fingerprinting

### DIFF
--- a/deploy/nginx/app.conf.template
+++ b/deploy/nginx/app.conf.template
@@ -50,7 +50,11 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     # SECURITY (H-I2): Permissions-Policy restricts browser APIs for XSS containment
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://${API_DOMAIN} https://i.scdn.co https://resources.tidal.com https://geo-media.beatport.com; media-src 'self' data:; connect-src 'self' https://${API_DOMAIN}; frame-src https://challenges.cloudflare.com https://open.spotify.com https://embed.tidal.com; frame-ancestors 'none'" always;
+    # SECURITY: 'unsafe-eval' is required by @thumbmarkjs/thumbmarkjs (lazy-loaded in
+    # useGuestIdentity for guest fingerprinting / human-verification on join/collect).
+    # The dev-proxy CSP already carries it; production was missing it, so guest
+    # fingerprinting was blocked. Tradeoff accepted to keep the anti-bot gate working.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://${API_DOMAIN} https://i.scdn.co https://resources.tidal.com https://geo-media.beatport.com; media-src 'self' data:; connect-src 'self' https://${API_DOMAIN}; frame-src https://challenges.cloudflare.com https://open.spotify.com https://embed.tidal.com; frame-ancestors 'none'" always;
 
     # Strip security headers from upstream (Next.js sets them too — nginx is authoritative)
     proxy_hide_header Strict-Transport-Security;
@@ -76,7 +80,7 @@ server {
         limit_req zone=wrzdj_edge burst=180 nodelay;
 
         # Override server-level framing restrictions for this path
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://${API_DOMAIN} https://i.scdn.co https://resources.tidal.com https://geo-media.beatport.com; media-src 'self' data:; connect-src 'self' https://${API_DOMAIN}; frame-src https://challenges.cloudflare.com; frame-ancestors *" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://${API_DOMAIN} https://i.scdn.co https://resources.tidal.com https://geo-media.beatport.com; media-src 'self' data:; connect-src 'self' https://${API_DOMAIN}; frame-src https://challenges.cloudflare.com; frame-ancestors *" always;
         # Omit X-Frame-Options entirely (CSP frame-ancestors takes precedence)
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Content-Type-Options "nosniff" always;


### PR DESCRIPTION
## Why

On production (`app.wrzdj.com`), the browser console throws on guest surfaces:

> CSP: The page's settings blocked a JavaScript eval (script-src) ... (Missing 'unsafe-eval')

`useGuestIdentity` lazy-loads `@thumbmarkjs/thumbmarkjs` and calls `getFingerprint()` to mint the guest identity that backs the **human-verification / anti-bot gate** (join, collect, NicknameGate). The fingerprint probes the JS engine via `eval`, which production CSP `script-src` blocks. The **dev-proxy CSP already includes `'unsafe-eval'`**, so it worked locally but silently degraded/broke guest fingerprinting in production — a dev→prod config drift.

## What

Add `'unsafe-eval'` to `script-src` in both CSP blocks (server-level + `/e/{code}/overlay`) of the production nginx template, restoring parity with the dev-proxy.

- Scoped to `app.yourdomain.com` via `server_name`; the API (`api.yourdomain.com`) CSP in `security_headers.py` is **untouched**.
- Security tradeoff: `'unsafe-eval'` weakens XSS mitigation. Accepted to keep the fingerprint-based human gate working (the same call the dev-proxy already permits). Documented inline.

**Not the kiosk bug:** the kiosk pairing/display paths deliberately avoid `useGuestIdentity`, so this is independent of the `fix/kiosk-pair-cors-header` effort (no file overlap).

## ⚠️ Production deploy

nginx is **host-level** — `deploy.sh` does **not** apply this. After merge + deploy, re-run:

```bash
APP_DOMAIN=app.wrzdj.com API_DOMAIN=api.wrzdj.com ./deploy/setup-nginx.sh
```

Then verify the response `Content-Security-Policy` header on `https://app.wrzdj.com` contains `'unsafe-eval'`.

## Testing
- [x] Confirmed dev-proxy already carries `'unsafe-eval'` (parity target)
- [x] No test/code asserts the nginx app CSP string (grep-verified; bridge-app + API CSPs are separate surfaces)
- [ ] Post-deploy: guest join/collect pages no longer log the CSP eval error; fingerprint POST `/api/public/guest/identify` succeeds
- [ ] `nginx -t` clean after `setup-nginx.sh`

🤖 Co-authored by Claude Opus 4.8 (1M context).