### PR TITLE
fix(dashboard): server-authoritative status_counts when request list is capped

### DIFF
--- a/dashboard/lib/__tests__/load-all-pages.test.ts
+++ b/dashboard/lib/__tests__/load-all-pages.test.ts
@@ -59,4 +59,24 @@ describe('loadAllPages', () => {
     });
     await expect(loadAllPages(fetcher, { signal: controller.signal })).rejects.toThrow();
   });
+
+  it('surfaces server status_counts from the fetcher (issue #521)', async () => {
+    const counts = { all: 5000, new: 4200, accepted: 600, playing: 0, played: 150, rejected: 50 };
+    const fetcher: PageFetcher<{ id: number }> = vi.fn(async ({ limit, offset }) => ({
+      total: 5000,
+      statusCounts: counts,
+      requests: Array.from({ length: Math.max(0, Math.min(limit, 5000 - offset)) }, (_, i) => ({
+        id: offset + i,
+      })),
+    }));
+    const res = await loadAllPages(fetcher);
+    expect(res.capped).toBe(true);
+    expect(res.requests).toHaveLength(REQUEST_LOAD_CAP); // client view is truncated
+    expect(res.statusCounts).toEqual(counts); // ...but counts are authoritative
+  });
+
+  it('leaves statusCounts undefined when the fetcher omits it', async () => {
+    const res = await loadAllPages(makeFetcher(30));
+    expect(res.statusCounts).toBeUndefined();
+  });
 });

--- a/dashboard/lib/__tests__/use-event-requests.test.ts
+++ b/dashboard/lib/__tests__/use-event-requests.test.ts
@@ -180,4 +180,68 @@ describe('useEventRequests', () => {
     });
     expect(result.current.loading).toBe(false);
   });
+
+  it('uses server status_counts when the event is capped (issue #521)', async () => {
+    // 5000-row event: the client can hold only the 2000-row cap, so counts derived
+    // from the in-memory set would undercount. The hook must surface the backend's
+    // authoritative per-status counts instead.
+    const serverCounts = { all: 5000, new: 4200, accepted: 600, playing: 0, played: 150, rejected: 50 };
+    getRequestsSpy.mockImplementation(
+      async (_code: string, options?: { limit?: number; offset?: number }) => {
+        const offset = options?.offset ?? 0;
+        const limit = options?.limit ?? 500;
+        const remaining = Math.max(0, 5000 - offset);
+        const ids = Array.from({ length: Math.min(limit, remaining) }, (_, i) => offset + i);
+        const resp = mockList(ids, 5000);
+        resp.status_counts = serverCounts;
+        return resp;
+      },
+    );
+    const { result } = renderHook(() =>
+      useEventRequests({
+        code: 'EVT',
+        enabled: true,
+        sortField: 'date_requested',
+        sortDirection: 'desc',
+        statusFilter: 'all',
+      }),
+    );
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+    expect(result.current.capped).toBe(true);
+    expect(result.current.allRequests).toHaveLength(2000); // client view truncated
+    expect(result.current.total).toBe(5000);
+    // Authoritative counts, not the capped-set length (which would be all:2000/new:2000).
+    expect(result.current.statusCounts.all).toBe(5000);
+    expect(result.current.statusCounts.new).toBe(4200);
+    expect(result.current.statusCounts.accepted).toBe(600);
+  });
+
+  it('keeps live client-derived counts on the non-capped path (issue #521)', async () => {
+    // Non-capped: counts must update LIVE on optimistic in-memory patches (a DJ
+    // accepting a request) without waiting for a refetch — so this path stays
+    // client-derived rather than frozen at the last server snapshot.
+    const { result } = renderHook(() =>
+      useEventRequests({
+        code: 'EVT',
+        enabled: true,
+        sortField: 'date_requested',
+        sortDirection: 'desc',
+        statusFilter: 'all',
+      }),
+    );
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+    expect(result.current.statusCounts.new).toBe(3);
+    expect(result.current.statusCounts.accepted).toBe(0);
+    act(() => {
+      result.current.setAllRequests((prev) =>
+        prev.map((r, i) => (i === 0 ? { ...r, status: 'accepted' } : r)),
+      );
+    });
+    expect(result.current.statusCounts.new).toBe(2);
+    expect(result.current.statusCounts.accepted).toBe(1);
+  });
 });

