### PR TITLE
refactor(bridge): extract shared HTTP retry/backoff/timeout helpers (#531)

### DIFF
--- a/bridge-app/src/main/__tests__/bridge-runner.test.ts
+++ b/bridge-app/src/main/__tests__/bridge-runner.test.ts
@@ -539,6 +539,64 @@ describe('BridgeRunner', () => {
     expect(logs.some((l) => l.message.includes('ABC123'))).toBe(true);
   });
 
+  it('stops the bridge on a 401 without retrying or recording a circuit failure', async () => {
+    await runner.start(TEST_CONFIG);
+    expect(runner.getStatus().backendReachable).toBe(true);
+
+    // Spy on the private circuit breaker so we can prove a 401 is treated as an
+    // auth problem, NOT a backend-availability failure.
+    const circuitBreaker = (runner as unknown as Record<string, unknown>).circuitBreaker as {
+      recordFailure: () => void;
+      recordSuccess: () => void;
+    };
+    const recordFailure = vi.spyOn(circuitBreaker, 'recordFailure');
+    const stopSpy = vi.spyOn(runner, 'stop');
+
+    // Only the FIRST POST gets a 401 (expired session token); the deferred
+    // shutdown status-POST that stop() issues succeeds, so it can't be confused
+    // for a retry of the 401'd request.
+    mockFetch.mockClear();
+    mockFetch
+      .mockResolvedValueOnce({ status: 401, ok: false, text: () => Promise.resolve('') })
+      .mockResolvedValue({ ok: true, text: () => Promise.resolve('') });
+
+    // A connection event triggers postBridgeStatus → postWithRetry.
+    const pluginBridge = (runner as unknown as Record<string, unknown>).pluginBridge as {
+      emit: (event: string, ...args: unknown[]) => boolean;
+    };
+    pluginBridge.emit('connection', { connected: true, deviceName: 'Test Device' });
+
+    // Resolve the 401 POST only — the retry loop returns immediately on 401 with
+    // NO backoff sleep, so a single microtask flush is enough to settle it.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const statusPostsBeforeStop = mockFetch.mock.calls.filter(
+      (call) =>
+        typeof call[0] === 'string' &&
+        call[0].includes('/bridge/status') &&
+        call[1]?.method === 'POST',
+    );
+    // Exactly one status POST — the 401 short-circuited the loop (no 2s/4s/8s retry).
+    expect(statusPostsBeforeStop).toHaveLength(1);
+
+    // Advancing through the full retry window must NOT produce a retry of that POST.
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    // 401 is an auth problem — it must NOT count as a circuit/backend failure,
+    // and backendReachable must be left untouched (no false "backend down").
+    expect(recordFailure).not.toHaveBeenCalled();
+    expect(runner.getStatus().backendReachable).toBe(true);
+
+    // The bridge is stopped with the session-expiry reason.
+    expect(stopSpy).toHaveBeenCalledWith('Session expired — please log in again');
+    expect(runner.isRunning).toBe(false);
+    expect(runner.getStatus().stopReason).toBe('Session expired — please log in again');
+
+    // Restore mock before afterEach cleanup.
+    mockFetch.mockResolvedValue({ ok: true, text: () => Promise.resolve('') });
+  });
+
   it('logs setbuilder transport command payloads from the command poller', () => {
     const logs: Array<{ message: string; level: string }> = [];
     runner.on('log', (msg: { message: string; level: string }) => logs.push(msg));

--- a/bridge-app/src/main/bridge-runner.ts
+++ b/bridge-app/src/main/bridge-runner.ts
@@ -12,6 +12,15 @@ import { EventEmitter } from 'events';
 import { PluginBridge } from '@bridge/plugin-bridge.js';
 import { getPlugin } from '@bridge/plugin-registry.js';
 import { CircuitBreaker } from '@bridge/circuit-breaker.js';
+import {
+  DELETE_BACKOFF_MS,
+  DELETE_MAX_RETRIES,
+  INITIAL_BACKOFF_MS,
+  MAX_RETRIES,
+  computeBackoff,
+  fetchWithTimeout,
+  sleep,
+} from '@bridge/http-retry.js';
 import { CommandPoller } from '@bridge/command-poller.js';
 import type { BridgeCommand } from '@bridge/command-poller.js';
 import { Logger, type LogLevel } from '@bridge/logger.js';
@@ -26,11 +35,6 @@ import type { BridgeRunnerConfig, BridgeStatus, DeckDisplay, IpcLogMessage, Trac
 // Register built-in plugins
 import '@bridge/plugins/index.js';
 
-const MAX_RETRIES = 3;
-const INITIAL_BACKOFF_MS = 2000;
-const FETCH_TIMEOUT_MS = 10_000;
-const DELETE_MAX_RETRIES = 2;
-const DELETE_BACKOFF_MS = 1000;
 const HEALTH_CHECK_INTERVAL_MS = 30_000;
 
 /**
@@ -332,24 +336,6 @@ export class BridgeRunner extends EventEmitter {
   // --- HTTP communication ---
 
   /**
-   * Make a fetch request with an AbortController timeout.
-   */
-  private async fetchWithTimeout(
-    url: string,
-    options: RequestInit,
-    timeoutMs: number = FETCH_TIMEOUT_MS,
-  ): Promise<Response> {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
-    try {
-      return await fetch(url, { ...options, signal: controller.signal });
-    } finally {
-      clearTimeout(timeoutId);
-    }
-  }
-
-  /**
    * POST with retry logic and circuit breaker.
    * Returns true if successful, false on failure.
    * Stops bridge on 401 (token expiry).
@@ -369,7 +355,7 @@ export class BridgeRunner extends EventEmitter {
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
-        const response = await this.fetchWithTimeout(`${this.config.apiUrl}${endpoint}`, {
+        const response = await fetchWithTimeout(`${this.config.apiUrl}${endpoint}`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -403,9 +389,9 @@ export class BridgeRunner extends EventEmitter {
       } catch (err) {
         lastError = err as Error;
         if (attempt < MAX_RETRIES) {
-          const backoff = INITIAL_BACKOFF_MS * Math.pow(2, attempt);
+          const backoff = computeBackoff(INITIAL_BACKOFF_MS, attempt);
           this.log(`Retry ${attempt + 1}/${MAX_RETRIES} in ${backoff}ms: ${lastError.message}`, 'warn');
-          await new Promise((resolve) => setTimeout(resolve, backoff));
+          await sleep(backoff);
         }
       }
     }
@@ -477,7 +463,7 @@ export class BridgeRunner extends EventEmitter {
 
     for (let attempt = 0; attempt <= DELETE_MAX_RETRIES; attempt++) {
       try {
-        const response = await this.fetchWithTimeout(`${this.config.apiUrl}${endpoint}`, {
+        const response = await fetchWithTimeout(`${this.config.apiUrl}${endpoint}`, {
           method: 'DELETE',
           headers: {
             'X-Bridge-API-Key': this.config.apiKey,
@@ -494,9 +480,9 @@ export class BridgeRunner extends EventEmitter {
       } catch (err) {
         const message = (err as Error).message;
         if (attempt < DELETE_MAX_RETRIES) {
-          const backoff = DELETE_BACKOFF_MS * Math.pow(2, attempt);
+          const backoff = computeBackoff(DELETE_BACKOFF_MS, attempt);
           this.log(`DELETE ${endpoint} retry ${attempt + 1}/${DELETE_MAX_RETRIES} in ${backoff}ms: ${message}`, 'warn');
-          await new Promise((resolve) => setTimeout(resolve, backoff));
+          await sleep(backoff);
         } else {
           this.log(`DELETE ${endpoint} failed after ${DELETE_MAX_RETRIES + 1} attempts: ${message}`, 'error');
         }

--- a/bridge/src/__tests__/http-retry.test.ts
+++ b/bridge/src/__tests__/http-retry.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the shared HTTP retry/backoff/timeout primitives.
+ *
+ * These pin the contract that BOTH bridge artifacts depend on — the headless
+ * bridge (`bridge/src/bridge.ts`) and the Electron bridge app
+ * (`bridge-app/src/main/bridge-runner.ts`). Drift in any constant or in the
+ * backoff math silently changes retry behavior in both consumers, so the values
+ * and progressions are asserted exactly.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  MAX_RETRIES,
+  INITIAL_BACKOFF_MS,
+  FETCH_TIMEOUT_MS,
+  DELETE_MAX_RETRIES,
+  DELETE_BACKOFF_MS,
+  computeBackoff,
+  sleep,
+  fetchWithTimeout,
+} from "../http-retry.js";
+
+describe("http-retry constants", () => {
+  it("pins the exact contract values both consumers depend on", () => {
+    expect(MAX_RETRIES).toBe(3);
+    expect(INITIAL_BACKOFF_MS).toBe(2000);
+    expect(FETCH_TIMEOUT_MS).toBe(10_000);
+    expect(DELETE_MAX_RETRIES).toBe(2);
+    expect(DELETE_BACKOFF_MS).toBe(1000);
+  });
+});
+
+describe("computeBackoff", () => {
+  it("doubles the POST backoff per attempt (no jitter, no cap)", () => {
+    expect(computeBackoff(INITIAL_BACKOFF_MS, 0)).toBe(2000);
+    expect(computeBackoff(INITIAL_BACKOFF_MS, 1)).toBe(4000);
+    expect(computeBackoff(INITIAL_BACKOFF_MS, 2)).toBe(8000);
+  });
+
+  it("doubles the DELETE backoff per attempt (no jitter, no cap)", () => {
+    expect(computeBackoff(DELETE_BACKOFF_MS, 0)).toBe(1000);
+    expect(computeBackoff(DELETE_BACKOFF_MS, 1)).toBe(2000);
+  });
+
+  it("returns the base unchanged at attempt 0 for any base", () => {
+    expect(computeBackoff(500, 0)).toBe(500);
+    expect(computeBackoff(3000, 3)).toBe(24_000);
+  });
+});
+
+describe("sleep", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves only after the given number of milliseconds", async () => {
+    let resolved = false;
+    const promise = sleep(2000).then(() => {
+      resolved = true;
+    });
+
+    // Not yet — short of the deadline.
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(resolved).toBe(false);
+
+    // Crossing the deadline resolves it.
+    await vi.advanceTimersByTimeAsync(1);
+    await promise;
+    expect(resolved).toBe(true);
+  });
+});
+
+describe("fetchWithTimeout", () => {
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    global.fetch = realFetch;
+  });
+
+  it("passes the AbortController signal through to fetch and returns its response", async () => {
+    let seenSignal: AbortSignal | undefined;
+    const response = { ok: true, status: 200 } as Response;
+    global.fetch = vi.fn(async (_url: string | URL | Request, options?: RequestInit) => {
+      seenSignal = options?.signal ?? undefined;
+      return response;
+    }) as unknown as typeof fetch;
+
+    const result = await fetchWithTimeout("https://api.wrzdj.com/x", { method: "POST" });
+
+    expect(result).toBe(response);
+    expect(seenSignal).toBeInstanceOf(AbortSignal);
+    expect(seenSignal?.aborted).toBe(false);
+  });
+
+  it("aborts the fetch at FETCH_TIMEOUT_MS when the request never resolves", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    // Reject when the signal fires (mirrors fetch's real AbortError behavior).
+    global.fetch = vi.fn(
+      (_url: string | URL | Request, options?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          capturedSignal = options?.signal ?? undefined;
+          capturedSignal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as unknown as typeof fetch;
+
+    const pending = fetchWithTimeout("https://api.wrzdj.com/x", { method: "POST" });
+    // Surface the rejection so the unhandled-rejection guard stays quiet.
+    const settled = pending.then(
+      () => ({ ok: true as const }),
+      (err: Error) => ({ ok: false as const, err }),
+    );
+
+    // Just short of the timeout: still pending, not aborted.
+    await vi.advanceTimersByTimeAsync(FETCH_TIMEOUT_MS - 1);
+    expect(capturedSignal?.aborted).toBe(false);
+
+    // Crossing FETCH_TIMEOUT_MS fires the abort and rejects the fetch.
+    await vi.advanceTimersByTimeAsync(1);
+    const outcome = await settled;
+    expect(outcome.ok).toBe(false);
+    expect(capturedSignal?.aborted).toBe(true);
+    if (!outcome.ok) {
+      expect(outcome.err.name).toBe("AbortError");
+    }
+  });
+
+  it("honors a caller-supplied timeout override", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    global.fetch = vi.fn(
+      (_url: string | URL | Request, options?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          capturedSignal = options?.signal ?? undefined;
+          capturedSignal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as unknown as typeof fetch;
+
+    const settled = fetchWithTimeout("https://api.wrzdj.com/x", { method: "GET" }, 500).then(
+      () => ({ ok: true as const }),
+      (err: Error) => ({ ok: false as const, err }),
+    );
+
+    // Default timeout would NOT have fired yet, but the 500ms override has.
+    await vi.advanceTimersByTimeAsync(500);
+    const outcome = await settled;
+    expect(outcome.ok).toBe(false);
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
+  it("clears the timeout timer once fetch resolves (no leak, no late abort)", async () => {
+    // Capture the controller the function constructs so we can prove it is never
+    // aborted after the fetch settles.
+    let capturedSignal: AbortSignal | undefined;
+    global.fetch = vi.fn(async (_url: string | URL | Request, options?: RequestInit) => {
+      capturedSignal = options?.signal ?? undefined;
+      return { ok: true, status: 200 } as Response;
+    }) as unknown as typeof fetch;
+
+    const setSpy = vi.spyOn(global, "setTimeout");
+    const clearSpy = vi.spyOn(global, "clearTimeout");
+
+    await fetchWithTimeout("https://api.wrzdj.com/x", { method: "POST" });
+
+    // The single timeout scheduled by fetchWithTimeout was cleared in `finally`.
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    const timeoutId = setSpy.mock.results[0]?.value;
+    expect(clearSpy).toHaveBeenCalledWith(timeoutId);
+
+    // And advancing well past FETCH_TIMEOUT_MS must NOT fire a late abort on the
+    // already-settled request.
+    await vi.advanceTimersByTimeAsync(FETCH_TIMEOUT_MS * 2);
+    expect(capturedSignal?.aborted).toBe(false);
+
+    setSpy.mockRestore();
+    clearSpy.mockRestore();
+  });
+});

--- a/bridge/src/bridge.ts
+++ b/bridge/src/bridge.ts
@@ -9,17 +9,20 @@
  */
 import { config } from "./config.js";
 import { CircuitBreaker } from "./circuit-breaker.js";
+import {
+  DELETE_BACKOFF_MS,
+  DELETE_MAX_RETRIES,
+  INITIAL_BACKOFF_MS,
+  MAX_RETRIES,
+  computeBackoff,
+  fetchWithTimeout,
+  sleep,
+} from "./http-retry.js";
 import { Logger } from "./logger.js";
 import { TrackHistoryBuffer } from "./track-history-buffer.js";
 import type { BridgeStatusPayload, DetailedBridgeStatus, NowPlayingPayload } from "./types.js";
 
 const log = new Logger("Bridge");
-
-const MAX_RETRIES = 3;
-const INITIAL_BACKOFF_MS = 2000;
-const FETCH_TIMEOUT_MS = 10_000;
-const DELETE_MAX_RETRIES = 2;
-const DELETE_BACKOFF_MS = 1000;
 
 /** Module start time for uptime calculation */
 const startTime = Date.now();
@@ -104,24 +107,6 @@ export function updateLastTrack(artist: string, title: string): void {
 }
 
 /**
- * Make a fetch request with an AbortController timeout.
- */
-async function fetchWithTimeout(
-  url: string,
-  options: RequestInit,
-  timeoutMs: number = FETCH_TIMEOUT_MS,
-): Promise<Response> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    return await fetch(url, { ...options, signal: controller.signal });
-  } finally {
-    clearTimeout(timeoutId);
-  }
-}
-
-/**
  * Make an HTTP POST with retry logic and circuit breaker.
  * Returns true if the request succeeded, false if it failed after all retries.
  */
@@ -158,9 +143,9 @@ async function postWithRetry(
     } catch (err) {
       lastError = err as Error;
       if (attempt < MAX_RETRIES) {
-        const backoff = INITIAL_BACKOFF_MS * Math.pow(2, attempt);
+        const backoff = computeBackoff(INITIAL_BACKOFF_MS, attempt);
         log.warn(`Retry ${attempt + 1}/${MAX_RETRIES} in ${backoff}ms: ${lastError.message}`);
-        await new Promise((resolve) => setTimeout(resolve, backoff));
+        await sleep(backoff);
       }
     }
   }
