### PR TITLE
fix(bridge-app): show the join code, not the collection code

### DIFF
--- a/bridge-app/src/main/__tests__/events-service.test.ts
+++ b/bridge-app/src/main/__tests__/events-service.test.ts
@@ -13,17 +13,19 @@ describe('fetchEvents', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve([
-        { id: 1, code: 'ABC123', name: 'Live Set', is_active: true, expires_at: '2026-12-31T00:00:00Z' },
-        { id: 2, code: 'DEF456', name: 'Expired Event', is_active: false, expires_at: '2025-01-01T00:00:00Z' },
-        { id: 3, code: 'GHI789', name: 'Another Set', is_active: true, expires_at: '2026-12-31T00:00:00Z' },
+        { id: 1, code: 'ABC123', join_code: 'JOIN01', name: 'Live Set', is_active: true, expires_at: '2026-12-31T00:00:00Z' },
+        { id: 2, code: 'DEF456', join_code: 'JOIN02', name: 'Expired Event', is_active: false, expires_at: '2025-01-01T00:00:00Z' },
+        { id: 3, code: 'GHI789', join_code: 'JOIN03', name: 'Another Set', is_active: true, expires_at: '2026-12-31T00:00:00Z' },
       ]),
     });
 
     const events = await fetchEvents('https://api.wrzdj.com', 'token-123');
 
