### PR TITLE
docs: fix production secret docs (Fernet key + missing HUMAN_COOKIE_SECRET)

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,12 +362,11 @@ See `deploy/DEPLOYMENT.md` for full setup instructions.
 ENV=production
 DATABASE_URL=<PostgreSQL connection string>
 JWT_SECRET=<openssl rand -hex 32>
-TOKEN_ENCRYPTION_KEY=<openssl rand -hex 32>
+TOKEN_ENCRYPTION_KEY=<Fernet key: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())">
 SPOTIFY_CLIENT_ID / SPOTIFY_CLIENT_SECRET
 TIDAL_CLIENT_ID / TIDAL_CLIENT_SECRET
 BEATPORT_CLIENT_ID / BEATPORT_CLIENT_SECRET
 BRIDGE_API_KEY=<openssl rand -hex 32>
-ANTHROPIC_API_KEY=<optional, enables AI Assist recommendations>
 TURNSTILE_SITE_KEY / TURNSTILE_SECRET_KEY  # Cloudflare Turnstile (human verification + DJ self-reg)
 HUMAN_COOKIE_SECRET=<openssl rand -base64 32>  # signs wrzdj_human cookie
 RESEND_API_KEY  # email verification provider

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -33,6 +33,15 @@ JWT_SECRET=change-me-use-openssl-rand-hex-32
 TOKEN_ENCRYPTION_KEY=change-me-generate-fernet-key
 
 # =============================================================================
+# Human Verification Cookie
+# =============================================================================
+# REQUIRED in production. HMAC-SHA256 key for signing the wrzdj_human cookie
+# issued after Cloudflare Turnstile verification. Missing in production is a
+# fatal startup error.
+# Generate with: openssl rand -base64 32
+HUMAN_COOKIE_SECRET=change-me-generate-base64-32
+
+# =============================================================================
 # Spotify API (https://developer.spotify.com/dashboard)
 # =============================================================================
 SPOTIFY_CLIENT_ID=your-client-id

--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -29,7 +29,7 @@ cp deploy/.env.example deploy/.env
 #   POSTGRES_PASSWORD, JWT_SECRET, TOKEN_ENCRYPTION_KEY, HUMAN_COOKIE_SECRET,
 #   CORS_ORIGINS, PUBLIC_URL, NEXT_PUBLIC_API_URL
 # Optional integrations (leave blank if unused):
-#   SPOTIFY_*, TIDAL_*, BEATPORT_*, TURNSTILE_*, ANTHROPIC_API_KEY, RESEND_*, BRIDGE_API_KEY
+#   SPOTIFY_*, TIDAL_*, BEATPORT_*, TURNSTILE_*, RESEND_*, BRIDGE_API_KEY
 
 # 3. Deploy
 ./deploy/deploy-ghcr.sh              # pulls latest, restarts stack, waits for /health
@@ -164,7 +164,9 @@ openssl rand -hex 32
 Fill in all required values in `deploy/.env`:
 - `POSTGRES_PASSWORD` - secure database password
 - `JWT_SECRET` - generated secret above
-- `TOKEN_ENCRYPTION_KEY` - `openssl rand -hex 32` (Fernet key for OAuth tokens at rest)
+- `TOKEN_ENCRYPTION_KEY` - Fernet key for OAuth tokens at rest. Generate with:
+  `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`
+  (a 44-char url-safe-base64 key — **not** `openssl rand -hex 32`, which is rejected at startup)
 - `HUMAN_COOKIE_SECRET` - `openssl rand -base64 32` (signs `wrzdj_human` verification cookie)
 - `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` - Spotify Developer Dashboard
 - `TIDAL_CLIENT_ID` / `TIDAL_CLIENT_SECRET` - Tidal Developer Portal (playlist sync)
@@ -173,8 +175,11 @@ Fill in all required values in `deploy/.env`:
 - `TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY` - Cloudflare Turnstile (human verification + DJ self-reg CAPTCHA)
 - `RESEND_API_KEY` - Resend transactional email (guest email verification + cross-device merge)
 - `EMAIL_FROM_ADDRESS` - verified send-from address (e.g. `noreply@send.yourdomain.com`)