--- a/dashboard/lib/load-all-pages.ts
+++ b/dashboard/lib/load-all-pages.ts
@@ -11,6 +11,11 @@ export const REQUEST_LOAD_CAP = 2000;
 export interface PageFetchResult<T> {
   requests: T[];
   total: number;
+  /**
+   * Server-authoritative per-status counts (issue #521). Pagination-independent,
+   * so it's identical across pages; optional so non-counting callers can omit it.
+   */
+  statusCounts?: Record<string, number>;
 }
 
 export type PageFetcher<T> = (opts: {
@@ -23,6 +28,11 @@ export interface LoadAllResult<T> {
   requests: T[];
   total: number;
   capped: boolean;
+  /**
+   * Last server-reported status_counts, when the fetcher supplies it (issue #521).
+   * The capped client renders these instead of counting its truncated set.
+   */
+  statusCounts?: Record<string, number>;
 }
 
 function throwIfAborted(signal?: AbortSignal): void {
@@ -48,6 +58,7 @@ export async function loadAllPages<T>(
   const acc: T[] = [];
   let total = 0;
   let offset = 0;
+  let statusCounts: Record<string, number> | undefined;
 
   for (;;) {
     throwIfAborted(signal);
@@ -55,6 +66,7 @@ export async function loadAllPages<T>(
     throwIfAborted(signal);
 
     total = page.total;
+    if (page.statusCounts) statusCounts = page.statusCounts;
     acc.push(...page.requests);
     offset += page.requests.length;
 
@@ -67,5 +79,5 @@ export async function loadAllPages<T>(
 
   const capped = total > REQUEST_LOAD_CAP;
   const requests = capped ? acc.slice(0, REQUEST_LOAD_CAP) : acc;
-  return { requests, total, capped };
+  return { requests, total, capped, statusCounts };
 }

--- a/dashboard/lib/request-sort.ts
+++ b/dashboard/lib/request-sort.ts
@@ -183,6 +183,24 @@ export function computeStatusCounts(
   return counts;
 }
 
+/**
+ * Coerce a server `status_counts` map into the strict StatusFilter-keyed record
+ * (issue #521). Used on the capped path, where the in-memory set is truncated and
+ * `computeStatusCounts` would undercount: the backend's authoritative counts are
+ * pagination-independent. Missing keys default to 0; unknown keys are ignored.
+ */
+export function normalizeStatusCounts(
+  raw: Record<string, number> | null | undefined,
+): Record<StatusFilter, number> {
+  const counts: Record<StatusFilter, number> = { ...EMPTY_STATUS_COUNTS };
+  if (!raw) return counts;
+  for (const key of Object.keys(counts) as StatusFilter[]) {
+    const value = raw[key];
+    if (typeof value === 'number' && Number.isFinite(value)) counts[key] = value;
+  }
+  return counts;
+}
+
 /** Filter rows by status tab; 'all' returns the full set. */
 export function filterByStatus<T extends SortableRequestRow>(
   rows: readonly T[],

--- a/dashboard/lib/use-event-requests.ts
+++ b/dashboard/lib/use-event-requests.ts
@@ -8,6 +8,7 @@ import { loadAllPages, type PageFetcher } from './load-all-pages';
 import {
   computeStatusCounts,
   filterByStatus,
+  normalizeStatusCounts,
   sortRequests,
   type ClientSortField,
 } from './request-sort';
@@ -53,6 +54,7 @@ export function useEventRequests(params: {
 
   const [allRequests, setAllRequests] = useState<SongRequest[]>([]);
   const [serverTotal, setServerTotal] = useState(0);
+  const [serverStatusCounts, setServerStatusCounts] = useState<Record<string, number> | null>(null);
   const [capped, setCapped] = useState(false);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<string | null>(null);
@@ -86,7 +88,7 @@ export function useEventRequests(params: {
         limit,
         offset,
       });
-      return { requests: resp.requests, total: resp.total };
+      return { requests: resp.requests, total: resp.total, statusCounts: resp.status_counts };
     };
 
     try {
@@ -94,6 +96,7 @@ export function useEventRequests(params: {
       if (controller.signal.aborted) return;
       setAllRequests(res.requests);
       setServerTotal(res.total);
+      setServerStatusCounts(res.statusCounts ?? null);
       setCapped(res.capped);
       setError(null);
     } catch (err) {
@@ -141,7 +144,14 @@ export function useEventRequests(params: {
     return sortRequests(filtered, sortField as ClientSortField, sortDirection);
   }, [allRequests, statusFilter, sortField, sortDirection]);
 
-  const statusCounts = useMemo(() => computeStatusCounts(allRequests), [allRequests]);
+  // The capped view holds only the first 2000 rows, so counting it would
+  // undercount the tabs — use the backend's authoritative, pagination-independent
+  // counts there (issue #521). The non-capped path stays client-derived so counts
+  // update live on optimistic in-memory patches without waiting for a refetch.
+  const statusCounts = useMemo(
+    () => (capped ? normalizeStatusCounts(serverStatusCounts) : computeStatusCounts(allRequests)),
+    [capped, serverStatusCounts, allRequests],
+  );
   const total = capped ? serverTotal : allRequests.length;
 
   return {


### PR DESCRIPTION
## Why
Follow-up to #489/PR #520, which moved both event-page request lists to client-side sort/filter/counts with a 2000-row safety cap. For events that **exceed** the cap, the client holds only the first 2000 rows, so the per-status tab counts (All/New/Accepted/…) were derived from a truncated set and **undercounted**. PR #520 surfaced this honestly via a "Showing 2000 of N" banner and accepted it as a documented tradeoff; this is the correct long-term fix.

## What
The backend already returns pagination-independent `status_counts` in **every** `RequestListResponse` (added in #478) — the client was simply discarding it. Now:

- `loadAllPages` threads the server's `status_counts` through to its result (optional field; non-counting callers unaffected).
- `useEventRequests` renders **server-authoritative** counts when the view is capped, and keeps **client-derived** counts on the common (`total ≤ 2000`) path so tabs still update live on optimistic in-memory patches without a refetch.
- New `normalizeStatusCounts` coerces the server map into the strict `StatusFilter` record (missing keys → 0, unknown keys ignored) — defensive against contract drift.

No backend change and **no added round-trip** — the counts already ride along in the existing paginated response. The truncation banner is unchanged.

## Testing
- [x] Unit tests pass — `dashboard` vitest: 105 files, 1388 tests green
- [x] New RED→GREEN tests: loader surfaces `status_counts`; capped hook reports server counts (all=5000 from a 2000-row set); non-capped stays live client-derived
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` exit 0
- [x] CI green

🤖 Co-authored by Claude Opus 4.8 (1M context). Closes #521.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of status counts in event request lists by using server-authoritative data when results are paginated and truncated, instead of deriving counts from the limited client-side data.

* **Tests**
  * Added test coverage for status count handling in paginated event requests to ensure correct behavior in both capped and uncapped scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->