### PR TITLE
chore(types): resync committed openapi.json + api-types.generated.ts

### DIFF
--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -1411,6 +1411,12 @@ export interface paths {
          *
          *     Priority: Tidal (primary) → Spotify (fallback) → Beatport (event toggle).
          *     Results are filtered for junk, deduplicated by ISRC, and sorted by popularity.
+         *
+         *     Auth model: anonymous guests must pass the human-verification gate
+         *     (require_verified_human_soft). The authenticated event OWNER bypasses it —
+         *     the DJ dashboard "Search for Song" tool reuses this endpoint, and the DJ
+         *     holds a JWT but no guest wrzdj_human cookie, so without the bypass an
+         *     enforced gate would 403 them on their own event.
          */
         get: operations["event_search_api_events__code__search_get"];
         put?: never;
@@ -4900,15 +4906,9 @@ export interface components {
             bpm_range_high: number | null;
             /** Bpm Range Low */
             bpm_range_low: number | null;
-            /**
-             * Dominant Genres
-             * @default []
-             */
+            /** Dominant Genres */
             dominant_genres: string[];
-            /**
-             * Dominant Keys
-             * @default []
-             */
+            /** Dominant Keys */
             dominant_keys: string[];
             /**
              * Enriched Count
@@ -6067,15 +6067,9 @@ export interface components {
              */
             llm_available: boolean;
             profile: components["schemas"]["EventMusicProfile"];
-            /**
-             * Services Used
-             * @default []
-             */
+            /** Services Used */
             services_used: string[];
-            /**
-             * Suggestions
-             * @default []
-             */
+            /** Suggestions */
             suggestions: components["schemas"]["RecommendedTrack"][];
             /**
              * Total Candidates Searched
@@ -7206,10 +7200,7 @@ export interface components {
              * @default false
              */
             frictionless_join_default: boolean;
-            /**
-             * Help Pages Seen
-             * @default []
-             */
+            /** Help Pages Seen */
             help_pages_seen: string[];
             /** Id */
             id: number;

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3701,7 +3701,6 @@
             "title": "Bpm Range Low"
           },
           "dominant_genres": {
-            "default": [],
             "items": {
               "type": "string"
             },
@@ -3709,7 +3708,6 @@
             "type": "array"
           },
           "dominant_keys": {
-            "default": [],
             "items": {
               "type": "string"
             },
@@ -7123,7 +7121,6 @@
             "$ref": "#/components/schemas/EventMusicProfile"
           },
           "services_used": {
-            "default": [],
             "items": {
               "type": "string"
             },
@@ -7131,7 +7128,6 @@
             "type": "array"
           },
           "suggestions": {
-            "default": [],
             "items": {
               "$ref": "#/components/schemas/RecommendedTrack"
             },
@@ -10624,7 +10620,6 @@
             "type": "boolean"
           },
           "help_pages_seen": {
-            "default": [],
             "items": {
               "type": "string"
             },
@@ -14917,6 +14912,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
         "summary": "Submit Request",
         "tags": [
           "events"
@@ -15085,7 +15085,7 @@
     },
     "/api/events/{code}/search": {
       "get": {
-        "description": "Public search endpoint for event guests.\n\nPriority: Tidal (primary) \u2192 Spotify (fallback) \u2192 Beatport (event toggle).\nResults are filtered for junk, deduplicated by ISRC, and sorted by popularity.",
+        "description": "Public search endpoint for event guests.\n\nPriority: Tidal (primary) \u2192 Spotify (fallback) \u2192 Beatport (event toggle).\nResults are filtered for junk, deduplicated by ISRC, and sorted by popularity.\n\nAuth model: anonymous guests must pass the human-verification gate\n(require_verified_human_soft). The authenticated event OWNER bypasses it \u2014\nthe DJ dashboard \"Search for Song\" tool reuses this endpoint, and the DJ\nholds a JWT but no guest wrzdj_human cookie, so without the bypass an\nenforced gate would 403 them on their own event.",
         "operationId": "event_search_api_events__code__search_get",
         "parameters": [
           {
@@ -15135,6 +15135,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
         "summary": "Event Search",
         "tags": [
           "events"


### PR DESCRIPTION
## Why
The committed contract artifacts (`server/openapi.json`, `dashboard/lib/api-types.generated.ts`) had drifted from `main` — they're regenerated manually, not per-PR, and there's no CI drift gate. Surfaced during the adversarial review of #534. Closes #536.

## What
Regenerated both artifacts from current `main` via `cd dashboard && npm run types:export && npm run types:generate`. **No source changes** — pure artifact resync. Three drift categories, all behavior-neutral:

- **`default: []` removed** from 5 `default_factory` list response fields (`EventMusicProfile.dominant_genres`/`.dominant_keys`, `RecommendationResponse.services_used`/`.suggestions`, `UserOut.help_pages_seen`) — reflects #530; now consistent with every other `default_factory` field.
- **`security: [{ OAuth2PasswordBearer: [] }]`** added to *Submit Request* and *Event Search* — these public endpoints gained an owner-JWT bypass (#492/#495), so FastAPI now emits the scheme.
- **`event_search` description** updated to the #492 owner-bypass docstring.

The generated-types diff is **JSDoc-only** (`@default []` comments removed, descriptions added); no TS type *shape* changed, so no consumer is affected.

## Drift-gate evaluation (per #536)
A hard CI gate (regenerate + `git diff --exit-code` on the two artifacts) would catch this automatically — but it would **fail every PR** touching a Pydantic schema, endpoint signature, docstring, or `security` setting until the author regenerates and commits, which is meaningful friction on an actively-changing API. It also needs the python-export step wired into the node typegen job (cross-job artifact passing). **Recommendation: defer the hard gate.** Regeneration is already a one-liner (`types:export` + `types:generate`); if drift recurrence proves costly, add a *non-blocking* drift warning or a pre-push hook in a separate PR. Left unimplemented here to keep this a pure resync.

## Testing
- [x] Regen is idempotent — running it a second time produces no further diff (artifacts now exactly match the code)
- [x] `dashboard` `npx tsc --noEmit` clean (exit 0)
- [x] `dashboard` `npm run lint` clean (exit 0)
- [x] No source/behavior change — generated artifacts only
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #536.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Updates**
  * Search and request submission endpoints now require authentication
  * Improved API documentation clarity regarding event verification and owner authorization behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->