### PR TITLE
feat(tracks): master enriched-track table + provenance-aware store (#540 Task 0)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-master-track-store.md
+++ b/docs/superpowers/plans/2026-06-23-master-track-store.md
@@ -1,0 +1,768 @@
+# Master Track Store — Foundation (PR1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the master `tracks` table + its read/write service (provenance-aware, precedence-guarded), the additive foundation of the hard cutover — mergeable on its own with no reader behavior change.
+
+**Architecture:** A single ISRC-first / signature-fallback `tracks` table is the future single source of truth for song data. A thin `app/services/tracks/` service exposes `get_track` and `upsert_track`; `upsert_track` writes each field's value + provenance together, gated by a source-precedence ladder so a lower-trust source never downgrades a higher one. This PR is purely additive — nothing reads from the table yet.
+
+**Tech Stack:** FastAPI · SQLAlchemy 2.0 (Mapped/mapped_column) · Alembic · Pydantic v2 · pytest (SQLite in-memory).
+
+**Spec:** `docs/superpowers/specs/2026-06-23-master-track-store-design.md` (§3 schema, §4 identity, §5 service, §9 errors, §10 testing).
+
+## Global Constraints
+
+- Backend lint: **ruff line-length 100**, rules E, F, I, UP (`== None`/`== True` allowed). Run `.venv/bin/ruff check . && .venv/bin/ruff format --check .` from `server/`.
+- **Energy scale is integer 0–10** everywhere.
+- **Coverage gate 85%** (`--cov-fail-under`) must hold — run the full `.venv/bin/pytest` before the final commit.
+- **Migrations:** numeric revision ids; current head is **`061`**, so the new revision is **`062`**, `down_revision="061"`. `alembic upgrade head && alembic check` must pass.
+- **Model registration:** every model is imported + listed in `server/app/models/__init__.py`; the test schema is `Base.metadata.create_all` over those, so registering `Track` there makes it appear in tests automatically.
+- **JSON columns:** use SQLAlchemy `JSON` (portable across SQLite tests + Postgres 16 prod).
+- **Imports to reuse:** `from app.models.base import Base`, `from app.core.time import utcnow`, `dedupe_signature` from `app.services.setbuilder.pool`.
+- **Commits:** Conventional Commits; end each with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **Branch:** `feat/540-master-track-store` off `origin/main`; never commit to `main`.
+
+---
+
+### Task 1: Read-site inventory (cutover blast-radius map)
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-06-23-track-read-site-inventory.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a documented enumeration consumed by the later cutover PRs (not by this PR's code).
+
+- [ ] **Step 1: Grep every track-metadata read/write site**
+
+Run from `server/`:
+```bash
+grep -rnE "\.(bpm|musical_key|camelot|genre|energy|duration_sec|isrc)\b|\.key\b" app | grep -vE "tests/|\.pyc" > /tmp/track_reads.txt
+grep -rnE "SetPoolTrack|TrackVibe|vibe_resolver|enrich_request_metadata|_track_meta" app | grep -vE "tests/|\.pyc" >> /tmp/track_reads.txt
+wc -l /tmp/track_reads.txt
+```
+
+- [ ] **Step 2: Write the inventory doc**
+
+Group the hits into a table with columns: `file:line` · field(s) touched · read|write · subsystem (request-pipeline | setbuilder | vibe | recommendation | dashboard). Include a "Cutover action" column (which PR repoints it). Write to the file above with this header:
+```markdown
+# Track-metadata read-site inventory (cutover blast-radius)
+Date: 2026-06-23 · Feeds #540 hard cutover (repoint targets for PR3/PR4, drop targets for PR5).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-06-23-track-read-site-inventory.md
+git commit -m "docs(tracks): read-site inventory for the master-table cutover (#540)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Provenance model + precedence ladder
+
+**Files:**
+- Create: `server/app/services/tracks/__init__.py` (empty package marker)
+- Create: `server/app/services/tracks/provenance.py`
+- Test: `server/tests/test_track_provenance.py`
+
+**Interfaces:**
+- Produces:
+  - `class FieldProvenance(BaseModel)` with `source: str`, `fetched_at: datetime`
+  - `SOURCE_PRECEDENCE: dict[str, int]`
+  - `def precedence(source: str) -> int`
+  - `def should_overwrite(existing: dict | None, new_source: str) -> bool` — `existing` is a stored provenance entry `{"source","fetched_at"}` or None
+  - `class FieldProvenance` is consumed by `upsert_track` (Task 5) to build/serialize each entry; no separate merge helper — gating happens inline in upsert via `should_overwrite`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# server/tests/test_track_provenance.py
+from datetime import datetime
+
+from app.services.tracks.provenance import (
+    precedence,
+    should_overwrite,
+)
+
+T0 = datetime(2026, 6, 23, 12, 0, 0)
+
+
+def test_precedence_ladder_orders_sources():
+    assert precedence("manual") > precedence("lexicon") > precedence("soundcharts")
+    assert precedence("soundcharts") > precedence("community") > precedence("llm")
+    assert precedence("unknown-source") == 0
+
+
+def test_should_overwrite_null_existing_is_true():
+    assert should_overwrite(None, "llm") is True
+
+
+def test_should_overwrite_blocks_downgrade():
+    existing = {"source": "soundcharts", "fetched_at": T0.isoformat()}
+    assert should_overwrite(existing, "llm") is False  # llm cannot clobber measured
+
+
+def test_should_overwrite_allows_equal_or_higher():
+    existing = {"source": "soundcharts", "fetched_at": T0.isoformat()}
+    assert should_overwrite(existing, "soundcharts") is True   # refresh same tier
+    assert should_overwrite(existing, "lexicon") is True       # higher tier wins
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_track_provenance.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.services.tracks'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# server/app/services/tracks/__init__.py
+```
+(empty file)
+
+```python
+# server/app/services/tracks/provenance.py
+"""Per-field provenance + source-precedence for the master tracks store (#540).
+
+The stored JSON shape is {field: {"source": str, "fetched_at": ISO8601 str}}.
+Precedence guards the cascade: a lower-trust source never downgrades a higher
+one (measured energy must survive a later LLM re-inference).
+"""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+SOURCE_PRECEDENCE: dict[str, int] = {
+    "manual": 100,
+    "lexicon": 90,
+    "soundcharts": 50,
+    "beatport": 50,
+    "tidal": 50,
+    "musicbrainz": 50,
+    "community": 40,
+    "llm": 10,
+}
+
+
+class FieldProvenance(BaseModel):
+    source: str
+    fetched_at: datetime
+
+
+def precedence(source: str) -> int:
+    return SOURCE_PRECEDENCE.get(source, 0)
+
+
+def should_overwrite(existing: dict | None, new_source: str) -> bool:
+    """True if a value sourced from new_source may replace the existing field."""
+    if existing is None:
+        return True
+    return precedence(new_source) >= precedence(existing.get("source", ""))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_track_provenance.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/services/tracks/__init__.py server/app/services/tracks/provenance.py server/tests/test_track_provenance.py
+git commit -m "feat(tracks): provenance model + source-precedence ladder (#540)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `Track` SQLAlchemy model + registration
+
+**Files:**
+- Create: `server/app/models/track.py`
+- Modify: `server/app/models/__init__.py` (add import + `__all__` entry)
+- Test: `server/tests/test_track_model.py`
+
+**Interfaces:**
+- Produces: `class Track(Base)` (table `tracks`) with the columns in spec §3; unique constraints `uq_tracks_isrc`, `uq_tracks_signature`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# server/tests/test_track_model.py
+from app.models.track import Track
+
+
+def test_track_table_and_columns():
+    cols = Track.__table__.columns.keys()
+    for expected in (
+        "isrc", "signature", "title", "artist", "soundcharts_uuid",
+        "bpm", "musical_key", "camelot", "genre", "duration_sec",
+        "energy", "danceability", "valence", "acousticness",
+        "instrumentalness", "speechiness", "liveness", "loudness_db",
+        "time_signature", "explicit", "artwork_url", "provenance",
+        "created_at", "updated_at",
+    ):
+        assert expected in cols, f"missing column {expected}"
+    assert Track.__tablename__ == "tracks"
+    assert Track.__table__.columns["signature"].nullable is False
+    assert Track.__table__.columns["isrc"].nullable is True
+
+
+def test_track_unique_constraints():
+    names = {c.name for c in Track.__table__.constraints}
+    assert "uq_tracks_isrc" in names
+    assert "uq_tracks_signature" in names
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_track_model.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.models.track'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# server/app/models/track.py
+"""Master enriched-track table (#540) — single source of truth for song data.
+
+ISRC-first identity with a normalized artist/title signature fallback, so every
+track gets exactly one row. Typed value columns are queryable; per-field
+source/freshness lives in the `provenance` JSON sidecar (see services/tracks).
+"""
+
+from datetime import datetime
+
+from sqlalchemy import JSON, Boolean, DateTime, Float, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.time import utcnow
+from app.models.base import Base
+
+
+class Track(Base):
+    __tablename__ = "tracks"
+    __table_args__ = (
+        UniqueConstraint("isrc", name="uq_tracks_isrc"),
+        UniqueConstraint("signature", name="uq_tracks_signature"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    isrc: Mapped[str | None] = mapped_column(String(15), nullable=True, index=True)
+    signature: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    artist: Mapped[str] = mapped_column(String(255), nullable=False)
+    soundcharts_uuid: Mapped[str | None] = mapped_column(String(36), nullable=True)
+
+    bpm: Mapped[float | None] = mapped_column(Float, nullable=True)
+    musical_key: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    camelot: Mapped[str | None] = mapped_column(String(3), nullable=True)
+    genre: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    duration_sec: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    energy: Mapped[int | None] = mapped_column(Integer, nullable=True)  # 0-10
+    danceability: Mapped[float | None] = mapped_column(Float, nullable=True)
+    valence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    acousticness: Mapped[float | None] = mapped_column(Float, nullable=True)
+    instrumentalness: Mapped[float | None] = mapped_column(Float, nullable=True)
+    speechiness: Mapped[float | None] = mapped_column(Float, nullable=True)
+    liveness: Mapped[float | None] = mapped_column(Float, nullable=True)
+    loudness_db: Mapped[float | None] = mapped_column(Float, nullable=True)
+    time_signature: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    explicit: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    artwork_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+    provenance: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow, onupdate=utcnow)
+```
+
+Then add to `server/app/models/__init__.py`: insert `from app.models.track import Track` in alphabetical position (after `from app.models.system_settings import SystemSettings`) and add `"Track",` to `__all__` (after `"SystemSettings",`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_track_model.py -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/models/track.py server/app/models/__init__.py server/tests/test_track_model.py
+git commit -m "feat(tracks): Track model (ISRC+signature keyed master table) (#540)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `normalize_isrc` helper + `get_track` lookup
+
+**Files:**
+- Modify: `server/services/track_normalizer.py` (add `normalize_isrc`)
+- Create: `server/app/services/tracks/store.py`
+- Test: `server/tests/test_track_normalizer.py` (add a test), `server/tests/test_track_store.py`
+
+**Interfaces:**
+- Consumes: `Track` (Task 3), `dedupe_signature` (existing).
+- Produces:
+  - `def normalize_isrc(isrc: str | None) -> str | None` in `track_normalizer`
+  - `def get_track(db: Session, *, isrc: str | None = None, signature: str | None = None) -> Track | None` in `store.py`
+
+> NOTE: `_normalize_isrc` already exists privately in `setbuilder/pool.py` and `services/soundcharts.py`. This task introduces the canonical public version in `track_normalizer`; migrating those two callers to it is deferred to a follow-up (out of scope for PR1 — don't touch the held `soundcharts.py`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# add to server/tests/test_track_normalizer.py
+from app.services.track_normalizer import normalize_isrc  # if module path differs, match existing imports
+
+
+def test_normalize_isrc_strips_and_uppercases():
+    assert normalize_isrc("us-um7-1900764") == "USUM71900764"
+    assert normalize_isrc("  usum71900764 ") == "USUM71900764"
+
+
+def test_normalize_isrc_empty_is_none():
+    assert normalize_isrc("") is None
+    assert normalize_isrc(None) is None
+```
+
+```python
+# server/tests/test_track_store.py
+from app.models.track import Track
+from app.services.tracks.store import get_track
+
+
+def _make_track(db, **kw):
+    t = Track(signature=kw.pop("signature", "sig-1"), title="T", artist="A", **kw)
+    db.add(t)
+    db.flush()
+    return t
+
+
+def test_get_track_by_isrc_wins(db):
+    _make_track(db, signature="sig-x", isrc="USUM71900764", energy=8)
+    found = get_track(db, isrc="USUM71900764")
+    assert found is not None and found.energy == 8
+
+
+def test_get_track_falls_back_to_signature(db):
+    _make_track(db, signature="sig-y", isrc=None, energy=5)
+    assert get_track(db, isrc="NONEXISTENT00", signature="sig-y").energy == 5
+
+
+def test_get_track_normalizes_isrc(db):
+    _make_track(db, signature="sig-z", isrc="USUM71900764")
+    assert get_track(db, isrc="us-um7-1900764") is not None
+
+
+def test_get_track_miss_returns_none(db):
+    assert get_track(db, isrc="MISS00000000", signature="nope") is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_track_store.py tests/test_track_normalizer.py::test_normalize_isrc_strips_and_uppercases -v`
+Expected: FAIL — `ImportError`/`ModuleNotFoundError` for `normalize_isrc` / `app.services.tracks.store`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `server/services/track_normalizer.py`:
+```python
+def normalize_isrc(isrc: str | None) -> str | None:
+    """Uppercase, trim, and strip hyphens/spaces so an ISRC matches as a key."""
+    if not isrc:
+        return None
+    cleaned = isrc.strip().upper().replace("-", "").replace(" ", "")
+    return cleaned or None
+```
+
+```python
+# server/app/services/tracks/store.py
+"""Read/write service for the master tracks table (#540)."""
+
+from sqlalchemy.orm import Session
+
+from app.models.track import Track
+from app.services.track_normalizer import normalize_isrc
+
+
+def get_track(
+    db: Session, *, isrc: str | None = None, signature: str | None = None
+) -> Track | None:
+    """Look up a track ISRC-first, then by signature."""
+    norm = normalize_isrc(isrc)
+    if norm:
+        found = db.query(Track).filter(Track.isrc == norm).first()
+        if found:
+            return found
+    if signature:
+        return db.query(Track).filter(Track.signature == signature).first()
+    return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_track_store.py tests/test_track_normalizer.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/services/track_normalizer.py server/app/services/tracks/store.py server/tests/test_track_store.py server/tests/test_track_normalizer.py
+git commit -m "feat(tracks): normalize_isrc + get_track ISRC-first lookup (#540)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `upsert_track` — insert + value/provenance write
+
+**Files:**
+- Modify: `server/app/services/tracks/store.py`
+- Test: `server/tests/test_track_store.py` (add)
+
+**Interfaces:**
+- Consumes: `get_track`, `FieldProvenance`, `Track`.
+- Produces:
+  - `@dataclass class TrackIdentity` with `title: str`, `artist: str`, `signature: str`, `isrc: str | None = None`, `soundcharts_uuid: str | None = None`
+  - `def upsert_track(db, *, identity: TrackIdentity, values: dict[str, object], sources: dict[str, str], fetched_at: datetime) -> Track`
+
+> This task writes values UNCONDITIONALLY (last-writer-wins). The precedence guard (Task 6) and ISRC backfill (Task 7) are added on top, each red-first — so this task's `upsert_track` must NOT yet gate on precedence or backfill ISRC on the update path.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to server/tests/test_track_store.py
+from datetime import datetime
+from app.services.tracks.store import TrackIdentity, upsert_track
+
+T0 = datetime(2026, 6, 23, 12, 0, 0)
+
+
+def test_upsert_inserts_new_track(db):
+    t = upsert_track(
+        db,
+        identity=TrackIdentity(title="Sandstorm", artist="Darude", signature="sig-sand", isrc="FIXXX1234567"),
+        values={"energy": 9, "bpm": 136.0},
+        sources={"energy": "soundcharts", "bpm": "beatport"},
+        fetched_at=T0,
+    )
+    assert t.id is not None
+    assert t.energy == 9 and t.bpm == 136.0
+    assert t.provenance["energy"]["source"] == "soundcharts"
+    assert t.provenance["bpm"]["source"] == "beatport"
+
+
+def test_upsert_updates_existing_by_signature_no_duplicate(db):
+    upsert_track(db, identity=TrackIdentity(title="S", artist="D", signature="sig-1"),
+                 values={"bpm": 120.0}, sources={"bpm": "tidal"}, fetched_at=T0)
+    upsert_track(db, identity=TrackIdentity(title="S", artist="D", signature="sig-1"),
+                 values={"genre": "trance"}, sources={"genre": "musicbrainz"}, fetched_at=T0)
+    rows = db.query(Track).filter(Track.signature == "sig-1").all()
+    assert len(rows) == 1
+    assert rows[0].bpm == 120.0 and rows[0].genre == "trance"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_track_store.py -k upsert -v`
+Expected: FAIL — `ImportError: cannot import name 'upsert_track'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `server/app/services/tracks/store.py`:
+```python
+from dataclasses import dataclass
+from datetime import datetime
+
+from app.services.tracks.provenance import FieldProvenance
+
+
+@dataclass
+class TrackIdentity:
+    title: str
+    artist: str
+    signature: str
+    isrc: str | None = None
+    soundcharts_uuid: str | None = None
+
+
+def upsert_track(
+    db: Session,
+    *,
+    identity: TrackIdentity,
+    values: dict[str, object],
+    sources: dict[str, str],
+    fetched_at: datetime,
+) -> Track:
+    """Insert or update the master row, writing each field's value + provenance
+    entry. Precedence gating is added in Task 6; ISRC backfill in Task 7."""
+    norm_isrc = normalize_isrc(identity.isrc)
+    track = get_track(db, isrc=norm_isrc, signature=identity.signature)
+    if track is None:
+        track = Track(
+            signature=identity.signature,
+            title=identity.title,
+            artist=identity.artist,
+            isrc=norm_isrc,
+            soundcharts_uuid=identity.soundcharts_uuid,
+        )
+        db.add(track)
+
+    prov: dict = dict(track.provenance or {})
+    for field, value in values.items():
+        setattr(track, field, value)
+        prov[field] = FieldProvenance(
+            source=sources[field], fetched_at=fetched_at
+        ).model_dump(mode="json")
+    track.provenance = prov
+    db.flush()
+    return track
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_track_store.py -k upsert -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/services/tracks/store.py server/tests/test_track_store.py
+git commit -m "feat(tracks): upsert_track insert + value/provenance write (#540)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: `upsert_track` — precedence guard (no downgrade)
+
+**Files:**
+- Modify: `server/app/services/tracks/store.py`
+- Test: `server/tests/test_track_store.py` (add)
+
+**Interfaces:**
+- Consumes: `upsert_track`, `should_overwrite` (Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to server/tests/test_track_store.py
+def test_upsert_does_not_downgrade_measured_energy(db):
+    upsert_track(db, identity=TrackIdentity(title="S", artist="D", signature="sig-e"),
+                 values={"energy": 8}, sources={"energy": "soundcharts"}, fetched_at=T0)
+    upsert_track(db, identity=TrackIdentity(title="S", artist="D", signature="sig-e"),
+                 values={"energy": 3}, sources={"energy": "llm"}, fetched_at=T0)
+    row = db.query(Track).filter(Track.signature == "sig-e").one()
+    assert row.energy == 8  # llm did not clobber soundcharts
+    assert row.provenance["energy"]["source"] == "soundcharts"
+
+
+def test_upsert_allows_higher_precedence_override(db):
+    upsert_track(db, identity=TrackIdentity(title="S", artist="D", signature="sig-o"),
+                 values={"energy": 8}, sources={"energy": "soundcharts"}, fetched_at=T0)
+    upsert_track(db, identity=TrackIdentity(title="S", artist="D", signature="sig-o"),
+                 values={"energy": 6}, sources={"energy": "lexicon"}, fetched_at=T0)
+    row = db.query(Track).filter(Track.signature == "sig-o").one()
+    assert row.energy == 6 and row.provenance["energy"]["source"] == "lexicon"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_track_store.py -k "downgrade or higher_precedence" -v`
+Expected: `test_upsert_does_not_downgrade_measured_energy` FAILS — Task 5 writes unconditionally, so `llm` energy 3 clobbers soundcharts 8 (`row.energy == 3`). (`test_upsert_allows_higher_precedence_override` already passes; together they characterize the guard.)
+
+- [ ] **Step 3: Add the precedence guard**
+
+In `server/app/services/tracks/store.py`, import `should_overwrite` and gate the write loop:
+```python
+from app.services.tracks.provenance import FieldProvenance, should_overwrite
+```
+Replace the value-write loop in `upsert_track` with:
+```python
+    prov: dict = dict(track.provenance or {})
+    for field, value in values.items():
+        if should_overwrite(prov.get(field), sources[field]):
+            setattr(track, field, value)
+            prov[field] = FieldProvenance(
+                source=sources[field], fetched_at=fetched_at
+            ).model_dump(mode="json")
+    track.provenance = prov
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_track_store.py -k upsert -v`
+Expected: PASS (all upsert tests, including the precedence pair)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/services/tracks/store.py server/tests/test_track_store.py
+git commit -m "feat(tracks): precedence guard in upsert_track (no downgrade) (#540)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: `upsert_track` — ISRC backfill onto signature-matched row
+
+**Files:**
+- Modify: `server/app/services/tracks/store.py`
+- Test: `server/tests/test_track_store.py` (add)
+
+**Interfaces:**
+- Consumes: `upsert_track`, `get_track`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to server/tests/test_track_store.py
+def test_upsert_backfills_isrc_onto_signature_row(db):
+    # First seen with no ISRC (e.g. manual add)
+    upsert_track(db, identity=TrackIdentity(title="Sandstorm", artist="Darude", signature="sig-bf"),
+                 values={"bpm": 136.0}, sources={"bpm": "manual"}, fetched_at=T0)
+    # Later seen WITH an ISRC, same signature → backfill, one row
+    upsert_track(db, identity=TrackIdentity(title="Sandstorm", artist="Darude", signature="sig-bf", isrc="FIXXX1234567"),
+                 values={"energy": 9}, sources={"energy": "soundcharts"}, fetched_at=T0)
+    rows = db.query(Track).filter(Track.signature == "sig-bf").all()
+    assert len(rows) == 1
+    assert rows[0].isrc == "FIXXX1234567"
+    assert rows[0].bpm == 136.0 and rows[0].energy == 9
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_track_store.py -k backfill -v`
+Expected: FAIL — Task 5 sets `isrc` only on INSERT, so the second (update) call leaves `rows[0].isrc is None` (assert `isrc == "FIXXX1234567"` fails).
+
+- [ ] **Step 3: Add the backfill branch**
+
+In `upsert_track`, after the get_track / insert block and before the value-write loop, add:
+```python
+    if norm_isrc and not track.isrc:
+        track.isrc = norm_isrc
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_track_store.py -k upsert -v`
+Expected: PASS (all upsert tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/app/services/tracks/store.py server/tests/test_track_store.py
+git commit -m "feat(tracks): ISRC backfill onto signature-matched row in upsert_track (#540)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Alembic migration for the `tracks` table
+
+**Files:**
+- Create: `server/alembic/versions/062_master_tracks_table.py`
+
+**Interfaces:**
+- Consumes: the `Track` model (Task 3).
+
+- [ ] **Step 1: Autogenerate the migration**
+
+Run from `server/` (DB must be up: `docker compose up -d db`):
+```bash
+.venv/bin/alembic revision --autogenerate -m "master tracks table"
+```
+Then rename the generated file to `062_master_tracks_table.py` and set `revision = "062"`, `down_revision = "061"` (match the format of `061_add_request_accepted_at.py`). Verify the autogenerated `upgrade()` creates `tracks` with all columns + `uq_tracks_isrc` / `uq_tracks_signature` + the `isrc`/`signature` indexes, and `downgrade()` drops the table. If autogenerate produced unrelated diffs, delete them — this migration is `tracks`-only.
+
+- [ ] **Step 2: Apply + verify no drift**
+
+Run:
+```bash
+.venv/bin/alembic upgrade head && .venv/bin/alembic check
+```
+Expected: upgrade succeeds; `alembic check` prints "No new upgrade operations detected."
+
+- [ ] **Step 3: Verify downgrade**
+
+Run:
+```bash
+.venv/bin/alembic downgrade -1 && .venv/bin/alembic upgrade head
+```
+Expected: both succeed (table drops then recreates cleanly).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/alembic/versions/062_master_tracks_table.py
+git commit -m "feat(tracks): migration for the master tracks table (#540)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Full CI gate + package export
+
+**Files:**
+- Modify: `server/app/services/tracks/__init__.py` (re-export the public API)
+
+**Interfaces:**
+- Produces: `from app.services.tracks import get_track, upsert_track, TrackIdentity`
+
+- [ ] **Step 1: Add the package re-exports**
+
+```python
+# server/app/services/tracks/__init__.py
+from app.services.tracks.provenance import FieldProvenance, should_overwrite
+from app.services.tracks.store import TrackIdentity, get_track, upsert_track
+
+__all__ = [
+    "FieldProvenance",
+    "TrackIdentity",
+    "get_track",
+    "should_overwrite",
+    "upsert_track",
+]
+```
+
+- [ ] **Step 2: Run the full backend CI gate**
+
+Run from `server/`:
+```bash
+.venv/bin/ruff check . && .venv/bin/ruff format --check . && \
+.venv/bin/bandit -r app -c pyproject.toml -q && \
+.venv/bin/pytest --tb=short -q
+```
+Expected: ruff clean; bandit "No issues identified"; pytest all pass with **coverage ≥ 85%**.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/app/services/tracks/__init__.py
+git commit -m "feat(tracks): export master-track-store public API (#540)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** §3 schema → Task 3 + Task 8. §4 identity (ISRC-first, signature fallback, backfill) → Tasks 4, 5, 7. §5 service API + precedence ladder → Tasks 2, 5, 6. §9 error handling (null fields, no-ISRC→signature) → Tasks 4/5 (null-safe upsert, signature fallback). §10 testing → every task is TDD; cache-aside reuse + characterization tests + #543 regression belong to the **write-wiring/cutover PRs** (out of PR1 scope, noted). Read-site inventory (§7, #540 AC) → Task 1.
+
+**Out of PR1 scope (follow-on plans, seeded by Task 1's inventory):** cache-aside populate-and-reuse write wiring (#541), repointing setbuilder/pass-1 reads + #543 regression (#542/#543), repointing request/recommendation reads, dropping legacy columns (#544 write path uses the already-built Soundcharts adapter).
+
+**Placeholder scan:** none — every code step has complete code; Task 1's "content" is data-gathering output, not a code placeholder.
+
+**Type consistency:** `get_track(db, *, isrc, signature)`, `upsert_track(db, *, identity, values, sources, fetched_at)`, `TrackIdentity(title, artist, signature, isrc?, soundcharts_uuid?)`, `FieldProvenance(source, fetched_at)`, `should_overwrite(existing, new_source)` — names/signatures consistent across Tasks 2/4/5/6/7/9. (`merge_provenance` dropped: gating happens inline in `upsert_track` via `should_overwrite`, so no separate merge helper exists.)
+
+**TDD ordering (pre-flight fix):** Task 5 implements `upsert_track` with UNCONDITIONAL writes; Task 6 adds the precedence guard red-first (its downgrade test fails against Task 5); Task 7 adds ISRC backfill red-first (its test fails against Task 5/6). Each task has a genuine red→green cycle.

--- a/docs/superpowers/specs/2026-06-23-master-track-store-design.md
+++ b/docs/superpowers/specs/2026-06-23-master-track-store-design.md
@@ -75,7 +75,7 @@ Value queries (e.g. "energy of ISRC X") are plain indexed column lookups — the
 
 ```python
 def get_track(db, *, isrc: str | None = None, signature: str | None = None) -> Track | None
-def upsert_track(db, *, identity: TrackIdentity, values: dict, provenance: dict[str, FieldProvenance]) -> Track
+def upsert_track(db, *, identity: TrackIdentity, values: dict, sources: dict[str, str], fetched_at: datetime) -> Track
 ```
 
 - `TrackIdentity` carries title, artist, isrc?, signature, soundcharts_uuid?.
@@ -87,6 +87,7 @@ def upsert_track(db, *, identity: TrackIdentity, values: dict, provenance: dict[
   ```
 - **Per-field precedence ("don't downgrade"):** `upsert_track` overwrites a field only when the new source's precedence ≥ the existing field's source precedence (or the field is null). Precedence (higher wins):
   `manual/own-override 100 · lexicon(measured) 90 · soundcharts/beatport/tidal/musicbrainz 50 · community 40 · llm(inferred) 10`.
+- **Boundary validation (as-built):** `upsert_track` takes `sources: dict[field,str]` + `fetched_at` (not a pre-built provenance dict); it constructs/serializes each `FieldProvenance` internally. Before any mutation it raises `ValueError` for any `values` field lacking a matching `sources` entry, or any source not in `KNOWN_SOURCES` (= `SOURCE_PRECEDENCE` keys) — guaranteeing no partial writes and failing loud on unknown sources. `energy` is additionally range-checked 0–10 by a DB `CheckConstraint`.
 - **Concurrency:** unique constraints on `isrc`/`signature`; on IntegrityError, re-read and merge (mirrors `uq_set_pool_track_sig`).
 
 ## 6. Data flow — cache-aside populate-and-reuse

--- a/docs/superpowers/specs/2026-06-23-master-track-store-design.md
+++ b/docs/superpowers/specs/2026-06-23-master-track-store-design.md
@@ -1,0 +1,146 @@
+# Master Song Store + Hard Cutover — Design Spec
+
+**Date:** 2026-06-23
+**Issues:** #539 (epic) · #540 (Task 0 — this table) · absorbs #541 / #542 / #543 · #544 (first audio-features writer)
+**Status:** Approved design, pending implementation plan.
+
+## 1. Context & decision
+
+WrzDJ has **no unified track table** (a deliberate prior stance: `set_pool.py` / `track_vibe.py` use free-form namespaced IDs, no FK). The costs:
+
+- The same recording is enriched repeatedly — `enrich_request_metadata` writes bpm/key/genre onto each `Request` row, so the same song requested at two events is enriched twice.
+- There is no single place a track's known bpm/key/genre/duration/energy lives, recallable across DJs/events/builder pools.
+- **Dead-energy bug (#543):** pass-1 reads `energy` off `SetPoolTrack.energy`, which is structurally always `None` — energy contributes nothing to set sequencing.
+
+**Decision (maintainer, 2026-06-23):** introduce a **master `tracks` table as the single source of truth** for song data, recallable by **any DJ, any event, and any WrzDJSet builder request**, and **hard-cut** all readers/writers over to it — retiring the redundant inline enrichment columns on `Request` / `SetPoolTrack`.
+
+This **overrides the epic's "never big-bang / one-surface-at-a-time" rule**, which exists to protect *other DJs' in-flight work* in a multi-tenant deployment. At **solo / private-VPS scale** that protection is moot, and a permanent dual-source-of-truth is more debt than it's worth. The cutover **absorbs** the read-migration work of #541/#542/#543 and **fixes #543 for free**.
+
+"Hard cutover" = the **end state** (no dual source of truth), **not** one reckless commit — it is sequenced into green-at-each-step PRs (§8).
+
+## 2. Goals / non-goals
+
+**Goals**
+- One global row per unique recording, written once, reused everywhere (zero re-enrichment per unique track).
+- ISRC-first identity with a universal signature fallback so *every* track gets a row.
+- Typed, queryable value columns; compact per-field provenance.
+- All enrichment readers consume the master table; redundant inline columns dropped.
+
+**Non-goals (now)**
+- No TTL / re-enrichment job (cache forever; `provenance.fetched_at` enables it later).
+- No ReccoBeats fallback wiring yet (the cascade leaves a hook; ReccoBeats is the future quota/backfill path).
+- No bulk catalog backfill tooling (Soundcharts has no batch endpoint; steady-state request-time enrichment is incremental — see #544 comment).
+
+## 3. Schema — `tracks`
+
+**Identity & keys**
+| Column | Type | Notes |
+|---|---|---|
+| `id` | int PK | surrogate |
+| `isrc` | String(15), unique, nullable, indexed | normalized upper / no-hyphens |
+| `signature` | String(64), unique, NOT NULL, indexed | `dedupe_signature(artist, title)` |
+| `title`, `artist` | String(255), NOT NULL | canonical display |
+| `soundcharts_uuid` | String(36), nullable | cached resolve |
+
+**Value columns (typed, directly queryable)**
+| Column | Type | Scale |
+|---|---|---|
+| `bpm` | Float | |
+| `musical_key` | String(20) | human "G Major" (via `pitch_class_to_key_string`) |
+| `camelot` | String(3) | |
+| `genre` | String(100) | single primary genre (first from the highest-precedence genre source: MusicBrainz artist genre, else Soundcharts' first sub-genre) |
+| `duration_sec` | Integer | |
+| `energy` | Integer | **0–10** (house scale; resolved best per cascade) |
+| `danceability`, `valence`, `acousticness`, `instrumentalness`, `speechiness`, `liveness` | Float | native 0–1 |
+| `loudness_db` | Float | dB |
+| `time_signature` | Integer | |
+| `explicit` | Boolean | clean-set pre-filter |
+| `artwork_url` | String(500) | |
+
+**Provenance & timestamps**
+| Column | Type | Notes |
+|---|---|---|
+| `provenance` | JSON | `{field: {source, fetched_at}}`; write-path validated by Pydantic |
+| `created_at`, `updated_at` | DateTime | `utcnow` default (matches house pattern) |
+
+Value queries (e.g. "energy of ISRC X") are plain indexed column lookups — the JSON is never in that path.
+
+## 4. Identity & dedup
+
+- Lookup order: **ISRC (if present) → signature**. `signature = dedupe_signature(artist, title)` (existing SHA256[:32], reused).
+- **ISRC backfill:** when an enrichment arrives with an ISRC for a track that currently exists only by signature, set `isrc` on that row (collapses to one row).
+- Same recording across two platform IDs but one ISRC → **one row** (unit-tested).
+
+## 5. Services API — `app/services/tracks/`
+
+```python
+def get_track(db, *, isrc: str | None = None, signature: str | None = None) -> Track | None
+def upsert_track(db, *, identity: TrackIdentity, values: dict, provenance: dict[str, FieldProvenance]) -> Track
+```
+
+- `TrackIdentity` carries title, artist, isrc?, signature, soundcharts_uuid?.
+- Provenance shape (validated at boundary):
+  ```python
+  class FieldProvenance(BaseModel):
+      source: str       # soundcharts|beatport|tidal|musicbrainz|lexicon|community|llm|manual
+      fetched_at: datetime
+  ```
+- **Per-field precedence ("don't downgrade"):** `upsert_track` overwrites a field only when the new source's precedence ≥ the existing field's source precedence (or the field is null). Precedence (higher wins):
+  `manual/own-override 100 · lexicon(measured) 90 · soundcharts/beatport/tidal/musicbrainz 50 · community 40 · llm(inferred) 10`.
+- **Concurrency:** unique constraints on `isrc`/`signature`; on IntegrityError, re-read and merge (mirrors `uq_set_pool_track_sig`).
+
+## 6. Data flow — cache-aside populate-and-reuse
+
+```
+enrich track (request submit, or pool import)
+   compute signature (+ ISRC if known)
+        │
+   get_track() ── hit & complete ──▶ REUSE — zero API calls   ← quota defense
+        │ miss / missing fields
+        ▼
+   call only the needed sources:
+     MusicBrainz → genre · Beatport/Tidal → bpm/key · Soundcharts → audio-features (by ISRC)
+        ▼
+   upsert_track(values, provenance)   (precedence-guarded)
+```
+
+**Energy cascade → `energy` column:** Soundcharts measured (primary) → Lexicon override (#526) → LLM-inferred (#391, via `TrackVibe`). Resolved best written to `tracks.energy` with `provenance.energy.source`. `TrackVibe`/`TrackVibeOverride` remain the vote/override layer feeding the column. The Soundcharts adapter (`app/services/soundcharts.py:get_song_features_by_isrc`, already built on `feat/544-soundcharts-audio-features`) is the first audio-features writer.
+
+## 7. Cutover
+
+- **FK linkage:** nullable `Request.track_id` and `SetPoolTrack.track_id` → `tracks.id`, set by enrichment.
+- **Readers repointed** to read enrichment from the master table: request pipeline, setbuilder pool, pass-1 `_track_meta` (fixes #543), `vibe_resolver`, recommendation engine.
+- **Columns dropped** after readers move: `Request.genre/bpm/musical_key`; `SetPoolTrack.genre/bpm/key/camelot/energy/isrc/duration_sec`. Each table keeps its membership/display fields (`title`, `artist`, `dedupe_sig`/`dedupe_key`, source linkage).
+- **Read-site inventory is a required deliverable** (#540 AC): exhaustively enumerate every read/write of `bpm/key/musical_key/camelot/genre/energy/duration_sec/isrc` on `Request`, `SetPoolTrack`, `TrackVibe`/`vibe_resolver`, recommendation, dashboard — the cutover must hit every one.
+
+## 8. Build sequence (green at every step)
+
+0. **(done, held)** Soundcharts audio-features adapter — `feat/544-soundcharts-audio-features` (#544).
+1. `tracks` table + migration + `tracks` service (get/upsert + provenance + precedence). Additive, no readers changed. (#540 core)
+2. Enrichment **writes** the store (cache-aside populate-and-reuse) + **backfill** existing data; dual-write alongside legacy columns. (#541)
+3. Repoint **setbuilder pool + pass-1 `_track_meta`** reads → store; characterization tests; **#543 regression** (energy changes ordering). (#542/#543)
+4. Repoint **request pipeline + recommendation** reads → store.
+5. **Drop** redundant inline enrichment columns (final cutover); migration.
+
+## 9. Error handling
+
+- Enrichment is best-effort, **never blocks a guest request**. Provider/quota failure → `upsert_track` writes resolved fields only; unresolved stay null (no provenance entry); row still exists by identity.
+- No ISRC → signature fallback always yields a row.
+- Provenance validated by Pydantic before write; malformed rejected.
+- Nullable `track_id` FK → un-resolved Request/pool track behaves like today's un-enriched state, never a crash.
+
+## 10. Testing
+
+- `tracks` service: ISRC-first/signature-fallback; insert/update/provenance-merge; ISRC backfill; precedence (no downgrade); identity dedup.
+- Cache-aside reuse: 2nd enrichment of a known track → **zero** provider calls.
+- Characterization tests around each repointed reader (identical output pre/post cutover).
+- Migration up/down clean; `alembic check` passes.
+- #543 regression pinned (non-null energy changes pass-1 candidate ordering).
+- Repo coverage gate (85%) held throughout.
+
+## 11. Open questions / future
+
+- ReccoBeats fallback + batch backfill (quota path) — hook left in the cascade.
+- Lexicon measured-energy override (#526) — slots in at precedence 90.
+- Provenance-driven re-enrichment/TTL job — enabled by `fetched_at`, deferred.
+- Soundcharts caching/redistribution licensing — confirm API agreement before enabling in prod (#544 gate); feature stays dark by default until then.

--- a/docs/superpowers/specs/2026-06-23-track-read-site-inventory.md
+++ b/docs/superpowers/specs/2026-06-23-track-read-site-inventory.md
@@ -1,0 +1,212 @@
+# Track-metadata read-site inventory (cutover blast-radius)
+Date: 2026-06-23 · Feeds #540 hard cutover (repoint targets for PR3/PR4, drop targets for PR5).
+
+## Background
+
+This inventory was produced by grepping all non-test Python source under `server/app/` for every
+direct field access to the seven canonical track-metadata columns (`bpm`, `musical_key`/`key`,
+`camelot`, `genre`, `energy`, `duration_sec`, `isrc`) and for all references to the key model
+classes and helpers (`SetPoolTrack`, `TrackVibe`, `vibe_resolver`, `enrich_request_metadata`,
+`_track_meta`).  439 raw grep hits were de-duplicated into the groups below.
+
+### Source tables that carry track metadata today
+
+| Table | Model class | Fields of interest |
+|---|---|---|
+| `requests` | `Request` | `bpm`, `musical_key`, `genre` (no energy/duration/isrc columns) |
+| `set_pool_tracks` | `SetPoolTrack` | `bpm`, `key`, `camelot`, `genre`, `energy`, `isrc`, `duration_sec` |
+| `track_vibes` | `TrackVibe` | `energy`, `mood`, `era`, `sing_along`, `dance_floor`, `transitional_role` |
+| `track_vibe_overrides` | `TrackVibeOverride` | `energy_override`, `mood_override` (per-DJ overrides) |
+
+### Key in-memory intermediaries (not in DB, must map to the new `tracks` table in PR3/PR4)
+
+| Dataclass | Module | Metadata fields carried |
+|---|---|---|
+| `PoolCandidate` | `services/setbuilder/pool.py` | `bpm`, `key`, `genre`, `energy`, `isrc`, `duration_sec` |
+| `TrackMeta` | `services/setbuilder/pass1_deterministic.py` | `bpm`, `key`, `energy`, `mood`, `transitional_role` |
+| `TrackProfile` | `services/recommendation/scorer.py` | `bpm`, `key`, `genre` |
+| `NormalizedTrack` | `services/track_normalizer.py` | (title/artist normalisation – no metadata fields) |
+| `SearchResult` | `schemas/search.py` | `bpm`, `key`, `isrc`, `genre` |
+| `ExportTrack` | `services/setbuilder/export_common.py` | `genre`, `bpm`, `key`, `camelot`, `isrc`, `duration_sec` |
+
+---
+
+## Inventory table
+
+The table groups hits by subsystem. "R" = read, "W" = write/mutation.
+
+### 1. Request pipeline
+
+| file:line | Field(s) | R/W | Notes | Cutover action |
+|---|---|---|---|---|
+| `api/public.py:345-347` | `bpm`, `musical_key`, `genre` | R | Guest-facing now-playing/history serialisation reads from `Request` | PR3: add `track_id` FK on `Request`; read from `tracks` if present, fall back to `Request` columns |
+| `api/requests.py:103-105` | `genre`, `bpm`, `musical_key` | R | DJ request-list serialisation | PR3: same fallback strategy |
+| `api/collect.py:208-210` | `bpm`, `musical_key`, `genre` | R | Request detail serialisation in collect flow | PR3: fallback |
+| `api/collect.py:425-427` | `bpm`, `musical_key`, `genre` | R | Second serialisation call in collect flow | PR3: fallback |
+| `api/collect.py:505` | `genre`, `bpm`, `musical_key` | R | Completeness gate: skips enrichment if all three present | PR3: check `tracks` row instead |
+| `api/collect.py:579-581` | `bpm`, `key`, `genre` | W | Writes best-match metadata back onto `Request` after search merge | PR4: write to `tracks` table instead |
+| `api/events.py:204-206` | `genre`, `bpm`, `musical_key` | R | Event request-list serialisation | PR3: fallback |
+| `api/events.py:231-233` | `bpm`, `key`, `genre` | R | Event music-profile aggregation (profile endpoint) | PR3: read from `tracks` |
+| `api/events.py:706-708` | `genre`, `bpm`, `musical_key` | W | Initial write of metadata when a new request is submitted | PR4: write to `tracks` |
+| `api/events.py:712` | `genre`, `bpm`, `musical_key` | R | Completeness gate after submission | PR3: check `tracks` |
+| `api/events.py:893-894` | `musical_key`, `bpm` | R | Bridge now-playing match: pulls key/bpm for enrichment log | PR3: read from `tracks` |
+| `api/events.py:902-903` | `musical_key`, `bpm` | R | SSE now-playing push body | PR3: fallback |
+| `api/events.py:1258` | `bpm`, `key`, `genre` (comment) | — | Comment referencing enrichment columns | No-op |
+| `api/events.py:1300` | — | — | Calls `enrich_request_metadata` (writes — see pipeline section) | — |
+| `api/events.py:1377` | `bpm`, `musical_key`, `genre` | R | Batch-enrichment filter: finds requests missing metadata | PR3: filter on `tracks` row instead |
+| `api/requests.py:42` | — | — | Calls `enrich_request_metadata` | — |
+| `services/request.py:221-223` | `genre`, `bpm`, `musical_key` | W | Clears metadata on request title-change | PR4: clear `tracks` row FK |
+| `services/export.py:74-76` | `genre`, `bpm`, `musical_key` | R | CSV export of requests | PR3: read from `tracks` |
+
+### 2. Enrichment / sync pipeline
+
+| file:line | Field(s) | R/W | Notes | Cutover action |
+|---|---|---|---|---|
+| `services/sync/enrichment_pipeline.py:204-209` | `genre`, `bpm`, `musical_key` | W | Copies best API hit fields onto `Request` (fill-in) | PR4: upsert into `tracks` table; keep `Request` write for backward compat until PR5 |
+| `services/sync/enrichment_pipeline.py:231` | `genre`, `bpm`, `musical_key` | R | Gate: skip LLM call if all three already present | PR3: gate on `tracks` row |
+| `services/sync/enrichment_pipeline.py:252-254` | `genre`, `bpm`, `musical_key` | R | Passes to LLM enrichment call | PR3: read from `tracks` |
+| `services/sync/enrichment_pipeline.py:259-270` | `bpm`, `musical_key` | R/W | Beatport direct-lookup; writes key/bpm back onto request | PR4: write to `tracks` |
+| `services/sync/enrichment_pipeline.py:277-288` | `bpm`, `musical_key` | R/W | Tidal direct-lookup; writes key/bpm back | PR4: write to `tracks` |
+| `services/sync/enrichment_pipeline.py:295-310` | `bpm`, `musical_key` | R/W | Spotify ISRC-based lookup; writes key/bpm | PR4: write to `tracks` |
+| `services/sync/enrichment_pipeline.py:318-322` | `genre` | W | Soundcharts genre fill | PR4: write to `tracks` |
+| `services/sync/enrichment_pipeline.py:327-352` | `bpm`, `musical_key`, `genre` | R/W | LLM fallback — checks, calls, writes | PR4: write to `tracks` |
+| `services/sync/enrichment_pipeline.py:362-386` | `bpm`, `musical_key` | R/W | Second LLM pass for remaining blanks | PR4: write to `tracks` |
+| `services/sync/enrichment_pipeline.py:396-427` | `bpm`, `musical_key` | R/W | Normalises key, BPM-context correction | PR4: normalise on `tracks` row |
+| `services/sync/enrichment_pipeline.py:433-435` | `genre`, `bpm`, `musical_key` | R | Final log / return values | PR3: read from `tracks` |
+| `services/sync/orchestrator.py:28` | — | — | Imports `enrich_request_metadata` for re-export | — |
+| `services/recommendation/enrichment.py:90-94` | `bpm`, `key` | R | Tidal search hit → track profile construction | PR3: these are transient objects, no DB read needed |
+| `services/recommendation/enrichment.py:154-173` | `bpm`, `key`, `genre` | R | Merge of Beatport+Tidal profiles | transient — no cutover |
+| `services/recommendation/enrichment.py:207-209` | `bpm`, `key`, `genre` | R | Combined profile for scoring | transient |
+| `services/recommendation/enrichment.py:252-266` | `bpm`, `key`, `genre` | R | Reads from `Request` to build `TrackProfile` | PR3: read from `tracks` |
+| `services/search_merge.py:89-91` | `bpm`, `key`, `isrc` | R | Builds `SearchResult` from Tidal hit | transient |
+| `services/search_merge.py:107-109` | `genre`, `bpm`, `key` | R | Builds `SearchResult` from Beatport hit | transient |
+| `services/search_merge.py:124-144` | `isrc`, `bpm`, `key`, `genre` | R | ISRC deduplication and field-merge of search results | transient — feeds `collect.py:579` write |
+| `services/tidal.py:204-210` | `bpm`, `key` | R | Reads from Tidal API object → transient | transient |
+| `services/soundcharts.py:17` | — | R | `parse_key` import | no cutover |
+| `services/soundcharts_candidates.py:78-79` | `bpm`, `key` | R | Constructs candidate from Tidal+Soundcharts | transient |
+
+### 3. Set-builder — pool management
+
+| file:line | Field(s) | R/W | Notes | Cutover action |
+|---|---|---|---|---|
+| `services/setbuilder/pool.py:155-156` | `dedupe_sig`, `isrc` | R | Existing-track deduplication query on `SetPoolTrack` | PR3: look up in `tracks` if ISRC present |
+| `services/setbuilder/pool.py:174-215` | `genre`, `bpm`, `key`, `camelot`, `energy`, `isrc`, `duration_sec` | W | **Main pool import write path**: creates `SetPoolTrack` rows from `PoolCandidate` | PR4: also write a `tracks` row (upsert by ISRC+sig) and set FK |
+| `services/setbuilder/pool.py:267-294` | `genre`, `bpm`, `key`, `isrc` | W | Imports from event requests into pool | PR4: upsert `tracks`; set FK |
+| `services/setbuilder/pool.py:318-320` | `genre`, `bpm`, `key` | W | Imports from public-URL / Spotify tracks | PR4: upsert `tracks`; set FK |
+| `services/setbuilder/pool.py:389` | `isrc` | R | Spotify GraphQL field selector (string literal) | no cutover |
+| `api/setbuilder.py:308-315` | — | R | Queries `SetPoolTrack` for track-id/pool-track-id filters | PR3: pass-through; FK lookup added |
+| `api/setbuilder.py:342-346` | `bpm`, `key`, `camelot`, `energy`, `duration_sec` | R | Pool-track serialisation (list endpoint) | PR3: read from `tracks` via FK |
+| `api/setbuilder.py:1214-1218` | `genre`, `bpm`, `key`, `isrc`, `duration_sec` | W | Manual-add endpoint writes `PoolCandidate` fields | PR4: also upsert `tracks` |
+| `services/setbuilder/export_common.py:61-66` | `genre`, `bpm`, `key`, `camelot`, `isrc`, `duration_sec` | R | Converts `SetPoolTrack` → `ExportTrack` for file export | PR3: read from `tracks` via FK |
+| `services/setbuilder/export_files.py:64-115` | `genre`, `isrc`, `duration_sec`, `bpm`, `key`, `camelot` | R | Writes metadata into export XML/M3U files | PR3: reads through `ExportTrack` (see above) |
+| `services/setbuilder/export_tidal.py:83-84` | `isrc` | R | ISRC-based Tidal match for export | PR3: read from `tracks` |
+| `services/setbuilder/document_snapshot.py:55` | `energy` | R | Snapshot serialises energy from `SetSlot.curve_point` | no cutover (curve, not pool) |
+| `services/setbuilder/document_snapshot.py:82-88` | `genre`, `bpm`, `key`, `camelot`, `energy`, `isrc`, `duration_sec` | R | Snapshot serialises pool-track metadata | PR3: read from `tracks` via FK |
+| `services/setbuilder/document_snapshot.py:109` | — | W | Deletes all `SetPoolTrack` rows on restore | PR4: also clear `tracks` FK? (tbd: tracks rows are global) |
+| `services/setbuilder/document_snapshot.py:136-149` | `genre`, `bpm`, `key`, `camelot`, `energy`, `isrc`, `duration_sec` | W | Re-creates `SetPoolTrack` rows on snapshot restore | PR4: re-upsert `tracks`; set FK |
+| `services/setbuilder/pairings.py:227` | `camelot`, `bpm` | R | Text search haystack construction | PR3: read from `tracks` |
+| `services/setbuilder/playhistory_feedback.py:104-139` | — | R | Holds `SetPoolTrack` refs for play-history match | PR3: pass-through |
+
+### 4. Set-builder — build passes (pass1 / pass2 / agent tools)
+
+| file:line | Field(s) | R/W | Notes | Cutover action |
+|---|---|---|---|---|
+| `services/setbuilder/pass1_deterministic.py:62` | — | R | `_track_meta(t)` — builds `TrackMeta` from `SetPoolTrack` | PR3: `_track_meta` reads from `tracks` via FK |
+| `services/setbuilder/pass1_deterministic.py:116` | — | R | `_track_meta` batch over pool | PR3: same |
+| `services/setbuilder/pass1_deterministic.py:196-204` | `bpm`, `key`, `camelot`, `energy` | R | `_track_meta` implementation — reads 4 fields from `SetPoolTrack` | **Key cutover point**: PR3 repoints to `tracks` table |
+| `services/setbuilder/pass1_deterministic.py:221` | `duration_sec` | R | Average duration calc | PR3: via `_track_meta` |
+| `services/setbuilder/pass1_deterministic.py:294` | `energy` | R | Energy-match scoring | PR3: via `_track_meta` |
+| `services/setbuilder/pass1_deterministic.py:315` | `bpm` | R | BPM transition score | PR3: via `_track_meta` |
+| `services/setbuilder/pass1_deterministic.py:321` | `key` | R | Camelot compatibility score | PR3: via `_track_meta` |
+| `services/setbuilder/pass2_agent.py:391-409` | `bpm`, `camelot`/`key`, `energy` | R | Agent JSON payload for LLM context | PR3: via `_pass1_track_meta` |
+| `services/setbuilder/agent_tools_sensing.py:53-215` | `bpm`, `key`, `energy`, `duration_sec`, `camelot` | R | All sensing tools read via `_pass1_track_meta` or direct field access on `SetPoolTrack` | PR3: `_pass1_track_meta` repoint covers most; direct `.duration_sec` on line 212 must also move |
+| `services/setbuilder/agent_tools_mutations.py:228` | `energy` | R | Serialises `CurvePoint.energy` (curve, not pool track) | no cutover |
+| `services/setbuilder/agent_tools_structural.py:51-52` | `duration_sec` | R | Duration check for set-length budget | PR3: via `_pass1_track_meta` or `tracks` FK |
+| `services/setbuilder/vibe_enrichment.py:120-125` | `genre`, `bpm` | R | Prompt-line construction for LLM vibe call | PR3: read from `tracks` via FK |
+| `services/setbuilder/curve.py:347` | `energy` | W | Writes `energy` onto `CurvePoint`, not `SetPoolTrack` | no cutover (separate model) |
+
+### 5. Vibe subsystem
+
+| file:line | Field(s) | R/W | Notes | Cutover action |
+|---|---|---|---|---|
+| `models/track_vibe.py:32-67` | `energy`, `mood`, `era`, etc. | — | `TrackVibe` table definition — LLM-vibe cache keyed by `track_id` string | PR5: `track_id` string column replaced by FK to `tracks.id` |
+| `models/track_vibe.py:69-end` | `energy_override`, `mood_override` | — | `TrackVibeOverride` table definition | PR5: same FK replacement |
+| `services/setbuilder/vibe_resolver.py:85-193` | — | R | Queries `TrackVibe` and `TrackVibeOverride` by `track_id` string key | PR5: repoint to FK |
+| `services/setbuilder/vibe_enrichment.py:88-275` | — | R/W | Batch LLM enrichment writes `TrackVibe` rows | PR5: write via FK |
+| `services/setbuilder/community_vibe.py:75-84` | — | R | Community consensus query over `TrackVibeOverride` | PR5: repoint |
+| `api/setbuilder.py:1268-1363` | `energy` | R/W | Reads vibe states, reads `energy`; writes `TrackVibeOverride` | PR3 (energy read via state), PR5 (write path) |
+| `services/setbuilder/share_service.py:91` | `energy` | R | Serialises `CurvePoint.energy` in share snapshot | no cutover (CurvePoint) |
+
+### 6. Recommendation engine
+
+| file:line | Field(s) | R/W | Notes | Cutover action |
+|---|---|---|---|---|
+| `services/recommendation/scorer.py:63-311` | `bpm`, `key`, `genre` | R | Event-profile scoring reads from `TrackProfile` objects | PR3: `TrackProfile` is transient; source data read path changes above |
+| `services/recommendation/service.py:430-761` | `genre`, `bpm`, `key` | R | Scoring service reads `TrackProfile`; genre block-list check | PR3: transient — source changes above |
+| `services/recommendation/llm_client.py:190-195` | `bpm`, `key`, `genre` | R | Builds LLM prompt from `TrackProfile` | transient |
+| `services/recommendation/template.py:57-85` | `bpm`, `key`, `genre` | R | Template-based recommendation uses same `TrackProfile` | transient |
+| `services/recommendation/soundcharts_candidates.py:78-79` | `bpm`, `key` | R | Constructs `TrackProfile` from combined Tidal result | transient |
+| `services/priority_scorer.py:227-228` | `musical_key`, `bpm` | R | Priority scorer reads from `Request` row | PR3: read from `tracks` via FK |
+| `services/request_sort.py:39,97` | `bpm`, `musical_key` | R | Sort key extraction from `Request` row | PR3: read from `tracks` via FK |
+
+### 7. Dashboard / API serialisation
+
+| file:line | Field(s) | R/W | Notes | Cutover action |
+|---|---|---|---|---|
+| `api/events.py:706-714` | `genre`, `bpm`, `musical_key` | W | Submit-request endpoint writes metadata to `Request` | PR4: write to `tracks` |
+| `api/events.py:893-903` | `musical_key`, `bpm` | R | Now-playing enrichment reads from matched `Request` | PR3: read from `tracks` |
+| `schemas/setbuilder.py:642` | — | — | `SetDocumentPoolTrack` — Pydantic schema mirrors `SetPoolTrack` fields | PR3: add `tracks_id` FK field; PR5: drop old fields |
+
+---
+
+## Summary statistics
+
+| Subsystem | Read sites | Write/mutation sites |
+|---|---|---|
+| Request pipeline | 14 | 4 |
+| Enrichment / sync | 15 | 10 |
+| Set-builder pool | 11 | 7 |
+| Set-builder build passes | 12 | 0 |
+| Vibe subsystem | 8 | 3 |
+| Recommendation engine | 7 | 0 |
+| Dashboard serialisation | 3 | 1 |
+| **Total** | **70** | **25** |
+
+---
+
+## Cutover PR assignment map
+
+| PR | Scope | Sites covered above |
+|---|---|---|
+| **PR3** (add FK + dual-read) | Add `tracks_id` FK to `SetPoolTrack`; all _read_ paths switch to preferring `tracks` with fallback to pool columns | All rows marked "PR3" |
+| **PR4** (flip writes) | All _write_ paths upsert into `tracks` and set FK; remove backward-compat writes on `Request.*` columns (except for bridge/serialisation fallback) | All rows marked "PR4" |
+| **PR5** (drop columns) | Remove old metadata columns from `Request` and `SetPoolTrack`; replace `track_id` string with FK in `TrackVibe` / `TrackVibeOverride` | All rows marked "PR5" |
+
+---
+
+## Special concerns
+
+1. **`Request.musical_key` vs `SetPoolTrack.key`** — field name inconsistency. The `tracks` table
+   should normalise to a single name (`musical_key`).  All call sites that map one to the other (e.g.
+   `pool.py:269`: `key=r.musical_key`) must be audited during PR3.
+
+2. **`SetPoolTrack.camelot` derived column** — written eagerly from `camelot_code(key)` at import time
+   (`pool.py:189`).  The `tracks` table should either store it redundantly (for query convenience) or
+   compute it on read.  Decide before PR4.
+
+3. **`energy` source confusion** — `SetPoolTrack.energy` is filled by the vibe enrichment LLM pass;
+   `CurvePoint.energy` is a separate DJ-set energy-curve column.  Lines referencing `.energy` in
+   `curve.py`, `agent_tools_mutations.py`, `share_service.py`, and `document_snapshot.py:55` are
+   **CurvePoint energy**, not track energy, and require no cutover.
+
+4. **Snapshot restore** (`document_snapshot.py:136-149`) re-creates `SetPoolTrack` rows from a
+   snapshot blob.  If PR4 has already migrated writes to `tracks`, the restore must also re-upsert
+   into `tracks`.  The global `tracks` row is non-destructive (upsert), so this is safe.
+
+5. **`TrackVibe.track_id` is a free-form string** (e.g. `"tidal:12345"`, `"request:9"`) with no FK —
+   by design, because no unified table existed.  PR5 replaces it with a real FK.  The vibe resolver
+   must be updated before the string column is dropped.
+
+6. **`services/sync/enrichment_pipeline.py:212`** defines `enrich_request_metadata` — the entry
+   point for all async enrichment background tasks.  This is the single widest blast-radius function;
+   PR4 must update it atomically.

--- a/server/alembic/versions/062_master_tracks_table.py
+++ b/server/alembic/versions/062_master_tracks_table.py
@@ -1,0 +1,63 @@
+"""Master enriched-track table (#540) — single source of truth for song data.
+
+ISRC-first identity with a normalised artist/title signature fallback; typed
+value columns for fast querying; per-field source/freshness in a ``provenance``
+JSON sidecar.
+
+Revision ID: 062
+Revises: 061
+Create Date: 2026-06-23
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "062"
+down_revision: str | None = "061"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tracks",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("isrc", sa.String(length=15), nullable=True),
+        sa.Column("signature", sa.String(length=64), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("artist", sa.String(length=255), nullable=False),
+        sa.Column("soundcharts_uuid", sa.String(length=36), nullable=True),
+        sa.Column("bpm", sa.Float(), nullable=True),
+        sa.Column("musical_key", sa.String(length=20), nullable=True),
+        sa.Column("camelot", sa.String(length=3), nullable=True),
+        sa.Column("genre", sa.String(length=100), nullable=True),
+        sa.Column("duration_sec", sa.Integer(), nullable=True),
+        sa.Column("energy", sa.Integer(), nullable=True),
+        sa.Column("danceability", sa.Float(), nullable=True),
+        sa.Column("valence", sa.Float(), nullable=True),
+        sa.Column("acousticness", sa.Float(), nullable=True),
+        sa.Column("instrumentalness", sa.Float(), nullable=True),
+        sa.Column("speechiness", sa.Float(), nullable=True),
+        sa.Column("liveness", sa.Float(), nullable=True),
+        sa.Column("loudness_db", sa.Float(), nullable=True),
+        sa.Column("time_signature", sa.Integer(), nullable=True),
+        sa.Column("explicit", sa.Boolean(), nullable=True),
+        sa.Column("artwork_url", sa.String(length=500), nullable=True),
+        sa.Column("provenance", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("isrc", name="uq_tracks_isrc"),
+        sa.UniqueConstraint("signature", name="uq_tracks_signature"),
+    )
+    op.create_index(op.f("ix_tracks_isrc"), "tracks", ["isrc"], unique=False)
+    op.create_index(op.f("ix_tracks_signature"), "tracks", ["signature"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_tracks_signature"), table_name="tracks")
+    op.drop_index(op.f("ix_tracks_isrc"), table_name="tracks")
+    op.drop_table("tracks")

--- a/server/alembic/versions/062_master_tracks_table.py
+++ b/server/alembic/versions/062_master_tracks_table.py
@@ -35,7 +35,7 @@ def upgrade() -> None:
         sa.Column("camelot", sa.String(length=3), nullable=True),
         sa.Column("genre", sa.String(length=100), nullable=True),
         sa.Column("duration_sec", sa.Integer(), nullable=True),
-        sa.Column("energy", sa.Integer(), nullable=True),
+        sa.Column("energy", sa.Integer(), nullable=True),  # 0-10; see ck_tracks_energy_range
         sa.Column("danceability", sa.Float(), nullable=True),
         sa.Column("valence", sa.Float(), nullable=True),
         sa.Column("acousticness", sa.Float(), nullable=True),
@@ -52,12 +52,9 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("isrc", name="uq_tracks_isrc"),
         sa.UniqueConstraint("signature", name="uq_tracks_signature"),
+        sa.CheckConstraint("energy >= 0 AND energy <= 10", name="ck_tracks_energy_range"),
     )
-    op.create_index(op.f("ix_tracks_isrc"), "tracks", ["isrc"], unique=False)
-    op.create_index(op.f("ix_tracks_signature"), "tracks", ["signature"], unique=False)
 
 
 def downgrade() -> None:
-    op.drop_index(op.f("ix_tracks_signature"), table_name="tracks")
-    op.drop_index(op.f("ix_tracks_isrc"), table_name="tracks")
     op.drop_table("tracks")

--- a/server/app/models/__init__.py
+++ b/server/app/models/__init__.py
@@ -20,6 +20,7 @@ from app.models.set_agent import SetAgentMessage, SetAgentSession
 from app.models.set_pairing import SetPairing
 from app.models.set_pool import SetPoolSource, SetPoolTrack
 from app.models.system_settings import SystemSettings
+from app.models.track import Track
 from app.models.track_vibe import TrackVibe, TrackVibeOverride
 from app.models.user import User
 
@@ -53,6 +54,7 @@ __all__ = [
     "SetPoolTrack",
     "SetSlot",
     "SystemSettings",
+    "Track",
     "TrackVibe",
     "TrackVibeOverride",
     "User",

--- a/server/app/models/track.py
+++ b/server/app/models/track.py
@@ -1,0 +1,50 @@
+"""Master enriched-track table (#540) — single source of truth for song data.
+
+ISRC-first identity with a normalized artist/title signature fallback, so every
+track gets exactly one row. Typed value columns are queryable; per-field
+source/freshness lives in the `provenance` JSON sidecar (see services/tracks).
+"""
+
+from datetime import datetime
+
+from sqlalchemy import JSON, Boolean, DateTime, Float, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.time import utcnow
+from app.models.base import Base
+
+
+class Track(Base):
+    __tablename__ = "tracks"
+    __table_args__ = (
+        UniqueConstraint("isrc", name="uq_tracks_isrc"),
+        UniqueConstraint("signature", name="uq_tracks_signature"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    isrc: Mapped[str | None] = mapped_column(String(15), nullable=True, index=True)
+    signature: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    artist: Mapped[str] = mapped_column(String(255), nullable=False)
+    soundcharts_uuid: Mapped[str | None] = mapped_column(String(36), nullable=True)
+
+    bpm: Mapped[float | None] = mapped_column(Float, nullable=True)
+    musical_key: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    camelot: Mapped[str | None] = mapped_column(String(3), nullable=True)
+    genre: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    duration_sec: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    energy: Mapped[int | None] = mapped_column(Integer, nullable=True)  # 0-10
+    danceability: Mapped[float | None] = mapped_column(Float, nullable=True)
+    valence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    acousticness: Mapped[float | None] = mapped_column(Float, nullable=True)
+    instrumentalness: Mapped[float | None] = mapped_column(Float, nullable=True)
+    speechiness: Mapped[float | None] = mapped_column(Float, nullable=True)
+    liveness: Mapped[float | None] = mapped_column(Float, nullable=True)
+    loudness_db: Mapped[float | None] = mapped_column(Float, nullable=True)
+    time_signature: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    explicit: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    artwork_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+    provenance: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow, onupdate=utcnow)

--- a/server/app/models/track.py
+++ b/server/app/models/track.py
@@ -7,7 +7,16 @@ source/freshness lives in the `provenance` JSON sidecar (see services/tracks).
 
 from datetime import datetime
 
-from sqlalchemy import JSON, Boolean, DateTime, Float, Integer, String, UniqueConstraint
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    Float,
+    Integer,
+    String,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.time import utcnow
@@ -19,11 +28,12 @@ class Track(Base):
     __table_args__ = (
         UniqueConstraint("isrc", name="uq_tracks_isrc"),
         UniqueConstraint("signature", name="uq_tracks_signature"),
+        CheckConstraint("energy >= 0 AND energy <= 10", name="ck_tracks_energy_range"),
     )
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    isrc: Mapped[str | None] = mapped_column(String(15), nullable=True, index=True)
-    signature: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    isrc: Mapped[str | None] = mapped_column(String(15), nullable=True)
+    signature: Mapped[str] = mapped_column(String(64), nullable=False)
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     artist: Mapped[str] = mapped_column(String(255), nullable=False)
     soundcharts_uuid: Mapped[str | None] = mapped_column(String(36), nullable=True)

--- a/server/app/services/track_normalizer.py
+++ b/server/app/services/track_normalizer.py
@@ -266,3 +266,18 @@ def normalize_track(title: str, artist: str) -> NormalizedTrack:
         remix_type=remix_type,
         has_named_remix=remix_artist is not None,
     )
+
+
+def normalize_isrc(isrc: str | None) -> str | None:
+    """Uppercase, trim, and strip hyphens/spaces so an ISRC matches as a key.
+
+    Args:
+        isrc: Raw ISRC string (e.g., "us-um7-1900764" or "  USUM71900764 ")
+
+    Returns:
+        Normalized ISRC in uppercase with no hyphens/spaces, or None if empty.
+    """
+    if not isrc:
+        return None
+    cleaned = isrc.strip().upper().replace("-", "").replace(" ", "")
+    return cleaned or None

--- a/server/app/services/tracks/__init__.py
+++ b/server/app/services/tracks/__init__.py
@@ -1,0 +1,10 @@
+from app.services.tracks.provenance import FieldProvenance, should_overwrite
+from app.services.tracks.store import TrackIdentity, get_track, upsert_track
+
+__all__ = [
+    "FieldProvenance",
+    "TrackIdentity",
+    "get_track",
+    "should_overwrite",
+    "upsert_track",
+]

--- a/server/app/services/tracks/provenance.py
+++ b/server/app/services/tracks/provenance.py
@@ -1,0 +1,37 @@
+"""Per-field provenance + source-precedence for the master tracks store (#540).
+
+The stored JSON shape is {field: {"source": str, "fetched_at": ISO8601 str}}.
+Precedence guards the cascade: a lower-trust source never downgrades a higher
+one (measured energy must survive a later LLM re-inference).
+"""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+SOURCE_PRECEDENCE: dict[str, int] = {
+    "manual": 100,
+    "lexicon": 90,
+    "soundcharts": 50,
+    "beatport": 50,
+    "tidal": 50,
+    "musicbrainz": 50,
+    "community": 40,
+    "llm": 10,
+}
+
+
+class FieldProvenance(BaseModel):
+    source: str
+    fetched_at: datetime
+
+
+def precedence(source: str) -> int:
+    return SOURCE_PRECEDENCE.get(source, 0)
+
+
+def should_overwrite(existing: dict | None, new_source: str) -> bool:
+    """True if a value sourced from new_source may replace the existing field."""
+    if existing is None:
+        return True
+    return precedence(new_source) >= precedence(existing.get("source", ""))

--- a/server/app/services/tracks/provenance.py
+++ b/server/app/services/tracks/provenance.py
@@ -20,6 +20,8 @@ SOURCE_PRECEDENCE: dict[str, int] = {
     "llm": 10,
 }
 
+KNOWN_SOURCES: frozenset[str] = frozenset(SOURCE_PRECEDENCE)
+
 
 class FieldProvenance(BaseModel):
     source: str

--- a/server/app/services/tracks/store.py
+++ b/server/app/services/tracks/store.py
@@ -70,9 +70,14 @@ def upsert_track(
     fetched_at: datetime,
 ) -> Track:
     """Insert or update the master row, writing each field's value + provenance
-    entry. Inputs are validated before any mutation — ValueError is raised (with
-    no DB write) if sources keys don't cover all values keys, or if any source
-    name is unknown."""
+    entry. Unresolved (None) values are dropped — a provider lacking a field must
+    not overwrite an existing value, and gets no provenance entry (spec §9).
+    Inputs are validated before any mutation — ValueError is raised (with no DB
+    write) if a values key is not a writable column, sources keys don't cover all
+    values keys, or any source name is unknown."""
+    # Drop unresolved fields up front so None never overwrites stored data.
+    values = {k: v for k, v in values.items() if v is not None}
+
     # --- Validate inputs BEFORE any DB mutation ---
     writable = {attr.key for attr in Track.__mapper__.column_attrs} - _NON_VALUE_FIELDS
     unknown_fields = set(values) - writable
@@ -123,5 +128,10 @@ def upsert_track(
                 mode="json"
             )
     track.provenance = prov
+    # NOTE (#540): a concurrent upsert of the same new ISRC/signature can lose the
+    # unique-constraint race at this flush and raise IntegrityError. upsert_track has
+    # no concurrent caller in this foundation PR; the IntegrityError re-read-and-merge
+    # reconciliation (spec §5) lands in PR2 (#541) alongside its first concurrent
+    # enrichment callers, where it can be integration-tested.
     db.flush()
     return track

--- a/server/app/services/tracks/store.py
+++ b/server/app/services/tracks/store.py
@@ -1,9 +1,13 @@
 """Read/write service for the master tracks table (#540)."""
 
+from dataclasses import dataclass
+from datetime import datetime
+
 from sqlalchemy.orm import Session
 
 from app.models.track import Track
 from app.services.track_normalizer import normalize_isrc
+from app.services.tracks.provenance import FieldProvenance
 
 
 def get_track(
@@ -27,3 +31,45 @@ def get_track(
     if signature:
         return db.query(Track).filter(Track.signature == signature).first()
     return None
+
+
+@dataclass
+class TrackIdentity:
+    title: str
+    artist: str
+    signature: str
+    isrc: str | None = None
+    soundcharts_uuid: str | None = None
+
+
+def upsert_track(
+    db: Session,
+    *,
+    identity: TrackIdentity,
+    values: dict[str, object],
+    sources: dict[str, str],
+    fetched_at: datetime,
+) -> Track:
+    """Insert or update the master row, writing each field's value + provenance
+    entry. Precedence gating is added in Task 6; ISRC backfill in Task 7."""
+    norm_isrc = normalize_isrc(identity.isrc)
+    track = get_track(db, isrc=norm_isrc, signature=identity.signature)
+    if track is None:
+        track = Track(
+            signature=identity.signature,
+            title=identity.title,
+            artist=identity.artist,
+            isrc=norm_isrc,
+            soundcharts_uuid=identity.soundcharts_uuid,
+        )
+        db.add(track)
+
+    prov: dict = dict(track.provenance or {})
+    for field, value in values.items():
+        setattr(track, field, value)
+        prov[field] = FieldProvenance(source=sources[field], fetched_at=fetched_at).model_dump(
+            mode="json"
+        )
+    track.provenance = prov
+    db.flush()
+    return track

--- a/server/app/services/tracks/store.py
+++ b/server/app/services/tracks/store.py
@@ -9,6 +9,25 @@ from app.models.track import Track
 from app.services.track_normalizer import normalize_isrc
 from app.services.tracks.provenance import KNOWN_SOURCES, FieldProvenance, should_overwrite
 
+# Columns NOT writable via the `values` dict: identity fields come from
+# TrackIdentity (signature/title/artist/isrc/soundcharts_uuid) and these are
+# ORM-managed (id/provenance/created_at/updated_at). `values` carries enrichment
+# fields only; any other key is a caller bug and must be rejected, not silently
+# set as a non-persisted instance attribute while provenance claims a write.
+_NON_VALUE_FIELDS = frozenset(
+    {
+        "id",
+        "signature",
+        "title",
+        "artist",
+        "isrc",
+        "soundcharts_uuid",
+        "provenance",
+        "created_at",
+        "updated_at",
+    }
+)
+
 
 def get_track(
     db: Session, *, isrc: str | None = None, signature: str | None = None
@@ -55,6 +74,13 @@ def upsert_track(
     no DB write) if sources keys don't cover all values keys, or if any source
     name is unknown."""
     # --- Validate inputs BEFORE any DB mutation ---
+    writable = {attr.key for attr in Track.__mapper__.column_attrs} - _NON_VALUE_FIELDS
+    unknown_fields = set(values) - writable
+    if unknown_fields:
+        raise ValueError(
+            f"upsert_track: unknown writable field(s) {sorted(unknown_fields)}; "
+            f"allowed fields are {sorted(writable)}"
+        )
     missing = set(values) - set(sources)
     if missing:
         raise ValueError(

--- a/server/app/services/tracks/store.py
+++ b/server/app/services/tracks/store.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.models.track import Track
 from app.services.track_normalizer import normalize_isrc
-from app.services.tracks.provenance import FieldProvenance, should_overwrite
+from app.services.tracks.provenance import KNOWN_SOURCES, FieldProvenance, should_overwrite
 
 
 def get_track(
@@ -51,8 +51,25 @@ def upsert_track(
     fetched_at: datetime,
 ) -> Track:
     """Insert or update the master row, writing each field's value + provenance
-    entry. Precedence gating is added in Task 6; ISRC backfill in Task 7."""
+    entry. Inputs are validated before any mutation — ValueError is raised (with
+    no DB write) if sources keys don't cover all values keys, or if any source
+    name is unknown."""
+    # --- Validate inputs BEFORE any DB mutation ---
+    missing = set(values) - set(sources)
+    if missing:
+        raise ValueError(
+            f"upsert_track: every values key must have a matching sources entry; "
+            f"missing sources for: {sorted(missing)}"
+        )
+    unknown = {src for src in sources.values() if src not in KNOWN_SOURCES}
+    if unknown:
+        raise ValueError(
+            f"upsert_track: unknown source(s) {sorted(unknown)}; "
+            f"known sources are {sorted(KNOWN_SOURCES)}"
+        )
+
     norm_isrc = normalize_isrc(identity.isrc)
+    # ISRC match is authoritative; signature is only a fallback.
     track = get_track(db, isrc=norm_isrc, signature=identity.signature)
     if track is None:
         track = Track(
@@ -67,6 +84,10 @@ def upsert_track(
     # Backfill ISRC onto signature-matched row if it was previously missing
     if norm_isrc and not track.isrc:
         track.isrc = norm_isrc
+
+    # Backfill soundcharts_uuid if the row was created without one
+    if identity.soundcharts_uuid and not track.soundcharts_uuid:
+        track.soundcharts_uuid = identity.soundcharts_uuid
 
     prov: dict = dict(track.provenance or {})
     for field, value in values.items():

--- a/server/app/services/tracks/store.py
+++ b/server/app/services/tracks/store.py
@@ -64,6 +64,10 @@ def upsert_track(
         )
         db.add(track)
 
+    # Backfill ISRC onto signature-matched row if it was previously missing
+    if norm_isrc and not track.isrc:
+        track.isrc = norm_isrc
+
     prov: dict = dict(track.provenance or {})
     for field, value in values.items():
         if should_overwrite(prov.get(field), sources[field]):

--- a/server/app/services/tracks/store.py
+++ b/server/app/services/tracks/store.py
@@ -1,0 +1,29 @@
+"""Read/write service for the master tracks table (#540)."""
+
+from sqlalchemy.orm import Session
+
+from app.models.track import Track
+from app.services.track_normalizer import normalize_isrc
+
+
+def get_track(
+    db: Session, *, isrc: str | None = None, signature: str | None = None
+) -> Track | None:
+    """Look up a track ISRC-first, then by signature.
+
+    Args:
+        db: SQLAlchemy session
+        isrc: ISRC to search (optional; will be normalized)
+        signature: Signature to fall back to (optional)
+
+    Returns:
+        Track if found, None otherwise. ISRC takes precedence over signature.
+    """
+    norm = normalize_isrc(isrc)
+    if norm:
+        found = db.query(Track).filter(Track.isrc == norm).first()
+        if found:
+            return found
+    if signature:
+        return db.query(Track).filter(Track.signature == signature).first()
+    return None

--- a/server/app/services/tracks/store.py
+++ b/server/app/services/tracks/store.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.models.track import Track
 from app.services.track_normalizer import normalize_isrc
-from app.services.tracks.provenance import FieldProvenance
+from app.services.tracks.provenance import FieldProvenance, should_overwrite
 
 
 def get_track(
@@ -66,10 +66,11 @@ def upsert_track(
 
     prov: dict = dict(track.provenance or {})
     for field, value in values.items():
-        setattr(track, field, value)
-        prov[field] = FieldProvenance(source=sources[field], fetched_at=fetched_at).model_dump(
-            mode="json"
-        )
+        if should_overwrite(prov.get(field), sources[field]):
+            setattr(track, field, value)
+            prov[field] = FieldProvenance(source=sources[field], fetched_at=fetched_at).model_dump(
+                mode="json"
+            )
     track.provenance = prov
     db.flush()
     return track

--- a/server/tests/test_track_model.py
+++ b/server/tests/test_track_model.py
@@ -39,3 +39,21 @@ def test_track_unique_constraints():
     names = {c.name for c in Track.__table__.constraints}
     assert "uq_tracks_isrc" in names
     assert "uq_tracks_signature" in names
+
+
+def test_track_no_redundant_indexes():
+    """isrc and signature must NOT have a separate non-unique index.
+
+    The UniqueConstraint already provides an index; a redundant ix_ is waste.
+    """
+    idx_names = {i.name for i in Track.__table__.indexes}
+    assert "ix_tracks_isrc" not in idx_names, "redundant non-unique index on isrc"
+    assert "ix_tracks_signature" not in idx_names, "redundant non-unique index on signature"
+
+
+def test_track_energy_check_constraint_present():
+    """CheckConstraint for energy range must exist on the table."""
+    from sqlalchemy import CheckConstraint
+
+    check_names = {c.name for c in Track.__table__.constraints if isinstance(c, CheckConstraint)}
+    assert "ck_tracks_energy_range" in check_names

--- a/server/tests/test_track_model.py
+++ b/server/tests/test_track_model.py
@@ -1,0 +1,41 @@
+from app.models.track import Track
+
+
+def test_track_table_and_columns():
+    cols = Track.__table__.columns.keys()
+    for expected in (
+        "isrc",
+        "signature",
+        "title",
+        "artist",
+        "soundcharts_uuid",
+        "bpm",
+        "musical_key",
+        "camelot",
+        "genre",
+        "duration_sec",
+        "energy",
+        "danceability",
+        "valence",
+        "acousticness",
+        "instrumentalness",
+        "speechiness",
+        "liveness",
+        "loudness_db",
+        "time_signature",
+        "explicit",
+        "artwork_url",
+        "provenance",
+        "created_at",
+        "updated_at",
+    ):
+        assert expected in cols, f"missing column {expected}"
+    assert Track.__tablename__ == "tracks"
+    assert Track.__table__.columns["signature"].nullable is False
+    assert Track.__table__.columns["isrc"].nullable is True
+
+
+def test_track_unique_constraints():
+    names = {c.name for c in Track.__table__.constraints}
+    assert "uq_tracks_isrc" in names
+    assert "uq_tracks_signature" in names

--- a/server/tests/test_track_normalizer.py
+++ b/server/tests/test_track_normalizer.py
@@ -8,6 +8,7 @@ from app.services.track_normalizer import (
     is_remix_title,
     normalize_artist,
     normalize_bpm_to_context,
+    normalize_isrc,
     normalize_track,
     normalize_track_title,
     primary_artist,
@@ -432,3 +433,15 @@ class TestIsOriginalMixName:
 
     def test_just_remastered(self):
         assert is_original_mix_name("Remastered") is False
+
+
+class TestNormalizeIsrc:
+    """Tests for normalize_isrc()."""
+
+    def test_normalize_isrc_strips_and_uppercases(self):
+        assert normalize_isrc("us-um7-1900764") == "USUM71900764"
+        assert normalize_isrc("  usum71900764 ") == "USUM71900764"
+
+    def test_normalize_isrc_empty_is_none(self):
+        assert normalize_isrc("") is None
+        assert normalize_isrc(None) is None

--- a/server/tests/test_track_provenance.py
+++ b/server/tests/test_track_provenance.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+from app.services.tracks.provenance import (
+    precedence,
+    should_overwrite,
+)
+
+T0 = datetime(2026, 6, 23, 12, 0, 0)
+
+
+def test_precedence_ladder_orders_sources():
+    assert precedence("manual") > precedence("lexicon") > precedence("soundcharts")
+    assert precedence("soundcharts") > precedence("community") > precedence("llm")
+    assert precedence("unknown-source") == 0
+
+
+def test_should_overwrite_null_existing_is_true():
+    assert should_overwrite(None, "llm") is True
+
+
+def test_should_overwrite_blocks_downgrade():
+    existing = {"source": "soundcharts", "fetched_at": T0.isoformat()}
+    assert should_overwrite(existing, "llm") is False  # llm cannot clobber measured
+
+
+def test_should_overwrite_allows_equal_or_higher():
+    existing = {"source": "soundcharts", "fetched_at": T0.isoformat()}
+    assert should_overwrite(existing, "soundcharts") is True  # refresh same tier
+    assert should_overwrite(existing, "lexicon") is True  # higher tier wins

--- a/server/tests/test_track_store.py
+++ b/server/tests/test_track_store.py
@@ -1,0 +1,31 @@
+"""Tests for track store — read/write service for master tracks table."""
+
+from app.models.track import Track
+from app.services.tracks.store import get_track
+
+
+def _make_track(db, **kw):
+    t = Track(signature=kw.pop("signature", "sig-1"), title="T", artist="A", **kw)
+    db.add(t)
+    db.flush()
+    return t
+
+
+def test_get_track_by_isrc_wins(db):
+    _make_track(db, signature="sig-x", isrc="USUM71900764", energy=8)
+    found = get_track(db, isrc="USUM71900764")
+    assert found is not None and found.energy == 8
+
+
+def test_get_track_falls_back_to_signature(db):
+    _make_track(db, signature="sig-y", isrc=None, energy=5)
+    assert get_track(db, isrc="NONEXISTENT00", signature="sig-y").energy == 5
+
+
+def test_get_track_normalizes_isrc(db):
+    _make_track(db, signature="sig-z", isrc="USUM71900764")
+    assert get_track(db, isrc="us-um7-1900764") is not None
+
+
+def test_get_track_miss_returns_none(db):
+    assert get_track(db, isrc="MISS00000000", signature="nope") is None

--- a/server/tests/test_track_store.py
+++ b/server/tests/test_track_store.py
@@ -171,6 +171,36 @@ def test_upsert_raises_for_unknown_source(db):
     assert db.query(Track).filter(Track.signature == "sig-bad-src").count() == 0
 
 
+def test_upsert_raises_for_unknown_field(db):
+    """A values key that is not a writable enrichment column → ValueError, no row.
+
+    Without this guard, setattr would create a non-persisted instance attribute
+    while provenance recorded a write (silent data-contract mismatch).
+    """
+    with pytest.raises(ValueError, match="unknown writable field"):
+        upsert_track(
+            db,
+            identity=TrackIdentity(title="T", artist="A", signature="sig-bad-field"),
+            values={"enrgy": 8},  # typo for "energy"
+            sources={"enrgy": "soundcharts"},
+            fetched_at=T0,
+        )
+    assert db.query(Track).filter(Track.signature == "sig-bad-field").count() == 0
+
+
+def test_upsert_rejects_identity_field_in_values(db):
+    """Identity columns (set via TrackIdentity) are not writable through values."""
+    with pytest.raises(ValueError, match="unknown writable field"):
+        upsert_track(
+            db,
+            identity=TrackIdentity(title="T", artist="A", signature="sig-ident"),
+            values={"signature": "hijack"},
+            sources={"signature": "manual"},
+            fetched_at=T0,
+        )
+    assert db.query(Track).filter(Track.signature == "sig-ident").count() == 0
+
+
 # ---------------------------------------------------------------------------
 # Fix 4: ISRC-authoritative on conflict (ISRC match wins over signature)
 # ---------------------------------------------------------------------------

--- a/server/tests/test_track_store.py
+++ b/server/tests/test_track_store.py
@@ -2,6 +2,9 @@
 
 from datetime import datetime
 
+import pytest
+from sqlalchemy.exc import IntegrityError
+
 from app.models.track import Track
 from app.services.tracks.store import TrackIdentity, get_track, upsert_track
 
@@ -134,3 +137,102 @@ def test_upsert_backfills_isrc_onto_signature_row(db):
     assert len(rows) == 1
     assert rows[0].isrc == "FIXXX1234567"
     assert rows[0].bpm == 136.0 and rows[0].energy == 9
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 / Fix 2: input validation — no partial write, clear error messages
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_raises_if_sources_key_missing(db):
+    """values has 'energy' but sources is missing 'energy' → ValueError, no row created."""
+    with pytest.raises(ValueError, match="sources"):
+        upsert_track(
+            db,
+            identity=TrackIdentity(title="T", artist="A", signature="sig-missing-src"),
+            values={"energy": 8, "genre": "x"},
+            sources={"energy": "soundcharts"},  # genre not in sources
+            fetched_at=T0,
+        )
+    # no row must have been committed
+    assert db.query(Track).filter(Track.signature == "sig-missing-src").count() == 0
+
+
+def test_upsert_raises_for_unknown_source(db):
+    """Typo'd source name → ValueError naming the offending source."""
+    with pytest.raises(ValueError, match="sondcharts"):
+        upsert_track(
+            db,
+            identity=TrackIdentity(title="T", artist="A", signature="sig-bad-src"),
+            values={"energy": 8},
+            sources={"energy": "sondcharts"},  # typo
+            fetched_at=T0,
+        )
+    assert db.query(Track).filter(Track.signature == "sig-bad-src").count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Fix 4: ISRC-authoritative on conflict (ISRC match wins over signature)
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_isrc_match_wins_over_different_signature(db):
+    """Row A created with sigA + ISRC; upserting with sigB + same ISRC updates row A, no new row."""
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="T", artist="A", signature="sigA", isrc="FIXXX1111111"),
+        values={"bpm": 120.0},
+        sources={"bpm": "beatport"},
+        fetched_at=T0,
+    )
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="T", artist="A", signature="sigB", isrc="FIXXX1111111"),
+        values={"genre": "house"},
+        sources={"genre": "musicbrainz"},
+        fetched_at=T0,
+    )
+    rows = db.query(Track).filter(Track.isrc == "FIXXX1111111").all()
+    assert len(rows) == 1, "ISRC match must be authoritative; no duplicate row for sigB"
+    assert rows[0].signature == "sigA"  # original row, not a new one
+    assert rows[0].genre == "house"  # value was written onto the ISRC row
+
+
+# ---------------------------------------------------------------------------
+# Fix 5: backfill soundcharts_uuid like ISRC
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_backfills_soundcharts_uuid(db):
+    """Row first created without soundcharts_uuid; second upsert with one → backfilled, one row."""
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="T", artist="A", signature="sig-sc1"),
+        values={"bpm": 120.0},
+        sources={"bpm": "beatport"},
+        fetched_at=T0,
+    )
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="T", artist="A", signature="sig-sc1", soundcharts_uuid="u-1"),
+        values={"genre": "techno"},
+        sources={"genre": "soundcharts"},
+        fetched_at=T0,
+    )
+    rows = db.query(Track).filter(Track.signature == "sig-sc1").all()
+    assert len(rows) == 1
+    assert rows[0].soundcharts_uuid == "u-1"
+
+
+# ---------------------------------------------------------------------------
+# Fix 7: energy CHECK constraint (0–10 range enforced by DB)
+# ---------------------------------------------------------------------------
+
+
+def test_energy_check_constraint_rejects_out_of_range(db):
+    """Inserting energy=50 must raise IntegrityError due to CHECK constraint."""
+    t = Track(signature="sig-energy-bad", title="T", artist="A", energy=50)
+    db.add(t)
+    with pytest.raises(IntegrityError):
+        db.flush()
+    db.rollback()

--- a/server/tests/test_track_store.py
+++ b/server/tests/test_track_store.py
@@ -109,3 +109,28 @@ def test_upsert_allows_higher_precedence_override(db):
     )
     row = db.query(Track).filter(Track.signature == "sig-o").one()
     assert row.energy == 6 and row.provenance["energy"]["source"] == "lexicon"
+
+
+def test_upsert_backfills_isrc_onto_signature_row(db):
+    # First seen with no ISRC (e.g. manual add)
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="Sandstorm", artist="Darude", signature="sig-bf"),
+        values={"bpm": 136.0},
+        sources={"bpm": "manual"},
+        fetched_at=T0,
+    )
+    # Later seen WITH an ISRC, same signature → backfill, one row
+    upsert_track(
+        db,
+        identity=TrackIdentity(
+            title="Sandstorm", artist="Darude", signature="sig-bf", isrc="FIXXX1234567"
+        ),
+        values={"energy": 9},
+        sources={"energy": "soundcharts"},
+        fetched_at=T0,
+    )
+    rows = db.query(Track).filter(Track.signature == "sig-bf").all()
+    assert len(rows) == 1
+    assert rows[0].isrc == "FIXXX1234567"
+    assert rows[0].bpm == 136.0 and rows[0].energy == 9

--- a/server/tests/test_track_store.py
+++ b/server/tests/test_track_store.py
@@ -1,7 +1,9 @@
 """Tests for track store — read/write service for master tracks table."""
 
+from datetime import datetime
+
 from app.models.track import Track
-from app.services.tracks.store import get_track
+from app.services.tracks.store import TrackIdentity, get_track, upsert_track
 
 
 def _make_track(db, **kw):
@@ -29,3 +31,42 @@ def test_get_track_normalizes_isrc(db):
 
 def test_get_track_miss_returns_none(db):
     assert get_track(db, isrc="MISS00000000", signature="nope") is None
+
+
+T0 = datetime(2026, 6, 23, 12, 0, 0)
+
+
+def test_upsert_inserts_new_track(db):
+    t = upsert_track(
+        db,
+        identity=TrackIdentity(
+            title="Sandstorm", artist="Darude", signature="sig-sand", isrc="FIXXX1234567"
+        ),
+        values={"energy": 9, "bpm": 136.0},
+        sources={"energy": "soundcharts", "bpm": "beatport"},
+        fetched_at=T0,
+    )
+    assert t.id is not None
+    assert t.energy == 9 and t.bpm == 136.0
+    assert t.provenance["energy"]["source"] == "soundcharts"
+    assert t.provenance["bpm"]["source"] == "beatport"
+
+
+def test_upsert_updates_existing_by_signature_no_duplicate(db):
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-1"),
+        values={"bpm": 120.0},
+        sources={"bpm": "tidal"},
+        fetched_at=T0,
+    )
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-1"),
+        values={"genre": "trance"},
+        sources={"genre": "musicbrainz"},
+        fetched_at=T0,
+    )
+    rows = db.query(Track).filter(Track.signature == "sig-1").all()
+    assert len(rows) == 1
+    assert rows[0].bpm == 120.0 and rows[0].genre == "trance"

--- a/server/tests/test_track_store.py
+++ b/server/tests/test_track_store.py
@@ -70,3 +70,42 @@ def test_upsert_updates_existing_by_signature_no_duplicate(db):
     rows = db.query(Track).filter(Track.signature == "sig-1").all()
     assert len(rows) == 1
     assert rows[0].bpm == 120.0 and rows[0].genre == "trance"
+
+
+def test_upsert_does_not_downgrade_measured_energy(db):
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-e"),
+        values={"energy": 8},
+        sources={"energy": "soundcharts"},
+        fetched_at=T0,
+    )
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-e"),
+        values={"energy": 3},
+        sources={"energy": "llm"},
+        fetched_at=T0,
+    )
+    row = db.query(Track).filter(Track.signature == "sig-e").one()
+    assert row.energy == 8  # llm did not clobber soundcharts
+    assert row.provenance["energy"]["source"] == "soundcharts"
+
+
+def test_upsert_allows_higher_precedence_override(db):
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-o"),
+        values={"energy": 8},
+        sources={"energy": "soundcharts"},
+        fetched_at=T0,
+    )
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-o"),
+        values={"energy": 6},
+        sources={"energy": "lexicon"},
+        fetched_at=T0,
+    )
+    row = db.query(Track).filter(Track.signature == "sig-o").one()
+    assert row.energy == 6 and row.provenance["energy"]["source"] == "lexicon"

--- a/server/tests/test_track_store.py
+++ b/server/tests/test_track_store.py
@@ -201,6 +201,30 @@ def test_upsert_rejects_identity_field_in_values(db):
     assert db.query(Track).filter(Track.signature == "sig-ident").count() == 0
 
 
+def test_upsert_skips_none_values(db):
+    """A provider lacking a field passes None; it must not overwrite stored data."""
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-none"),
+        values={"energy": 8},
+        sources={"energy": "soundcharts"},
+        fetched_at=T0,
+    )
+    # Later enrichment has no energy/bpm → passes None at equal/higher precedence
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-none"),
+        values={"energy": None, "bpm": None},
+        sources={"energy": "lexicon", "bpm": "beatport"},
+        fetched_at=T0,
+    )
+    row = db.query(Track).filter(Track.signature == "sig-none").one()
+    assert row.energy == 8  # None did not clobber the measured value
+    assert row.bpm is None
+    assert row.provenance["energy"]["source"] == "soundcharts"  # unchanged
+    assert "bpm" not in row.provenance  # no provenance for an unresolved field
+
+
 # ---------------------------------------------------------------------------
 # Fix 4: ISRC-authoritative on conflict (ISRC match wins over signature)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The WrzDJSet builder and the request pipeline both need each track's bpm/key/energy/genre/duration, but WrzDJ has **no unified track table** — the same recording is enriched repeatedly (per `Request` row, per event), and there's no single place a track's known metadata lives, recallable across DJs/events/builder pools. (This also underlies the dead-energy bug #543: pass-1 reads `energy` off `SetPoolTrack`, which is structurally always `None`.)

This is **Task 0 (#540)** of the pool→builder data-contract epic (#539): the **master `tracks` table** — the single source of truth for song data, recallable by any DJ, any event, and any WrzDJSet builder request. Per the maintainer's decision, the epic moves to a **hard cutover** (single source of truth) rather than the incremental dual-source migration, appropriate at solo/private-VPS scale; this PR lays the foundation that the cutover PRs build on.

## What

Purely **additive foundation** — no readers are repointed and no legacy columns are dropped yet (those are the follow-on cutover PRs). This PR adds:

- **`tracks` table** (migration `062`) — ISRC-first identity with a normalized artist/title **signature fallback** (dual unique key); typed, queryable value columns (`bpm`, `musical_key`, `camelot`, `genre`, `duration_sec`, `energy` 0–10, `danceability`/`valence`/`acousticness`/`instrumentalness`/`speechiness`/`liveness`, `loudness_db`, `time_signature`, `explicit`, …); a **JSON `provenance` sidecar** (`{field: {source, fetched_at}}`); `energy` range enforced by a `CheckConstraint`.
- **`app/services/tracks/`** — `get_track` (ISRC-first → signature fallback), `upsert_track` (cache-aside insert/update with **per-field source-precedence guard** so a lower-trust source never downgrades a higher one, **ISRC/UUID backfill** onto signature-matched rows, and **boundary validation** that rejects unknown sources / missing-source fields before any write).
- **Source-precedence ladder**: `manual 100 · lexicon 90 · soundcharts/beatport/tidal/musicbrainz 50 · community 40 · llm 10`.
- **Read-site inventory** (`docs/superpowers/specs/2026-06-23-track-read-site-inventory.md`) — the blast-radius map the cutover PRs consume.
- Design spec + implementation plan under `docs/superpowers/`.

## Testing

- [x] Unit tests pass — provenance/precedence, identity dedup + ISRC backfill, precedence guard (no downgrade), boundary validation, energy range, model/migration
- [x] Full backend suite: **3193 passed**, coverage **89.23%** (gate 85%)
- [x] `ruff check` + `ruff format --check` clean; `bandit` no issues
- [x] `alembic upgrade head && alembic check` clean; downgrade/re-upgrade verified
- [ ] CI green
- [ ] CodeRabbit review addressed

## Notes

- Built via TDD (red→green per task) with an opus whole-branch review; all review findings fixed except one deferred DRY consolidation (`normalize_isrc` in `setbuilder/pool.py`) which is on the cutover path anyway.
- The Soundcharts audio-features adapter (#544) — the first audio-features *writer* into this store — is held separately and is not part of this PR.

🤖 Co-authored by Claude Opus 4.8. Closes #540. Part of #539.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced unified track metadata store for improved track identification and consistency.
  * Track lookup now prioritizes ISRC matching with signature-based fallback.

* **Improvements**
  * Energy values standardized to 0–10 range with validation enforcement.
  * Track metadata updates respect source precedence to prevent data quality downgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->