### PR TITLE
feat(setbuilder): import_from_url agent tool — public Spotify/Tidal playlist URLs (#442 Family 4b)

### DIFF
--- a/server/app/services/setbuilder/agent_common.py
+++ b/server/app/services/setbuilder/agent_common.py
@@ -36,6 +36,7 @@ MUTATION_TOOLS = {
     "import_from_event",
     "import_from_tidal",
     "import_from_beatport",
+    "import_from_url",
 }
 
 

--- a/server/app/services/setbuilder/agent_display.py
+++ b/server/app/services/setbuilder/agent_display.py
@@ -176,7 +176,12 @@ def _tool_display_summary(
             f"now ~{now_min} min of ~{target_min} min."
         )
         return f"{base} Hit the per-turn insert cap." if result.get("capped") else base
-    if name in {"import_from_event", "import_from_tidal", "import_from_beatport"}:
+    if name in {
+        "import_from_event",
+        "import_from_tidal",
+        "import_from_beatport",
+        "import_from_url",
+    }:
         added = int(result.get("added") or 0)
         deduped = int(result.get("deduped") or 0)
         label = result.get("source_label") or "source"
@@ -184,6 +189,7 @@ def _tool_display_summary(
             "event": f"event '{label}'",
             "tidal": f"Tidal playlist '{label}'",
             "beatport": f"Beatport playlist '{label}'",
+            "public_url": f"playlist '{label}'",
         }.get(result.get("source_kind"), label)
         dup = f" ({deduped} duplicate{'s' if deduped != 1 else ''} skipped)" if deduped else ""
         return f"Imported {added} track{'s' if added != 1 else ''} from {where} into the pool{dup}."

--- a/server/app/services/setbuilder/agent_tool_specs.py
+++ b/server/app/services/setbuilder/agent_tool_specs.py
@@ -237,6 +237,20 @@ def _agent_tools() -> list[ToolSpec]:
                 "required": ["playlist", "rationale"],
             },
         ),
+        ToolSpec(
+            name="import_from_url",
+            description=(
+                "Import a public Spotify or Tidal playlist URL into the set's track pool. "
+                "'url' is the full https playlist link. Tidal URLs require a connected Tidal "
+                "account; unsupported hosts (Apple Music / YouTube / SoundCloud / Beatport) "
+                "return a clear message — use import_from_beatport for Beatport."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {"url": {"type": "string"}, "rationale": {"type": "string"}},
+                "required": ["url", "rationale"],
+            },
+        ),
         _critique_tool(),
     ]
 

--- a/server/app/services/setbuilder/agent_tools_imports.py
+++ b/server/app/services/setbuilder/agent_tools_imports.py
@@ -21,6 +21,7 @@ from app.models.user import User
 from app.services import beatport, tidal
 from app.services.setbuilder import pool
 from app.services.setbuilder.agent_common import AgentToolError
