### PR TITLE
fix(now-playing): match tracks when equipment embeds "(ft. …)" in the title

### DIFF
--- a/server/app/services/now_playing.py
+++ b/server/app/services/now_playing.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 # Re-export normalizer functions for backward compatibility
 from app.services.track_normalizer import (  # noqa: F401
+    artist_match_score,
     fuzzy_match_score,
     normalize_artist,
     normalize_track_title,
@@ -221,7 +222,10 @@ def fuzzy_match_pending_request(
         req_artist = normalize_artist(req.artist)
 
         title_score = fuzzy_match_score(req_title, norm_title)
-        artist_score = fuzzy_match_score(req_artist, norm_artist)
+        # Multi-artist-aware: equipment may report only the primary artist while
+        # the request lists every collaborator (e.g. "Lil Jon" vs
+        # "Lil Jon, The EastSide Boyz, Ying Yang Twins").
+        artist_score = artist_match_score(req_artist, norm_artist)
         combined = title_score * 0.7 + artist_score * 0.3
 
         if combined > threshold and combined > best_score:

--- a/server/app/services/track_normalizer.py
+++ b/server/app/services/track_normalizer.py
@@ -29,12 +29,15 @@ MULTI_SPACE_RE = re.compile(r"\s{2,}")
 # metadata, e.g. "Get Low (ft. Ying Yang Twins)" or "Promiscuous [feat. Timbaland]".
 # Guests rarely type these, so strip them before fuzzy matching. "with" is
 # intentionally excluded here to avoid eating real title words ("Dancing With Myself").
+# All quantifiers are bounded ({n,m}) so the patterns stay linear-time — an
+# unbounded \s+ adjacent to a class that also matches spaces is a polynomial
+# (ReDoS) backtracking risk flagged by CodeQL.
 FEAT_PAREN_RE = re.compile(
-    r"[\(\[]\s*(?:featuring|feat|ft)\.?\s+[^\)\]]*[\)\]]",
+    r"[\(\[]\s{0,3}(?:featuring|feat|ft)\.?\s{1,3}[^\)\]]{0,100}[\)\]]",
     re.IGNORECASE,
 )
 FEAT_TRAILING_RE = re.compile(
-    r"\s+(?:featuring|feat|ft)\.?\s+.*$",
+    r"\s{1,3}(?:featuring|feat|ft)\.?\s{1,3}.{0,150}$",
     re.IGNORECASE,
 )
 

--- a/server/app/services/track_normalizer.py
+++ b/server/app/services/track_normalizer.py
@@ -25,6 +25,19 @@ GENERIC_SUFFIX_DASH_RE = re.compile(rf"\s+-\s+(?:{_GENERIC_SUFFIXES})\s*$", re.I
 FEAT_RE = re.compile(r"\b(?:featuring|feat\.?|ft\.?|with)(?=\s)", re.IGNORECASE)
 MULTI_SPACE_RE = re.compile(r"\s{2,}")
 
+# Featured-artist credits embedded in titles by DJ equipment / streaming
+# metadata, e.g. "Get Low (ft. Ying Yang Twins)" or "Promiscuous [feat. Timbaland]".
+# Guests rarely type these, so strip them before fuzzy matching. "with" is
+# intentionally excluded here to avoid eating real title words ("Dancing With Myself").
+FEAT_PAREN_RE = re.compile(
+    r"[\(\[]\s*(?:featuring|feat|ft)\.?\s+[^\)\]]*[\)\]]",
+    re.IGNORECASE,
+)
+FEAT_TRAILING_RE = re.compile(
+    r"\s+(?:featuring|feat|ft)\.?\s+.*$",
+    re.IGNORECASE,
+)
+
 # Remix detection: "Artist Remix", "Artist Edit", etc. in parentheses or after dash
 _REMIX_PAREN_RE = re.compile(
     r"[\(\[]([\w\s&.]+?)\s+(remix|edit|bootleg|rework|flip|mix)\s*[\)\]]",
@@ -75,11 +88,15 @@ def normalize_track_title(title: str) -> str:
     """Normalize a track title for fuzzy matching.
 
     Strips generic mix suffixes (Original Mix, Extended Mix, Radio Edit, etc.)
-    but preserves named remixes (e.g. "Skrillex Remix"), special versions
-    (Instrumental, Acoustic, Live, VIP, Dub Mix, A Cappella), and arbitrary
-    parenthetical content (e.g. "2024 Remaster").
+    and featured-artist credits ("(ft. ...)", "feat. ...") that DJ equipment
+    embeds in titles, but preserves named remixes (e.g. "Skrillex Remix"),
+    special versions (Instrumental, Acoustic, Live, VIP, Dub Mix, A Cappella),
+    and arbitrary parenthetical content (e.g. "2024 Remaster").
     """
     result = GENERIC_SUFFIX_PAREN_RE.sub("", title)
+    # Replace a feat paren with a space so a following named remix stays spaced.
+    result = FEAT_PAREN_RE.sub(" ", result)
+    result = FEAT_TRAILING_RE.sub("", result)
     result = GENERIC_SUFFIX_DASH_RE.sub("", result)
     result = MULTI_SPACE_RE.sub(" ", result).strip()
     return result

--- a/server/tests/test_now_playing.py
+++ b/server/tests/test_now_playing.py
@@ -313,6 +313,58 @@ class TestFuzzyMatchPendingRequest:
         assert result is not None
         assert result.id == req.id
 
+    def test_match_feat_embedded_in_title_multi_artist(self, db: Session, test_event: Event):
+        """Regression (prod event RMLNDZ / request #491): the bridge reported
+        'Get Low (ft. Ying Yang Twins)' by 'Lil Jon & The Eastside Boyz' while
+        the accepted request was 'Get Low' by
+        'Lil Jon, The EastSide Boyz, Ying Yang Twins'. The featured artist
+        embedded in the title tanked the fuzzy score below threshold, so the
+        request was never auto-matched/marked played.
+        """
+        req = Request(
+            event_id=test_event.id,
+            song_title="Get Low",
+            artist="Lil Jon, The EastSide Boyz, Ying Yang Twins",
+            source="spotify",
+            status=RequestStatus.ACCEPTED.value,
+            dedupe_key="get_low_feat_title_key",
+        )
+        db.add(req)
+        db.commit()
+
+        result = fuzzy_match_pending_request(
+            db,
+            test_event.id,
+            "Get Low (ft. Ying Yang Twins)",
+            "Lil Jon & The Eastside Boyz",
+        )
+        assert result is not None
+        assert result.id == req.id
+
+    def test_match_primary_artist_only_vs_multi_artist_request(
+        self, db: Session, test_event: Event
+    ):
+        """Equipment often reports only the primary artist while the guest
+        request lists every collaborator. Multi-artist-aware scoring must let
+        'Lil Jon' match 'Lil Jon, The EastSide Boyz, Ying Yang Twins'.
+        """
+        req = Request(
+            event_id=test_event.id,
+            song_title="Get Low",
+            artist="Lil Jon, The EastSide Boyz, Ying Yang Twins",
+            source="spotify",
+            status=RequestStatus.ACCEPTED.value,
+            dedupe_key="get_low_primary_only_key",
+        )
+        db.add(req)
+        db.commit()
+
+        result = fuzzy_match_pending_request(
+            db, test_event.id, "Get Low (ft. Ying Yang Twins)", "Lil Jon"
+        )
+        assert result is not None
+        assert result.id == req.id
+
     def test_matches_new_requests(self, db: Session, test_event: Event):
         """Matches NEW requests (not just ACCEPTED)."""
         new_req = Request(

--- a/server/tests/test_track_normalizer.py
+++ b/server/tests/test_track_normalizer.py
@@ -62,6 +62,31 @@ class TestNormalizeTrackTitle:
     def test_plain_title_unchanged(self):
         assert normalize_track_title("Strobe") == "Strobe"
 
+    def test_strips_feat_parenthetical(self):
+        # DJ equipment / streaming metadata embeds the featured artist in the
+        # title; guests rarely type it. Strip it before fuzzy matching.
+        assert normalize_track_title("Get Low (ft. Ying Yang Twins)") == "Get Low"
+
+    def test_strips_featuring_parenthetical(self):
+        assert normalize_track_title("Promiscuous (feat. Timbaland)") == "Promiscuous"
+
+    def test_strips_feat_brackets(self):
+        assert normalize_track_title("Get Low [ft. Ying Yang Twins]") == "Get Low"
+
+    def test_strips_feat_trailing(self):
+        assert normalize_track_title("Get Low feat. Ying Yang Twins") == "Get Low"
+
+    def test_feat_strip_keeps_named_remix(self):
+        # Strip the feat credit but preserve a following named remix.
+        assert (
+            normalize_track_title("Otherside (ft. Foo) (Skrillex Remix)")
+            == "Otherside (Skrillex Remix)"
+        )
+
+    def test_feat_strip_ignores_plain_with(self):
+        # "with" is not a feat marker in titles — don't eat real words.
+        assert normalize_track_title("Dancing With Myself") == "Dancing With Myself"
+
 
 class TestNormalizeArtist:
     """Tests for normalize_artist()."""

--- a/server/tests/test_track_normalizer.py
+++ b/server/tests/test_track_normalizer.py
@@ -87,6 +87,22 @@ class TestNormalizeTrackTitle:
         # "with" is not a feat marker in titles — don't eat real words.
         assert normalize_track_title("Dancing With Myself") == "Dancing With Myself"
 
+    def test_feat_regexes_are_linear_on_pathological_input(self):
+        # ReDoS guard (CodeQL polynomial-regex alert): the feat patterns must
+        # not backtrack quadratically on a long run of spaces after "(ft ".
+        # Bounded quantifiers keep them linear; the unbounded versions were
+        # O(n^2) and took seconds on this input.
+        import time
+
+        from app.services.track_normalizer import FEAT_PAREN_RE, FEAT_TRAILING_RE
+
+        payload = "(ft " + " " * 100_000
+        start = time.perf_counter()
+        FEAT_PAREN_RE.sub(" ", payload)
+        FEAT_TRAILING_RE.sub("", payload)
+        elapsed = time.perf_counter() - start
+        assert elapsed < 0.2, f"feat regexes took {elapsed:.3f}s (possible ReDoS)"
+
 
 class TestNormalizeArtist:
     """Tests for normalize_artist()."""


### PR DESCRIPTION
## Why
On production event **RMLNDZ**, the DJ played "Get Low" and the bridge reported it correctly, but the accepted request stayed in the queue and was never marked played. The DJ also saw the reconnect-but-still-unmatched behaviour.

Ground truth from prod (event id 16):
- Bridge (Denon Prime 4+ / StageLinQ) reported `Get Low (ft. Ying Yang Twins)` by `Lil Jon & The Eastside Boyz`.
- Accepted request #491: `Get Low` by `Lil Jon, The EastSide Boyz, Ying Yang Twins`.
- `now_playing.matched_request_id` = NULL — never matched.

## What
The fuzzy matcher's title normalizer only stripped generic *mix* suffixes, leaving featured-artist credits like `(ft. Ying Yang Twins)` in the title. That collapsed `SequenceMatcher` to ~0.39, dropping the combined score below the 0.8 threshold so the request never auto-matched (and reconnecting just re-ran the same failing match). The artist side also used the raw ratio instead of the multi-artist-aware scorer.

- `normalize_track_title` now strips featured-artist credits — parenthetical, bracketed, and trailing `feat./ft./featuring …`. Named remixes/versions are preserved; `with` is excluded so it doesn't eat real title words ("Dancing With Myself").
- `fuzzy_match_pending_request` uses the multi-artist-aware `artist_match_score`, so equipment reporting only `Lil Jon` still matches a multi-artist request.

Bridge-app side (collection-code-vs-join-code display) is a separate, independent fix and will be its own PR.

## Testing
- [x] Unit tests pass (`test_track_normalizer.py` — feat-strip cases + guard for `with`/remix preservation)
- [x] Integration/regression tests pass (`test_now_playing.py` — pins prod event RMLNDZ / request #491, incl. primary-artist-only case)
- [x] Full backend suite: 3073 passed, coverage 88.62% (≥85% gate)
- [x] ruff check + format + bandit clean
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #500.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved track matching accuracy by better handling featured artist credits in track titles.
  * Enhanced multi-artist matching to provide more reliable results when multiple collaborators are involved.

* **Tests**
  * Added regression tests for multi-artist matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->