### PR TITLE
fix(kiosk): use public event search endpoint so kiosk song search works

### DIFF
--- a/dashboard/app/e/[code]/display/components/RequestModal.tsx
+++ b/dashboard/app/e/[code]/display/components/RequestModal.tsx
@@ -18,6 +18,8 @@ export function RequestModal({ code, onClose, onRequestsClosed }: RequestModalPr
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [searching, setSearching] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
   const [selectedSong, setSelectedSong] = useState<SearchResult | null>(null);
   const [note, setNote] = useState('');
   const [nickname, setNickname] = useState('');
@@ -102,12 +104,17 @@ export function RequestModal({ code, onClose, onRequestsClosed }: RequestModalPr
 
     setSearching(true);
     setSearchResults([]);
+    setSearchError(null);
     try {
-      const results = await api.search(searchQuery);
+      // Public guest endpoint — the kiosk has no DJ login. Using api.search()
+      // (the DJ-only /api/search) here returned 401 and silently showed nothing.
+      const results = await api.eventSearch(code, searchQuery);
       setSearchResults(results);
     } catch {
       setSearchResults([]);
+      setSearchError('Search failed — please try again.');
     } finally {
+      setHasSearched(true);
       setSearching(false);
     }
   };
@@ -300,6 +307,10 @@ export function RequestModal({ code, onClose, onRequestsClosed }: RequestModalPr
                 {searching ? '...' : 'Search'}
               </button>
             </form>
+            {searchError && <p className="search-feedback search-feedback-error">{searchError}</p>}
+            {!searchError && hasSearched && !searching && searchResults.length === 0 && (
+              <p className="search-feedback">No songs found</p>
+            )}
             {searchResults.length > 0 && (
               <div className={`search-results${showKeyboard ? ' search-results-compact' : ''}`}>
                 {searchResults.map((result, index) => (

--- a/dashboard/app/e/[code]/display/components/__tests__/RequestModal.test.tsx
+++ b/dashboard/app/e/[code]/display/components/__tests__/RequestModal.test.tsx
@@ -23,6 +23,7 @@ vi.mock('simple-keyboard', () => ({
 vi.mock('@/lib/api', () => ({
   api: {
     search: vi.fn(),
+    eventSearch: vi.fn(),
     submitRequest: vi.fn(),
   },
   ApiError: class ApiError extends Error {
@@ -88,11 +89,11 @@ describe('RequestModal', () => {
     await act(async () => {
       fireEvent.submit(screen.getByRole('button', { name: 'Search' }));
     });
-    expect(api.search).not.toHaveBeenCalled();
+    expect(api.eventSearch).not.toHaveBeenCalled();
   });
 
   it('searches and displays results', async () => {
-    vi.mocked(api.search).mockResolvedValue(mockResults);
+    vi.mocked(api.eventSearch).mockResolvedValue(mockResults);
 
     renderModal();
 
@@ -103,14 +104,34 @@ describe('RequestModal', () => {
       fireEvent.submit(screen.getByRole('button', { name: 'Search' }));
     });
 
-    expect(api.search).toHaveBeenCalledWith('strobe');
+    expect(api.eventSearch).toHaveBeenCalledWith('TEST01', 'strobe');
     expect(screen.getByText('Strobe')).toBeInTheDocument();
     expect(screen.getByText('deadmau5')).toBeInTheDocument();
     expect(screen.getByText('Levels')).toBeInTheDocument();
   });
 
-  it('handles search error gracefully', async () => {
-    vi.mocked(api.search).mockRejectedValue(new Error('Network error'));
+  // Regression: the kiosk is an un-authenticated guest device. It previously
+  // called api.search() (the DJ-only /api/search, which 401s without a JWT),
+  // so search silently returned nothing. It must call the PUBLIC event endpoint
+  // (api.eventSearch) with the event code, and never the DJ-only api.search.
+  it('searches via the public event endpoint, not the DJ-only endpoint', async () => {
+    vi.mocked(api.eventSearch).mockResolvedValue(mockResults);
+
+    renderModal();
+
+    fireEvent.change(screen.getByPlaceholderText('Search for a song...'), {
+      target: { value: 'strobe' },
+    });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: 'Search' }));
+    });
+
+    expect(api.eventSearch).toHaveBeenCalledWith('TEST01', 'strobe');
+    expect(api.search).not.toHaveBeenCalled();
+  });
+
+  it('shows an error message when search fails', async () => {
+    vi.mocked(api.eventSearch).mockRejectedValue(new Error('Network error'));
 
     renderModal();
 
@@ -121,12 +142,28 @@ describe('RequestModal', () => {
       fireEvent.submit(screen.getByRole('button', { name: 'Search' }));
     });
 
-    // Should not crash — results are empty
+    // Should not crash, no results, and a visible error (no longer silent)
     expect(screen.queryByText('Strobe')).not.toBeInTheDocument();
+    expect(screen.getByText('Search failed — please try again.')).toBeInTheDocument();
+  });
+
+  it('shows "No songs found" when search returns no results', async () => {
+    vi.mocked(api.eventSearch).mockResolvedValue([]);
+
+    renderModal();
+
+    fireEvent.change(screen.getByPlaceholderText('Search for a song...'), {
+      target: { value: 'asdfqwer' },
+    });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: 'Search' }));
+    });
+
+    expect(screen.getByText('No songs found')).toBeInTheDocument();
   });
 
   it('selects a song and shows confirmation view', async () => {
-    vi.mocked(api.search).mockResolvedValue(mockResults);
+    vi.mocked(api.eventSearch).mockResolvedValue(mockResults);
 
     renderModal();
 
@@ -148,7 +185,7 @@ describe('RequestModal', () => {
   });
 
   it('goes back from confirmation to search results', async () => {
-    vi.mocked(api.search).mockResolvedValue(mockResults);
+    vi.mocked(api.eventSearch).mockResolvedValue(mockResults);
 
     renderModal();
 
@@ -167,7 +204,7 @@ describe('RequestModal', () => {
   });
 
   it('submits request and shows success message', async () => {
-    vi.mocked(api.search).mockResolvedValue(mockResults);
+    vi.mocked(api.eventSearch).mockResolvedValue(mockResults);
     vi.mocked(api.submitRequest).mockResolvedValue({
       id: 1,
       artist: 'deadmau5',
@@ -195,7 +232,7 @@ describe('RequestModal', () => {
   });
 
   it('shows "Vote Added!" for duplicate requests', async () => {
-    vi.mocked(api.search).mockResolvedValue(mockResults);
+    vi.mocked(api.eventSearch).mockResolvedValue(mockResults);
     vi.mocked(api.submitRequest).mockResolvedValue({
       id: 1,
       artist: 'deadmau5',
@@ -224,7 +261,7 @@ describe('RequestModal', () => {
   });
 
   it('auto-closes after 2.5s on success', async () => {
-    vi.mocked(api.search).mockResolvedValue(mockResults);
+    vi.mocked(api.eventSearch).mockResolvedValue(mockResults);
     vi.mocked(api.submitRequest).mockResolvedValue({
       id: 1,
       artist: 'deadmau5',
@@ -259,7 +296,7 @@ describe('RequestModal', () => {
   });
 
   it('calls onRequestsClosed on 403 error', async () => {
-    vi.mocked(api.search).mockResolvedValue(mockResults);
+    vi.mocked(api.eventSearch).mockResolvedValue(mockResults);
     vi.mocked(api.submitRequest).mockRejectedValue(
       new (ApiError as unknown as new (msg: string, status: number) => Error)('Requests closed', 403)
     );
@@ -345,7 +382,7 @@ describe('RequestModal', () => {
     });
 
     it('keeps keyboard visible after search so touch-through does not close modal', async () => {
-      vi.mocked(api.search).mockResolvedValue(mockResults);
+      vi.mocked(api.eventSearch).mockResolvedValue(mockResults);
 
       const { container } = renderModal();
 
@@ -367,7 +404,7 @@ describe('RequestModal', () => {
     });
 
     it('shows keyboard for note input after selecting a song', async () => {
-      vi.mocked(api.search).mockResolvedValue(mockResults);
+      vi.mocked(api.eventSearch).mockResolvedValue(mockResults);
 
       const { container } = renderModal();
 
@@ -387,7 +424,7 @@ describe('RequestModal', () => {
     });
 
     it('labels keyboard done key "Submit" on confirm view to trigger submission', async () => {
-      vi.mocked(api.search).mockResolvedValue(mockResults);
+      vi.mocked(api.eventSearch).mockResolvedValue(mockResults);
 
       renderModal();
 
@@ -420,7 +457,7 @@ describe('RequestModal', () => {
   });
 
   it('renders placeholder icon for results without album art', async () => {
-    vi.mocked(api.search).mockResolvedValue([
+    vi.mocked(api.eventSearch).mockResolvedValue([
       {
         title: 'No Art Song', artist: 'Unknown', spotify_id: 'sp3', url: null, album_art: null,
         album: null, popularity: 0, preview_url: null, source: 'spotify' as const,

--- a/dashboard/app/e/[code]/display/page.tsx
+++ b/dashboard/app/e/[code]/display/page.tsx
@@ -962,6 +962,15 @@ export default function KioskDisplayPage() {
           gap: 0.5rem;
           margin-bottom: 1rem;
         }
+        .search-feedback {
+          margin: 0.5rem 0 1rem;
+          text-align: center;
+          color: #9ca3af;
+          font-size: 1rem;
+        }
+        .search-feedback-error {
+          color: #f87171;
+        }
         .search-input {
           flex: 1;
           background: #374151;


### PR DESCRIPTION
## Problem

On the Raspberry Pi kiosk display, a guest could touch the screen, the on-screen keyboard popped up, and they could type a query — but firing the search did **nothing**: no results, no error, no feedback.

## Root cause

The kiosk request modal called `api.search()` → `GET /api/search`, the **DJ-only** endpoint gated by `Depends(get_current_active_user)` (`server/app/api/search.py`). The kiosk is an un-authenticated guest device with no JWT, so every search returned **401 Unauthorized** — and `handleSearch`'s empty `catch {}` swallowed it (`setSearchResults([])`). The results block only renders when `searchResults.length > 0`, so the screen showed nothing.

This was inconsistent with the modal's own (already-working) `submitRequest`, which correctly uses the public event endpoint.

## Fix

- Search now calls `api.eventSearch(code, query)` → the **public** `GET /api/events/{code}/search` endpoint — the same one `submitRequest` uses. It succeeds for anonymous guests under the current soft-mode human-verification gate (`SystemSettings.human_verification_enforced` defaults to `False`).
- Added visible feedback so failures/empty results are no longer silent: a **"Search failed — please try again."** error and a **"No songs found"** empty state (dark-theme styled-jsx, no Tailwind).

### Files
- `dashboard/app/e/[code]/display/components/RequestModal.tsx` — endpoint swap + `searchError`/`hasSearched` state
- `dashboard/app/e/[code]/display/page.tsx` — `.search-feedback` / `.search-feedback-error` styles
- `dashboard/app/e/[code]/display/components/__tests__/RequestModal.test.tsx` — repointed mocks/assertions, regression test, feedback tests

## Out of scope (noted)

If `human_verification_enforced` is ever flipped to `True`, the kiosk would 403 on both search **and** submit (no `wrzdj_human` cookie / no Turnstile flow). That is a **pre-existing** condition affecting the already-deployed submit path equally — a separate follow-up (e.g. exempt paired kiosks via `X-Kiosk-Session`, or an invisible-Turnstile bootstrap).

## Test plan

- [x] `npm test -- --run RequestModal` → 19/19 pass (incl. regression test asserting the public endpoint is hit and `api.search` is never called, plus error/empty-state tests)
- [x] `npx tsc --noEmit` → clean
- [x] `npm run lint` → clean
- [ ] Manual: load `/e/{code}/display`, open request modal, type a query, submit → results render; gibberish → "No songs found"; backend down → "Search failed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visible error messages when search queries fail.
  * Improved empty results messaging to display only after a search attempt.

* **Tests**
  * Updated test coverage for search error handling and result messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->