@@ -246,9 +231,9 @@ export async function clearNowPlaying(): Promise<void> {
     } catch (err) {
       const message = (err as Error).message;
       if (attempt < DELETE_MAX_RETRIES) {
-        const backoff = DELETE_BACKOFF_MS * Math.pow(2, attempt);
+        const backoff = computeBackoff(DELETE_BACKOFF_MS, attempt);
         log.warn(`DELETE ${endpoint} retry ${attempt + 1}/${DELETE_MAX_RETRIES} in ${backoff}ms: ${message}`);
-        await new Promise((resolve) => setTimeout(resolve, backoff));
+        await sleep(backoff);
       } else {
         log.error(`DELETE ${endpoint} failed after ${DELETE_MAX_RETRIES + 1} attempts: ${message}`);
       }

--- a/bridge/src/http-retry.ts
+++ b/bridge/src/http-retry.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared HTTP retry/backoff/timeout primitives for the WrzDJ bridge artifacts.
+ *
+ * Consumed by both the headless bridge (`bridge/src/bridge.ts`, imported as
+ * `./http-retry.js`) and the Electron bridge app
+ * (`bridge-app/src/main/bridge-runner.ts`, imported via the `@bridge/*` alias as
+ * `@bridge/http-retry.js` — the same pattern `bridge-runner.ts` already uses for
+ * `@bridge/circuit-breaker.js`).
+ *
+ * This module owns ONLY the genuinely identical primitives — the retry/backoff
+ * constants, the `AbortController`-based fetch timeout, and the exponential
+ * backoff math + sleep. The retry loops themselves stay in each artifact because
+ * they diverge legitimately: the bridge app records `backendReachable`/status
+ * transitions and stops the bridge on a 401 (token expiry), neither of which the
+ * headless bridge does. That divergence must NOT be folded in here.
+ */
+
+/** Number of POST retries after the initial attempt. */
+export const MAX_RETRIES = 3;
+/** Base backoff for POST retries (doubles per attempt). */
+export const INITIAL_BACKOFF_MS = 2000;
+/** AbortController timeout applied to every fetch. */
+export const FETCH_TIMEOUT_MS = 10_000;
+/** Number of DELETE retries after the initial attempt. */
+export const DELETE_MAX_RETRIES = 2;
+/** Base backoff for DELETE retries (doubles per attempt). */
+export const DELETE_BACKOFF_MS = 1000;
+
+/**
+ * Make a fetch request with an AbortController timeout.
+ *
+ * The timer is always cleared in a `finally` so it never leaks, regardless of
+ * whether the fetch resolves, rejects, or is aborted.
+ */
+export async function fetchWithTimeout(
+  url: string,
+  options: RequestInit,
+  timeoutMs: number = FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Exponential backoff for a given retry attempt: `baseMs * 2 ** attempt`.
+ *
+ * @param baseMs   the base backoff in milliseconds
+ * @param attempt  zero-based attempt index (0 → baseMs, 1 → 2·baseMs, …)
+ */
+export function computeBackoff(baseMs: number, attempt: number): number {
+  return baseMs * Math.pow(2, attempt);
+}
+
+/** Resolve after `ms` milliseconds (respects fake timers in tests). */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Why

The HTTP retry/backoff/timeout layer was duplicated byte-for-byte across the two bridge artifacts (`bridge/src/bridge.ts` and `bridge-app/src/main/bridge-runner.ts`): the same constants, the same `AbortController`-based `fetchWithTimeout`, and the same exponential backoff math + sleep. Both already share `CircuitBreaker` via the `@bridge/*` alias; the retry layer should follow that proven pattern. This is convenience dedup, not load-bearing.

## What

Extracts the genuinely identical primitives into a new shared module `bridge/src/http-retry.ts`, consumed by both artifacts:

- `bridge` imports it relatively: `./http-retry.js`
- `bridge-app` imports it via the existing `@bridge/*` alias: `@bridge/http-retry.js` (same pattern as `@bridge/circuit-breaker.js`)

The shared module owns only the constants (`MAX_RETRIES`, `INITIAL_BACKOFF_MS`, `FETCH_TIMEOUT_MS`, `DELETE_MAX_RETRIES`, `DELETE_BACKOFF_MS`), `fetchWithTimeout`, and two small pure helpers (`computeBackoff(baseMs, attempt)` = `baseMs * 2 ** attempt`, and `sleep(ms)`). No behavior changes: the constants, circuit-breaker config (`failureThreshold: 3, cooldownMs: 60_000`), and all retry semantics are identical to before.

## Design decisions

- **Module name/location:** `bridge/src/http-retry.ts` — lives alongside `circuit-breaker.ts` so `bridge-app` can reach it through the established `@bridge/*` alias. Exactly mirrors how `bridge-runner.ts` already imports `@bridge/circuit-breaker.js`.
- **What was extracted:** only the truly identical primitives — the five constants, `fetchWithTimeout` (was byte-identical in both files), and the backoff math + sleep (`computeBackoff` + `sleep`). These were the real duplication.
- **What deliberately stayed in `bridge-runner.ts` (and why):** the retry *loops* themselves (`postWithRetry` / DELETE retry). They diverge legitimately and must not be collapsed into one callback-laden helper:
  - **401 stop-on-token-expiry** — on `response.status === 401` the bridge app logs "session expired" and asynchronously calls `this.stop('Session expired — please log in again')`. This is Electron-GUI-specific and is intentionally NOT folded into the shared helper (per the issue).
  - **`backendReachable` / `emitStatus()` transitions** — the bridge app flips `backendReachable` and emits an IPC status update on success/failure transitions for the GUI. The headless bridge has no GUI and does neither.
  - **Logging signature** — `bridge` uses module-level `log.warn(msg)`; `bridge-app` uses `this.log(msg, level)`.
  - **Circuit-breaker instance** — module-level singleton in `bridge` vs. per-`BridgeRunner` instance field in `bridge-app`.

  Forcing those through one shared `postWithRetry` would require a knot of callbacks/flags — exactly the over-abstraction the issue warns against. Two clear loops calling shared primitives is the right altitude.
- **`HEALTH_CHECK_INTERVAL_MS`** stays local to `bridge-runner.ts` — it's bridge-app-only and unrelated to HTTP retry.

## Testing

- [x] `npx tsc --noEmit` green in `bridge/`
- [x] `npm test -- --run` green in `bridge/` (15 files, 343 tests)
- [x] `npx tsc --noEmit` green in `bridge-app/`
- [x] `npm test -- --run` green in `bridge-app/` (8 files, 77 tests)
- [x] Electron build verified: `electron-forge` Vite production bundle builds; minified `main.js` confirmed to inline the shared `fetchWithTimeout`/`computeBackoff`/`sleep` into the retry loops, and externalization still copies `stagelinq` + `alphatheta-connect` (with transitive deps) into the build's `node_modules/`. (The final `out/` packaging step needs to download the Electron binary, which the sandbox couldn't fetch — unrelated to this change.)
- [x] Electron-specific 401 stop-on-token-expiry path intact (verified in source and in the minified bundle: "Session expired — please log in again")
- [x] No behavior change — constants identical (timeout 10s, INITIAL=2000ms, DELETE=1000ms), circuit breaker `failureThreshold: 3` / `cooldownMs: 60_000` unchanged in both
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #531.