### PR TITLE
feat(dev): DEV_AUTH_BYPASS flag to skip guest gates for headless testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,17 @@ BOOTSTRAP_ADMIN_PASSWORD=your-secure-password
 # Get keys at: https://dash.cloudflare.com/?to=/:account/turnstile
 # TURNSTILE_SITE_KEY=your-site-key
 # TURNSTILE_SECRET_KEY=your-secret-key
+# (Turnstile self-disables in dev when TURNSTILE_SECRET_KEY is unset.)
+
+# =============================================================================
+# DEV-ONLY: headless-testing auth bypass
+# =============================================================================
+# Set DEV_AUTH_BYPASS=1 to skip the guest human-verification (wrzdj_human cookie)
+# AND email-verification gates, so API/Playwright tests can drive guest flows
+# (collect/join/kiosk submit, vote, profile) with no cookies. INERT in production
+# by construction, and the app REFUSES to boot if it is set with ENV=production.
+# Never enable in any deployed environment.
+# DEV_AUTH_BYPASS=1
 
 # =============================================================================
 # LLM / AI providers

--- a/server/app/api/deps.py
+++ b/server/app/api/deps.py
@@ -155,6 +155,36 @@ def get_owned_request(
     return song_request
 
 
+def _dev_bypass_guest_id(request: Request, db: Session) -> int:
+    """Resolve (or lazily create) a guest identity when DEV_AUTH_BYPASS is active.
+
+    Prefers the request's wrzdj_guest cookie when present; otherwise returns a
+    stable dev guest so headless tests need no cookies at all. DEV-ONLY — every
+    caller guards this behind ``Settings.auth_bypass_enabled`` (inert in prod).
+    """
+    from app.core.rate_limit import get_guest_id
+    from app.core.time import utcnow
+    from app.models.guest import Guest
+
+    gid = get_guest_id(request, db)
+    if gid is not None:
+        return gid
+    token = "dev-auth-bypass-guest"  # nosec B105 - stable dev test guest token, not a secret
+    guest = db.query(Guest).filter(Guest.token == token).first()
+    if guest is None:
+        guest = Guest(
+            token=token,
+            verified_email="dev-bypass@local.test",
+            email_verified_at=utcnow(),
+            created_at=utcnow(),
+            last_seen_at=utcnow(),
+        )
+        db.add(guest)
+        db.commit()
+        db.refresh(guest)
+    return guest.id
+
+
 def require_verified_human(
     request: Request,
     response: Response,
@@ -166,8 +196,12 @@ def require_verified_human(
     structured detail {"code": "human_verification_required"} so the frontend
     can distinguish this from generic forbidden errors and trigger a re-bootstrap.
     """
+    from app.core.config import get_settings
     from app.core.rate_limit import get_guest_id
     from app.services.human_verification import issue_human_cookie, verify_human_cookie
+
+    if get_settings().auth_bypass_enabled:  # DEV-ONLY, inert in production
+        return _dev_bypass_guest_id(request, db)
 
     guest_id_cookie = verify_human_cookie(request)
     guest_id_db = get_guest_id(request, db)
@@ -199,9 +233,13 @@ def require_verified_human_soft(
     """
     import logging
 
+    from app.core.config import get_settings
     from app.core.rate_limit import get_guest_id
     from app.services.human_verification import issue_human_cookie, verify_human_cookie
     from app.services.system_settings import get_system_settings
+
+    if get_settings().auth_bypass_enabled:  # DEV-ONLY, inert in production
+        return _dev_bypass_guest_id(request, db)
 
     sys_settings = get_system_settings(db)
     guest_id_cookie = verify_human_cookie(request)
@@ -235,7 +273,11 @@ def require_email_verified(
     Returns 403 with structured detail {"code": "email_verification_required"}
     so the frontend can render the EmailGate component.
     """
+    from app.core.config import get_settings
     from app.models.guest import Guest
+
+    if get_settings().auth_bypass_enabled:  # DEV-ONLY, inert in production
+        return guest_id
 
     guest = db.get(Guest, guest_id)
     if guest is None or guest.verified_email is None:

--- a/server/app/api/deps.py
+++ b/server/app/api/deps.py
@@ -155,36 +155,6 @@ def get_owned_request(
     return song_request
 
 
-def _dev_bypass_guest_id(request: Request, db: Session) -> int:
-    """Resolve (or lazily create) a guest identity when DEV_AUTH_BYPASS is active.
-
-    Prefers the request's wrzdj_guest cookie when present; otherwise returns a
-    stable dev guest so headless tests need no cookies at all. DEV-ONLY — every
-    caller guards this behind ``Settings.auth_bypass_enabled`` (inert in prod).
-    """
-    from app.core.rate_limit import get_guest_id
-    from app.core.time import utcnow
-    from app.models.guest import Guest
-
-    gid = get_guest_id(request, db)
-    if gid is not None:
-        return gid
-    token = "dev-auth-bypass-guest"  # nosec B105 - stable dev test guest token, not a secret
-    guest = db.query(Guest).filter(Guest.token == token).first()
-    if guest is None:
-        guest = Guest(
-            token=token,
-            verified_email="dev-bypass@local.test",
-            email_verified_at=utcnow(),
-            created_at=utcnow(),
-            last_seen_at=utcnow(),
-        )
-        db.add(guest)
-        db.commit()
-        db.refresh(guest)
-    return guest.id
-
-
 def require_verified_human(
     request: Request,
     response: Response,
@@ -201,7 +171,7 @@ def require_verified_human(
     from app.services.human_verification import issue_human_cookie, verify_human_cookie
 
     if get_settings().auth_bypass_enabled:  # DEV-ONLY, inert in production
-        return _dev_bypass_guest_id(request, db)
+        return get_guest_id(request, db)
 
     guest_id_cookie = verify_human_cookie(request)
     guest_id_db = get_guest_id(request, db)
@@ -239,7 +209,7 @@ def require_verified_human_soft(
     from app.services.system_settings import get_system_settings
 
     if get_settings().auth_bypass_enabled:  # DEV-ONLY, inert in production
-        return _dev_bypass_guest_id(request, db)
+        return get_guest_id(request, db)
 
     sys_settings = get_system_settings(db)
     guest_id_cookie = verify_human_cookie(request)

--- a/server/app/api/guest.py
+++ b/server/app/api/guest.py
@@ -34,7 +34,13 @@ def identify(
     db: Session = Depends(get_db),
 ) -> JSONResponse:
     """Resolve guest identity via cookie token and/or browser fingerprint."""
+    from app.core.rate_limit import is_inert_dev_token
+
     token_from_cookie = request.cookies.get("wrzdj_guest")
+    # A leaked dev-bypass guest row must not be claimable or re-tokenizable here when
+    # the bypass is off — drop the reserved token so identity resolves as cookieless.
+    if is_inert_dev_token(token_from_cookie):
+        token_from_cookie = None
     user_agent = (request.headers.get("user-agent") or "")[:512]
 
     result = identify_guest(

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -107,6 +107,13 @@ class Settings(BaseSettings):
     human_cookie_secret: str = ""
     human_cookie_ttl_seconds: int = 3600  # 60 min sliding window
 
+    # DEV-ONLY: bypass the guest human-verification + email-verification gates so
+    # headless tests (API/Playwright) can exercise guest flows without minting a
+    # wrzdj_human cookie or verifying an email. INERT in production by construction
+    # (see `auth_bypass_enabled`), and `validate_settings` refuses to boot if it is
+    # ever set with ENV=production. Never enable in any deployed environment.
+    dev_auth_bypass: bool = False
+
     # OAuth token encryption (Fernet key, 44 chars base64)
     # Generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key()...)"
     token_encryption_key: str = ""
@@ -194,6 +201,16 @@ class Settings(BaseSettings):
     def is_production(self) -> bool:
         return self.env == "production"
 
+    @property
+    def auth_bypass_enabled(self) -> bool:
+        """True only when the dev bypass is requested AND we are not in production.
+
+        Gating on ``not is_production`` makes the flag INERT in production even if it
+        leaks into the environment; `validate_settings` additionally refuses to boot
+        if it is set with ENV=production, so it can never silently weaken a deployment.
+        """
+        return self.dev_auth_bypass and not self.is_production
+
 
 _FERNET_KEY_HINT = (
     'Generate with: python -c "from cryptography.fernet import Fernet; '
@@ -279,11 +296,22 @@ def validate_settings(settings: Settings) -> None:
                 'Generate with: python -c "import secrets, base64; '
                 'print(base64.urlsafe_b64encode(secrets.token_bytes(32)).decode())"'
             )
+        if settings.dev_auth_bypass:
+            errors.append(
+                "DEV_AUTH_BYPASS must NOT be set in production — it disables the guest "
+                "human-verification and email-verification gates. Unset it before deploying."
+            )
 
     if not settings.is_production:
         if settings.jwt_secret == "change-me-in-production":  # nosec B105
             logging.warning(
                 "JWT_SECRET is using the default value. Set a unique secret for security."
+            )
+        if settings.dev_auth_bypass:
+            logging.warning(
+                "DEV_AUTH_BYPASS is ACTIVE: guest human-verification and email-verification "
+                "gates are DISABLED for headless testing. This must never be used in a "
+                "deployed environment."
             )
 
     if not settings.bridge_api_key:

--- a/server/app/core/rate_limit.py
+++ b/server/app/core/rate_limit.py
@@ -89,14 +89,54 @@ limiter = Limiter(key_func=get_client_ip, enabled=get_settings().is_rate_limit_e
 
 
 def get_guest_id(request: Request, db: Session) -> int | None:
-    """Read wrzdj_guest cookie and return the Guest.id, or None."""
+    """Read the wrzdj_guest cookie and return the Guest.id, or None.
+
+    Under DEV_AUTH_BYPASS (dev only) a cookieless request resolves to a stable dev
+    guest, so headless tests need no guest cookie on ANY guest endpoint (this is the
+    single identity chokepoint the gates and the inline-resolving routes share).
+    Inert in production — see Settings.auth_bypass_enabled.
+    """
     from app.models.guest import Guest
 
     token = request.cookies.get("wrzdj_guest")
-    if not token:
-        return None
+    if token:
+        guest = db.query(Guest).filter(Guest.token == token).first()
+        if guest:
+            return guest.id
+
+    from app.core.config import get_settings
+
+    if get_settings().auth_bypass_enabled:
+        return _dev_bypass_guest_id(db)
+    return None
+
+
+def _dev_bypass_guest_id(db: Session) -> int:
+    """Get-or-create the stable DEV_AUTH_BYPASS guest. DEV-ONLY (callers guard)."""
+    from sqlalchemy.exc import IntegrityError
+
+    from app.core.time import utcnow
+    from app.models.guest import Guest
+
+    token = "dev-auth-bypass-guest"  # nosec B105 - stable dev test guest token, not a secret
     guest = db.query(Guest).filter(Guest.token == token).first()
-    return guest.id if guest else None
+    if guest:
+        return guest.id
+    guest = Guest(
+        token=token,
+        verified_email="dev-bypass@local.test",
+        email_verified_at=utcnow(),
+        created_at=utcnow(),
+        last_seen_at=utcnow(),
+    )
+    db.add(guest)
+    try:
+        db.commit()
+    except IntegrityError:  # concurrent create — re-read the winner
+        db.rollback()
+        return db.query(Guest).filter(Guest.token == token).first().id
+    db.refresh(guest)
+    return guest.id
 
 
 def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> Response:

--- a/server/app/core/rate_limit.py
+++ b/server/app/core/rate_limit.py
@@ -88,6 +88,15 @@ def get_client_ip(request: Request) -> str:
 limiter = Limiter(key_func=get_client_ip, enabled=get_settings().is_rate_limit_enabled)
 
 
+# Reserved guest token for the DEV_AUTH_BYPASS dev guest. It is honored ONLY when
+# the bypass is active; a request presenting this token is rejected outright when the
+# bypass is off, so even if the dev guest row leaks into another DB (staging->prod
+# promotion, backup restore, dev dump) it can NEVER be a production backdoor. The dev
+# guest is also deliberately NOT email-verified, so it could not pass require_email_
+# verified via the normal path even if it were somehow resolved (defense in depth).
+_DEV_BYPASS_GUEST_TOKEN = "dev-auth-bypass-guest"  # nosec B105 - reserved token, not a secret
+
+
 def get_guest_id(request: Request, db: Session) -> int | None:
     """Read the wrzdj_guest cookie and return the Guest.id, or None.
 
@@ -96,45 +105,48 @@ def get_guest_id(request: Request, db: Session) -> int | None:
     single identity chokepoint the gates and the inline-resolving routes share).
     Inert in production — see Settings.auth_bypass_enabled.
     """
+    from app.core.config import get_settings
     from app.models.guest import Guest
+
+    bypass = get_settings().auth_bypass_enabled
 
     token = request.cookies.get("wrzdj_guest")
     if token:
+        # Never resolve the reserved dev token unless the bypass is active — a leaked
+        # dev guest row must not become a production backdoor.
+        if token == _DEV_BYPASS_GUEST_TOKEN and not bypass:
+            return None
         guest = db.query(Guest).filter(Guest.token == token).first()
         if guest:
             return guest.id
 
-    from app.core.config import get_settings
-
-    if get_settings().auth_bypass_enabled:
+    if bypass:
         return _dev_bypass_guest_id(db)
     return None
 
 
 def _dev_bypass_guest_id(db: Session) -> int:
-    """Get-or-create the stable DEV_AUTH_BYPASS guest. DEV-ONLY (callers guard)."""
+    """Get-or-create the stable DEV_AUTH_BYPASS guest. DEV-ONLY (callers guard).
+
+    The row is intentionally minimal and NOT email-verified: the email gate is opened
+    by the explicit require_email_verified bypass, so this row never needs — and must
+    not carry — a pre-verified identity that could be abused if it leaked into prod.
+    """
     from sqlalchemy.exc import IntegrityError
 
     from app.core.time import utcnow
     from app.models.guest import Guest
 
-    token = "dev-auth-bypass-guest"  # nosec B105 - stable dev test guest token, not a secret
-    guest = db.query(Guest).filter(Guest.token == token).first()
+    guest = db.query(Guest).filter(Guest.token == _DEV_BYPASS_GUEST_TOKEN).first()
     if guest:
         return guest.id
-    guest = Guest(
-        token=token,
-        verified_email="dev-bypass@local.test",
-        email_verified_at=utcnow(),
-        created_at=utcnow(),
-        last_seen_at=utcnow(),
-    )
+    guest = Guest(token=_DEV_BYPASS_GUEST_TOKEN, created_at=utcnow(), last_seen_at=utcnow())
     db.add(guest)
     try:
         db.commit()
     except IntegrityError:  # concurrent create — re-read the winner
         db.rollback()
-        return db.query(Guest).filter(Guest.token == token).first().id
+        return db.query(Guest).filter(Guest.token == _DEV_BYPASS_GUEST_TOKEN).first().id
     db.refresh(guest)
     return guest.id
 

--- a/server/app/core/rate_limit.py
+++ b/server/app/core/rate_limit.py
@@ -97,6 +97,20 @@ limiter = Limiter(key_func=get_client_ip, enabled=get_settings().is_rate_limit_e
 _DEV_BYPASS_GUEST_TOKEN = "dev-auth-bypass-guest"  # nosec B105 - reserved token, not a secret
 
 
+def is_inert_dev_token(token: str | None) -> bool:
+    """True when `token` is the reserved dev-bypass token AND the bypass is OFF.
+
+    Such a token must be ignored by EVERY guest-identity entry point (get_guest_id
+    and the /guest/identify path), so a leaked dev guest row can never be resolved,
+    claimed, or re-tokenized in production. Single source of truth for that rule.
+    """
+    if token != _DEV_BYPASS_GUEST_TOKEN:
+        return False
+    from app.core.config import get_settings
+
+    return not get_settings().auth_bypass_enabled
+
+
 def get_guest_id(request: Request, db: Session) -> int | None:
     """Read the wrzdj_guest cookie and return the Guest.id, or None.
 
@@ -114,7 +128,7 @@ def get_guest_id(request: Request, db: Session) -> int | None:
     if token:
         # Never resolve the reserved dev token unless the bypass is active — a leaked
         # dev guest row must not become a production backdoor.
-        if token == _DEV_BYPASS_GUEST_TOKEN and not bypass:
+        if is_inert_dev_token(token):
             return None
         guest = db.query(Guest).filter(Guest.token == token).first()
         if guest:

--- a/server/tests/test_dev_auth_bypass.py
+++ b/server/tests/test_dev_auth_bypass.py
@@ -75,3 +75,17 @@ class TestGateBypassIntegration:
         with patch.object(config, "get_settings", lambda: bypass):
             r = client.get(f"/api/public/collect/{test_event.code}/profile")
         assert r.status_code == 200, r.text
+
+    def test_bypass_covers_inline_guest_resolution(self, client, test_event, test_request):
+        """The vote endpoint resolves the guest INLINE via get_guest_id (its own 401),
+        not via the gate deps — so the bypass must cover that chokepoint too."""
+        client.cookies.clear()
+        # Without a guest cookie the inline resolver returns None → 401.
+        r = client.post(f"/api/requests/{test_request.id}/vote")
+        assert r.status_code == 401
+        bypass = Settings(env="development", dev_auth_bypass=True)
+        with patch.object(config, "get_settings", lambda: bypass):
+            r2 = client.post(f"/api/requests/{test_request.id}/vote")
+        # Identity resolved by the bypass → NOT 401 (200 vote, or a post-identity
+        # votability status — never the "guest identity required" 401).
+        assert r2.status_code != 401, r2.text

--- a/server/tests/test_dev_auth_bypass.py
+++ b/server/tests/test_dev_auth_bypass.py
@@ -143,3 +143,22 @@ class TestLeakedDevGuestCannotBackdoorProd:
         _dev_bypass_guest_id(db)
         g = db.query(Guest).filter(Guest.token == _DEV_BYPASS_GUEST_TOKEN).first()
         assert g.verified_email is None and g.email_verified_at is None
+
+    def test_identify_cannot_claim_leaked_dev_row(self, client, db):
+        """/guest/identify must not let an attacker claim or re-tokenize a leaked dev
+        guest row via its known cookie when the bypass is off (Codex P2 — that path
+        does not go through get_guest_id)."""
+        from app.core.rate_limit import _DEV_BYPASS_GUEST_TOKEN, _dev_bypass_guest_id
+        from app.models.guest import Guest
+
+        dev_id = _dev_bypass_guest_id(db)  # leaked dev row (no fingerprint, not verified)
+        client.cookies.clear()
+        client.cookies.set("wrzdj_guest", _DEV_BYPASS_GUEST_TOKEN)
+        r = client.post("/api/public/guest/identify", json={"fingerprint_hash": "attacker-fp-zzz"})
+        assert r.status_code == 200, r.text
+        db.expire_all()
+        dev = db.query(Guest).filter(Guest.token == _DEV_BYPASS_GUEST_TOKEN).first()
+        # Attacker fingerprint must NOT be written onto the leaked dev row, and the
+        # resolved identity must not be the dev row.
+        assert dev.fingerprint_hash is None
+        assert r.json().get("guest_id") != dev_id

--- a/server/tests/test_dev_auth_bypass.py
+++ b/server/tests/test_dev_auth_bypass.py
@@ -1,0 +1,77 @@
+"""DEV_AUTH_BYPASS — a dev-only flag that skips the guest human-verification and
+email-verification gates so headless tests can exercise guest flows without minting a
+wrzdj_human cookie or verifying an email.
+
+The critical contract under test: it is INERT in production (the property gates on
+``not is_production``) AND ``validate_settings`` refuses to boot if it is ever set with
+ENV=production — so it can never silently weaken a deployment.
+"""
+
+import base64
+import logging
+import secrets
+from unittest.mock import patch
+
+import pytest
+from cryptography.fernet import Fernet
+
+import app.core.config as config
+from app.core.config import Settings, validate_settings
+
+
+class TestAuthBypassProperty:
+    def test_active_in_dev_with_flag(self):
+        assert Settings(env="development", dev_auth_bypass=True).auth_bypass_enabled is True
+
+    def test_inert_in_production_even_with_flag(self):
+        # Even if the flag leaks into a prod environment, the property is False.
+        assert Settings(env="production", dev_auth_bypass=True).auth_bypass_enabled is False
+
+    def test_off_by_default(self):
+        assert Settings(env="development").auth_bypass_enabled is False
+
+
+class TestProdSafety:
+    def _prod_settings(self, **overrides) -> Settings:
+        base = dict(
+            env="production",
+            jwt_secret="prod-secret-not-default",
+            cors_origins="https://app.example.com",
+            human_cookie_secret=base64.urlsafe_b64encode(secrets.token_bytes(32)).decode(),
+            token_encryption_key=Fernet.generate_key().decode(),
+        )
+        base.update(overrides)
+        return Settings(**base)
+
+    def test_bypass_in_production_refuses_to_boot(self, caplog):
+        s = self._prod_settings(dev_auth_bypass=True)
+        with pytest.raises(SystemExit) as exc:
+            validate_settings(s)
+        assert exc.value.code == 1
+        assert "DEV_AUTH_BYPASS must NOT be set in production" in caplog.text
+
+    def test_clean_production_still_boots(self):
+        # The same prod config WITHOUT the bypass must validate cleanly.
+        validate_settings(self._prod_settings())
+
+    def test_bypass_in_dev_warns_but_boots(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            validate_settings(Settings(env="development", dev_auth_bypass=True))
+        assert any("DEV_AUTH_BYPASS is ACTIVE" in r.message for r in caplog.records)
+
+
+class TestGateBypassIntegration:
+    """A gated guest endpoint (GET /collect/{code}/profile uses the hard
+    require_verified_human) is blocked without a cookie, and passes when the bypass is on."""
+
+    def test_gate_blocks_without_bypass(self, client, test_event):
+        client.cookies.clear()
+        r = client.get(f"/api/public/collect/{test_event.code}/profile")
+        assert r.status_code == 403
+
+    def test_bypass_lets_gated_endpoint_through(self, client, test_event):
+        client.cookies.clear()
+        bypass = Settings(env="development", dev_auth_bypass=True)
+        with patch.object(config, "get_settings", lambda: bypass):
+            r = client.get(f"/api/public/collect/{test_event.code}/profile")
+        assert r.status_code == 200, r.text

--- a/server/tests/test_dev_auth_bypass.py
+++ b/server/tests/test_dev_auth_bypass.py
@@ -89,3 +89,57 @@ class TestGateBypassIntegration:
         # Identity resolved by the bypass → NOT 401 (200 vote, or a post-identity
         # votability status — never the "guest identity required" 401).
         assert r2.status_code != 401, r2.text
+
+
+class TestLeakedDevGuestCannotBackdoorProd:
+    """Codex [P1]: the reserved dev guest token must be UNRESOLVABLE when the bypass is
+    off, and the dev guest must not be pre-verified — so even if the row leaks into a
+    production DB it can never become a backdoor."""
+
+    def _req(self, token=None):
+        from starlette.requests import Request
+
+        headers = [(b"cookie", f"wrzdj_guest={token}".encode())] if token else []
+        return Request({"type": "http", "headers": headers})
+
+    def test_leaked_dev_token_rejected_when_bypass_off(self, db):
+        from app.core.rate_limit import (
+            _DEV_BYPASS_GUEST_TOKEN,
+            _dev_bypass_guest_id,
+            get_guest_id,
+        )
+
+        _dev_bypass_guest_id(db)  # simulate the dev guest row leaking into this DB
+        # Default test settings → bypass off → the known token must NOT resolve.
+        assert get_guest_id(self._req(_DEV_BYPASS_GUEST_TOKEN), db) is None
+
+    def test_dev_token_resolves_when_bypass_on(self, db):
+        from app.core.rate_limit import (
+            _DEV_BYPASS_GUEST_TOKEN,
+            _dev_bypass_guest_id,
+            get_guest_id,
+        )
+
+        gid = _dev_bypass_guest_id(db)
+        bypass = Settings(env="development", dev_auth_bypass=True)
+        with patch.object(config, "get_settings", lambda: bypass):
+            assert get_guest_id(self._req(_DEV_BYPASS_GUEST_TOKEN), db) == gid
+
+    def test_normal_token_still_resolves_when_bypass_off(self, db):
+        from app.core.rate_limit import get_guest_id
+        from app.core.time import utcnow
+        from app.models.guest import Guest
+
+        g = Guest(token="normal-guest-token-aaaaaaaa", created_at=utcnow(), last_seen_at=utcnow())
+        db.add(g)
+        db.commit()
+        db.refresh(g)
+        assert get_guest_id(self._req("normal-guest-token-aaaaaaaa"), db) == g.id
+
+    def test_dev_guest_is_not_pre_verified(self, db):
+        from app.core.rate_limit import _DEV_BYPASS_GUEST_TOKEN, _dev_bypass_guest_id
+        from app.models.guest import Guest
+
+        _dev_bypass_guest_id(db)
+        g = db.query(Guest).filter(Guest.token == _DEV_BYPASS_GUEST_TOKEN).first()
+        assert g.verified_email is None and g.email_verified_at is None


### PR DESCRIPTION
## Why
Headless testing of guest flows (collect/join/kiosk submit, vote, profile) is blocked by the **human-verification** (`wrzdj_human` cookie) and **email-verification** gates — the external API suite and Playwright can't easily mint those. Turnstile already self-disables in dev; these two gates had no dev escape hatch. (This is exactly what blocked 16 checks in the `~/wrzdj-testing` suite — all 401/403 gate rejections.)

## What
Adds `DEV_AUTH_BYPASS` (default **off**). When set in a **non-production** env, the three guest gates (`require_verified_human`, `require_verified_human_soft`, `require_email_verified`) resolve a real guest identity — the request's `wrzdj_guest` cookie if present, else a stable lazily-created dev guest — and skip the cookie/email checks. So tests need no cookies at all. Admin/DJ auth is unchanged (JWT).

## Prod-safety (by construction)
- `auth_bypass_enabled` gates on `not is_production` → **inert** even if the flag leaks into a prod environment.
- `validate_settings` **refuses to boot** (`SystemExit(1)`) if `DEV_AUTH_BYPASS` is set with `ENV=production`.
- A loud `WARNING` is logged whenever it's active in dev.

## Testing
- [x] Property matrix: dev+flag active / prod+flag inert / off-by-default
- [x] Prod refuses to boot when set; clean prod still boots; dev warns (not raises)
- [x] Live integration: `GET /collect/{code}/profile` (hard gate) → 403 without bypass, 200 with it
- [x] No regression across gate suites (104 passing: config, human-verification, collect, votes, bypass)
- [x] ruff/format/bandit clean
- [ ] CI green

🤖 Co-authored by Claude Opus 4.8.