-- `ANTHROPIC_API_KEY` - optional, enables AI Assist recommendations
 - `SOUNDCHARTS_APP_ID` / `SOUNDCHARTS_API_KEY` - optional, third candidate source for recommendations
+
+> **Note:** `ANTHROPIC_API_KEY` no longer enables AI Assist. The env-var credential
+> path was removed in #343; LLM credentials now flow through the LLM Gateway connector
+> system (configured in-app, see `ARCHITECTURE.md`). Setting `ANTHROPIC_API_KEY` has no effect.
 
 ### 3. Configure nginx
 

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -220,6 +220,27 @@ def _fernet_key_error(key: str) -> str | None:
     return None
 
 
+def _fernet_key_list_error(keys: str, setting_name: str) -> str | None:
+    """Validate a comma-separated Fernet key list (rotation support).
+
+    Parses ``keys`` exactly as ``app.core.encryption._get_fernet`` does (strip
+    whitespace, drop empties) so validation mirrors what the runtime loads, then
+    shape-checks every remaining entry. Returns the first error (naming the
+    setting + 1-based entry index) or None. Empty/blank input → "no valid keys".
+    """
+    key_list = [key.strip() for key in keys.split(",") if key.strip()]
+    if not key_list:
+        return f"{setting_name} contains no valid keys. {_FERNET_KEY_HINT}"
+
+    # For a single key, keep the plain setting name; only a rotation list (>1
+    # entry) gets the "entry N" qualifier so operators can spot which key is bad.
+    for index, key in enumerate(key_list, start=1):
+        if error := _fernet_key_error(key):
+            target = setting_name if len(key_list) == 1 else f"{setting_name} entry {index}"
+            return error.replace("TOKEN_ENCRYPTION_KEY", target, 1)
+    return None
+
+
 def validate_settings(settings: Settings) -> None:
     """Validate required settings and print helpful error messages."""
     errors = []
@@ -233,9 +254,20 @@ def validate_settings(settings: Settings) -> None:
                 "CORS_ORIGINS should not be '*' in production - "
                 "set to your frontend domain (e.g., https://app.wrzdj.com)"
             )
-        if not settings.token_encryption_key:
-            errors.append(f"TOKEN_ENCRYPTION_KEY must be set in production. {_FERNET_KEY_HINT}")
-        elif fernet_error := _fernet_key_error(settings.token_encryption_key):
+        # Mirror app.core.encryption: prefer the rotation list, fall back to the
+        # single legacy key. Validate whichever source the runtime will load so a
+        # malformed rotation list fails at startup and a valid rotation-only
+        # config is not rejected as "missing".
+        token_keys = settings.token_encryption_keys or settings.token_encryption_key
+        token_keys_name = (
+            "TOKEN_ENCRYPTION_KEYS" if settings.token_encryption_keys else "TOKEN_ENCRYPTION_KEY"
+        )
+        if not token_keys:
+            errors.append(
+                "TOKEN_ENCRYPTION_KEY or TOKEN_ENCRYPTION_KEYS must be set in production. "
+                f"{_FERNET_KEY_HINT}"
+            )
+        elif fernet_error := _fernet_key_list_error(token_keys, token_keys_name):
             errors.append(fernet_error)
         if not settings.human_cookie_secret:
             errors.append(

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -191,6 +191,35 @@ class Settings(BaseSettings):
         return self.env == "production"
 
 
+_FERNET_KEY_HINT = (
+    'Generate with: python -c "from cryptography.fernet import Fernet; '
+    'print(Fernet.generate_key().decode())"'
+)
+
+
+def _fernet_key_error(key: str) -> str | None:
+    """Return an error message if ``key`` is non-empty but not a valid Fernet
+    key, else None. Empty input is ignored (presence is checked separately).
+
+    Uses the same ``Fernet`` constructor as ``app.core.encryption`` so the
+    accepted shape can never drift from what the runtime actually loads. This
+    catches a 64-char ``openssl rand -hex 32`` value at startup instead of at
+    the first OAuth token encryption (#504).
+    """
+    if not key:
+        return None
+    from cryptography.fernet import Fernet
+
+    try:
+        Fernet(key.encode())
+    except (ValueError, TypeError):
+        return (
+            "TOKEN_ENCRYPTION_KEY is not a valid Fernet key (must be 32 url-safe "
+            f"base64-encoded bytes = 44 chars; a hex string is rejected). {_FERNET_KEY_HINT}"
+        )
+    return None
+
+
 def validate_settings(settings: Settings) -> None:
     """Validate required settings and print helpful error messages."""
     errors = []
@@ -205,11 +234,9 @@ def validate_settings(settings: Settings) -> None:
                 "set to your frontend domain (e.g., https://app.wrzdj.com)"
             )
         if not settings.token_encryption_key:
