### PR TITLE
feat(tracks): track-store foundation — Soundcharts adapter + concurrent-upsert reconciliation (#541 PR1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,19 @@ TIDAL_REDIRECT_URI=your-sites-oauth-callback
 # BEATPORT_AUTH_BASE_URL=https://account.beatport.com
 
 # =============================================================================
+# Soundcharts API (genre/BPM/key discovery + audio-features enrichment)
+# =============================================================================
+# Used for recommendation song discovery and (when enabled) audio-features
+# enrichment (energy/danceability/valence) resolved by ISRC. Free legacy tier
+# is 1000 calls/month. Leave creds empty to disable Soundcharts entirely.
+# SOUNDCHARTS_APP_ID=your-app-id
+# SOUNDCHARTS_API_KEY=your-api-key
+#
+# Audio-features enrichment (#544) is DARK BY DEFAULT. Keep it off until a paid
+# tier + caching/redistribution licensing are validated; set true to enable.
+# SOUNDCHARTS_AUDIO_FEATURES_ENABLED=false
+
+# =============================================================================
 # StageLinQ Bridge
 # =============================================================================
 # Shared secret used by the bridge to authenticate with the backend.

--- a/docs/superpowers/specs/2026-06-23-request-time-enrichment-541-design.md
+++ b/docs/superpowers/specs/2026-06-23-request-time-enrichment-541-design.md
@@ -1,0 +1,166 @@
+# Request-time Enrichment → Global Track Store (#541) — Design Spec
+
+**Date:** 2026-06-23
+**Issue:** #541 (child of epic #539; depends on #540 master `tracks` table, now merged)
+**Consumes:** #544 Soundcharts audio-features adapter (held in `stash@{0}`)
+**Status:** Approved design, pending implementation plan.
+
+## 1. Context
+
+#540 shipped the master `tracks` table + provenance-aware `get_track`/`upsert_track`
+service (`app/services/tracks/`), but **no writer is wired to it yet**. Today
+`enrich_request_metadata` (`app/services/sync/enrichment_pipeline.py`) fills
+`genre`/`bpm`/`musical_key` onto each **`Request` row** — so the same recording
+requested at two events is enriched twice, and `energy`/`duration` are never
+enriched at request time at all.
+
+This slice makes enrichment **populate the global store once per unique recording
+and reuse it** (cache-aside), restores the #544 Soundcharts adapter as the first
+audio-features writer, and discharges the concurrent-upsert reconciliation
+deferred from #540 (the `NOTE (#540)` at the `db.flush()` in `store.py`).
+
+Per the epic build sequence (master-track-store design §8) this is **step 2**:
+enrichment *writes* the store + backfill, dual-writing alongside the legacy
+`Request` columns. Read-repoint (the cutover that consumes a `Request.track_id`
+FK) is deliberately **out of scope** here — it lands in #542+.
+
+## 2. Goals / non-goals
+
+**Goals**
+- One global `tracks` row per unique recording, written at request time, reused
+  with **zero** extra API calls on the next request of the same song.
+- Capture ISRC during enrichment (currently discovered then discarded) so a
+  request and a later pool-import of the same recording collapse to one row.
+- Add the energy/audio-features cascade hook (Soundcharts primary, dark by
+  default) — energy populates when the gate is enabled; otherwise backfills later.
+- Discharge the deferred concurrent-upsert `IntegrityError` reconciliation.
+- Backfill existing `Request` metadata into the store, idempotently.
+
+**Non-goals (now)**
+- No `Request.track_id` FK and no read-repoint — readers still read `Request`
+  columns (deferred to #542+).
+- No TTL/re-enrichment (cache forever; `provenance.fetched_at` enables it later).
+- No ReccoBeats fallback (the cascade leaves the hook; #544 future path).
+- No schema migration in either PR (all changes are code + a script).
+
+## 3. Delivery — two sequential PRs
+
+### PR1 — Foundation (`feat/541-enrichment-store-foundation`)
+No enrichment behavior change; both pieces are foundational and green.
+
+1. **`upsert_track` IntegrityError reconciliation** (spec §5 of the master design;
+   the deferred `NOTE (#540)`). Wrap the insert path in a `Session.begin_nested()`
+   savepoint. On `IntegrityError` from `uq_tracks_isrc`/`uq_tracks_signature` (a
+   concurrent caller inserted the same identity first), roll back **only the
+   savepoint**, re-read the now-existing row by `isrc`→`signature`, and re-apply
+   the precedence-guarded merge onto it. Net: exactly one row, no lost writes.
+2. **Restore the #544 Soundcharts adapter** from `stash@{0}`:
+   `soundcharts.py:get_song_features_by_isrc`, the `SoundchartsAudioFeatures`
+   dataclass, energy/ISRC normalizers, the `soundcharts_audio_features_enabled`
+   config gate (**dark by default**), `.env.example` docs, and `test_soundcharts.py`.
+   Additive and unit-tested; dead until PR2 wires it.
+
+### PR2 — #541 core (`feat/541-request-time-enrichment`)
+The demonstrable change: enrichment writes + reuses the store.
+
+3. Rewire `enrich_request_metadata` to **cache-aside dual-write** (§4).
+4. One-shot idempotent **backfill script** (§6).
+
+## 4. Data flow (PR2)
+
+```
+request submitted → BackgroundTask: enrich_request_metadata(db, request_id)
+  sig = dedupe_signature(artist, song_title)            # same helper pool import uses
+  cached = get_track(db, signature=sig)
+    ├─ complete? → copy genre/bpm/musical_key onto Request, return     ← ZERO API calls (dedupe win)
+    └─ miss/partial → existing Beatport/Tidal/Spotify/MusicBrainz lookups,
+                       now CAPTURING isrc + per-field source into an accumulator
+        [gate ON + isrc] soundcharts.get_song_features_by_isrc(isrc)
+                          → energy/danceability/valence/explicit/…
+        upsert_track(identity{sig, isrc}, values, sources, fetched_at)  ← store = source of truth
+        write genre/bpm/musical_key onto Request                         ← dual-write for current UI
+  db.commit()
+```
+
+- **Completeness gate for the short-circuit:** the same fields the current early
+  return checks — `genre AND bpm AND musical_key` present on the store row → skip
+  all providers and copy down. (`duration`/`energy` do not gate the skip; they are
+  best-effort extras and backfill independently.)
+- **Cache forever:** no freshness check; a complete row is always reused.
+
+## 5. Components & key decisions
+
+1. **Provenance threading.** `_apply_enrichment_result` currently sets
+   `request.bpm/key/genre` with no source record. Introduce a small accumulator
+   `resolved: dict[field → (value, source)]` populated alongside the Request
+   writes; `values`/`sources` for `upsert_track` come directly from it — no
+   post-hoc source guessing. Source labels map provider → ladder name:
+   Beatport→`beatport`, Tidal→`tidal`, MusicBrainz→`musicbrainz`,
+   Soundcharts→`soundcharts`, LLM→`llm`.
+2. **Capture ISRC.** `_get_isrc_from_spotify` (and ISRC on Tidal/Beatport hits)
+   feeds `TrackIdentity.isrc` rather than being discarded after the Tidal lookup.
+3. **New `legacy` provenance source @ precedence 30** (below `community` 40) in
+   `SOURCE_PRECEDENCE`. The backfill copies existing `Request` columns that record
+   no original source; attributing them `legacy` (lowest) guarantees any real
+   later enrichment overrides them. `KNOWN_SOURCES` derives from the dict, so the
+   new source is automatically accepted by `upsert_track`'s boundary validation.
+4. **Energy gate.** Soundcharts is called only when
+   `settings.soundcharts_audio_features_enabled` is true **and** an ISRC is in
+   hand **and** the store row lacks energy. Off by default → no-op → energy
+   backfills via the cascade later. This keeps quota and caching/redistribution
+   licensing concerns dark until validated (#544 gate).
+
+## 6. Backfill script
+
+`app/scripts/backfill_tracks.py`, runnable as `python -m app.scripts.backfill_tracks`.
+
+- Walk `Request` rows with any of `genre`/`bpm`/`musical_key` set.
+- For each, `sig = dedupe_signature(artist, song_title)`; `upsert_track` the
+  present fields with `source="legacy"`, `fetched_at = request.updated_at`.
+- **Idempotent:** sig-dedup + precedence guard make re-runs no-ops (legacy never
+  downgrades an existing legacy/higher value).
+- Logs counts (rows scanned, tracks upserted) and never raises on a single bad row.
+
+## 7. Error handling
+
+- Enrichment is best-effort on a `BackgroundTask`; it never blocks a guest request
+  (existing pattern in `events.py`/`requests.py`/`collect.py`).
+- Per-source `try/except` already isolates provider failures. A Soundcharts/quota
+  failure leaves `energy` null (backfills later); other resolved fields still
+  upsert.
+- The `upsert_track` call is wrapped so an unexpected store error logs and still
+  lets the Request's own dual-write + commit land — the store is strictly
+  additive and must never regress the existing request flow.
+- The concurrent-insert race is absorbed inside `upsert_track` (PR1).
+
+## 8. Testing
+
+**PR1**
+- Reconciliation: monkeypatch `get_track` to return `None` on the first call
+  (simulating the TOCTOU window) while a conflicting row is already committed;
+  assert the insert hits `IntegrityError`, reconciles onto the existing row, ends
+  with exactly one row and the merged (precedence-correct) values — no data loss.
+- Adapter: `test_soundcharts.py` rides in with the stash (response parsing,
+  energy 0–1→0–10 normalization, ISRC normalization, quota-saver single-call).
+
+**PR2**
+- **Headline regression (AC):** request song X at event A → enrich → `tracks` row
+  exists; request X at event B → enrich → `get_track` hit → assert mocked
+  Beatport/Tidal/MusicBrainz are **not called** and Request B is populated from
+  the store. Pins "enrich once, reuse everywhere."
+- Provenance recorded per field with the right source.
+- Dual-write: `Request.genre/bpm/musical_key` still populated (current behavior
+  preserved) **and** the `tracks` row populated.
+- Energy gate: off → Soundcharts not called, `energy` null; on + ISRC → adapter
+  called (mocked), `energy` written with `source="soundcharts"`.
+- Backfill: seed Requests → run → `tracks` upserted with `source="legacy"`;
+  re-run is a no-op (idempotent).
+- Coverage held ≥85%; `alembic check` clean (no migration in either PR).
+
+## 9. Open questions / future
+
+- `Request.track_id` FK + read-repoint — #542+ (the cutover that consumes the store).
+- ReccoBeats fallback + bulk backfill (quota path) — hook left in the cascade (#544).
+- Provenance-driven re-enrichment/TTL — enabled by `fetched_at`, deferred.
+- Soundcharts caching/redistribution licensing — confirm before enabling the gate
+  in prod; feature stays dark by default until then.

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -124,6 +124,10 @@ class Settings(BaseSettings):
     # Soundcharts API (song discovery for recommendations)
     soundcharts_app_id: str = ""
     soundcharts_api_key: str = ""
+    # Audio-features enrichment (#544) — DARK BY DEFAULT. Keeps the discovery
+    # key usable in prod while energy/danceability/valence lookup stays off
+    # until a paid tier + caching/redistribution licensing are validated.
+    soundcharts_audio_features_enabled: bool = False
 
     # ListenBrainz API (artist discovery for recommendations)
     listenbrainz_user_token: str = ""

--- a/server/app/services/soundcharts.py
+++ b/server/app/services/soundcharts.py
@@ -297,7 +297,15 @@ def _fetch_song_object(url: str, settings) -> dict | None:
         logger.warning("Soundcharts song request failed: %s", e)
         return None
 
-    obj = response.json().get("object")
+    try:
+        payload = response.json()
+    except ValueError as e:
+        # A non-JSON payload (HTML error page, truncated body) must degrade to a
+        # miss, not break the best-effort enrichment flow.
+        logger.warning("Soundcharts song API returned invalid JSON: %s", e)
+        return None
+
+    obj = payload.get("object") if isinstance(payload, dict) else None
     if isinstance(obj, list):
         obj = obj[0] if obj else None
     return obj if isinstance(obj, dict) else None

--- a/server/app/services/soundcharts.py
+++ b/server/app/services/soundcharts.py
@@ -21,6 +21,9 @@ logger = logging.getLogger(__name__)
 BASE_URL = "https://customer.api.soundcharts.com"
 REQUEST_TIMEOUT = 15
 
+# Song endpoints (audio features, ISRC lookup) live under the v2.25 API.
+SONG_API_BASE = f"{BASE_URL}/api/v2.25/song"
+
 
 # Camelot position → (pitch_class 0-11, mode 0=minor/1=major)
 # Derived from _KEY_DEFINITIONS in camelot.py
@@ -66,6 +69,36 @@ class SoundchartsTrack:
     soundcharts_uuid: str
 
 
+@dataclass(frozen=True)
+class SoundchartsAudioFeatures:
+    """Audio features for one track, resolved by ISRC (#544).
+
+    ``energy`` is normalized to WrzDJ's 0–10 integer scale; the remaining
+    perceptual features keep Soundcharts' native 0.0–1.0 floats. ``key`` is a
+    pitch class (-1 unknown, 0–11), ``mode`` is 0 minor / 1 major. ``genres``
+    is a flattened, de-duplicated tuple of the sub-genre strings. Any field is
+    ``None`` when the provider did not supply it (e.g. no audio analysis).
+    """
+
+    isrc: str
+    soundcharts_uuid: str
+    energy: int | None
+    danceability: float | None
+    valence: float | None
+    acousticness: float | None
+    instrumentalness: float | None
+    speechiness: float | None
+    liveness: float | None
+    loudness_db: float | None
+    tempo_bpm: float | None
+    key: int | None
+    mode: int | None
+    time_signature: int | None
+    explicit: bool | None
+    duration_sec: int | None
+    genres: tuple[str, ...]
+
+
 def key_to_soundcharts_filter(key_str: str) -> tuple[int, int] | None:
     """Convert a key string to Soundcharts (pitch_class, mode) filter values.
 
@@ -82,6 +115,19 @@ def pitch_class_to_key_string(pitch_class: int, mode: int) -> str:
     note = _NOTE_NAMES[pitch_class % 12]
     quality = "Major" if mode == 1 else "Minor"
     return f"{note} {quality}"
+
+
+def _normalize_energy_0_10(value: float | None) -> int | None:
+    """Convert a Soundcharts 0.0–1.0 energy value to WrzDJ's 0–10 integer scale.
+
+    Returns None when no value is available. Uses standard rounding (not
+    Python's banker's ``round``) and clamps defensively to [0, 10] so a
+    provider value outside the documented range can never escape the scale.
+    """
+    if value is None:
+        return None
+    scaled = int(value * 10 + 0.5)
+    return max(0, min(10, scaled))
 
 
 def _build_request_body(
@@ -210,3 +256,104 @@ def discover_songs(
         keys,
     )
     return tracks
+
+
+def _normalize_isrc(isrc: str | None) -> str | None:
+    """Uppercase, trim, and strip hyphens so the ISRC matches Soundcharts' key."""
+    if not isrc:
+        return None
+    cleaned = isrc.strip().upper().replace("-", "")
+    return cleaned or None
+
+
+def _flatten_genres(genres: list | None) -> tuple[str, ...]:
+    """Flatten Soundcharts' [{root, sub:[...]}] genre list to ordered unique subs."""
+    out: list[str] = []
+    for entry in genres or []:
+        for sub in entry.get("sub", []) or []:
+            if sub and sub not in out:
+                out.append(sub)
+    return tuple(out)
+
+
+def _fetch_song_object(url: str, settings) -> dict | None:
+    """GET a Soundcharts song endpoint and return its ``object`` dict (or None)."""
+    try:
+        response = httpx.get(
+            url,
+            headers={
+                "x-app-id": settings.soundcharts_app_id,
+                "x-api-key": settings.soundcharts_api_key,
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        logger.warning(
+            "Soundcharts song API error %s: %s", e.response.status_code, e.response.text[:200]
+        )
+        return None
+    except httpx.HTTPError as e:
+        logger.warning("Soundcharts song request failed: %s", e)
+        return None
+
+    obj = response.json().get("object")
+    if isinstance(obj, list):
+        obj = obj[0] if obj else None
+    return obj if isinstance(obj, dict) else None
+
+
+def _parse_song_features(obj: dict, isrc: str) -> SoundchartsAudioFeatures:
+    """Build an audio-features record from a Soundcharts song object."""
+    audio = obj.get("audio") or {}
+    return SoundchartsAudioFeatures(
+        isrc=isrc,
+        soundcharts_uuid=obj.get("uuid", ""),
+        energy=_normalize_energy_0_10(audio.get("energy")),
+        danceability=audio.get("danceability"),
+        valence=audio.get("valence"),
+        acousticness=audio.get("acousticness"),
+        instrumentalness=audio.get("instrumentalness"),
+        speechiness=audio.get("speechiness"),
+        liveness=audio.get("liveness"),
+        loudness_db=audio.get("loudness"),
+        tempo_bpm=audio.get("tempo"),
+        key=audio.get("key"),
+        mode=audio.get("mode"),
+        time_signature=audio.get("timeSignature"),
+        explicit=obj.get("explicit"),
+        duration_sec=obj.get("duration"),
+        genres=_flatten_genres(obj.get("genres")),
+    )
+
+
+def get_song_features_by_isrc(isrc: str) -> SoundchartsAudioFeatures | None:
+    """Resolve a track's audio features (energy/danceability/valence/…) by ISRC.
+
+    Dark by default: returns None unless ``soundcharts_audio_features_enabled``
+    is set AND credentials are configured. Resolves ISRC → song UUID → metadata
+    (two calls), but skips the second call when the ISRC lookup already carries
+    the audio block. Returns None on miss or API failure.
+    """
+    settings = get_settings()
+    if not settings.soundcharts_audio_features_enabled:
+        logger.debug("Soundcharts audio-features disabled, skipping lookup")
+        return None
+    if not settings.soundcharts_app_id or not settings.soundcharts_api_key:
+        logger.debug("Soundcharts not configured, skipping audio-features lookup")
+        return None
+
+    normalized = _normalize_isrc(isrc)
+    if not normalized:
+        return None
+
+    obj = _fetch_song_object(f"{SONG_API_BASE}/by-isrc/{normalized}", settings)
+    if not obj or not obj.get("uuid"):
+        return None
+
+    if "audio" not in obj:
+        obj = _fetch_song_object(f"{SONG_API_BASE}/{obj['uuid']}", settings)
+        if not obj:
+            return None
+
+    return _parse_song_features(obj, normalized)

--- a/server/app/services/tracks/store.py
+++ b/server/app/services/tracks/store.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models.track import Track
@@ -103,14 +104,7 @@ def upsert_track(
     # ISRC match is authoritative; signature is only a fallback.
     track = get_track(db, isrc=norm_isrc, signature=identity.signature)
     if track is None:
-        track = Track(
-            signature=identity.signature,
-            title=identity.title,
-            artist=identity.artist,
-            isrc=norm_isrc,
-            soundcharts_uuid=identity.soundcharts_uuid,
-        )
-        db.add(track)
+        track = _insert_identity_reconciling(db, identity=identity, norm_isrc=norm_isrc)
 
     # Backfill ISRC onto signature-matched row if it was previously missing
     if norm_isrc and not track.isrc:
@@ -128,10 +122,48 @@ def upsert_track(
                 mode="json"
             )
     track.provenance = prov
-    # NOTE (#540): a concurrent upsert of the same new ISRC/signature can lose the
-    # unique-constraint race at this flush and raise IntegrityError. upsert_track has
-    # no concurrent caller in this foundation PR; the IntegrityError re-read-and-merge
-    # reconciliation (spec §5) lands in PR2 (#541) alongside its first concurrent
-    # enrichment callers, where it can be integration-tested.
     db.flush()
     return track
+
+
+def _insert_identity_reconciling(
+    db: Session, *, identity: TrackIdentity, norm_isrc: str | None
+) -> Track:
+    """Insert a new row with only its identity columns, tolerating a lost race.
+
+    Two callers can both miss in get_track and both try to create the same new
+    ISRC/signature. The first INSERT wins; the second hits uq_tracks_isrc /
+    uq_tracks_signature. We materialize ONLY the bare identity INSERT inside a
+    SAVEPOINT so an IntegrityError rolls back just that INSERT (not the caller's
+    outer work). On conflict we re-read the row the winner committed and return
+    it for the precedence-guarded value merge — net result one row, no lost
+    writes (spec §5).
+
+    Empirical note (#540): in this codebase Session.begin_nested() flushes
+    pending objects while taking its snapshot, so db.add() MUST happen INSIDE the
+    savepoint — otherwise the INSERT fires during begin_nested() and the
+    IntegrityError escapes the try. After sp.rollback() the conflicting pending
+    Track is already evicted from the session (no db.expunge() needed).
+    """
+    sp = db.begin_nested()
+    try:
+        track = Track(
+            signature=identity.signature,
+            title=identity.title,
+            artist=identity.artist,
+            isrc=norm_isrc,
+            soundcharts_uuid=identity.soundcharts_uuid,
+        )
+        db.add(track)
+        db.flush()
+        sp.commit()
+        return track
+    except IntegrityError:
+        sp.rollback()
+        # A concurrent caller inserted the same identity first — reconcile by
+        # re-reading the now-existing row and merging onto it.
+        existing = get_track(db, isrc=norm_isrc, signature=identity.signature)
+        if existing is None:
+            # Genuinely unreconcilable unique violation — do not swallow it.
+            raise
+        return existing

--- a/server/tests/test_soundcharts.py
+++ b/server/tests/test_soundcharts.py
@@ -274,6 +274,20 @@ class TestGetSongFeaturesByIsrc:
 
     @patch("app.services.soundcharts.httpx.get")
     @patch("app.services.soundcharts.get_settings")
+    def test_invalid_json_payload_returns_none(self, mock_settings, mock_get):
+        """A non-JSON payload (HTML error page, truncated body) degrades to a
+        miss instead of raising and breaking the best-effort enrichment flow."""
+        mock_settings.return_value = self._settings()
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.side_effect = ValueError("Expecting value: line 1 column 1 (char 0)")
+        mock_get.return_value = resp
+
+        assert get_song_features_by_isrc("USUM71900764") is None
+        assert mock_get.call_count == 1
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
     def test_isrc_normalized_before_request(self, mock_settings, mock_get):
         mock_settings.return_value = self._settings()
         mock_get.return_value = _mock_get_response({"object": _FULL_SONG_OBJECT})

--- a/server/tests/test_soundcharts.py
+++ b/server/tests/test_soundcharts.py
@@ -2,13 +2,55 @@
 
 from unittest.mock import MagicMock, patch
 
+import httpx
+
 from app.services.soundcharts import (
+    SoundchartsAudioFeatures,
     SoundchartsTrack,
     _build_request_body,
+    _normalize_energy_0_10,
     discover_songs,
+    get_song_features_by_isrc,
     key_to_soundcharts_filter,
     pitch_class_to_key_string,
 )
+
+
+def _mock_get_response(payload: dict) -> MagicMock:
+    """Build a mock httpx GET response whose .json() returns ``payload``."""
+    resp = MagicMock()
+    resp.json.return_value = payload
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+# A trimmed copy of the real GET /api/v2.25/song/{uuid} payload for "bad guy".
+_FULL_SONG_OBJECT = {
+    "uuid": "7d534228-5165-11e9-9375-549f35161576",
+    "name": "bad guy",
+    "isrc": {"value": "USUM71900764", "countryCode": "US"},
+    "duration": 194,
+    "explicit": False,
+    "genres": [
+        {"root": "alternative", "sub": ["alternative"]},
+        {"root": "electro", "sub": ["electronic", "dance"]},
+        {"root": "rock", "sub": ["rock"]},
+    ],
+    "audio": {
+        "acousticness": 0.33,
+        "danceability": 0.7,
+        "energy": 0.43,
+        "instrumentalness": 0.13,
+        "key": 7,
+        "liveness": 0.1,
+        "loudness": -10.97,
+        "mode": 1,
+        "speechiness": 0.38,
+        "tempo": 135.13,
+        "timeSignature": 4,
+        "valence": 0.56,
+    },
+}
 
 
 class TestKeyToSoundchartsFilter:
@@ -129,6 +171,157 @@ class TestBuildRequestBody:
         body = _build_request_body(genres=["Rock"])
         assert body["sort"]["platform"] == "spotify"
         assert body["sort"]["order"] == "desc"
+
+
+class TestNormalizeEnergy:
+    """Soundcharts returns energy on 0.0–1.0; WrzDJ stores energy as a 0–10 int."""
+
+    def test_midrange_value(self):
+        # "bad guy" energy 0.43 → 4 (standard rounding of 4.3)
+        assert _normalize_energy_0_10(0.43) == 4
+
+    def test_rounds_half_up(self):
+        assert _normalize_energy_0_10(0.55) == 6
+        assert _normalize_energy_0_10(0.45) == 5
+
+    def test_bounds(self):
+        assert _normalize_energy_0_10(0.0) == 0
+        assert _normalize_energy_0_10(1.0) == 10
+
+    def test_none_passthrough(self):
+        assert _normalize_energy_0_10(None) is None
+
+    def test_clamps_out_of_range(self):
+        # Defensive: a provider value outside [0,1] must still land in [0,10].
+        assert _normalize_energy_0_10(1.5) == 10
+        assert _normalize_energy_0_10(-0.2) == 0
+
+
+class TestGetSongFeaturesByIsrc:
+    """Audio-features lookup by ISRC — primary energy source for #544.
+
+    Dark by default: gated on a dedicated SOUNDCHARTS_AUDIO_FEATURES_ENABLED
+    flag *and* credentials, so production keeps its Soundcharts discovery key
+    while audio-features stays off until licensing is validated.
+    """
+
+    def _settings(self, *, enabled=True, app_id="test-id", api_key="test-key"):
+        return MagicMock(
+            soundcharts_audio_features_enabled=enabled,
+            soundcharts_app_id=app_id,
+            soundcharts_api_key=api_key,
+        )
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_disabled_returns_none_without_calling_api(self, mock_settings, mock_get):
+        mock_settings.return_value = self._settings(enabled=False)
+        assert get_song_features_by_isrc("USUM71900764") is None
+        mock_get.assert_not_called()
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_not_configured_returns_none(self, mock_settings, mock_get):
+        mock_settings.return_value = self._settings(app_id="", api_key="")
+        assert get_song_features_by_isrc("USUM71900764") is None
+        mock_get.assert_not_called()
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_two_call_resolve_returns_normalized_features(self, mock_settings, mock_get):
+        mock_settings.return_value = self._settings()
+        # by-isrc returns identity (no audio) → second call fetches full metadata.
+        mock_get.side_effect = [
+            _mock_get_response({"object": {"uuid": "7d534228-5165-11e9-9375-549f35161576"}}),
+            _mock_get_response({"object": _FULL_SONG_OBJECT}),
+        ]
+
+        result = get_song_features_by_isrc("USUM71900764")
+
+        assert result == SoundchartsAudioFeatures(
+            isrc="USUM71900764",
+            soundcharts_uuid="7d534228-5165-11e9-9375-549f35161576",
+            energy=4,  # 0.43 → 4 on the 0–10 scale
+            danceability=0.7,
+            valence=0.56,
+            acousticness=0.33,
+            instrumentalness=0.13,
+            speechiness=0.38,
+            liveness=0.1,
+            loudness_db=-10.97,
+            tempo_bpm=135.13,
+            key=7,
+            mode=1,
+            time_signature=4,
+            explicit=False,
+            duration_sec=194,
+            genres=("alternative", "electronic", "dance", "rock"),
+        )
+        assert mock_get.call_count == 2
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_single_call_when_by_isrc_includes_audio(self, mock_settings, mock_get):
+        """Quota-saver: if by-isrc already carries the audio block, skip call 2."""
+        mock_settings.return_value = self._settings()
+        mock_get.return_value = _mock_get_response({"object": _FULL_SONG_OBJECT})
+
+        result = get_song_features_by_isrc("USUM71900764")
+
+        assert result is not None
+        assert result.energy == 4
+        assert mock_get.call_count == 1
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_isrc_normalized_before_request(self, mock_settings, mock_get):
+        mock_settings.return_value = self._settings()
+        mock_get.return_value = _mock_get_response({"object": _FULL_SONG_OBJECT})
+
+        get_song_features_by_isrc("usum7-1900764")
+
+        first_url = mock_get.call_args_list[0][0][0]
+        assert first_url.endswith("/song/by-isrc/USUM71900764")
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_isrc_not_found_returns_none(self, mock_settings, mock_get):
+        mock_settings.return_value = self._settings()
+        mock_get.return_value = _mock_get_response({"object": None, "errors": ["not found"]})
+        assert get_song_features_by_isrc("USUM71900764") is None
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_api_error_returns_none(self, mock_settings, mock_get):
+        mock_settings.return_value = self._settings()
+        mock_get.side_effect = httpx.ConnectError("Connection refused")
+        assert get_song_features_by_isrc("USUM71900764") is None
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_missing_audio_returns_record_with_none_energy(self, mock_settings, mock_get):
+        """A song with no audio analysis still yields metadata; energy is None."""
+        mock_settings.return_value = self._settings()
+        no_audio = {
+            "uuid": "u-1",
+            "isrc": {"value": "USUM71900764"},
+            "duration": 200,
+            "explicit": True,
+            "genres": [{"root": "pop", "sub": ["pop"]}],
+        }
+        mock_get.side_effect = [
+            _mock_get_response({"object": {"uuid": "u-1"}}),
+            _mock_get_response({"object": no_audio}),
+        ]
+
+        result = get_song_features_by_isrc("USUM71900764")
+
+        assert result is not None
+        assert result.energy is None
+        assert result.danceability is None
+        assert result.explicit is True
+        assert result.duration_sec == 200
+        assert result.genres == ("pop",)
 
 
 class TestDiscoverSongs:

--- a/server/tests/test_track_store.py
+++ b/server/tests/test_track_store.py
@@ -6,6 +6,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 from app.models.track import Track
+from app.services.tracks import store
 from app.services.tracks.store import TrackIdentity, get_track, upsert_track
 
 
@@ -290,3 +291,147 @@ def test_energy_check_constraint_rejects_out_of_range(db):
     with pytest.raises(IntegrityError):
         db.flush()
     db.rollback()
+
+
+# ---------------------------------------------------------------------------
+# #540 debt: concurrent-insert reconciliation (spec §5)
+#
+# Two callers both miss in get_track for the same new identity and both create a
+# Track; the first INSERT wins and the second must NOT raise IntegrityError — it
+# must roll back its savepoint, re-read the now-existing row, and apply the
+# precedence-guarded merge onto it. Net: exactly one row, no lost writes.
+#
+# The race is exercised deterministically in a single session by monkeypatching
+# get_track so its FIRST call returns None (the TOCTOU window where the caller
+# believes the row is absent) while a conflicting row is already committed; later
+# calls delegate to the real lookup so reconciliation can re-read the winner.
+# ---------------------------------------------------------------------------
+
+
+def _first_call_none(monkeypatch):
+    """Patch store.get_track so the first invocation returns None, then real.
+
+    Returns a one-element list whose item is the count of times the patched
+    first-None branch was taken (proves the reconciliation path ran).
+    """
+    real_get_track = store.get_track
+    state = {"calls": 0, "forced_none": 0}
+
+    def fake_get_track(db, **kwargs):
+        state["calls"] += 1
+        if state["calls"] == 1:
+            state["forced_none"] += 1
+            return None  # simulate the TOCTOU miss
+        return real_get_track(db, **kwargs)
+
+    monkeypatch.setattr(store, "get_track", fake_get_track)
+    return state
+
+
+def test_upsert_reconciles_concurrent_signature_insert(db, monkeypatch):
+    """A racing signature INSERT loses cleanly: re-read existing row, merge, one row."""
+    # A concurrent caller already created+committed the row with measured energy.
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-race"),
+        values={"energy": 8, "bpm": 120.0},
+        sources={"energy": "soundcharts", "bpm": "beatport"},
+        fetched_at=T0,
+    )
+    db.commit()
+
+    state = _first_call_none(monkeypatch)
+
+    # This caller thinks the row is absent (first get_track → None), tries to
+    # INSERT the same signature, hits the unique constraint, and must reconcile.
+    track = upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-race"),
+        values={"energy": 3, "genre": "trance"},
+        sources={"energy": "llm", "genre": "musicbrainz"},
+        fetched_at=T0,
+    )
+
+    # (a) no exception — reached here. (e) the first-None reconciliation branch ran.
+    assert state["forced_none"] == 1, "reconciliation path was not exercised"
+
+    # (b) exactly one row for that signature.
+    rows = db.query(Track).filter(Track.signature == "sig-race").all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert track.id == row.id
+
+    # (c) precedence-correct merge: musicbrainz (50) wrote a new field; llm (10)
+    #     did NOT downgrade the measured soundcharts (50) energy.
+    assert row.genre == "trance"
+    assert row.provenance["genre"]["source"] == "musicbrainz"
+    assert row.energy == 8, "low-precedence llm must not clobber measured energy"
+    assert row.provenance["energy"]["source"] == "soundcharts"
+
+    # (d) no pre-existing value was lost.
+    assert row.bpm == 120.0
+    assert row.provenance["bpm"]["source"] == "beatport"
+
+
+def test_upsert_reconciles_concurrent_isrc_insert(db, monkeypatch):
+    """A racing INSERT colliding on the ISRC unique constraint reconciles too."""
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-isrc-a", isrc="FIXXX9999999"),
+        values={"bpm": 128.0},
+        sources={"bpm": "beatport"},
+        fetched_at=T0,
+    )
+    db.commit()
+
+    state = _first_call_none(monkeypatch)
+
+    # Different signature, SAME ISRC → collides on uq_tracks_isrc, must reconcile
+    # onto the existing ISRC row (ISRC is authoritative).
+    track = upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-isrc-b", isrc="FIXXX9999999"),
+        values={"genre": "house"},
+        sources={"genre": "musicbrainz"},
+        fetched_at=T0,
+    )
+
+    assert state["forced_none"] == 1, "reconciliation path was not exercised"
+
+    rows = db.query(Track).filter(Track.isrc == "FIXXX9999999").all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert track.id == row.id
+    assert row.signature == "sig-isrc-a"  # original row survived
+    assert row.genre == "house"  # merged onto it
+    assert row.bpm == 128.0  # pre-existing value not lost
+
+
+def test_upsert_reraises_when_conflict_unreconcilable(db, monkeypatch):
+    """If get_track keeps returning None after a real IntegrityError, re-raise.
+
+    A genuine unique violation that cannot be reconciled (the conflicting row is
+    not findable) must not be silently swallowed.
+    """
+    # Commit a real conflicting row so the INSERT genuinely violates the constraint.
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-unrec"),
+        values={"bpm": 100.0},
+        sources={"bpm": "beatport"},
+        fetched_at=T0,
+    )
+    db.commit()
+
+    # get_track ALWAYS returns None → caller inserts, collides, re-reads, still
+    # finds nothing → the IntegrityError must propagate.
+    monkeypatch.setattr(store, "get_track", lambda db, **kw: None)
+
+    with pytest.raises(IntegrityError):
+        upsert_track(
+            db,
+            identity=TrackIdentity(title="S", artist="D", signature="sig-unrec"),
+            values={"energy": 5},
+            sources={"energy": "llm"},
+            fetched_at=T0,
+        )


### PR DESCRIPTION
## Why

Foundation for #541 (request-time enrichment writes the master track store). Two
pieces that the request-time rewire (PR2) depends on, isolated here so they land
green and reviewable on their own:

1. The master store (#540) needs a writer that's safe under concurrency. Two guest
   requests for the same song fire two background enrichments → two `upsert_track`
   calls racing to insert the same identity. The deferred `NOTE (#540)` at the
   `db.flush()` acknowledged this race; PR2 introduces the first concurrent callers,
   so the reconciliation must exist first.
2. Energy/audio-features enrichment needs a provider. The #544 Soundcharts adapter
   was built and held in a stash; this restores it (dark by default) so PR2 can wire
   it as the first audio-features writer.

## What

- **Concurrent-upsert reconciliation (#540 debt).** `upsert_track` now materializes
  the bare identity INSERT inside a `begin_nested()` savepoint; on a
  `uq_tracks_isrc`/`uq_tracks_signature` `IntegrityError` it rolls back only that
  savepoint, re-reads the winner row, and applies the existing precedence-guarded
  value/provenance merge onto it — net one row, no lost writes. A genuinely
  unreconcilable violation re-raises rather than being swallowed.
  - Subtlety captured in the docstring: `begin_nested()` flushes pending objects
    while taking its snapshot, so `db.add()` must happen *inside* the savepoint or
    the `IntegrityError` escapes the `try`. Verified empirically via TDD.
- **Soundcharts audio-features adapter (#544), dark by default.**
  `get_song_features_by_isrc` resolves energy/danceability/valence/explicit by ISRC
  in a single quota-saving call, energy normalized to the 0–10 house scale. Gated
  behind `soundcharts_audio_features_enabled` (off) until quota + caching/redistribution
  licensing are validated. Additive; wired into enrichment in PR2.

No schema migration, no model change → `alembic check` unaffected.

## Testing

- [x] Reconciliation unit tests (signature collision, ISRC collision, unreconcilable
      re-raise) — each asserts the reconciliation branch actually ran, precedence-correct
      merge, and no data loss
- [x] Soundcharts adapter unit tests (44) — response parsing, energy normalization,
      ISRC normalization, single-call quota saver
- [x] Full backend suite: 3212 passed, coverage 89.24% (≥ 85% gate)
- [x] `ruff check` / `ruff format --check` / `bandit` clean
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Foundation for #541; restores the #544 adapter; discharges the #540 deferred reconciliation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Soundcharts-based audio features enrichment, including genre, BPM, musical key, and energy data when enabled.
  * Added a new configuration option to control whether audio-features enrichment runs.

* **Bug Fixes**
  * Improved track saving so duplicate concurrent creates are handled more reliably.
  * Existing track metadata can now be reused and filled in more consistently during enrichment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->