### PR TITLE
refactor(setbuilder): extract pure helpers out of BuilderWorkspace (#532)

### DIFF
--- a/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/BuilderWorkspace.tsx
@@ -29,30 +29,9 @@ import {
   slotStartSec,
   totalDuration,
 } from './transportMath';
-import { buildMovedIds } from './reorderMath';
+import { buildMovedIds, buildReorderedIds } from './reorderMath';
+import { insertPoolTrackIntoDocument, lockSlotsInDocument } from './documentMath';
 import sbStyles from '../setbuilder.module.css';
-
-/**
- * Pure helper: given the current ordered slots, a slot id being dragged, and
- * an insertion index, return the new ordered id array — or null if the move is
- * a no-op, targets an unknown slot, or would displace a locked slot anchor.
- */
-export function buildReorderedIds(
-  slots: SlotView[],
-  slotId: number,
-  insertIdx: number,
-): number[] | null {
-  const fromIdx = slots.findIndex((s) => s.id === slotId);
-  if (fromIdx < 0) return null;
-  const target = insertIdx > fromIdx ? insertIdx - 1 : insertIdx;
-  if (target === fromIdx) return null; // no-op
-  const ids = slots.map((s) => s.id);
-  const without = ids.filter((id) => id !== slotId);
-  without.splice(target, 0, slotId);
-  // Locked slots are immovable anchors — reject any move that shifts one.
-  if (slots.some((s, idx) => s.locked && without[idx] !== s.id)) return null;
-  return without;
-}
 
 const SCRUB_KEY = 'wrzdj.transport.scrubEnabled';
 
@@ -86,53 +65,6 @@ const DEFAULT_TARGET_SETTINGS: TargetSettings = {
   targetDurationSec: null,
   avgTransitionOverlapSec: 8,
 };
-
-type DocumentPoolTrack = SetDocumentSnapshot['pool']['tracks'][number];
-
-function slotTrackIdFromPoolTrack(track: DocumentPoolTrack): string {
-  return track.track_id ?? `pool:${track.id}`;
-}
-
-function insertPoolTrackIntoDocument(
-  snapshot: SetDocumentSnapshot,
-  poolTrackId: number,
-  insertIdx: number,
-): SetDocumentSnapshot {
-  const track = snapshot.pool.tracks.find((candidate) => candidate.id === poolTrackId);
-  if (!track) throw new Error('Pool track not found');
-  const sortedSlots = [...snapshot.slots].sort((a, b) => a.position - b.position || a.id - b.id);
-  const boundedIdx = Math.max(0, Math.min(insertIdx, sortedSlots.length));
-  const nextId = Math.max(0, ...sortedSlots.map((slot) => slot.id)) + 1;
-  const nextSlots = [...sortedSlots];
-  nextSlots.splice(boundedIdx, 0, {
-    id: nextId,
-    position: boundedIdx,
-    track_id: slotTrackIdFromPoolTrack(track),
-    locked: false,
-    notes: null,
-    transition_score: null,
-    transition_warnings: null,
-    target_energy: null,
-  });
-  return {
-    ...snapshot,
-    slots: nextSlots.map((slot, position) => ({ ...slot, position })),
-  };
-}
-
-function lockSlotsInDocument(
-  snapshot: SetDocumentSnapshot,
-  slotIds: number[],
-  locked: boolean,
-): SetDocumentSnapshot {
-  const idSet = new Set(slotIds);
-  return {
-    ...snapshot,
-    slots: snapshot.slots.map((slot) =>
-      idSet.has(slot.id) ? { ...slot, locked } : slot,
-    ),
-  };
-}
 
 function TimelineSummary({
   projection,

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/buildReorderedIds.test.ts
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/buildReorderedIds.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildReorderedIds } from '../BuilderWorkspace';
+import { buildReorderedIds } from '../reorderMath';
 import type { SlotView } from '../types';
 
 function slot(id: number, locked = false): SlotView {

--- a/dashboard/app/(dj)/setbuilder/components/documentMath.ts
+++ b/dashboard/app/(dj)/setbuilder/components/documentMath.ts
@@ -1,0 +1,57 @@
+import type { SetDocumentSnapshot } from '@/lib/api-types';
+
+type DocumentPoolTrack = SetDocumentSnapshot['pool']['tracks'][number];
+
+function slotTrackIdFromPoolTrack(track: DocumentPoolTrack): string {
+  return track.track_id ?? `pool:${track.id}`;
+}
+
+/**
+ * Pure helper: insert a pool track into the set document at `insertIdx`,
+ * returning a new snapshot with re-numbered slot positions. Throws if the
+ * pool track id is unknown.
+ */
+export function insertPoolTrackIntoDocument(
+  snapshot: SetDocumentSnapshot,
+  poolTrackId: number,
+  insertIdx: number,
+): SetDocumentSnapshot {
+  const track = snapshot.pool.tracks.find((candidate) => candidate.id === poolTrackId);
+  if (!track) throw new Error('Pool track not found');
+  const sortedSlots = [...snapshot.slots].sort((a, b) => a.position - b.position || a.id - b.id);
+  const boundedIdx = Math.max(0, Math.min(insertIdx, sortedSlots.length));
+  const nextId = Math.max(0, ...sortedSlots.map((slot) => slot.id)) + 1;
+  const nextSlots = [...sortedSlots];
+  nextSlots.splice(boundedIdx, 0, {
+    id: nextId,
+    position: boundedIdx,
+    track_id: slotTrackIdFromPoolTrack(track),
+    locked: false,
+    notes: null,
+    transition_score: null,
+    transition_warnings: null,
+    target_energy: null,
+  });
+  return {
+    ...snapshot,
+    slots: nextSlots.map((slot, position) => ({ ...slot, position })),
+  };
+}
+
+/**
+ * Pure helper: return a new snapshot with the given slot ids' `locked` flag
+ * set to `locked`. All other slots are returned unchanged.
+ */
+export function lockSlotsInDocument(
+  snapshot: SetDocumentSnapshot,
+  slotIds: number[],
+  locked: boolean,
+): SetDocumentSnapshot {
+  const idSet = new Set(slotIds);
+  return {
+    ...snapshot,
+    slots: snapshot.slots.map((slot) =>
+      idSet.has(slot.id) ? { ...slot, locked } : slot,
+    ),
+  };
+}

--- a/dashboard/app/(dj)/setbuilder/components/reorderMath.ts
+++ b/dashboard/app/(dj)/setbuilder/components/reorderMath.ts
@@ -25,3 +25,29 @@ export function buildMovedIds(
   if (slots.some((s, idx) => s.locked && without[idx] !== s.id)) return null;
   return without;
 }
+
+/**
+ * Pure helper: given the current ordered slots, a slot id being dragged, and
+ * an insertion index, return the new ordered id array — or null if the move is
+ * a no-op, targets an unknown slot, or would displace a locked slot anchor.
+ *
+ * This is the desktop drag-and-drop counterpart to buildMovedIds (one-step
+ * move). The two are intentionally separate parallel implementations of the
+ * same locked-slot-anchor invariant — do NOT merge them.
+ */
+export function buildReorderedIds(
+  slots: SlotView[],
+  slotId: number,
+  insertIdx: number,
+): number[] | null {
+  const fromIdx = slots.findIndex((s) => s.id === slotId);
+  if (fromIdx < 0) return null;
+  const target = insertIdx > fromIdx ? insertIdx - 1 : insertIdx;
+  if (target === fromIdx) return null; // no-op
+  const ids = slots.map((s) => s.id);
+  const without = ids.filter((id) => id !== slotId);
+  without.splice(target, 0, slotId);
+  // Locked slots are immovable anchors — reject any move that shifts one.
+  if (slots.some((s, idx) => s.locked && without[idx] !== s.id)) return null;
+  return without;
+}


### PR DESCRIPTION
## Why

Three pure helpers lived inside the `BuilderWorkspace` React component instead of in focused, independently-testable modules. The parallel one-step `buildMovedIds` helper already lives in pure `reorderMath.ts`, and the test for the drag helper imported it *from the component*. This is a behavior-preserving code-move to put the pure logic where it belongs.

## What

All under `dashboard/app/(dj)/setbuilder/components/`:

- Moved `buildReorderedIds` (drag, locked-slot anchor) out of `BuilderWorkspace.tsx` into `reorderMath.ts`, alongside `buildMovedIds`.
- Moved `insertPoolTrackIntoDocument` and `lockSlotsInDocument` (plus their private `slotTrackIdFromPoolTrack` / `DocumentPoolTrack` dependencies) into a new `documentMath.ts`.
- Updated `BuilderWorkspace.tsx` to import these from the new modules.
- Updated the test import in `__tests__/buildReorderedIds.test.ts` from `'../BuilderWorkspace'` to `'../reorderMath'`.

No runtime behavior changes — the function bodies are byte-for-byte identical, only relocated.

## Design decisions

- **`buildReorderedIds` landed in `reorderMath.ts`** (not a new file) so the two reorder helpers sit together. **`buildMovedIds` and `buildReorderedIds` were kept as separate exports** — they are intentionally distinct parallel implementations of the same locked-slot-anchor invariant (one-step move vs. desktop drag-and-drop). They were NOT merged or abstracted; a doc comment on `buildReorderedIds` now records that they are deliberate counterparts.
- **The document helpers landed in a new `documentMath.ts`** (snapshot/document mutations), distinct from `reorderMath.ts` (slot-order math), keeping each module cohesive. The private `slotTrackIdFromPoolTrack` helper and its `DocumentPoolTrack` type moved with `insertPoolTrackIntoDocument` since that's their only consumer.
- `SetDocumentSnapshot` remains imported in `BuilderWorkspace.tsx` (still used by the component props), so its import was left untouched.

## Testing

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — exit 0
- [x] `npm test -- --run` — 105 files / 1391 tests passed
- [x] No behavior change (pure code move; function bodies unchanged)
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #532.