### PR TITLE
refactor(schemas): use Field(default_factory=list) for mutable-list defaults (#530)

### DIFF
--- a/server/app/schemas/recommendation.py
+++ b/server/app/schemas/recommendation.py
@@ -25,16 +25,16 @@ class EventMusicProfile(BaseModel):
     avg_bpm: float | None = None
     bpm_range_low: float | None = None
     bpm_range_high: float | None = None
-    dominant_keys: list[str] = []
-    dominant_genres: list[str] = []
+    dominant_keys: list[str] = Field(default_factory=list)
+    dominant_genres: list[str] = Field(default_factory=list)
     track_count: int = 0
     enriched_count: int = 0
 
 
 class RecommendationResponse(BaseModel):
-    suggestions: list[RecommendedTrack] = []
+    suggestions: list[RecommendedTrack] = Field(default_factory=list)
     profile: EventMusicProfile
-    services_used: list[str] = []
+    services_used: list[str] = Field(default_factory=list)
     total_candidates_searched: int = 0
     llm_available: bool = False
 
@@ -52,11 +52,11 @@ class LLMQueryInfo(BaseModel):
 
 
 class LLMRecommendationResponse(BaseModel):
-    suggestions: list[RecommendedTrack] = []
+    suggestions: list[RecommendedTrack] = Field(default_factory=list)
     profile: EventMusicProfile
-    services_used: list[str] = []
+    services_used: list[str] = Field(default_factory=list)
     total_candidates_searched: int = 0
-    llm_queries: list[LLMQueryInfo] = []
+    llm_queries: list[LLMQueryInfo] = Field(default_factory=list)
     llm_available: bool = True
     llm_model: str = ""
 
@@ -71,7 +71,7 @@ class PlaylistInfo(BaseModel):
 
 
 class PlaylistListResponse(BaseModel):
-    playlists: list[PlaylistInfo] = []
+    playlists: list[PlaylistInfo] = Field(default_factory=list)
 
 
 class TemplatePlaylistRequest(BaseModel):

--- a/server/app/schemas/user.py
+++ b/server/app/schemas/user.py
@@ -15,7 +15,7 @@ class UserOut(BaseSchema):
     email: str | None = None
     role: str
     created_at: datetime
-    help_pages_seen: list[str] = []
+    help_pages_seen: list[str] = Field(default_factory=list)
     pending_email: str | None = None
     frictionless_join_default: bool = False
 


### PR DESCRIPTION
## Why
Style/consistency cleanup broken out from #507 (candidate 6). The schemas in `user.py` and `recommendation.py` declared mutable-list defaults as bare `list[...] = []`. Pydantic v2 deep-copies mutable defaults so this was never a shared-mutable-state bug — but `Field(default_factory=list)` is clearer and is already the established house pattern (`server/app/schemas/setbuilder.py:120,498,520`).

## What
Replaced all 8 mutable-list defaults across the two files with `Field(default_factory=list)`:

- `server/app/schemas/user.py` — `UserOut.help_pages_seen`
- `server/app/schemas/recommendation.py` — `EventMusicProfile.dominant_keys` / `.dominant_genres`; `RecommendationResponse.suggestions` / `.services_used`; `LLMRecommendationResponse.suggestions` / `.services_used` / `.llm_queries`; `PlaylistListResponse.playlists`

Both files already imported `Field` from pydantic, so no import changes were needed.

## Design decisions
- **No new regression test added.** This is a pure, behavior-preserving style cleanup. The default value (empty list) is unchanged, and the existing suite (3169 tests, which already construct these schemas via the recommendation/user code paths) is the appropriate bar. Adding a test asserting `default_factory` would be testing Pydantic, not our code, and would only pad coverage artificially.
- Caught `PlaylistListResponse.playlists` at line 74 (listed in the issue scope) in addition to the explicitly enumerated lines.

### Schema-metadata note (from adversarial review — Codex / GPT-5.5)
An independent adversarial review flagged (MEDIUM) that this is not *strictly* behavior-preserving at the JSON-Schema layer: `Field(default_factory=list)` no longer emits `default: []` in `model_json_schema()` / the OpenAPI spec, whereas bare `= []` did. Runtime is fully unaffected (`model_dump`, `exclude_unset`, `exclude_defaults`, `model_fields_set`, and requiredness all verified identical on Pydantic 2.13.4). Decision: **accept the metadata change** —
- it matches the established house pattern: every existing `default_factory` list field (e.g. `AgentChatOut.tool_calls`, `BuildSetResponse.slots`) already omits `default: []` in the committed `openapi.json`;
- these are always-populated `required` response fields, so the `default` is purely informational for consumers.

The committed `server/openapi.json` / `dashboard/lib/api-types.generated.ts` are **not** regenerated in this PR: a regen pulls in unrelated pre-existing drift already on `main` (the `SetDocumentSnapshot-Input/-Output` merge, added `security:` blocks, updated endpoint descriptions) that does not belong in a style PR. That regeneration is tracked separately (see follow-up issue).

## Testing
- [x] Unit tests pass (`pytest`: 3169 passed; coverage 89.20%, gate 85% held)
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean (424 files already formatted)
- [x] `bandit -r app -c pyproject.toml -q` clean (only pre-existing nosec/comment warnings)
- [x] No *runtime* behavior change (empty-list default preserved; see schema-metadata note above)
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #530.
