### PR TITLE
feat(enrichment): write the master track store at request time — enrich once, reuse everywhere (#541)

### DIFF
--- a/dashboard/app/(dj)/events/[code]/components/DjSongSearchModal.tsx
+++ b/dashboard/app/(dj)/events/[code]/components/DjSongSearchModal.tsx
@@ -51,6 +51,7 @@ export function DjSongSearchModal({ code, onSongAdded, onClose }: DjSongSearchMo
           genre: result.genre || undefined,
           bpm: result.bpm || undefined,
           musical_key: result.key || undefined,
+          isrc: result.isrc || undefined,
         },
         result.source,
       );

--- a/dashboard/app/collect/[code]/page.tsx
+++ b/dashboard/app/collect/[code]/page.tsx
@@ -130,6 +130,7 @@ export default function CollectPage() {
         source_url: song.url ?? undefined,
         artwork_url: song.album_art ?? undefined,
         nickname: submitNickname,
+        isrc: song.isrc ?? undefined,
       }, reverify);
 
       if (result.is_duplicate) {

--- a/dashboard/app/e/[code]/display/components/RequestModal.tsx
+++ b/dashboard/app/e/[code]/display/components/RequestModal.tsx
@@ -136,7 +136,7 @@ export function RequestModal({ code, onClose, onRequestsClosed }: RequestModalPr
         selectedSong.url || undefined,
         selectedSong.album_art || undefined,
         undefined,
-        undefined,
+        { isrc: selectedSong.isrc || undefined },
         undefined,
         nickname || undefined,
       );

--- a/dashboard/app/join/[code]/page.tsx
+++ b/dashboard/app/join/[code]/page.tsx
@@ -386,7 +386,7 @@ export default function JoinEventPage() {
         selectedSong.url || undefined,
         selectedSong.album_art || undefined,
         searchQuery || undefined,
-        { genre: selectedSong.genre ?? undefined, bpm: selectedSong.bpm ?? undefined, musical_key: selectedSong.key ?? undefined },
+        { genre: selectedSong.genre ?? undefined, bpm: selectedSong.bpm ?? undefined, musical_key: selectedSong.key ?? undefined, isrc: selectedSong.isrc ?? undefined },
         selectedSong.source,
         nickname || undefined,
         reverify,

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -174,6 +174,21 @@ describe('ApiClient', () => {
       expect(body.title).toBe('Title');
       expect(body.note).toBe('Please play!');
     });
+
+    it('forwards the search-result ISRC into the request body (#552)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 2, artist: 'deadmau5', song_title: 'Strobe', status: 'new' }),
+      });
+
+      await api.submitRequest('ABC123', 'deadmau5', 'Strobe', undefined, undefined, undefined, undefined, {
+        source: 'beatport',
+        isrc: 'USXYZ1234567',
+      });
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(JSON.parse(options.body).isrc).toBe('USXYZ1234567');
+    });
   });
 
   // A kiosk is a trusted DJ-paired device with no JWT and no human-verification

--- a/dashboard/lib/__tests__/collect-api.test.ts
+++ b/dashboard/lib/__tests__/collect-api.test.ts
@@ -56,6 +56,19 @@ describe("collect api client", () => {
     expect(r.id).toBe(7);
   });
 
