### PR TITLE
fix(kiosk): bypass human-verification gate for paired kiosks so song search works

### DIFF
--- a/dashboard/app/e/[code]/display/__tests__/no-identify.test.tsx
+++ b/dashboard/app/e/[code]/display/__tests__/no-identify.test.tsx
@@ -59,6 +59,7 @@ vi.mock('@/lib/api', () => ({
     getNowPlaying: vi.fn().mockResolvedValue(null),
     getPlayHistory: vi.fn().mockResolvedValue({ items: [] }),
     getKioskAssignment: vi.fn(),
+    setKioskSession: vi.fn(),
   },
   ApiError: class extends Error { status = 0; },
   PUBLIC_PAGE_MAX: 500,

--- a/dashboard/app/e/[code]/display/page.test.tsx
+++ b/dashboard/app/e/[code]/display/page.test.tsx
@@ -82,6 +82,7 @@ vi.mock('@/lib/api', () => ({
     getNowPlaying: vi.fn(),
     getPlayHistory: vi.fn(),
     getKioskAssignment: vi.fn(),
+    setKioskSession: vi.fn(),
     search: vi.fn(),
     submitRequest: vi.fn(),
   },

--- a/dashboard/app/e/[code]/display/page.tsx
+++ b/dashboard/app/e/[code]/display/page.tsx
@@ -139,6 +139,18 @@ export default function KioskDisplayPage() {
     onBridgeStatusChanged: () => { loadDisplayRef.current(); },
   });
 
+  // Register the kiosk's session token with the API client so the request
+  // modal's search/submit calls carry X-Kiosk-Session and bypass the guest
+  // human-verification gate (issue #514). Cleared on unmount so the token never
+  // leaks into a non-kiosk client.
+  useEffect(() => {
+    const token = typeof window !== 'undefined'
+      ? localStorage.getItem(SESSION_TOKEN_KEY)
+      : null;
+    api.setKioskSession(token);
+    return () => api.setKioskSession(null);
+  }, []);
+
   // Check kiosk session validity — detect unpair
   useEffect(() => {
     const token = typeof window !== 'undefined'

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -176,6 +176,49 @@ describe('ApiClient', () => {
     });
   });
 
+  // A kiosk is a trusted DJ-paired device with no JWT and no human-verification
+  // cookie. It identifies itself with its X-Kiosk-Session token so the public
+  // event endpoints bypass the human gate (issue #514). Normal guest/DJ flows
+  // must NOT send the header.
+  describe('kiosk session header', () => {
+    afterEach(() => {
+      api.setKioskSession(null);
+    });
+
+    it('eventSearch sends X-Kiosk-Session when a kiosk session is set', async () => {
+      api.setKioskSession('kiosk-token-abc');
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+      await api.eventSearch('JOIN42', 'strobe');
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/events/JOIN42/search');
+      expect(options.headers['X-Kiosk-Session']).toBe('kiosk-token-abc');
+    });
+
+    it('submitRequest sends X-Kiosk-Session when a kiosk session is set', async () => {
+      api.setKioskSession('kiosk-token-abc');
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 1, artist: 'A', song_title: 'T', status: 'new' }),
+      });
+
+      await api.submitRequest('JOIN42', 'deadmau5', 'Strobe');
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.headers['X-Kiosk-Session']).toBe('kiosk-token-abc');
+    });
+
+    it('omits X-Kiosk-Session for normal guest/DJ flows (no kiosk session)', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+      await api.eventSearch('JOIN42', 'strobe');
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.headers['X-Kiosk-Session']).toBeUndefined();
+    });
+  });
+
   describe('getPlayHistory', () => {
     it('fetches play history with default parameters', async () => {
       const mockHistoryResponse = {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -415,10 +415,22 @@ function getApiUrl(): string {
 
 class ApiClient {
   private token: string | null = null;
+  private kioskSession: string | null = null;
   private onUnauthorized: (() => void) | null = null;
 
   setToken(token: string | null) {
     this.token = token;
+  }
+
+  /**
+   * Register the kiosk's session token. A paired kiosk is a trusted physical
+   * device with no JWT and no human-verification cookie, so it sends this token
+   * as X-Kiosk-Session on the public event search/submit endpoints to bypass
+   * the guest human-verification gate (issue #514). Set once on the kiosk
+   * display page; null on every other client.
+   */
+  setKioskSession(token: string | null) {
+    this.kioskSession = token;
   }
 
   /**
@@ -1096,6 +1108,7 @@ class ApiClient {
   ): Promise<SongRequest> {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     if (this.token) headers['Authorization'] = `Bearer ${this.token}`;
+    if (this.kioskSession) headers['X-Kiosk-Session'] = this.kioskSession;
     const doFetch = () =>
       fetch(`${getApiUrl()}/api/events/${code}/requests`, {
         method: 'POST',
@@ -1144,6 +1157,7 @@ class ApiClient {
       // have no token and fall through to the cookie-based gate + reverify retry.
       const headers: Record<string, string> = {};
       if (this.token) headers['Authorization'] = `Bearer ${this.token}`;
+      if (this.kioskSession) headers['X-Kiosk-Session'] = this.kioskSession;
       return fetch(`${getApiUrl()}/api/events/${code}/search?q=${encodeURIComponent(query)}`, {
         credentials: 'include',
         headers,

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -91,6 +91,7 @@ from app.services.export import (
     generate_export_filename,
     generate_play_history_export_filename,
 )
+from app.services.kiosk import is_trusted_kiosk_for_event
 from app.services.now_playing import (
     get_manual_hide_setting,
     get_play_history,
@@ -439,10 +440,13 @@ def event_search(
     if lookup_result in (EventLookupResult.EXPIRED, EventLookupResult.ARCHIVED):
         raise HTTPException(status_code=410, detail="Event has expired")
 
-    # Owner (authenticated DJ) bypasses the guest human-verification gate;
-    # everyone else still passes through it (soft- or enforced-mode).
+    # The authenticated owner AND a paired kiosk (a trusted physical device on
+    # this event) both bypass the guest human-verification gate. The kiosk holds
+    # no JWT and no wrzdj_human cookie, so without this an enforced gate 403s
+    # every kiosk search (issue #514). Everyone else passes through the gate.
     is_owner = current_user is not None and current_user.id == event_obj.created_by_user_id
-    if not is_owner:
+    is_kiosk = is_trusted_kiosk_for_event(db, request.headers.get("X-Kiosk-Session"), event_obj)
+    if not is_owner and not is_kiosk:
         require_verified_human_soft(request, response, db)
 
     sys_settings = get_system_settings(db)
@@ -674,12 +678,14 @@ def submit_request(
     if lookup_result == EventLookupResult.ARCHIVED:
         raise HTTPException(status_code=410, detail="Event has been archived")
 
-    # Owner (authenticated DJ) bypasses the guest human-verification gate; the DJ
-    # dashboard "Add" button in the song-search modal reuses this endpoint and the
-    # DJ holds a JWT but no guest wrzdj_human cookie, so an enforced gate would 403
-    # them on their own event. Everyone else still passes through it (soft/enforced).
+    # The authenticated owner (DJ dashboard "Add" button) AND a paired kiosk (a
+    # trusted physical device on this event) both bypass the guest
+    # human-verification gate. Neither holds a wrzdj_human cookie, so an enforced
+    # gate would 403 them — the kiosk submit path included (issue #514). Everyone
+    # else still passes through it (soft/enforced).
     is_owner = current_user is not None and current_user.id == event.created_by_user_id
-    if not is_owner:
+    is_kiosk = is_trusted_kiosk_for_event(db, request.headers.get("X-Kiosk-Session"), event)
+    if not is_owner and not is_kiosk:
         require_verified_human_soft(request, response, db)
 
     if not event.requests_open:

--- a/server/app/services/kiosk.py
+++ b/server/app/services/kiosk.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from sqlalchemy.orm import Session
 
 from app.core.time import utcnow
+from app.models.event import Event
 from app.models.kiosk import Kiosk
 
 # Same safe alphabet as event codes — no O/0/I/1
@@ -57,6 +58,21 @@ def get_kiosk_by_pair_code(db: Session, code: str) -> Kiosk | None:
 def get_kiosk_by_session_token(db: Session, token: str) -> Kiosk | None:
     """Find a kiosk by its session token."""
     return db.query(Kiosk).filter(Kiosk.session_token == token).first()
+
+
+def is_trusted_kiosk_for_event(db: Session, session_token: str | None, event: Event) -> bool:
+    """True when `session_token` identifies an active kiosk paired to `event`.
+
+    A DJ-paired kiosk is a trusted physical device controlled by the event
+    owner, so — like the authenticated owner — it bypasses the guest
+    human-verification gate on public event endpoints. Scoped to the kiosk's
+    assigned event (its stored collection `code`) so one kiosk's token cannot
+    vouch for a different event, and only `active` kiosks qualify.
+    """
+    if not session_token:
+        return False
+    kiosk = get_kiosk_by_session_token(db, session_token)
+    return kiosk is not None and kiosk.status == "active" and kiosk.event_code == event.code
 
 
 def get_kiosk_by_id(db: Session, kiosk_id: int) -> Kiosk | None:

--- a/server/tests/test_kiosk_search_bypass.py
+++ b/server/tests/test_kiosk_search_bypass.py
@@ -1,0 +1,166 @@
+"""Kiosk song-search / submit under human-verification enforcement (issue #514).
+
+A DJ-paired kiosk is a trusted physical device: it holds a server-validated
+`session_token`, sent as the `X-Kiosk-Session` header (the same one it already
+uses to poll its event assignment). Like the authenticated event owner, an
+*active* kiosk paired to the event must bypass the guest human-verification
+gate — otherwise kiosk search/submit returns 403 in production once enforcement
+is on, which is exactly the bug PR #513 left behind (it fixed the older 401 from
+the DJ-only /api/search, but the kiosk then hit the 403 human gate instead).
+
+The bypass is scoped to the kiosk's assigned event so one kiosk's token can't
+vouch for a different event, and only `active` kiosks qualify.
+"""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.models.event import Event
+from app.models.kiosk import Kiosk
+from app.models.system_settings import SystemSettings
+from app.schemas.search import SearchResult
+
+KIOSK_HEADER = "X-Kiosk-Session"
+
+SPOTIFY_RESULT = SearchResult(
+    title="Strobe",
+    artist="deadmau5",
+    album="For Lack of a Better Name",
+    popularity=72,
+    spotify_id="sp_strobe",
+    source="spotify",
+)
+
+
+def _enforce(db: Session) -> None:
+    """Turn human-verification enforcement ON (the production posture)."""
+    sys_settings = db.query(SystemSettings).filter_by(id=1).first()
+    if sys_settings is None:
+        sys_settings = SystemSettings(id=1, human_verification_enforced=True)
+        db.add(sys_settings)
+    else:
+        sys_settings.human_verification_enforced = True
+    db.commit()
+
+
+def _make_kiosk(
+    db: Session,
+    *,
+    session_token: str,
+    event_code: str | None,
+    status: str = "active",
+    pair_code: str,
+) -> Kiosk:
+    kiosk = Kiosk(
+        pair_code=pair_code,
+        session_token=session_token,
+        event_code=event_code,
+        status=status,
+        pair_expires_at=utcnow() + timedelta(hours=1),
+    )
+    db.add(kiosk)
+    db.commit()
+    db.refresh(kiosk)
+    return kiosk
+
+
+class TestKioskSessionBypassesHumanGate:
+    @patch("app.services.spotify.search_songs")
+    def test_search_with_active_kiosk_session_bypasses_enforced_gate(
+        self, mock_search, client: TestClient, db: Session, test_event: Event
+    ):
+        _enforce(db)
+        mock_search.return_value = [SPOTIFY_RESULT]
+        _make_kiosk(
+            db, session_token="kiosk-tok-search", event_code=test_event.code, pair_code="KSK001"
+        )
+
+        # The kiosk reaches the event via its public join_code (its display URL),
+        # never the collection code — exactly like the real device.
+        response = client.get(
+            f"/api/events/{test_event.join_code}/search?q=deadmau5",
+            headers={KIOSK_HEADER: "kiosk-tok-search"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()[0]["title"] == "Strobe"
+
+    def test_submit_with_active_kiosk_session_bypasses_enforced_gate(
+        self, client: TestClient, db: Session, test_event: Event
+    ):
+        _enforce(db)
+        _make_kiosk(
+            db, session_token="kiosk-tok-submit", event_code=test_event.code, pair_code="KSK002"
+        )
+
+        response = client.post(
+            f"/api/events/{test_event.join_code}/requests",
+            json={
+                "title": "Strobe",
+                "artist": "deadmau5",
+                "source": "spotify",
+                "source_url": "https://open.spotify.com/track/x",
+            },
+            headers={KIOSK_HEADER: "kiosk-tok-submit"},
+        )
+
+        assert response.status_code in (200, 201)
+
+
+class TestKioskBypassIsScoped:
+    """The bypass must not become a blanket hole in the human gate."""
+
+    @patch("app.services.spotify.search_songs")
+    def test_search_unknown_kiosk_token_still_403(
+        self, mock_search, client: TestClient, db: Session, test_event: Event
+    ):
+        _enforce(db)
+        mock_search.return_value = [SPOTIFY_RESULT]
+
+        response = client.get(
+            f"/api/events/{test_event.join_code}/search?q=deadmau5",
+            headers={KIOSK_HEADER: "no-such-kiosk"},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "human_verification_required"
+
+    @patch("app.services.spotify.search_songs")
+    def test_search_kiosk_paired_to_other_event_still_403(
+        self, mock_search, client: TestClient, db: Session, test_event: Event
+    ):
+        _enforce(db)
+        mock_search.return_value = [SPOTIFY_RESULT]
+        _make_kiosk(db, session_token="kiosk-other-event", event_code="OTHER9", pair_code="KSK003")
+
+        response = client.get(
+            f"/api/events/{test_event.join_code}/search?q=deadmau5",
+            headers={KIOSK_HEADER: "kiosk-other-event"},
+        )
+
+        assert response.status_code == 403
+
+    @patch("app.services.spotify.search_songs")
+    def test_search_pairing_status_kiosk_still_403(
+        self, mock_search, client: TestClient, db: Session, test_event: Event
+    ):
+        _enforce(db)
+        mock_search.return_value = [SPOTIFY_RESULT]
+        _make_kiosk(
+            db,
+            session_token="kiosk-still-pairing",
+            event_code=test_event.code,
+            status="pairing",
+            pair_code="KSK004",
+        )
+
+        response = client.get(
+            f"/api/events/{test_event.join_code}/search?q=deadmau5",
+            headers={KIOSK_HEADER: "kiosk-still-pairing"},
+        )
+
+        assert response.status_code == 403


### PR DESCRIPTION
## Why
On the kiosk display (`/e/{join_code}/display`), the request modal shows the on-screen keyboard and accepts characters, but **song search errors** and a request can't be submitted. PR #513 was meant to fix this but didn't.

**Root cause (confirmed against production):** the kiosk is an **anonymous device** — no JWT, and no `wrzdj_human` cookie because it never runs the Turnstile flow. With `human_verification_enforced=True` in production, the two public event endpoints it calls both 403 it via `require_verified_human_soft`:

```
$ curl -s "https://api.wrzdj.com/api/events/4GX43T/search?q=strobe"
HTTP/2 403
{"detail":{"code":"human_verification_required"}}
```

PR #513 correctly fixed the *previous* layer (the modal called the DJ-only `/api/search`, which 401s without a JWT) — but the kiosk then hit the *next* wall: the 403 human gate. Both look identical in the UI, which is why search still appeared broken. The same gate also blocks `POST .../requests`, so the kiosk request flow was broken **end-to-end**, not just search.

## What
A DJ-paired kiosk is a **trusted physical device** with a server-validated `session_token` (already sent as `X-Kiosk-Session` to the assignment poll). This treats a valid kiosk session for the resolved event as a bypass of the human-verification gate — **exactly mirroring the existing authenticated-owner bypass**.

- **Backend** — new `is_trusted_kiosk_for_event(db, session_token, event)` helper in `services/kiosk.py`; both `event_search` and `submit_request` now bypass the gate for the owner **or** a trusted kiosk. Scoped to the kiosk's assigned event and to `active` kiosks only, so one kiosk's token can't vouch for another event.
- **Frontend** — `api.setKioskSession()` registered on the display page (cleared on unmount); `X-Kiosk-Session` sent on `eventSearch`/`submitRequest`. The header is already in the prod CORS `allow_headers` list, so no preflight gap.

## Testing
- [x] Backend: kiosk session bypasses the gate on search + submit under enforcement
- [x] Backend: unknown / wrong-event / not-yet-active kiosk tokens still 403 (bypass stays scoped)
- [x] Frontend: kiosk sends `X-Kiosk-Session` on search + submit; normal guest/DJ flows do not
- [x] Backend suite: 3091 passed, 88.80% coverage (gate 85%)
- [x] Frontend suite: 1352 passed; `tsc --noEmit` + ESLint clean
- [ ] Manual: on a paired kiosk, search returns results and a request submits
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #514.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Kiosk devices can now register and authenticate their sessions on startup
  * Authenticated kiosk devices bypass human verification when searching for songs and submitting requests, provided they're properly paired to the event

* **Tests**
  * Added test coverage for kiosk session authentication and human verification bypass behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->