### PR TITLE
feat(setbuilder): pool import resolves master tracks store + pre-build coverage gate

### DIFF
--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -2715,6 +2715,10 @@ export interface paths {
         /**
          * Build Set
          * @description Run deterministic pass 1 after explicit user confirmation.
+         *
+         *     Coverage of the five required pool→builder fields is computed and returned so
+         *     the build-confirmation dialog can show data completeness and a SOFT,
+         *     overridable warning (#542/#538) — the build itself is never blocked on it.
          */
         post: operations["build_set_api_setbuilder_sets__set_id__build_post"];
         delete?: never;
@@ -4249,6 +4253,7 @@ export interface components {
          * @description Result of the deterministic pass.
          */
         BuildSetResponse: {
+            coverage: components["schemas"]["PoolCoverageOut"];
             /** Iterations */
             iterations: number;
             /** Slot Count */
@@ -5785,6 +5790,27 @@ export interface components {
             num_tracks: number;
             /** Source */
             source: string;
+        };
+        /**
+         * PoolCoverageOut
+         * @description Pre-build coverage of the five required pool→builder contract fields (#542).
+         *
+         *     A SOFT, overridable signal surfaced in the build-confirmation dialog (#538):
+         *     ``missing`` is the per-field count of pool tracks lacking each field,
+         *     ``fully_covered_count`` how many carry all five, and ``ready`` whether the
+         *     pool clears the readiness threshold. The build is never hard-blocked on this.
+         */
+        PoolCoverageOut: {
+            /** Fully Covered Count */
+            fully_covered_count: number;
+            /** Missing */
+            missing: {
+                [key: string]: number;
+            };
+            /** Pool Size */
+            pool_size: number;
+            /** Ready */
+            ready: boolean;
         };
         /**
          * PoolImportEventIn

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -54,6 +54,7 @@ from app.schemas.setbuilder import (
     PlaybackReportSummary,
     PlaybackSlotOutcomeOut,
     PlayHistoryFeedbackOut,
+    PoolCoverageOut,
     PoolImportEventIn,
     PoolImportManualIn,
     PoolImportPlaylistIn,
@@ -112,6 +113,9 @@ from app.services.setbuilder import (
     set_service,
     vibe_enrichment,
     vibe_resolver,
+)
+from app.services.setbuilder import (
+    coverage as pool_coverage_service,
 )
 from app.services.setbuilder.playlist_url import InvalidPlaylistUrl, parse_public_playlist_url
 
@@ -665,10 +669,15 @@ def build_set(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ) -> BuildSetResponse:
-    """Run deterministic pass 1 after explicit user confirmation."""
+    """Run deterministic pass 1 after explicit user confirmation.
+
+    Coverage of the five required pool→builder fields is computed and returned so
+    the build-confirmation dialog can show data completeness and a SOFT,
+    overridable warning (#542/#538) — the build itself is never blocked on it."""
     set_obj = _get_owned_or_404(db, set_id, current_user)
     if not payload.confirmed:
         raise HTTPException(status_code=400, detail="Build requires explicit confirmation")
+    coverage = pool_coverage_service.coverage_for_set(db, set_obj.id)
     result = pass1_deterministic.build_set(db, set_obj)
     db.expire(set_obj, ["slots"])
     return BuildSetResponse(
@@ -676,6 +685,7 @@ def build_set(
         iterations=result.iterations,
         slots=_slots_out(db, set_obj),
         transition_scores=_transition_scores_out(result.transition_scores),
+        coverage=PoolCoverageOut(**coverage),
     )
 
 
@@ -1079,6 +1089,7 @@ def import_pool_event(
         label=event.name,
         meta="WrzDJ event requests",
     )
+    candidates = pool.hydrate_candidates_from_store(db, candidates, user=current_user)
     added, deduped = pool.import_candidates(db, set_obj, source, candidates)
     return _import_result(db, set_obj.id, source, added, deduped)
 
@@ -1108,6 +1119,7 @@ def import_pool_tidal(
         label=payload.label or "Tidal playlist",
         meta="Tidal playlist",
     )
+    candidates = pool.hydrate_candidates_from_store(db, candidates, user=current_user)
     added, deduped = pool.import_candidates(db, set_obj, source, candidates)
     return _import_result(db, set_obj.id, source, added, deduped)
 
@@ -1133,6 +1145,7 @@ def import_pool_beatport(
         label=payload.label or "Beatport playlist",
         meta="Beatport playlist",
     )
+    candidates = pool.hydrate_candidates_from_store(db, candidates, user=current_user)
     added, deduped = pool.import_candidates(db, set_obj, source, candidates)
     return _import_result(db, set_obj.id, source, added, deduped)
 
@@ -1192,6 +1205,7 @@ def import_pool_url(
         label=name,
         meta=f"Public {parsed.provider} playlist",
     )
+    candidates = pool.hydrate_candidates_from_store(db, candidates, user=current_user)
     added, deduped = pool.import_candidates(db, set_obj, source, candidates)
     return _import_result(db, set_obj.id, source, added, deduped)
 
@@ -1223,7 +1237,8 @@ def import_pool_manual(
     source = pool.get_or_create_source(
         db, set_obj, kind="manual", external_ref=None, label="Manual", meta="Single-track search"
     )
-    added, deduped = pool.import_candidates(db, set_obj, source, [candidate])
+    candidates = pool.hydrate_candidates_from_store(db, [candidate], user=current_user)
+    added, deduped = pool.import_candidates(db, set_obj, source, candidates)
     return _import_result(db, set_obj.id, source, added, deduped)
 
 

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -443,6 +443,21 @@ class TransitionScoreOut(BaseModel):
     warnings: list[str]
 
 
+class PoolCoverageOut(BaseModel):
+    """Pre-build coverage of the five required pool→builder contract fields (#542).
+
+    A SOFT, overridable signal surfaced in the build-confirmation dialog (#538):
+    ``missing`` is the per-field count of pool tracks lacking each field,
+    ``fully_covered_count`` how many carry all five, and ``ready`` whether the
+    pool clears the readiness threshold. The build is never hard-blocked on this.
+    """
+
+    pool_size: int
+    fully_covered_count: int
+    ready: bool
+    missing: dict[str, int]
+
+
 class BuildSetResponse(BaseModel):
     """Result of the deterministic pass."""
 
@@ -450,6 +465,7 @@ class BuildSetResponse(BaseModel):
     iterations: int
     slots: list[SlotOut]
     transition_scores: list[TransitionScoreOut]
+    coverage: PoolCoverageOut
 
 
 class SlotOrderRequest(BaseModel):

--- a/server/app/services/setbuilder/agent_display.py
+++ b/server/app/services/setbuilder/agent_display.py
@@ -136,10 +136,13 @@ def _tool_display_summary(
     if name == "analyze_pool_gaps":
         missing = result.get("missing_camelot_keys") or []
         sparse = result.get("sparse_bands") or []
+        missing_genre = int(result.get("missing_genre_count") or 0)
+        missing_energy = int(result.get("missing_energy_count") or 0)
         return (
             f"Analyzed pool gaps over {int(result.get('pool_size') or 0)} tracks: "
             f"{len(missing)} missing Camelot key{'s' if len(missing) != 1 else ''}, "
-            f"{len(sparse)} sparse BPM band{'s' if len(sparse) != 1 else ''}."
+            f"{len(sparse)} sparse BPM band{'s' if len(sparse) != 1 else ''}, "
+            f"{missing_genre} missing genre, {missing_energy} missing energy."
         )
     if name == "critique_set":
         grade = result.get("overall_grade")
@@ -161,10 +164,16 @@ def _tool_display_summary(
     if name == "autobuild":
         slots = int(result.get("slot_count") or 0)
         iterations = int(result.get("iterations") or 0)
-        return (
+        summary = (
             f"Rebuilt the set: {slots} slot{'s' if slots != 1 else ''}, "
             f"{iterations} refinement pass{'es' if iterations != 1 else ''}."
         )
+        coverage = result.get("coverage") or {}
+        pool_size = int(coverage.get("pool_size") or 0)
+        fully = int(coverage.get("fully_covered_count") or 0)
+        if pool_size and fully < pool_size:
+            summary += f" {fully}/{pool_size} pool tracks fully enriched."
+        return summary
     if name == "fill_to_duration":
         added = int(result.get("inserted_count") or 0)
         now_min = int(result.get("estimated_total_sec") or 0) // 60

--- a/server/app/services/setbuilder/agent_tool_specs.py
+++ b/server/app/services/setbuilder/agent_tool_specs.py
@@ -186,7 +186,10 @@ def _agent_tools() -> list[ToolSpec]:
         ),
         ToolSpec(
             name="analyze_pool_gaps",
-            description=("Report pool coverage holes: missing Camelot keys and sparse BPM bands."),
+            description=(
+                "Report pool coverage holes: missing Camelot keys, sparse BPM bands, "
+                "and how many tracks are missing genre or energy."
+            ),
             input_schema={"type": "object", "properties": {}},
         ),
         ToolSpec(

--- a/server/app/services/setbuilder/agent_tools_imports.py
+++ b/server/app/services/setbuilder/agent_tools_imports.py
@@ -104,6 +104,7 @@ def _tool_import_from_event(
         label=event.name,
         meta="WrzDJ event requests",
     )
+    candidates = pool.hydrate_candidates_from_store(db, candidates, user=owner, commit=False)
     added, deduped = pool.import_candidates(db, set_obj, source, candidates, commit=False)
     return _import_summary(source, added, deduped), set()
 
@@ -151,6 +152,7 @@ def _connected_playlist_import(
         label=playlist.name,
         meta=f"{kind.capitalize()} playlist",
     )
+    candidates = pool.hydrate_candidates_from_store(db, candidates, user=owner, commit=False)
     added, deduped = pool.import_candidates(db, set_obj, source, candidates, commit=False)
     return _import_summary(source, added, deduped), set()
 
@@ -219,5 +221,6 @@ def _tool_import_from_url(
         label=name,
         meta=f"Public {parsed.provider} playlist",
     )
+    candidates = pool.hydrate_candidates_from_store(db, candidates, user=owner, commit=False)
     added, deduped = pool.import_candidates(db, set_obj, source, candidates, commit=False)
     return _import_summary(source, added, deduped), set()

--- a/server/app/services/setbuilder/agent_tools_sensing.py
+++ b/server/app/services/setbuilder/agent_tools_sensing.py
@@ -255,26 +255,40 @@ def _energy_profile(values: list[float | None]) -> dict[str, Any]:
 def _tool_analyze_pool_gaps(
     db: Session, set_obj: Set, payload: dict[str, Any]
 ) -> tuple[dict[str, Any], set[int]]:
-    """Read-only coverage report over the set's pool (missing keys + BPM bands)."""
+    """Read-only coverage report over the set's pool: missing Camelot keys, BPM
+    bands, and genre + energy coverage (#542).
+
+    Genre + energy are read straight from the resolved pool rows (which #542's
+    store hydration now fills), not from the previously-dead pool energy column —
+    consistent with the build-gate ``coverage.pool_coverage`` field set."""
     del payload
-    metas = [_pass1_track_meta(t) for t in _pool_tracks(db, set_obj.id)]
+    pool = _pool_tracks(db, set_obj.id)
+    metas = [_pass1_track_meta(t) for t in pool]
     camelot_keys = [str(pos) for pos in (parse_key(m.key) for m in metas) if pos is not None]
     bpms = [float(m.bpm) for m in metas if m.bpm is not None]
+    genre_count = sum(1 for t in pool if t.genre)
+    energy_count = sum(1 for t in pool if t.energy is not None)
     present = set(camelot_keys)
     missing = [key for key in ALL_CAMELOT_KEYS if key not in present]
     bands = _bpm_bands(set_obj, bpms)
     logger.debug(
-        "Set %s analyze_pool_gaps: pool=%d keyed=%d bpm=%d missing_keys=%d",
+        "Set %s analyze_pool_gaps: pool=%d keyed=%d bpm=%d genre=%d energy=%d missing_keys=%d",
         set_obj.id,
         len(metas),
         len(camelot_keys),
         len(bpms),
+        genre_count,
+        energy_count,
         len(missing),
     )
     return {
         "pool_size": len(metas),
         "keyed_track_count": len(camelot_keys),
         "bpm_track_count": len(bpms),
+        "genre_track_count": genre_count,
+        "energy_track_count": energy_count,
+        "missing_genre_count": len(metas) - genre_count,
+        "missing_energy_count": len(metas) - energy_count,
         "missing_camelot_keys": missing,
         "bpm_bands": bands,
         "sparse_bands": [b for b in bands if b["count"] < SPARSE_BAND_THRESHOLD],

--- a/server/app/services/setbuilder/agent_tools_structural.py
+++ b/server/app/services/setbuilder/agent_tools_structural.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 from app.models.set import Set
 from app.services.setbuilder.agent_common import AgentToolError, _ordered_slots, _pool_tracks
 from app.services.setbuilder.agent_tools_mutations import _insert_track_at
+from app.services.setbuilder.coverage import coverage_for_set
 from app.services.setbuilder.pass1_deterministic import AVG_TRACK_LENGTH_SEC, build_set
 from app.services.setbuilder.pass1_deterministic import _track_meta as _pass1_track_meta
 
@@ -35,15 +36,27 @@ def _tool_autobuild(
     already honors locked slots and saved pairings. Runs with ``commit=False``
     so the agent turn commits/rolls back as one unit.
     """
+    # Coverage of the five required pool→builder fields BEFORE the rebuild, so the
+    # agent can warn the DJ about under-enriched tracks (#542). Soft/advisory only:
+    # autobuild proceeds regardless, mirroring the REST build's overridable gate.
+    coverage = coverage_for_set(db, set_obj.id)
     result = build_set(db, set_obj, commit=False)
     affected = {slot.position for slot in result.slots}
     logger.info(
-        "setbuilder autobuild: set %s rebuilt to %s slots (%s refinement iterations)",
+        "setbuilder autobuild: set %s rebuilt to %s slots (%s refinement iterations); "
+        "pool coverage ready=%s (%s/%s fully enriched)",
         set_obj.id,
         result.slot_count,
         result.iterations,
+        coverage["ready"],
+        coverage["fully_covered_count"],
+        coverage["pool_size"],
     )
-    return {"slot_count": result.slot_count, "iterations": result.iterations}, affected
+    return {
+        "slot_count": result.slot_count,
+        "iterations": result.iterations,
+        "coverage": coverage,
+    }, affected
 
 
 def _duration_for(track) -> int:

--- a/server/app/services/setbuilder/coverage.py
+++ b/server/app/services/setbuilder/coverage.py
@@ -1,0 +1,88 @@
+"""Pre-build pool coverage check (#542).
+
+The pool→builder contract is: **bpm + key + energy + genre + duration must be
+present for every pool track before set generation.** This module reports how
+well a set's pool satisfies that contract — per-field missing counts plus an
+overall ``ready`` signal — so the deterministic build endpoint and the agent
+autobuild path can surface a SOFT, overridable warning (never a hard block) in
+the build-confirmation dialog (#538).
+
+It is intentionally pure and synchronous: it reads only the pool rows handed to
+it (already resolved against the master tracks store on import, see
+``pool.hydrate_candidates_from_store``) and computes counts — no DB writes, no
+provider calls, trivially unit-testable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy.orm import Session
+
+from app.models.set_pool import SetPoolTrack
+
+# The five required pool→builder contract fields, in display order. ``key`` maps
+# to ``camelot or key`` (what the builder reads via pass1 ``_track_meta``) and
+# ``duration`` to ``duration_sec``; the rest are direct column names.
+REQUIRED_FIELDS: tuple[str, ...] = ("bpm", "key", "genre", "duration", "energy")
+
+# A pool is "ready" to build when at least this fraction of its tracks carry all
+# five fields. Soft gate only — the build is overridable below it (#538/#542).
+READY_THRESHOLD = 0.80
+
+
+def _has_field(track: SetPoolTrack, field: str) -> bool:
+    """Whether a pool track carries the named contract field.
+
+    ``key`` is satisfied by either the resolved Camelot code or a raw key, to
+    match the builder's ``camelot or key`` read; the others map to a single
+    column. ``bpm``/``duration``/``energy`` use ``is not None`` so a legitimate
+    0 still counts as present (never reached for bpm/duration in practice, but
+    explicit so the contract is unambiguous)."""
+    if field == "key":
+        return bool(track.camelot or track.key)
+    if field == "genre":
+        return bool(track.genre)
+    column = "duration_sec" if field == "duration" else field
+    return getattr(track, column) is not None
+
+
+def pool_coverage(tracks: Sequence[SetPoolTrack]) -> dict[str, object]:
+    """Report coverage of the five required contract fields over a set's pool.
+
+    Returns a JSON-serializable dict:
+      * ``pool_size`` — total pool tracks,
+      * ``missing`` — ``{field: count_of_tracks_missing_it}`` for each required field,
+      * ``fully_covered_count`` — tracks carrying ALL five fields,
+      * ``ready`` — True when the fully-covered fraction meets ``READY_THRESHOLD``
+        (an empty pool is vacuously ready: there is nothing under-enriched to warn
+        about; the empty-pool case is handled elsewhere).
+    """
+    pool_size = len(tracks)
+    missing = {field: 0 for field in REQUIRED_FIELDS}
+    fully_covered = 0
+    for track in tracks:
+        complete = True
+        for field in REQUIRED_FIELDS:
+            if not _has_field(track, field):
+                missing[field] += 1
+                complete = False
+        if complete:
+            fully_covered += 1
+
+    ready = pool_size == 0 or (fully_covered / pool_size) >= READY_THRESHOLD
+    return {
+        "pool_size": pool_size,
+        "missing": missing,
+        "fully_covered_count": fully_covered,
+        "ready": ready,
+    }
+
+
+def coverage_for_set(db: Session, set_id: int) -> dict[str, object]:
+    """Convenience wrapper: load a set's pool tracks and report their coverage.
+
+    Used by the build endpoint and the agent autobuild path to attach coverage
+    to their result without each re-querying the pool."""
+    tracks = db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_id).all()
+    return pool_coverage(tracks)

--- a/server/app/services/setbuilder/pool.py
+++ b/server/app/services/setbuilder/pool.py
@@ -221,7 +221,12 @@ def import_candidates(
 
 # Pool→builder contract fields mapped to (PoolCandidate attr, store attr). `key`
 # resolves to the store's Camelot `musical_key`; the rest are 1:1. These are the
-# fields hydrated DOWN from a store row onto a candidate.
+# fields hydrated DOWN from a store row onto a candidate (per-field, #554 FIX 3).
+# Energy may be hydrated from an authoritative row but is DELIBERATELY excluded
+# from the provider-enrich gate (`_has_provider_gap`): it comes only from
+# Soundcharts/Lexicon (dark, #543/#544), so gating enrich on it would re-hit
+# Beatport/Tidal on every import. Energy completeness is reported separately by
+# `pool_coverage` for the build gate.
 _CONTRACT_FIELDS: tuple[tuple[str, str], ...] = (
     ("bpm", "bpm"),
     ("key", "musical_key"),
@@ -229,14 +234,6 @@ _CONTRACT_FIELDS: tuple[tuple[str, str], ...] = (
     ("duration_sec", "duration_sec"),
     ("energy", "energy"),
 )
-
-# The cache short-circuit (skip the provider cascade) gates on the fields the
-# wired providers (`enrich_track` = Beatport→Tidal) can actually fill. Energy is
-# DELIBERATELY excluded: it comes only from Soundcharts/Lexicon (currently dark,
-# #543/#544), so gating on it would re-hit Beatport/Tidal on every import and
-# defeat the dedupe win. Energy completeness is still reported by `pool_coverage`
-# for the build gate — the two concerns are separate.
-_CACHE_GATE_FIELDS: tuple[str, ...] = ("bpm", "musical_key", "genre", "duration_sec")
 
 
 def hydrate_candidates_from_store(
@@ -301,7 +298,15 @@ def hydrate_candidates_from_store(
 def _hydrate_one(
     db: Session, candidate: PoolCandidate, user: User | None, *, commit: bool
 ) -> PoolCandidate:
-    """Resolve one candidate against the store and return a gap-filled copy."""
+    """Resolve one candidate against the store and return a gap-filled copy.
+
+    Per-field, not all-or-nothing (#554 FIX 3): each missing candidate field is
+    filled from the row when the row's value is present AND authoritative — so a
+    PARTIALLY-cached row still contributes (a provider-less DJ benefits from
+    whatever the store already holds). Only AFTER that do remaining gaps decide
+    populate-vs-enrich-vs-leave, and the store is populated with the candidate's
+    OWN brought fields only — never the values just read from the row (which would
+    be churn / a provenance downgrade)."""
     title = (candidate.title or "").strip()
     artist = (candidate.artist or "").strip()
     if not title or not artist:
@@ -310,72 +315,94 @@ def _hydrate_one(
     sig = dedupe_signature(artist, title)
 
     row = get_track(db, isrc=isrc, signature=sig)
-    if row is not None and _row_trusted_complete(row):
-        return _hydrate_from_row(candidate, row)
+    hydrated_fields: set[str] = set()
+    if row is not None:
+        candidate, hydrated_fields = _hydrate_authoritative_fields(candidate, row)
 
-    # Candidate carries usable fields the store lacks → populate the store from it.
-    if _candidate_has_provider_fields(candidate):
+    # Populate the store from the candidate's OWN provider-grade fields that the
+    # store still lacks — excluding anything we just hydrated FROM the row.
+    if _candidate_has_writable_fields(candidate, exclude=hydrated_fields):
         _write_candidate_to_store(
-            db, candidate, title=title, artist=artist, sig=sig, isrc=isrc, commit=commit
+            db,
+            candidate,
+            title=title,
+            artist=artist,
+            sig=sig,
+            isrc=isrc,
+            commit=commit,
+            exclude=hydrated_fields,
         )
-        return candidate
 
-    # Genuine gaps: only a connected DJ can run the provider cascade.
-    if user is None:
-        return candidate
-    return _enrich_and_writeback(
-        db, candidate, user, title=title, artist=artist, sig=sig, isrc=isrc, commit=commit
-    )
+    # Genuine remaining gaps in the provider-fillable fields: only a connected DJ
+    # can run the cascade. Energy stays out of this gate by design.
+    if _has_provider_gap(candidate) and user is not None:
+        return _enrich_and_writeback(
+            db, candidate, user, title=title, artist=artist, sig=sig, isrc=isrc, commit=commit
+        )
+    return candidate
 
 
-def _row_trusted_complete(row) -> bool:
-    """True when the store row carries every provider-fillable contract field
-    (bpm/key/genre/duration) AND each comes from a real measured/authoritative
-    provider (the 50+ precedence tier).
+def _hydrate_authoritative_fields(candidate: PoolCandidate, row) -> tuple[PoolCandidate, set[str]]:
+    """Fill each MISSING candidate field from the row when the row's value is
+    present AND from an authoritative source (50+ precedence). Per-field — a row
+    that is only partially trusted still contributes its trusted fields.
 
-    Energy is excluded by design (see ``_CACHE_GATE_FIELDS``). A low-trust/legacy
-    row is NOT served as a cache hit (mirrors the request-side ``_trio_trusted``):
-    falling through lets a connected DJ's real providers upgrade it rather than
-    copying unupgraded values onto every future pool."""
+    Returns the (possibly new) candidate plus the set of candidate-attr names that
+    were hydrated FROM the row, so the caller never writes those back to the store.
+    Existing candidate values always win (an import that carries data keeps it).
+    ``key`` takes the row's Camelot ``musical_key``/``camelot`` so
+    ``import_candidates`` derives the pool ``camelot`` from it. Energy may be
+    copied here when authoritative, even though it is excluded from the provider
+    short-circuit gate."""
     prov = row.provenance or {}
-    for store_attr in _CACHE_GATE_FIELDS:
-        value = (
-            (row.camelot or row.musical_key)
-            if store_attr == "musical_key"
-            else getattr(row, store_attr)
-        )
-        if value is None:
-            return False
-        if not is_cache_authoritative(prov.get(store_attr, {}).get("source", "")):
-            return False
-    return True
-
-
-def _hydrate_from_row(candidate: PoolCandidate, row) -> PoolCandidate:
-    """Return a copy of the candidate with each MISSING field filled from the row.
-
-    Existing candidate values win (an import that already carries data keeps it);
-    only gaps are filled. ``key`` takes the row's Camelot ``musical_key`` (or
-    ``camelot``) so ``import_candidates`` derives the pool ``camelot`` from it."""
     updates: dict[str, object] = {}
+    hydrated: set[str] = set()
     for cand_attr, store_attr in _CONTRACT_FIELDS:
         if getattr(candidate, cand_attr) is not None:
             continue
         row_value = (
-            row.camelot or row.musical_key
+            (row.camelot or row.musical_key)
             if store_attr == "musical_key"
             else getattr(row, store_attr)
         )
-        if row_value is not None:
-            updates[cand_attr] = row_value
-    return dataclasses.replace(candidate, **updates) if updates else candidate
+        if row_value is None:
+            continue
+        if not is_cache_authoritative(prov.get(store_attr, {}).get("source", "")):
+            continue
+        updates[cand_attr] = row_value
+        hydrated.add(cand_attr)
+    if not updates:
+        return candidate, hydrated
+    return dataclasses.replace(candidate, **updates), hydrated
 
 
-def _candidate_has_provider_fields(candidate: PoolCandidate) -> bool:
-    """True if the candidate carries at least one core provider field worth
-    persisting (bpm/key/genre) — i.e. it arrived from a metadata-rich playlist
-    import (Beatport/Tidal) rather than an empty Spotify/manual row."""
-    return any((candidate.bpm is not None, candidate.key, candidate.genre))
+def _has_provider_gap(candidate: PoolCandidate) -> bool:
+    """True if any provider-fillable field (bpm/key/genre/duration) is still
+    missing — the trigger for running the enrich cascade. Energy is excluded (it
+    comes only from Soundcharts/Lexicon, dark per #543/#544)."""
+    return (
+        candidate.bpm is None
+        or not candidate.key
+        or not candidate.genre
+        or candidate.duration_sec is None
+    )
+
+
+def _candidate_has_writable_fields(candidate: PoolCandidate, *, exclude: set[str]) -> bool:
+    """True if the candidate carries at least one core provider field (bpm/key/
+    genre) worth persisting to the store that was NOT just hydrated from the row.
+
+    ``exclude`` is the set of candidate-attr names filled FROM the row this pass —
+    those must not be written back (no churn, no provenance downgrade, #554 FIX 3).
+    A candidate brings store-worthy data only when one of bpm/key/genre is its OWN
+    (e.g. a Beatport/Tidal playlist row, or a new field on top of a partial row)."""
+    return any(
+        (
+            candidate.bpm is not None and "bpm" not in exclude,
+            bool(candidate.key) and "key" not in exclude,
+            bool(candidate.genre) and "genre" not in exclude,
+        )
+    )
 
 
 def _candidate_source(candidate: PoolCandidate) -> str:
@@ -400,25 +427,29 @@ def _write_candidate_to_store(
     sig: str,
     isrc: str | None,
     commit: bool,
+    exclude: set[str],
 ) -> None:
-    """Upsert the candidate's carried fields into the store (commit-first when
+    """Upsert the candidate's OWN carried fields into the store (commit-first when
     ``commit``).
 
-    Commits any pending work FIRST so a store-write failure can't poison an
-    outer transaction (mirrors the request-side ``_safe_upsert_track``); the
-    store is strictly additive."""
+    ``exclude`` holds candidate-attr names that were hydrated FROM the row this
+    pass — they are skipped so a value just read from the store is never written
+    back (#554 FIX 3). Commits any pending work FIRST so a store-write failure
+    can't poison an outer transaction (mirrors the request-side
+    ``_safe_upsert_track``); the store is strictly additive."""
     source = _candidate_source(candidate)
     values: dict[str, object] = {}
-    if candidate.bpm is not None:
+    if candidate.bpm is not None and "bpm" not in exclude:
         values["bpm"] = float(candidate.bpm)
-    key_camelot = camelot_code(candidate.key)
-    if key_camelot:
-        values["musical_key"] = key_camelot
-    if candidate.genre:
+    if "key" not in exclude:
+        key_camelot = camelot_code(candidate.key)
+        if key_camelot:
+            values["musical_key"] = key_camelot
+    if candidate.genre and "genre" not in exclude:
         values["genre"] = candidate.genre
-    if candidate.duration_sec is not None:
+    if candidate.duration_sec is not None and "duration_sec" not in exclude:
         values["duration_sec"] = candidate.duration_sec
-    if candidate.energy is not None:
+    if candidate.energy is not None and "energy" not in exclude:
         values["energy"] = candidate.energy
     if not values:
         return
@@ -479,8 +510,23 @@ def _enrich_and_writeback(
         sources=sources,
         commit=commit,
     )
-    row = get_track(db, signature=sig)
-    return _hydrate_from_row(candidate, row) if row is not None else candidate
+    # Fill the candidate from its OWN freshly-enriched values (gap-fill, not
+    # authority-gated): this is the data we just resolved for this candidate, so it
+    # flows back regardless of the store row's trust tier.
+    return _fill_missing(candidate, values)
+
+
+def _fill_missing(candidate: PoolCandidate, values: dict[str, object]) -> PoolCandidate:
+    """Return a copy of the candidate with each missing contract field filled from
+    a store ``values`` payload (keyed by store-attr). ``musical_key`` maps to the
+    candidate's ``key``. Existing candidate values are preserved."""
+    store_to_cand = {store_attr: cand_attr for cand_attr, store_attr in _CONTRACT_FIELDS}
+    updates = {
+        store_to_cand[store_attr]: value
+        for store_attr, value in values.items()
+        if store_attr in store_to_cand and getattr(candidate, store_to_cand[store_attr]) is None
+    }
+    return dataclasses.replace(candidate, **updates) if updates else candidate
 
 
 def _safe_upsert(

--- a/server/app/services/setbuilder/pool.py
+++ b/server/app/services/setbuilder/pool.py
@@ -398,18 +398,23 @@ def _has_provider_gap(candidate: PoolCandidate) -> bool:
 
 
 def _candidate_has_writable_fields(candidate: PoolCandidate, *, exclude: set[str]) -> bool:
-    """True if the candidate carries at least one core provider field (bpm/key/
-    genre) worth persisting to the store that was NOT just hydrated from the row.
+    """True if the candidate carries at least one contract field (bpm/key/genre/
+    duration) worth persisting to the store that was NOT just hydrated from the row.
 
     ``exclude`` is the set of candidate-attr names filled FROM the row this pass —
     those must not be written back (no churn, no provenance downgrade, #554 FIX 3).
-    A candidate brings store-worthy data only when one of bpm/key/genre is its OWN
-    (e.g. a Beatport/Tidal playlist row, or a new field on top of a partial row)."""
+    Must list every field ``_write_candidate_to_store`` actually persists: duration
+    is a required pool→builder contract field it writes, so omitting it here skipped
+    the store write for a duration-only candidate (e.g. a Spotify/public-URL import
+    that carries duration but no bpm/key/genre) and the duration never cached
+    (#554 FIX 8). Energy is intentionally NOT a trigger on its own (it never gates a
+    build/enrich), but it still rides along when another field triggers the write."""
     return any(
         (
             candidate.bpm is not None and "bpm" not in exclude,
             bool(candidate.key) and "key" not in exclude,
             bool(candidate.genre) and "genre" not in exclude,
+            candidate.duration_sec is not None and "duration_sec" not in exclude,
         )
     )
 

--- a/server/app/services/setbuilder/pool.py
+++ b/server/app/services/setbuilder/pool.py
@@ -316,7 +316,16 @@ def _hydrate_one(
 
     row = get_track(db, isrc=isrc, signature=sig)
     hydrated_fields: set[str] = set()
-    if row is not None:
+    # get_track is ISRC-first then SIGNATURE-fallback, so a candidate with a valid
+    # ISRC not in the store can match a DIFFERENT recording's row (same normalized
+    # artist/title, different ISRC). Hydrating would copy the wrong recording's
+    # fields onto this candidate. Only hydrate when ISRC-compatible — mirrors the
+    # request-side guard in sync/enrichment_pipeline. An ISRC-less row (or an
+    # ISRC-less candidate) is a compatible signature hit and still hydrates; on a
+    # genuine conflict we skip hydration and let enrichment fill the candidate
+    # (upsert_track separately refuses the conflicting write, #552/#554 FIX 6).
+    isrc_compatible = isrc is None or row is None or row.isrc in (None, isrc)
+    if row is not None and isrc_compatible:
         candidate, hydrated_fields = _hydrate_authoritative_fields(candidate, row)
 
     # Populate the store from the candidate's OWN provider-grade fields that the

--- a/server/app/services/setbuilder/pool.py
+++ b/server/app/services/setbuilder/pool.py
@@ -864,15 +864,20 @@ def candidate_from_manual(
 ) -> PoolCandidate:
     """Build a candidate from a manual search pick (validated at the API layer).
 
-    A real ``source_track_id`` (only present for providers that expose a usable id)
-    mints a server-trusted ``beatport:<id>``/``tidal:<id>`` track_id. A manual pick
-    that carries no such id stays ``track_id=None`` → stored as ``legacy``: the
-    client-asserted ``source_service`` alone is NOT trusted as provenance (it is
-    unverifiable and would let a client poison the shared store — see
-    ``_candidate_source``, #554 P1)."""
+    ``source_service``/``source_track_id`` are CLIENT input, so this must NEVER mint
+    an authoritative ``beatport:``/``tidal:`` track_id from them — that prefix is the
+    authority signal ``_candidate_source`` trusts, and forging it would let a crafted
+    request write fabricated provider-grade data into the shared, multi-tenant store
+    (#554 P1). Authoritative beatport/tidal prefixes come ONLY from the server-side
+    playlist builders (``candidates_from_beatport``/``candidates_from_tidal``), which
+    mint them from the DJ's OAuth'd server-side fetch — never from this path.
+
+    We keep ONLY a non-authoritative ``spotify:<id>`` reference (Spotify resolves to
+    ``legacy`` in ``_candidate_source`` regardless, and it is the one provider the FE
+    actually sends an id for). Everything else stays ``track_id=None`` → ``legacy``."""
     track_id = None
-    if source_track_id and source_service != "manual":
-        track_id = f"{source_service}:{source_track_id}"
+    if source_track_id and source_service == "spotify":
+        track_id = f"spotify:{source_track_id}"
     return PoolCandidate(
         track_id=track_id,
         title=title,

--- a/server/app/services/setbuilder/pool.py
+++ b/server/app/services/setbuilder/pool.py
@@ -10,6 +10,7 @@ normalized artist+title signature (via services/track_normalizer). The
 first import wins — the original source tag is preserved.
 """
 
+import dataclasses
 import hashlib
 import logging
 from collections.abc import Iterable
@@ -17,13 +18,17 @@ from dataclasses import dataclass
 
 from sqlalchemy.orm import Session
 
+from app.core.time import utcnow
 from app.models.event import Event
 from app.models.request import Request, RequestStatus
 from app.models.set import Set
 from app.models.set_pool import SetPoolSource, SetPoolTrack
 from app.models.user import User
 from app.services.recommendation.camelot import parse_key
-from app.services.track_normalizer import normalize_track
+from app.services.recommendation.enrichment import enrich_track
+from app.services.track_normalizer import normalize_track, valid_isrc
+from app.services.tracks.provenance import is_cache_authoritative
+from app.services.tracks.store import TrackIdentity, get_track, upsert_track
 
 logger = logging.getLogger(__name__)
 
@@ -204,6 +209,306 @@ def import_candidates(
     else:
         db.flush()
     return added, deduped
+
+
+# ---------------------------------------------------------------------------
+# Master tracks store resolution (#542)
+#
+# Every import flow runs `hydrate_candidates_from_store` BEFORE `import_candidates`
+# so each candidate is enriched once and reused across sets/events via the global
+# `tracks` store — the pool-side mirror of the request-side cache-aside (#541).
+# `import_candidates` stays a pure dedupe-insert.
+
+# Pool→builder contract fields mapped to (PoolCandidate attr, store attr). `key`
+# resolves to the store's Camelot `musical_key`; the rest are 1:1. These are the
+# fields hydrated DOWN from a store row onto a candidate.
+_CONTRACT_FIELDS: tuple[tuple[str, str], ...] = (
+    ("bpm", "bpm"),
+    ("key", "musical_key"),
+    ("genre", "genre"),
+    ("duration_sec", "duration_sec"),
+    ("energy", "energy"),
+)
+
+# The cache short-circuit (skip the provider cascade) gates on the fields the
+# wired providers (`enrich_track` = Beatport→Tidal) can actually fill. Energy is
+# DELIBERATELY excluded: it comes only from Soundcharts/Lexicon (currently dark,
+# #543/#544), so gating on it would re-hit Beatport/Tidal on every import and
+# defeat the dedupe win. Energy completeness is still reported by `pool_coverage`
+# for the build gate — the two concerns are separate.
+_CACHE_GATE_FIELDS: tuple[str, ...] = ("bpm", "musical_key", "genre", "duration_sec")
+
+
+def hydrate_candidates_from_store(
+    db: Session,
+    candidates: Iterable[PoolCandidate],
+    *,
+    user: User | None = None,
+    commit: bool = True,
+) -> list[PoolCandidate]:
+    """Resolve each candidate to the master `tracks` store and fill its gaps.
+
+    Per candidate (immutably — a NEW PoolCandidate is returned, never mutated):
+      1. Resolve the store row by ISRC → signature.
+      2. Trusted+complete row → hydrate the candidate's missing fields from it
+         (ZERO API calls — the dedupe win).
+      3. Store miss but the candidate already carries fields → upsert to POPULATE
+         the store from the candidate (ZERO API calls).
+      4. Genuine gaps AND a connected `user` → run the provider cascade once
+         (`enrich_track`), write the result back to the store, then hydrate.
+      5. Gaps with no connected `user` → return the candidate unchanged.
+
+    ``commit`` follows ``import_candidates``: the REST import flows commit the
+    store write durably (commit-first, so it never poisons the import); the agent
+    import tools pass ``commit=False`` so the store write rides the single
+    agent-turn transaction and rolls back with it (a dropped cache row is
+    harmless and recomputes next import).
+
+    Per-candidate failures are isolated and logged (the import must not abort
+    over a best-effort store write); the candidate falls through unhydrated.
+    """
+    resolved: list[PoolCandidate] = []
+    for candidate in candidates:
+        try:
+            resolved.append(_hydrate_one(db, candidate, user, commit=commit))
+        except Exception:
+            # commit=False (agent turn): the session may be poisoned and the turn
+            # owns the transaction — re-raise so the turn rolls back atomically
+            # rather than continuing on a broken session. commit=True (REST): each
+            # candidate is independent and no pool rows are committed yet, so we
+            # recover the session and import this one unhydrated.
+            if not commit:
+                raise
+            logger.warning(
+                "Pool store hydration failed for '%s' by '%s'; importing as-is.",
+                candidate.title,
+                candidate.artist,
+            )
+            db.rollback()
+            resolved.append(candidate)
+    return resolved
+
+
+def _hydrate_one(
+    db: Session, candidate: PoolCandidate, user: User | None, *, commit: bool
+) -> PoolCandidate:
+    """Resolve one candidate against the store and return a gap-filled copy."""
+    title = (candidate.title or "").strip()
+    artist = (candidate.artist or "").strip()
+    if not title or not artist:
+        return candidate
+    isrc = valid_isrc(candidate.isrc)
+    sig = dedupe_signature(artist, title)
+
+    row = get_track(db, isrc=isrc, signature=sig)
+    if row is not None and _row_trusted_complete(row):
+        return _hydrate_from_row(candidate, row)
+
+    # Candidate carries usable fields the store lacks → populate the store from it.
+    if _candidate_has_provider_fields(candidate):
+        _write_candidate_to_store(
+            db, candidate, title=title, artist=artist, sig=sig, isrc=isrc, commit=commit
+        )
+        return candidate
+
+    # Genuine gaps: only a connected DJ can run the provider cascade.
+    if user is None:
+        return candidate
+    return _enrich_and_writeback(
+        db, candidate, user, title=title, artist=artist, sig=sig, commit=commit
+    )
+
+
+def _row_trusted_complete(row) -> bool:
+    """True when the store row carries every provider-fillable contract field
+    (bpm/key/genre/duration) AND each comes from a real measured/authoritative
+    provider (the 50+ precedence tier).
+
+    Energy is excluded by design (see ``_CACHE_GATE_FIELDS``). A low-trust/legacy
+    row is NOT served as a cache hit (mirrors the request-side ``_trio_trusted``):
+    falling through lets a connected DJ's real providers upgrade it rather than
+    copying unupgraded values onto every future pool."""
+    prov = row.provenance or {}
+    for store_attr in _CACHE_GATE_FIELDS:
+        value = (
+            (row.camelot or row.musical_key)
+            if store_attr == "musical_key"
+            else getattr(row, store_attr)
+        )
+        if value is None:
+            return False
+        if not is_cache_authoritative(prov.get(store_attr, {}).get("source", "")):
+            return False
+    return True
+
+
+def _hydrate_from_row(candidate: PoolCandidate, row) -> PoolCandidate:
+    """Return a copy of the candidate with each MISSING field filled from the row.
+
+    Existing candidate values win (an import that already carries data keeps it);
+    only gaps are filled. ``key`` takes the row's Camelot ``musical_key`` (or
+    ``camelot``) so ``import_candidates`` derives the pool ``camelot`` from it."""
+    updates: dict[str, object] = {}
+    for cand_attr, store_attr in _CONTRACT_FIELDS:
+        if getattr(candidate, cand_attr) is not None:
+            continue
+        row_value = (
+            row.camelot or row.musical_key
+            if store_attr == "musical_key"
+            else getattr(row, store_attr)
+        )
+        if row_value is not None:
+            updates[cand_attr] = row_value
+    return dataclasses.replace(candidate, **updates) if updates else candidate
+
+
+def _candidate_has_provider_fields(candidate: PoolCandidate) -> bool:
+    """True if the candidate carries at least one core provider field worth
+    persisting (bpm/key/genre) — i.e. it arrived from a metadata-rich playlist
+    import (Beatport/Tidal) rather than an empty Spotify/manual row."""
+    return any((candidate.bpm is not None, candidate.key, candidate.genre))
+
+
+def _candidate_source(candidate: PoolCandidate) -> str:
+    """Map a candidate's namespaced ``track_id`` prefix to a store source name.
+
+    Beatport/Tidal/manual carry real provider-grade metadata; Spotify/request/
+    unprefixed carry only what was typed/seeded, so they attribute ``legacy``
+    (lowest precedence) and never masquerade as an authoritative provider."""
+    track_id = candidate.track_id or ""
+    prefix = track_id.split(":", 1)[0] if ":" in track_id else ""
+    if prefix in ("beatport", "tidal", "manual"):
+        return prefix
+    return "legacy"
+
+
+def _write_candidate_to_store(
+    db: Session,
+    candidate: PoolCandidate,
+    *,
+    title: str,
+    artist: str,
+    sig: str,
+    isrc: str | None,
+    commit: bool,
+) -> None:
+    """Upsert the candidate's carried fields into the store (commit-first when
+    ``commit``).
+
+    Commits any pending work FIRST so a store-write failure can't poison an
+    outer transaction (mirrors the request-side ``_safe_upsert_track``); the
+    store is strictly additive."""
+    source = _candidate_source(candidate)
+    values: dict[str, object] = {}
+    if candidate.bpm is not None:
+        values["bpm"] = float(candidate.bpm)
+    key_camelot = camelot_code(candidate.key)
+    if key_camelot:
+        values["musical_key"] = key_camelot
+    if candidate.genre:
+        values["genre"] = candidate.genre
+    if candidate.duration_sec is not None:
+        values["duration_sec"] = candidate.duration_sec
+    if candidate.energy is not None:
+        values["energy"] = candidate.energy
+    if not values:
+        return
+    sources = {field: source for field in values}
+    _safe_upsert(
+        db,
+        title=title,
+        artist=artist,
+        sig=sig,
+        isrc=isrc,
+        values=values,
+        sources=sources,
+        commit=commit,
+    )
+
+
+def _enrich_and_writeback(
+    db: Session,
+    candidate: PoolCandidate,
+    user: User,
+    *,
+    title: str,
+    artist: str,
+    sig: str,
+    commit: bool,
+) -> PoolCandidate:
+    """Run the provider cascade once, write the result back, and hydrate.
+
+    `enrich_track` (Beatport→Tidal) is the same gap-fill the recommendation
+    surface uses; its result is upserted to the store at provider precedence so
+    the next import of this recording is served from cache."""
+    profile = enrich_track(db, user, title, artist)
+    values: dict[str, object] = {}
+    if profile.bpm is not None:
+        values["bpm"] = float(profile.bpm)
+    key_camelot = camelot_code(profile.key)
+    if key_camelot:
+        values["musical_key"] = key_camelot
+    if profile.genre:
+        values["genre"] = profile.genre
+    if profile.duration_seconds is not None:
+        values["duration_sec"] = profile.duration_seconds
+    if not values:
+        return candidate
+    source = profile.source if profile.source in ("beatport", "tidal") else "legacy"
+    sources = {field: source for field in values}
+    _safe_upsert(
+        db,
+        title=title,
+        artist=artist,
+        sig=sig,
+        isrc=None,
+        values=values,
+        sources=sources,
+        commit=commit,
+    )
+    row = get_track(db, signature=sig)
+    return _hydrate_from_row(candidate, row) if row is not None else candidate
+
+
+def _safe_upsert(
+    db: Session,
+    *,
+    title: str,
+    artist: str,
+    sig: str,
+    isrc: str | None,
+    values: dict[str, object],
+    sources: dict[str, str],
+    commit: bool,
+) -> None:
+    """Store upsert with the import's commit discipline.
+
+    REST path (``commit=True``): commit-first — durably flush outer work, then
+    write the store on top, rolling back only the store write on failure (never
+    the import). Agent path (``commit=False``): just flush, so the store write
+    rides the single agent-turn transaction (and rolls back with it on undo)."""
+    if not commit:
+        upsert_track(
+            db,
+            identity=TrackIdentity(title=title, artist=artist, signature=sig, isrc=isrc),
+            values=values,
+            sources=sources,
+            fetched_at=utcnow(),
+        )
+        return
+    db.commit()
+    try:
+        upsert_track(
+            db,
+            identity=TrackIdentity(title=title, artist=artist, signature=sig, isrc=isrc),
+            values=values,
+            sources=sources,
+            fetched_at=utcnow(),
+        )
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.warning("Pool store upsert failed for '%s' by '%s'.", title, artist)
 
 
 # ---------------------------------------------------------------------------

--- a/server/app/services/setbuilder/pool.py
+++ b/server/app/services/setbuilder/pool.py
@@ -52,11 +52,6 @@ class PoolCandidate:
     isrc: str | None = None
     duration_sec: int | None = None
     artwork_url: str | None = None
-    # The provider the candidate's metadata came from, when known ("beatport"/
-    # "tidal"). Carries provider provenance for manual search picks, whose
-    # track_id is None (the unified SearchResult schema only has spotify_id), so
-    # _candidate_source can't recover it from a track_id prefix (#554 review).
-    source_service: str | None = None
 
 
 def dedupe_signature(artist: str, title: str) -> str:
@@ -413,15 +408,22 @@ def _candidate_has_writable_fields(candidate: PoolCandidate, *, exclude: set[str
 def _candidate_source(candidate: PoolCandidate) -> str:
     """Resolve the store source name a candidate's metadata should be written under.
 
-    Prefer the explicit ``source_service`` (set for manual Beatport/Tidal picks,
-    which carry no namespaced track_id — #554 review), then fall back to the
-    ``track_id`` prefix the playlist builders still carry (``beatport:<id>`` /
-    ``tidal:<id>``). Only Beatport/Tidal are authoritative providers here; Spotify
-    (not a bpm/key source), request/manual-typed, and unprefixed metadata attribute
-    ``legacy`` (lowest precedence) and never masquerade as an authoritative
-    provider — so a later real-provider enrichment cleanly overrides them."""
-    if candidate.source_service in ("beatport", "tidal"):
-        return candidate.source_service
+    Authority comes ONLY from a server-trusted namespaced ``track_id`` prefix that
+    the connected-account playlist builders mint (``beatport:<id>`` / ``tidal:<id>``
+    — the DJ's own OAuth'd fetch, so the provenance is real). Everything else —
+    Spotify (not a bpm/key authority), event requests, and manual SEARCH PICKS —
+    attributes ``legacy`` (lowest precedence) and never masquerades as a provider.
+
+    Manual picks are deliberately ``legacy`` even when the client asserts a
+    provider: that assertion (``PoolImportManualIn.source_service``) is
+    CLIENT-SUPPLIED and unverifiable server-side (the unified search result has no
+    server-side provider id — the gap that makes verification impossible). Trusting
+    it would let any authenticated DJ POST fabricated bpm/key/genre tagged
+    "beatport" and POISON the shared, multi-tenant tracks store that other DJs
+    hydrate from. A ``legacy`` row self-heals: the next connected-DJ import runs
+    ``enrich_track`` SERVER-SIDE and upgrades it to real beatport/tidal precedence,
+    so the precedence guard cleanly overrides it. The one-time re-enrichment cost is
+    consciously accepted; security over the dedupe optimization (#554 P1)."""
     track_id = candidate.track_id or ""
     prefix = track_id.split(":", 1)[0] if ":" in track_id else ""
     if prefix in ("beatport", "tidal"):
@@ -851,17 +853,17 @@ def candidate_from_manual(
     source_service: str = "manual",
     source_track_id: str | None = None,
 ) -> PoolCandidate:
-    """Build a candidate from a manual search pick (validated at the API layer)."""
+    """Build a candidate from a manual search pick (validated at the API layer).
+
+    A real ``source_track_id`` (only present for providers that expose a usable id)
+    mints a server-trusted ``beatport:<id>``/``tidal:<id>`` track_id. A manual pick
+    that carries no such id stays ``track_id=None`` → stored as ``legacy``: the
+    client-asserted ``source_service`` alone is NOT trusted as provenance (it is
+    unverifiable and would let a client poison the shared store — see
+    ``_candidate_source``, #554 P1)."""
     track_id = None
     if source_track_id and source_service != "manual":
         track_id = f"{source_service}:{source_track_id}"
-    # Carry the provider explicitly for authoritative picks (Beatport/Tidal): the
-    # unified search result has no beatport_id/tidal_id, so source_track_id is None
-    # for them and the track_id above stays None — without this their measured
-    # bpm/key/genre would be stored as `legacy` and never reused (#554 review).
-    # Spotify (not a bpm/key authority) and hand-typed "manual" intentionally stay
-    # None → `legacy`.
-    store_source = source_service if source_service in ("beatport", "tidal") else None
     return PoolCandidate(
         track_id=track_id,
         title=title,
@@ -873,5 +875,4 @@ def candidate_from_manual(
         isrc=isrc,
         duration_sec=duration_sec,
         artwork_url=artwork_url,
-        source_service=store_source,
     )

--- a/server/app/services/setbuilder/pool.py
+++ b/server/app/services/setbuilder/pool.py
@@ -267,6 +267,15 @@ def hydrate_candidates_from_store(
     Per-candidate failures are isolated and logged (the import must not abort
     over a best-effort store write); the candidate falls through unhydrated.
     """
+    # REST path: the caller has just flushed (not committed) its SetPoolSource row
+    # via get_or_create_source. A later per-candidate ``db.rollback()`` (commit=True
+    # recovery below) would discard that uncommitted source, leaving
+    # import_candidates to insert pool tracks against a dead source.id. Commit ONCE
+    # up front so the source is durable; per-candidate rollbacks can then only ever
+    # throw away in-flight store-write state, never the source (#554 FIX 1). The
+    # agent path (commit=False) owns its single transaction and must NOT commit here.
+    if commit:
+        db.commit()
     resolved: list[PoolCandidate] = []
     for candidate in candidates:
         try:

--- a/server/app/services/setbuilder/pool.py
+++ b/server/app/services/setbuilder/pool.py
@@ -52,6 +52,11 @@ class PoolCandidate:
     isrc: str | None = None
     duration_sec: int | None = None
     artwork_url: str | None = None
+    # The provider the candidate's metadata came from, when known ("beatport"/
+    # "tidal"). Carries provider provenance for manual search picks, whose
+    # track_id is None (the unified SearchResult schema only has spotify_id), so
+    # _candidate_source can't recover it from a track_id prefix (#554 review).
+    source_service: str | None = None
 
 
 def dedupe_signature(artist: str, title: str) -> str:
@@ -406,14 +411,20 @@ def _candidate_has_writable_fields(candidate: PoolCandidate, *, exclude: set[str
 
 
 def _candidate_source(candidate: PoolCandidate) -> str:
-    """Map a candidate's namespaced ``track_id`` prefix to a store source name.
+    """Resolve the store source name a candidate's metadata should be written under.
 
-    Beatport/Tidal/manual carry real provider-grade metadata; Spotify/request/
-    unprefixed carry only what was typed/seeded, so they attribute ``legacy``
-    (lowest precedence) and never masquerade as an authoritative provider."""
+    Prefer the explicit ``source_service`` (set for manual Beatport/Tidal picks,
+    which carry no namespaced track_id — #554 review), then fall back to the
+    ``track_id`` prefix the playlist builders still carry (``beatport:<id>`` /
+    ``tidal:<id>``). Only Beatport/Tidal are authoritative providers here; Spotify
+    (not a bpm/key source), request/manual-typed, and unprefixed metadata attribute
+    ``legacy`` (lowest precedence) and never masquerade as an authoritative
+    provider — so a later real-provider enrichment cleanly overrides them."""
+    if candidate.source_service in ("beatport", "tidal"):
+        return candidate.source_service
     track_id = candidate.track_id or ""
     prefix = track_id.split(":", 1)[0] if ":" in track_id else ""
-    if prefix in ("beatport", "tidal", "manual"):
+    if prefix in ("beatport", "tidal"):
         return prefix
     return "legacy"
 
@@ -844,6 +855,13 @@ def candidate_from_manual(
     track_id = None
     if source_track_id and source_service != "manual":
         track_id = f"{source_service}:{source_track_id}"
+    # Carry the provider explicitly for authoritative picks (Beatport/Tidal): the
+    # unified search result has no beatport_id/tidal_id, so source_track_id is None
+    # for them and the track_id above stays None — without this their measured
+    # bpm/key/genre would be stored as `legacy` and never reused (#554 review).
+    # Spotify (not a bpm/key authority) and hand-typed "manual" intentionally stay
+    # None → `legacy`.
+    store_source = source_service if source_service in ("beatport", "tidal") else None
     return PoolCandidate(
         track_id=track_id,
         title=title,
@@ -855,4 +873,5 @@ def candidate_from_manual(
         isrc=isrc,
         duration_sec=duration_sec,
         artwork_url=artwork_url,
+        source_service=store_source,
     )

--- a/server/app/services/setbuilder/pool.py
+++ b/server/app/services/setbuilder/pool.py
@@ -324,7 +324,7 @@ def _hydrate_one(
     if user is None:
         return candidate
     return _enrich_and_writeback(
-        db, candidate, user, title=title, artist=artist, sig=sig, commit=commit
+        db, candidate, user, title=title, artist=artist, sig=sig, isrc=isrc, commit=commit
     )
 
 
@@ -443,13 +443,17 @@ def _enrich_and_writeback(
     title: str,
     artist: str,
     sig: str,
+    isrc: str | None,
     commit: bool,
 ) -> PoolCandidate:
     """Run the provider cascade once, write the result back, and hydrate.
 
     `enrich_track` (Beatport→Tidal) is the same gap-fill the recommendation
     surface uses; its result is upserted to the store at provider precedence so
-    the next import of this recording is served from cache."""
+    the next import of this recording is served from cache. The candidate's
+    validated ISRC keys the store row so a later by-ISRC lookup hits it — e.g. a
+    Spotify/public-URL candidate that carries an ISRC but no bpm/key/genre (#554
+    FIX 2; consistent with #552 storing the submitted ISRC)."""
     profile = enrich_track(db, user, title, artist)
     values: dict[str, object] = {}
     if profile.bpm is not None:
@@ -470,7 +474,7 @@ def _enrich_and_writeback(
         title=title,
         artist=artist,
         sig=sig,
-        isrc=None,
+        isrc=isrc,
         values=values,
         sources=sources,
         commit=commit,

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1710,6 +1710,9 @@
       "BuildSetResponse": {
         "description": "Result of the deterministic pass.",
         "properties": {
+          "coverage": {
+            "$ref": "#/components/schemas/PoolCoverageOut"
+          },
           "iterations": {
             "title": "Iterations",
             "type": "integer"
@@ -1734,6 +1737,7 @@
           }
         },
         "required": [
+          "coverage",
           "iterations",
           "slot_count",
           "slots",
@@ -6230,6 +6234,38 @@
           "source"
         ],
         "title": "PlaylistInfo",
+        "type": "object"
+      },
+      "PoolCoverageOut": {
+        "description": "Pre-build coverage of the five required pool\u2192builder contract fields (#542).\n\nA SOFT, overridable signal surfaced in the build-confirmation dialog (#538):\n``missing`` is the per-field count of pool tracks lacking each field,\n``fully_covered_count`` how many carry all five, and ``ready`` whether the\npool clears the readiness threshold. The build is never hard-blocked on this.",
+        "properties": {
+          "fully_covered_count": {
+            "title": "Fully Covered Count",
+            "type": "integer"
+          },
+          "missing": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Missing",
+            "type": "object"
+          },
+          "pool_size": {
+            "title": "Pool Size",
+            "type": "integer"
+          },
+          "ready": {
+            "title": "Ready",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "fully_covered_count",
+          "missing",
+          "pool_size",
+          "ready"
+        ],
+        "title": "PoolCoverageOut",
         "type": "object"
       },
       "PoolImportEventIn": {
@@ -18337,7 +18373,7 @@
     },
     "/api/setbuilder/sets/{set_id}/build": {
       "post": {
-        "description": "Run deterministic pass 1 after explicit user confirmation.",
+        "description": "Run deterministic pass 1 after explicit user confirmation.\n\nCoverage of the five required pool\u2192builder fields is computed and returned so\nthe build-confirmation dialog can show data completeness and a SOFT,\noverridable warning (#542/#538) \u2014 the build itself is never blocked on it.",
         "operationId": "build_set_api_setbuilder_sets__set_id__build_post",
         "parameters": [
           {

--- a/server/tests/test_setbuilder_coverage.py
+++ b/server/tests/test_setbuilder_coverage.py
@@ -1,0 +1,73 @@
+"""Pre-build pool coverage check (#542).
+
+`pool_coverage` reports per-field completeness of the five required
+pool→builder contract fields (bpm, key, genre, duration, energy) plus an
+overall ready signal, so the build endpoint and the agent autobuild path can
+surface a soft, overridable warning before generating a set.
+"""
+
+from app.models.set_pool import SetPoolTrack
+from app.services.setbuilder.coverage import REQUIRED_FIELDS, pool_coverage
+
+
+def _track(**kwargs) -> SetPoolTrack:
+    """A detached pool track carrying only the fields under test."""
+    base = dict(title="T", artist="A", dedupe_sig="sig")
+    base.update(kwargs)
+    return SetPoolTrack(**base)
+
+
+class TestPoolCoverage:
+    def test_empty_pool_is_ready_with_zero_tracks(self):
+        cov = pool_coverage([])
+        assert cov["pool_size"] == 0
+        assert cov["fully_covered_count"] == 0
+        assert cov["ready"] is True
+        assert all(cov["missing"][f] == 0 for f in REQUIRED_FIELDS)
+
+    def test_fully_enriched_pool_is_ready(self):
+        tracks = [
+            _track(bpm=124.0, camelot="8A", genre="House", duration_sec=200, energy=6),
+            _track(bpm=126.0, camelot="9A", genre="Techno", duration_sec=210, energy=7),
+        ]
+        cov = pool_coverage(tracks)
+        assert cov["pool_size"] == 2
+        assert cov["fully_covered_count"] == 2
+        assert cov["ready"] is True
+        assert all(cov["missing"][f] == 0 for f in REQUIRED_FIELDS)
+
+    def test_counts_each_missing_field(self):
+        tracks = [
+            _track(bpm=124.0, camelot="8A", genre="House", duration_sec=200, energy=6),
+            _track(bpm=None, camelot="9A", genre=None, duration_sec=210, energy=None),
+        ]
+        cov = pool_coverage(tracks)
+        assert cov["pool_size"] == 2
+        assert cov["fully_covered_count"] == 1
+        assert cov["missing"]["bpm"] == 1
+        assert cov["missing"]["genre"] == 1
+        assert cov["missing"]["energy"] == 1
+        assert cov["missing"]["key"] == 0
+        assert cov["missing"]["duration"] == 0
+        assert cov["ready"] is False
+
+    def test_raw_key_counts_as_keyed_when_no_camelot(self):
+        # The builder reads `camelot or key`, so a raw `key` with no camelot still
+        # counts as covered — mirror that here so coverage agrees with the engine.
+        tracks = [_track(bpm=124.0, key="F minor", genre="House", duration_sec=200, energy=6)]
+        cov = pool_coverage(tracks)
+        assert cov["missing"]["key"] == 0
+        assert cov["fully_covered_count"] == 1
+        assert cov["ready"] is True
+
+    def test_below_threshold_is_not_ready(self):
+        # 1 of 4 fully covered = 25% < the 80% readiness threshold.
+        tracks = [
+            _track(bpm=124.0, camelot="8A", genre="House", duration_sec=200, energy=6),
+            _track(bpm=None),
+            _track(bpm=None),
+            _track(bpm=None),
+        ]
+        cov = pool_coverage(tracks)
+        assert cov["fully_covered_count"] == 1
+        assert cov["ready"] is False

--- a/server/tests/test_setbuilder_pass2.py
+++ b/server/tests/test_setbuilder_pass2.py
@@ -737,6 +737,9 @@ def _mk_set_with_pool(db: Session, user: User, tracks: list[dict]) -> Set:
                 bpm=row.get("bpm"),
                 key=row.get("key"),
                 camelot=row.get("camelot"),
+                genre=row.get("genre"),
+                energy=row.get("energy"),
+                duration_sec=row.get("duration_sec"),
                 dedupe_sig=f"gap-sig-{idx}",
             )
             for idx, row in enumerate(tracks)
@@ -781,6 +784,30 @@ def test_analyze_pool_gaps_reports_missing_keys_and_sparse_bands(db: Session, te
     assert sparse and sparse <= band_labels
 
 
+def test_analyze_pool_gaps_reports_energy_and_genre_coverage(db: Session, test_user: User):
+    # 3 tracks: only one carries genre; two carry energy. analyze_pool_gaps must
+    # report genre + energy coverage sourced from the resolved pool rows (#542),
+    # not the previously-dead energy column.
+    set_obj = _mk_set_with_pool(
+        db,
+        test_user,
+        [
+            {"camelot": "8A", "bpm": 124, "genre": "House", "energy": 6},
+            {"camelot": "9A", "bpm": 128, "energy": 7},
+            {"camelot": "10A", "bpm": 130},
+        ],
+    )
+
+    gaps, affected = apply_tool_call(db, set_obj, "analyze_pool_gaps", {})
+
+    assert affected == set()
+    assert gaps["pool_size"] == 3
+    assert gaps["genre_track_count"] == 1
+    assert gaps["energy_track_count"] == 2
+    assert gaps["missing_genre_count"] == 2
+    assert gaps["missing_energy_count"] == 1
+
+
 def test_analyze_pool_gaps_empty_pool_is_everything_a_gap(db: Session, test_user: User):
     set_obj = _mk_set_with_pool(db, test_user, [])
 
@@ -790,6 +817,10 @@ def test_analyze_pool_gaps_empty_pool_is_everything_a_gap(db: Session, test_user
     assert gaps["pool_size"] == 0
     assert gaps["keyed_track_count"] == 0
     assert gaps["bpm_track_count"] == 0
+    assert gaps["genre_track_count"] == 0
+    assert gaps["energy_track_count"] == 0
+    assert gaps["missing_genre_count"] == 0
+    assert gaps["missing_energy_count"] == 0
     assert len(gaps["missing_camelot_keys"]) == 24
     assert gaps["bpm_bands"] == []
     assert gaps["sparse_bands"] == []
@@ -852,12 +883,17 @@ def test_tool_display_summary_analyze_pool_gaps():
             "pool_size": 4,
             "missing_camelot_keys": ["1A", "1B"],
             "sparse_bands": [{"label": "130-140", "min": 130, "max": 140, "count": 1}],
+            "missing_genre_count": 2,
+            "missing_energy_count": 3,
         },
         {},
         {},
     )
 
-    assert summary == "Analyzed pool gaps over 4 tracks: 2 missing Camelot keys, 1 sparse BPM band."
+    assert summary == (
+        "Analyzed pool gaps over 4 tracks: 2 missing Camelot keys, 1 sparse BPM band, "
+        "2 missing genre, 3 missing energy."
+    )
 
 
 def _meta(**overrides) -> TrackMeta:

--- a/server/tests/test_setbuilder_pass_api.py
+++ b/server/tests/test_setbuilder_pass_api.py
@@ -65,6 +65,28 @@ def test_build_set_endpoint_creates_timeline(client, auth_headers, db):
     assert body["slots"][0]["title"] == "Track 0"
 
 
+def test_build_set_response_carries_pool_coverage(client, auth_headers, db):
+    # #542: the build response exposes pool coverage so the FE build-confirm
+    # dialog can show "fully enriched: N/M" and a soft, overridable warning.
+    set_obj = _mk_set(client, auth_headers)
+    _mk_pool(db, set_obj["id"])  # 4 tracks, all fields EXCEPT genre
+
+    resp = client.post(
+        f"/api/setbuilder/sets/{set_obj['id']}/build",
+        json={"confirmed": True},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200, resp.json()
+    coverage = resp.json()["coverage"]
+    assert coverage["pool_size"] == 4
+    # Every track is missing genre → none fully covered → soft not-ready warning.
+    assert coverage["fully_covered_count"] == 0
+    assert coverage["missing"]["genre"] == 4
+    assert coverage["missing"]["bpm"] == 0
+    assert coverage["ready"] is False
+
+
 def test_pass_endpoints_owner_isolation(client, auth_headers, db, test_user):
     from app.models.set import Set
     from app.models.user import User

--- a/server/tests/test_setbuilder_pool_api.py
+++ b/server/tests/test_setbuilder_pool_api.py
@@ -201,6 +201,53 @@ class TestPlaylistImports:
         assert body["source"]["kind"] == "tidal"
         assert body["source"]["label"] == "Friday Warmup"
 
+    def test_hydration_failure_on_first_candidate_keeps_source_and_imports_rest(
+        self, client, auth_headers, set_id, db, monkeypatch
+    ):
+        """#554 FIX 1: a candidate whose hydration raises must not roll back the
+        freshly-created (uncommitted) source row, or import_candidates would then
+        insert pool tracks against a stale source.id (orphan/FK break). The source
+        must survive and the remaining candidates must still import against it."""
+        from app.models.set_pool import SetPoolSource, SetPoolTrack
+        from app.services.setbuilder import pool as pool_mod
+        from app.services.setbuilder.pool import PoolCandidate
+
+        monkeypatch.setattr(
+            "app.services.setbuilder.pool.candidates_from_tidal",
+            lambda db, user, pid: [
+                PoolCandidate(track_id="tidal:1", title="Boom Song", artist="Boom Artist"),
+                PoolCandidate(
+                    track_id="tidal:2", title="Good Song", artist="Good Artist", bpm=128.0, key="8A"
+                ),
+            ],
+        )
+
+        # Make ONLY the first candidate's hydration blow up mid-flow.
+        real_hydrate_one = pool_mod._hydrate_one
+
+        def _explode_first(db_, candidate, user, *, commit):
+            if candidate.title == "Boom Song":
+                raise RuntimeError("simulated hydration failure")
+            return real_hydrate_one(db_, candidate, user, commit=commit)
+
+        monkeypatch.setattr(pool_mod, "_hydrate_one", _explode_first)
+
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/tidal",
+            json={"playlist_id": "abc-123", "label": "Resilient"},
+            headers=auth_headers,
+        )
+
+        assert resp.status_code == 200, resp.json()
+        source_id = resp.json()["source"]["id"]
+        # The source row survived the per-candidate rollback ...
+        survived = db.query(SetPoolSource).filter(SetPoolSource.id == source_id).one_or_none()
+        assert survived is not None
+        # ... and every imported pool track references that LIVE source (no orphan).
+        tracks = db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_id).all()
+        assert tracks  # at least the non-failing candidate imported
+        assert all(t.source_id == source_id for t in tracks)
+
     def test_import_tidal_fetch_failure_502(self, client, auth_headers, set_id, monkeypatch):
         from app.services.tidal import TidalFetchError
 

--- a/server/tests/test_setbuilder_pool_api.py
+++ b/server/tests/test_setbuilder_pool_api.py
@@ -369,7 +369,12 @@ class TestUrlImport:
 
 
 class TestManualImport:
-    def test_manual_import(self, client, auth_headers, set_id):
+    def test_manual_import_does_not_mint_provider_track_id(self, client, auth_headers, set_id):
+        # #554 FIX 7 (P1): a manual pick must NOT mint an authoritative
+        # beatport:/tidal: track_id from client-supplied source_service +
+        # source_track_id (that prefix is the authority signal _candidate_source
+        # trusts). Even with a client-supplied tidal source_track_id, track_id stays
+        # null so the metadata is stored at legacy precedence, not as provider data.
         resp = client.post(
             f"/api/setbuilder/sets/{set_id}/pool/import/manual",
             json={
@@ -387,8 +392,25 @@ class TestManualImport:
         assert body["added"] == 1
         assert body["source"]["kind"] == "manual"
         track = body["pool"]["tracks"][0]
-        assert track["track_id"] == "tidal:555"
+        assert track["track_id"] is None  # NOT "tidal:555" — no forged authority
         assert track["camelot"] == "8A"
+
+    def test_manual_import_keeps_spotify_reference_id(self, client, auth_headers, set_id):
+        # Spotify is non-authoritative (legacy) and the one provider the FE sends an
+        # id for, so a spotify: reference is retained.
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/manual",
+            json={
+                "title": "One More Time",
+                "artist": "Daft Punk",
+                "source_service": "spotify",
+                "source_track_id": "0DiWol3AO6WpXZgp0goxAV",
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        track = resp.json()["pool"]["tracks"][0]
+        assert track["track_id"] == "spotify:0DiWol3AO6WpXZgp0goxAV"
 
     def test_manual_dedupe_toast_counts(self, client, auth_headers, set_id):
         payload = {"title": "Bad Romance", "artist": "Lady Gaga"}

--- a/server/tests/test_setbuilder_pool_api.py
+++ b/server/tests/test_setbuilder_pool_api.py
@@ -123,6 +123,36 @@ class TestEventImport:
         )
         assert resp.status_code == 404
 
+    def test_import_already_enriched_pool_calls_zero_providers(
+        self, client, db, auth_headers, set_id, test_event, monkeypatch
+    ):
+        """#542 acceptance criterion: importing an already-enriched pool performs
+        ZERO provider enrichment calls (served from the candidate/store), and the
+        master store is populated from the carried fields for later reuse."""
+        from app.models.track import Track
+        from app.services.setbuilder import pool as pool_mod
+        from app.services.setbuilder.pool import dedupe_signature
+
+        _seed_requests(db, test_event)  # "Pool Track A" arrives complete
+
+        def _boom(*a, **k):  # pragma: no cover - must never run
+            raise AssertionError("enrich_track must not run for already-enriched candidates")
+
+        monkeypatch.setattr(pool_mod, "enrich_track", _boom)
+
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/event",
+            json={"event_id": test_event.id},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        # The complete request populated the store from its carried fields.
+        sig = dedupe_signature("Artist A", "Pool Track A")
+        row = db.query(Track).filter(Track.signature == sig).one()
+        assert row.bpm == 126.0
+        assert row.genre == "House"
+        assert row.musical_key == "8A"
+
     def test_reimport_event_dedupes_and_reuses_source(
         self, client, db, auth_headers, set_id, test_event
     ):

--- a/server/tests/test_setbuilder_pool_store.py
+++ b/server/tests/test_setbuilder_pool_store.py
@@ -394,6 +394,47 @@ class TestManualPickProvenance:
         assert row is not None
         assert row.provenance["bpm"]["source"] == "legacy"
 
+    def test_forged_beatport_track_id_cannot_mint_authority(self):
+        """#554 FIX 7 (P1): even a crafted POST that supplies BOTH
+        source_service="beatport" AND a source_track_id must NOT mint a
+        ``beatport:`` prefix — that prefix is the authority signal _candidate_source
+        trusts. candidate_from_manual must never forge it from client input."""
+        pick = pool.candidate_from_manual(
+            title="Pwned",
+            artist="Attacker",
+            bpm=200.0,
+            key="1A",
+            genre="Fabricated",
+            source_service="beatport",
+            source_track_id="123",  # the attack: a fake id to force a beatport: prefix
+        )
+        assert pick.track_id is None
+        assert pool._candidate_source(pick) == "legacy"
+
+    def test_forged_tidal_track_id_cannot_mint_authority(self):
+        pick = pool.candidate_from_manual(
+            title="Pwned2",
+            artist="Attacker",
+            bpm=180.0,
+            source_service="tidal",
+            source_track_id="456",
+        )
+        assert pick.track_id is None
+        assert pool._candidate_source(pick) == "legacy"
+
+    def test_manual_spotify_pick_mints_spotify_prefix_but_stays_legacy(self):
+        """Spotify is the one provider the FE sends an id for; it may keep a
+        ``spotify:`` reference id, but Spotify is non-authoritative so the source
+        still resolves to ``legacy``."""
+        pick = pool.candidate_from_manual(
+            title="Get Lucky",
+            artist="Daft Punk",
+            source_service="spotify",
+            source_track_id="69kOkLUCkxyZ",
+        )
+        assert pick.track_id == "spotify:69kOkLUCkxyZ"
+        assert pool._candidate_source(pick) == "legacy"
+
     def test_manual_spotify_pick_stays_legacy(self, db, dj_user, monkeypatch):
         self._no_enrich(monkeypatch)
         pick = pool.candidate_from_manual(

--- a/server/tests/test_setbuilder_pool_store.py
+++ b/server/tests/test_setbuilder_pool_store.py
@@ -1,0 +1,181 @@
+"""Pool import resolves & populates the master tracks store (#542).
+
+`hydrate_candidates_from_store` is the cache-aside step every pool-import flow
+runs BEFORE `import_candidates`. It mirrors the request-side pipeline (#541):
+  * a trusted+complete store row hydrates the candidate's gaps with ZERO API,
+  * a candidate that already carries provider fields POPULATES the store (0 API),
+  * genuine gaps with a connected DJ run the provider cascade once, then write
+    back to the store and hydrate.
+
+Monkeypatch note: `enrich_track` is top-imported into pool.py, so it is patched
+on the pool module. The store write goes through `app.services.tracks.store`.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.track import Track
+from app.models.user import User
+from app.services.recommendation.scorer import TrackProfile
+from app.services.setbuilder import pool
+from app.services.setbuilder.pool import dedupe_signature, hydrate_candidates_from_store
+from app.services.tracks.store import TrackIdentity, get_track, upsert_track
+
+
+@pytest.fixture
+def dj_user(db: Session) -> User:
+    from app.services.auth import get_password_hash
+
+    user = User(
+        username="pool_store_dj",
+        password_hash=get_password_hash("testpassword123"),
+        beatport_access_token="fake_bp_token",
+        tidal_access_token="fake_tidal_token",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _seed_trusted_complete(db: Session, *, title: str, artist: str) -> Track:
+    """A store row fully covered by a real (beatport, precedence 50) provider."""
+    sig = dedupe_signature(artist, title)
+    row = upsert_track(
+        db,
+        identity=TrackIdentity(title=title, artist=artist, signature=sig),
+        values={
+            "bpm": 124.0,
+            "musical_key": "8A",
+            "genre": "House",
+            "duration_sec": 200,
+            "energy": 6,
+        },
+        sources={f: "beatport" for f in ("bpm", "musical_key", "genre", "duration_sec", "energy")},
+        fetched_at=datetime.now(UTC),
+    )
+    db.commit()
+    return row
+
+
+class TestHydrateFromStore:
+    def test_trusted_complete_row_hydrates_with_zero_api(self, db, dj_user, monkeypatch):
+        _seed_trusted_complete(db, title="Strobe", artist="deadmau5")
+        called = {"n": 0}
+
+        def _boom(*a, **k):  # pragma: no cover - must never run
+            called["n"] += 1
+            raise AssertionError("enrich_track must not be called on a store hit")
+
+        monkeypatch.setattr(pool, "enrich_track", _boom)
+
+        candidate = pool.PoolCandidate(title="Strobe", artist="deadmau5")
+        out = hydrate_candidates_from_store(db, [candidate], user=dj_user)
+
+        assert called["n"] == 0
+        assert len(out) == 1
+        assert out[0].bpm == 124.0
+        assert out[0].key == "8A"
+        assert out[0].genre == "House"
+        assert out[0].duration_sec == 200
+        assert out[0].energy == 6
+
+    def test_candidate_with_fields_populates_store_with_zero_api(self, db, dj_user, monkeypatch):
+        def _boom(*a, **k):  # pragma: no cover
+            raise AssertionError("enrich_track must not be called when candidate is complete")
+
+        monkeypatch.setattr(pool, "enrich_track", _boom)
+
+        candidate = pool.PoolCandidate(
+            title="Opus",
+            artist="Eric Prydz",
+            track_id="beatport:111",
+            bpm=126.0,
+            key="4A",
+            genre="Progressive House",
+            duration_sec=540,
+            isrc="SEUM71200001",
+        )
+        out = hydrate_candidates_from_store(db, [candidate], user=dj_user)
+
+        # The candidate is returned unchanged (it already carries the fields) ...
+        assert out[0].bpm == 126.0
+        # ... and the store now has a row populated from it.
+        sig = dedupe_signature("Eric Prydz", "Opus")
+        row = get_track(db, isrc="SEUM71200001", signature=sig)
+        assert row is not None
+        assert row.bpm == 126.0
+        assert row.genre == "Progressive House"
+        assert row.duration_sec == 540
+
+    def test_gap_with_user_enriches_once_and_writes_back(self, db, dj_user, monkeypatch):
+        calls = {"n": 0}
+
+        def _fake_enrich(db_, user_, title, artist):
+            calls["n"] += 1
+            return TrackProfile(
+                title=title,
+                artist=artist,
+                bpm=128.0,
+                key="5A",
+                genre="Trance",
+                duration_seconds=400,
+                source="beatport",
+            )
+
+        monkeypatch.setattr(pool, "enrich_track", _fake_enrich)
+
+        candidate = pool.PoolCandidate(title="Adagio", artist="Tiesto")
+        out = hydrate_candidates_from_store(db, [candidate], user=dj_user)
+
+        assert calls["n"] == 1
+        assert out[0].bpm == 128.0
+        assert out[0].key == "5A"
+        assert out[0].genre == "Trance"
+        # The enriched fields are written back to the store for reuse.
+        sig = dedupe_signature("Tiesto", "Adagio")
+        row = get_track(db, signature=sig)
+        assert row is not None
+        assert row.bpm == 128.0
+
+    def test_gap_without_user_leaves_candidate_unenriched(self, db, monkeypatch):
+        def _boom(*a, **k):  # pragma: no cover
+            raise AssertionError("enrich_track must not run without a connected user")
+
+        monkeypatch.setattr(pool, "enrich_track", _boom)
+
+        candidate = pool.PoolCandidate(title="Mystery", artist="Unknown")
+        out = hydrate_candidates_from_store(db, [candidate], user=None)
+
+        assert out[0].bpm is None
+        assert out[0].genre is None
+
+    def test_second_import_of_same_track_serves_from_store(self, db, dj_user, monkeypatch):
+        # First import enriches once; a second import of the same recording must
+        # hit the store and make zero further provider calls (the dedupe win).
+        calls = {"n": 0}
+
+        def _fake_enrich(db_, user_, title, artist):
+            calls["n"] += 1
+            return TrackProfile(
+                title=title,
+                artist=artist,
+                bpm=120.0,
+                key="1A",
+                genre="Tech House",
+                duration_seconds=360,
+                source="beatport",
+            )
+
+        monkeypatch.setattr(pool, "enrich_track", _fake_enrich)
+
+        c1 = pool.PoolCandidate(title="Percolator", artist="Cajmere")
+        hydrate_candidates_from_store(db, [c1], user=dj_user)
+        assert calls["n"] == 1
+
+        c2 = pool.PoolCandidate(title="Percolator", artist="Cajmere")
+        out2 = hydrate_candidates_from_store(db, [c2], user=dj_user)
+        assert calls["n"] == 1  # no new provider call
+        assert out2[0].bpm == 120.0

--- a/server/tests/test_setbuilder_pool_store.py
+++ b/server/tests/test_setbuilder_pool_store.py
@@ -234,6 +234,71 @@ class TestHydrateFromStore:
         assert row.provenance["bpm"]["source"] == "beatport"
         assert row.genre == "Drum & Bass"
 
+    def test_isrc_conflict_skips_signature_fallback_hydration(self, db, monkeypatch):
+        """#554 FIX 6: get_track is ISRC-first then signature-fallback, so a candidate
+        with a valid ISRC NOT in the store can match a DIFFERENT recording's row (same
+        normalized artist/title, different ISRC). Hydrating from it would copy the
+        WRONG recording's bpm/key onto this candidate. On ISRC conflict, hydration must
+        be SKIPPED (no contamination); enrichment fills the candidate instead."""
+
+        def _boom(*a, **k):  # pragma: no cover
+            raise AssertionError("must not enrich without a connected user")
+
+        monkeypatch.setattr(pool, "enrich_track", _boom)
+
+        # A pre-existing row for a DIFFERENT recording with the same signature.
+        sig = dedupe_signature("ACDC", "Thunderstruck")
+        upsert_track(
+            db,
+            identity=TrackIdentity(
+                title="Thunderstruck",
+                artist="ACDC",
+                signature=sig,
+                isrc="GBXYZ7654321",  # the OTHER recording's ISRC
+            ),
+            values={"bpm": 134.0, "musical_key": "9A", "genre": "Rock", "duration_sec": 292},
+            sources={f: "beatport" for f in ("bpm", "musical_key", "genre", "duration_sec")},
+            fetched_at=datetime.now(UTC),
+        )
+        db.commit()
+
+        # This candidate carries a DIFFERENT valid ISRC (a distinct recording),
+        # not in the store; its signature collides with the row above.
+        candidate = pool.PoolCandidate(title="Thunderstruck", artist="ACDC", isrc="USABC1234567")
+        out = hydrate_candidates_from_store(db, [candidate], user=None)
+
+        # No contamination: the other recording's fields were NOT copied over.
+        assert out[0].bpm is None
+        assert out[0].key is None
+        assert out[0].genre is None
+
+    def test_isrcless_row_still_hydrates_on_signature_hit(self, db, monkeypatch):
+        """FIX 6 must not break the normal case: a signature-matched row with NO ISRC
+        is a compatible cache hit and still hydrates a candidate that carries an ISRC
+        (the ISRC lookup missed, so this can't be a different recording's row)."""
+
+        def _boom(*a, **k):  # pragma: no cover
+            raise AssertionError("must not enrich on a compatible signature hit")
+
+        monkeypatch.setattr(pool, "enrich_track", _boom)
+
+        sig = dedupe_signature("Moderat", "A New Error")
+        upsert_track(
+            db,
+            identity=TrackIdentity(title="A New Error", artist="Moderat", signature=sig),
+            values={"bpm": 100.0, "musical_key": "6A", "genre": "Electronica", "duration_sec": 400},
+            sources={f: "beatport" for f in ("bpm", "musical_key", "genre", "duration_sec")},
+            fetched_at=datetime.now(UTC),
+        )
+        db.commit()
+
+        candidate = pool.PoolCandidate(title="A New Error", artist="Moderat", isrc="DEABC1900001")
+        out = hydrate_candidates_from_store(db, [candidate], user=None)
+
+        assert out[0].bpm == 100.0
+        assert out[0].key == "6A"
+        assert out[0].genre == "Electronica"
+
     def test_gap_without_user_leaves_candidate_unenriched(self, db, monkeypatch):
         def _boom(*a, **k):  # pragma: no cover
             raise AssertionError("enrich_track must not run without a connected user")

--- a/server/tests/test_setbuilder_pool_store.py
+++ b/server/tests/test_setbuilder_pool_store.py
@@ -276,10 +276,13 @@ class TestHydrateFromStore:
 
 
 class TestManualPickProvenance:
-    """#554 review (4th P2): a manual Beatport/Tidal search pick carries no
-    track_id (the unified SearchResult schema has only spotify_id), so its
-    provider-measured bpm/key/genre must still be stored at the provider's
-    authoritative precedence — via the explicit source_service — not as legacy."""
+    """#554 review (P1 security): a manual search pick's asserted provider
+    ("source_service") is CLIENT-SUPPLIED and unverifiable server-side, so its
+    bpm/key/genre must be stored as ``legacy`` (low precedence), NEVER as
+    authoritative provider data. Trusting it would let any authenticated DJ poison
+    the shared, multi-tenant tracks store with fabricated provider-grade values
+    other DJs then hydrate. A ``legacy`` row self-heals: the next connected-DJ
+    import runs ``enrich_track`` server-side and upgrades it to real precedence."""
 
     def _no_enrich(self, monkeypatch):
         def _boom(*a, **k):  # pragma: no cover
@@ -287,12 +290,10 @@ class TestManualPickProvenance:
 
         monkeypatch.setattr(pool, "enrich_track", _boom)
 
-    def test_manual_beatport_pick_stores_authoritative_and_is_reused(
-        self, db, dj_user, monkeypatch
-    ):
+    def test_manual_beatport_pick_stays_legacy(self, db, dj_user, monkeypatch):
         self._no_enrich(monkeypatch)
-
-        # Manual Beatport pick: real source_service, NO track_id (FE has no id).
+        # Client claims source_service="beatport", but the server cannot verify it
+        # → stored as legacy, never authoritative (anti-poisoning).
         pick = pool.candidate_from_manual(
             title="Strobe",
             artist="deadmau5",
@@ -303,24 +304,15 @@ class TestManualPickProvenance:
             source_service="beatport",
             source_track_id=None,
         )
-        assert pick.track_id is None  # the bug's precondition
+        assert pick.track_id is None
         hydrate_candidates_from_store(db, [pick], user=dj_user)
 
-        sig = dedupe_signature("deadmau5", "Strobe")
-        row = get_track(db, signature=sig)
+        row = get_track(db, signature=dedupe_signature("deadmau5", "Strobe"))
         assert row is not None
-        # Stored at beatport precedence (authoritative ≥50), NOT legacy.
-        assert row.provenance["bpm"]["source"] == "beatport"
-        assert row.provenance["genre"]["source"] == "beatport"
+        assert row.provenance["bpm"]["source"] == "legacy"
+        assert row.provenance["genre"]["source"] == "legacy"
 
-        # A later import of the same recording hydrates from the row — cache hit,
-        # zero provider calls (the dedupe win that was previously lost).
-        c2 = pool.PoolCandidate(title="Strobe", artist="deadmau5")
-        out = hydrate_candidates_from_store(db, [c2], user=dj_user)
-        assert out[0].bpm == 128.0
-        assert out[0].genre == "Progressive House"
-
-    def test_manual_tidal_pick_stores_authoritative(self, db, dj_user, monkeypatch):
+    def test_manual_tidal_pick_stays_legacy(self, db, dj_user, monkeypatch):
         self._no_enrich(monkeypatch)
         pick = pool.candidate_from_manual(
             title="Innerbloom",
@@ -335,11 +327,10 @@ class TestManualPickProvenance:
         hydrate_candidates_from_store(db, [pick], user=dj_user)
         row = get_track(db, signature=dedupe_signature("Rufus Du Sol", "Innerbloom"))
         assert row is not None
-        assert row.provenance["bpm"]["source"] == "tidal"
+        assert row.provenance["bpm"]["source"] == "legacy"
 
     def test_manual_spotify_pick_stays_legacy(self, db, dj_user, monkeypatch):
         self._no_enrich(monkeypatch)
-        # Spotify isn't an authoritative bpm/key source — must stay legacy.
         pick = pool.candidate_from_manual(
             title="Get Lucky",
             artist="Daft Punk",
@@ -357,8 +348,6 @@ class TestManualPickProvenance:
 
     def test_typed_manual_pick_stays_legacy(self, db, dj_user, monkeypatch):
         self._no_enrich(monkeypatch)
-        # Hand-typed metadata (source_service defaults to "manual") must not claim
-        # provider precedence — it stays legacy.
         pick = pool.candidate_from_manual(
             title="Untitled Demo",
             artist="Local Artist",
@@ -370,3 +359,43 @@ class TestManualPickProvenance:
         row = get_track(db, signature=dedupe_signature("Local Artist", "Untitled Demo"))
         assert row is not None
         assert row.provenance["bpm"]["source"] == "legacy"
+
+    def test_legacy_manual_row_self_heals_via_server_side_enrich(self, db, dj_user, monkeypatch):
+        """The accepted trade-off: a manual pick lands as legacy, but a later import
+        whose candidate carries NO metadata runs the SERVER-SIDE provider cascade,
+        whose authoritative result upgrades the row (precedence guard lets a real
+        provider overwrite legacy)."""
+        # First: a manual pick seeds the row at legacy.
+        pick = pool.candidate_from_manual(
+            title="Opus",
+            artist="Eric Prydz",
+            bpm=99.0,  # deliberately wrong/typed value
+            key="1A",
+            genre="House",
+            source_service="beatport",
+        )
+        hydrate_candidates_from_store(db, [pick], user=None)
+        sig = dedupe_signature("Eric Prydz", "Opus")
+        row = get_track(db, signature=sig)
+        assert row.provenance["bpm"]["source"] == "legacy"
+
+        # Later: a metadata-less candidate triggers the server-side cascade, whose
+        # authoritative beatport result upgrades the row.
+        def _fake_enrich(db_, user_, title, artist):
+            return TrackProfile(
+                title=title,
+                artist=artist,
+                bpm=126.0,
+                key="4A",
+                genre="Progressive House",
+                duration_seconds=540,
+                source="beatport",
+            )
+
+        monkeypatch.setattr(pool, "enrich_track", _fake_enrich)
+        hydrate_candidates_from_store(
+            db, [pool.PoolCandidate(title="Opus", artist="Eric Prydz")], user=dj_user
+        )
+        db.refresh(row)
+        assert row.bpm == 126.0
+        assert row.provenance["bpm"]["source"] == "beatport"

--- a/server/tests/test_setbuilder_pool_store.py
+++ b/server/tests/test_setbuilder_pool_store.py
@@ -299,6 +299,27 @@ class TestHydrateFromStore:
         assert out[0].key == "6A"
         assert out[0].genre == "Electronica"
 
+    def test_duration_only_candidate_is_cached(self, db, monkeypatch):
+        """#554 FIX 8: duration is a required pool→builder contract field that
+        _write_candidate_to_store persists, but the write-gate only counted
+        bpm/key/genre — so a candidate whose ONLY contributed field is duration_sec
+        (e.g. a Spotify/public-URL import) skipped the store write entirely and the
+        duration never cached. The store row must carry it for later hydration."""
+
+        def _no_provider(*a, **k):  # user=None below, but guard anyway
+            raise AssertionError("no enrich without a user")
+
+        monkeypatch.setattr(pool, "enrich_track", _no_provider)
+
+        candidate = pool.PoolCandidate(
+            title="Ambient Piece", artist="Stars of the Lid", duration_sec=480
+        )
+        hydrate_candidates_from_store(db, [candidate], user=None)
+
+        row = get_track(db, signature=dedupe_signature("Stars of the Lid", "Ambient Piece"))
+        assert row is not None
+        assert row.duration_sec == 480
+
     def test_gap_without_user_leaves_candidate_unenriched(self, db, monkeypatch):
         def _boom(*a, **k):  # pragma: no cover
             raise AssertionError("enrich_track must not run without a connected user")

--- a/server/tests/test_setbuilder_pool_store.py
+++ b/server/tests/test_setbuilder_pool_store.py
@@ -140,6 +140,35 @@ class TestHydrateFromStore:
         assert row is not None
         assert row.bpm == 128.0
 
+    def test_enrich_writeback_persists_the_candidate_isrc(self, db, dj_user, monkeypatch):
+        """#554 FIX 2: a Spotify-style candidate (valid ISRC, no bpm/key/genre) takes
+        the enrich path; the resulting store row must carry the candidate's ISRC so a
+        later by-ISRC lookup hits the cache instead of re-running providers."""
+
+        def _fake_enrich(db_, user_, title, artist):
+            return TrackProfile(
+                title=title,
+                artist=artist,
+                bpm=122.0,
+                key="3A",
+                genre="Deep House",
+                duration_seconds=380,
+                source="beatport",
+            )
+
+        monkeypatch.setattr(pool, "enrich_track", _fake_enrich)
+
+        candidate = pool.PoolCandidate(
+            title="Innerbloom", artist="Rufus", track_id="spotify:abc", isrc="AUXXX1700001"
+        )
+        hydrate_candidates_from_store(db, [candidate], user=dj_user)
+
+        # The store row is keyed by the candidate's ISRC (not signature-only).
+        row = get_track(db, isrc="AUXXX1700001")
+        assert row is not None
+        assert row.isrc == "AUXXX1700001"
+        assert row.bpm == 122.0
+
     def test_gap_without_user_leaves_candidate_unenriched(self, db, monkeypatch):
         def _boom(*a, **k):  # pragma: no cover
             raise AssertionError("enrich_track must not run without a connected user")

--- a/server/tests/test_setbuilder_pool_store.py
+++ b/server/tests/test_setbuilder_pool_store.py
@@ -273,3 +273,100 @@ class TestHydrateFromStore:
         out2 = hydrate_candidates_from_store(db, [c2], user=dj_user)
         assert calls["n"] == 1  # no new provider call
         assert out2[0].bpm == 120.0
+
+
+class TestManualPickProvenance:
+    """#554 review (4th P2): a manual Beatport/Tidal search pick carries no
+    track_id (the unified SearchResult schema has only spotify_id), so its
+    provider-measured bpm/key/genre must still be stored at the provider's
+    authoritative precedence — via the explicit source_service — not as legacy."""
+
+    def _no_enrich(self, monkeypatch):
+        def _boom(*a, **k):  # pragma: no cover
+            raise AssertionError("enrich_track must not run on a cache hit / complete candidate")
+
+        monkeypatch.setattr(pool, "enrich_track", _boom)
+
+    def test_manual_beatport_pick_stores_authoritative_and_is_reused(
+        self, db, dj_user, monkeypatch
+    ):
+        self._no_enrich(monkeypatch)
+
+        # Manual Beatport pick: real source_service, NO track_id (FE has no id).
+        pick = pool.candidate_from_manual(
+            title="Strobe",
+            artist="deadmau5",
+            bpm=128.0,
+            key="4A",
+            genre="Progressive House",
+            duration_sec=600,
+            source_service="beatport",
+            source_track_id=None,
+        )
+        assert pick.track_id is None  # the bug's precondition
+        hydrate_candidates_from_store(db, [pick], user=dj_user)
+
+        sig = dedupe_signature("deadmau5", "Strobe")
+        row = get_track(db, signature=sig)
+        assert row is not None
+        # Stored at beatport precedence (authoritative ≥50), NOT legacy.
+        assert row.provenance["bpm"]["source"] == "beatport"
+        assert row.provenance["genre"]["source"] == "beatport"
+
+        # A later import of the same recording hydrates from the row — cache hit,
+        # zero provider calls (the dedupe win that was previously lost).
+        c2 = pool.PoolCandidate(title="Strobe", artist="deadmau5")
+        out = hydrate_candidates_from_store(db, [c2], user=dj_user)
+        assert out[0].bpm == 128.0
+        assert out[0].genre == "Progressive House"
+
+    def test_manual_tidal_pick_stores_authoritative(self, db, dj_user, monkeypatch):
+        self._no_enrich(monkeypatch)
+        pick = pool.candidate_from_manual(
+            title="Innerbloom",
+            artist="Rufus Du Sol",
+            bpm=120.0,
+            key="9A",
+            genre="Melodic House",
+            duration_sec=560,
+            source_service="tidal",
+            source_track_id=None,
+        )
+        hydrate_candidates_from_store(db, [pick], user=dj_user)
+        row = get_track(db, signature=dedupe_signature("Rufus Du Sol", "Innerbloom"))
+        assert row is not None
+        assert row.provenance["bpm"]["source"] == "tidal"
+
+    def test_manual_spotify_pick_stays_legacy(self, db, dj_user, monkeypatch):
+        self._no_enrich(monkeypatch)
+        # Spotify isn't an authoritative bpm/key source — must stay legacy.
+        pick = pool.candidate_from_manual(
+            title="Get Lucky",
+            artist="Daft Punk",
+            bpm=116.0,
+            key="11B",
+            genre="Disco",
+            duration_sec=369,
+            source_service="spotify",
+            source_track_id="abc123",
+        )
+        hydrate_candidates_from_store(db, [pick], user=dj_user)
+        row = get_track(db, signature=dedupe_signature("Daft Punk", "Get Lucky"))
+        assert row is not None
+        assert row.provenance["bpm"]["source"] == "legacy"
+
+    def test_typed_manual_pick_stays_legacy(self, db, dj_user, monkeypatch):
+        self._no_enrich(monkeypatch)
+        # Hand-typed metadata (source_service defaults to "manual") must not claim
+        # provider precedence — it stays legacy.
+        pick = pool.candidate_from_manual(
+            title="Untitled Demo",
+            artist="Local Artist",
+            bpm=125.0,
+            key="8A",
+            genre="House",
+        )
+        hydrate_candidates_from_store(db, [pick], user=dj_user)
+        row = get_track(db, signature=dedupe_signature("Local Artist", "Untitled Demo"))
+        assert row is not None
+        assert row.provenance["bpm"]["source"] == "legacy"

--- a/server/tests/test_setbuilder_pool_store.py
+++ b/server/tests/test_setbuilder_pool_store.py
@@ -169,6 +169,71 @@ class TestHydrateFromStore:
         assert row.isrc == "AUXXX1700001"
         assert row.bpm == 122.0
 
+    def test_partial_trusted_row_hydrates_per_field_even_without_user(self, db, monkeypatch):
+        """#554 FIX 3: a store row with authoritative bpm/key/duration but NO genre
+        must hydrate those three onto a later candidate (per-field, not all-or-
+        nothing) — even with user=None (no providers to fill the gap) — leaving only
+        genre missing. Previously the whole row was ignored unless all four were
+        present, so a provider-less user got nothing."""
+
+        def _boom(*a, **k):  # pragma: no cover
+            raise AssertionError("enrich_track must not run without a connected user")
+
+        monkeypatch.setattr(pool, "enrich_track", _boom)
+
+        sig = dedupe_signature("Pendulum", "Watercolour")
+        upsert_track(
+            db,
+            identity=TrackIdentity(title="Watercolour", artist="Pendulum", signature=sig),
+            values={"bpm": 174.0, "musical_key": "11A", "duration_sec": 240},
+            sources={f: "beatport" for f in ("bpm", "musical_key", "duration_sec")},
+            fetched_at=datetime.now(UTC),
+        )
+        db.commit()
+
+        candidate = pool.PoolCandidate(title="Watercolour", artist="Pendulum")
+        out = hydrate_candidates_from_store(db, [candidate], user=None)
+
+        assert out[0].bpm == 174.0
+        assert out[0].key == "11A"
+        assert out[0].duration_sec == 240
+        assert out[0].genre is None  # the only remaining gap
+
+    def test_partial_row_does_not_rewrite_read_values_to_store(self, db, dj_user, monkeypatch):
+        """#554 FIX 3 caveat: fields hydrated FROM the row must not be written BACK
+        to the store. A candidate that brought a NEW field (genre) on top of a
+        partial trusted row populates only that new field; the row's existing
+        beatport-sourced bpm keeps its provenance (no legacy downgrade churn)."""
+
+        def _boom(*a, **k):  # pragma: no cover
+            raise AssertionError("a candidate completed by row+own fields must not enrich")
+
+        monkeypatch.setattr(pool, "enrich_track", _boom)
+
+        sig = dedupe_signature("Sub Focus", "Turn Back Time")
+        upsert_track(
+            db,
+            identity=TrackIdentity(title="Turn Back Time", artist="Sub Focus", signature=sig),
+            values={"bpm": 170.0, "musical_key": "2A", "duration_sec": 300},
+            sources={f: "beatport" for f in ("bpm", "musical_key", "duration_sec")},
+            fetched_at=datetime.now(UTC),
+        )
+        db.commit()
+
+        # Candidate brings genre the store lacks (and re-states the bpm the row has).
+        candidate = pool.PoolCandidate(
+            title="Turn Back Time", artist="Sub Focus", genre="Drum & Bass", track_id="manual:1"
+        )
+        out = hydrate_candidates_from_store(db, [candidate], user=dj_user)
+
+        assert out[0].bpm == 170.0  # hydrated from the row
+        assert out[0].genre == "Drum & Bass"  # candidate's own
+        row = get_track(db, signature=sig)
+        # bpm provenance stays beatport (NOT downgraded by a read-back legacy write);
+        # genre is newly populated from the candidate.
+        assert row.provenance["bpm"]["source"] == "beatport"
+        assert row.genre == "Drum & Bass"
+
     def test_gap_without_user_leaves_candidate_unenriched(self, db, monkeypatch):
         def _boom(*a, **k):  # pragma: no cover
             raise AssertionError("enrich_track must not run without a connected user")

--- a/server/tests/test_setbuilder_structural.py
+++ b/server/tests/test_setbuilder_structural.py
@@ -65,6 +65,12 @@ def test_autobuild_regenerates_order_and_reports_counts(db: Session, test_user: 
     assert result["slot_count"] > 0
     assert isinstance(result["iterations"], int)
     assert positions == {s.position for s in slots}
+    # #542: autobuild surfaces pool coverage (soft/advisory). The structural pool
+    # carries every field except genre, so none are fully covered.
+    coverage = result["coverage"]
+    assert coverage["pool_size"] == 4
+    assert coverage["missing"]["genre"] == 4
+    assert coverage["fully_covered_count"] == 0
 
 
 def test_autobuild_preserves_locked_slot(db: Session, test_user: User):


### PR DESCRIPTION
## Why

The pool→builder contract is **bpm + key + energy + genre + duration present for every pool track before generation** (#539). Until now nothing enforced it: every imported `SetPoolTrack` was independently enriched (re-hitting Beatport/Tidal for songs already resolved elsewhere) and the builder silently degraded on gaps. With the global `tracks` store in place (#540/#541), the pool can resolve each candidate to its global row, backfill only the gaps, and surface coverage before the build.

## What

**Backend only** (the FE build-confirm dialog is handled separately; this PR just exposes coverage in the API response).

- **Pool import resolves & populates the master store.** A new `hydrate_candidates_from_store` runs in every import flow (5 REST endpoints + 4 agent import tools) BEFORE `import_candidates`, keeping the latter a pure dedupe-insert. Per candidate:
  - trusted+complete store row → hydrate gaps, **zero** provider calls (the dedupe win);
  - store miss but candidate carries fields (Beatport/Tidal playlists) → upsert to **populate** the store, zero provider calls;
  - genuine gaps + a connected DJ → run `enrich_track` once, write back, hydrate.
  - Commit discipline mirrors the request-side `_safe_upsert_track`: REST commits the store write durably (never poisons the import); agent tools pass `commit=False` so the write rides the single agent-turn transaction.
  - Canonical provider BPM only — per-event BPM correction stays request-side and is never written to the store.
- **Pre-build coverage check** (`setbuilder/coverage.py`): a pure function reporting per-field missing counts + an overall `ready` signal over the five contract fields.
- **Build gate (soft, overridable):** the deterministic `POST /sets/{id}/build` and the agent `autobuild` attach coverage to their response (new `PoolCoverageOut`). Aligns with #538's overridable build-confirm dialog — structured data + a soft warning, never a hard 4xx.
- **`analyze_pool_gaps` extended** to report energy + genre coverage, read from the resolved pool rows rather than the previously-dead pool energy column.
- Regenerated `server/openapi.json` + `dashboard/lib/api-types.generated.ts`.

### Design note
The cache short-circuit gates on bpm/key/genre/duration (the provider-fillable fields). **Energy is deliberately excluded** from that gate — it comes only from Soundcharts/Lexicon (currently dark, #543/#544), so gating on it would re-hit Beatport/Tidal on every import and defeat the dedupe win. Energy completeness is still reported by `pool_coverage` for the build gate; the two concerns are separate.

## Testing
- [x] Unit tests pass — new `test_setbuilder_coverage.py`, `test_setbuilder_pool_store.py`; extended pass2/structural/pass-api/pool-api suites
- [x] Acceptance criterion pinned: importing an already-enriched pool performs **zero** provider calls (mocked `enrich_track` asserted not-called at both service and API level)
- [x] Full backend suite: **3268 passed**, coverage **89.34%** (gate 85%)
- [x] `ruff check` + `ruff format --check` clean; `bandit` clean
- [x] `alembic upgrade head` + `alembic check` → no new operations (#542 adds no migration)
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8. Closes #542.