+  it("submitCollectRequest forwards the search-result ISRC (#552)", async () => {
+    const mock = fetch as unknown as ReturnType<typeof vi.fn>;
+    mock.mockResolvedValue(OK_RESPONSE({ id: 8, is_duplicate: false }));
+    await apiClient.submitCollectRequest("ABC", {
+      song_title: "Strobe",
+      artist: "deadmau5",
+      source: "beatport",
+      isrc: "USXYZ1234567",
+    });
+    const [, opts] = mock.mock.calls[0];
+    expect(JSON.parse((opts as RequestInit).body as string).isrc).toBe("USXYZ1234567");
+  });
+
   it("submitCollectRequest throws ApiError on 409", async () => {
     (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
       ERR_RESPONSE(409, "You already picked this one!")

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -4497,6 +4497,8 @@ export interface components {
             artist: string;
             /** Artwork Url */
             artwork_url?: string | null;
+            /** Isrc */
+            isrc?: string | null;
             /** Nickname */
             nickname?: string | null;
             /** Note */
@@ -6142,6 +6144,8 @@ export interface components {
             bpm?: number | null;
             /** Genre */
             genre?: string | null;
+            /** Isrc */
+            isrc?: string | null;
             /** Musical Key */
             musical_key?: string | null;
             /** Nickname */

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1101,7 +1101,7 @@ class ApiClient {
     sourceUrl?: string,
     artworkUrl?: string,
     rawSearchQuery?: string,
-    metadata?: { source?: string; genre?: string; bpm?: number; musical_key?: string },
+    metadata?: { source?: string; genre?: string; bpm?: number; musical_key?: string; isrc?: string },
     source?: string,
     nickname?: string,
     reverify?: () => Promise<void>,
@@ -1126,6 +1126,7 @@ class ApiClient {
           genre: metadata?.genre,
           bpm: metadata?.bpm,
           musical_key: metadata?.musical_key,
+          isrc: metadata?.isrc,
         }),
       });
     if (reverify) {
@@ -2096,6 +2097,7 @@ class ApiClient {
       artwork_url?: string;
       note?: string;
       nickname?: string;
+      isrc?: string;
     },
     reverify?: () => Promise<void>,
   ): Promise<{ id: number; is_duplicate: boolean }> {

--- a/server/alembic/versions/063_add_request_isrc.py
+++ b/server/alembic/versions/063_add_request_isrc.py
@@ -1,0 +1,29 @@
+"""Add isrc to requests (#552) — carry the search-result ISRC from submit.
+
+Search (Tidal/Beatport/Spotify) already returns an ISRC; capturing it on the
+Request lets enrichment use it as the ISRC-first cache key + master-store
+identity, instead of re-deriving it during the background cascade.
+
+Revision ID: 063
+Revises: 062
+Create Date: 2026-06-24
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "063"
+down_revision: str | None = "062"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("requests", sa.Column("isrc", sa.String(length=15), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("requests", "isrc")

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -57,6 +57,7 @@ from app.services.sync.enrichment_pipeline import _find_best_match
 from app.services.sync.orchestrator import _enrich_with_fresh_session
 from app.services.system_settings import get_system_settings
 from app.services.tidal import sync_collection_requests_batch
+from app.services.track_normalizer import normalize_isrc
 from app.services.vote import add_vote
 
 logger = logging.getLogger(__name__)
@@ -478,6 +479,7 @@ def submit(
         status=RequestStatus.NEW.value,
         dedupe_key=compute_dedupe_key(payload.artist, payload.song_title),
         guest_id=guest_id,
+        isrc=normalize_isrc(payload.isrc),
         submitted_during_collection=True,
     )
     db.add(row)

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -54,7 +54,7 @@ from app.services.dedup import compute_dedupe_key, find_duplicate
 from app.services.event import get_event_by_public_code_with_status
 from app.services.guest_names import generate_unique_nickname
 from app.services.sync.enrichment_pipeline import _find_best_match
-from app.services.sync.orchestrator import enrich_request_metadata
+from app.services.sync.orchestrator import _enrich_with_fresh_session
 from app.services.system_settings import get_system_settings
 from app.services.tidal import sync_collection_requests_batch
 from app.services.vote import add_vote
@@ -62,23 +62,6 @@ from app.services.vote import add_vote
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-
-def _enrich_with_fresh_session(request_id: int) -> None:
-    """Run enrichment in its own DB session.
-
-    FastAPI keeps the request-scoped `db` open until all background tasks finish;
-    passing it (or a live row) pins the pool connection through the slow external
-    metadata lookups. A fresh `SessionLocal()` releases its connection as soon as
-    the task ends (issue #505).
-    """
-    from app.db.session import SessionLocal
-
-    session = SessionLocal()
-    try:
-        enrich_request_metadata(session, request_id)
-    finally:
-        session.close()
 
 
 def _sync_collection_requests_with_fresh_session(event_id: int, request_ids: list[int]) -> None:
@@ -500,10 +483,14 @@ def submit(
     db.add(row)
     db.commit()
     db.refresh(row)
-    # Pass IDs so each task opens and closes its own session instead of pinning
-    # the request-scoped connection through the slow external API calls (issue #505).
-    if not (row.genre and row.bpm and row.musical_key):
-        background_tasks.add_task(_enrich_with_fresh_session, row.id)
+    # Enqueue enrichment UNCONDITIONALLY (matches submit_request in events.py): even
+    # an already-complete submission must seed the master tracks store so repeats
+    # reuse it (#541). enrich_request_metadata returns fast on a complete trio via
+    # _seed_complete_request, so this costs nothing. A completeness guard here would
+    # reintroduce the pre-#541 silent-skip the moment the collect schema gains trio
+    # fields. Pass the ID so each task opens/closes its own session rather than
+    # pinning the request-scoped connection through slow external calls (issue #505).
+    background_tasks.add_task(_enrich_with_fresh_session, row.id)
     if event.tidal_sync_enabled and get_system_settings(db).tidal_enabled:
         background_tasks.add_task(_sync_collection_requests_with_fresh_session, event.id, [row.id])
     log_activity(

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -110,7 +110,7 @@ from app.services.request_sort import (
     get_sorted_requests,
     status_counts,
 )
-from app.services.sync.orchestrator import enrich_request_metadata, sync_requests_batch
+from app.services.sync.orchestrator import _enrich_with_fresh_session, sync_requests_batch
 from app.services.sync.registry import get_connected_adapters
 from app.services.tidal import (
     remove_collection_tracks_batch,
@@ -1288,22 +1288,6 @@ def bulk_review(
 
 
 ENRICH_ALL_BATCH_LIMIT = 25
-
-
-def _enrich_with_fresh_session(request_id: int) -> None:
-    """Run enrichment in its own DB session.
-
-    The request-scoped `db` from `get_db` stays open until all background tasks finish — for a
-    large batch this exhausts the SQLAlchemy connection pool. A fresh `SessionLocal()` per task
-    releases its connection as soon as the task ends.
-    """
-    from app.db.session import SessionLocal
-
-    session = SessionLocal()
-    try:
-        enrich_request_metadata(session, request_id)
-    finally:
-        session.close()
 
 
 def _sync_requests_with_fresh_session(request_ids: list[int]) -> None:

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -708,9 +708,11 @@ def submit_request(
         musical_key=request_data.musical_key,
     )
 
-    # Enrich missing metadata in background (Beatport, MusicBrainz)
-    has_full_metadata = song_request.genre and song_request.bpm and song_request.musical_key
-    if not is_duplicate and not has_full_metadata:
+    # Enrich missing metadata in the background (Beatport, MusicBrainz). Enqueue
+    # even for already-complete submissions: enrich_request_metadata seeds the
+    # master track store and returns fast when the trio is present, so a complete
+    # search-result submission still populates the store for reuse (#541).
+    if not is_duplicate:
         background_tasks.add_task(enrich_request_metadata, db, song_request.id)
 
     if not is_duplicate:

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -711,9 +711,11 @@ def submit_request(
     # Enrich missing metadata in the background (Beatport, MusicBrainz). Enqueue
     # even for already-complete submissions: enrich_request_metadata seeds the
     # master track store and returns fast when the trio is present, so a complete
-    # search-result submission still populates the store for reuse (#541).
+    # search-result submission still populates the store for reuse (#541). Use a
+    # FRESH session (not the request-scoped `db`) so the task — which may make
+    # Spotify/Soundcharts network calls — doesn't pin a pool connection (#505).
     if not is_duplicate:
-        background_tasks.add_task(enrich_request_metadata, db, song_request.id)
+        background_tasks.add_task(_enrich_with_fresh_session, song_request.id)
 
     if not is_duplicate:
         publish_event(

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -706,6 +706,7 @@ def submit_request(
         genre=request_data.genre,
         bpm=request_data.bpm,
         musical_key=request_data.musical_key,
+        isrc=request_data.isrc,
     )
 
     # Enrich missing metadata in the background (Beatport, MusicBrainz). Enqueue

--- a/server/app/api/requests.py
+++ b/server/app/api/requests.py
@@ -20,28 +20,11 @@ from app.services.request import (
     get_request_by_id,
     update_request_status,
 )
-from app.services.sync.orchestrator import enrich_request_metadata, sync_request_to_services
+from app.services.sync.orchestrator import _enrich_with_fresh_session, sync_request_to_services
 from app.services.sync.registry import get_connected_adapters
 from app.services.tidal import remove_track_from_collection_playlist
 
 router = APIRouter()
-
-
-def _enrich_with_fresh_session(request_id: int) -> None:
-    """Run enrichment in its own DB session.
-
-    FastAPI keeps the request-scoped `db` open until all background tasks finish;
-    passing it (or a live row) pins the pool connection through the slow external
-    metadata lookups. A fresh `SessionLocal()` releases its connection as soon as
-    the task ends (issue #505).
-    """
-    from app.db.session import SessionLocal
-
-    session = SessionLocal()
-    try:
-        enrich_request_metadata(session, request_id)
-    finally:
-        session.close()
 
 
 def _sync_request_to_services_with_fresh_session(request_id: int) -> None:

--- a/server/app/models/request.py
+++ b/server/app/models/request.py
@@ -65,6 +65,9 @@ class Request(Base):
     genre: Mapped[str | None] = mapped_column(String(100), nullable=True)
     bpm: Mapped[float | None] = mapped_column(Float, nullable=True)
     musical_key: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # ISRC carried from the chosen search result (#552). Enrichment uses it as the
+    # ISRC-first master-store cache key + identity, rather than re-deriving it.
+    isrc: Mapped[str | None] = mapped_column(String(15), nullable=True)
 
     # Voting
     vote_count: Mapped[int] = mapped_column(Integer, default=0)

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -7,6 +7,7 @@ from pydantic import AfterValidator, BaseModel, Field, StringConstraints
 
 from app.core.validation import contains_profanity
 from app.schemas.request import RequestSort, SortDirection
+from app.services.track_normalizer import valid_isrc
 
 
 def _check_nickname_profanity(v: str) -> str:
@@ -138,8 +139,9 @@ class CollectSubmitRequest(BaseModel):
     artwork_url: str | None = Field(default=None, max_length=500)
     note: Note | None = None
     nickname: Nickname | None = None
-    # ISRC from the chosen search result (#552); normalized on store.
-    isrc: str | None = Field(default=None, max_length=15)
+    # ISRC from the chosen search result (#552); normalized + shape-validated (a
+    # malformed value is dropped rather than used as identity / a provider key).
+    isrc: Annotated[str | None, AfterValidator(valid_isrc)] = Field(default=None, max_length=15)
 
 
 class LiveJoinCodeResponse(BaseModel):

--- a/server/app/schemas/collect.py
+++ b/server/app/schemas/collect.py
@@ -138,6 +138,8 @@ class CollectSubmitRequest(BaseModel):
     artwork_url: str | None = Field(default=None, max_length=500)
     note: Note | None = None
     nickname: Nickname | None = None
+    # ISRC from the chosen search result (#552); normalized on store.
+    isrc: str | None = Field(default=None, max_length=15)
 
 
 class LiveJoinCodeResponse(BaseModel):

--- a/server/app/schemas/request.py
+++ b/server/app/schemas/request.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field, field_validator
 from app.core.validation import contains_profanity, normalize_single_line, normalize_text
 from app.models.request import RequestSource, RequestStatus
 from app.schemas.common import BaseSchema, IsoDatetime
+from app.services.track_normalizer import valid_isrc
 
 ALLOWED_URL_SCHEMES = {"http", "https", "spotify"}
 
@@ -32,6 +33,13 @@ class RequestCreate(BaseModel):
     def normalize_single_line_fields(cls, v: str) -> str:
         normalized = normalize_single_line(v)
         return normalized if normalized else v
+
+    @field_validator("isrc")
+    @classmethod
+    def validate_isrc(cls, v: str | None) -> str | None:
+        # Normalize + drop a malformed ISRC (it would defeat the ISRC-first cache
+        # and drive bad provider by-ISRC calls if treated as identity). #552
+        return valid_isrc(v)
 
     @field_validator("note")
     @classmethod

--- a/server/app/schemas/request.py
+++ b/server/app/schemas/request.py
@@ -23,6 +23,9 @@ class RequestCreate(BaseModel):
     genre: str | None = Field(default=None, max_length=100)
     bpm: float | None = Field(default=None, ge=1, le=999)
     musical_key: str | None = Field(default=None, max_length=20)
+    # ISRC from the chosen search result (#552); normalized on store. max_length 15
+    # accommodates the hyphenated form (e.g. "US-UM7-19-00764").
+    isrc: str | None = Field(default=None, max_length=15)
 
     @field_validator("artist", "title")
     @classmethod

--- a/server/app/scripts/backfill_tracks.py
+++ b/server/app/scripts/backfill_tracks.py
@@ -1,0 +1,110 @@
+"""Backfill the master tracks table from existing Request metadata (#541).
+
+Existing `requests` rows carry genre/bpm/musical_key that pre-date the master
+`tracks` store (#540) and have no original-source record. This one-shot, idempotent
+script copies those columns into `tracks`, attributing them the lowest-trust
+``legacy`` provenance source so any real later enrichment cleanly overrides them.
+
+Idempotent by construction: the normalized artist+title signature dedupes
+re-runs onto the same row, and the precedence guard in ``upsert_track`` means a
+second pass re-writes identical legacy values without creating rows or losing
+higher-precedence data.
+
+Run with: ``python -m app.scripts.backfill_tracks``
+"""
+
+import logging
+
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.db.session import SessionLocal
+from app.models.request import Request
+from app.services.setbuilder.pool import dedupe_signature
+from app.services.tracks.store import TrackIdentity, upsert_track
+
+logger = logging.getLogger(__name__)
+
+# Request column -> Track column. Request.musical_key and Track.musical_key share
+# the name, as do genre/bpm; mapping is 1:1 but kept explicit for clarity.
+_FIELD_MAP: dict[str, str] = {
+    "genre": "genre",
+    "bpm": "bpm",
+    "musical_key": "musical_key",
+}
+
+
+def backfill_tracks(db: Session) -> dict:
+    """Copy genre/bpm/musical_key from Request rows into the master tracks store.
+
+    Scans every Request with at least one of those fields populated, upserting a
+    ``legacy``-sourced track per row. Each row is isolated in try/except so one
+    bad row never aborts the run. Commits once at the end.
+
+    Returns a summary: {"scanned": rows_with_metadata, "upserted": rows_upserted,
+    "errors": rows_that_raised}.
+    """
+    requests = (
+        db.query(Request)
+        .filter(
+            (Request.genre.isnot(None))
+            | (Request.bpm.isnot(None))
+            | (Request.musical_key.isnot(None))
+        )
+        .order_by(Request.id)
+        .all()
+    )
+
+    scanned = 0
+    upserted = 0
+    errors = 0
+    for request in requests:
+        scanned += 1
+        try:
+            values = {
+                track_field: getattr(request, req_field)
+                for req_field, track_field in _FIELD_MAP.items()
+                if getattr(request, req_field) is not None
+            }
+            if not values:
+                # Defensive: the query guarantees at least one field, but skip
+                # cleanly if a value vanished between query and read.
+                scanned -= 1
+                continue
+            sources = {field: "legacy" for field in values}
+            signature = dedupe_signature(request.artist, request.song_title)
+            upsert_track(
+                db,
+                identity=TrackIdentity(
+                    title=request.song_title,
+                    artist=request.artist,
+                    signature=signature,
+                ),
+                values=values,
+                sources=sources,
+                fetched_at=request.updated_at or utcnow(),
+            )
+            upserted += 1
+        except Exception:
+            errors += 1
+            logger.exception("backfill_tracks: skipping request id=%s", request.id)
+
+    db.commit()
+    return {"scanned": scanned, "upserted": upserted, "errors": errors}
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    db = SessionLocal()
+    try:
+        summary = backfill_tracks(db)
+        print(
+            f"backfill_tracks: scanned={summary['scanned']} "
+            f"upserted={summary['upserted']} errors={summary['errors']}"
+        )
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/server/app/scripts/backfill_tracks.py
+++ b/server/app/scripts/backfill_tracks.py
@@ -37,9 +37,11 @@ _FIELD_MAP: dict[str, str] = {
 def backfill_tracks(db: Session) -> dict:
     """Copy genre/bpm/musical_key from Request rows into the master tracks store.
 
-    Scans every Request with at least one of those fields populated, upserting a
-    ``legacy``-sourced track per row. Each row is isolated in try/except so one
-    bad row never aborts the run. Commits once at the end.
+    Streams every Request with at least one of those fields populated (so memory
+    stays bounded as the table grows), upserting a ``legacy``-sourced track per
+    row. Each row's write is wrapped in its own SAVEPOINT: a failed flush rolls
+    back only that row (the shared Session stays usable and prior rows survive),
+    so one bad row never aborts the run. Commits once at the end.
 
     Returns a summary: {"scanned": rows_with_metadata, "upserted": rows_upserted,
     "errors": rows_that_raised}.
@@ -52,7 +54,7 @@ def backfill_tracks(db: Session) -> dict:
             | (Request.musical_key.isnot(None))
         )
         .order_by(Request.id)
-        .all()
+        .yield_per(500)
     )
 
     scanned = 0
@@ -73,17 +75,26 @@ def backfill_tracks(db: Session) -> dict:
                 continue
             sources = {field: "legacy" for field in values}
             signature = dedupe_signature(request.artist, request.song_title)
-            upsert_track(
-                db,
-                identity=TrackIdentity(
-                    title=request.song_title,
-                    artist=request.artist,
-                    signature=signature,
-                ),
-                values=values,
-                sources=sources,
-                fetched_at=request.updated_at or utcnow(),
-            )
+            # Per-row savepoint: a flush/constraint error here would otherwise leave
+            # the shared Session in a rollback-needed state and abort every later row
+            # plus the final commit. Roll back just this row's savepoint and go on.
+            savepoint = db.begin_nested()
+            try:
+                upsert_track(
+                    db,
+                    identity=TrackIdentity(
+                        title=request.song_title,
+                        artist=request.artist,
+                        signature=signature,
+                    ),
+                    values=values,
+                    sources=sources,
+                    fetched_at=request.updated_at or utcnow(),
+                )
+                savepoint.commit()
+            except Exception:
+                savepoint.rollback()
+                raise
             upserted += 1
         except Exception:
             errors += 1

--- a/server/app/services/request.py
+++ b/server/app/services/request.py
@@ -7,6 +7,7 @@ from app.models.event import Event
 from app.models.request import Request, RequestStatus
 from app.services.dedup import compute_dedupe_key, find_duplicate
 from app.services.recommendation.camelot import parse_key
+from app.services.track_normalizer import normalize_isrc
 from app.services.vote import add_vote
 
 # Valid state transitions for request status
@@ -50,6 +51,7 @@ def create_request(
     genre: str | None = None,
     bpm: float | None = None,
     musical_key: str | None = None,
+    isrc: str | None = None,
 ) -> tuple[Request, bool]:
     """
     Create a new song request.
@@ -79,6 +81,7 @@ def create_request(
         genre=genre,
         bpm=bpm,
         musical_key=normalize_key(musical_key),
+        isrc=normalize_isrc(isrc),
         # Flag based on event phase so /join and /collect entry points produce
         # equivalent rows during collection — otherwise /join submissions are
         # invisible in the collect leaderboard despite being valid.

--- a/server/app/services/sync/enrichment_pipeline.py
+++ b/server/app/services/sync/enrichment_pipeline.py
@@ -16,6 +16,8 @@ import statistics
 
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
+from app.core.time import utcnow
 from app.models.request import Request, RequestStatus
 from app.services.musicbrainz import lookup_artist_genre
 from app.services.request import normalize_key
@@ -28,6 +30,7 @@ from app.services.track_normalizer import (
     primary_artist,
     score_track_match,
 )
+from app.services.tracks.store import TrackIdentity, get_track, upsert_track
 
 logger = logging.getLogger(__name__)
 
@@ -199,14 +202,31 @@ def _get_isrc_from_spotify(source_url: str | None) -> str | None:
         return None
 
 
-def _apply_enrichment_result(request: Request, best, *, with_genre: bool = False) -> None:
-    """Apply BPM/key (and optionally genre) from a matched result to a request."""
+def _apply_enrichment_result(
+    request: Request,
+    best,
+    *,
+    source: str,
+    resolved: dict[str, tuple[object, str]],
+    with_genre: bool = False,
+) -> None:
+    """Apply BPM/key (and optionally genre) from a matched result to a request.
+
+    Each field written onto the request is also recorded in ``resolved`` as
+    ``field -> (value, source)`` so the master tracks store can be dual-written
+    with accurate per-field provenance (#541). ``musical_key`` is normalized to
+    its Camelot code so the store matches what the request displays.
+    """
     if with_genre and not request.genre and getattr(best, "genre", None):
         request.genre = best.genre
+        resolved["genre"] = (best.genre, source)
     if not request.bpm and best.bpm:
         request.bpm = float(best.bpm)
+        resolved["bpm"] = (float(best.bpm), source)
     if not request.musical_key and getattr(best, "key", None):
-        request.musical_key = normalize_key(best.key)
+        normalized = normalize_key(best.key)
+        request.musical_key = normalized
+        resolved["musical_key"] = (normalized, source)
 
 
 def enrich_request_metadata(db: Session, request_id: int) -> None:
@@ -230,6 +250,38 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
 
     if request.genre and request.bpm and request.musical_key:
         return  # Already complete
+
+    # Cache-aside short-circuit: if the master store already has this recording
+    # fully resolved, copy the missing fields down and skip ALL providers — the
+    # dedupe win that makes the same song requested at two events cost one set of
+    # API calls, not two (#541). dedupe_signature is the same key pool import uses.
+    from app.services.setbuilder.pool import dedupe_signature
+
+    sig = dedupe_signature(request.artist, request.song_title)
+    cached = get_track(db, signature=sig)
+    if cached is not None and cached.genre and cached.bpm and cached.musical_key:
+        if not request.genre:
+            request.genre = cached.genre
+        if not request.bpm:
+            request.bpm = cached.bpm
+        if not request.musical_key:
+            request.musical_key = cached.musical_key
+        db.commit()
+        logger.info(
+            "Request %d served from track store (sig=%s): genre=%s bpm=%s key=%s",
+            request_id,
+            sig,
+            request.genre,
+            request.bpm,
+            request.musical_key,
+        )
+        return
+
+    # Per-field provenance accumulator: field -> (value, source). Populated
+    # alongside the Request writes so the store dual-write below carries accurate
+    # sources without post-hoc guessing.
+    resolved: dict[str, tuple[object, str]] = {}
+    resolved_isrc: str | None = None
 
     user = request.event.created_by
     search_query = f"{primary_artist(request.artist)} {request.song_title}"
@@ -269,7 +321,11 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
                         direct.bpm,
                         direct.key,
                     )
-                    _apply_enrichment_result(request, direct, with_genre=True)
+                    _apply_enrichment_result(
+                        request, direct, source="beatport", resolved=resolved, with_genre=True
+                    )
+                    if getattr(direct, "isrc", None):
+                        resolved_isrc = direct.isrc
             except Exception:
                 logger.warning("Beatport direct fetch failed for request %d", request_id)
 
@@ -287,7 +343,9 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
                         direct.bpm,
                         direct.key,
                     )
-                    _apply_enrichment_result(request, direct)
+                    _apply_enrichment_result(request, direct, source="tidal", resolved=resolved)
+                    if getattr(direct, "isrc", None):
+                        resolved_isrc = direct.isrc
             except Exception:
                 logger.warning("Tidal direct fetch failed for request %d", request_id)
 
@@ -297,6 +355,7 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
             try:
                 isrc = _get_isrc_from_spotify(request.source_url)
                 if isrc:
+                    resolved_isrc = isrc
                     from app.services.tidal import search_tidal_by_isrc
 
                     isrc_match = search_tidal_by_isrc(db, user, isrc)
@@ -310,7 +369,9 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
                             isrc_match.key,
                             isrc,
                         )
-                        _apply_enrichment_result(request, isrc_match)
+                        _apply_enrichment_result(
+                            request, isrc_match, source="tidal", resolved=resolved
+                        )
             except Exception:
                 logger.warning("ISRC enrichment failed for request %d", request_id)
 
@@ -320,6 +381,7 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
             genre = lookup_artist_genre(request.artist)
             if genre:
                 request.genre = genre
+                resolved["genre"] = (genre, "musicbrainz")
         except Exception:
             logger.warning("MusicBrainz enrichment failed for request %d", request_id)
 
@@ -352,7 +414,11 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
                             best.key,
                             best.mix_name,
                         )
-                        _apply_enrichment_result(request, best, with_genre=True)
+                        _apply_enrichment_result(
+                            request, best, source="beatport", resolved=resolved, with_genre=True
+                        )
+                        if getattr(best, "isrc", None):
+                            resolved_isrc = best.isrc
                     else:
                         logger.info("Beatport: no match for request %d", request_id)
             except Exception:
@@ -386,7 +452,9 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
                             best.bpm,
                             getattr(best, "key", None),
                         )
-                        _apply_enrichment_result(request, best)
+                        _apply_enrichment_result(request, best, source="tidal", resolved=resolved)
+                        if getattr(best, "isrc", None):
+                            resolved_isrc = best.isrc
                     else:
                         logger.info("Tidal: no match for request %d", request_id)
             except Exception:
@@ -425,6 +493,67 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
                 statistics.median(context_bpms),
             )
             request.bpm = corrected
+            # Keep the store in sync with the context-corrected value, preserving
+            # the original provider source (the correction is a refinement of it).
+            if "bpm" in resolved:
+                resolved["bpm"] = (corrected, resolved["bpm"][1])
+
+    # 5. Soundcharts audio features (energy/danceability/…) — gated, dark by
+    # default. Only when the flag is on, an ISRC is in hand, and the store row
+    # lacks energy. bpm/key/genre stay with the existing cascade to avoid
+    # equal-precedence churn; Soundcharts contributes audio features only.
+    resolved_uuid: str | None = None
+    if (
+        get_settings().soundcharts_audio_features_enabled
+        and resolved_isrc
+        and (cached is None or cached.energy is None)
+    ):
+        try:
+            from app.services.soundcharts import get_song_features_by_isrc
+
+            feats = get_song_features_by_isrc(resolved_isrc)
+            if feats:
+                resolved_uuid = feats.soundcharts_uuid or None
+                audio_fields = {
+                    "energy": feats.energy,
+                    "danceability": feats.danceability,
+                    "valence": feats.valence,
+                    "acousticness": feats.acousticness,
+                    "instrumentalness": feats.instrumentalness,
+                    "speechiness": feats.speechiness,
+                    "liveness": feats.liveness,
+                    "loudness_db": feats.loudness_db,
+                    "time_signature": feats.time_signature,
+                    "explicit": feats.explicit,
+                    "duration_sec": feats.duration_sec,
+                }
+                for field, value in audio_fields.items():
+                    if value is not None:
+                        resolved[field] = (value, "soundcharts")
+        except Exception:
+            logger.warning("Soundcharts audio-features lookup failed for request %d", request_id)
+
+    # Dual-write the master tracks store. Wrapped so a store failure never
+    # regresses the request's own commit — the store is strictly additive (#541).
+    if resolved:
+        values = {field: value for field, (value, _src) in resolved.items()}
+        sources = {field: src for field, (_value, src) in resolved.items()}
+        try:
+            upsert_track(
+                db,
+                identity=TrackIdentity(
+                    title=request.song_title,
+                    artist=request.artist,
+                    signature=sig,
+                    isrc=resolved_isrc,
+                    soundcharts_uuid=resolved_uuid,
+                ),
+                values=values,
+                sources=sources,
+                fetched_at=utcnow(),
+            )
+        except Exception:
+            logger.warning("Track store upsert failed for request %d", request_id)
 
     db.commit()
     logger.info(

--- a/server/app/services/sync/enrichment_pipeline.py
+++ b/server/app/services/sync/enrichment_pipeline.py
@@ -30,6 +30,7 @@ from app.services.track_normalizer import (
     primary_artist,
     score_track_match,
 )
+from app.services.tracks.provenance import is_cache_authoritative
 from app.services.tracks.store import TrackIdentity, get_track, upsert_track
 
 logger = logging.getLogger(__name__)
@@ -328,18 +329,24 @@ def _safe_upsert_track(
 
 
 def _trio_trusted(track) -> bool:
-    """True when genre/bpm/musical_key are all present AND none is ``legacy``-sourced.
+    """True when genre/bpm/musical_key are all present AND each comes from a real
+    measured/authoritative provider (the 50+ precedence tier).
 
     The cache-aside short-circuit may only fire on a TRUSTED row. A row whose trio
-    was backfilled/seeded as ``legacy`` (lowest precedence) is NOT authoritative:
-    short-circuiting on it would copy stale migrated values onto every future
-    request and prevent real providers from ever upgrading them despite the
-    precedence ladder (#541). Falling through instead lets Beatport/Tidal/MusicBrainz
-    run and re-upsert at higher precedence, after which the row becomes trusted."""
+    was backfilled/seeded as ``legacy`` — or that carries low-trust (community/llm)
+    or missing/unknown provenance — is NOT authoritative: short-circuiting on it
+    would copy unupgraded values onto every future request and prevent real
+    providers from ever improving them (#541). Falling through instead lets
+    Beatport/Tidal/MusicBrainz run and re-upsert at higher precedence, after which
+    the row becomes trusted. (``is_cache_authoritative`` treats unknown/missing
+    sources as precedence 0, so unprovenanced rows never short-circuit.)"""
     if not (track.genre and track.bpm and track.musical_key):
         return False
     prov = track.provenance or {}
-    return all(prov.get(f, {}).get("source") != "legacy" for f in ("genre", "bpm", "musical_key"))
+    return all(
+        is_cache_authoritative(prov.get(f, {}).get("source", ""))
+        for f in ("genre", "bpm", "musical_key")
+    )
 
 
 def _seed_complete_request(db: Session, request: Request, sig: str) -> None:
@@ -350,8 +357,13 @@ def _seed_complete_request(db: Session, request: Request, sig: str) -> None:
     could not reuse it (#541). The Request records no per-field source, so the
     trio is attributed ``legacy`` (lowest precedence); the precedence guard keeps
     it from downgrading a stronger existing row, and a later incomplete request
-    upgrades it via real providers (see ``_trio_trusted``)."""
-    values = {"genre": request.genre, "bpm": request.bpm, "musical_key": request.musical_key}
+    upgrades it via real providers (see ``_trio_trusted``). The key is normalized
+    to Camelot so the seeded row matches what the cascade would have written."""
+    values = {
+        "genre": request.genre,
+        "bpm": request.bpm,
+        "musical_key": normalize_key(request.musical_key),
+    }
     sources = {field: "legacy" for field in values}
     _safe_upsert_track(
         db,
@@ -392,6 +404,13 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
         # reuse it. Search-result submissions arrive complete and skip the cascade,
         # so they would otherwise never populate the store (#541).
         _seed_complete_request(db, request, sig)
+        # The complete path must not bypass energy backfill: when the gate is on
+        # and the seeded row lacks energy, fetch Soundcharts audio features onto it
+        # (the core cascade still never runs here).
+        if get_settings().soundcharts_audio_features_enabled:
+            cached = get_track(db, signature=sig)
+            if cached is not None and cached.energy is None:
+                _backfill_energy_for_cached(db, request, cached, sig)
         return
 
     # Cache-aside short-circuit: if the master store already has this recording
@@ -497,19 +516,19 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
             except Exception:
                 logger.warning("Tidal direct fetch failed for request %d", request_id)
 
-    # 0b. Spotify URL → ISRC. Capture the ISRC INDEPENDENTLY of Tidal auth: it
-    # feeds both the optional Tidal exact-match below AND the Soundcharts
-    # audio-features lookup, so nesting it under tidal_access_token would starve
-    # Soundcharts for DJs without a Tidal token (#541). Fetch it whenever bpm/key
-    # are still missing OR the Soundcharts gate is on (its only other consumer).
+    # 0b. Spotify URL → ISRC. Capture the ISRC INDEPENDENTLY of Tidal auth (so the
+    # Soundcharts lookup isn't starved for DJs without a Tidal token), but ONLY when
+    # a consumer actually exists — otherwise the external Spotify call is wasted
+    # (#541). The two consumers: the Tidal exact-match (needs a token + missing
+    # bpm/key) and the Soundcharts audio-features lookup (needs the gate on).
+    needs_isrc_for_tidal = bool(
+        (not request.bpm or not request.musical_key) and user and user.tidal_access_token
+    )
+    needs_isrc_for_soundcharts = get_settings().soundcharts_audio_features_enabled
     if (
         source_svc == "spotify"
         and not resolved_isrc
-        and (
-            not request.bpm
-            or not request.musical_key
-            or get_settings().soundcharts_audio_features_enabled
-        )
+        and (needs_isrc_for_tidal or needs_isrc_for_soundcharts)
     ):
         resolved_isrc = _get_isrc_from_spotify(request.source_url)
 

--- a/server/app/services/sync/enrichment_pipeline.py
+++ b/server/app/services/sync/enrichment_pipeline.py
@@ -229,6 +229,104 @@ def _apply_enrichment_result(
         resolved["musical_key"] = (normalized, source)
 
 
+def _soundcharts_audio_values(feats) -> dict[str, tuple[object, str]]:
+    """Map a SoundchartsAudioFeatures result to resolved ``field -> (value, source)``
+    entries, dropping None values (a missing feature must not overwrite the store)."""
+    audio_fields = {
+        "energy": feats.energy,
+        "danceability": feats.danceability,
+        "valence": feats.valence,
+        "acousticness": feats.acousticness,
+        "instrumentalness": feats.instrumentalness,
+        "speechiness": feats.speechiness,
+        "liveness": feats.liveness,
+        "loudness_db": feats.loudness_db,
+        "time_signature": feats.time_signature,
+        "explicit": feats.explicit,
+        "duration_sec": feats.duration_sec,
+    }
+    return {
+        field: (value, "soundcharts") for field, value in audio_fields.items() if value is not None
+    }
+
+
+def _backfill_energy_for_cached(db: Session, request: Request, cached, sig: str) -> None:
+    """Backfill Soundcharts audio features onto an already-trio-complete store row.
+
+    Reached only from the cache-aside short-circuit when the gate is on and the
+    cached row lacks energy (spec §2/§4/§5.4/§7). Resolves the ISRC from the row
+    itself (preferred) or the request's Spotify source_url, fetches features, and
+    upserts the audio fields onto the existing row WITHOUT running the core
+    provider cascade. Best-effort: any failure is isolated and never regresses the
+    request commit (the store is strictly additive)."""
+    resolved_isrc = cached.isrc or _get_isrc_from_spotify(request.source_url)
+    if not resolved_isrc:
+        return
+    try:
+        from app.services.soundcharts import get_song_features_by_isrc
+
+        feats = get_song_features_by_isrc(resolved_isrc)
+    except Exception:
+        logger.warning("Soundcharts energy backfill lookup failed for request %d", request.id)
+        return
+    if not feats:
+        return
+    resolved = _soundcharts_audio_values(feats)
+    if not resolved:
+        return
+    values = {field: value for field, (value, _src) in resolved.items()}
+    sources = {field: src for field, (_value, src) in resolved.items()}
+    _safe_upsert_track(
+        db,
+        identity=TrackIdentity(
+            title=request.song_title,
+            artist=request.artist,
+            signature=sig,
+            isrc=resolved_isrc,
+            soundcharts_uuid=feats.soundcharts_uuid or None,
+        ),
+        values=values,
+        sources=sources,
+        request_id=request.id,
+    )
+
+
+def _safe_upsert_track(
+    db: Session,
+    *,
+    identity: TrackIdentity,
+    values: dict[str, object],
+    sources: dict[str, str],
+    request_id: int,
+) -> None:
+    """Durably commit the Request's own enrichment, then upsert the store on top.
+
+    A DB-level failure inside ``upsert_track`` (e.g. a flush-time error from a
+    constraint or a transient Postgres OperationalError) poisons the session, so a
+    naive trailing ``db.commit()`` would raise ``PendingRollbackError`` and discard
+    the Request's freshly enriched bpm/genre/key — the opposite of the "store is
+    strictly additive, never regress the request commit" guarantee (#541).
+
+    To make that guarantee real we commit the pending Request enrichment FIRST so
+    it is durable, then run the store upsert and commit it separately. If the store
+    write fails we ``db.rollback()`` to recover the poisoned session — the Request
+    is already committed, so nothing it owns is lost; only the best-effort store
+    write is dropped (it recomputes on the next request)."""
+    db.commit()  # persist the Request's own enrichment before the additive store write
+    try:
+        upsert_track(
+            db,
+            identity=identity,
+            values=values,
+            sources=sources,
+            fetched_at=utcnow(),
+        )
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.warning("Track store upsert failed for request %d", request_id)
+
+
 def enrich_request_metadata(db: Session, request_id: int) -> None:
     """Background task: fill missing genre/BPM/key on a request.
 
@@ -266,6 +364,13 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
             request.bpm = cached.bpm
         if not request.musical_key:
             request.musical_key = cached.musical_key
+        # The trio (genre/bpm/key) is complete, so the full provider cascade is
+        # skipped. But energy may still be missing on this row — when the gate is
+        # on, backfill ONLY the Soundcharts audio features onto the existing row
+        # (spec §2/§4/§5.4/§7: "energy backfills later"). The core cascade stays
+        # skipped, preserving the zero-extra-core-API-calls dedupe win.
+        if get_settings().soundcharts_audio_features_enabled and cached.energy is None:
+            _backfill_energy_for_cached(db, request, cached, sig)
         db.commit()
         logger.info(
             "Request %d served from track store (sig=%s): genre=%s bpm=%s key=%s",
@@ -514,48 +619,50 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
             feats = get_song_features_by_isrc(resolved_isrc)
             if feats:
                 resolved_uuid = feats.soundcharts_uuid or None
-                audio_fields = {
-                    "energy": feats.energy,
-                    "danceability": feats.danceability,
-                    "valence": feats.valence,
-                    "acousticness": feats.acousticness,
-                    "instrumentalness": feats.instrumentalness,
-                    "speechiness": feats.speechiness,
-                    "liveness": feats.liveness,
-                    "loudness_db": feats.loudness_db,
-                    "time_signature": feats.time_signature,
-                    "explicit": feats.explicit,
-                    "duration_sec": feats.duration_sec,
-                }
-                for field, value in audio_fields.items():
-                    if value is not None:
-                        resolved[field] = (value, "soundcharts")
+                resolved.update(_soundcharts_audio_values(feats))
         except Exception:
             logger.warning("Soundcharts audio-features lookup failed for request %d", request_id)
 
-    # Dual-write the master tracks store. Wrapped so a store failure never
-    # regresses the request's own commit — the store is strictly additive (#541).
+    # Seed the request's own pre-supplied/cascade-confirmed core fields into the
+    # store payload even when no provider NEWLY resolved them this run (#541). A
+    # request can arrive with partial metadata (RequestCreate accepts
+    # genre/bpm/musical_key; the frontend submits search-result fields), and
+    # `_apply_enrichment_result` only records a field into `resolved` when the
+    # Request was MISSING it — so a request that already carried, say, genre would
+    # write a genre-less store row, which can never satisfy the cache-aside gate
+    # (genre AND bpm AND musical_key) and re-hits every provider forever. Seed each
+    # core field the Request holds but `resolved` lacks, attributed to the lowest
+    # `legacy` provenance so any real later enrichment cleanly overrides it (the
+    # `should_overwrite` precedence guard keeps a stronger existing source).
+    for field, value in (
+        ("genre", request.genre),
+        ("bpm", request.bpm),
+        ("musical_key", request.musical_key),
+    ):
+        if field not in resolved and value is not None:
+            resolved[field] = (value, "legacy")
+
+    # Dual-write the master tracks store. `_safe_upsert_track` commits the
+    # Request's own enrichment first, so a store-write failure never regresses it
+    # — the store is strictly additive (#541).
     if resolved:
         values = {field: value for field, (value, _src) in resolved.items()}
         sources = {field: src for field, (_value, src) in resolved.items()}
-        try:
-            upsert_track(
-                db,
-                identity=TrackIdentity(
-                    title=request.song_title,
-                    artist=request.artist,
-                    signature=sig,
-                    isrc=resolved_isrc,
-                    soundcharts_uuid=resolved_uuid,
-                ),
-                values=values,
-                sources=sources,
-                fetched_at=utcnow(),
-            )
-        except Exception:
-            logger.warning("Track store upsert failed for request %d", request_id)
-
-    db.commit()
+        _safe_upsert_track(
+            db,
+            identity=TrackIdentity(
+                title=request.song_title,
+                artist=request.artist,
+                signature=sig,
+                isrc=resolved_isrc,
+                soundcharts_uuid=resolved_uuid,
+            ),
+            values=values,
+            sources=sources,
+            request_id=request_id,
+        )
+    else:
+        db.commit()
     logger.info(
         "Enriched request %d: genre=%s, bpm=%s, key=%s",
         request_id,

--- a/server/app/services/sync/enrichment_pipeline.py
+++ b/server/app/services/sync/enrichment_pipeline.py
@@ -40,6 +40,7 @@ from app.services.track_normalizer import (
     is_original_mix_name,
     is_remix_title,
     normalize_bpm_to_context,
+    normalize_isrc,
     primary_artist,
     score_track_match,
 )
@@ -481,14 +482,25 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
     # providers — the dedupe win that makes the same song requested at two events
     # cost one set of API calls, not two (#541). A trio that is only ``legacy``
     # sourced is NOT authoritative — fall through so real providers can upgrade it.
-    cached = get_track(db, isrc=request.isrc, signature=sig)
-    if cached is not None and _trio_trusted(cached):
+    req_isrc = normalize_isrc(request.isrc)
+    cached = get_track(db, isrc=req_isrc, signature=sig)
+    # A signature fallback must NOT serve a DIFFERENT recording: if the request
+    # carries an ISRC but the cached row has a different non-null ISRC (same
+    # artist/title, different release/remaster), fall through to the providers so
+    # the request's own recording is resolved (#552). An ISRC-less cached row is
+    # still trusted, and gets the request's ISRC backfilled below.
+    isrc_compatible = req_isrc is None or cached is None or cached.isrc in (None, req_isrc)
+    if cached is not None and isrc_compatible and _trio_trusted(cached):
         if not request.genre:
             request.genre = cached.genre
         if not request.bpm:
             request.bpm = cached.bpm
         if not request.musical_key:
             request.musical_key = cached.musical_key
+        # Backfill the request's ISRC onto a previously ISRC-less row: the ISRC
+        # lookup above missed, so this cannot collide with another row's ISRC.
+        if req_isrc and cached.isrc is None:
+            cached.isrc = req_isrc
         # The trio (genre/bpm/key) is complete, so the full provider cascade is
         # skipped. But energy may still be missing on this row — when the gate is
         # on, backfill ONLY the Soundcharts audio features onto the existing row

--- a/server/app/services/sync/enrichment_pipeline.py
+++ b/server/app/services/sync/enrichment_pipeline.py
@@ -371,7 +371,12 @@ def _seed_complete_request(db: Session, request: Request, sig: str) -> None:
     trio is attributed ``legacy`` (lowest precedence); the precedence guard keeps
     it from downgrading a stronger existing row, and a later incomplete request
     upgrades it via real providers (see ``_trio_trusted``). The key is normalized
-    to Camelot so the seeded row matches what the cascade would have written."""
+    to Camelot so the seeded row matches what the cascade would have written.
+
+    Seeds with the Request's ISRC when present (#552): a complete submission that
+    carries the search-result ISRC collapses onto the existing ISRC-keyed row even
+    when its normalized signature differs (e.g. a collab/credit variant), instead
+    of inserting a second signature-only row."""
     values = {
         "genre": request.genre,
         "bpm": request.bpm,
@@ -380,7 +385,12 @@ def _seed_complete_request(db: Session, request: Request, sig: str) -> None:
     sources = {field: "legacy" for field in values}
     _safe_upsert_track(
         db,
-        identity=TrackIdentity(title=request.song_title, artist=request.artist, signature=sig),
+        identity=TrackIdentity(
+            title=request.song_title,
+            artist=request.artist,
+            signature=sig,
+            isrc=request.isrc,
+        ),
         values=values,
         sources=sources,
         request_id=request.id,
@@ -461,7 +471,7 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
         # and the seeded row lacks energy, fetch Soundcharts audio features onto it
         # (the core cascade still never runs here).
         if get_settings().soundcharts_audio_features_enabled:
-            cached = get_track(db, signature=sig)
+            cached = get_track(db, isrc=request.isrc, signature=sig)
             if cached is not None and cached.energy is None:
                 _backfill_energy_for_cached(db, request, cached, sig)
         return
@@ -471,7 +481,7 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
     # providers — the dedupe win that makes the same song requested at two events
     # cost one set of API calls, not two (#541). A trio that is only ``legacy``
     # sourced is NOT authoritative — fall through so real providers can upgrade it.
-    cached = get_track(db, signature=sig)
+    cached = get_track(db, isrc=request.isrc, signature=sig)
     if cached is not None and _trio_trusted(cached):
         if not request.genre:
             request.genre = cached.genre
@@ -504,7 +514,10 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
     # alongside the Request writes so the store dual-write below carries accurate
     # sources without post-hoc guessing.
     resolved: dict[str, tuple[object, str]] = {}
-    resolved_isrc: str | None = None
+    # Seed from the Request's own ISRC (carried from the chosen search result, #552)
+    # so the store identity is ISRC-first even before any provider resolves one;
+    # provider hits below may still set it if the request arrived without one.
+    resolved_isrc: str | None = request.isrc
 
     user = request.event.created_by
     search_query = f"{primary_artist(request.artist)} {request.song_title}"

--- a/server/app/services/sync/enrichment_pipeline.py
+++ b/server/app/services/sync/enrichment_pipeline.py
@@ -327,6 +327,41 @@ def _safe_upsert_track(
         logger.warning("Track store upsert failed for request %d", request_id)
 
 
+def _trio_trusted(track) -> bool:
+    """True when genre/bpm/musical_key are all present AND none is ``legacy``-sourced.
+
+    The cache-aside short-circuit may only fire on a TRUSTED row. A row whose trio
+    was backfilled/seeded as ``legacy`` (lowest precedence) is NOT authoritative:
+    short-circuiting on it would copy stale migrated values onto every future
+    request and prevent real providers from ever upgrading them despite the
+    precedence ladder (#541). Falling through instead lets Beatport/Tidal/MusicBrainz
+    run and re-upsert at higher precedence, after which the row becomes trusted."""
+    if not (track.genre and track.bpm and track.musical_key):
+        return False
+    prov = track.provenance or {}
+    return all(prov.get(f, {}).get("source") != "legacy" for f in ("genre", "bpm", "musical_key"))
+
+
+def _seed_complete_request(db: Session, request: Request, sig: str) -> None:
+    """Seed the store from a Request that already carries the full trio.
+
+    Search-result submissions arrive complete and skip the provider cascade
+    entirely, so without this they would never populate the store and repeats
+    could not reuse it (#541). The Request records no per-field source, so the
+    trio is attributed ``legacy`` (lowest precedence); the precedence guard keeps
+    it from downgrading a stronger existing row, and a later incomplete request
+    upgrades it via real providers (see ``_trio_trusted``)."""
+    values = {"genre": request.genre, "bpm": request.bpm, "musical_key": request.musical_key}
+    sources = {field: "legacy" for field in values}
+    _safe_upsert_track(
+        db,
+        identity=TrackIdentity(title=request.song_title, artist=request.artist, signature=sig),
+        values=values,
+        sources=sources,
+        request_id=request.id,
+    )
+
+
 def enrich_request_metadata(db: Session, request_id: int) -> None:
     """Background task: fill missing genre/BPM/key on a request.
 
@@ -346,18 +381,26 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
     if not request:
         return
 
-    if request.genre and request.bpm and request.musical_key:
-        return  # Already complete
-
-    # Cache-aside short-circuit: if the master store already has this recording
-    # fully resolved, copy the missing fields down and skip ALL providers — the
-    # dedupe win that makes the same song requested at two events cost one set of
-    # API calls, not two (#541). dedupe_signature is the same key pool import uses.
+    # dedupe_signature is the same key the pool import uses, so a request and a
+    # later pool-import of the same recording collapse to one tracks row.
     from app.services.setbuilder.pool import dedupe_signature
 
     sig = dedupe_signature(request.artist, request.song_title)
+
+    if request.genre and request.bpm and request.musical_key:
+        # Already complete on the Request — but still SEED the store so repeats can
+        # reuse it. Search-result submissions arrive complete and skip the cascade,
+        # so they would otherwise never populate the store (#541).
+        _seed_complete_request(db, request, sig)
+        return
+
+    # Cache-aside short-circuit: if the master store already has this recording
+    # fully resolved BY REAL PROVIDERS, copy the missing fields down and skip ALL
+    # providers — the dedupe win that makes the same song requested at two events
+    # cost one set of API calls, not two (#541). A trio that is only ``legacy``
+    # sourced is NOT authoritative — fall through so real providers can upgrade it.
     cached = get_track(db, signature=sig)
-    if cached is not None and cached.genre and cached.bpm and cached.musical_key:
+    if cached is not None and _trio_trusted(cached):
         if not request.genre:
             request.genre = cached.genre
         if not request.bpm:
@@ -454,31 +497,47 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
             except Exception:
                 logger.warning("Tidal direct fetch failed for request %d", request_id)
 
-    # 0b. ISRC matching: Spotify URL → fetch ISRC → exact Tidal lookup
-    if source_svc == "spotify" and (not request.bpm or not request.musical_key):
-        if user and user.tidal_access_token:
-            try:
-                isrc = _get_isrc_from_spotify(request.source_url)
-                if isrc:
-                    resolved_isrc = isrc
-                    from app.services.tidal import search_tidal_by_isrc
+    # 0b. Spotify URL → ISRC. Capture the ISRC INDEPENDENTLY of Tidal auth: it
+    # feeds both the optional Tidal exact-match below AND the Soundcharts
+    # audio-features lookup, so nesting it under tidal_access_token would starve
+    # Soundcharts for DJs without a Tidal token (#541). Fetch it whenever bpm/key
+    # are still missing OR the Soundcharts gate is on (its only other consumer).
+    if (
+        source_svc == "spotify"
+        and not resolved_isrc
+        and (
+            not request.bpm
+            or not request.musical_key
+            or get_settings().soundcharts_audio_features_enabled
+        )
+    ):
+        resolved_isrc = _get_isrc_from_spotify(request.source_url)
 
-                    isrc_match = search_tidal_by_isrc(db, user, isrc)
-                    if isrc_match:
-                        logger.info(
-                            "ISRC match for %d: '%s' by '%s' bpm=%s key=%s (ISRC=%s)",
-                            request_id,
-                            isrc_match.title,
-                            isrc_match.artist,
-                            isrc_match.bpm,
-                            isrc_match.key,
-                            isrc,
-                        )
-                        _apply_enrichment_result(
-                            request, isrc_match, source="tidal", resolved=resolved
-                        )
-            except Exception:
-                logger.warning("ISRC enrichment failed for request %d", request_id)
+    # Exact Tidal match by ISRC needs a token and only helps when bpm/key are blank.
+    if (
+        source_svc == "spotify"
+        and resolved_isrc
+        and (not request.bpm or not request.musical_key)
+        and user
+        and user.tidal_access_token
+    ):
+        try:
+            from app.services.tidal import search_tidal_by_isrc
+
+            isrc_match = search_tidal_by_isrc(db, user, resolved_isrc)
+            if isrc_match:
+                logger.info(
+                    "ISRC match for %d: '%s' by '%s' bpm=%s key=%s (ISRC=%s)",
+                    request_id,
+                    isrc_match.title,
+                    isrc_match.artist,
+                    isrc_match.bpm,
+                    isrc_match.key,
+                    resolved_isrc,
+                )
+                _apply_enrichment_result(request, isrc_match, source="tidal", resolved=resolved)
+        except Exception:
+            logger.warning("ISRC enrichment failed for request %d", request_id)
 
     # 1. MusicBrainz for genre (artist-level, free, rate-limited)
     if not request.genre and request.artist:

--- a/server/app/services/sync/enrichment_pipeline.py
+++ b/server/app/services/sync/enrichment_pipeline.py
@@ -1,11 +1,24 @@
-"""Enrichment pipeline — fills missing genre/BPM/key on requests.
+"""Enrichment pipeline — resolves song metadata and writes the master track store.
 
-Sources (in priority order):
+`enrich_request_metadata` is the single abstracted enrichment entry point for every
+request-queue surface (guest submit / collect / kiosk / DJ add / bulk / refresh).
+It both fills missing genre/BPM/key on the Request (for the existing UI) AND, since
+#541, CACHE-ASIDE dual-writes a master `tracks` row (the single source of truth for
+song data) so each unique recording is enriched once and reused across events.
+
+Provider cascade (only for fields still missing):
 0. Direct fetch via source_url (Beatport/Tidal URL → exact track)
-0b. ISRC matching (Spotify URL → ISRC → exact Tidal match)
+0b. Spotify URL → ISRC (feeds the optional Tidal exact-match + the Soundcharts lookup)
 1. MusicBrainz artist lookup (genre — artist-level, 1 req/sec rate limit)
 2. Beatport search (BPM + key, backfill genre if MusicBrainz missed)
 3. Tidal search (BPM + key backup when Beatport unavailable)
+4. BPM context-correction (per-event; request-only, never written to the store)
+5. Soundcharts audio-features (energy/danceability/… — gated, dark by default)
+
+Store write (#541): the master `tracks` row is keyed by ISRC → dedupe_signature,
+written with per-field provenance under a precedence ladder; a trusted complete row
+short-circuits the whole cascade (the dedupe win). See app/services/tracks/. The
+WrzDJSet pool's own master-store write is deferred to #542.
 """
 
 from __future__ import annotations
@@ -417,18 +430,16 @@ def _apply_bpm_context_correction(db: Session, request: Request) -> float | None
 
 
 def enrich_request_metadata(db: Session, request_id: int) -> None:
-    """Background task: fill missing genre/BPM/key on a request.
+    """Background task: resolve a request's metadata and dual-write the master store.
 
-    Sources (in priority order):
-    0. Direct fetch via source_url (Beatport/Tidal URL → exact track)
-    0b. ISRC matching (Spotify URL → ISRC → exact Tidal match)
-    1. MusicBrainz artist lookup (genre — artist-level, 1 req/sec rate limit)
-    2. Beatport search (BPM + key, backfill genre if MusicBrainz missed)
-    3. Tidal search (BPM + key backup when Beatport unavailable)
-
-    Only queries sources for missing fields. Skips if all fields present.
-    Results are fuzzy-matched against the request to avoid enriching
-    with metadata from a wrong track.
+    Fills missing genre/BPM/key on the Request (existing UI) AND writes a master
+    `tracks` row cache-aside (#541): a trusted complete store row is reused with zero
+    provider calls; otherwise the provider cascade runs (module docstring) and the
+    resolved fields are upserted with per-field provenance. An already-complete
+    Request still SEEDS the store (so search-result submissions populate it too).
+    Results are fuzzy-matched against the request to avoid enriching from a wrong
+    track. Best-effort: a store-write failure never regresses the Request's own
+    commit. The module-level docstring documents the full cascade + store semantics.
     """
     # Re-fetch request in this background task's context
     request = db.query(Request).filter(Request.id == request_id).first()
@@ -694,11 +705,11 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
 
     # 4. BPM context correction: detect half-time/double-time from other event
     # tracks (shared with the cache-hit path via _apply_bpm_context_correction).
-    corrected = _apply_bpm_context_correction(db, request)
-    if corrected is not None and "bpm" in resolved:
-        # Keep the store in sync with the context-corrected value, preserving the
-        # original provider source (the correction is a refinement of it).
-        resolved["bpm"] = (corrected, resolved["bpm"][1])
+    # This mutates ONLY request.bpm — the event-specific corrected value must NOT
+    # be written to the global store. The store keeps the canonical provider BPM
+    # (resolved["bpm"]) so future cache hits at other events re-derive their own
+    # per-event correction from it, instead of inheriting this event's tempo (#541).
+    _apply_bpm_context_correction(db, request)
 
     # 5. Soundcharts audio features (energy/danceability/…) — gated, dark by
     # default. Only when the flag is on, an ISRC is in hand, and the store row

--- a/server/app/services/sync/enrichment_pipeline.py
+++ b/server/app/services/sync/enrichment_pipeline.py
@@ -709,6 +709,10 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
     # be written to the global store. The store keeps the canonical provider BPM
     # (resolved["bpm"]) so future cache hits at other events re-derive their own
     # per-event correction from it, instead of inheriting this event's tempo (#541).
+    # Stash the canonical pre-correction value for the legacy store seed below: a
+    # pre-supplied BPM is not in `resolved`, so the seed would otherwise persist the
+    # event-corrected request.bpm globally.
+    canonical_bpm = request.bpm
     _apply_bpm_context_correction(db, request)
 
     # 5. Soundcharts audio features (energy/danceability/…) — gated, dark by
@@ -744,7 +748,7 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
     # `should_overwrite` precedence guard keeps a stronger existing source).
     for field, value in (
         ("genre", request.genre),
-        ("bpm", request.bpm),
+        ("bpm", canonical_bpm),  # pre-correction value — never the event-corrected one
         ("musical_key", request.musical_key),
     ):
         if field not in resolved and value is not None:

--- a/server/app/services/sync/enrichment_pipeline.py
+++ b/server/app/services/sync/enrichment_pipeline.py
@@ -374,6 +374,48 @@ def _seed_complete_request(db: Session, request: Request, sig: str) -> None:
     )
 
 
+def _apply_bpm_context_correction(db: Session, request: Request) -> float | None:
+    """Half/double-time correct ``request.bpm`` to the event's accepted-track tempo
+    context. Mutates ``request.bpm`` and returns the corrected value if it changed,
+    else None.
+
+    This is PER-EVENT (the same recording can need different octave correction at
+    different events), so it runs on BOTH the provider/miss path and the cache-hit
+    fast path — a trusted cached BPM must still be context-corrected for the event
+    it's being served into, not committed raw (#541)."""
+    if not request.bpm:
+        return None
+    context_bpms = [
+        float(r.bpm)
+        for r in db.query(Request)
+        .filter(
+            Request.event_id == request.event_id,
+            Request.id != request.id,
+            Request.bpm.isnot(None),
+            Request.status.in_(
+                [
+                    RequestStatus.ACCEPTED.value,
+                    RequestStatus.PLAYING.value,
+                    RequestStatus.PLAYED.value,
+                ]
+            ),
+        )
+        .all()
+    ]
+    corrected = normalize_bpm_to_context(request.bpm, context_bpms)
+    if corrected != request.bpm:
+        logger.info(
+            "BPM corrected for request %d: %.1f → %.1f (median context: %.1f)",
+            request.id,
+            request.bpm,
+            corrected,
+            statistics.median(context_bpms),
+        )
+        request.bpm = corrected
+        return corrected
+    return None
+
+
 def enrich_request_metadata(db: Session, request_id: int) -> None:
     """Background task: fill missing genre/BPM/key on a request.
 
@@ -433,6 +475,9 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
         # skipped, preserving the zero-extra-core-API-calls dedupe win.
         if get_settings().soundcharts_audio_features_enabled and cached.energy is None:
             _backfill_energy_for_cached(db, request, cached, sig)
+        # Context-correct the served BPM for THIS event (the cached value is canonical;
+        # half/double-time correction is per-event and must not be skipped on a hit).
+        _apply_bpm_context_correction(db, request)
         db.commit()
         logger.info(
             "Request %d served from track store (sig=%s): genre=%s bpm=%s key=%s",
@@ -647,39 +692,13 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
     if request.musical_key:
         request.musical_key = normalize_key(request.musical_key)
 
-    # 4. BPM context correction: detect half-time/double-time from other event tracks
-    if request.bpm:
-        context_bpms = [
-            float(r.bpm)
-            for r in db.query(Request)
-            .filter(
-                Request.event_id == request.event_id,
-                Request.id != request.id,
-                Request.bpm.isnot(None),
-                Request.status.in_(
-                    [
-                        RequestStatus.ACCEPTED.value,
-                        RequestStatus.PLAYING.value,
-                        RequestStatus.PLAYED.value,
-                    ]
-                ),
-            )
-            .all()
-        ]
-        corrected = normalize_bpm_to_context(request.bpm, context_bpms)
-        if corrected != request.bpm:
-            logger.info(
-                "BPM corrected for request %d: %.1f → %.1f (median context: %.1f)",
-                request_id,
-                request.bpm,
-                corrected,
-                statistics.median(context_bpms),
-            )
-            request.bpm = corrected
-            # Keep the store in sync with the context-corrected value, preserving
-            # the original provider source (the correction is a refinement of it).
-            if "bpm" in resolved:
-                resolved["bpm"] = (corrected, resolved["bpm"][1])
+    # 4. BPM context correction: detect half-time/double-time from other event
+    # tracks (shared with the cache-hit path via _apply_bpm_context_correction).
+    corrected = _apply_bpm_context_correction(db, request)
+    if corrected is not None and "bpm" in resolved:
+        # Keep the store in sync with the context-corrected value, preserving the
+        # original provider source (the correction is a refinement of it).
+        resolved["bpm"] = (corrected, resolved["bpm"][1])
 
     # 5. Soundcharts audio features (energy/danceability/…) — gated, dark by
     # default. Only when the flag is on, an ISRC is in hand, and the store row

--- a/server/app/services/sync/orchestrator.py
+++ b/server/app/services/sync/orchestrator.py
@@ -33,6 +33,28 @@ from app.services.track_normalizer import normalize_track
 logger = logging.getLogger(__name__)
 
 
+def _enrich_with_fresh_session(request_id: int) -> None:
+    """Run request enrichment in its OWN DB session — the single shared scheduler.
+
+    FastAPI tears down the ``yield``-based ``get_db`` only after background tasks
+    finish, so scheduling enrichment with the request-scoped ``db`` pins a pooled
+    connection through the enrichment's slow external API calls (#505). A fresh
+    ``SessionLocal()`` per task releases its connection as soon as the task ends.
+
+    EVERY router (events / collect / requests) schedules request-time enrichment
+    through THIS one helper, so the master-store write (#541) and the fresh-session
+    hygiene (#505) happen identically no matter the entry point — never copy a
+    per-router variant, or the two can silently drift apart.
+    """
+    from app.db.session import SessionLocal
+
+    session = SessionLocal()
+    try:
+        enrich_request_metadata(session, request_id)
+    finally:
+        session.close()
+
+
 @dataclass
 class MultiSyncResult:
     """Aggregate result from syncing to all connected services."""

--- a/server/app/services/track_normalizer.py
+++ b/server/app/services/track_normalizer.py
@@ -281,3 +281,21 @@ def normalize_isrc(isrc: str | None) -> str | None:
         return None
     cleaned = isrc.strip().upper().replace("-", "").replace(" ", "")
     return cleaned or None
+
+
+# Normalized ISRC shape (ISO 3901): 2-letter country + 3-char alphanumeric
+# registrant + 7 digits (2-digit year + 5-digit designation) = 12 chars.
+_ISRC_RE = re.compile(r"^[A-Z]{2}[A-Z0-9]{3}[0-9]{7}$")
+
+
+def valid_isrc(isrc: str | None) -> str | None:
+    """Normalize an ISRC and return it ONLY if it matches the ISO 3901 shape, else None.
+
+    Validates untrusted submitted ISRCs before they are stored or used as a
+    cache/provider lookup key (#552): a malformed value is dropped (treated as no
+    ISRC) rather than mistaken for an authoritative recording identity or sent to a
+    provider's by-ISRC endpoint."""
+    normalized = normalize_isrc(isrc)
+    if normalized and _ISRC_RE.match(normalized):
+        return normalized
+    return None

--- a/server/app/services/tracks/provenance.py
+++ b/server/app/services/tracks/provenance.py
@@ -17,6 +17,10 @@ SOURCE_PRECEDENCE: dict[str, int] = {
     "tidal": 50,
     "musicbrainz": 50,
     "community": 40,
+    # Pre-store data backfilled from existing Request columns (#541): carries no
+    # original-source record, so it sits lowest above the unknown floor — any real
+    # later enrichment cleanly overrides it, and it never downgrades a real source.
+    "legacy": 30,
     "llm": 10,
 }
 

--- a/server/app/services/tracks/provenance.py
+++ b/server/app/services/tracks/provenance.py
@@ -36,6 +36,22 @@ def precedence(source: str) -> int:
     return SOURCE_PRECEDENCE.get(source, 0)
 
 
+# A cached track row may only short-circuit live enrichment when its fields come
+# from a real measured/authoritative provider (the 50+ tier: soundcharts/beatport/
+# tidal/musicbrainz and above). community(40)/legacy(30)/llm(10)/unknown(0) are
+# low-trust: a row sourced only from them must fall through so real providers can
+# upgrade it, rather than being served as a sticky cache hit (#541).
+CACHE_TRUST_FLOOR = 50
+
+
+def is_cache_authoritative(source: str) -> bool:
+    """True if a field from this source may serve as an authoritative cache hit.
+
+    Unknown/missing sources (precedence 0) are NOT authoritative, so an
+    unprovenanced complete row cannot short-circuit provider upgrades."""
+    return precedence(source) >= CACHE_TRUST_FLOOR
+
+
 def should_overwrite(existing: dict | None, new_source: str) -> bool:
     """True if a value sourced from new_source may replace the existing field."""
     if existing is None:

--- a/server/app/services/tracks/store.py
+++ b/server/app/services/tracks/store.py
@@ -108,15 +108,19 @@ def upsert_track(
     track = get_track(db, isrc=norm_isrc, signature=identity.signature)
     if track is None:
         track = _insert_identity_reconciling(db, identity=identity, norm_isrc=norm_isrc)
-    elif norm_isrc and track.isrc and track.isrc != norm_isrc:
-        # ISRC CONFLICT: get_track fell back to the signature and matched a row for a
-        # DIFFERENT recording (same normalized artist/title, different release/
-        # remaster — the two ISRCs identify distinct recordings). The signature is
-        # UNIQUE, so this recording cannot get its own row here; refuse to overwrite
-        # the existing row's data with a different recording's values. The recording
-        # is simply not stored (its metadata still lives on the caller's Request);
-        # this prevents corruption. Full multi-recording-per-signature support is a
-        # #542 schema concern (signature is the identity bottleneck, not ISRC).
+
+    # ISRC CONFLICT — checked AFTER resolution so it covers BOTH the initial
+    # get_track signature fallback AND the reconcile-race re-read inside
+    # _insert_identity_reconciling (which can also land on a signature-matched row
+    # for a DIFFERENT recording). The two ISRCs identify distinct recordings (same
+    # normalized artist/title, different release/remaster); the signature is UNIQUE
+    # so this recording cannot get its own row here. Refuse to overwrite the
+    # existing row's data — the recording is simply not stored (its metadata still
+    # lives on the caller's Request); this prevents corruption. Full
+    # multi-recording-per-signature support is a #542 schema concern (signature is
+    # the identity bottleneck, not ISRC). A freshly INSERTED row has isrc==norm_isrc,
+    # so this never trips on the insert path.
+    if norm_isrc and track.isrc and track.isrc != norm_isrc:
         logger.warning(
             "upsert_track: ISRC conflict on signature %s (existing isrc=%s, incoming=%s); "
             "skipping write to avoid overwriting a different recording.",

--- a/server/app/services/tracks/store.py
+++ b/server/app/services/tracks/store.py
@@ -1,5 +1,6 @@
 """Read/write service for the master tracks table (#540)."""
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -9,6 +10,8 @@ from sqlalchemy.orm import Session
 from app.models.track import Track
 from app.services.track_normalizer import normalize_isrc
 from app.services.tracks.provenance import KNOWN_SOURCES, FieldProvenance, should_overwrite
+
+logger = logging.getLogger(__name__)
 
 # Columns NOT writable via the `values` dict: identity fields come from
 # TrackIdentity (signature/title/artist/isrc/soundcharts_uuid) and these are
@@ -105,6 +108,23 @@ def upsert_track(
     track = get_track(db, isrc=norm_isrc, signature=identity.signature)
     if track is None:
         track = _insert_identity_reconciling(db, identity=identity, norm_isrc=norm_isrc)
+    elif norm_isrc and track.isrc and track.isrc != norm_isrc:
+        # ISRC CONFLICT: get_track fell back to the signature and matched a row for a
+        # DIFFERENT recording (same normalized artist/title, different release/
+        # remaster — the two ISRCs identify distinct recordings). The signature is
+        # UNIQUE, so this recording cannot get its own row here; refuse to overwrite
+        # the existing row's data with a different recording's values. The recording
+        # is simply not stored (its metadata still lives on the caller's Request);
+        # this prevents corruption. Full multi-recording-per-signature support is a
+        # #542 schema concern (signature is the identity bottleneck, not ISRC).
+        logger.warning(
+            "upsert_track: ISRC conflict on signature %s (existing isrc=%s, incoming=%s); "
+            "skipping write to avoid overwriting a different recording.",
+            identity.signature,
+            track.isrc,
+            norm_isrc,
+        )
+        return track
 
     # Backfill ISRC onto signature-matched row if it was previously missing
     if norm_isrc and not track.isrc:

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -2485,6 +2485,18 @@
             ],
             "title": "Artwork Url"
           },
+          "isrc": {
+            "anyOf": [
+              {
+                "maxLength": 15,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Isrc"
+          },
           "nickname": {
             "anyOf": [
               {
@@ -7366,6 +7378,18 @@
               }
             ],
             "title": "Genre"
+          },
+          "isrc": {
+            "anyOf": [
+              {
+                "maxLength": 15,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Isrc"
           },
           "musical_key": {
             "anyOf": [

--- a/server/tests/test_backfill_tracks.py
+++ b/server/tests/test_backfill_tracks.py
@@ -1,0 +1,166 @@
+"""Tests for the request->tracks backfill script (#541).
+
+Seeds Request rows (some sharing artist/title, some with partial metadata, one
+with none), runs the backfill, and asserts:
+  * tracks rows are created with source="legacy" and the present values,
+  * a same-song duplicate request collapses to ONE track row (sig dedup),
+  * re-running is a pure no-op (no new rows, values unchanged) — idempotent.
+"""
+
+from app.models.request import Request, RequestStatus
+from app.models.track import Track
+from app.scripts.backfill_tracks import backfill_tracks
+from app.services.setbuilder.pool import dedupe_signature
+
+
+def _make_request(db, event, **kw):
+    r = Request(
+        event_id=event.id,
+        song_title=kw.pop("song_title"),
+        artist=kw.pop("artist"),
+        source="manual",
+        status=RequestStatus.NEW.value,
+        dedupe_key=kw.pop("dedupe_key"),
+        **kw,
+    )
+    db.add(r)
+    db.flush()
+    return r
+
+
+def test_backfill_creates_legacy_tracks(db, test_event):
+    _make_request(
+        db,
+        test_event,
+        song_title="Sandstorm",
+        artist="Darude",
+        dedupe_key="dk-1",
+        genre="trance",
+        bpm=136.0,
+        musical_key="8A",
+    )
+    db.commit()
+
+    result = backfill_tracks(db)
+
+    assert result["scanned"] == 1
+    assert result["upserted"] == 1
+    assert result["errors"] == 0
+
+    sig = dedupe_signature("Darude", "Sandstorm")
+    track = db.query(Track).filter(Track.signature == sig).one()
+    assert track.genre == "trance"
+    assert track.bpm == 136.0
+    assert track.musical_key == "8A"
+    assert track.provenance["genre"]["source"] == "legacy"
+    assert track.provenance["bpm"]["source"] == "legacy"
+    assert track.provenance["musical_key"]["source"] == "legacy"
+
+
+def test_backfill_partial_metadata_only_writes_present_fields(db, test_event):
+    _make_request(
+        db,
+        test_event,
+        song_title="Strobe",
+        artist="Deadmau5",
+        dedupe_key="dk-2",
+        bpm=128.0,
+        # genre and musical_key left None
+    )
+    db.commit()
+
+    backfill_tracks(db)
+
+    sig = dedupe_signature("Deadmau5", "Strobe")
+    track = db.query(Track).filter(Track.signature == sig).one()
+    assert track.bpm == 128.0
+    assert track.genre is None
+    assert track.musical_key is None
+    assert "bpm" in track.provenance
+    assert "genre" not in track.provenance
+    assert "musical_key" not in track.provenance
+
+
+def test_backfill_skips_requests_with_no_metadata(db, test_event):
+    _make_request(
+        db,
+        test_event,
+        song_title="Nothing Here",
+        artist="No Meta",
+        dedupe_key="dk-3",
+        # no genre/bpm/musical_key at all
+    )
+    db.commit()
+
+    result = backfill_tracks(db)
+
+    assert result["scanned"] == 0
+    assert result["upserted"] == 0
+    sig = dedupe_signature("No Meta", "Nothing Here")
+    assert db.query(Track).filter(Track.signature == sig).count() == 0
+
+
+def test_backfill_duplicate_song_collapses_to_one_row(db, test_event):
+    # Two requests for the same song (same artist/title) → one track row.
+    _make_request(
+        db,
+        test_event,
+        song_title="Levels",
+        artist="Avicii",
+        dedupe_key="dk-4a",
+        bpm=126.0,
+    )
+    _make_request(
+        db,
+        test_event,
+        song_title="Levels",
+        artist="Avicii",
+        dedupe_key="dk-4b",
+        genre="house",
+    )
+    db.commit()
+
+    result = backfill_tracks(db)
+
+    assert result["scanned"] == 2
+    sig = dedupe_signature("Avicii", "Levels")
+    rows = db.query(Track).filter(Track.signature == sig).all()
+    assert len(rows) == 1, "same-song duplicate requests must collapse to one track"
+    # Both contributions land on the single row.
+    assert rows[0].bpm == 126.0
+    assert rows[0].genre == "house"
+
+
+def test_backfill_is_idempotent(db, test_event):
+    _make_request(
+        db,
+        test_event,
+        song_title="One More Time",
+        artist="Daft Punk",
+        dedupe_key="dk-5",
+        genre="french house",
+        bpm=123.0,
+        musical_key="11B",
+    )
+    db.commit()
+
+    backfill_tracks(db)
+    sig = dedupe_signature("Daft Punk", "One More Time")
+    first = db.query(Track).filter(Track.signature == sig).one()
+    first_id = first.id
+    first_prov = dict(first.provenance)
+    rows_before = db.query(Track).count()
+
+    # Second run must add no rows and change no values.
+    result = backfill_tracks(db)
+    rows_after = db.query(Track).count()
+    assert rows_after == rows_before, "re-run must not create new rows"
+
+    again = db.query(Track).filter(Track.signature == sig).one()
+    assert again.id == first_id
+    assert again.genre == "french house"
+    assert again.bpm == 123.0
+    assert again.musical_key == "11B"
+    assert again.provenance == first_prov
+    # The legacy source is still the recorded provenance (no spurious overwrite).
+    assert result["upserted"] == 1  # scanned+upsert still counted, but no-op data-wise

--- a/server/tests/test_backfill_tracks.py
+++ b/server/tests/test_backfill_tracks.py
@@ -7,6 +7,7 @@ with none), runs the backfill, and asserts:
   * re-running is a pure no-op (no new rows, values unchanged) — idempotent.
 """
 
+import app.scripts.backfill_tracks as bf
 from app.models.request import Request, RequestStatus
 from app.models.track import Track
 from app.scripts.backfill_tracks import backfill_tracks
@@ -164,3 +165,48 @@ def test_backfill_is_idempotent(db, test_event):
     assert again.provenance == first_prov
     # The legacy source is still the recorded provenance (no spurious overwrite).
     assert result["upserted"] == 1  # scanned+upsert still counted, but no-op data-wise
+
+
+def test_backfill_isolates_a_failing_row(db, test_event, monkeypatch):
+    """REGRESSION (review #541): a row whose write raises and POISONS the Session
+    must be isolated by its per-row savepoint — the run continues and other rows
+    still upsert, instead of one bad row aborting the whole backfill + final commit.
+    """
+    from sqlalchemy import text
+
+    # "Bad Row" sorts first by id (inserted first) → processed first.
+    _make_request(
+        db, test_event, song_title="Bad Row", artist="Boom", dedupe_key="dk-bad", bpm=100.0
+    )
+    _make_request(
+        db, test_event, song_title="Good Row", artist="Nice", dedupe_key="dk-good", bpm=120.0
+    )
+    db.commit()
+
+    real_upsert = bf.upsert_track
+    bad_sig = dedupe_signature("Boom", "Bad Row")
+
+    def flaky_upsert(db, *, identity, values, sources, fetched_at):
+        if identity.signature == bad_sig:
+            # A real flush-time IntegrityError (NULL signature) leaves the Session
+            # in a rollback-needed state — exactly what the savepoint must recover.
+            db.execute(
+                text(
+                    "INSERT INTO tracks (signature, title, artist, provenance) "
+                    "VALUES (NULL, 'x', 'y', '{}')"
+                )
+            )
+        return real_upsert(
+            db, identity=identity, values=values, sources=sources, fetched_at=fetched_at
+        )
+
+    monkeypatch.setattr(bf, "upsert_track", flaky_upsert)
+
+    result = backfill_tracks(db)
+
+    assert result["errors"] == 1
+    assert result["upserted"] == 1  # the good row survived the bad row's failure
+    good_sig = dedupe_signature("Nice", "Good Row")
+    assert db.query(Track).filter(Track.signature == good_sig).one().bpm == 120.0
+    # The poisoning insert was rolled back with its savepoint — no NULL row leaked.
+    assert db.query(Track).filter(Track.signature == bad_sig).count() == 0

--- a/server/tests/test_backfill_tracks.py
+++ b/server/tests/test_backfill_tracks.py
@@ -208,5 +208,7 @@ def test_backfill_isolates_a_failing_row(db, test_event, monkeypatch):
     assert result["upserted"] == 1  # the good row survived the bad row's failure
     good_sig = dedupe_signature("Nice", "Good Row")
     assert db.query(Track).filter(Track.signature == good_sig).one().bpm == 120.0
-    # The poisoning insert was rolled back with its savepoint — no NULL row leaked.
+    # The poisoning insert was rolled back with its savepoint: neither the bad
+    # row's own signature nor the NULL-signature poison row leaked into the table.
     assert db.query(Track).filter(Track.signature == bad_sig).count() == 0
+    assert db.query(Track).filter(Track.signature.is_(None)).count() == 0

--- a/server/tests/test_bg_fresh_sessions.py
+++ b/server/tests/test_bg_fresh_sessions.py
@@ -397,3 +397,28 @@ def test_patch_accept_schedules_request_id_not_orm(
     func, args, kwargs = sync_tasks[0]
     _assert_no_orm_or_session(args, kwargs)
     assert args == (row.id,)
+
+
+def test_submit_request_schedules_fresh_session_not_db(
+    client, db, auth_headers, test_event, monkeypatch
+):
+    """POST /requests enriches via _enrich_with_fresh_session(id) — never the
+    request-scoped `db`/ORM row. #541 broadened this enqueue to complete
+    submissions too; with Soundcharts enabled the task makes network calls, so it
+    must not pin a pool connection (#505)."""
+    scheduled = _record_scheduled_tasks(monkeypatch)
+
+    resp = client.post(
+        f"/api/events/{test_event.code}/requests",
+        json={"title": "Sandstorm", "artist": "Darude"},
+        headers=auth_headers,
+    )
+    assert resp.status_code in (200, 201), resp.text
+
+    for func, args, kwargs in scheduled:
+        _assert_no_orm_or_session(args, kwargs)
+
+    enrich_tasks = [s for s in scheduled if s[0] is events_module._enrich_with_fresh_session]
+    assert len(enrich_tasks) == 1, "submit must schedule exactly one fresh-session enrich task"
+    args = enrich_tasks[0][1]
+    assert len(args) == 1 and isinstance(args[0], int)  # a single int request ID

--- a/server/tests/test_bg_fresh_sessions.py
+++ b/server/tests/test_bg_fresh_sessions.py
@@ -16,6 +16,7 @@ import pytest
 import app.api.collect as collect_module
 import app.api.events as events_module
 import app.api.requests as requests_module
+import app.services.sync.orchestrator as orchestrator_module
 from app.models.request import Request as SongRequest
 from app.models.request import RequestStatus
 
@@ -55,7 +56,7 @@ def _patch_session_local(monkeypatch, module, spy: _SpySession) -> None:
 def test_enrich_helper_closes_session_on_success(monkeypatch):
     spy = _SpySession()
     _patch_session_local(monkeypatch, events_module, spy)
-    monkeypatch.setattr(events_module, "enrich_request_metadata", lambda db, rid: None)
+    monkeypatch.setattr(orchestrator_module, "enrich_request_metadata", lambda db, rid: None)
 
     events_module._enrich_with_fresh_session(123)
 
@@ -69,7 +70,7 @@ def test_enrich_helper_closes_session_on_exception(monkeypatch):
     def boom(db, rid):
         raise RuntimeError("enrich failed")
 
-    monkeypatch.setattr(events_module, "enrich_request_metadata", boom)
+    monkeypatch.setattr(orchestrator_module, "enrich_request_metadata", boom)
 
     # Assert the error actually propagates — the helper must NOT swallow it — so
     # the regression also guards against a future try/except hiding failures.
@@ -168,7 +169,7 @@ def test_remove_collection_tracks_helper_passes_ids_and_closes(monkeypatch):
 def test_requests_enrich_helper_closes_session(monkeypatch):
     spy = _SpySession()
     _patch_session_local(monkeypatch, requests_module, spy)
-    monkeypatch.setattr(requests_module, "enrich_request_metadata", lambda db, rid: None)
+    monkeypatch.setattr(orchestrator_module, "enrich_request_metadata", lambda db, rid: None)
 
     requests_module._enrich_with_fresh_session(5)
 
@@ -246,7 +247,7 @@ def test_remove_collection_track_helper_requeries_and_closes(monkeypatch):
 def test_collect_enrich_helper_closes_session(monkeypatch):
     spy = _SpySession()
     _patch_session_local(monkeypatch, collect_module, spy)
-    monkeypatch.setattr(collect_module, "enrich_request_metadata", lambda db, rid: None)
+    monkeypatch.setattr(orchestrator_module, "enrich_request_metadata", lambda db, rid: None)
 
     collect_module._enrich_with_fresh_session(9)
 
@@ -422,3 +423,62 @@ def test_submit_request_schedules_fresh_session_not_db(
     assert len(enrich_tasks) == 1, "submit must schedule exactly one fresh-session enrich task"
     args = enrich_tasks[0][1]
     assert len(args) == 1 and isinstance(args[0], int)  # a single int request ID
+
+
+def test_refresh_metadata_schedules_fresh_session(
+    client, db, auth_headers, test_event, monkeypatch
+):
+    """POST /requests/{id}/refresh-metadata re-enriches via the one shared
+    fresh-session helper (the same object all routers import) — by int ID."""
+    row = SongRequest(
+        event_id=test_event.id,
+        song_title="Refresh Me",
+        artist="DJ R",
+        source="spotify",
+        status=RequestStatus.NEW.value,
+        dedupe_key="refresh-me",
+        genre="house",
+        bpm=120.0,
+        musical_key="8A",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+
+    scheduled = _record_scheduled_tasks(monkeypatch)
+    resp = client.post(f"/api/requests/{row.id}/refresh-metadata", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+
+    enrich_tasks = [s for s in scheduled if s[0] is requests_module._enrich_with_fresh_session]
+    assert len(enrich_tasks) == 1
+    _assert_no_orm_or_session(enrich_tasks[0][1], enrich_tasks[0][2])
+    assert enrich_tasks[0][1] == (row.id,)
+
+
+def test_enrich_all_schedules_fresh_session_per_incomplete(
+    client, db, auth_headers, test_event, monkeypatch
+):
+    """POST /events/{code}/enrich-all schedules one fresh-session enrich per
+    incomplete request — all via the shared helper, by int ID."""
+    for i in range(3):
+        db.add(
+            SongRequest(
+                event_id=test_event.id,
+                song_title=f"Inc {i}",
+                artist=f"A{i}",
+                source="spotify",
+                status=RequestStatus.NEW.value,
+                dedupe_key=f"inc-{i}",
+            )
+        )
+    db.commit()
+
+    scheduled = _record_scheduled_tasks(monkeypatch)
+    resp = client.post(f"/api/events/{test_event.code}/enrich-all", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+
+    enrich_tasks = [s for s in scheduled if s[0] is events_module._enrich_with_fresh_session]
+    assert len(enrich_tasks) == 3, "one fresh-session enrich task per incomplete request"
+    for _func, args, kwargs in enrich_tasks:
+        _assert_no_orm_or_session(args, kwargs)
+        assert len(args) == 1 and isinstance(args[0], int)

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -904,7 +904,9 @@ def test_collect_submit_triggers_enrichment(client, db, test_event: Event):
 
     _enable_collection(db, test_event)
 
-    with patch("app.api.collect.enrich_request_metadata") as mock_enrich:
+    # The shared _enrich_with_fresh_session helper (orchestrator) is what the collect
+    # background task runs; patch enrichment there so the task is a no-op + observable.
+    with patch("app.services.sync.orchestrator.enrich_request_metadata") as mock_enrich:
         r = client.post(
             f"/api/public/collect/{test_event.code}/requests",
             json={

--- a/server/tests/test_enrichment_store_writes.py
+++ b/server/tests/test_enrichment_store_writes.py
@@ -842,3 +842,41 @@ def test_cache_hit_applies_bpm_context_correction(db: Session, bp_user: User, mo
     assert request.bpm == 132.0
     # The canonical store value is unchanged — correction is per-event, request-only.
     assert get_track(db, signature=sig).bpm == 66.0
+
+
+def test_miss_path_stores_canonical_bpm_not_event_corrected(
+    db: Session, bp_user: User, monkeypatch
+):
+    """REGRESSION (Codex #550 P2): on the miss path the global store keeps the
+    CANONICAL provider BPM, never the event-context-corrected value. The Request
+    gets the corrected value (for this event); the tracks row keeps the provider
+    value so OTHER events re-derive their own per-event correction from it."""
+    from app.schemas.beatport import BeatportSearchResult
+
+    event = _make_event(db, bp_user, "CANBPM", "CANBPW")
+    # >=3 ACCEPTED tracks at ~130 BPM → a provider 66 BPM double-corrects to 132.
+    _make_request(db, event, "C1", "A1", "cbpm1", bpm=130.0)
+    _make_request(db, event, "C2", "A2", "cbpm2", bpm=130.0)
+    _make_request(db, event, "C3", "A3", "cbpm3", bpm=130.0)
+    request = _make_request(db, event, "Strobe", "deadmau5", "canbpm_req")  # incomplete
+
+    hit = BeatportSearchResult(
+        track_id="9",
+        title="Strobe",
+        artist="deadmau5",
+        genre="Progressive House",
+        bpm=66,
+        key="F Minor",
+    )
+    monkeypatch.setattr("app.services.beatport.search_beatport_tracks", _Spy([hit]))
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+
+    enrich_request_metadata(db, request.id)
+
+    db.refresh(request)
+    assert request.bpm == 132.0  # event-corrected on the Request
+    track = get_track(db, signature=dedupe_signature("deadmau5", "Strobe"))
+    assert track is not None
+    assert track.bpm == 66.0  # CANONICAL provider value in the store, NOT 132
+    assert track.provenance["bpm"]["source"] == "beatport"

--- a/server/tests/test_enrichment_store_writes.py
+++ b/server/tests/test_enrichment_store_writes.py
@@ -68,6 +68,7 @@ def _make_request(
     genre: str | None = None,
     bpm: float | None = None,
     musical_key: str | None = None,
+    isrc: str | None = None,
 ) -> Request:
     request = Request(
         event_id=event.id,
@@ -79,6 +80,7 @@ def _make_request(
         genre=genre,
         bpm=bpm,
         musical_key=musical_key,
+        isrc=isrc,
     )
     db.add(request)
     db.commit()
@@ -910,3 +912,94 @@ def test_presupplied_bpm_seeded_canonical_not_event_corrected(
     assert track is not None
     assert track.bpm == 66.0  # canonical pre-supplied value seeded, NOT 132
     assert track.provenance["bpm"]["source"] == "legacy"
+
+
+def test_isrc_first_cache_hit_across_variant_signature(db: Session, bp_user: User, monkeypatch):
+    """ISRC-FIRST cache (#552): an incomplete request whose ISRC matches a trusted
+    store row reuses it even when the normalized signature DIFFERS (credit variant)
+    — zero provider calls, no re-derivation."""
+    from app.models.track import Track
+
+    db.add(
+        Track(
+            signature="unrelated-credit-variant-sig",
+            isrc="USXYZ1234567",
+            title="Strobe",
+            artist="deadmau5 & Friend",
+            genre="Progressive House",
+            bpm=128.0,
+            musical_key="4A",
+            provenance={
+                f: {"source": "beatport", "fetched_at": "2026-06-24T00:00:00"}
+                for f in ("genre", "bpm", "musical_key")
+            },
+        )
+    )
+    db.commit()
+
+    event = _make_event(db, bp_user, "ISRCFC", "ISRCFW")
+    # Normalizes to a DIFFERENT signature, but carries the same ISRC.
+    request = _make_request(db, event, "Strobe", "deadmau5", "isrc_fc", isrc="USXYZ1234567")
+    assert dedupe_signature("deadmau5", "Strobe") != "unrelated-credit-variant-sig"
+
+    beatport_spy = _Spy([_beatport_hit("Strobe", "deadmau5")])
+    monkeypatch.setattr("app.services.beatport.search_beatport_tracks", beatport_spy)
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+
+    enrich_request_metadata(db, request.id)
+
+    assert beatport_spy.calls == 0  # ISRC-keyed cache hit → no provider re-derivation
+    db.refresh(request)
+    assert request.genre == "Progressive House"
+    assert request.bpm == 128.0
+    assert request.musical_key == "4A"
+
+
+def test_complete_submission_with_isrc_collapses_no_duplicate(
+    db: Session, bp_user: User, monkeypatch
+):
+    """ISRC-first seed (#552): a COMPLETE submission carrying an ISRC collapses onto
+    the existing ISRC row even under a different signature — no duplicate row (the
+    edge Codex flagged)."""
+    from app.models.track import Track
+
+    db.add(
+        Track(
+            signature="existing-sig-for-isrc",
+            isrc="USABC7654321",
+            title="Strobe",
+            artist="deadmau5",
+            genre="Trance",
+            bpm=130.0,
+            musical_key="8A",
+            provenance={
+                f: {"source": "beatport", "fetched_at": "2026-06-24T00:00:00"}
+                for f in ("genre", "bpm", "musical_key")
+            },
+        )
+    )
+    db.commit()
+
+    event = _make_event(db, bp_user, "ISRCDUP", "ISRCDW")
+    # Complete submission, credit-variant signature, SAME ISRC.
+    request = _make_request(
+        db,
+        event,
+        "Strobe",
+        "deadmau5 & Guest",
+        "isrc_dup",
+        genre="Techno",
+        bpm=132.0,
+        musical_key="9A",
+        isrc="USABC7654321",
+    )
+    monkeypatch.setattr("app.services.beatport.search_beatport_tracks", _Spy([]))
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+
+    enrich_request_metadata(db, request.id)
+
+    rows = db.query(Track).filter(Track.isrc == "USABC7654321").all()
+    assert len(rows) == 1, "complete submission with ISRC must collapse onto the existing row"
+    assert rows[0].signature == "existing-sig-for-isrc"  # no second signature-only row

--- a/server/tests/test_enrichment_store_writes.py
+++ b/server/tests/test_enrichment_store_writes.py
@@ -946,6 +946,11 @@ def test_isrc_first_cache_hit_across_variant_signature(db: Session, bp_user: Use
     monkeypatch.setattr("app.services.beatport.search_beatport_tracks", beatport_spy)
     monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
     monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+    # Pin the Soundcharts gate OFF so the cache-hit energy-backfill arm can't make
+    # a real API call if the env happens to enable it (config-coupled flakiness).
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline.get_settings", lambda: _settings_stub(enabled=False)
+    )
 
     enrich_request_metadata(db, request.id)
 
@@ -997,9 +1002,94 @@ def test_complete_submission_with_isrc_collapses_no_duplicate(
     monkeypatch.setattr("app.services.beatport.search_beatport_tracks", _Spy([]))
     monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
     monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+    # Pin the Soundcharts gate OFF so the seeded-row energy-backfill arm can't make
+    # a real API call if the env happens to enable it (config-coupled flakiness).
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline.get_settings", lambda: _settings_stub(enabled=False)
+    )
 
     enrich_request_metadata(db, request.id)
 
     rows = db.query(Track).filter(Track.isrc == "USABC7654321").all()
     assert len(rows) == 1, "complete submission with ISRC must collapse onto the existing row"
     assert rows[0].signature == "existing-sig-for-isrc"  # no second signature-only row
+
+
+def test_signature_fallback_not_trusted_for_different_isrc(db: Session, bp_user: User, monkeypatch):
+    """REGRESSION (Codex #550): a request carrying ISRC_A must NOT short-circuit on a
+    signature-matched row whose ISRC differs (a different release of the same
+    artist/title). The fast path would otherwise serve the wrong recording's data
+    and skip providers — so providers must run instead."""
+    from app.models.track import Track
+
+    sig = dedupe_signature("deadmau5", "Strobe")
+    db.add(
+        Track(
+            signature=sig,
+            isrc="USREL0000001",  # a DIFFERENT recording's ISRC
+            title="Strobe",
+            artist="deadmau5",
+            genre="Trance",
+            bpm=130.0,
+            musical_key="8A",
+            provenance={
+                f: {"source": "beatport", "fetched_at": "2026-06-24T00:00:00"}
+                for f in ("genre", "bpm", "musical_key")
+            },
+        )
+    )
+    db.commit()
+
+    event = _make_event(db, bp_user, "ISRCDIF", "ISRCDF")
+    request = _make_request(db, event, "Strobe", "deadmau5", "isrc_diff", isrc="USREL0000002")
+    beatport_spy = _Spy([_beatport_hit("Strobe", "deadmau5")])
+    monkeypatch.setattr("app.services.beatport.search_beatport_tracks", beatport_spy)
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline.get_settings", lambda: _settings_stub(enabled=False)
+    )
+
+    enrich_request_metadata(db, request.id)
+
+    assert beatport_spy.calls == 1  # different-ISRC row not trusted → providers ran
+
+
+def test_isrc_backfilled_onto_isrc_less_cache_hit(db: Session, bp_user: User, monkeypatch):
+    """A trusted ISRC-less cached row is still used on the fast path, and the
+    request's ISRC is backfilled onto it so future lookups are ISRC-keyed (#552)."""
+    from app.models.track import Track
+
+    sig = dedupe_signature("deadmau5", "Strobe")
+    db.add(
+        Track(
+            signature=sig,
+            isrc=None,  # no ISRC yet
+            title="Strobe",
+            artist="deadmau5",
+            genre="Trance",
+            bpm=130.0,
+            musical_key="8A",
+            provenance={
+                f: {"source": "beatport", "fetched_at": "2026-06-24T00:00:00"}
+                for f in ("genre", "bpm", "musical_key")
+            },
+        )
+    )
+    db.commit()
+
+    event = _make_event(db, bp_user, "ISRCBF", "ISRCBW")
+    request = _make_request(db, event, "Strobe", "deadmau5", "isrc_bf", isrc="USNEW0000001")
+    beatport_spy = _Spy([_beatport_hit("Strobe", "deadmau5")])
+    monkeypatch.setattr("app.services.beatport.search_beatport_tracks", beatport_spy)
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline.get_settings", lambda: _settings_stub(enabled=False)
+    )
+
+    enrich_request_metadata(db, request.id)
+
+    assert beatport_spy.calls == 0  # ISRC-less trusted row → short-circuit, no providers
+    track = get_track(db, signature=sig)
+    assert track.isrc == "USNEW0000001"  # request's ISRC backfilled onto the row

--- a/server/tests/test_enrichment_store_writes.py
+++ b/server/tests/test_enrichment_store_writes.py
@@ -645,3 +645,152 @@ def test_spotify_isrc_captured_without_tidal_token_for_soundcharts(
     assert track is not None
     assert track.energy == 6
     assert track.isrc == "USABC1234567"
+
+
+def test_complete_request_backfills_energy_when_gate_on(db: Session, bp_user: User, monkeypatch):
+    """REGRESSION (Codex #550 P2): the complete-request seed path must not bypass the
+    Soundcharts energy backfill — when the gate is on and the seeded row lacks
+    energy, audio features must still be fetched (without the core cascade)."""
+    from app.services.soundcharts import SoundchartsAudioFeatures
+
+    event = _make_event(db, bp_user, "CMPENG", "CMPENW")
+    request = _make_request(
+        db,
+        event,
+        "Strobe",
+        "deadmau5",
+        "complete_energy",
+        genre="Techno",
+        bpm=130.0,
+        musical_key="8A",
+    )
+    request.source_url = "https://open.spotify.com/track/abc123"
+    db.commit()
+
+    beatport_spy = _Spy([])
+    monkeypatch.setattr("app.services.beatport.search_beatport_tracks", beatport_spy)
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline._get_isrc_from_spotify", lambda url: "USABC1234567"
+    )
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline.get_settings", lambda: _settings_stub(enabled=True)
+    )
+    feats = SoundchartsAudioFeatures(
+        isrc="USABC1234567",
+        soundcharts_uuid="u-ce",
+        energy=9,
+        danceability=0.5,
+        valence=0.5,
+        acousticness=0.1,
+        instrumentalness=0.0,
+        speechiness=0.05,
+        liveness=0.2,
+        loudness_db=-5.0,
+        tempo_bpm=130.0,
+        key=5,
+        mode=0,
+        time_signature=4,
+        explicit=False,
+        duration_sec=300,
+        genres=(),
+    )
+    feature_spy = _Spy(feats)
+    monkeypatch.setattr("app.services.soundcharts.get_song_features_by_isrc", feature_spy)
+
+    enrich_request_metadata(db, request.id)
+
+    assert feature_spy.calls == 1  # energy backfilled on the complete path
+    assert beatport_spy.calls == 0  # core cascade still skipped
+    track = get_track(db, signature=dedupe_signature("deadmau5", "Strobe"))
+    assert track is not None
+    assert track.energy == 9
+    assert track.provenance["energy"]["source"] == "soundcharts"
+
+
+def test_no_spotify_isrc_fetch_when_no_consumer(db: Session, bp_user: User, monkeypatch):
+    """REGRESSION (Codex #550 P2): for a Spotify request with NO Tidal token and the
+    Soundcharts gate OFF, nothing consumes an ISRC — so the external Spotify lookup
+    must be skipped entirely."""
+    bp_user.tidal_access_token = None
+    db.commit()
+
+    event = _make_event(db, bp_user, "NOCONS", "NOCONW")
+    request = _make_request(db, event, "Strobe", "deadmau5", "no_consumer")
+    request.source_url = "https://open.spotify.com/track/abc123"
+    db.commit()
+
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr(
+        "app.services.beatport.search_beatport_tracks", _Spy([_beatport_hit("Strobe", "deadmau5")])
+    )
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+    isrc_spy = _Spy("USABC1234567")
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline._get_isrc_from_spotify", isrc_spy)
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline.get_settings", lambda: _settings_stub(enabled=False)
+    )
+
+    enrich_request_metadata(db, request.id)
+
+    assert isrc_spy.calls == 0  # no Tidal token + gate off → ISRC has no consumer
+
+
+def test_complete_request_seed_normalizes_key(db: Session, bp_user: User, monkeypatch):
+    """REGRESSION (CodeRabbit #550): a complete request's key is normalized to Camelot
+    before seeding, so the store matches what the cascade would have written."""
+    event = _make_event(db, bp_user, "SEEDNK", "SEEDNW")
+    request = _make_request(
+        db,
+        event,
+        "Strobe",
+        "deadmau5",
+        "seed_norm_key",
+        genre="Techno",
+        bpm=130.0,
+        musical_key="F Minor",
+    )
+    monkeypatch.setattr("app.services.beatport.search_beatport_tracks", _Spy([]))
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+
+    enrich_request_metadata(db, request.id)
+
+    track = get_track(db, signature=dedupe_signature("deadmau5", "Strobe"))
+    assert track is not None
+    assert track.musical_key == "4A"  # "F Minor" normalized to Camelot on seed
+
+
+def test_unprovenanced_complete_row_is_not_authoritative(db: Session, bp_user: User, monkeypatch):
+    """REGRESSION (CodeRabbit #550): a complete row with MISSING provenance must not be
+    treated as an authoritative cache hit — real providers must still run to upgrade it."""
+    from app.models.track import Track
+
+    title, artist = "Strobe", "deadmau5"
+    sig = dedupe_signature(artist, title)
+    db.add(
+        Track(
+            signature=sig,
+            title=title,
+            artist=artist,
+            genre="Old",
+            bpm=100.0,
+            musical_key="1A",
+            provenance={},
+        )
+    )
+    db.commit()
+
+    event = _make_event(db, bp_user, "UNPROV", "UNPRVW")
+    request = _make_request(db, event, title, artist, "unprov_req")
+    beatport_spy = _Spy([_beatport_hit(title, artist)])
+    monkeypatch.setattr("app.services.beatport.search_beatport_tracks", beatport_spy)
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+
+    enrich_request_metadata(db, request.id)
+
+    assert beatport_spy.calls == 1  # missing provenance → not trusted → providers ran
+    track = get_track(db, signature=sig)
+    assert track.provenance["genre"]["source"] == "beatport"  # upgraded from unprovenanced

--- a/server/tests/test_enrichment_store_writes.py
+++ b/server/tests/test_enrichment_store_writes.py
@@ -58,7 +58,17 @@ def _make_event(db: Session, owner: User, code: str, join_code: str) -> Event:
     return event
 
 
-def _make_request(db: Session, event: Event, title: str, artist: str, dedupe: str) -> Request:
+def _make_request(
+    db: Session,
+    event: Event,
+    title: str,
+    artist: str,
+    dedupe: str,
+    *,
+    genre: str | None = None,
+    bpm: float | None = None,
+    musical_key: str | None = None,
+) -> Request:
     request = Request(
         event_id=event.id,
         song_title=title,
@@ -66,6 +76,9 @@ def _make_request(db: Session, event: Event, title: str, artist: str, dedupe: st
         source="spotify",
         status=RequestStatus.ACCEPTED.value,
         dedupe_key=dedupe,
+        genre=genre,
+        bpm=bpm,
+        musical_key=musical_key,
     )
     db.add(request)
     db.commit()
@@ -303,3 +316,191 @@ def test_energy_gate_on_writes_energy_with_provenance(db: Session, bp_user: User
     # ISRC + uuid captured into identity.
     assert track.isrc == "USABC1234567"
     assert track.soundcharts_uuid == "uuid-1234"
+
+
+def test_presupplied_field_yields_complete_store_row_and_reuse(
+    db: Session, bp_user: User, monkeypatch
+):
+    """REGRESSION (review #541): a request arriving WITH genre pre-set + a Beatport
+    hit supplying bpm/key must write a fully complete store row (genre/bpm/key all
+    set), so a second same-song request short-circuits with ZERO provider calls.
+
+    Before the fix, `_apply_enrichment_result` only recorded a field into the store
+    payload when the Request was MISSING it, so a pre-supplied genre never reached
+    the store — the row stayed genre-less, failing the cache-aside gate forever and
+    re-hitting every provider on each repeat.
+    """
+    event_a = _make_event(db, bp_user, "PRESPA", "PRSPAA")
+    event_b = _make_event(db, bp_user, "PRESPB", "PRSPBB")
+
+    title, artist = "Strobe", "deadmau5"
+    # Request A arrives WITH genre pre-populated (from frontend search metadata).
+    request_a = _make_request(db, event_a, title, artist, "presupplied_a", genre="Techno")
+
+    genre_spy = _Spy(None)  # MusicBrainz not even consulted (genre present)
+    beatport_spy = _Spy([_beatport_hit(title, artist)])  # supplies bpm + key
+    tidal_spy = _Spy([])
+
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", genre_spy)
+    monkeypatch.setattr("app.services.beatport.search_beatport_tracks", beatport_spy)
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", tidal_spy)
+
+    enrich_request_metadata(db, request_a.id)
+
+    # Store row is COMPLETE on the trio — the pre-supplied genre was persisted too.
+    sig = dedupe_signature(artist, title)
+    track = get_track(db, signature=sig)
+    assert track is not None
+    assert track.genre == "Techno"
+    assert track.bpm == 128.0
+    assert track.musical_key == "4A"
+    # Pre-supplied genre carries the lowest 'legacy' provenance (no original source);
+    # bpm/key carry their real provider source.
+    assert track.provenance["genre"]["source"] == "legacy"
+    assert track.provenance["bpm"]["source"] == "beatport"
+
+    # Second same-song request must short-circuit — ZERO new provider calls.
+    beatport_calls_before = beatport_spy.calls
+    genre_calls_before = genre_spy.calls
+    tidal_calls_before = tidal_spy.calls
+
+    request_b = _make_request(db, event_b, title, artist, "presupplied_b")
+    enrich_request_metadata(db, request_b.id)
+
+    assert beatport_spy.calls == beatport_calls_before
+    assert genre_spy.calls == genre_calls_before
+    assert tidal_spy.calls == tidal_calls_before
+
+    db.refresh(request_b)
+    assert request_b.genre == "Techno"
+    assert request_b.bpm == 128.0
+    assert request_b.musical_key == "4A"
+
+
+def test_energy_backfills_onto_complete_cached_row_on_repeat(
+    db: Session, bp_user: User, monkeypatch
+):
+    """REGRESSION (review #541): a trio-complete cached row that lacks energy must
+    backfill energy from Soundcharts on a repeat request when the gate is on —
+    WITHOUT re-running the core Beatport/Tidal/MusicBrainz cascade.
+
+    Before the fix the cache-aside short-circuit returned unconditionally on a
+    complete-trio row, so its `cached.energy is None` Soundcharts arm was dead and
+    energy could never backfill (contradicting spec §2/§4/§5.4/§7).
+    """
+    from app.services.soundcharts import SoundchartsAudioFeatures
+
+    event_a = _make_event(db, bp_user, "ENGBKA", "ENGBKW")
+    event_b = _make_event(db, bp_user, "ENGBKB", "ENGBKX")
+    title, artist = "Strobe", "deadmau5"
+
+    # First request enriches the trio with the gate OFF → row complete, energy None.
+    request_a = _make_request(db, event_a, title, artist, "energy_backfill_a")
+    request_a.source_url = "https://open.spotify.com/track/abc123"
+    db.commit()
+
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr(
+        "app.services.beatport.search_beatport_tracks",
+        _Spy([_beatport_hit(title, artist)]),
+    )
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline._get_isrc_from_spotify",
+        lambda url: "USABC1234567",
+    )
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline.get_settings",
+        lambda: _settings_stub(enabled=False),
+    )
+
+    enrich_request_metadata(db, request_a.id)
+
+    sig = dedupe_signature(artist, title)
+    track = get_track(db, signature=sig)
+    assert track is not None
+    assert track.genre and track.bpm and track.musical_key  # complete trio
+    assert track.energy is None  # dark gate → no energy yet
+
+    # Second same-song request with the gate ON → backfill ONLY energy, no cascade.
+    beatport_spy = _Spy([_beatport_hit(title, artist)])
+    tidal_spy = _Spy([])
+    genre_spy = _Spy(None)
+    monkeypatch.setattr("app.services.beatport.search_beatport_tracks", beatport_spy)
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", tidal_spy)
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", genre_spy)
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline.get_settings",
+        lambda: _settings_stub(enabled=True),
+    )
+
+    feats = SoundchartsAudioFeatures(
+        isrc="USABC1234567",
+        soundcharts_uuid="uuid-9999",
+        energy=7,
+        danceability=0.6,
+        valence=0.5,
+        acousticness=0.1,
+        instrumentalness=0.0,
+        speechiness=0.05,
+        liveness=0.2,
+        loudness_db=-6.0,
+        tempo_bpm=128.0,
+        key=5,
+        mode=0,
+        time_signature=4,
+        explicit=False,
+        duration_sec=300,
+        genres=("progressive house",),
+    )
+    feature_spy = _Spy(feats)
+    monkeypatch.setattr("app.services.soundcharts.get_song_features_by_isrc", feature_spy)
+
+    request_b = _make_request(db, event_b, title, artist, "energy_backfill_b")
+    request_b.source_url = "https://open.spotify.com/track/abc123"
+    db.commit()
+    enrich_request_metadata(db, request_b.id)
+
+    # Soundcharts WAS called; core cascade was NOT (dedupe win preserved).
+    assert feature_spy.calls == 1
+    assert beatport_spy.calls == 0
+    assert tidal_spy.calls == 0
+    assert genre_spy.calls == 0
+
+    db.refresh(track)
+    assert track.energy == 7
+    assert track.provenance["energy"]["source"] == "soundcharts"
+    assert track.soundcharts_uuid == "uuid-9999"
+
+
+def test_store_upsert_failure_preserves_request_enrichment(db: Session, bp_user: User, monkeypatch):
+    """REGRESSION (review #541): a DB-level upsert_track failure must NOT discard the
+    Request's freshly enriched bpm/genre/key.
+
+    Before the fix, a flush-time error left the session in PendingRollback and the
+    trailing unconditional db.commit() raised PendingRollbackError, losing the
+    Request enrichment. The fix commits the Request enrichment first, then runs the
+    store write under its own commit/rollback recovery.
+    """
+    event = _make_event(db, bp_user, "STFAIL", "STFALW")
+    request = _make_request(db, event, "Strobe", "deadmau5", "store_fail")
+
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr(
+        "app.services.beatport.search_beatport_tracks",
+        _Spy([_beatport_hit("Strobe", "deadmau5")]),
+    )
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated store flush failure")
+
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.upsert_track", _boom)
+
+    # Must not raise despite the store write blowing up.
+    enrich_request_metadata(db, request.id)
+
+    db.refresh(request)
+    # The Request's own enrichment survived the poisoned store write.
+    assert request.bpm == 128.0
+    assert request.musical_key == "4A"

--- a/server/tests/test_enrichment_store_writes.py
+++ b/server/tests/test_enrichment_store_writes.py
@@ -1,0 +1,305 @@
+"""Cache-aside dual-write of enrichment into the master tracks store (#541).
+
+`enrich_request_metadata` must:
+  * write the global `tracks` row once per unique recording (provenance-tagged),
+  * reuse a complete store row with ZERO provider calls on the next request of
+    the same song (the dedupe win),
+  * still dual-write genre/bpm/musical_key onto the Request (current UI),
+  * call Soundcharts for audio features only behind the dark gate + an ISRC.
+
+Monkeypatch note: provider clients are LOCAL-imported inside
+`enrich_request_metadata`, so they are patched on their SOURCE module
+(`app.services.beatport`, `app.services.soundcharts`). `lookup_artist_genre`
+is top-imported into the pipeline, so it is patched on the pipeline module.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.event import Event
+from app.models.request import Request, RequestStatus
+from app.models.user import User
+from app.services.setbuilder.pool import dedupe_signature
+from app.services.sync.enrichment_pipeline import enrich_request_metadata
+from app.services.tracks.store import get_track
+
+
+@pytest.fixture
+def bp_user(db: Session) -> User:
+    """A DJ user with a Beatport token (so the Beatport block is entered)."""
+    from app.services.auth import get_password_hash
+
+    user = User(
+        username="enrich_store_user",
+        password_hash=get_password_hash("testpassword123"),
+        beatport_access_token="fake_bp_token",
+        tidal_access_token="fake_tidal_token",
+        tidal_token_expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _make_event(db: Session, owner: User, code: str, join_code: str) -> Event:
+    event = Event(
+        code=code,
+        join_code=join_code,
+        name=f"Event {code}",
+        created_by_user_id=owner.id,
+        expires_at=datetime.now(UTC) + timedelta(hours=6),
+    )
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+    return event
+
+
+def _make_request(db: Session, event: Event, title: str, artist: str, dedupe: str) -> Request:
+    request = Request(
+        event_id=event.id,
+        song_title=title,
+        artist=artist,
+        source="spotify",
+        status=RequestStatus.ACCEPTED.value,
+        dedupe_key=dedupe,
+    )
+    db.add(request)
+    db.commit()
+    db.refresh(request)
+    return request
+
+
+def _beatport_hit(title: str, artist: str):
+    from app.schemas.beatport import BeatportSearchResult
+
+    return BeatportSearchResult(
+        track_id="123",
+        title=title,
+        artist=artist,
+        genre="Progressive House",
+        bpm=128,
+        key="F Minor",
+    )
+
+
+def _settings_stub(*, enabled: bool):
+    """Minimal settings stand-in carrying only the audio-features gate."""
+    from unittest.mock import MagicMock
+
+    return MagicMock(soundcharts_audio_features_enabled=enabled)
+
+
+class _Spy:
+    """Callable returning a fixed value, counting invocations."""
+
+    def __init__(self, return_value):
+        self.return_value = return_value
+        self.calls = 0
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+        return self.return_value
+
+
+def test_enrich_once_reuse_everywhere(db: Session, bp_user: User, monkeypatch):
+    """HEADLINE REGRESSION: enrich song X at event A, then reuse at event B.
+
+    The second enrichment must hit the store (zero provider calls) and still
+    populate Request B's genre/bpm/musical_key from the cached row.
+    """
+    event_a = _make_event(db, bp_user, "STOREA", "STRAAA")
+    event_b = _make_event(db, bp_user, "STOREB", "STRBBB")
+
+    title, artist = "Strobe", "deadmau5"
+    request_a = _make_request(db, event_a, title, artist, "store_dedupe_a")
+
+    genre_spy = _Spy(None)  # MusicBrainz misses; Beatport backfills genre
+    beatport_spy = _Spy([_beatport_hit(title, artist)])
+    tidal_spy = _Spy([])
+
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", genre_spy)
+    monkeypatch.setattr("app.services.beatport.search_beatport_tracks", beatport_spy)
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", tidal_spy)
+
+    enrich_request_metadata(db, request_a.id)
+
+    # Store row written for the recording, fully populated + provenance-tagged.
+    sig = dedupe_signature(artist, title)
+    track = get_track(db, signature=sig)
+    assert track is not None
+    assert track.genre == "Progressive House"
+    assert track.bpm == 128.0
+    assert track.musical_key == "4A"  # F Minor -> 4A Camelot
+    assert track.provenance["genre"]["source"] == "beatport"
+    assert track.provenance["bpm"]["source"] == "beatport"
+
+    db.refresh(request_a)
+    assert request_a.genre == "Progressive House"
+    assert request_a.bpm == 128.0
+    assert request_a.musical_key == "4A"
+
+    # Second event requests the SAME song — reset provider counters.
+    beatport_calls_before = beatport_spy.calls
+    genre_calls_before = genre_spy.calls
+    tidal_calls_before = tidal_spy.calls
+
+    request_b = _make_request(db, event_b, title, artist, "store_dedupe_b")
+    enrich_request_metadata(db, request_b.id)
+
+    # ZERO new provider calls — the dedupe win.
+    assert beatport_spy.calls == beatport_calls_before
+    assert genre_spy.calls == genre_calls_before
+    assert tidal_spy.calls == tidal_calls_before
+
+    # Request B populated entirely from the store.
+    db.refresh(request_b)
+    assert request_b.genre == "Progressive House"
+    assert request_b.bpm == 128.0
+    assert request_b.musical_key == "4A"
+
+
+def test_provenance_recorded_per_field(db: Session, bp_user: User, monkeypatch):
+    """Each field is recorded with the source that resolved it."""
+    event = _make_event(db, bp_user, "PROVEN", "PRVNNN")
+    request = _make_request(db, event, "Strobe", "deadmau5", "prov_dedupe")
+
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline.lookup_artist_genre",
+        _Spy("electronic"),  # MusicBrainz provides genre
+    )
+    monkeypatch.setattr(
+        "app.services.beatport.search_beatport_tracks",
+        _Spy([_beatport_hit("Strobe", "deadmau5")]),  # Beatport provides bpm/key
+    )
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+
+    enrich_request_metadata(db, request.id)
+
+    sig = dedupe_signature("deadmau5", "Strobe")
+    track = get_track(db, signature=sig)
+    assert track is not None
+    assert track.genre == "electronic"
+    assert track.provenance["genre"]["source"] == "musicbrainz"
+    assert track.provenance["bpm"]["source"] == "beatport"
+    assert track.provenance["musical_key"]["source"] == "beatport"
+
+
+def test_dual_write_preserved_on_miss(db: Session, bp_user: User, monkeypatch):
+    """On the miss path the Request columns are still populated (current UI)."""
+    event = _make_event(db, bp_user, "DUALWR", "DUALWW")
+    request = _make_request(db, event, "Strobe", "deadmau5", "dual_dedupe")
+
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr(
+        "app.services.beatport.search_beatport_tracks",
+        _Spy([_beatport_hit("Strobe", "deadmau5")]),
+    )
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+
+    enrich_request_metadata(db, request.id)
+
+    db.refresh(request)
+    assert request.genre == "Progressive House"
+    assert request.bpm == 128.0
+    assert request.musical_key == "4A"
+
+
+def test_energy_gate_off_does_not_call_soundcharts(db: Session, bp_user: User, monkeypatch):
+    """Default (gate off): Soundcharts feature fn is never called; energy stays None."""
+    event = _make_event(db, bp_user, "ENGOFF", "ENGOFW")
+    # Spotify source_url so an ISRC is discoverable.
+    request = _make_request(db, event, "Strobe", "deadmau5", "energy_off")
+    request.source_url = "https://open.spotify.com/track/abc123"
+    db.commit()
+
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr(
+        "app.services.beatport.search_beatport_tracks",
+        _Spy([_beatport_hit("Strobe", "deadmau5")]),
+    )
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline._get_isrc_from_spotify",
+        lambda url: "USABC1234567",
+    )
+
+    feature_spy = _Spy(None)
+    monkeypatch.setattr("app.services.soundcharts.get_song_features_by_isrc", feature_spy)
+    # Ensure the gate is off (default) for the pipeline's pre-call check.
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline.get_settings",
+        lambda: _settings_stub(enabled=False),
+    )
+
+    enrich_request_metadata(db, request.id)
+
+    assert feature_spy.calls == 0
+    sig = dedupe_signature("deadmau5", "Strobe")
+    track = get_track(db, signature=sig)
+    assert track is not None
+    assert track.energy is None
+
+
+def test_energy_gate_on_writes_energy_with_provenance(db: Session, bp_user: User, monkeypatch):
+    """Gate on + ISRC: Soundcharts adapter is called; energy written as 'soundcharts'."""
+    from app.services.soundcharts import SoundchartsAudioFeatures
+
+    event = _make_event(db, bp_user, "ENGON1", "ENGONW")
+    request = _make_request(db, event, "Strobe", "deadmau5", "energy_on")
+    request.source_url = "https://open.spotify.com/track/abc123"
+    db.commit()
+
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr(
+        "app.services.beatport.search_beatport_tracks",
+        _Spy([_beatport_hit("Strobe", "deadmau5")]),
+    )
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline._get_isrc_from_spotify",
+        lambda url: "USABC1234567",
+    )
+
+    feats = SoundchartsAudioFeatures(
+        isrc="USABC1234567",
+        soundcharts_uuid="uuid-1234",
+        energy=8,
+        danceability=0.7,
+        valence=0.6,
+        acousticness=0.1,
+        instrumentalness=0.0,
+        speechiness=0.05,
+        liveness=0.2,
+        loudness_db=-5.0,
+        tempo_bpm=128.0,
+        key=5,
+        mode=0,
+        time_signature=4,
+        explicit=False,
+        duration_sec=320,
+        genres=("progressive house",),
+    )
+    feature_spy = _Spy(feats)
+    monkeypatch.setattr("app.services.soundcharts.get_song_features_by_isrc", feature_spy)
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline.get_settings",
+        lambda: _settings_stub(enabled=True),
+    )
+
+    enrich_request_metadata(db, request.id)
+
+    assert feature_spy.calls == 1
+    sig = dedupe_signature("deadmau5", "Strobe")
+    track = get_track(db, signature=sig)
+    assert track is not None
+    assert track.energy == 8
+    assert track.provenance["energy"]["source"] == "soundcharts"
+    # Soundcharts must NOT clobber the cascade's bpm/key/genre.
+    assert track.provenance["bpm"]["source"] == "beatport"
+    # ISRC + uuid captured into identity.
+    assert track.isrc == "USABC1234567"
+    assert track.soundcharts_uuid == "uuid-1234"

--- a/server/tests/test_enrichment_store_writes.py
+++ b/server/tests/test_enrichment_store_writes.py
@@ -794,3 +794,51 @@ def test_unprovenanced_complete_row_is_not_authoritative(db: Session, bp_user: U
     assert beatport_spy.calls == 1  # missing provenance → not trusted → providers ran
     track = get_track(db, signature=sig)
     assert track.provenance["genre"]["source"] == "beatport"  # upgraded from unprovenanced
+
+
+def test_cache_hit_applies_bpm_context_correction(db: Session, bp_user: User, monkeypatch):
+    """REGRESSION (Codex #550 P2): the cache-hit fast path must context-correct the
+    served BPM for THIS event (half/double-time), not commit the canonical store
+    value raw — matching the miss path. The store value itself stays canonical."""
+    from app.models.track import Track
+
+    title, artist = "Strobe", "deadmau5"
+    sig = dedupe_signature(artist, title)
+    prov = {
+        f: {"source": "beatport", "fetched_at": "2026-06-24T00:00:00"}
+        for f in ("genre", "bpm", "musical_key")
+    }
+    db.add(
+        Track(
+            signature=sig,
+            title=title,
+            artist=artist,
+            genre="Progressive House",
+            bpm=66.0,
+            musical_key="4A",
+            provenance=prov,
+        )
+    )
+    db.commit()
+
+    event = _make_event(db, bp_user, "BPMCTX", "BPMCTW")
+    # >=3 ACCEPTED tracks at ~130 BPM establish the event's tempo context
+    # (normalize_bpm_to_context requires at least 3 context values).
+    _make_request(db, event, "Ctx1", "A1", "ctx1", bpm=130.0)
+    _make_request(db, event, "Ctx2", "A2", "ctx2", bpm=130.0)
+    _make_request(db, event, "Ctx3", "A3", "ctx3", bpm=130.0)
+    request = _make_request(db, event, title, artist, "bpmctx_req")  # incomplete → cache hit
+
+    beatport_spy = _Spy([_beatport_hit(title, artist)])
+    monkeypatch.setattr("app.services.beatport.search_beatport_tracks", beatport_spy)
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+
+    enrich_request_metadata(db, request.id)
+
+    assert beatport_spy.calls == 0  # served from the trusted store row, no providers
+    db.refresh(request)
+    # 66 BPM doubled to match the ~130 event context (half/double-time correction).
+    assert request.bpm == 132.0
+    # The canonical store value is unchanged — correction is per-event, request-only.
+    assert get_track(db, signature=sig).bpm == 66.0

--- a/server/tests/test_enrichment_store_writes.py
+++ b/server/tests/test_enrichment_store_writes.py
@@ -880,3 +880,33 @@ def test_miss_path_stores_canonical_bpm_not_event_corrected(
     assert track is not None
     assert track.bpm == 66.0  # CANONICAL provider value in the store, NOT 132
     assert track.provenance["bpm"]["source"] == "beatport"
+
+
+def test_presupplied_bpm_seeded_canonical_not_event_corrected(
+    db: Session, bp_user: User, monkeypatch
+):
+    """REGRESSION (Codex #550 P2): a PRE-SUPPLIED bpm seeded as `legacy` must be the
+    CANONICAL value, not the event-corrected one — the store-canonical rule has to
+    hold on the legacy-seed path too, not only the provider-resolved path."""
+    event = _make_event(db, bp_user, "PSBPM", "PSBPMW")
+    _make_request(db, event, "C1", "A1", "psb1", bpm=130.0)
+    _make_request(db, event, "C2", "A2", "psb2", bpm=130.0)
+    _make_request(db, event, "C3", "A3", "psb3", bpm=130.0)
+    # Arrives WITH bpm=66 pre-supplied, missing genre/key → bpm is seeded `legacy`.
+    request = _make_request(db, event, "Strobe", "deadmau5", "psbpm_req", bpm=66.0)
+
+    # Beatport supplies genre/key; its bpm is ignored (request already has one).
+    monkeypatch.setattr(
+        "app.services.beatport.search_beatport_tracks", _Spy([_beatport_hit("Strobe", "deadmau5")])
+    )
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+
+    enrich_request_metadata(db, request.id)
+
+    db.refresh(request)
+    assert request.bpm == 132.0  # event-corrected on the Request (66 doubled)
+    track = get_track(db, signature=dedupe_signature("deadmau5", "Strobe"))
+    assert track is not None
+    assert track.bpm == 66.0  # canonical pre-supplied value seeded, NOT 132
+    assert track.provenance["bpm"]["source"] == "legacy"

--- a/server/tests/test_enrichment_store_writes.py
+++ b/server/tests/test_enrichment_store_writes.py
@@ -318,34 +318,30 @@ def test_energy_gate_on_writes_energy_with_provenance(db: Session, bp_user: User
     assert track.soundcharts_uuid == "uuid-1234"
 
 
-def test_presupplied_field_yields_complete_store_row_and_reuse(
-    db: Session, bp_user: User, monkeypatch
-):
+def test_presupplied_field_reaches_complete_store_row(db: Session, bp_user: User, monkeypatch):
     """REGRESSION (review #541): a request arriving WITH genre pre-set + a Beatport
     hit supplying bpm/key must write a fully complete store row (genre/bpm/key all
-    set), so a second same-song request short-circuits with ZERO provider calls.
+    set), with the pre-supplied genre persisted at `legacy` provenance.
 
     Before the fix, `_apply_enrichment_result` only recorded a field into the store
     payload when the Request was MISSING it, so a pre-supplied genre never reached
-    the store — the row stayed genre-less, failing the cache-aside gate forever and
-    re-hitting every provider on each repeat.
+    the store — the row stayed genre-less and could never satisfy the cache-aside
+    gate. (The legacy genre is then UPGRADED by real providers on the next
+    incomplete request — see `test_legacy_row_is_not_an_authoritative_cache_hit`.)
     """
-    event_a = _make_event(db, bp_user, "PRESPA", "PRSPAA")
-    event_b = _make_event(db, bp_user, "PRESPB", "PRSPBB")
+    event = _make_event(db, bp_user, "PRESPA", "PRSPAA")
 
     title, artist = "Strobe", "deadmau5"
-    # Request A arrives WITH genre pre-populated (from frontend search metadata).
-    request_a = _make_request(db, event_a, title, artist, "presupplied_a", genre="Techno")
+    # Request arrives WITH genre pre-populated (from frontend search metadata).
+    request = _make_request(db, event, title, artist, "presupplied_a", genre="Techno")
 
     genre_spy = _Spy(None)  # MusicBrainz not even consulted (genre present)
     beatport_spy = _Spy([_beatport_hit(title, artist)])  # supplies bpm + key
-    tidal_spy = _Spy([])
-
     monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", genre_spy)
     monkeypatch.setattr("app.services.beatport.search_beatport_tracks", beatport_spy)
-    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", tidal_spy)
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
 
-    enrich_request_metadata(db, request_a.id)
+    enrich_request_metadata(db, request.id)
 
     # Store row is COMPLETE on the trio — the pre-supplied genre was persisted too.
     sig = dedupe_signature(artist, title)
@@ -358,23 +354,6 @@ def test_presupplied_field_yields_complete_store_row_and_reuse(
     # bpm/key carry their real provider source.
     assert track.provenance["genre"]["source"] == "legacy"
     assert track.provenance["bpm"]["source"] == "beatport"
-
-    # Second same-song request must short-circuit — ZERO new provider calls.
-    beatport_calls_before = beatport_spy.calls
-    genre_calls_before = genre_spy.calls
-    tidal_calls_before = tidal_spy.calls
-
-    request_b = _make_request(db, event_b, title, artist, "presupplied_b")
-    enrich_request_metadata(db, request_b.id)
-
-    assert beatport_spy.calls == beatport_calls_before
-    assert genre_spy.calls == genre_calls_before
-    assert tidal_spy.calls == tidal_calls_before
-
-    db.refresh(request_b)
-    assert request_b.genre == "Techno"
-    assert request_b.bpm == 128.0
-    assert request_b.musical_key == "4A"
 
 
 def test_energy_backfills_onto_complete_cached_row_on_repeat(
@@ -504,3 +483,165 @@ def test_store_upsert_failure_preserves_request_enrichment(db: Session, bp_user:
     # The Request's own enrichment survived the poisoned store write.
     assert request.bpm == 128.0
     assert request.musical_key == "4A"
+
+
+def test_complete_submission_seeds_store_without_providers(db: Session, bp_user: User, monkeypatch):
+    """REGRESSION (Codex #549 P2): a request arriving with the FULL trio must still
+    seed the store (so repeats reuse it) and must NOT call any provider.
+
+    Before the fix, the early `if genre and bpm and key: return` skipped the store
+    write entirely, so search-result submissions never populated the store.
+    """
+    event = _make_event(db, bp_user, "CMPSUB", "CMPSUW")
+    request = _make_request(
+        db,
+        event,
+        "Strobe",
+        "deadmau5",
+        "complete_seed",
+        genre="Techno",
+        bpm=130.0,
+        musical_key="8A",
+    )
+
+    beatport_spy = _Spy([_beatport_hit("Strobe", "deadmau5")])
+    genre_spy = _Spy("electronic")
+    tidal_spy = _Spy([])
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", genre_spy)
+    monkeypatch.setattr("app.services.beatport.search_beatport_tracks", beatport_spy)
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", tidal_spy)
+
+    enrich_request_metadata(db, request.id)
+
+    # No provider was consulted for an already-complete request.
+    assert beatport_spy.calls == 0
+    assert genre_spy.calls == 0
+    assert tidal_spy.calls == 0
+
+    # The store was seeded with the Request's trio at `legacy` provenance.
+    sig = dedupe_signature("deadmau5", "Strobe")
+    track = get_track(db, signature=sig)
+    assert track is not None
+    assert track.genre == "Techno"
+    assert track.bpm == 130.0
+    assert track.musical_key == "8A"
+    assert track.provenance["genre"]["source"] == "legacy"
+    assert track.provenance["bpm"]["source"] == "legacy"
+
+
+def test_legacy_row_is_not_an_authoritative_cache_hit(db: Session, bp_user: User, monkeypatch):
+    """REGRESSION (Codex #549 P2): a complete-but-legacy store row must NOT short-circuit.
+
+    A request that seeded the trio as `legacy` (e.g. a search-result submission)
+    leaves a complete row whose values are low-trust. A later incomplete request for
+    the same song must fall through to real providers and UPGRADE the row, rather
+    than being served the sticky legacy values forever.
+    """
+    event_a = _make_event(db, bp_user, "LEGAUT", "LEGAUW")
+    event_b = _make_event(db, bp_user, "LEGAUB", "LEGAUX")
+    title, artist = "Strobe", "deadmau5"
+
+    # Request A arrives complete → seeds a `legacy` trio (genre "Techno").
+    request_a = _make_request(
+        db,
+        event_a,
+        title,
+        artist,
+        "legacy_seed_a",
+        genre="Techno",
+        bpm=130.0,
+        musical_key="8A",
+    )
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr("app.services.beatport.search_beatport_tracks", _Spy([]))
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+    enrich_request_metadata(db, request_a.id)
+
+    sig = dedupe_signature(artist, title)
+    track = get_track(db, signature=sig)
+    assert track is not None and track.provenance["genre"]["source"] == "legacy"
+
+    # Request B is incomplete → must NOT short-circuit on the legacy row; real
+    # providers run and upgrade the trio to a trusted source.
+    request_b = _make_request(db, event_b, title, artist, "legacy_seed_b")
+    beatport_spy = _Spy([_beatport_hit(title, artist)])  # genre "Progressive House"
+    genre_spy = _Spy(None)
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", genre_spy)
+    monkeypatch.setattr("app.services.beatport.search_beatport_tracks", beatport_spy)
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+
+    enrich_request_metadata(db, request_b.id)
+
+    # Providers WERE consulted (no short-circuit on the legacy row)…
+    assert beatport_spy.calls == 1
+    # …and the store row was upgraded to the real provider source.
+    db.refresh(track)
+    assert track.genre == "Progressive House"
+    assert track.provenance["genre"]["source"] == "beatport"
+
+
+def test_spotify_isrc_captured_without_tidal_token_for_soundcharts(
+    db: Session, bp_user: User, monkeypatch
+):
+    """REGRESSION (Codex #549 P2): the Spotify ISRC must be captured INDEPENDENTLY of
+    a Tidal token so Soundcharts (gate on) can use it.
+
+    Before the fix, `resolved_isrc` was assigned only inside the
+    `if user.tidal_access_token` branch, so a DJ without a Tidal token never fed an
+    ISRC to the Soundcharts block and energy was silently skipped.
+    """
+    from app.services.soundcharts import SoundchartsAudioFeatures
+
+    bp_user.tidal_access_token = None  # DJ has Beatport but NO Tidal
+    db.commit()
+
+    event = _make_event(db, bp_user, "NOTIDL", "NOTIDW")
+    request = _make_request(db, event, "Strobe", "deadmau5", "no_tidal_isrc")
+    request.source_url = "https://open.spotify.com/track/abc123"
+    db.commit()
+
+    monkeypatch.setattr("app.services.sync.enrichment_pipeline.lookup_artist_genre", _Spy(None))
+    monkeypatch.setattr(
+        "app.services.beatport.search_beatport_tracks",
+        _Spy([_beatport_hit("Strobe", "deadmau5")]),
+    )
+    monkeypatch.setattr("app.services.tidal.search_tidal_tracks", _Spy([]))
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline._get_isrc_from_spotify",
+        lambda url: "USABC1234567",
+    )
+    monkeypatch.setattr(
+        "app.services.sync.enrichment_pipeline.get_settings",
+        lambda: _settings_stub(enabled=True),
+    )
+    feats = SoundchartsAudioFeatures(
+        isrc="USABC1234567",
+        soundcharts_uuid="uuid-nt",
+        energy=6,
+        danceability=0.5,
+        valence=0.5,
+        acousticness=0.1,
+        instrumentalness=0.0,
+        speechiness=0.05,
+        liveness=0.2,
+        loudness_db=-7.0,
+        tempo_bpm=128.0,
+        key=5,
+        mode=0,
+        time_signature=4,
+        explicit=False,
+        duration_sec=300,
+        genres=("progressive house",),
+    )
+    feature_spy = _Spy(feats)
+    monkeypatch.setattr("app.services.soundcharts.get_song_features_by_isrc", feature_spy)
+
+    enrich_request_metadata(db, request.id)
+
+    # ISRC was captured despite the missing Tidal token → Soundcharts ran.
+    assert feature_spy.calls == 1
+    sig = dedupe_signature("deadmau5", "Strobe")
+    track = get_track(db, signature=sig)
+    assert track is not None
+    assert track.energy == 6
+    assert track.isrc == "USABC1234567"

--- a/server/tests/test_input_validation.py
+++ b/server/tests/test_input_validation.py
@@ -10,7 +10,7 @@ from app.core.validation import (
     validate_event_code,
     validate_length,
 )
-from app.schemas.collect import CollectProfileRequest
+from app.schemas.collect import CollectProfileRequest, CollectSubmitRequest
 from app.schemas.request import RequestCreate
 
 
@@ -260,3 +260,31 @@ class TestNicknameProfanityValidation:
     def test_collect_profile_allows_clean_nickname(self):
         req = CollectProfileRequest(nickname="DancingQueen")
         assert req.nickname == "DancingQueen"
+
+
+class TestIsrcValidation:
+    """Submitted ISRC is normalized + shape-validated; a malformed value is dropped
+    to None so it can't be mistaken for an authoritative identity / provider key (#552)."""
+
+    def test_hyphenated_isrc_normalized(self):
+        assert RequestCreate(artist="A", title="T", isrc="us-um7-19-00764").isrc == "USUM71900764"
+
+    def test_already_normalized_isrc_kept(self):
+        assert RequestCreate(artist="A", title="T", isrc="GBUM71029604").isrc == "GBUM71029604"
+
+    def test_malformed_isrc_dropped(self):
+        assert RequestCreate(artist="A", title="T", isrc="not-an-isrc").isrc is None
+        assert RequestCreate(artist="A", title="T", isrc="12345").isrc is None
+
+    def test_absent_isrc_is_none(self):
+        assert RequestCreate(artist="A", title="T").isrc is None
+
+    def test_collect_submit_valid_isrc_normalized(self):
+        req = CollectSubmitRequest(
+            song_title="T", artist="A", source="spotify", isrc="US-UM7-19-00764"
+        )
+        assert req.isrc == "USUM71900764"
+
+    def test_collect_submit_malformed_isrc_dropped(self):
+        req = CollectSubmitRequest(song_title="T", artist="A", source="spotify", isrc="garbage!!")
+        assert req.isrc is None

--- a/server/tests/test_track_store.py
+++ b/server/tests/test_track_store.py
@@ -490,3 +490,36 @@ def test_upsert_reraises_when_conflict_unreconcilable(db, monkeypatch):
             sources={"energy": "llm"},
             fetched_at=T0,
         )
+
+
+def test_upsert_isrc_conflict_does_not_overwrite_different_recording(db):
+    """ISRC CONFLICT (#552): when the signature matches a row whose ISRC is a
+    DIFFERENT non-null recording, upsert must NOT overwrite it with the incoming
+    recording's values. Signature is unique so the new recording can't get its own
+    row — the existing row is preserved (no corruption) rather than clobbered."""
+    upsert_track(
+        db,
+        identity=TrackIdentity(
+            title="T", artist="A", signature="sig-conflict", isrc="USAAA1111111"
+        ),
+        values={"bpm": 120.0},
+        sources={"bpm": "beatport"},
+        fetched_at=T0,
+    )
+
+    # Same signature, DIFFERENT ISRC (a different release) — must not clobber.
+    result = upsert_track(
+        db,
+        identity=TrackIdentity(
+            title="T", artist="A", signature="sig-conflict", isrc="USBBB2222222"
+        ),
+        values={"bpm": 200.0},
+        sources={"bpm": "beatport"},
+        fetched_at=T0,
+    )
+
+    rows = db.query(Track).filter(Track.signature == "sig-conflict").all()
+    assert len(rows) == 1  # signature is unique — no second row
+    assert rows[0].isrc == "USAAA1111111"  # the original recording's ISRC is kept
+    assert rows[0].bpm == 120.0  # NOT overwritten by the conflicting recording's 200
+    assert result.isrc == "USAAA1111111"  # returned the existing row, unchanged

--- a/server/tests/test_track_store.py
+++ b/server/tests/test_track_store.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import IntegrityError
 
 from app.models.track import Track
 from app.services.tracks import store
+from app.services.tracks.provenance import precedence
 from app.services.tracks.store import TrackIdentity, get_track, upsert_track
 
 
@@ -138,6 +139,60 @@ def test_upsert_backfills_isrc_onto_signature_row(db):
     assert len(rows) == 1
     assert rows[0].isrc == "FIXXX1234567"
     assert rows[0].bpm == 136.0 and rows[0].energy == 9
+
+
+# ---------------------------------------------------------------------------
+# #541: "legacy" provenance source — lowest-trust, attributes pre-store data
+# backfilled from existing Request columns. Any real later enrichment overrides
+# it; legacy never downgrades a higher-precedence value.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_precedence_is_below_community():
+    assert precedence("legacy") == 30
+    assert precedence("legacy") < precedence("community")
+
+
+def test_non_legacy_source_overwrites_legacy_value(db):
+    """A real provider (musicbrainz, 50) must overwrite a legacy-sourced value."""
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-leg-up"),
+        values={"genre": "pop"},
+        sources={"genre": "legacy"},
+        fetched_at=T0,
+    )
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-leg-up"),
+        values={"genre": "house"},
+        sources={"genre": "musicbrainz"},
+        fetched_at=T0,
+    )
+    row = db.query(Track).filter(Track.signature == "sig-leg-up").one()
+    assert row.genre == "house"
+    assert row.provenance["genre"]["source"] == "musicbrainz"
+
+
+def test_legacy_does_not_downgrade_higher_precedence(db):
+    """legacy (30) must NOT clobber an existing higher-precedence value."""
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-leg-keep"),
+        values={"genre": "house"},
+        sources={"genre": "musicbrainz"},
+        fetched_at=T0,
+    )
+    upsert_track(
+        db,
+        identity=TrackIdentity(title="S", artist="D", signature="sig-leg-keep"),
+        values={"genre": "pop"},
+        sources={"genre": "legacy"},
+        fetched_at=T0,
+    )
+    row = db.query(Track).filter(Track.signature == "sig-leg-keep").one()
+    assert row.genre == "house"  # legacy did not downgrade musicbrainz
+    assert row.provenance["genre"]["source"] == "musicbrainz"
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_track_store.py
+++ b/server/tests/test_track_store.py
@@ -523,3 +523,49 @@ def test_upsert_isrc_conflict_does_not_overwrite_different_recording(db):
     assert rows[0].isrc == "USAAA1111111"  # the original recording's ISRC is kept
     assert rows[0].bpm == 120.0  # NOT overwritten by the conflicting recording's 200
     assert result.isrc == "USAAA1111111"  # returned the existing row, unchanged
+
+
+def test_upsert_isrc_conflict_via_reconcile_race_does_not_overwrite(db, monkeypatch):
+    """The ISRC-conflict guard must also catch the reconcile-RACE path: when the
+    insert loses the signature unique-constraint and re-reads a DIFFERENT-ISRC row,
+    the guard (now checked after resolution, not just on the initial get_track)
+    still prevents overwriting it (#552, review)."""
+    upsert_track(
+        db,
+        identity=TrackIdentity(
+            title="T", artist="A", signature="sig-race-conflict", isrc="USAAA1111111"
+        ),
+        values={"bpm": 120.0},
+        sources={"bpm": "beatport"},
+        fetched_at=T0,
+    )
+    db.commit()
+
+    # Force the TOCTOU window: first get_track → None (so the insert path runs and
+    # collides on the unique signature), later calls delegate to the real lookup.
+    real = store.get_track
+    state = {"n": 0}
+
+    def fake(db, **kw):
+        state["n"] += 1
+        return None if state["n"] == 1 else real(db, **kw)
+
+    monkeypatch.setattr(store, "get_track", fake)
+
+    # Incoming: same signature, DIFFERENT ISRC — resolved via the reconcile re-read.
+    result = upsert_track(
+        db,
+        identity=TrackIdentity(
+            title="T", artist="A", signature="sig-race-conflict", isrc="USBBB2222222"
+        ),
+        values={"bpm": 200.0},
+        sources={"bpm": "beatport"},
+        fetched_at=T0,
+    )
+
+    assert state["n"] >= 2, "reconcile re-read path must have been taken"
+    rows = db.query(Track).filter(Track.signature == "sig-race-conflict").all()
+    assert len(rows) == 1
+    assert rows[0].isrc == "USAAA1111111"  # original recording preserved
+    assert rows[0].bpm == 120.0  # NOT overwritten via the reconcile path
+    assert result.isrc == "USAAA1111111"


### PR DESCRIPTION
> Supersedes #549 (auto-closed when its stacked base branch was deleted by the #548 merge). Same branch, now rebased onto `main`; PR1's foundation (#548) is already merged.

## Why

`enrich_request_metadata` wrote genre/bpm/key onto each **`Request` row**, so the same recording requested at two events was enriched twice, and energy/duration were never enriched at request time. #540 shipped the master `tracks` store; #548 added the writer foundation. This wires enrichment to **populate the global store once per unique recording and reuse it** — the next request for the same song costs **zero** provider calls.

## What

- **Cache-aside dual-write** in `enrich_request_metadata`: `dedupe_signature` → `get_track()`; if the store row is complete *and trusted*, copy fields onto the `Request` and skip all providers (the dedupe win). Otherwise run the existing cascade, thread **per-field provenance**, and `upsert_track()` while still writing `Request.genre/bpm/musical_key` for the current UI.
- **ISRC captured** (was discarded) so a request and a later pool-import of the same recording collapse to one row.
- **Soundcharts audio-features** (energy/danceability/valence/…) behind the dark gate; `bpm/key/genre` stay with the existing cascade.
- **`legacy` provenance source** (precedence 30) + idempotent **backfill script** (`python -m app.scripts.backfill_tracks`).
- No schema migration (FK + read-repoint deferred to #542+).

### Hardening from two adversarial review passes
**Workflow review (3 fixed):** pre-supplied metadata now reaches the store; store-upsert failure no longer poisons the Request commit (commit-first recovery); energy backfills onto a complete cached row.
**Codex review (3 fixed):** `legacy`-only rows are no longer authoritative cache hits (real providers upgrade them); Spotify ISRC capture decoupled from the Tidal token (feeds Soundcharts tokenless); already-complete search-result submissions now seed the store.

## Testing

- [x] Headline regression: same song at two events → one enrichment, zero provider calls on the repeat
- [x] Legacy-not-authoritative, complete-submission-seeds-store, tokenless-Spotify-ISRC, provenance, dual-write, energy gate on/off, store-failure-preserves-request, backfill idempotency
- [x] Full backend suite: 3232 passed, coverage 89.26% (≥ 85% gate); ruff + bandit clean
- [ ] CI green (now runs against `main`)

🤖 Co-authored by Claude Opus 4.8. Closes #541. Built via TDD + multi-agent + Codex adversarial review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a one-time backfill to populate the master track store from legacy request metadata (with legacy provenance).
  * Added ISRC support across request/collect flows end-to-end (API schema, validation, database, and UI forwarding from search results).
  * Expanded enrichment with provenance-aware “trusted cache” reuse and master-store seeding for already-complete submissions.
* **Bug Fixes**
  * Prevented master-store upserts from overwriting an existing recording when the signature matches but ISRC conflicts.
  * Improved enrichment reliability and background scheduling by always refreshing metadata via a safe background task.
* **Tests**
  * Added/expanded coverage for backfill correctness, idempotency, per-row failure isolation, dual-write behavior, trusted cache rules, and fresh-task scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->