+    // The bridge must surface join_code (the code guests use / shown in the
+    // dashboard), not just the internal collection code.
     expect(events).toEqual([
-      { id: 1, code: 'ABC123', name: 'Live Set', isActive: true, expiresAt: '2026-12-31T00:00:00Z' },
-      { id: 3, code: 'GHI789', name: 'Another Set', isActive: true, expiresAt: '2026-12-31T00:00:00Z' },
+      { id: 1, code: 'ABC123', joinCode: 'JOIN01', name: 'Live Set', isActive: true, expiresAt: '2026-12-31T00:00:00Z' },
+      { id: 3, code: 'GHI789', joinCode: 'JOIN03', name: 'Another Set', isActive: true, expiresAt: '2026-12-31T00:00:00Z' },
     ]);
 
     expect(mockFetch).toHaveBeenCalledWith(

--- a/bridge-app/src/main/events-service.ts
+++ b/bridge-app/src/main/events-service.ts
@@ -3,6 +3,7 @@ import type { EventInfo } from '../shared/types.js';
 interface EventResponse {
   id: number;
   code: string;
+  join_code: string;
   name: string;
   is_active: boolean;
   expires_at: string;
@@ -35,6 +36,7 @@ export async function fetchEvents(
     .map((e) => ({
       id: e.id,
       code: e.code,
+      joinCode: e.join_code,
       name: e.name,
       isActive: e.is_active,
       expiresAt: e.expires_at,

--- a/bridge-app/src/renderer/App.tsx
+++ b/bridge-app/src/renderer/App.tsx
@@ -71,9 +71,10 @@ export function App() {
         <BridgeControls
           status={bridgeStatus}
           selectedEventCode={selectedEvent?.code ?? null}
+          joinCode={selectedEvent?.joinCode ?? null}
         />
 
-        <StatusPanel status={bridgeStatus} />
+        <StatusPanel status={bridgeStatus} joinCode={selectedEvent?.joinCode ?? null} />
 
         <LogPanel entries={logEntries} onClear={clearLog} />
 

--- a/bridge-app/src/renderer/App.tsx
+++ b/bridge-app/src/renderer/App.tsx
@@ -8,6 +8,7 @@ import { BridgeControls } from './components/BridgeControls.js';
 import { StatusPanel } from './components/StatusPanel.js';
 import { SettingsPanel } from './components/SettingsPanel.js';
 import { LogPanel } from './components/LogPanel.js';
+import { runningJoinCode } from './running-join-code.js';
 import type { EventInfo } from '../shared/types.js';
 
 export function App() {
@@ -32,6 +33,10 @@ export function App() {
   const handleEventRemoved = useCallback((code: string) => {
     setSelectedEvent((prev) => (prev?.code === code ? null : prev));
   }, []);
+
+  // Show the join code only when the selection still matches the running bridge,
+  // so changing selection mid-run can't display a different event's join code.
+  const displayJoinCode = runningJoinCode(selectedEvent, bridgeStatus.eventCode);
 
   // Loading state
   if (loading && !authState.isAuthenticated) {
@@ -71,10 +76,10 @@ export function App() {
         <BridgeControls
           status={bridgeStatus}
           selectedEventCode={selectedEvent?.code ?? null}
-          joinCode={selectedEvent?.joinCode ?? null}
+          joinCode={displayJoinCode}
         />
 
-        <StatusPanel status={bridgeStatus} joinCode={selectedEvent?.joinCode ?? null} />
+        <StatusPanel status={bridgeStatus} joinCode={displayJoinCode} />
 
         <LogPanel entries={logEntries} onClear={clearLog} />
 

--- a/bridge-app/src/renderer/__tests__/running-join-code.test.ts
+++ b/bridge-app/src/renderer/__tests__/running-join-code.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { runningJoinCode } from '../running-join-code.js';
+import type { EventInfo } from '../../shared/types.js';
+
+const eventA: EventInfo = {
+  id: 1,
+  code: 'AAA111',
+  joinCode: 'JOINAA',
+  name: 'Event A',
+  isActive: true,
+  expiresAt: '2026-12-31T00:00:00Z',
+};
+const eventB: EventInfo = {
+  id: 2,
+  code: 'BBB222',
+  joinCode: 'JOINBB',
+  name: 'Event B',
+  isActive: true,
+  expiresAt: '2026-12-31T00:00:00Z',
+};
+
+describe('runningJoinCode', () => {
+  it('returns the selected event join code when it matches the running event', () => {
+    expect(runningJoinCode(eventA, 'AAA111')).toBe('JOINAA');
+  });
+
+  it('returns null when the selection diverges from the running event', () => {
+    // DJ started the bridge for A, then clicked B in the still-rendered list —
+    // must NOT show B's join code for A's running bridge.
+    expect(runningJoinCode(eventB, 'AAA111')).toBeNull();
+  });
+
+  it('returns null when no event is selected', () => {
+    expect(runningJoinCode(null, 'AAA111')).toBeNull();
+  });
+
+  it('returns null when the bridge is not running (no running event code)', () => {
+    expect(runningJoinCode(eventA, null)).toBeNull();
+  });
+});

--- a/bridge-app/src/renderer/components/BridgeControls.tsx
+++ b/bridge-app/src/renderer/components/BridgeControls.tsx
@@ -5,9 +5,11 @@ import type { BridgeStatus } from '../../shared/types.js';
 interface BridgeControlsProps {
   status: BridgeStatus;
   selectedEventCode: string | null;
+  /** Live join code (what guests use / the dashboard shows) for display. */
+  joinCode: string | null;
 }
 
-export function BridgeControls({ status, selectedEventCode }: BridgeControlsProps) {
+export function BridgeControls({ status, selectedEventCode, joinCode }: BridgeControlsProps) {
   const [starting, setStarting] = useState(false);
   const [stopping, setStopping] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -75,7 +77,7 @@ export function BridgeControls({ status, selectedEventCode }: BridgeControlsProp
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             <span className="status-dot status-dot-green" />
-            <span>Running for event <strong>{status.eventCode}</strong></span>
+            <span>Running for event <strong>{joinCode ?? status.eventCode}</strong></span>
           </div>
           <button className="btn btn-danger btn-sm" onClick={handleStop} disabled={busy}>
             {stopping ? 'Stopping...' : 'Stop Bridge'}

--- a/bridge-app/src/renderer/components/EventSelector.tsx
+++ b/bridge-app/src/renderer/components/EventSelector.tsx
@@ -102,7 +102,7 @@ export function EventSelector({ selectedCode, onSelect, onEventRemoved }: EventS
             onClick={() => onSelect(event)}
           >
             <span className="event-item-name">{event.name}</span>
-            <span className="event-item-code">{event.code}</span>
+            <span className="event-item-code">{event.joinCode}</span>
           </div>
         ))}
       </div>

--- a/bridge-app/src/renderer/components/StatusPanel.tsx
+++ b/bridge-app/src/renderer/components/StatusPanel.tsx
@@ -2,9 +2,11 @@ import type { BridgeStatus } from '../../shared/types.js';
 
 interface StatusPanelProps {
   status: BridgeStatus;
+  /** Live join code (what guests use / the dashboard shows) for display. */
+  joinCode: string | null;
 }
 
-export function StatusPanel({ status }: StatusPanelProps) {
+export function StatusPanel({ status, joinCode }: StatusPanelProps) {
   if (!status.isRunning) {
     return null;
   }
@@ -41,7 +43,7 @@ export function StatusPanel({ status }: StatusPanelProps) {
           </div>
           <div className="status-item">
             <div className="status-item-label">Event</div>
-            <div className="status-item-value">{status.eventCode || '-'}</div>
+            <div className="status-item-value">{joinCode || status.eventCode || '-'}</div>
           </div>
         </div>
 

--- a/bridge-app/src/renderer/running-join-code.ts
+++ b/bridge-app/src/renderer/running-join-code.ts
@@ -1,0 +1,22 @@
+import type { EventInfo } from '../shared/types.js';
+
+/**
+ * Pick the join code to display for the *running* bridge.
+ *
+ * The running bridge's authoritative identifier is its collection code
+ * (`status.eventCode`). The join code lives on the selected event, but the
+ * event list stays clickable while the bridge runs — so the selection can
+ * diverge from what's actually running. Only surface the selected event's join
+ * code when it still matches the running event; otherwise return null so the
+ * caller falls back to the authoritative running code rather than showing a
+ * different event's join code.
+ */
+export function runningJoinCode(
+  selectedEvent: EventInfo | null,
+  runningEventCode: string | null,
+): string | null {
+  if (!selectedEvent || runningEventCode === null) {
+    return null;
+  }
+  return selectedEvent.code === runningEventCode ? selectedEvent.joinCode : null;
+}

--- a/bridge-app/src/shared/types.ts
+++ b/bridge-app/src/shared/types.ts
@@ -93,7 +93,10 @@ export interface PluginMeta {
 /** Event info from the backend */
 export interface EventInfo {
   readonly id: number;
+  /** Internal collection code — the identifier the bridge API resolves by. */
   readonly code: string;
+  /** Live join code (QR target) — the code guests use and the DJ dashboard shows. */
+  readonly joinCode: string;
   readonly name: string;
   readonly isActive: boolean;
   readonly expiresAt: string;


### PR DESCRIPTION
## Why
In the bridge app the DJ sees the **collection code** (e.g. `4GX43T`) for an event, but the DJ dashboard and guest join flow use the **join code** (e.g. `RMLNDZ`) for that same event. The codes don't match, so the DJ can't tell guests the right one. (Observed on event "testing bridge" / id 16.)

## What
`events-service.ts` mapped only `code` from `GET /api/events` and dropped `join_code`, and the UI rendered that collection code. `EventOut` already exposes `join_code`, so this is a **bridge-app-only** change.

The bridge API endpoints (`/api/bridge/nowplaying`, `/status`, command queue) legitimately resolve by the collection `code`, so the bridge still **sends** `code` on the wire — only the display changes:
- `EventInfo` / `fetchEvents` now carry `join_code` → `joinCode`.
- `EventSelector`, `BridgeControls`, and `StatusPanel` render `joinCode`; event selection and bridge start/stop still key on the collection `code`.

Independent of the now-playing matching fix (#500 / PR #501).

## Testing
- [x] `events-service` unit test updated/passing (asserts `joinCode` is surfaced)
- [x] `npx tsc --noEmit` clean (bridge + bridge-app deps installed)
- [x] `npx vitest run` — 73 passed
- [ ] Manual: confirm bridge app shows the same code as the dashboard
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #502.