### PR TITLE
fix(kiosk): allow X-Pair-Nonce through production CORS so kiosks can re-pair

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -173,7 +173,7 @@ def create_app(*, lifespan_context=lifespan) -> FastAPI:
             allow_origins=origins,
             allow_credentials=True,
             allow_methods=CORS_ALLOW_METHODS,
-            allow_headers=["Authorization", "Content-Type", "X-Kiosk-Session"],
+            allow_headers=["Authorization", "Content-Type", "X-Kiosk-Session", "X-Pair-Nonce"],
             expose_headers=["Content-Disposition"],
         )
 

--- a/server/tests/test_cors.py
+++ b/server/tests/test_cors.py
@@ -5,7 +5,9 @@ causing preflight failures on the Tidal settings endpoint in production.
 """
 
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.testclient import TestClient
 
+from app import main
 from app.main import CORS_ALLOW_METHODS, app
 
 
@@ -33,3 +35,34 @@ class TestCorsConfiguration:
             None,
         )
         assert cors_mw is not None, "CORSMiddleware not found on app"
+
+    def test_cors_allows_kiosk_pair_nonce_preflight_in_production(self, monkeypatch):
+        """Prod CORS must allow the X-Pair-Nonce header on the kiosk pair preflight.
+
+        Regression: a browser pairing a kiosk POSTs /api/public/kiosk/pair with a
+        custom X-Pair-Nonce header, which triggers a CORS preflight. Under
+        non-wildcard (production) origins the header was absent from allow_headers,
+        so the preflight returned 400 "Disallowed CORS headers" and the kiosk page
+        surfaced "Failed to create pairing session" — the device could never
+        create a fresh pairing after being unpaired.
+        """
+        monkeypatch.setattr(main.settings, "cors_origins", "https://app.wrzdj.com")
+        prod_app = main.create_app()
+
+        # No context manager → lifespan/background tasks stay off; the preflight is
+        # short-circuited by CORSMiddleware before routing, so no DB is needed.
+        client = TestClient(prod_app)
+        resp = client.options(
+            "/api/public/kiosk/pair",
+            headers={
+                "Origin": "https://app.wrzdj.com",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "x-pair-nonce",
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        allowed = resp.headers.get("access-control-allow-headers", "").lower()
+        assert "x-pair-nonce" in allowed, (
+            f"X-Pair-Nonce not allowed by prod CORS; allow-headers={allowed!r}"
+        )


### PR DESCRIPTION
## Why
A kiosk that gets unpaired from its event shows **"Failed to create pairing session"** and never displays a fresh QR code, so it can't be re-paired to another event.

The kiosk's `POST /api/public/kiosk/pair` carries a custom `X-Pair-Nonce` header, which triggers a browser CORS preflight. Production's non-wildcard CORS `allow_headers` never included `X-Pair-Nonce`, so the preflight returns `400 Disallowed CORS headers` and the browser blocks the request before it's sent.

This has been latent since the nonce flow (#272): the live-display path uses `X-Kiosk-Session` (already allow-listed) so paired kiosks kept working, and local dev/tests use `CORS_ORIGINS=*` (`allow_headers=["*"]`) so it never reproduced. Unpairing forces the one code path the prod allow-list blocked.

## What
- Add `X-Pair-Nonce` to the production CORS `allow_headers` in `server/app/main.py`.
- Add a regression test that builds the app under production-style explicit origins and asserts the kiosk pair-endpoint preflight allows `x-pair-nonce` (reproduced the exact `400` before the fix).

⚠️ Server-side fix — the kiosk only recovers after a **backend redeploy** to production.

## Testing
- [x] Backend unit tests pass (3062 passed; new `test_cors.py` regression test included)
- [x] Coverage gate met (88.62% ≥ 85%)
- [x] ruff check + ruff format clean; bandit clean
- [ ] Manual verification: after deploy, unpair the kiosk → it shows a fresh QR code and can pair to a new event
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #497.