+from app.services.setbuilder.playlist_url import InvalidPlaylistUrl, parse_public_playlist_url
 
 
 def _resolve_one(
@@ -182,3 +183,41 @@ def _tool_import_from_beatport(
         fetch_candidates=pool.candidates_from_beatport,
         fetch_error_types=(),
     )
+
+
+def _tool_import_from_url(
+    db: Session, set_obj: Set, payload: dict[str, Any]
+) -> tuple[dict[str, Any], set[int]]:
+    """Import a public Spotify/Tidal playlist URL into the pool.
+
+    Reuses the SSRF-safe parser (parse-only, https + exact-host allowlist) and
+    the existing public-URL fetch path. Invalid/unsupported URLs and fetch
+    failures surface as AgentToolError; Tidal URLs require a connected account
+    (the fetch path raises PoolImportError with that message). Mirrors the REST
+    ``import_pool_url`` handler so source dedupe stays consistent across paths.
+    """
+    owner = _owner(db, set_obj)
+    try:
+        parsed = parse_public_playlist_url(str(payload.get("url") or ""))
+    except InvalidPlaylistUrl as exc:
+        raise AgentToolError(str(exc)) from exc
+    if not parsed.supported:
+        raise AgentToolError(parsed.message or "That playlist provider isn't supported yet.")
+    try:
+        name, candidates = pool.candidates_from_public_url(
+            db, owner, parsed.provider, parsed.playlist_id
+        )
+    except pool.PoolImportError as exc:
+        raise AgentToolError(str(exc)) from exc
+    if not candidates:
+        raise AgentToolError("That playlist has no importable tracks.")
+    source = pool.get_or_create_source(
+        db,
+        set_obj,
+        kind="public_url",
+        external_ref=f"{parsed.provider}:{parsed.playlist_id}",
+        label=name,
+        meta=f"Public {parsed.provider} playlist",
+    )
+    added, deduped = pool.import_candidates(db, set_obj, source, candidates, commit=False)
+    return _import_summary(source, added, deduped), set()

--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -33,6 +33,7 @@ from app.services.setbuilder.agent_tools_imports import (
     _tool_import_from_beatport,
     _tool_import_from_event,
     _tool_import_from_tidal,
+    _tool_import_from_url,
 )
 from app.services.setbuilder.agent_tools_mutations import (
     _tool_add_pairing,
@@ -333,6 +334,7 @@ def apply_tool_call(
         "import_from_event": _tool_import_from_event,
         "import_from_tidal": _tool_import_from_tidal,
         "import_from_beatport": _tool_import_from_beatport,
+        "import_from_url": _tool_import_from_url,
         "analyze_transition": _tool_analyze_transition,
         "explain_transition": _tool_explain_transition,
         "get_track_vibes": _tool_get_track_vibes,

--- a/server/tests/test_setbuilder_imports.py
+++ b/server/tests/test_setbuilder_imports.py
@@ -319,3 +319,108 @@ def test_import_from_tidal_no_playlists_errors(db: Session, test_user: User, mon
     monkeypatch.setattr("app.services.tidal.list_user_playlists", lambda d, u: [])
     with pytest.raises(AgentToolError, match="No Tidal playlists found"):
         apply_tool_call(db, set_obj, "import_from_tidal", {"playlist": "x", "rationale": "r"})
+
+
+# --- import_from_url (public Spotify/Tidal playlist URLs, #442 Family 4b) -----
+
+# A real, well-formed Spotify playlist URL — exercised through the real
+# parse_public_playlist_url so the parse->fetch wiring (provider + id) is pinned;
+# only the network fetch (pool.candidates_from_public_url) is monkeypatched.
+_SPOTIFY_URL = "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M"
+_SPOTIFY_PID = "37i9dQZF1DXcBWIGoYBM5M"
+
+
+def test_import_from_url_resolves_and_imports(db: Session, test_user: User, monkeypatch):
+    set_obj = _mk_set(db, test_user)
+
+    def fake_candidates(d, u, provider, pid):
+        assert provider == "spotify"
+        assert pid == _SPOTIFY_PID
+        return "Summer Vibes", [
+            pool.PoolCandidate(title="U1", artist="A1"),
+            pool.PoolCandidate(title="U2", artist="A2"),
+        ]
+
+    monkeypatch.setattr("app.services.setbuilder.pool.candidates_from_public_url", fake_candidates)
+
+    result, positions = apply_tool_call(
+        db, set_obj, "import_from_url", {"url": _SPOTIFY_URL, "rationale": "Pull the public set."}
+    )
+
+    assert positions == set()
+    assert result == {
+        "added": 2,
+        "deduped": 0,
+        "source_label": "Summer Vibes",
+        "source_kind": "public_url",
+    }
+    assert db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_obj.id).count() == 2
+
+
+def test_import_from_url_invalid_url_errors(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user)
+    with pytest.raises(AgentToolError, match="https"):
+        apply_tool_call(
+            db, set_obj, "import_from_url", {"url": "ftp://example.com/x", "rationale": "r"}
+        )
+
+
+def test_import_from_url_unsupported_provider_errors(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user)
+    with pytest.raises(AgentToolError, match="Apple Music"):
+        apply_tool_call(
+            db,
+            set_obj,
+            "import_from_url",
+            {"url": "https://music.apple.com/us/playlist/foo/pl.u-123", "rationale": "r"},
+        )
+
+
+def test_import_from_url_fetch_error_maps_to_tool_error(db: Session, test_user: User, monkeypatch):
+    set_obj = _mk_set(db, test_user)
+
+    def boom(d, u, provider, pid):
+        raise pool.PoolImportError("Couldn't fetch that Spotify playlist — is it public?")
+
+    monkeypatch.setattr("app.services.setbuilder.pool.candidates_from_public_url", boom)
+    with pytest.raises(AgentToolError, match="Couldn't fetch that Spotify"):
+        apply_tool_call(db, set_obj, "import_from_url", {"url": _SPOTIFY_URL, "rationale": "r"})
+
+
+def test_import_from_url_empty_errors(db: Session, test_user: User, monkeypatch):
+    set_obj = _mk_set(db, test_user)
+    monkeypatch.setattr(
+        "app.services.setbuilder.pool.candidates_from_public_url",
+        lambda d, u, provider, pid: ("Empty Playlist", []),
+    )
+    with pytest.raises(AgentToolError, match="no importable tracks"):
+        apply_tool_call(db, set_obj, "import_from_url", {"url": _SPOTIFY_URL, "rationale": "r"})
+
+
+def test_import_from_url_requires_rationale(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user)
+    with pytest.raises(AgentToolError, match="rationale"):
+        apply_tool_call(db, set_obj, "import_from_url", {"url": _SPOTIFY_URL})
+
+
+def test_import_from_url_missing_arg_errors(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user)
+    with pytest.raises(AgentToolError, match="empty"):
+        apply_tool_call(db, set_obj, "import_from_url", {"rationale": "no url arg"})
+
+
+def test_import_from_url_in_mutation_tools():
+    assert "import_from_url" in MUTATION_TOOLS
+
+
+def test_import_from_url_display_summary():
+    s = _tool_display_summary(
+        "import_from_url",
+        {"rationale": "x"},
+        {"added": 12, "deduped": 2, "source_label": "Summer Vibes", "source_kind": "public_url"},
+        {},
+        {},
+    )
+    assert (
+        s == "Imported 12 tracks from playlist 'Summer Vibes' into the pool (2 duplicates skipped)."
+    )


### PR DESCRIPTION
## Why

Epic #442 Family 4 adds cross-surface pool imports to the WrzDJSet agent toolkit. Family 4a (#524, PR #525, merged) delivered `import_from_event` / `import_from_tidal` / `import_from_beatport`. **Family 4b — the last remaining slice of #442 —** exposes the existing **public playlist URL** import (Spotify / Tidal) as an agent tool, so the LLM can build a pool from a pasted public link.

## What

A new `import_from_url` agent tool, mirroring the REST `import_pool_url` handler. It's a thin wrapper over infrastructure that already exists and was already REST-wired:

- `parse_public_playlist_url` — SSRF-safe (parse-only, https + exact-host allowlist; never fetches the user URL). Reusing it means the agent path inherits that security posture for free.
- `pool.candidates_from_public_url` → `get_or_create_source(kind="public_url", …)` → `import_candidates(commit=False)` (turn atomicity, same flag introduced in #524).

Error handling: `InvalidPlaylistUrl`, recognized-but-unsupported hosts (`supported=False`, e.g. Apple Music / YouTube / SoundCloud / Beatport → "use import_from_beatport"), and `pool.PoolImportError` all surface as `AgentToolError`. Tidal URLs require a connected Tidal account (the fetch path raises with that message).

Registered in the usual four spots — `MUTATION_TOOLS`, `ToolSpec`, `pass2_agent` handlers, `agent_display`. **Backend-only:** additive pool import rides the existing global undo (#493/#494), so no destructive-undo hint and no frontend change. The `requests` table is never touched; affected positions are `set()`.

This completes the last slice of **epic #442**.

## Testing

- [x] Unit/integration tests pass — 9 new tests in `test_setbuilder_imports.py` (happy path, invalid URL, unsupported provider, `PoolImportError` mapping, empty playlist, rationale gate, missing-arg, `MUTATION_TOOLS` membership, display summary). Tests run the **real** parser and mock only the network fetch, pinning the parse→fetch wiring.
- [x] Full backend suite: **3169 passed**, coverage **89.17%** (gate 85%).
- [x] `ruff check` + `ruff format --check` clean; `bandit` clean.
- [x] No model/migration changes → no alembic drift.
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #528.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import public Spotify and Tidal playlists using direct URLs to quickly add tracks to set pools. Supports valid HTTPS playlist links with proper error handling for unsupported providers.

* **Tests**
  * Added comprehensive test coverage for URL-based playlist imports, validating input handling and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->