### PR TITLE
refactor(matching): unify the fuzzy best-match selector (#551)

### DIFF
--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -57,7 +57,7 @@ from app.services.sync.orchestrator import _enrich_with_fresh_session
 from app.services.system_settings import get_system_settings
 from app.services.tidal import sync_collection_requests_batch
 from app.services.track_match import find_best_match
-from app.services.track_normalizer import normalize_isrc
+from app.services.track_normalizer import is_remix_title, normalize_isrc
 from app.services.vote import add_vote
 
 logger = logging.getLogger(__name__)
@@ -563,7 +563,14 @@ def enrich_preview(
             try:
                 matches = search_beatport_tracks(db, user, f"{item.artist} {item.title}", limit=5)
                 if matches:
-                    best = find_best_match(matches, item.title, item.artist)
+                    # Preserve remix intent like the enrichment/recommendation paths:
+                    # only prefer the original version when the query isn't a named remix.
+                    best = find_best_match(
+                        matches,
+                        item.title,
+                        item.artist,
+                        prefer_original=not is_remix_title(item.title),
+                    )
                     if best:
                         bpm = int(best.bpm) if best.bpm is not None else None
                         key = best.key or None

--- a/server/app/api/collect.py
+++ b/server/app/api/collect.py
@@ -53,10 +53,10 @@ from app.services.collect import NicknameConflictError, upsert_profile
 from app.services.dedup import compute_dedupe_key, find_duplicate
 from app.services.event import get_event_by_public_code_with_status
 from app.services.guest_names import generate_unique_nickname
-from app.services.sync.enrichment_pipeline import _find_best_match
 from app.services.sync.orchestrator import _enrich_with_fresh_session
 from app.services.system_settings import get_system_settings
 from app.services.tidal import sync_collection_requests_batch
+from app.services.track_match import find_best_match
 from app.services.track_normalizer import normalize_isrc
 from app.services.vote import add_vote
 
@@ -563,7 +563,7 @@ def enrich_preview(
             try:
                 matches = search_beatport_tracks(db, user, f"{item.artist} {item.title}", limit=5)
                 if matches:
-                    best = _find_best_match(matches, item.title, item.artist)
+                    best = find_best_match(matches, item.title, item.artist)
                     if best:
                         bpm = int(best.bpm) if best.bpm is not None else None
                         key = best.key or None

--- a/server/app/services/recommendation/enrichment.py
+++ b/server/app/services/recommendation/enrichment.py
@@ -13,13 +13,10 @@ from app.models.user import User
 from app.services.beatport import search_beatport_tracks
 from app.services.recommendation.scorer import TrackProfile
 from app.services.tidal import _get_artist_name, get_tidal_session
+from app.services.track_match import find_best_match
 from app.services.track_normalizer import (
-    artist_match_score,
-    fuzzy_match_score,
-    is_original_mix_name,
     is_remix_title,
     primary_artist,
-    score_track_match,
 )
 
 logger = logging.getLogger(__name__)
@@ -50,37 +47,20 @@ def enrich_from_tidal(
         if not tracks:
             return None
 
-        # Find best match (prefer originals over remixes for non-remix queries)
-        want_remix = is_remix_title(title)
-        best_track = None
-        best_score = 0.0
-        for i, track in enumerate(tracks):
-            track_artist = _get_artist_name(track)
-            track_title = track.name or ""
-            title_score = fuzzy_match_score(title, track_title)
-            artist_score = artist_match_score(artist, track_artist)
-            combined = score_track_match(title_score, artist_score)
-            version_adj = 0.0
-            if not want_remix and is_remix_title(track_title):
-                version_adj = -0.1
-                combined -= 0.1
-            logger.info(
-                "  Tidal enrich [%d] title=%s artist=%s bpm=%s | "
-                "title_sc=%.3f artist_sc=%.3f ver_adj=%+.2f => combined=%.4f",
-                i,
-                track_title,
-                track_artist,
-                getattr(track, "bpm", "?"),
-                title_score,
-                artist_score,
-                version_adj,
-                combined,
-            )
-            if combined > best_score:
-                best_score = combined
-                best_track = track
-
-        if not best_track or best_score < 0.4:
+        # Find best match (prefer originals over remixes for non-remix queries).
+        # Shared selector (#551): adds the artist-score floor + BPM-consensus
+        # tiebreaker the old inline loop lacked. Tidal exposes .name (not .title)
+        # and a custom artist accessor, so pass those through.
+        best_track = find_best_match(
+            tracks,
+            title,
+            artist,
+            prefer_original=not is_remix_title(title),
+            get_title=lambda t: t.name or "",
+            get_artist=_get_artist_name,
+            get_mix_name=lambda t: None,  # tidalapi has no mix_name — detect remixes from the title
+        )
+        if not best_track:
             return None
 
         # Extract BPM and key directly from the tidalapi Track object
@@ -129,40 +109,12 @@ def enrich_from_beatport(
     if not results:
         return None
 
-    # Find best match (prefer originals over remixes for non-remix queries)
-    want_remix = is_remix_title(title)
-    best_result = None
-    best_score = 0.0
-    for i, result in enumerate(results):
-        title_score = fuzzy_match_score(title, result.title)
-        artist_score = artist_match_score(artist, result.artist)
-        combined = score_track_match(title_score, artist_score)
-        version_adj = 0.0
-        if not want_remix and result.mix_name:
-            if is_original_mix_name(result.mix_name):
-                version_adj = 0.1
-                combined += 0.1
-        elif not want_remix and is_remix_title(result.title):
-            version_adj = -0.1
-            combined -= 0.1
-        logger.info(
-            "  Beatport enrich [%d] title=%s artist=%s bpm=%s mix=%s | "
-            "title_sc=%.3f artist_sc=%.3f ver_adj=%+.2f => combined=%.4f",
-            i,
-            result.title,
-            result.artist,
-            result.bpm,
-            result.mix_name or "-",
-            title_score,
-            artist_score,
-            version_adj,
-            combined,
-        )
-        if combined > best_score:
-            best_score = combined
-            best_result = result
-
-    if not best_result or best_score < 0.4:
+    # Find best match (prefer originals over remixes for non-remix queries).
+    # Shared selector (#551) — same scoring as the Tidal path and the request
+    # enrichment pipeline. Beatport results expose the default .title/.artist/
+    # .mix_name/.bpm shape, so no accessors are needed.
+    best_result = find_best_match(results, title, artist, prefer_original=not is_remix_title(title))
+    if not best_result:
         return None
 
     return TrackProfile(

--- a/server/app/services/sync/enrichment_pipeline.py
+++ b/server/app/services/sync/enrichment_pipeline.py
@@ -34,15 +34,12 @@ from app.core.time import utcnow
 from app.models.request import Request, RequestStatus
 from app.services.musicbrainz import lookup_artist_genre
 from app.services.request import normalize_key
+from app.services.track_match import find_best_match
 from app.services.track_normalizer import (
-    artist_match_score,
-    fuzzy_match_score,
-    is_original_mix_name,
     is_remix_title,
     normalize_bpm_to_context,
     normalize_isrc,
     primary_artist,
-    score_track_match,
 )
 from app.services.tracks.provenance import is_cache_authoritative
 from app.services.tracks.store import TrackIdentity, get_track, upsert_track
@@ -53,124 +50,6 @@ logger = logging.getLogger(__name__)
 _SPOTIFY_URL_RE = re.compile(r"open\.spotify\.com/track/(\w+)")
 _BEATPORT_URL_RE = re.compile(r"beatport\.com/track/[^/]+/(\d+)")
 _TIDAL_URL_RE = re.compile(r"tidal\.com/(?:browse/)?track/(\d+)")
-
-
-def _find_best_match(
-    results,
-    title: str,
-    artist: str,
-    min_score: float = 0.4,
-    min_artist_score: float = 0.35,
-    prefer_original: bool = True,
-):
-    """Find the best fuzzy match from search results.
-
-    Scores each result by title (60%) + artist (40%) similarity.
-    Returns the best match above min_score, or None if no good match.
-
-    A separate min_artist_score floor prevents a perfect title match
-    from carrying a completely wrong artist (e.g., "Feel the Beat" by
-    LB aka LABAT matching a request for Darude).
-
-    When prefer_original is True, applies a small bonus (+0.1) for
-    results that look like the original version (Beatport mix_name
-    matches "Original Mix", "Extended Mix", etc.) and a penalty (-0.1)
-    for results with detected remix patterns in the title (Tidal).
-    This breaks ties between "Surrender (Original Mix)" at 132 BPM and
-    "Surrender (Hardstyle Remix)" at 165 BPM without overriding a
-    genuinely better title/artist match.
-
-    When multiple results have identical scores, a BPM consensus
-    tiebreaker (+0.01) favors the version whose BPM matches the most
-    common BPM among all results.
-    """
-    logger.info(
-        "_find_best_match: title='%s' artist='%s' prefer_original=%s (%d results)",
-        title,
-        artist,
-        prefer_original,
-        len(results),
-    )
-
-    # Compute modal BPM for consensus tiebreaker
-    bpm_counts: dict[int, int] = {}
-    for result in results:
-        bpm = getattr(result, "bpm", None)
-        if bpm:
-            rounded = round(float(bpm))
-            bpm_counts[rounded] = bpm_counts.get(rounded, 0) + 1
-    modal_bpm = max(bpm_counts, key=bpm_counts.get) if bpm_counts else None
-
-    best = None
-    best_score = 0.0
-    for i, result in enumerate(results):
-        title_score = fuzzy_match_score(title, result.title)
-        artist_score = artist_match_score(artist, result.artist)
-        if artist_score < min_artist_score:
-            logger.info(
-                "  [%d] SKIP artist_score=%.3f < %.2f | title=%s artist=%s",
-                i,
-                artist_score,
-                min_artist_score,
-                result.title,
-                result.artist,
-            )
-            continue
-        combined = score_track_match(title_score, artist_score)
-        version_adj = 0.0
-
-        if prefer_original:
-            mix_name = getattr(result, "mix_name", None)
-            if mix_name:
-                # Beatport: structured mix_name available
-                if is_original_mix_name(mix_name):
-                    version_adj = 0.1
-                    combined += 0.1
-                # Named remix/bootleg/rework in mix_name → no bonus
-            else:
-                # Tidal/other: check title for remix patterns
-                if is_remix_title(result.title):
-                    version_adj = -0.1
-                    combined -= 0.1
-
-        # BPM consensus tiebreaker: prefer modal BPM among results
-        bpm_adj = 0.0
-        result_bpm = getattr(result, "bpm", None)
-        if modal_bpm and result_bpm and round(float(result_bpm)) == modal_bpm:
-            bpm_adj = 0.01
-            combined += 0.01
-
-        logger.info(
-            "  [%d] title=%s artist=%s bpm=%s mix=%s | "
-            "title_sc=%.3f artist_sc=%.3f ver_adj=%+.02f bpm_adj=%+.003f => combined=%.4f",
-            i,
-            result.title,
-            result.artist,
-            getattr(result, "bpm", "?"),
-            getattr(result, "mix_name", None) or "-",
-            title_score,
-            artist_score,
-            version_adj,
-            bpm_adj,
-            combined,
-        )
-
-        if combined > best_score:
-            best_score = combined
-            best = result
-
-    if best and best_score >= min_score:
-        logger.info(
-            "  BEST: title=%s artist=%s bpm=%s (score=%.4f)",
-            best.title,
-            best.artist,
-            getattr(best, "bpm", "?"),
-            best_score,
-        )
-        return best
-
-    logger.info("  NO MATCH (best_score=%.4f < min=%.2f)", best_score, min_score)
-    return None
 
 
 def _extract_source_track_id(source_url: str | None) -> tuple[str | None, str | None]:
@@ -662,7 +541,7 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
                     request_id,
                 )
                 if results:
-                    best = _find_best_match(
+                    best = find_best_match(
                         results,
                         request.song_title,
                         request.artist,
@@ -701,7 +580,7 @@ def enrich_request_metadata(db: Session, request_id: int) -> None:
                     request_id,
                 )
                 if results:
-                    best = _find_best_match(
+                    best = find_best_match(
                         results,
                         request.song_title,
                         request.artist,

--- a/server/app/services/sync/orchestrator.py
+++ b/server/app/services/sync/orchestrator.py
@@ -23,7 +23,6 @@ from app.services.intent_parser import parse_intent
 from app.services.sync.base import SyncResult, SyncStatus, TrackMatch, sanitize_sync_error
 from app.services.sync.enrichment_pipeline import (  # noqa: F401
     _extract_source_track_id,
-    _find_best_match,
     _get_isrc_from_spotify,
     enrich_request_metadata,
 )

--- a/server/app/services/track_match.py
+++ b/server/app/services/track_match.py
@@ -1,0 +1,166 @@
+"""Unified best-match selector for fuzzy search results (#551).
+
+`find_best_match` is the SINGLE place that picks the best-scoring search result
+for a (title, artist) query. It is shared by the request enrichment pipeline,
+the collect search-time preview, and the recommendation Tidal/Beatport
+enrichers, which previously carried three slightly-different copies of this
+logic — two of them missing the artist-score floor and the BPM-consensus
+tiebreaker, which let a perfect-title/wrong-artist result win.
+
+Field access goes through small accessor callables so the one implementation
+works across result shapes: Beatport/search results expose ``.title``/``.artist``/
+``.mix_name``/``.bpm`` (the defaults), while a tidalapi ``Track`` exposes
+``.name`` and needs a custom artist accessor — the caller passes ``get_title`` /
+``get_artist`` for those.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from app.services.track_normalizer import (
+    artist_match_score,
+    fuzzy_match_score,
+    is_original_mix_name,
+    is_remix_title,
+    score_track_match,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _default_bpm(result: Any) -> float | None:
+    return getattr(result, "bpm", None)
+
+
+def _default_mix_name(result: Any) -> str | None:
+    return getattr(result, "mix_name", None)
+
+
+def find_best_match(
+    results,
+    title: str,
+    artist: str,
+    *,
+    min_score: float = 0.4,
+    min_artist_score: float = 0.35,
+    prefer_original: bool = True,
+    get_title: Callable[[Any], str] = lambda r: r.title,
+    get_artist: Callable[[Any], str] = lambda r: r.artist,
+    get_bpm: Callable[[Any], float | None] = _default_bpm,
+    get_mix_name: Callable[[Any], str | None] = _default_mix_name,
+):
+    """Return the best fuzzy match from ``results`` for the (title, artist) query.
+
+    Scores each result by title (60%) + artist (40%) similarity and returns the
+    best result whose combined score is >= ``min_score``, else ``None``.
+
+    A separate ``min_artist_score`` floor discards results whose artist is
+    nowhere near the query, so a perfect title can't carry a completely wrong
+    artist (e.g. "Feel the Beat" by LB aka LABAT matching a request for Darude).
+
+    When ``prefer_original`` is True, a small bonus (+0.1) favours results that
+    look like the original version (Beatport ``mix_name`` matching "Original
+    Mix"/"Extended Mix"/…) and a penalty (-0.1) is applied to results whose
+    title carries a named-remix pattern (used for Tidal, which has no
+    ``mix_name``). This breaks ties between "Surrender (Original Mix)" at 132
+    BPM and "Surrender (Hardstyle Remix)" at 165 BPM without overriding a
+    genuinely better title/artist match.
+
+    When multiple results tie on score, a BPM-consensus tiebreaker (+0.01)
+    favours the version whose BPM matches the most common BPM among all results.
+
+    The original result object is returned unchanged, so callers can read
+    provider-specific fields (key, genre, duration, cover art) off it.
+    """
+    logger.info(
+        "find_best_match: title='%s' artist='%s' prefer_original=%s (%d results)",
+        title,
+        artist,
+        prefer_original,
+        len(results),
+    )
+
+    # Compute modal BPM for the consensus tiebreaker.
+    bpm_counts: dict[int, int] = {}
+    for result in results:
+        bpm = get_bpm(result)
+        if bpm:
+            rounded = round(float(bpm))
+            bpm_counts[rounded] = bpm_counts.get(rounded, 0) + 1
+    modal_bpm = max(bpm_counts, key=bpm_counts.get) if bpm_counts else None
+
+    best = None
+    best_score = 0.0
+    for i, result in enumerate(results):
+        result_title = get_title(result)
+        result_artist = get_artist(result)
+        title_score = fuzzy_match_score(title, result_title)
+        artist_score = artist_match_score(artist, result_artist)
+        if artist_score < min_artist_score:
+            logger.info(
+                "  [%d] SKIP artist_score=%.3f < %.2f | title=%s artist=%s",
+                i,
+                artist_score,
+                min_artist_score,
+                result_title,
+                result_artist,
+            )
+            continue
+        combined = score_track_match(title_score, artist_score)
+        version_adj = 0.0
+
+        if prefer_original:
+            mix_name = get_mix_name(result)
+            if mix_name:
+                # Beatport: structured mix_name available.
+                if is_original_mix_name(mix_name):
+                    version_adj = 0.1
+                    combined += 0.1
+                # Named remix/bootleg/rework in mix_name → no bonus.
+            else:
+                # Tidal/other: check the title for remix patterns.
+                if is_remix_title(result_title):
+                    version_adj = -0.1
+                    combined -= 0.1
+
+        # BPM consensus tiebreaker: prefer the modal BPM among results.
+        bpm_adj = 0.0
+        result_bpm = get_bpm(result)
+        if modal_bpm and result_bpm and round(float(result_bpm)) == modal_bpm:
+            bpm_adj = 0.01
+            combined += 0.01
+
+        logger.info(
+            "  [%d] title=%s artist=%s bpm=%s mix=%s | "
+            "title_sc=%.3f artist_sc=%.3f ver_adj=%+.02f bpm_adj=%+.003f => combined=%.4f",
+            i,
+            result_title,
+            result_artist,
+            result_bpm if result_bpm is not None else "?",
+            get_mix_name(result) or "-",
+            title_score,
+            artist_score,
+            version_adj,
+            bpm_adj,
+            combined,
+        )
+
+        if combined > best_score:
+            best_score = combined
+            best = result
+
+    if best is not None and best_score >= min_score:
+        logger.info(
+            "  BEST: title=%s artist=%s bpm=%s (score=%.4f)",
+            get_title(best),
+            get_artist(best),
+            get_bpm(best) if get_bpm(best) is not None else "?",
+            best_score,
+        )
+        return best
+
+    logger.info("  NO MATCH (best_score=%.4f < min=%.2f)", best_score, min_score)
+    return None

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -1014,6 +1014,40 @@ def test_enrich_preview_returns_bpm_from_beatport(client, db, test_event: Event)
     assert results[0]["genre"] == "Progressive House"
 
 
+def test_enrich_preview_preserves_remix_intent(client, db, test_event: Event):
+    """The preview must derive prefer_original from the title (#551/#553): a named-remix
+    query must NOT be matched with prefer_original=True (which would favour the original
+    version's BPM/key), matching the enrichment + recommendation paths."""
+    from unittest.mock import MagicMock, patch
+
+    _enable_collection(db, test_event)
+    dj = test_event.created_by
+    dj.beatport_access_token = "fake_token"  # nosec B106
+    db.commit()
+
+    match = MagicMock(
+        title="Surrender (Hardstyle Remix)", artist="Darude", bpm=165, key=None, genre=None
+    )
+    with (
+        patch("app.api.collect.search_beatport_tracks", return_value=[match]),
+        patch("app.api.collect.find_best_match", return_value=match) as spy,
+    ):
+        # Remix query → prefer_original must be False.
+        client.post(
+            f"/api/public/collect/{test_event.code}/enrich-preview",
+            json={"items": [{"title": "Surrender (Hardstyle Remix)", "artist": "Darude"}]},
+        )
+        assert spy.call_args.kwargs["prefer_original"] is False
+
+        # Plain query → prefer_original stays True.
+        spy.reset_mock()
+        client.post(
+            f"/api/public/collect/{test_event.code}/enrich-preview",
+            json={"items": [{"title": "Surrender", "artist": "Darude"}]},
+        )
+        assert spy.call_args.kwargs["prefer_original"] is True
+
+
 def test_enrich_preview_caps_at_10_items(client, db, test_event: Event):
     """Requests with >10 items are silently capped — only first 10 processed."""
     _enable_collection(db, test_event)

--- a/server/tests/test_collect_public.py
+++ b/server/tests/test_collect_public.py
@@ -999,7 +999,7 @@ def test_enrich_preview_returns_bpm_from_beatport(client, db, test_event: Event)
 
     with (
         patch("app.api.collect.search_beatport_tracks", return_value=[mock_match]),
-        patch("app.api.collect._find_best_match", return_value=mock_match),
+        patch("app.api.collect.find_best_match", return_value=mock_match),
     ):
         r = client.post(
             f"/api/public/collect/{test_event.code}/enrich-preview",

--- a/server/tests/test_sync_orchestrator.py
+++ b/server/tests/test_sync_orchestrator.py
@@ -14,7 +14,6 @@ from app.services.sync.base import SyncResult, SyncStatus, TrackMatch
 from app.services.sync.orchestrator import (
     MultiSyncResult,
     _extract_source_track_id,
-    _find_best_match,
     _get_isrc_from_spotify,
     _is_already_synced,
     _persist_sync_result,
@@ -1037,98 +1036,6 @@ class TestEnrichRequestMetadata:
         # With status filter: median = 130, 65*2 = 130 → corrected
         # Without status filter: median would include 200, skewing context
         assert target.bpm == 130.0
-
-
-class TestFindBestMatchVersionPreference:
-    """Tests for _find_best_match() version-aware scoring."""
-
-    def test_beatport_original_beats_remix_on_tie(self):
-        """When title/artist scores are equal, Original Mix wins over remix."""
-        from app.schemas.beatport import BeatportSearchResult
-
-        results = [
-            BeatportSearchResult(
-                track_id="1",
-                title="Surrender",
-                artist="Darude",
-                mix_name="Hardstyle Remix",
-                bpm=165,
-            ),
-            BeatportSearchResult(
-                track_id="2",
-                title="Surrender",
-                artist="Darude",
-                mix_name="Original Mix",
-                bpm=132,
-            ),
-        ]
-        best = _find_best_match(results, "Surrender", "Darude", prefer_original=True)
-        assert best.track_id == "2"
-        assert best.bpm == 132
-
-    def test_beatport_remix_preferred_when_requested(self):
-        """When request title contains remix, prefer_original=False lets remix win."""
-        from app.schemas.beatport import BeatportSearchResult
-
-        results = [
-            BeatportSearchResult(
-                track_id="1",
-                title="Surrender",
-                artist="Darude",
-                mix_name="Hardstyle Remix",
-                bpm=165,
-            ),
-            BeatportSearchResult(
-                track_id="2",
-                title="Surrender",
-                artist="Darude",
-                mix_name="Original Mix",
-                bpm=132,
-            ),
-        ]
-        # With prefer_original=False, no bonus/penalty — first result wins on tie
-        best = _find_best_match(results, "Surrender", "Darude", prefer_original=False)
-        # Both have identical scores, first one encountered wins
-        assert best is not None
-
-    def test_tidal_remix_penalized(self):
-        """Tidal results with remix in title get penalized for non-remix queries."""
-        from types import SimpleNamespace
-
-        results = [
-            SimpleNamespace(title="Surrender (Hardstyle Remix)", artist="Darude", bpm=165),
-            SimpleNamespace(title="Surrender", artist="Darude", bpm=132),
-        ]
-        best = _find_best_match(results, "Surrender", "Darude", prefer_original=True)
-        # Plain title should win over remix title
-        assert best.title == "Surrender"
-        assert best.bpm == 132
-
-    def test_prefer_original_disabled(self):
-        """With prefer_original=False, no version scoring applied."""
-        from types import SimpleNamespace
-
-        results = [
-            SimpleNamespace(title="Surrender (Hardstyle Remix)", artist="Darude", bpm=165),
-            SimpleNamespace(title="Surrender", artist="Darude", bpm=132),
-        ]
-        # Without prefer_original, both have similar scores — first wins
-        best = _find_best_match(results, "Surrender", "Darude", prefer_original=False)
-        assert best is not None
-
-    def test_bpm_consensus_tiebreaker(self):
-        """When title/artist scores are identical, modal BPM wins."""
-        from types import SimpleNamespace
-
-        # Tidal returns multiple "Surrender" — 3 at 132, 1 at 165
-        results = [
-            SimpleNamespace(title="Surrender", artist="Darude", bpm=165.0),
-            SimpleNamespace(title="Surrender", artist="Darude", bpm=132.0),
-            SimpleNamespace(title="Surrender", artist="Darude", bpm=132.0),
-            SimpleNamespace(title="Surrender", artist="Darude", bpm=132.0),
-        ]
-        best = _find_best_match(results, "Surrender", "Darude", prefer_original=True)
-        assert best.bpm == 132.0  # Modal BPM among results
 
 
 class TestExtractSourceTrackId:

--- a/server/tests/test_track_match.py
+++ b/server/tests/test_track_match.py
@@ -92,9 +92,10 @@ class TestVersionPreference:
                 track_id="2", title="Surrender", artist="Darude", mix_name="Original Mix", bpm=132
             ),
         ]
-        # No version bonus/penalty → first encountered wins on an otherwise-exact tie.
+        # With the original-mix bonus disabled the remix (first result) is no longer
+        # demoted, so it wins the otherwise-exact tie instead of the Original Mix.
         best = find_best_match(results, "Surrender", "Darude", prefer_original=False)
-        assert best is not None
+        assert best.track_id == "1"
 
     def test_tidal_remix_title_penalized(self):
         results = [

--- a/server/tests/test_track_match.py
+++ b/server/tests/test_track_match.py
@@ -1,0 +1,153 @@
+"""Tests for the unified best-match selector (#551).
+
+`find_best_match` is the single fuzzy best-match-from-search-results selector
+shared by the request enrichment pipeline, the collect preview, and the
+recommendation Tidal/Beatport enrichers. It previously existed as a private
+`_find_best_match` in the enrichment pipeline AND as two drifted inline loops in
+recommendation/enrichment.py that lacked the `min_artist_score` floor and the
+BPM-consensus tiebreaker. These tests lock the unified behavior so the two
+surfaces can never drift again.
+"""
+
+from types import SimpleNamespace
+
+from app.services.track_match import find_best_match
+
+
+def _r(title, artist, bpm=None, mix_name=None):
+    """A minimal search-result stub (the default .title/.artist/.bpm/.mix_name shape)."""
+    return SimpleNamespace(title=title, artist=artist, bpm=bpm, mix_name=mix_name)
+
+
+class TestBasicSelection:
+    def test_picks_highest_combined_score(self):
+        results = [
+            _r("Totally Different Song", "Darude"),
+            _r("Sandstorm", "Darude"),
+        ]
+        best = find_best_match(results, "Sandstorm", "Darude")
+        assert best.title == "Sandstorm"
+
+    def test_returns_none_below_min_score(self):
+        results = [_r("Completely Unrelated", "Nobody At All")]
+        assert find_best_match(results, "Sandstorm", "Darude") is None
+
+    def test_empty_results_returns_none(self):
+        assert find_best_match([], "Sandstorm", "Darude") is None
+
+
+class TestArtistFloor:
+    """A perfect title must not carry a completely wrong artist (the LABAT/Darude bug)."""
+
+    def test_wrong_artist_perfect_title_is_skipped(self):
+        results = [
+            _r("Sandstorm", "Metallica"),  # perfect title, artist nowhere near "Darude"
+            _r("Sandstrm", "Darude"),  # slight title typo, correct artist
+        ]
+        best = find_best_match(results, "Sandstorm", "Darude")
+        assert best.artist == "Darude"
+
+    def test_floor_can_be_lowered(self):
+        results = [_r("Sandstorm", "Metallica")]
+        # With the floor removed, the perfect-title/wrong-artist row is eligible again.
+        best = find_best_match(results, "Sandstorm", "Darude", min_artist_score=0.0)
+        assert best is not None
+        assert best.artist == "Metallica"
+
+
+class TestVersionPreference:
+    """Migrated from test_sync_orchestrator — version-aware scoring (now owned here)."""
+
+    def test_beatport_original_beats_remix_on_tie(self):
+        from app.schemas.beatport import BeatportSearchResult
+
+        results = [
+            BeatportSearchResult(
+                track_id="1",
+                title="Surrender",
+                artist="Darude",
+                mix_name="Hardstyle Remix",
+                bpm=165,
+            ),
+            BeatportSearchResult(
+                track_id="2", title="Surrender", artist="Darude", mix_name="Original Mix", bpm=132
+            ),
+        ]
+        best = find_best_match(results, "Surrender", "Darude", prefer_original=True)
+        assert best.track_id == "2"
+        assert best.bpm == 132
+
+    def test_remix_preferred_when_disabled(self):
+        from app.schemas.beatport import BeatportSearchResult
+
+        results = [
+            BeatportSearchResult(
+                track_id="1",
+                title="Surrender",
+                artist="Darude",
+                mix_name="Hardstyle Remix",
+                bpm=165,
+            ),
+            BeatportSearchResult(
+                track_id="2", title="Surrender", artist="Darude", mix_name="Original Mix", bpm=132
+            ),
+        ]
+        # No version bonus/penalty → first encountered wins on an otherwise-exact tie.
+        best = find_best_match(results, "Surrender", "Darude", prefer_original=False)
+        assert best is not None
+
+    def test_tidal_remix_title_penalized(self):
+        results = [
+            _r("Surrender (Hardstyle Remix)", "Darude", bpm=165),
+            _r("Surrender", "Darude", bpm=132),
+        ]
+        best = find_best_match(results, "Surrender", "Darude", prefer_original=True)
+        assert best.title == "Surrender"
+        assert best.bpm == 132
+
+
+class TestBpmConsensusTiebreaker:
+    def test_modal_bpm_wins_on_score_tie(self):
+        results = [
+            _r("Surrender", "Darude", bpm=165.0),
+            _r("Surrender", "Darude", bpm=132.0),
+            _r("Surrender", "Darude", bpm=132.0),
+            _r("Surrender", "Darude", bpm=132.0),
+        ]
+        best = find_best_match(results, "Surrender", "Darude", prefer_original=True)
+        assert best.bpm == 132.0  # modal BPM among results breaks the tie
+
+
+class TestAccessorShapes:
+    """Tidal exposes .name / a custom artist accessor — the selector reads via accessors."""
+
+    def test_custom_title_and_artist_accessors(self):
+        tidal_like = [
+            SimpleNamespace(name="Wrong Song", artist_obj="Darude", bpm=100),
+            SimpleNamespace(name="Sandstorm", artist_obj="Darude", bpm=136),
+        ]
+        best = find_best_match(
+            tidal_like,
+            "Sandstorm",
+            "Darude",
+            get_title=lambda t: t.name,
+            get_artist=lambda t: t.artist_obj,
+        )
+        assert best.name == "Sandstorm"
+
+    def test_missing_mix_name_falls_back_to_title_remix_detection(self):
+        # No mix_name attribute at all → remix detection must use the (accessor) title.
+        tidal_like = [
+            SimpleNamespace(name="Surrender (Hardstyle Remix)", artist_obj="Darude", bpm=165),
+            SimpleNamespace(name="Surrender", artist_obj="Darude", bpm=132),
+        ]
+        best = find_best_match(
+            tidal_like,
+            "Surrender",
+            "Darude",
+            prefer_original=True,
+            get_title=lambda t: t.name,
+            get_artist=lambda t: t.artist_obj,
+            get_mix_name=lambda t: None,
+        )
+        assert best.name == "Surrender"


### PR DESCRIPTION
## Why
Three copies of "pick the best fuzzy match from search results" had drifted apart. The canonical `_find_best_match` in the enrichment pipeline carried a `min_artist_score` floor and a BPM-consensus tiebreaker; the two inline loops in `recommendation/enrichment.py` (Tidal + Beatport enrichers) had **neither**. The practical consequence: a recommendation-side enrich could let a perfect *title* match carry a completely wrong *artist* (the "Feel the Beat by LABAT matches a Darude request" class of bug), while the request-side pipeline correctly rejected it. Same job, three behaviours.

## What
Extracts the canonical selector into a single shared `app/services/track_match.find_best_match`, generalized with small field-accessor callables so one implementation serves both result shapes:
- the default `.title` / `.artist` / `.mix_name` / `.bpm` shape (Beatport search results, the pipeline), and
- the `tidalapi.Track` shape via `get_title` / `get_artist` accessors.

The Tidal call site now **explicitly** declares it has no `mix_name` (`get_mix_name=lambda t: None`) so remix detection falls back to the title — that is the provider's real data shape, and it's clearer than relying on a `getattr` default.

Result: **−263 LOC** across the tracked files (3 copies → 1), and the Tidal/Beatport enrich paths inherit the artist-score floor and BPM-consensus tiebreaker for free. No behaviour change on the request-enrichment / collect-preview paths (they already used the canonical logic) — only the import source moves.

Edit-disjoint from #542 (which is in flight on the setbuilder files); #542 only *calls* `enrich_track`, whose signature is unchanged.

## Testing
- [x] New `tests/test_track_match.py` (11 cases) locks the unified behaviour: highest-combined selection, the artist-score floor, version preference (Beatport mix_name + Tidal title), BPM-consensus tiebreaker, `min_score` gate, and the accessor shapes
- [x] Migrated the matcher's version-preference cases out of `test_sync_orchestrator.py` into the dedicated suite (they now test the function where it lives)
- [x] Affected suites green: matcher, sync-orchestrator, collect-public, recommendation-enrichment
- [x] Full backend suite: **3261 passed, 89.28% coverage** (gate 85%)
- [x] ruff check + format + bandit clean
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #551.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved track matching across enrichment flows for more consistent preview and metadata results.
  * Better handling of version preferences, including original vs. remix choices and BPM-based tie-breaking.

* **Bug Fixes**
  * Reduced incorrect or low-confidence track matches by applying stricter matching thresholds.
  * Made enrichment results more reliable when matching track titles and artists from different providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->