### PR TITLE
feat(setbuilder): autobuild + fill_to_duration agent tools (#491)

### DIFF
--- a/dashboard/app/(dj)/setbuilder/components/ChatPanelBody.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/ChatPanelBody.tsx
@@ -5,6 +5,8 @@ import type { AppliedToolCall, SetCritique, TransitionScore } from '@/lib/api-ty
 import type { AgentChatController, Persona } from './useAgentChat';
 import styles from '../setbuilder.module.css';
 
+const DESTRUCTIVE_TOOL_NAMES = new Set(['autobuild', 'fill_to_duration']);
+
 function flagTone(type: string): string {
   if (type === 'transition_brilliant') return styles.flagBrilliant;
   if (type === 'energy_dip' || type === 'banger_buried' || type === 'vibe_clash') {
@@ -93,6 +95,11 @@ function ToolCard({ tool }: { tool: AppliedToolCall }) {
         <div className={styles.toolSummary}>{summary}</div>
         {rationale && rationale !== summary && (
           <div className={styles.toolRationale}>{rationale}</div>
+        )}
+        {DESTRUCTIVE_TOOL_NAMES.has(tool.name) && (
+          <div className={styles.toolUndoHint} data-testid="agent-undo-hint">
+            Rebuilt your whole set — press ⌘Z (or Undo) to revert.
+          </div>
         )}
         {skippedLocks.map((reason) => (
           <div key={reason} className={styles.toolRationale} data-testid="agent-lock-skip">

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/ChatPanelBody.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/ChatPanelBody.test.tsx
@@ -73,4 +73,35 @@ describe('ChatPanelBody', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Send' }));
     expect(send).toHaveBeenCalledTimes(1);
   });
+
+  function entryWithTool(name: string) {
+    return {
+      id: 3,
+      role: 'assistant' as const,
+      content: 'Rebuilt the set: 12 slots, 3 refinement passes.',
+      display_summary: 'Rebuilt the set: 12 slots, 3 refinement passes.',
+      tool_calls: [
+        {
+          id: `${name}-1`,
+          name,
+          args: { rationale: 'Rebuild' },
+          rationale: null,
+          result: { slot_count: 12, iterations: 3 },
+          mutating: true,
+          display_summary: 'Rebuilt the set: 12 slots, 3 refinement passes.',
+        },
+      ],
+      affected_transition_scores: [],
+    };
+  }
+
+  it('shows an undo hint on a destructive autobuild tool card', () => {
+    render(<ChatPanelBody chat={makeController({ entries: [entryWithTool('autobuild')] })} />);
+    expect(screen.getByTestId('agent-undo-hint')).toHaveTextContent(/undo/i);
+  });
+
+  it('does not show the undo hint on a non-destructive tool card', () => {
+    render(<ChatPanelBody chat={makeController({ entries: [entryWithTool('swap_slots')] })} />);
+    expect(screen.queryByTestId('agent-undo-hint')).not.toBeInTheDocument();
+  });
 });

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/ChatPanelBody.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/ChatPanelBody.test.tsx
@@ -95,10 +95,13 @@ describe('ChatPanelBody', () => {
     };
   }
 
-  it('shows an undo hint on a destructive autobuild tool card', () => {
-    render(<ChatPanelBody chat={makeController({ entries: [entryWithTool('autobuild')] })} />);
-    expect(screen.getByTestId('agent-undo-hint')).toHaveTextContent(/undo/i);
-  });
+  it.each([['autobuild'], ['fill_to_duration']])(
+    'shows an undo hint on a destructive %s tool card',
+    (name) => {
+      render(<ChatPanelBody chat={makeController({ entries: [entryWithTool(name)] })} />);
+      expect(screen.getByTestId('agent-undo-hint')).toHaveTextContent(/undo/i);
+    },
+  );
 
   it('does not show the undo hint on a non-destructive tool card', () => {
     render(<ChatPanelBody chat={makeController({ entries: [entryWithTool('swap_slots')] })} />);

--- a/dashboard/app/(dj)/setbuilder/setbuilder.module.css
+++ b/dashboard/app/(dj)/setbuilder/setbuilder.module.css
@@ -870,6 +870,12 @@
   font-style: italic;
 }
 
+.toolUndoHint {
+  margin-top: 0.3rem;
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+}
+
 .scoreUpdate {
   display: flex;
   flex-wrap: wrap;

--- a/docs/superpowers/plans/2026-06-22-setbuilder-autobuild-fill.md
+++ b/docs/superpowers/plans/2026-06-22-setbuilder-autobuild-fill.md
@@ -1,0 +1,958 @@
+# autobuild + fill_to_duration Agent Tools — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the two destructive Family-3 WrzDJSet agent tools — `autobuild` (regenerate the whole order) and `fill_to_duration` (append pool tracks to the duration target) — riding the existing global undo for recovery.
+
+**Architecture:** Two new mutating tools in a new `agent_tools_structural.py` module, wired through the existing closed allowlist (`MUTATION_TOOLS` + `_agent_tools()` + `apply_tool_call` + `_tool_display_summary`). `autobuild` wraps `pass1_deterministic.build_set` (which already honors locked slots + saved pairings); `fill_to_duration` appends unused pool tracks via the existing `_insert_track_at` primitive. Undo is **not** re-implemented — #493/#494's global undo snapshots the whole document before every mutating turn, so these tools are revertible for free; the only frontend change is a discoverability hint.
+
+**Tech Stack:** FastAPI + SQLAlchemy backend (pytest, SQLite in-memory test DB), Next.js/React 19 frontend (Vitest + Testing Library, vanilla CSS modules).
+
+**Spec:** `docs/superpowers/specs/2026-06-21-setbuilder-autobuild-fill-design.md`
+**Issue:** #491 (epic #442, Family 3). **Branch:** `feat/issue-491-autobuild-fill-duration` (already created).
+
+## Global Constraints
+
+- Backend lint: ruff line-length 100, rules E, F, I, UP. `== None` / `== True` allowed. Run `.venv/bin/ruff format .` after edits.
+- Backend coverage is an **enforced hard gate at 85%** (`--cov-fail-under`). New code must be covered.
+- Every mutating agent tool: `db.flush()` not `db.commit()` (the turn owns commit/rollback); member of `MUTATION_TOOLS`; requires a non-empty `rationale`; owner-scoped via the already-scoped `set_obj`; **never writes the `requests` table** (pin with a regression test).
+- Tools are dispatched only through `apply_tool_call`'s closed allowlist; an unknown name raises `AgentToolError`.
+- Frontend: vanilla CSS modules + `var(--*)` design tokens only — no Tailwind, no hardcoded hex.
+- Commits: Conventional Commits; end every commit with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- All backend commands run from `server/`; frontend from `dashboard/`.
+
+---
+
+## File Structure
+
+**Create:**
+- `server/app/services/setbuilder/agent_tools_structural.py` — the two structural tools + `_duration_for` helper + `MAX_FILL_INSERTS`.
+- `server/tests/test_setbuilder_structural.py` — tests for both tools (the existing `test_setbuilder_pass2.py` is 2517 lines, well over budget — do not add to it).
+
+**Modify:**
+- `server/app/services/setbuilder/pass1_deterministic.py` — thread `commit: bool = True` through `build_set` / `_persist_slots`.
+- `server/app/services/setbuilder/agent_common.py` — add 2 names to `MUTATION_TOOLS`.
+- `server/app/services/setbuilder/agent_tool_specs.py` — add 2 `ToolSpec`s.
+- `server/app/services/setbuilder/pass2_agent.py` — import + 2 handler entries.
+- `server/app/services/setbuilder/agent_display.py` — 2 display-summary cases.
+- `server/tests/test_setbuilder_pass1.py` — test for the `commit` param.
+- `dashboard/app/(dj)/setbuilder/components/ChatPanelBody.tsx` — destructive-tool undo hint.
+- `dashboard/app/(dj)/setbuilder/setbuilder.module.css` — `.toolUndoHint` class.
+- `dashboard/app/(dj)/setbuilder/components/__tests__/ChatPanelBody.test.tsx` — hint test.
+
+---
+
+## Task 1: `build_set` gains a `commit` flag
+
+`autobuild` must run inside an agent turn that owns the single commit/rollback, but `build_set` currently commits internally. Add an opt-out so the agent path flushes instead. The one existing REST caller keeps the default and is unchanged.
+
+**Files:**
+- Modify: `server/app/services/setbuilder/pass1_deterministic.py` (`build_set` ~L55-102, `_persist_slots` ~L421-453)
+- Test: `server/tests/test_setbuilder_pass1.py`
+
+**Interfaces:**
+- Produces: `build_set(db, set_obj, *, commit: bool = True) -> BuildResult` — when `commit=False`, persists via `db.flush()` only (caller commits/rolls back). `BuildResult` unchanged (`.slots`, `.slot_count`, `.iterations`, `.transition_scores`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/tests/test_setbuilder_pass1.py`:
+
+```python
+def test_build_set_commit_false_defers_persistence_to_caller(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, duration=7 * 60)
+    src = _mk_source(db, set_obj)
+    for idx in range(4):
+        _mk_track(db, set_obj, src, idx)
+
+    # commit=False only flushes, so a rollback discards the generated slots.
+    build_set(db, set_obj, commit=False)
+    assert db.query(SetSlot).filter(SetSlot.set_id == set_obj.id).count() > 0
+    db.rollback()
+    assert db.query(SetSlot).filter(SetSlot.set_id == set_obj.id).count() == 0
+
+    # Default commit=True persists across a rollback.
+    build_set(db, set_obj)
+    db.rollback()
+    assert db.query(SetSlot).filter(SetSlot.set_id == set_obj.id).count() > 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_setbuilder_pass1.py::test_build_set_commit_false_defers_persistence_to_caller -v`
+Expected: FAIL — `build_set()` got an unexpected keyword argument `commit`.
+
+- [ ] **Step 3: Implement the `commit` flag**
+
+In `pass1_deterministic.py`, change the `build_set` signature and its persistence calls:
+
+```python
+def build_set(db: Session, set_obj: Set, *, commit: bool = True) -> BuildResult:
+    """Build and persist a deterministic ordered set from the set pool."""
+```
+
+Replace the two persistence lines near the end of `build_set` (currently `slots = _persist_slots(...)` then `scores = recompute_transition_scores(db, set_obj, slots)`):
+
+```python
+    slots = _persist_slots(db, set_obj.id, locked_by_pos, chosen, targets, commit=commit)
+    scores = recompute_transition_scores(db, set_obj, slots, commit=commit)
+```
+
+Change `_persist_slots` to accept and honor `commit` (it currently ends with `db.commit()`):
+
+```python
+def _persist_slots(
+    db: Session,
+    set_id: int,
+    locked_by_pos: dict[int, SetSlot],
+    chosen: list[TrackMeta | None],
+    targets: list[float],
+    *,
+    commit: bool = True,
+) -> list[SetSlot]:
+```
+
+and replace its final `db.commit()` with:
+
+```python
+    if commit:
+        db.commit()
+    else:
+        db.flush()
+    return _ordered_slots(db, set_id)
+```
+
+(`recompute_transition_scores` already has a `commit: bool = True` param that flushes when `False` — no change needed there.)
+
+- [ ] **Step 4: Run test + format to verify it passes**
+
+Run: `.venv/bin/ruff format app/services/setbuilder/pass1_deterministic.py && .venv/bin/pytest tests/test_setbuilder_pass1.py -v`
+Expected: PASS (all pass1 tests, including the new one).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/services/setbuilder/pass1_deterministic.py server/tests/test_setbuilder_pass1.py
+git commit -m "feat(setbuilder): add commit flag to build_set for agent-turn atomicity (#491)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `autobuild` tool
+
+Wholesale regeneration via `build_set(commit=False)`. Includes the new module, full allowlist wiring, display summary, and the snapshot round-trip acceptance test proving the global-undo guarantee.
+
+**Files:**
+- Create: `server/app/services/setbuilder/agent_tools_structural.py`
+- Create: `server/tests/test_setbuilder_structural.py`
+- Modify: `server/app/services/setbuilder/agent_common.py` (`MUTATION_TOOLS` ~L15-34)
+- Modify: `server/app/services/setbuilder/agent_tool_specs.py` (`_agent_tools()` list ~after L123)
+- Modify: `server/app/services/setbuilder/pass2_agent.py` (imports ~L32, `handlers` dict ~L306-332)
+- Modify: `server/app/services/setbuilder/agent_display.py` (`_tool_display_summary` ~before the final fallback `return`)
+
+**Interfaces:**
+- Consumes: `build_set(db, set_obj, *, commit=False)` (Task 1).
+- Produces: `_tool_autobuild(db, set_obj, payload) -> tuple[dict, set[int]]` returning `({"slot_count": int, "iterations": int}, affected_positions)`. Tool name `"autobuild"`, in `MUTATION_TOOLS`, requires `rationale`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `server/tests/test_setbuilder_structural.py`:
+
+```python
+"""Tests for the destructive structural WrzDJSet agent tools (#491, #442 Family 3)."""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.request import Request
+from app.models.set import Set, SetSlot
+from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.models.user import User
+from app.services.llm.base import ChatResponse, ToolCall
+from app.services.setbuilder.agent_display import _tool_display_summary
+from app.services.setbuilder.document_snapshot import build_snapshot, restore_snapshot
+from app.services.setbuilder.pass2_agent import (
+    MUTATION_TOOLS,
+    AgentToolError,
+    apply_tool_call,
+    chat_with_agent,
+)
+
+
+def _mk_set(db: Session, user: User, *, n_tracks: int, n_slots: int, duration: int) -> Set:
+    """Set with ``n_tracks`` pool tracks (210s each) and ``n_slots`` seeded slots."""
+    set_obj = Set(owner_id=user.id, name="Structural Set", target_duration_sec=duration)
+    db.add(set_obj)
+    db.flush()
+    source = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(source)
+    db.flush()
+    db.add_all(
+        [
+            SetPoolTrack(
+                set_id=set_obj.id,
+                source_id=source.id,
+                track_id=f"tidal:{idx}",
+                title=f"Track {idx}",
+                artist=f"Artist {idx}",
+                bpm=124 + idx,
+                key="8A",
+                camelot="8A",
+                energy=5,
+                duration_sec=210,
+                dedupe_sig=f"struct-sig-{idx}",
+            )
+            for idx in range(n_tracks)
+        ]
+    )
+    db.flush()
+    db.add_all(
+        [SetSlot(set_id=set_obj.id, position=i, track_id=f"tidal:{i}") for i in range(n_slots)]
+    )
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def test_autobuild_regenerates_order_and_reports_counts(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, n_tracks=4, n_slots=0, duration=14 * 60)
+
+    result, positions = apply_tool_call(
+        db, set_obj, "autobuild", {"rationale": "Auto-arrange from the pool."}
+    )
+
+    slots = db.query(SetSlot).filter(SetSlot.set_id == set_obj.id).all()
+    assert result["slot_count"] == len(slots)
+    assert result["slot_count"] > 0
+    assert isinstance(result["iterations"], int)
+    assert positions == {s.position for s in slots}
+
+
+def test_autobuild_preserves_locked_slot(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, n_tracks=6, n_slots=0, duration=14 * 60)
+    db.add(SetSlot(set_id=set_obj.id, position=1, track_id="tidal:5", locked=True))
+    db.commit()
+
+    apply_tool_call(db, set_obj, "autobuild", {"rationale": "Rebuild around the pin."})
+
+    locked = (
+        db.query(SetSlot)
+        .filter(SetSlot.set_id == set_obj.id, SetSlot.locked == True)  # noqa: E712
+        .one()
+    )
+    assert locked.position == 1
+    assert locked.track_id == "tidal:5"
+
+
+def test_autobuild_requires_rationale(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, n_tracks=3, n_slots=0, duration=7 * 60)
+
+    with pytest.raises(AgentToolError, match="rationale"):
+        apply_tool_call(db, set_obj, "autobuild", {})
+
+
+def test_autobuild_in_mutation_tools():
+    assert "autobuild" in MUTATION_TOOLS
+
+
+def test_autobuild_leaves_event_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set(db, test_user, n_tracks=4, n_slots=0, duration=14 * 60)
+    before_count = db.query(Request).count()
+    before_title = test_request.song_title
+
+    apply_tool_call(db, set_obj, "autobuild", {"rationale": "Rebuild it."})
+
+    db.refresh(test_request)
+    assert db.query(Request).count() == before_count
+    assert test_request.song_title == before_title
+
+
+@pytest.mark.asyncio
+async def test_autobuild_then_failing_tool_rolls_back_whole_turn(
+    monkeypatch, db: Session, test_user: User
+):
+    """commit=False means a later tool failure rolls the autobuild back too."""
+    set_obj = _mk_set(db, test_user, n_tracks=3, n_slots=2, duration=7 * 60)
+    original = [
+        s.track_id
+        for s in db.query(SetSlot)
+        .filter(SetSlot.set_id == set_obj.id)
+        .order_by(SetSlot.position)
+        .all()
+    ]
+
+    async def fake_dispatch(*args, **kwargs):
+        return ChatResponse(
+            stop_reason="tool_use",
+            tool_calls=[
+                ToolCall(id="ab", name="autobuild", input={"rationale": "Rebuild."}),
+                ToolCall(
+                    id="boom",
+                    name="swap_slots",
+                    input={"slot_a_id": 999999, "slot_b_id": 999998, "rationale": "boom"},
+                ),
+            ],
+        )
+
+    monkeypatch.setattr("app.services.setbuilder.pass2_agent.Gateway.dispatch", fake_dispatch)
+
+    with pytest.raises(AgentToolError):
+        await chat_with_agent(db, test_user, set_obj, message="Rebuild then break")
+
+    remaining = [
+        s.track_id
+        for s in db.query(SetSlot)
+        .filter(SetSlot.set_id == set_obj.id)
+        .order_by(SetSlot.position)
+        .all()
+    ]
+    assert remaining == original
+
+
+def test_autobuild_then_restore_snapshot_returns_prior_order(db: Session, test_user: User):
+    """#491 acceptance: the captured snapshot restores the exact pre-autobuild order."""
+    set_obj = _mk_set(db, test_user, n_tracks=4, n_slots=2, duration=14 * 60)
+    before = build_snapshot(set_obj)
+    before_ids = [s.track_id for s in sorted(set_obj.slots, key=lambda s: s.position)]
+
+    apply_tool_call(db, set_obj, "autobuild", {"rationale": "Rebuild wholesale."})
+    db.commit()
+    db.refresh(set_obj)
+
+    restore_snapshot(db, set_obj, before)
+    db.refresh(set_obj)
+
+    after_ids = [s.track_id for s in sorted(set_obj.slots, key=lambda s: s.position)]
+    assert after_ids == before_ids
+
+
+def test_autobuild_display_summary_is_human_readable():
+    summary = _tool_display_summary(
+        "autobuild", {"rationale": "x"}, {"slot_count": 12, "iterations": 3}, {}, {}
+    )
+    assert summary == "Rebuilt the set: 12 slots, 3 refinement passes."
+
+    one = _tool_display_summary(
+        "autobuild", {"rationale": "x"}, {"slot_count": 1, "iterations": 1}, {}, {}
+    )
+    assert one == "Rebuilt the set: 1 slot, 1 refinement pass."
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_setbuilder_structural.py -v`
+Expected: FAIL — `AgentToolError: Unknown tool: autobuild` (and the MUTATION_TOOLS/display assertions fail).
+
+- [ ] **Step 3: Create the structural module**
+
+Create `server/app/services/setbuilder/agent_tools_structural.py`:
+
+```python
+"""Destructive structural WrzDJSet agent tools (#491, #442 Family 3).
+
+``autobuild`` regenerates the whole order from the pool + curve; both tools are
+in ``MUTATION_TOOLS`` and dispatched only through ``apply_tool_call``. They are
+undoable via the frontend global-undo stack (#493/#494), which snapshots the
+whole document before every mutating agent turn.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.models.set import Set
+from app.services.setbuilder.pass1_deterministic import build_set
+
+
+def _tool_autobuild(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Regenerate the entire ordering from the pool + curve (wholesale).
+
+    Thin owner-scoped wrapper over ``pass1_deterministic.build_set``, which
+    already honors locked slots and saved pairings. Runs with ``commit=False``
+    so the agent turn commits/rolls back as one unit.
+    """
+    result = build_set(db, set_obj, commit=False)
+    affected = {slot.position for slot in result.slots}
+    return {"slot_count": result.slot_count, "iterations": result.iterations}, affected
+```
+
+- [ ] **Step 4: Wire `autobuild` into the allowlist**
+
+In `agent_common.py`, add `"autobuild"` to the `MUTATION_TOOLS` set (e.g. after `"apply_curve_template",`):
+
+```python
+    "apply_curve_template",
+    "autobuild",
+```
+
+In `agent_tool_specs.py`, add this `ToolSpec` to the `_agent_tools()` list immediately after the `apply_curve_template` `ToolSpec` block (before the `analyze_transition` block):
+
+```python
+        ToolSpec(
+            name="autobuild",
+            description=(
+                "Regenerate the ENTIRE set order from the pool and energy curve "
+                "(deterministic pass 1). This REPLACES the current hand-arranged "
+                "order wholesale; locked slots and saved pairings are preserved. "
+                "Destructive — use only when the DJ asks to rebuild / auto-arrange."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {"rationale": {"type": "string"}},
+                "required": ["rationale"],
+            },
+        ),
+```
+
+In `pass2_agent.py`, add the import (after the `agent_tools_sensing` import block, ~L62):
+
+```python
+from app.services.setbuilder.agent_tools_structural import _tool_autobuild
+```
+
+and add to the `handlers` dict in `apply_tool_call` (after `"apply_curve_template": _tool_apply_curve_template,`):
+
+```python
+        "autobuild": _tool_autobuild,
+```
+
+- [ ] **Step 5: Add the display summary**
+
+In `agent_display.py`, add this case to `_tool_display_summary` just before the final fallback `return name.replace("_", " ").capitalize() + "."`:
+
+```python
+    if name == "autobuild":
+        slots = int(result.get("slot_count") or 0)
+        iterations = int(result.get("iterations") or 0)
+        return (
+            f"Rebuilt the set: {slots} slot{'s' if slots != 1 else ''}, "
+            f"{iterations} refinement pass{'es' if iterations != 1 else ''}."
+        )
+```
+
+- [ ] **Step 6: Run tests + format to verify they pass**
+
+Run: `.venv/bin/ruff format app/services/setbuilder/ && .venv/bin/pytest tests/test_setbuilder_structural.py -v`
+Expected: PASS (all autobuild tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/app/services/setbuilder/agent_tools_structural.py \
+        server/app/services/setbuilder/agent_common.py \
+        server/app/services/setbuilder/agent_tool_specs.py \
+        server/app/services/setbuilder/pass2_agent.py \
+        server/app/services/setbuilder/agent_display.py \
+        server/tests/test_setbuilder_structural.py
+git commit -m "feat(setbuilder): autobuild agent tool — wholesale pass-1 rebuild (#491)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `fill_to_duration` tool
+
+Append unused pool tracks until the set reaches `target_duration_sec`, bounded by a per-turn cap.
+
+**Files:**
+- Modify: `server/app/services/setbuilder/agent_tools_structural.py`
+- Modify: `server/app/services/setbuilder/agent_common.py` (`MUTATION_TOOLS`)
+- Modify: `server/app/services/setbuilder/agent_tool_specs.py` (`_agent_tools()`)
+- Modify: `server/app/services/setbuilder/pass2_agent.py` (import + handler)
+- Modify: `server/app/services/setbuilder/agent_display.py`
+- Test: `server/tests/test_setbuilder_structural.py`
+
+**Interfaces:**
+- Consumes: `_insert_track_at(db, set_obj, track, position)` from `agent_tools_mutations.py`; `AVG_TRACK_LENGTH_SEC` + `_track_meta` from `pass1_deterministic.py`; `_pool_tracks`/`_ordered_slots` from `agent_common.py`.
+- Produces: `_tool_fill_to_duration(db, set_obj, payload) -> tuple[dict, set[int]]` returning `({"inserted_count", "estimated_total_sec", "target_duration_sec", "capped", "pool_exhausted"}, affected)`. Module constant `MAX_FILL_INSERTS = 100`. Tool name `"fill_to_duration"`, in `MUTATION_TOOLS`, requires `rationale`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `server/tests/test_setbuilder_structural.py`:
+
+```python
+def test_fill_to_duration_stops_at_target(db: Session, test_user: User):
+    # 1 seeded slot (210s) + 4 unused tracks; target 840s needs 3 more (4*210=840).
+    set_obj = _mk_set(db, test_user, n_tracks=5, n_slots=1, duration=4 * 210)
+
+    result, positions = apply_tool_call(
+        db, set_obj, "fill_to_duration", {"rationale": "Fill to the target."}
+    )
+
+    assert result["inserted_count"] == 3
+    assert result["estimated_total_sec"] == 4 * 210
+    assert result["capped"] is False
+    assert result["pool_exhausted"] is False
+    assert db.query(SetSlot).filter(SetSlot.set_id == set_obj.id).count() == 4
+    assert positions == {1, 2, 3}
+
+
+def test_fill_to_duration_stops_when_pool_exhausted(db: Session, test_user: User):
+    # Only 2 unused tracks but the target wants far more — stop, flag exhausted.
+    set_obj = _mk_set(db, test_user, n_tracks=3, n_slots=1, duration=99 * 210)
+
+    result, _ = apply_tool_call(
+        db, set_obj, "fill_to_duration", {"rationale": "Use everything available."}
+    )
+
+    assert result["inserted_count"] == 2
+    assert result["pool_exhausted"] is True
+    assert result["capped"] is False
+
+
+def test_fill_to_duration_respects_insert_cap(monkeypatch, db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, n_tracks=6, n_slots=1, duration=99 * 210)
+    monkeypatch.setattr(
+        "app.services.setbuilder.agent_tools_structural.MAX_FILL_INSERTS", 2
+    )
+
+    result, _ = apply_tool_call(
+        db, set_obj, "fill_to_duration", {"rationale": "Bounded fill."}
+    )
+
+    assert result["inserted_count"] == 2
+    assert result["capped"] is True
+
+
+def test_fill_to_duration_errors_without_target(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, n_tracks=3, n_slots=1, duration=7 * 60)
+    set_obj.target_duration_sec = None
+    db.commit()
+
+    with pytest.raises(AgentToolError, match="target duration"):
+        apply_tool_call(db, set_obj, "fill_to_duration", {"rationale": "Fill it."})
+
+
+def test_fill_to_duration_never_moves_locked_slot(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, n_tracks=5, n_slots=0, duration=4 * 210)
+    db.add(SetSlot(set_id=set_obj.id, position=0, track_id="tidal:0", locked=True))
+    db.commit()
+
+    apply_tool_call(db, set_obj, "fill_to_duration", {"rationale": "Append after the pin."})
+
+    locked = (
+        db.query(SetSlot)
+        .filter(SetSlot.set_id == set_obj.id, SetSlot.locked == True)  # noqa: E712
+        .one()
+    )
+    assert locked.position == 0
+    assert locked.track_id == "tidal:0"
+
+
+def test_fill_to_duration_requires_rationale(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, n_tracks=3, n_slots=1, duration=7 * 60)
+
+    with pytest.raises(AgentToolError, match="rationale"):
+        apply_tool_call(db, set_obj, "fill_to_duration", {})
+
+
+def test_fill_to_duration_in_mutation_tools():
+    assert "fill_to_duration" in MUTATION_TOOLS
+
+
+def test_fill_to_duration_leaves_event_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set(db, test_user, n_tracks=5, n_slots=1, duration=4 * 210)
+    before_count = db.query(Request).count()
+    before_title = test_request.song_title
+
+    apply_tool_call(db, set_obj, "fill_to_duration", {"rationale": "Fill to target."})
+
+    db.refresh(test_request)
+    assert db.query(Request).count() == before_count
+    assert test_request.song_title == before_title
+
+
+def test_fill_to_duration_display_summary_is_human_readable():
+    added = _tool_display_summary(
+        "fill_to_duration",
+        {"rationale": "x"},
+        {
+            "inserted_count": 3,
+            "estimated_total_sec": 840,
+            "target_duration_sec": 840,
+            "capped": False,
+            "pool_exhausted": False,
+        },
+        {},
+        {},
+    )
+    assert added == "Added 3 tracks toward target; now ~14 min of ~14 min."
+
+    none_added = _tool_display_summary(
+        "fill_to_duration",
+        {"rationale": "x"},
+        {
+            "inserted_count": 0,
+            "estimated_total_sec": 600,
+            "target_duration_sec": 600,
+            "capped": False,
+            "pool_exhausted": False,
+        },
+        {},
+        {},
+    )
+    assert none_added == "No tracks added; set already ~10 min of ~10 min target."
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_setbuilder_structural.py -k fill_to_duration -v`
+Expected: FAIL — `AgentToolError: Unknown tool: fill_to_duration`.
+
+- [ ] **Step 3: Implement `fill_to_duration` + helper**
+
+In `agent_tools_structural.py`, extend the imports and add the constant + helper + tool. Final import block:
+
+```python
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.models.set import Set
+from app.services.setbuilder.agent_common import AgentToolError, _ordered_slots, _pool_tracks
+from app.services.setbuilder.agent_tools_mutations import _insert_track_at
+from app.services.setbuilder.pass1_deterministic import AVG_TRACK_LENGTH_SEC, build_set
+from app.services.setbuilder.pass1_deterministic import _track_meta as _pass1_track_meta
+
+logger = logging.getLogger(__name__)
+
+# Per-turn safety cap: one fill_to_duration call can never append more than this
+# many slots, independent of pool size (the issue's bounded-insert requirement).
+MAX_FILL_INSERTS = 100
+```
+
+Add the helper and tool below `_tool_autobuild`:
+
+```python
+def _duration_for(track) -> int:
+    """A pool track's duration in seconds, falling back to the pass-1 average."""
+    if track is not None and track.duration_sec and track.duration_sec > 0:
+        return track.duration_sec
+    return AVG_TRACK_LENGTH_SEC
+
+
+def _tool_fill_to_duration(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Append unused pool tracks (in pool order) until the set reaches its
+    ``target_duration_sec``, never moving locked slots and never appending more
+    than ``MAX_FILL_INSERTS`` in one turn.
+    """
+    target = set_obj.target_duration_sec
+    if not target:
+        raise AgentToolError("Set a target duration first (target_duration_sec).")
+
+    pool = _pool_tracks(db, set_obj.id)
+    by_slot_track_id = {_pass1_track_meta(t).slot_track_id: t for t in pool}
+    slots = _ordered_slots(db, set_obj.id)
+    used = {slot.track_id for slot in slots if slot.track_id}
+    total = sum(_duration_for(by_slot_track_id.get(slot.track_id)) for slot in slots)
+    candidates = [t for t in pool if _pass1_track_meta(t).slot_track_id not in used]
+
+    base_count = len(slots)
+    affected: set[int] = set()
+    inserted = 0
+    capped = False
+    for track in candidates:
+        if total >= target:
+            break
+        if inserted >= MAX_FILL_INSERTS:
+            capped = True
+            break
+        _, positions = _insert_track_at(db, set_obj, track, base_count + inserted)
+        affected |= positions
+        total += _duration_for(track)
+        inserted += 1
+
+    pool_exhausted = total < target and not capped
+    logger.info(
+        "setbuilder fill_to_duration: set %s added %s tracks (target=%ss, est_total=%ss, "
+        "capped=%s, pool_exhausted=%s)",
+        set_obj.id,
+        inserted,
+        target,
+        total,
+        capped,
+        pool_exhausted,
+    )
+    return {
+        "inserted_count": inserted,
+        "estimated_total_sec": total,
+        "target_duration_sec": target,
+        "capped": capped,
+        "pool_exhausted": pool_exhausted,
+    }, affected
+```
+
+- [ ] **Step 4: Wire `fill_to_duration` into the allowlist**
+
+In `agent_common.py`, add `"fill_to_duration"` to `MUTATION_TOOLS` (after `"autobuild",`):
+
+```python
+    "autobuild",
+    "fill_to_duration",
+```
+
+In `agent_tool_specs.py`, add this `ToolSpec` right after the `autobuild` `ToolSpec`:
+
+```python
+        ToolSpec(
+            name="fill_to_duration",
+            description=(
+                "Append pool tracks not already in the set, in pool order, until "
+                "the set reaches its target_duration_sec. Requires a duration "
+                "target. Never moves locked slots; the number of inserts is capped "
+                "per turn. Can add many slots at once — destructive-ish."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {"rationale": {"type": "string"}},
+                "required": ["rationale"],
+            },
+        ),
+```
+
+In `pass2_agent.py`, extend the structural import:
+
+```python
+from app.services.setbuilder.agent_tools_structural import _tool_autobuild, _tool_fill_to_duration
+```
+
+and add to the `handlers` dict (after `"autobuild": _tool_autobuild,`):
+
+```python
+        "fill_to_duration": _tool_fill_to_duration,
+```
+
+- [ ] **Step 5: Add the display summary**
+
+In `agent_display.py`, add this case just before the final fallback `return` (after the `autobuild` case):
+
+```python
+    if name == "fill_to_duration":
+        added = int(result.get("inserted_count") or 0)
+        now_min = int(result.get("estimated_total_sec") or 0) // 60
+        target_min = int(result.get("target_duration_sec") or 0) // 60
+        if added == 0:
+            return f"No tracks added; set already ~{now_min} min of ~{target_min} min target."
+        base = (
+            f"Added {added} track{'s' if added != 1 else ''} toward target; "
+            f"now ~{now_min} min of ~{target_min} min."
+        )
+        return f"{base} Hit the per-turn insert cap." if result.get("capped") else base
+```
+
+- [ ] **Step 6: Run tests + format to verify they pass**
+
+Run: `.venv/bin/ruff format app/services/setbuilder/ && .venv/bin/pytest tests/test_setbuilder_structural.py -v`
+Expected: PASS (all structural tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/app/services/setbuilder/agent_tools_structural.py \
+        server/app/services/setbuilder/agent_common.py \
+        server/app/services/setbuilder/agent_tool_specs.py \
+        server/app/services/setbuilder/pass2_agent.py \
+        server/app/services/setbuilder/agent_display.py \
+        server/tests/test_setbuilder_structural.py
+git commit -m "feat(setbuilder): fill_to_duration agent tool — bounded pool fill to target (#491)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Backend full-suite + lint gate
+
+Confirm the whole backend suite and the lint/coverage gates are green before touching the frontend.
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Lint, format check, full suite**
+
+Run:
+```bash
+.venv/bin/ruff check . && .venv/bin/ruff format --check . && .venv/bin/pytest --tb=short -q
+```
+Expected: ruff clean; all tests pass; coverage ≥ 85% (no `--cov-fail-under` failure).
+
+- [ ] **Step 2: If coverage dipped, add the missing-branch test**
+
+If the gate reports an uncovered line in `agent_tools_structural.py`, add a focused test to `test_setbuilder_structural.py` covering it (e.g. the `_duration_for` fallback when a slot's track is missing `duration_sec`), then re-run Step 1. Commit any addition:
+
+```bash
+git add server/tests/test_setbuilder_structural.py
+git commit -m "test(setbuilder): cover structural-tool edge branch (#491)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Frontend undo-discoverability hint
+
+Destructive ToolCards tell the DJ the rebuild is revertible via the existing global undo. Presentational only — no new undo path, no type changes.
+
+**Files:**
+- Modify: `dashboard/app/(dj)/setbuilder/components/ChatPanelBody.tsx` (`ToolCard` ~L83-118)
+- Modify: `dashboard/app/(dj)/setbuilder/setbuilder.module.css` (after `.toolRationale` ~L871)
+- Test: `dashboard/app/(dj)/setbuilder/components/__tests__/ChatPanelBody.test.tsx`
+
+**Interfaces:**
+- Consumes: `AppliedToolCall.name` (already on the generated type).
+- Produces: a `data-testid="agent-undo-hint"` element rendered only for `autobuild` / `fill_to_duration` tool cards.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `ChatPanelBody.test.tsx` inside the `describe('ChatPanelBody', ...)` block:
+
+```typescript
+  function entryWithTool(name: string) {
+    return {
+      id: 3,
+      role: 'assistant' as const,
+      content: 'Rebuilt the set: 12 slots, 3 refinement passes.',
+      display_summary: 'Rebuilt the set: 12 slots, 3 refinement passes.',
+      tool_calls: [
+        {
+          id: `${name}-1`,
+          name,
+          args: { rationale: 'Rebuild' },
+          result: { slot_count: 12, iterations: 3 },
+          mutating: true,
+          display_summary: 'Rebuilt the set: 12 slots, 3 refinement passes.',
+        },
+      ],
+      affected_transition_scores: [],
+    };
+  }
+
+  it('shows an undo hint on a destructive autobuild tool card', () => {
+    render(<ChatPanelBody chat={makeController({ entries: [entryWithTool('autobuild')] })} />);
+    expect(screen.getByTestId('agent-undo-hint')).toHaveTextContent(/undo/i);
+  });
+
+  it('does not show the undo hint on a non-destructive tool card', () => {
+    render(<ChatPanelBody chat={makeController({ entries: [entryWithTool('swap_slots')] })} />);
+    expect(screen.queryByTestId('agent-undo-hint')).not.toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- --run ChatPanelBody`
+Expected: FAIL — `Unable to find an element by: [data-testid="agent-undo-hint"]`.
+
+- [ ] **Step 3: Implement the hint**
+
+In `ChatPanelBody.tsx`, add this module-level constant near the top (after the imports):
+
+```typescript
+const DESTRUCTIVE_TOOL_NAMES = new Set(['autobuild', 'fill_to_duration']);
+```
+
+In the `ToolCard` component, add the hint inside `<div className={styles.toolBody}>`, right after the `{rationale && ...}` block:
+
+```tsx
+        {DESTRUCTIVE_TOOL_NAMES.has(tool.name) && (
+          <div className={styles.toolUndoHint} data-testid="agent-undo-hint">
+            Rebuilt your whole set — press ⌘Z (or Undo) to revert.
+          </div>
+        )}
+```
+
+- [ ] **Step 4: Add the CSS class**
+
+In `setbuilder.module.css`, add after the `.toolRationale { ... }` block:
+
+```css
+.toolUndoHint {
+  margin-top: 0.3rem;
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+}
+```
+
+- [ ] **Step 5: Run tests + lint + types to verify they pass**
+
+Run: `npm test -- --run ChatPanelBody && npm run lint && npx tsc --noEmit`
+Expected: PASS; ESLint clean; no TS errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/app/\(dj\)/setbuilder/components/ChatPanelBody.tsx \
+        dashboard/app/\(dj\)/setbuilder/setbuilder.module.css \
+        dashboard/app/\(dj\)/setbuilder/components/__tests__/ChatPanelBody.test.tsx
+git commit -m "feat(setbuilder): undo-discoverability hint on destructive agent tool cards (#491)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Final full CI sweep
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Backend**
+
+From `server/`:
+```bash
+.venv/bin/ruff check . && .venv/bin/ruff format --check . && \
+.venv/bin/bandit -r app -c pyproject.toml -q && .venv/bin/pytest --tb=short -q
+```
+Expected: all green, coverage ≥ 85%.
+
+- [ ] **Step 2: Migration drift (should be a no-op — no model changes)**
+
+```bash
+.venv/bin/alembic upgrade head && .venv/bin/alembic check
+```
+Expected: "No new upgrade operations detected." (This PR adds no columns/models.)
+
+- [ ] **Step 3: Frontend**
+
+From `dashboard/`:
+```bash
+npm run lint && npx tsc --noEmit && npm test -- --run
+```
+Expected: all green. (If `next-env.d.ts` was auto-modified, `git checkout dashboard/next-env.d.ts` before any further commit.)
+
+- [ ] **Step 4: Push + open PR**
+
+```bash
+git push -u origin feat/issue-491-autobuild-fill-duration
+```
+Then open a PR titled `feat(setbuilder): autobuild + fill_to_duration agent tools (#491)` with a Why/What/Testing body, `Closes #491`, and the agent credit. Move the issue to **In review** (`gh-project-move 491 "In review"`).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- autobuild (wraps build_set, honors locked/pairings) → Task 2. ✅
+- fill_to_duration (bounded, logged, never moves locked, errors without target) → Task 3. ✅
+- `build_set` commit-flag for turn atomicity → Task 1. ✅
+- Undo via global undo + discoverability hint → Task 5 (hint) + Task 2 (snapshot round-trip identity test proving restore fidelity). ✅
+- Allowlist wiring (MUTATION_TOOLS, _agent_tools, handler, display) → Tasks 2 & 3. ✅
+- `requests` untouched regression tests → Tasks 2 & 3. ✅
+- Coverage gate / full CI → Tasks 4 & 6. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✅
+
+**Type consistency:** `_tool_autobuild` / `_tool_fill_to_duration` signatures `(db, set_obj, payload) -> tuple[dict, set[int]]` match the handler dict and the existing tool contract. `build_set(..., *, commit=...)` is consistent between Task 1 (definition) and Task 2 (caller). Result keys used in display summaries (`slot_count`, `iterations`, `inserted_count`, `estimated_total_sec`, `target_duration_sec`, `capped`) match those returned by the tools. ✅

--- a/docs/superpowers/specs/2026-06-21-setbuilder-autobuild-fill-design.md
+++ b/docs/superpowers/specs/2026-06-21-setbuilder-autobuild-fill-design.md
@@ -1,0 +1,162 @@
+# Design — `autobuild` + `fill_to_duration` agent tools (#491, #442 Family 3)
+
+**Date:** 2026-06-21
+**Issue:** #491 (epic #442, Family 3 — structural/destructive)
+**Branch:** `feat/issue-491-autobuild-fill-duration`
+
+## Why
+
+Family 3 of the WrzDJSet agent toolkit adds the two *wholesale / destructive*
+structural tools. The reversible Family 3 tools (`move_range` #481, pairing tools
+#482) already shipped; these two are different because they rewrite the timeline
+en masse:
+
+- **`autobuild`** — regenerate the entire ordering from the pool + curve.
+- **`fill_to_duration`** — keep appending pool tracks until the set reaches its
+  target duration.
+
+#442 flagged these as *"higher impact: needs undo UX"* — the original gate. That
+gate is now satisfied (see below), so the tools are unblocked.
+
+## The undo gate is already closed (changes #491's Task 0)
+
+#491's written Task 0 assumed a **backend** capture-before-destroy plus a
+per-ToolCard *"Undo this rebuild"* button. That is no longer the right design:
+**#493 / #494 already shipped a global undo** that snapshots the *whole document*
+before every mutating agent turn.
+
+- `useSetDocumentHistory.commit()` captures `before = fetchCurrent()` (full
+  document) *before* running the action, then pushes that snapshot onto the undo
+  stack when `shouldRecord(result)` is true.
+- `useAgentChat.send()` wraps the whole turn in `commit()` with
+  `shouldRecord = didMutate` (true when any returned tool call has
+  `mutating: true`).
+
+So any mutating agent turn — including a future `autobuild` — is automatically
+captured-before and revertible via ⌘Z / the Undo button, **for free**, as long as
+the tool lands in `MUTATION_TOOLS`. Building a second, per-tool undo path would
+duplicate state the global undo already captures.
+
+**Decision (user-approved):** rely on the existing global undo; do **not** build a
+second undo path. Address the real concern — *discoverability* of undo for a
+wholesale rebuild — with a small hint on the destructive ToolCards, and prove
+safety with a backend snapshot round-trip identity test.
+
+## Architecture & boundaries
+
+Two new mutating tools live in a **new module**
+`server/app/services/setbuilder/agent_tools_structural.py`.
+
+Rationale for a new module rather than extending `agent_tools_mutations.py`: that
+file is already 500 lines (the house budget edge), and the rule is *never add to a
+file already over budget — extract first*. A dedicated module also gives a clean
+cohesion boundary: wholesale/structural ops vs. the granular per-slot edits.
+
+Each tool follows the established toolkit contract:
+
+- Signature `_tool_x(db, set_obj, payload) -> tuple[dict[str, Any], set[int]]`.
+- `db.flush()`, never `db.commit()` — `chat_with_agent` owns the single per-turn
+  commit/rollback so a multi-tool turn stays atomic.
+- Owner-scoped structurally: `set_obj` arrives already scoped via
+  `set_service.get_owned_set`.
+- Member of `MUTATION_TOOLS` → rationale is required *and* the frontend global
+  undo records the turn.
+- **Never** writes the `requests` table (pinned by a regression test).
+
+## `autobuild`
+
+Thin wrapper over `pass1_deterministic.build_set(db, set_obj)`, which already
+honors locked slots (`_locked_slots` → `locked_by_pos`) and saved pairings
+(`PAIRING_BOOST_POINTS`), regenerates the order, persists, and rescoring.
+
+**Supporting change:** `build_set` currently commits internally (in
+`_persist_slots` and its `recompute_transition_scores` call). Add a
+`commit: bool = True` parameter threaded through both, so the agent path calls
+`build_set(db, set_obj, commit=False)` (flush only) and the turn owns the commit.
+The single existing REST caller (`api/setbuilder.py:672`) keeps the default
+`True` → behavior unchanged.
+
+- Result: `{"slot_count": int, "iterations": int}`.
+- Affected positions: all slot positions (whole set rescored).
+- Spec: a bare `ToolSpec` (only `rationale` required) with a description that
+  makes the *wholesale* nature explicit so the model treats it as destructive.
+
+## `fill_to_duration`
+
+- Guard: `set_obj.target_duration_sec` unset → `AgentToolError("Set a target
+  duration first")`.
+- Estimate the current total from each slot's pool-track `duration_sec`
+  (fallback `AVG_TRACK_LENGTH_SEC` for missing values).
+- Append **unused** pool tracks (not already referenced by a slot's `track_id`),
+  in deterministic pool order, via the existing
+  `_insert_track_at(db, set_obj, track, position)` primitive at the tail — which
+  already refuses to displace a locked slot.
+- Stop when: estimated total ≥ target **OR** pool exhausted **OR** a hard cap
+  `MAX_FILL_INSERTS` is reached (safety bound required by the issue).
+- `log()` the number of tracks added.
+- Result: `{"inserted_count": int, "estimated_total_sec": int, "target_duration_sec":
+  int, "capped": bool, "pool_exhausted": bool}`; affected = the new positions.
+
+**Track-selection is intentionally simple** (pool order, not quality-ranked): the
+DJ can run `autobuild` afterward to reorder. This keeps the tool small and avoids
+duplicating pass-1 candidate scoring.
+
+## Wiring (additive spots)
+
+- `agent_common.py` — add `"autobuild"`, `"fill_to_duration"` to `MUTATION_TOOLS`.
+- `agent_tool_specs.py` — add two bare `ToolSpec`s (required: `["rationale"]`).
+- `pass2_agent.py` `apply_tool_call` handlers dict — `+2` entries, importing the
+  new `agent_tools_structural` module.
+- `agent_display.py` `_tool_display_summary` — `+2` cases:
+  - autobuild → *"Rebuilt the set: N slots, M refinement passes."*
+  - fill_to_duration → *"Filled toward target: added N tracks (~X min), now Y min."*
+
+## Frontend — undo discoverability only
+
+`dashboard/app/(dj)/setbuilder/components/ChatPanelBody.tsx`, in `ToolCard`:
+
+- A `DESTRUCTIVE_TOOL_NAMES = new Set(['autobuild', 'fill_to_duration'])`.
+- When `tool.name` is in the set, render a hint line:
+  *"Rebuilt your whole set — press ⌘Z (or Undo) to revert."*
+- One small CSS class in `setbuilder.module.css`. Keys off `tool.name`; no
+  API/type changes (`AppliedToolCall` is generated and already carries `name`).
+
+## Tests (TDD; must hold the 85% backend coverage gate)
+
+**Backend**
+- `autobuild` regenerates order honoring locked slots; requires rationale; leaves
+  `requests` untouched.
+- **Turn atomicity:** an `autobuild` followed by a failing tool in the same turn
+  rolls back entirely (proves `commit=False`).
+- `fill_to_duration`: stops at target; respects `MAX_FILL_INSERTS` (logged);
+  never moves locked slots; errors with no `target_duration_sec`; leaves
+  `requests` untouched.
+- **Snapshot round-trip identity:** `build_snapshot → restore_snapshot` returns
+  the exact prior slot order / targets / curve / pool (acceptance criterion that
+  replaces the per-tool undo button). Use a set whose slots reference real pool
+  tracks (so the synthetic-`pool:<id>` remap path is meaningful).
+
+**Frontend**
+- `ToolCard` renders the undo hint for `autobuild` / `fill_to_duration` and not
+  for other tools.
+
+## Acceptance criteria (mapped from #491)
+
+- [x] Task 0 (undo): satisfied by the global undo (#493/#494) + discoverability
+  hint; round-trip identity test proves restore fidelity.
+- [ ] After `autobuild`, restoring the captured snapshot returns the exact prior
+  slot order/targets/curve (round-trip test).
+- [ ] `autobuild` honors locked slots; `fill_to_duration` stops at target with a
+  bounded, logged insert count.
+- [ ] Both owner-scoped, require rationale, in `MUTATION_TOOLS`, render in
+  ToolCard, leave `requests` untouched (regression tests).
+- [ ] TDD throughout; full backend suite green at the coverage gate.
+
+## Out of scope
+
+- Family 4 cross-surface imports (`import_from_event` / `import_from_tidal`) —
+  separate issue under #442.
+- Any quality-ranked `fill_to_duration` selection.
+- A second / per-tool undo affordance (global undo already covers it).
+
+🤖 Co-authored by Claude Opus 4.8 (1M context). Part of #442 (Family 3, structural).

--- a/server/app/services/setbuilder/agent_common.py
+++ b/server/app/services/setbuilder/agent_common.py
@@ -26,6 +26,7 @@ MUTATION_TOOLS = {
     "set_curve_point",
     "remove_curve_point",
     "apply_curve_template",
+    "autobuild",
     "set_target",
     "lock_slot",
     "unlock_slot",

--- a/server/app/services/setbuilder/agent_common.py
+++ b/server/app/services/setbuilder/agent_common.py
@@ -27,6 +27,7 @@ MUTATION_TOOLS = {
     "remove_curve_point",
     "apply_curve_template",
     "autobuild",
+    "fill_to_duration",
     "set_target",
     "lock_slot",
     "unlock_slot",

--- a/server/app/services/setbuilder/agent_display.py
+++ b/server/app/services/setbuilder/agent_display.py
@@ -165,6 +165,17 @@ def _tool_display_summary(
             f"Rebuilt the set: {slots} slot{'s' if slots != 1 else ''}, "
             f"{iterations} refinement pass{'es' if iterations != 1 else ''}."
         )
+    if name == "fill_to_duration":
+        added = int(result.get("inserted_count") or 0)
+        now_min = int(result.get("estimated_total_sec") or 0) // 60
+        target_min = int(result.get("target_duration_sec") or 0) // 60
+        if added == 0:
+            return f"No tracks added; set already ~{now_min} min of ~{target_min} min target."
+        base = (
+            f"Added {added} track{'s' if added != 1 else ''} toward target; "
+            f"now ~{now_min} min of ~{target_min} min."
+        )
+        return f"{base} Hit the per-turn insert cap." if result.get("capped") else base
     return name.replace("_", " ").capitalize() + "."
 
 

--- a/server/app/services/setbuilder/agent_display.py
+++ b/server/app/services/setbuilder/agent_display.py
@@ -158,6 +158,13 @@ def _tool_display_summary(
         return f"{verb} {transition}."
     if name == "remove_pairing":
         return f"Unpinned the transition {result.get('from_label')} → {result.get('into_label')}."
+    if name == "autobuild":
+        slots = int(result.get("slot_count") or 0)
+        iterations = int(result.get("iterations") or 0)
+        return (
+            f"Rebuilt the set: {slots} slot{'s' if slots != 1 else ''}, "
+            f"{iterations} refinement pass{'es' if iterations != 1 else ''}."
+        )
     return name.replace("_", " ").capitalize() + "."
 
 

--- a/server/app/services/setbuilder/agent_tool_specs.py
+++ b/server/app/services/setbuilder/agent_tool_specs.py
@@ -122,6 +122,20 @@ def _agent_tools() -> list[ToolSpec]:
             },
         ),
         ToolSpec(
+            name="autobuild",
+            description=(
+                "Regenerate the ENTIRE set order from the pool and energy curve "
+                "(deterministic pass 1). This REPLACES the current hand-arranged "
+                "order wholesale; locked slots and saved pairings are preserved. "
+                "Destructive — use only when the DJ asks to rebuild / auto-arrange."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {"rationale": {"type": "string"}},
+                "required": ["rationale"],
+            },
+        ),
+        ToolSpec(
             name="analyze_transition",
             description="Analyze one transition by destination slot position.",
             input_schema={

--- a/server/app/services/setbuilder/agent_tool_specs.py
+++ b/server/app/services/setbuilder/agent_tool_specs.py
@@ -136,6 +136,20 @@ def _agent_tools() -> list[ToolSpec]:
             },
         ),
         ToolSpec(
+            name="fill_to_duration",
+            description=(
+                "Append pool tracks not already in the set, in pool order, until "
+                "the set reaches its target_duration_sec. Requires a duration "
+                "target. Never moves locked slots; the number of inserts is capped "
+                "per turn. Can add many slots at once — destructive-ish."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {"rationale": {"type": "string"}},
+                "required": ["rationale"],
+            },
+        ),
+        ToolSpec(
             name="analyze_transition",
             description="Analyze one transition by destination slot position.",
             input_schema={

--- a/server/app/services/setbuilder/agent_tools_structural.py
+++ b/server/app/services/setbuilder/agent_tools_structural.py
@@ -1,0 +1,30 @@
+"""Destructive structural WrzDJSet agent tools (#491, #442 Family 3).
+
+``autobuild`` regenerates the whole order from the pool + curve; both tools are
+in ``MUTATION_TOOLS`` and dispatched only through ``apply_tool_call``. They are
+undoable via the frontend global-undo stack (#493/#494), which snapshots the
+whole document before every mutating agent turn.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.models.set import Set
+from app.services.setbuilder.pass1_deterministic import build_set
+
+
+def _tool_autobuild(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Regenerate the entire ordering from the pool + curve (wholesale).
+
+    Thin owner-scoped wrapper over ``pass1_deterministic.build_set``, which
+    already honors locked slots and saved pairings. Runs with ``commit=False``
+    so the agent turn commits/rolls back as one unit.
+    """
+    result = build_set(db, set_obj, commit=False)
+    affected = {slot.position for slot in result.slots}
+    return {"slot_count": result.slot_count, "iterations": result.iterations}, affected

--- a/server/app/services/setbuilder/agent_tools_structural.py
+++ b/server/app/services/setbuilder/agent_tools_structural.py
@@ -55,7 +55,10 @@ def _tool_fill_to_duration(
     than ``MAX_FILL_INSERTS`` in one turn.
     """
     target = set_obj.target_duration_sec
-    if not target:
+    # Explicit None check: a target of 0 is a valid (if unusual) assigned value —
+    # the loop below treats it as "already met" and appends nothing, rather than
+    # erroring as if no target were set.
+    if target is None:
         raise AgentToolError("Set a target duration first (target_duration_sec).")
 
     pool = _pool_tracks(db, set_obj.id)

--- a/server/app/services/setbuilder/agent_tools_structural.py
+++ b/server/app/services/setbuilder/agent_tools_structural.py
@@ -8,12 +8,22 @@ whole document before every mutating agent turn.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from sqlalchemy.orm import Session
 
 from app.models.set import Set
-from app.services.setbuilder.pass1_deterministic import build_set
+from app.services.setbuilder.agent_common import AgentToolError, _ordered_slots, _pool_tracks
+from app.services.setbuilder.agent_tools_mutations import _insert_track_at
+from app.services.setbuilder.pass1_deterministic import AVG_TRACK_LENGTH_SEC, build_set
+from app.services.setbuilder.pass1_deterministic import _track_meta as _pass1_track_meta
+
+logger = logging.getLogger(__name__)
+
+# Per-turn safety cap: one fill_to_duration call can never append more than this
+# many slots, independent of pool size (the issue's bounded-insert requirement).
+MAX_FILL_INSERTS = 100
 
 
 def _tool_autobuild(
@@ -28,3 +38,63 @@ def _tool_autobuild(
     result = build_set(db, set_obj, commit=False)
     affected = {slot.position for slot in result.slots}
     return {"slot_count": result.slot_count, "iterations": result.iterations}, affected
+
+
+def _duration_for(track) -> int:
+    """A pool track's duration in seconds, falling back to the pass-1 average."""
+    if track is not None and track.duration_sec and track.duration_sec > 0:
+        return track.duration_sec
+    return AVG_TRACK_LENGTH_SEC
+
+
+def _tool_fill_to_duration(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Append unused pool tracks (in pool order) until the set reaches its
+    ``target_duration_sec``, never moving locked slots and never appending more
+    than ``MAX_FILL_INSERTS`` in one turn.
+    """
+    target = set_obj.target_duration_sec
+    if not target:
+        raise AgentToolError("Set a target duration first (target_duration_sec).")
+
+    pool = _pool_tracks(db, set_obj.id)
+    by_slot_track_id = {_pass1_track_meta(t).slot_track_id: t for t in pool}
+    slots = _ordered_slots(db, set_obj.id)
+    used = {slot.track_id for slot in slots if slot.track_id}
+    total = sum(_duration_for(by_slot_track_id.get(slot.track_id)) for slot in slots)
+    candidates = [t for t in pool if _pass1_track_meta(t).slot_track_id not in used]
+
+    base_count = len(slots)
+    affected: set[int] = set()
+    inserted = 0
+    capped = False
+    for track in candidates:
+        if total >= target:
+            break
+        if inserted >= MAX_FILL_INSERTS:
+            capped = True
+            break
+        _, positions = _insert_track_at(db, set_obj, track, base_count + inserted)
+        affected |= positions
+        total += _duration_for(track)
+        inserted += 1
+
+    pool_exhausted = total < target and not capped
+    logger.info(
+        "setbuilder fill_to_duration: set %s added %s tracks (target=%ss, est_total=%ss, "
+        "capped=%s, pool_exhausted=%s)",
+        set_obj.id,
+        inserted,
+        target,
+        total,
+        capped,
+        pool_exhausted,
+    )
+    return {
+        "inserted_count": inserted,
+        "estimated_total_sec": total,
+        "target_duration_sec": target,
+        "capped": capped,
+        "pool_exhausted": pool_exhausted,
+    }, affected

--- a/server/app/services/setbuilder/agent_tools_structural.py
+++ b/server/app/services/setbuilder/agent_tools_structural.py
@@ -37,6 +37,12 @@ def _tool_autobuild(
     """
     result = build_set(db, set_obj, commit=False)
     affected = {slot.position for slot in result.slots}
+    logger.info(
+        "setbuilder autobuild: set %s rebuilt to %s slots (%s refinement iterations)",
+        set_obj.id,
+        result.slot_count,
+        result.iterations,
+    )
     return {"slot_count": result.slot_count, "iterations": result.iterations}, affected
 
 

--- a/server/app/services/setbuilder/pass1_deterministic.py
+++ b/server/app/services/setbuilder/pass1_deterministic.py
@@ -52,7 +52,7 @@ class BuildResult:
     transition_scores: list[TransitionScore]
 
 
-def build_set(db: Session, set_obj: Set) -> BuildResult:
+def build_set(db: Session, set_obj: Set, *, commit: bool = True) -> BuildResult:
     """Build and persist a deterministic ordered set from the set pool."""
     pool_tracks = _pool_tracks(db, set_obj.id)
     locked = _locked_slots(db, set_obj.id)
@@ -92,8 +92,8 @@ def build_set(db: Session, set_obj: Set) -> BuildResult:
         targets=targets,
         key_strictness=set_obj.key_strictness,
     )
-    slots = _persist_slots(db, set_obj.id, locked_by_pos, chosen, targets)
-    scores = recompute_transition_scores(db, set_obj, slots)
+    slots = _persist_slots(db, set_obj.id, locked_by_pos, chosen, targets, commit=commit)
+    scores = recompute_transition_scores(db, set_obj, slots, commit=commit)
     return BuildResult(
         slots=slots,
         slot_count=slot_count,
@@ -424,6 +424,8 @@ def _persist_slots(
     locked_by_pos: dict[int, SetSlot],
     chosen: list[TrackMeta | None],
     targets: list[float],
+    *,
+    commit: bool = True,
 ) -> list[SetSlot]:
     for slot in (
         db.query(SetSlot)
@@ -449,5 +451,8 @@ def _persist_slots(
                 target_energy=targets[pos],
             )
         )
-    db.commit()
+    if commit:
+        db.commit()
+    else:
+        db.flush()
     return _ordered_slots(db, set_id)

--- a/server/app/services/setbuilder/pass1_deterministic.py
+++ b/server/app/services/setbuilder/pass1_deterministic.py
@@ -454,5 +454,7 @@ def _persist_slots(
     if commit:
         db.commit()
     else:
+        # Agent path (autobuild): flush so _ordered_slots sees the new rows, but
+        # leave the transaction open so the chat turn owns the commit/rollback.
         db.flush()
     return _ordered_slots(db, set_id)

--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -60,7 +60,7 @@ from app.services.setbuilder.agent_tools_sensing import (
     _tool_summarize_set,
     _track_summary,
 )
-from app.services.setbuilder.agent_tools_structural import _tool_autobuild
+from app.services.setbuilder.agent_tools_structural import _tool_autobuild, _tool_fill_to_duration
 from app.services.setbuilder.pass1_deterministic import (
     TransitionScore,
     recompute_transition_scores,
@@ -319,6 +319,7 @@ def apply_tool_call(
         "remove_curve_point": _tool_remove_curve_point,
         "apply_curve_template": _tool_apply_curve_template,
         "autobuild": _tool_autobuild,
+        "fill_to_duration": _tool_fill_to_duration,
         "set_target": _tool_set_target,
         "lock_slot": _tool_lock_slot,
         "unlock_slot": _tool_unlock_slot,

--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -60,6 +60,7 @@ from app.services.setbuilder.agent_tools_sensing import (
     _tool_summarize_set,
     _track_summary,
 )
+from app.services.setbuilder.agent_tools_structural import _tool_autobuild
 from app.services.setbuilder.pass1_deterministic import (
     TransitionScore,
     recompute_transition_scores,
@@ -317,6 +318,7 @@ def apply_tool_call(
         "set_curve_point": _tool_set_curve_point,
         "remove_curve_point": _tool_remove_curve_point,
         "apply_curve_template": _tool_apply_curve_template,
+        "autobuild": _tool_autobuild,
         "set_target": _tool_set_target,
         "lock_slot": _tool_lock_slot,
         "unlock_slot": _tool_unlock_slot,

--- a/server/tests/test_setbuilder_pass1.py
+++ b/server/tests/test_setbuilder_pass1.py
@@ -99,3 +99,21 @@ def test_saved_pairing_boost_keeps_adjacent_pair(db: Session, test_user: User):
     result = build_set(db, set_obj)
 
     assert [slot.track_id for slot in result.slots] == ["tidal:a", "tidal:b"]
+
+
+def test_build_set_commit_false_defers_persistence_to_caller(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, duration=7 * 60)
+    src = _mk_source(db, set_obj)
+    for idx in range(4):
+        _mk_track(db, set_obj, src, idx)
+
+    # commit=False only flushes, so a rollback discards the generated slots.
+    build_set(db, set_obj, commit=False)
+    assert db.query(SetSlot).filter(SetSlot.set_id == set_obj.id).count() > 0
+    db.rollback()
+    assert db.query(SetSlot).filter(SetSlot.set_id == set_obj.id).count() == 0
+
+    # Default commit=True persists across a rollback.
+    build_set(db, set_obj)
+    db.rollback()
+    assert db.query(SetSlot).filter(SetSlot.set_id == set_obj.id).count() > 0

--- a/server/tests/test_setbuilder_structural.py
+++ b/server/tests/test_setbuilder_structural.py
@@ -298,3 +298,38 @@ def test_fill_to_duration_display_summary_is_human_readable():
         {},
     )
     assert none_added == "No tracks added; set already ~10 min of ~10 min target."
+
+
+def test_duration_for_falls_back_to_average_when_missing():
+    from app.services.setbuilder.agent_tools_structural import (
+        AVG_TRACK_LENGTH_SEC,
+        _duration_for,
+    )
+
+    class _FakeTrack:
+        duration_sec = None
+
+    assert _duration_for(None) == AVG_TRACK_LENGTH_SEC
+    assert _duration_for(_FakeTrack()) == AVG_TRACK_LENGTH_SEC
+    _FakeTrack.duration_sec = 0
+    assert _duration_for(_FakeTrack()) == AVG_TRACK_LENGTH_SEC
+    _FakeTrack.duration_sec = 180
+    assert _duration_for(_FakeTrack()) == 180
+
+
+def test_fill_to_duration_display_summary_notes_cap():
+    capped = _tool_display_summary(
+        "fill_to_duration",
+        {"rationale": "x"},
+        {
+            "inserted_count": 2,
+            "estimated_total_sec": 420,
+            "target_duration_sec": 9999,
+            "capped": True,
+            "pool_exhausted": False,
+        },
+        {},
+        {},
+    )
+    assert "Added 2 tracks toward target" in capped
+    assert "Hit the per-turn insert cap." in capped

--- a/server/tests/test_setbuilder_structural.py
+++ b/server/tests/test_setbuilder_structural.py
@@ -227,6 +227,25 @@ def test_fill_to_duration_errors_without_target(db: Session, test_user: User):
         apply_tool_call(db, set_obj, "fill_to_duration", {"rationale": "Fill it."})
 
 
+def test_fill_to_duration_zero_target_is_noop(db: Session, test_user: User):
+    # A target of 0 is a valid assigned value (set_target allows min 0), not
+    # "missing": fill treats it as already met and appends nothing instead of
+    # raising. Regression for the `if not target` → `if target is None` fix.
+    set_obj = _mk_set(db, test_user, n_tracks=3, n_slots=1, duration=7 * 60)
+    set_obj.target_duration_sec = 0
+    db.commit()
+
+    result, positions = apply_tool_call(
+        db, set_obj, "fill_to_duration", {"rationale": "Target is zero."}
+    )
+
+    assert result["inserted_count"] == 0
+    assert result["capped"] is False
+    assert result["pool_exhausted"] is False
+    assert positions == set()
+    assert db.query(SetSlot).filter(SetSlot.set_id == set_obj.id).count() == 1
+
+
 def test_fill_to_duration_never_moves_locked_slot(db: Session, test_user: User):
     set_obj = _mk_set(db, test_user, n_tracks=5, n_slots=0, duration=4 * 210)
     db.add(SetSlot(set_id=set_obj.id, position=0, track_id="tidal:0", locked=True))

--- a/server/tests/test_setbuilder_structural.py
+++ b/server/tests/test_setbuilder_structural.py
@@ -177,3 +177,124 @@ def test_autobuild_display_summary_is_human_readable():
         "autobuild", {"rationale": "x"}, {"slot_count": 1, "iterations": 1}, {}, {}
     )
     assert one == "Rebuilt the set: 1 slot, 1 refinement pass."
+
+
+def test_fill_to_duration_stops_at_target(db: Session, test_user: User):
+    # 1 seeded slot (210s) + 4 unused tracks; target 840s needs 3 more (4*210=840).
+    set_obj = _mk_set(db, test_user, n_tracks=5, n_slots=1, duration=4 * 210)
+
+    result, positions = apply_tool_call(
+        db, set_obj, "fill_to_duration", {"rationale": "Fill to the target."}
+    )
+
+    assert result["inserted_count"] == 3
+    assert result["estimated_total_sec"] == 4 * 210
+    assert result["capped"] is False
+    assert result["pool_exhausted"] is False
+    assert db.query(SetSlot).filter(SetSlot.set_id == set_obj.id).count() == 4
+    assert positions == {1, 2, 3}
+
+
+def test_fill_to_duration_stops_when_pool_exhausted(db: Session, test_user: User):
+    # Only 2 unused tracks but the target wants far more — stop, flag exhausted.
+    set_obj = _mk_set(db, test_user, n_tracks=3, n_slots=1, duration=99 * 210)
+
+    result, _ = apply_tool_call(
+        db, set_obj, "fill_to_duration", {"rationale": "Use everything available."}
+    )
+
+    assert result["inserted_count"] == 2
+    assert result["pool_exhausted"] is True
+    assert result["capped"] is False
+
+
+def test_fill_to_duration_respects_insert_cap(monkeypatch, db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, n_tracks=6, n_slots=1, duration=99 * 210)
+    monkeypatch.setattr("app.services.setbuilder.agent_tools_structural.MAX_FILL_INSERTS", 2)
+
+    result, _ = apply_tool_call(db, set_obj, "fill_to_duration", {"rationale": "Bounded fill."})
+
+    assert result["inserted_count"] == 2
+    assert result["capped"] is True
+
+
+def test_fill_to_duration_errors_without_target(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, n_tracks=3, n_slots=1, duration=7 * 60)
+    set_obj.target_duration_sec = None
+    db.commit()
+
+    with pytest.raises(AgentToolError, match="target duration"):
+        apply_tool_call(db, set_obj, "fill_to_duration", {"rationale": "Fill it."})
+
+
+def test_fill_to_duration_never_moves_locked_slot(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, n_tracks=5, n_slots=0, duration=4 * 210)
+    db.add(SetSlot(set_id=set_obj.id, position=0, track_id="tidal:0", locked=True))
+    db.commit()
+
+    apply_tool_call(db, set_obj, "fill_to_duration", {"rationale": "Append after the pin."})
+
+    locked = (
+        db.query(SetSlot)
+        .filter(SetSlot.set_id == set_obj.id, SetSlot.locked == True)  # noqa: E712
+        .one()
+    )
+    assert locked.position == 0
+    assert locked.track_id == "tidal:0"
+
+
+def test_fill_to_duration_requires_rationale(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, n_tracks=3, n_slots=1, duration=7 * 60)
+
+    with pytest.raises(AgentToolError, match="rationale"):
+        apply_tool_call(db, set_obj, "fill_to_duration", {})
+
+
+def test_fill_to_duration_in_mutation_tools():
+    assert "fill_to_duration" in MUTATION_TOOLS
+
+
+def test_fill_to_duration_leaves_event_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set(db, test_user, n_tracks=5, n_slots=1, duration=4 * 210)
+    before_count = db.query(Request).count()
+    before_title = test_request.song_title
+
+    apply_tool_call(db, set_obj, "fill_to_duration", {"rationale": "Fill to target."})
+
+    db.refresh(test_request)
+    assert db.query(Request).count() == before_count
+    assert test_request.song_title == before_title
+
+
+def test_fill_to_duration_display_summary_is_human_readable():
+    added = _tool_display_summary(
+        "fill_to_duration",
+        {"rationale": "x"},
+        {
+            "inserted_count": 3,
+            "estimated_total_sec": 840,
+            "target_duration_sec": 840,
+            "capped": False,
+            "pool_exhausted": False,
+        },
+        {},
+        {},
+    )
+    assert added == "Added 3 tracks toward target; now ~14 min of ~14 min."
+
+    none_added = _tool_display_summary(
+        "fill_to_duration",
+        {"rationale": "x"},
+        {
+            "inserted_count": 0,
+            "estimated_total_sec": 600,
+            "target_duration_sec": 600,
+            "capped": False,
+            "pool_exhausted": False,
+        },
+        {},
+        {},
+    )
+    assert none_added == "No tracks added; set already ~10 min of ~10 min target."

--- a/server/tests/test_setbuilder_structural.py
+++ b/server/tests/test_setbuilder_structural.py
@@ -1,0 +1,179 @@
+"""Tests for the destructive structural WrzDJSet agent tools (#491, #442 Family 3)."""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.request import Request
+from app.models.set import Set, SetSlot
+from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.models.user import User
+from app.services.llm.base import ChatResponse, ToolCall
+from app.services.setbuilder.agent_display import _tool_display_summary
+from app.services.setbuilder.document_snapshot import build_snapshot, restore_snapshot
+from app.services.setbuilder.pass2_agent import (
+    MUTATION_TOOLS,
+    AgentToolError,
+    apply_tool_call,
+    chat_with_agent,
+)
+
+
+def _mk_set(db: Session, user: User, *, n_tracks: int, n_slots: int, duration: int) -> Set:
+    """Set with ``n_tracks`` pool tracks (210s each) and ``n_slots`` seeded slots."""
+    set_obj = Set(owner_id=user.id, name="Structural Set", target_duration_sec=duration)
+    db.add(set_obj)
+    db.flush()
+    source = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(source)
+    db.flush()
+    db.add_all(
+        [
+            SetPoolTrack(
+                set_id=set_obj.id,
+                source_id=source.id,
+                track_id=f"tidal:{idx}",
+                title=f"Track {idx}",
+                artist=f"Artist {idx}",
+                bpm=124 + idx,
+                key="8A",
+                camelot="8A",
+                energy=5,
+                duration_sec=210,
+                dedupe_sig=f"struct-sig-{idx}",
+            )
+            for idx in range(n_tracks)
+        ]
+    )
+    db.flush()
+    db.add_all(
+        [SetSlot(set_id=set_obj.id, position=i, track_id=f"tidal:{i}") for i in range(n_slots)]
+    )
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def test_autobuild_regenerates_order_and_reports_counts(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, n_tracks=4, n_slots=0, duration=14 * 60)
+
+    result, positions = apply_tool_call(
+        db, set_obj, "autobuild", {"rationale": "Auto-arrange from the pool."}
+    )
+
+    slots = db.query(SetSlot).filter(SetSlot.set_id == set_obj.id).all()
+    assert result["slot_count"] == len(slots)
+    assert result["slot_count"] > 0
+    assert isinstance(result["iterations"], int)
+    assert positions == {s.position for s in slots}
+
+
+def test_autobuild_preserves_locked_slot(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, n_tracks=6, n_slots=0, duration=14 * 60)
+    db.add(SetSlot(set_id=set_obj.id, position=1, track_id="tidal:5", locked=True))
+    db.commit()
+
+    apply_tool_call(db, set_obj, "autobuild", {"rationale": "Rebuild around the pin."})
+
+    locked = (
+        db.query(SetSlot)
+        .filter(SetSlot.set_id == set_obj.id, SetSlot.locked == True)  # noqa: E712
+        .one()
+    )
+    assert locked.position == 1
+    assert locked.track_id == "tidal:5"
+
+
+def test_autobuild_requires_rationale(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user, n_tracks=3, n_slots=0, duration=7 * 60)
+
+    with pytest.raises(AgentToolError, match="rationale"):
+        apply_tool_call(db, set_obj, "autobuild", {})
+
+
+def test_autobuild_in_mutation_tools():
+    assert "autobuild" in MUTATION_TOOLS
+
+
+def test_autobuild_leaves_event_requests_untouched(
+    db: Session, test_user: User, test_request: Request
+):
+    set_obj = _mk_set(db, test_user, n_tracks=4, n_slots=0, duration=14 * 60)
+    before_count = db.query(Request).count()
+    before_title = test_request.song_title
+
+    apply_tool_call(db, set_obj, "autobuild", {"rationale": "Rebuild it."})
+
+    db.refresh(test_request)
+    assert db.query(Request).count() == before_count
+    assert test_request.song_title == before_title
+
+
+@pytest.mark.asyncio
+async def test_autobuild_then_failing_tool_rolls_back_whole_turn(
+    monkeypatch, db: Session, test_user: User
+):
+    """commit=False means a later tool failure rolls the autobuild back too."""
+    set_obj = _mk_set(db, test_user, n_tracks=3, n_slots=2, duration=7 * 60)
+    original = [
+        s.track_id
+        for s in db.query(SetSlot)
+        .filter(SetSlot.set_id == set_obj.id)
+        .order_by(SetSlot.position)
+        .all()
+    ]
+
+    async def fake_dispatch(*args, **kwargs):
+        return ChatResponse(
+            stop_reason="tool_use",
+            tool_calls=[
+                ToolCall(id="ab", name="autobuild", input={"rationale": "Rebuild."}),
+                ToolCall(
+                    id="boom",
+                    name="swap_slots",
+                    input={"slot_a_id": 999999, "slot_b_id": 999998, "rationale": "boom"},
+                ),
+            ],
+        )
+
+    monkeypatch.setattr("app.services.setbuilder.pass2_agent.Gateway.dispatch", fake_dispatch)
+
+    with pytest.raises(AgentToolError):
+        await chat_with_agent(db, test_user, set_obj, message="Rebuild then break")
+
+    remaining = [
+        s.track_id
+        for s in db.query(SetSlot)
+        .filter(SetSlot.set_id == set_obj.id)
+        .order_by(SetSlot.position)
+        .all()
+    ]
+    assert remaining == original
+
+
+def test_autobuild_then_restore_snapshot_returns_prior_order(db: Session, test_user: User):
+    """#491 acceptance: the captured snapshot restores the exact pre-autobuild order."""
+    set_obj = _mk_set(db, test_user, n_tracks=4, n_slots=2, duration=14 * 60)
+    before = build_snapshot(set_obj)
+    before_ids = [s.track_id for s in sorted(set_obj.slots, key=lambda s: s.position)]
+
+    apply_tool_call(db, set_obj, "autobuild", {"rationale": "Rebuild wholesale."})
+    db.commit()
+    db.refresh(set_obj)
+
+    restore_snapshot(db, set_obj, before)
+    db.refresh(set_obj)
+
+    after_ids = [s.track_id for s in sorted(set_obj.slots, key=lambda s: s.position)]
+    assert after_ids == before_ids
+
+
+def test_autobuild_display_summary_is_human_readable():
+    summary = _tool_display_summary(
+        "autobuild", {"rationale": "x"}, {"slot_count": 12, "iterations": 3}, {}, {}
+    )
+    assert summary == "Rebuilt the set: 12 slots, 3 refinement passes."
+
+    one = _tool_display_summary(
+        "autobuild", {"rationale": "x"}, {"slot_count": 1, "iterations": 1}, {}, {}
+    )
+    assert one == "Rebuilt the set: 1 slot, 1 refinement pass."


### PR DESCRIPTION
## Why
The WrzDJSet chat agent could sense the set and make granular edits, but had no way to (re)build it wholesale. This closes **Family 3** of epic #442 with the two destructive *structural* tools. The family was gated on undo UX — now resolved by the global-undo stack from #493/#494.

## What
- **`autobuild`** — regenerate the entire set order from the pool + energy curve via the deterministic pass-1 builder (already honors locked slots and saved pairings). Replaces the hand-arranged order wholesale.
- **`fill_to_duration`** — append unused pool tracks (deterministic pool order) until the set reaches its `target_duration_sec`; bounded by a per-turn hard cap (`MAX_FILL_INSERTS`) and never moves locked slots.
- **Supporting change** — `build_set` gained `commit: bool = True`; the agent path calls it with `commit=False` so a multi-tool chat turn stays atomic (the turn owns commit/rollback). The one REST caller keeps the default → unchanged.
- **Undo** — *not* re-implemented. Both tools join `MUTATION_TOOLS`, so the existing global-undo stack (#493/#494) snapshots the whole document before the turn and makes them revertible for free (⌘Z / Undo). The frontend adds only a discoverability hint on destructive tool cards.

Design + plan: `docs/superpowers/specs/2026-06-21-setbuilder-autobuild-fill-design.md`, `docs/superpowers/plans/2026-06-22-setbuilder-autobuild-fill.md`.

## Testing
- [x] Backend tests pass — 3137 passed, coverage **89.10%** (≥ 85% gate)
- [x] Frontend tests pass — 1391 passed; ESLint + `tsc --noEmit` clean
- [x] ruff + bandit clean; no models/migrations touched (alembic drift N/A)
- [x] Regression tests: snapshot round-trip identity (autobuild → restore = prior order); turn-atomicity (autobuild + failing tool → full rollback); `requests` table left untouched
- [ ] CI green
- [ ] Manual: ask the agent to "rebuild the set" and "fill to 2 hours" — confirm changes apply and ⌘Z reverts the rebuild

🤖 Co-authored by Claude Opus 4.8 (1M context). Closes #491.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **autobuild**: regenerates the full set order from the pool/curve while preserving locked slots and saved pairings.
  * Added **fill_to_duration**: appends unused pool tracks until **target duration** is reached (with per-turn insertion limits).
  * Destructive tool cards (**autobuild** and **fill_to_duration**) now show an **“undo” hint** to make rollback behavior more discoverable.
* **Improvements**
  * Enhanced the way these tools’ results are summarized for clearer, user-facing feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->