### PR TITLE
fix(tidal): persist manual-sync result so the dashboard chip turns green

### DIFF
--- a/server/app/services/tidal.py
+++ b/server/app/services/tidal.py
@@ -657,7 +657,7 @@ def _record_tidal_sync_result(
     except (json.JSONDecodeError, TypeError):
         entries = []
 
-    entries = [e for e in entries if e.get("service") != "tidal"]
+    entries = [e for e in entries if isinstance(e, dict) and e.get("service") != "tidal"]
     entries.append(
         {
             "service": "tidal",

--- a/server/app/services/tidal.py
+++ b/server/app/services/tidal.py
@@ -5,6 +5,7 @@ Third-party OAuth scopes don't have access to playlist creation,
 so we use tidalapi's device login which has first-party credentials.
 """
 
+import json
 import logging
 import threading
 from dataclasses import dataclass, field
@@ -19,6 +20,7 @@ from app.models.event import Event
 from app.models.request import Request, RequestStatus, TidalSyncStatus
 from app.models.user import User
 from app.schemas.tidal import TidalSearchResult, TidalSyncResult
+from app.services.sync.base import SyncStatus
 from app.services.track_normalizer import artist_match_score, primary_artist
 
 logger = logging.getLogger(__name__)
@@ -632,6 +634,42 @@ def poll_tidal_collection_removals(db: Session, event: Event) -> int:
     return count
 
 
+def _record_tidal_sync_result(
+    request: Request,
+    status: SyncStatus,
+    *,
+    url: str | None = None,
+    track_id: str | None = None,
+    error: str | None = None,
+) -> None:
+    """Upsert this request's Tidal entry in sync_results_json.
+
+    The dashboard badge renders from sync_results_json. The multi-service
+    orchestrator writes it on auto-sync; the manual retry path (sync_request_to_tidal)
+    must do the same, or a retry that actually succeeds never turns the chip green.
+    Uses the same status vocabulary ("added"/"not_found"/"error") so both paths
+    render identically.
+    """
+    try:
+        entries = json.loads(request.sync_results_json) if request.sync_results_json else []
+        if not isinstance(entries, list):
+            entries = []
+    except (json.JSONDecodeError, TypeError):
+        entries = []
+
+    entries = [e for e in entries if e.get("service") != "tidal"]
+    entries.append(
+        {
+            "service": "tidal",
+            "status": status.value,
+            "url": url,
+            "track_id": track_id,
+            "error": error,
+        }
+    )
+    request.sync_results_json = json.dumps(entries)
+
+
 def sync_request_to_tidal(
     db: Session,
     request: Request,
@@ -664,6 +702,8 @@ def sync_request_to_tidal(
 
     track = search_track(db, user, request.artist, request.song_title)
     if not track:
+        _record_tidal_sync_result(request, SyncStatus.NOT_FOUND, error="Track not found on Tidal")
+        db.commit()
         return TidalSyncResult(
             request_id=request.id,
             status=TidalSyncStatus.NOT_FOUND,
@@ -671,6 +711,9 @@ def sync_request_to_tidal(
         )
 
     if add_track_to_playlist(db, user, playlist_id, track.track_id):
+        _record_tidal_sync_result(
+            request, SyncStatus.ADDED, url=track.tidal_url, track_id=track.track_id
+        )
         db.commit()
         return TidalSyncResult(
             request_id=request.id,
@@ -678,6 +721,10 @@ def sync_request_to_tidal(
             tidal_track_id=track.track_id,
         )
     else:
+        _record_tidal_sync_result(
+            request, SyncStatus.ERROR, error="Failed to add track to playlist"
+        )
+        db.commit()
         return TidalSyncResult(
             request_id=request.id,
             status=TidalSyncStatus.ERROR,

--- a/server/tests/test_tidal.py
+++ b/server/tests/test_tidal.py
@@ -425,6 +425,70 @@ class TestTidalSyncPipeline:
         assert result.status == TidalSyncStatus.ERROR
         assert "add track" in result.error.lower()
 
+    @patch("app.services.tidal.add_track_to_playlist")
+    @patch("app.services.tidal.search_track")
+    @patch("app.services.tidal.create_event_playlist")
+    def test_successful_sync_updates_sync_results_json_to_added(
+        self,
+        mock_create_playlist: MagicMock,
+        mock_search: MagicMock,
+        mock_add: MagicMock,
+        db: Session,
+        tidal_request: Request,
+    ):
+        """A successful manual sync must replace a stale error entry with 'added'.
+
+        The dashboard badge renders from sync_results_json; without this the chip
+        stays red after a retry that actually succeeded (feedback loop missing on
+        the manual path).
+        """
+        import json
+
+        tidal_request.sync_results_json = json.dumps(
+            [{"service": "tidal", "status": "error", "error": "old failure"}]
+        )
+        db.commit()
+
+        mock_create_playlist.return_value = "playlist123"
+        mock_search.return_value = TidalSearchResult(
+            track_id="track789",
+            title="Test Song",
+            artist="Test Artist",
+            tidal_url="https://tidal.com/browse/track/track789",
+        )
+        mock_add.return_value = True
+
+        result = sync_request_to_tidal(db, tidal_request)
+
+        assert result.status == TidalSyncStatus.SYNCED
+        entries = json.loads(tidal_request.sync_results_json)
+        tidal_entries = [e for e in entries if e["service"] == "tidal"]
+        assert len(tidal_entries) == 1  # upsert, not appended twice
+        assert tidal_entries[0]["status"] == "added"
+        assert tidal_entries[0]["url"] == "https://tidal.com/browse/track/track789"
+
+    @patch("app.services.tidal.search_track")
+    @patch("app.services.tidal.create_event_playlist")
+    def test_not_found_sync_updates_sync_results_json(
+        self,
+        mock_create_playlist: MagicMock,
+        mock_search: MagicMock,
+        db: Session,
+        tidal_request: Request,
+    ):
+        """A not-found manual sync records 'not_found' so the badge shows T?."""
+        import json
+
+        mock_create_playlist.return_value = "playlist123"
+        mock_search.return_value = None
+
+        result = sync_request_to_tidal(db, tidal_request)
+
+        assert result.status == TidalSyncStatus.NOT_FOUND
+        entries = json.loads(tidal_request.sync_results_json)
+        tidal_entry = next(e for e in entries if e["service"] == "tidal")
+        assert tidal_entry["status"] == "not_found"
+
 
 class TestPlaylistSelfHeal:
     """A stored Tidal playlist deleted out-of-band must self-heal, not fail forever.

--- a/server/tests/test_tidal.py
+++ b/server/tests/test_tidal.py
@@ -11,6 +11,7 @@ from app.models.event import Event
 from app.models.request import Request, RequestStatus, TidalSyncStatus
 from app.models.user import User
 from app.schemas.tidal import TidalSearchResult
+from app.services.sync.base import SyncStatus
 from app.services.tidal import (
     _track_to_result,
     cancel_device_login,
@@ -488,6 +489,26 @@ class TestTidalSyncPipeline:
         entries = json.loads(tidal_request.sync_results_json)
         tidal_entry = next(e for e in entries if e["service"] == "tidal")
         assert tidal_entry["status"] == "not_found"
+
+    def test_record_tidal_sync_result_tolerates_non_dict_entries(self):
+        """Upsert must not crash on corrupt/legacy sync_results_json with non-dict items."""
+        import json
+
+        from app.services.tidal import _record_tidal_sync_result
+
+        request = MagicMock()
+        request.sync_results_json = json.dumps(
+            ["corrupt-string", {"service": "tidal", "status": "error"}, {"service": "beatport"}]
+        )
+
+        _record_tidal_sync_result(request, SyncStatus.ADDED, url="u", track_id="t")
+
+        entries = json.loads(request.sync_results_json)
+        tidal = [e for e in entries if isinstance(e, dict) and e.get("service") == "tidal"]
+        assert len(tidal) == 1
+        assert tidal[0]["status"] == "added"
+        # other services' entries are preserved
+        assert any(isinstance(e, dict) and e.get("service") == "beatport" for e in entries)
 
 
 class TestPlaylistSelfHeal:


### PR DESCRIPTION
## Why
Follow-up to #510. The self-heal fix made the manual **T!** retry actually sync the track (and de-dupe), but the chip stayed red — no feedback that it worked. The badge renders from `request.sync_results_json` (status `"added"` → green **T**); the multi-service orchestrator writes that field on auto-sync, but the manual retry path (`sync_request_to_tidal`) committed the track without ever updating `sync_results_json`, so a successful retry left the stale `"error"` entry and the post-sync reload kept showing red. One direction (sync) was migrated to the orchestrator; the other (feedback persistence) was not.

## What
`sync_request_to_tidal` now upserts its outcome (`added` / `not_found` / `error`) into `sync_results_json` using the same status vocabulary as the orchestrator, then commits. The frontend's existing post-sync reload flips the chip correctly in every direction (green **T** / **T?** / red **T!**). Backend-only — no frontend change, no API contract change, no migration.

## Testing
- [x] New regression tests: stale `error` entry flips to `added`+url on success; `not_found` recorded on miss (fail-first, then pass)
- [x] Full backend suite: 3088 passed, coverage 88.78% (gate 85%)
- [x] ruff check + format + bandit clean; no import cycle
- [ ] Manual verification: click red **T!** on a live event — track syncs **and** chip turns green
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #511.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tidal sync operations now properly update existing sync result records to avoid duplicate entries.
  * Tidal sync results now reliably capture outcome details (including track URL and error information).

* **Tests**
  * Added coverage to verify sync-result recording behavior for successful upserts, not-found cases, and robustness against legacy or corrupted saved sync-result JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->