-            errors.append(
-                "TOKEN_ENCRYPTION_KEY must be set in production. "
-                'Generate with: python -c "from cryptography.fernet import Fernet; '
-                'print(Fernet.generate_key().decode())"'
-            )
+            errors.append(f"TOKEN_ENCRYPTION_KEY must be set in production. {_FERNET_KEY_HINT}")
+        elif fernet_error := _fernet_key_error(settings.token_encryption_key):
+            errors.append(fernet_error)
         if not settings.human_cookie_secret:
             errors.append(
                 "HUMAN_COOKIE_SECRET must be set in production. "

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -4,8 +4,9 @@ import base64
 import secrets
 
 import pytest
+from cryptography.fernet import Fernet
 
-from app.core.config import Settings
+from app.core.config import Settings, _fernet_key_error, validate_settings
 
 
 def _make_settings(**overrides) -> Settings:
@@ -60,3 +61,47 @@ class TestEffectiveHumanCookieSecret:
         s = _make_settings(env="production", human_cookie_secret="")
         with pytest.raises(RuntimeError, match="HUMAN_COOKIE_SECRET"):
             _ = s.effective_human_cookie_secret
+
+
+class TestFernetKeyError:
+    """Shape-validate TOKEN_ENCRYPTION_KEY so a malformed key fails loud at
+    startup instead of crashing at the first OAuth token encryption (#504).
+    """
+
+    def test_valid_fernet_key_returns_none(self) -> None:
+        assert _fernet_key_error(Fernet.generate_key().decode()) is None
+
+    def test_hex_key_returns_error(self) -> None:
+        # `openssl rand -hex 32` → 64 hex chars: not a valid Fernet key.
+        hex_key = secrets.token_hex(32)
+        assert len(hex_key) == 64
+        err = _fernet_key_error(hex_key)
+        assert err is not None
+        assert "Fernet" in err
+
+    def test_empty_returns_none(self) -> None:
+        # Presence is checked separately; shape check ignores empty input.
+        assert _fernet_key_error("") is None
+
+
+class TestValidateSettingsFernetShape:
+    """validate_settings() must reject a hex TOKEN_ENCRYPTION_KEY in production."""
+
+    def _prod_settings(self, token_key: str) -> Settings:
+        return _make_settings(
+            env="production",
+            jwt_secret="prod-secret-not-default",
+            cors_origins="https://app.example.com",
+            human_cookie_secret=base64.urlsafe_b64encode(secrets.token_bytes(32)).decode(),
+            token_encryption_key=token_key,
+        )
+
+    def test_hex_token_key_exits(self) -> None:
+        s = self._prod_settings(secrets.token_hex(32))
+        with pytest.raises(SystemExit):
+            validate_settings(s)
+
+    def test_valid_fernet_token_key_passes(self) -> None:
+        s = self._prod_settings(Fernet.generate_key().decode())
+        # Should not raise SystemExit.
+        validate_settings(s)

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -6,7 +6,12 @@ import secrets
 import pytest
 from cryptography.fernet import Fernet
 
-from app.core.config import Settings, _fernet_key_error, validate_settings
+from app.core.config import (
+    Settings,
+    _fernet_key_error,
+    _fernet_key_list_error,
+    validate_settings,
+)
 
 
 def _make_settings(**overrides) -> Settings:
@@ -84,24 +89,72 @@ class TestFernetKeyError:
         assert _fernet_key_error("") is None
 
 
-class TestValidateSettingsFernetShape:
-    """validate_settings() must reject a hex TOKEN_ENCRYPTION_KEY in production."""
+class TestFernetKeyListError:
+    """Validate the comma-separated rotation list (TOKEN_ENCRYPTION_KEYS) the
+    same way app.core.encryption parses it: strip whitespace, drop empties,
+    every remaining entry must be a valid Fernet key.
+    """
 
-    def _prod_settings(self, token_key: str) -> Settings:
+    def test_all_valid_returns_none(self) -> None:
+        keys = f"{Fernet.generate_key().decode()}, {Fernet.generate_key().decode()}"
+        assert _fernet_key_list_error(keys, "TOKEN_ENCRYPTION_KEYS") is None
+
+    def test_blank_only_returns_no_valid_keys(self) -> None:
+        err = _fernet_key_list_error(" , ", "TOKEN_ENCRYPTION_KEYS")
+        assert err is not None
+        assert "no valid keys" in err
+
+    def test_one_bad_entry_names_the_setting_and_index(self) -> None:
+        keys = f"{Fernet.generate_key().decode()},{secrets.token_hex(32)}"
+        err = _fernet_key_list_error(keys, "TOKEN_ENCRYPTION_KEYS")
+        assert err is not None
+        assert "TOKEN_ENCRYPTION_KEYS entry 2" in err
+
+
+class TestValidateSettingsFernetShape:
+    """validate_settings() must reject a malformed Fernet key in production for
+    either the single TOKEN_ENCRYPTION_KEY or the rotation TOKEN_ENCRYPTION_KEYS,
+    mirroring the precedence app.core.encryption uses at runtime.
+    """
+
+    def _prod_settings(self, *, token_key: str = "", token_keys: str = "") -> Settings:
         return _make_settings(
             env="production",
             jwt_secret="prod-secret-not-default",
             cors_origins="https://app.example.com",
             human_cookie_secret=base64.urlsafe_b64encode(secrets.token_bytes(32)).decode(),
             token_encryption_key=token_key,
+            token_encryption_keys=token_keys,
         )
 
-    def test_hex_token_key_exits(self) -> None:
-        s = self._prod_settings(secrets.token_hex(32))
-        with pytest.raises(SystemExit):
+    def test_hex_token_key_exits(self, caplog) -> None:
+        s = self._prod_settings(token_key=secrets.token_hex(32))
+        with pytest.raises(SystemExit) as excinfo:
             validate_settings(s)
+        assert excinfo.value.code == 1
+        assert "TOKEN_ENCRYPTION_KEY is not a valid Fernet key" in caplog.text
 
     def test_valid_fernet_token_key_passes(self) -> None:
-        s = self._prod_settings(Fernet.generate_key().decode())
+        s = self._prod_settings(token_key=Fernet.generate_key().decode())
         # Should not raise SystemExit.
         validate_settings(s)
+
+    def test_rotation_only_valid_passes(self) -> None:
+        # token_encryption_keys set, token_encryption_key empty — a valid
+        # rotation-only config must NOT be rejected as "missing".
+        s = self._prod_settings(token_keys=Fernet.generate_key().decode())
+        validate_settings(s)
+
+    def test_rotation_with_bad_entry_exits(self, caplog) -> None:
+        keys = f"{Fernet.generate_key().decode()},{secrets.token_hex(32)}"
+        s = self._prod_settings(token_keys=keys)
+        with pytest.raises(SystemExit) as excinfo:
+            validate_settings(s)
+        assert excinfo.value.code == 1
+        assert "TOKEN_ENCRYPTION_KEYS entry 2" in caplog.text
+
+    def test_neither_key_set_exits(self, caplog) -> None:
+        s = self._prod_settings()
+        with pytest.raises(SystemExit):
+            validate_settings(s)
+        assert "TOKEN_ENCRYPTION_KEY" in caplog.text


### PR DESCRIPTION
## Why

Operators following the README / `deploy/DEPLOYMENT.md` could produce a deployment that either fails to start or crashes at first OAuth use, because the docs disagreed with what the code actually requires (surfaced by the 2026-06-19 refactor review, validated against the code).

1. **`HUMAN_COOKIE_SECRET` missing from `deploy/.env.example`** — `deploy/docker-compose.yml:51` hard-requires it (`${HUMAN_COOKIE_SECRET:?...}`), but it never appeared in the example. A deploy copied from the example **failed at `docker compose up`**. *(The only immediately deploy-breaking item.)*
2. **Invalid Fernet key in docs** — README and `DEPLOYMENT.md` said `TOKEN_ENCRYPTION_KEY=<openssl rand -hex 32>`. A 64-char hex string is **not** a valid Fernet key (needs 32 url-safe-base64 bytes = 44 chars). Startup validated only *presence*, so it booted and then raised `ValueError` at the first OAuth token encryption.
3. **Stale `ANTHROPIC_API_KEY` claim** — docs claimed it enables AI Assist; the env-var credential path was removed in #343 (LLM creds now flow through the gateway connector).

## What

- **`deploy/.env.example`**: added a `HUMAN_COOKIE_SECRET` section (`openssl rand -base64 32`) with a comment, in the existing section style.
- **README.md + `deploy/DEPLOYMENT.md`**: replaced the invalid `openssl rand -hex 32` command for `TOKEN_ENCRYPTION_KEY` with the Fernet generate command already used in `deploy/.env.example` and `config.py`.
- **`ANTHROPIC_API_KEY`**: removed from the README required-vars manifest; in `DEPLOYMENT.md` replaced the AI-Assist claim with a brief historical migration note pointing at the gateway connector system.
- **Startup hardening**: `validate_settings` now rejects a malformed `TOKEN_ENCRYPTION_KEY` in production (not only a missing one), so a bad key fails loud at startup instead of at first OAuth use.

## Design decisions

- **Added the optional Fernet shape validation.** It directly closes the root cause item #2 describes (boots, then `ValueError` later), turning a latent runtime crash into a loud startup failure — the issue's stated optional-hardening intent. The new `_fernet_key_error()` helper reuses the same `Fernet(key.encode())` constructor that `app.core.encryption` uses, so the validator's notion of "valid key" can never drift from what the runtime actually loads. Empty input is ignored (presence is checked separately), so the two error branches never both fire.
- **Single commit / single PR.** The doc claims and the shape validator both encode "what a valid Fernet key is," so they belong together as one demonstrable change.
- **`ANTHROPIC_API_KEY` fully removed from the README key list** rather than softened in place: that list is the operator's "what must I set" manifest, so a now-inert var doesn't belong there; the honest place for the historical note is the DEPLOYMENT prose.

## Testing

- [x] New config unit tests: `_fernet_key_error` (valid / hex / empty) and `validate_settings` rejecting a hex `TOKEN_ENCRYPTION_KEY` in production (RED → GREEN).
- [x] `docker compose -f deploy/docker-compose.yml config` succeeds from a `.env` copied verbatim from `deploy/.env.example` (and verified it still **fails** when `HUMAN_COOKIE_SECRET` is stripped — fix is load-bearing).
- [x] grep guard: no doc recommends `openssl rand -hex 32` for `TOKEN_ENCRYPTION_KEY`.
- [x] Backend: `ruff check`, `ruff format --check`, `bandit` all pass.
- [x] Backend: `pytest` — 3106 passed, coverage 88.93% (gate 85%).
- [x] Follow-up (CodeRabbit): `validate_settings` now validates the effective Fernet source (`TOKEN_ENCRYPTION_KEYS or TOKEN_ENCRYPTION_KEY`) mirroring `app.core.encryption`, so a malformed rotation list fails at startup and a valid rotation-only config is not rejected; tightened the exit-path assertions.
- [x] CI green

🤖 Co-authored by Claude Opus 4.8 (1M context). Closes #504.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Updated environment-variable guidance for `TOKEN_ENCRYPTION_KEY` to require proper Fernet key generation
* Added `HUMAN_COOKIE_SECRET` as a required production setting for human verification cookie signing
* Removed `ANTHROPIC_API_KEY` from required variables; updated docs to reflect gateway-based AI credential handling

## Bug Fixes / Reliability
* Added startup validation for Fernet token encryption key(s), including rotation-list inputs, with clear failure messages for invalid formats

## Tests
* Expanded configuration validation coverage for both single-key and rotation-list scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
