### PR TITLE
fix(setbuilder): wire resolved vibe energy/mood into pass-1 scoring (#543)

### DIFF
--- a/server/app/services/setbuilder/pass1_deterministic.py
+++ b/server/app/services/setbuilder/pass1_deterministic.py
@@ -14,9 +14,11 @@ from sqlalchemy.orm import Session
 
 from app.models.set import Set, SetSlot
 from app.models.set_pool import SetPoolTrack
+from app.models.user import User
 from app.services.recommendation.camelot import compatibility_score, parse_key
 from app.services.recommendation.scorer import _score_bpm
 from app.services.setbuilder.curve import BUILTIN_TEMPLATES, interpolate_energy, uniform_midpoints
+from app.services.setbuilder.vibe_resolver import ResolvedVibe, build_pool_vibe_states
 
 AVG_TRACK_LENGTH_SEC = 210
 MAX_SWAP_ITERATIONS = 50
@@ -59,7 +61,8 @@ def build_set(db: Session, set_obj: Set, *, commit: bool = True) -> BuildResult:
     pairings = _saved_pairings(db, set_obj.id)
     slot_count = _slot_count(set_obj, pool_tracks, locked)
     targets = _target_energies(db, set_obj, slot_count)
-    metas = [_track_meta(t) for t in pool_tracks]
+    vibes = _pool_vibes(db, set_obj)
+    metas = [_track_meta(t, vibes.get(t.id)) for t in pool_tracks]
     by_track_id = {m.slot_track_id: m for m in metas}
 
     locked_by_pos = {slot.position: slot for slot in locked if slot.position < slot_count}
@@ -113,7 +116,8 @@ def recompute_transition_scores(
     """Recompute transition scores for all or affected slots, honoring current order."""
     if slots is None:
         slots = _ordered_slots(db, set_obj.id)
-    pool_metas = [_track_meta(t) for t in _pool_tracks(db, set_obj.id)]
+    vibes = _pool_vibes(db, set_obj)
+    pool_metas = [_track_meta(t, vibes.get(t.id)) for t in _pool_tracks(db, set_obj.id)]
     tracks_by_id = {meta.slot_track_id: meta for meta in pool_metas}
     scores: list[TransitionScore] = []
     for idx, slot in enumerate(slots):
@@ -193,7 +197,26 @@ def _saved_pairings(db: Session, set_id: int) -> set[tuple[str, str]]:
     return pairings
 
 
-def _track_meta(track: SetPoolTrack) -> TrackMeta:
+def _track_meta(track: SetPoolTrack, resolved: ResolvedVibe | None = None) -> TrackMeta:
+    """Build a scoring meta for a pool track.
+
+    Energy and mood are sourced from the read-time vibe cascade (own > community
+    > LLM, #391) when ``resolved`` is supplied — the pool row's own ``energy``/
+    ``mood`` are structurally ``None`` in production (no import fills them), so
+    without this overlay the builder's ``0.30 * _energy_match`` and mood terms
+    are dead constants (#543). The pool row remains the fallback so callers that
+    pass no resolved vibe (and any row that does carry its own value) still work.
+
+    ``transitional_role`` has no resolver source yet — the cascade only carries
+    energy/mood — so its scoring term stays a neutral constant (see ``_role_fit``
+    TODO). Re-point energy/mood at the global ``tracks`` row when that lands.
+    """
+    energy = track.energy
+    mood = None
+    if resolved is not None:
+        if resolved.energy is not None:
+            energy = resolved.energy
+        mood = resolved.mood
     return TrackMeta(
         pool_id=track.id,
         slot_track_id=track.track_id or f"pool:{track.id}",
@@ -201,8 +224,25 @@ def _track_meta(track: SetPoolTrack) -> TrackMeta:
         artist=track.artist,
         bpm=track.bpm,
         key=track.camelot or track.key,
-        energy=track.energy,
+        energy=energy,
+        mood=mood,
     )
+
+
+def _pool_vibes(db: Session, set_obj: Set) -> dict[int, ResolvedVibe]:
+    """Resolve each pool track's vibe (own > community > LLM) keyed by pool id.
+
+    The cascade needs the acting DJ; the build path only carries ``(db, set_obj)``,
+    so the owner is resolved the same way the agent import tools do
+    (``db.get(User, set_obj.owner_id)``). Missing owner degrades neutrally to an
+    empty map — the builder then falls back to pool-row values (all ``None`` in
+    prod), i.e. exactly the pre-#543 behavior, never a crash.
+    """
+    owner = db.get(User, set_obj.owner_id)
+    if owner is None:
+        return {}
+    states = build_pool_vibe_states(db, owner, set_obj)
+    return {state.pool_track_id: state.resolved for state in states}
 
 
 def _slot_count(set_obj: Set, tracks: list[SetPoolTrack], locked: list[SetSlot]) -> int:
@@ -330,6 +370,13 @@ def _mood_continuity(previous: TrackMeta | None, current: TrackMeta) -> float:
 
 
 def _role_fit(role: str | None, position: int, slot_count: int, target: float) -> float:
+    # TODO(#543): ``transitional_role`` has no resolver source — the vibe cascade
+    # (own > community > LLM) surfaces only energy/mood, never role. TrackMeta.
+    # transitional_role is therefore always None today, so this term is a neutral
+    # 0.5 constant. The scoring logic below is kept (not deleted) so the term goes
+    # live for free once a role source is wired (e.g. via the global tracks row or
+    # an extended cascade); deleting it would silently re-weight the other terms
+    # and collide with the genre work in #545.
     if not role:
         return 0.5
     normalized = role.strip().lower().replace("-", "_").replace(" ", "_")

--- a/server/tests/test_setbuilder_pass1_vibe.py
+++ b/server/tests/test_setbuilder_pass1_vibe.py
@@ -1,0 +1,220 @@
+"""Regression tests: pass-1 must score on RESOLVED vibe energy/mood (#543).
+
+Before #543 the deterministic builder read ``energy``/``mood`` straight off the
+``SetPoolTrack`` row, which is structurally always ``None`` in production (no
+import source fills it; LLM-inferred energy lives in the ``TrackVibe`` cache and
+was only resolved read-time for the UI). So the ``0.30 * _energy_match`` term was
+a constant and the energy curve had nothing to match against.
+
+These tests seed the realistic production shape — pool rows with ``energy=None``,
+energy living only in the LLM ``TrackVibe`` cache — and assert the builder now
+threads resolved energy into candidate scoring so the per-slot ``target_energy``
+curve actually drives selection.
+"""
+
+from sqlalchemy.orm import Session
+
+from app.models.set import Set
+from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.models.track_vibe import TrackVibe
+from app.models.user import User
+from app.services.setbuilder.curve import BUILTIN_TEMPLATES, interpolate_energy, uniform_midpoints
+from app.services.setbuilder.pass1_deterministic import _pool_vibes, build_set
+from app.services.setbuilder.vibe_enrichment import PROMPT_VERSION, SCHEMA_VERSION
+
+
+def _mk_set(db: Session, user: User, *, duration: int) -> Set:
+    set_obj = Set(owner_id=user.id, name="Vibe-driven", target_duration_sec=duration)
+    db.add(set_obj)
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def _mk_source(db: Session, set_obj: Set) -> SetPoolSource:
+    src = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(src)
+    db.commit()
+    db.refresh(src)
+    return src
+
+
+def _mk_track(db: Session, set_obj: Set, source: SetPoolSource, idx: int, **kw) -> SetPoolTrack:
+    """Pool track with energy LEFT NULL — mirrors production (no import fills it)."""
+    defaults = dict(
+        set_id=set_obj.id,
+        source_id=source.id,
+        track_id=f"tidal:{idx}",
+        title=f"Track {idx}",
+        artist=f"Artist {idx}",
+        bpm=124.0,
+        key="8A",
+        camelot="8A",
+        energy=None,  # structurally None in prod
+        duration_sec=210,
+        dedupe_sig=f"sig-{idx}",
+    )
+    defaults.update(kw)
+    track = SetPoolTrack(**defaults)
+    db.add(track)
+    db.commit()
+    db.refresh(track)
+    return track
+
+
+def _llm_energy(db: Session, track_id: str, *, energy: int, mood: str | None = None) -> None:
+    """Seed a current-version global LLM vibe row (the resolver's tier-3 source)."""
+    db.add(
+        TrackVibe(
+            track_id=track_id,
+            energy=energy,
+            mood=mood,
+            confidence=0.9,
+            llm_provider="anthropic_apikey",
+            llm_model="claude-haiku-4-5",
+            prompt_version=PROMPT_VERSION,
+            schema_version=SCHEMA_VERSION,
+        )
+    )
+    db.commit()
+
+
+def test_resolved_energy_breaks_tie_toward_slot_target(db: Session, test_user: User):
+    """Two otherwise-identical candidates compete for slot 0; the one whose RESOLVED
+    energy is closer to that slot's target_energy must win.
+
+    Before #543 both candidates scored identically (energy term constant on
+    pool-row None) and the deterministic tie-break ``-pool_id`` would pick the
+    LOWER pool_id. We arrange the energy-correct track to have the HIGHER pool_id
+    so the *only* way it can win is the now-live energy term — making this a true
+    regression test that would have failed before the fix.
+    """
+    set_obj = _mk_set(db, test_user, duration=210)  # one slot
+    src = _mk_source(db, set_obj)
+
+    # Determine slot 0's target on the default Open-Format curve.
+    points = BUILTIN_TEMPLATES["Open-Format"]
+    target = round(interpolate_energy(points, uniform_midpoints(1)[0]), 1)
+
+    far = max(0, min(10, round(target) - 4))
+    near = max(0, min(10, round(target)))
+    assert far != near, "fixture needs distinguishable energies"
+
+    # Lower pool_id = the FAR-from-target track (would win the -pool_id tie-break).
+    far_track = _mk_track(db, set_obj, src, 0, track_id="tidal:far")
+    near_track = _mk_track(db, set_obj, src, 1, track_id="tidal:near")
+    assert far_track.id < near_track.id
+
+    _llm_energy(db, "tidal:far", energy=far)
+    _llm_energy(db, "tidal:near", energy=near)
+
+    result = build_set(db, set_obj)
+
+    assert result.slot_count == 1
+    assert result.slots[0].track_id == "tidal:near"
+
+
+# Track i is seeded with resolved energy == 2*i (a full 0..10 spread over 6
+# tracks), so a slot's chosen energy is recoverable from its track_id suffix.
+_CURVE_ENERGIES = [0, 2, 4, 6, 8, 10]
+
+
+def _curve_mae(result) -> float:
+    """Mean absolute error of each slot's chosen energy vs its target_energy."""
+    errors = []
+    for slot in result.slots:
+        idx = (slot.track_id or "").split(":")[-1]
+        if not idx.isdigit() or slot.target_energy is None:
+            continue
+        errors.append(abs(_CURVE_ENERGIES[int(idx)] - slot.target_energy))
+    assert errors, "expected scored slots"
+    return sum(errors) / len(errors)
+
+
+def test_energy_curve_adherence_improves_with_resolved_energy(db: Session, test_user: User):
+    """A/B on the SAME pool: building with resolved energy must track the target
+    curve measurably better than the identical builder run energy-blind.
+
+    The energy-blind baseline is reproduced by deleting the TrackVibe rows (pool
+    rows are already ``None``), so the energy term collapses to its constant 0.5
+    — exactly the pre-#543 behavior. Comparing the two MAEs isolates the fix from
+    the refinement pass's transition-smoothing trade-offs, which are out of scope.
+    """
+    set_obj = _mk_set(db, test_user, duration=210 * 6)  # ~6 slots
+    src = _mk_source(db, set_obj)
+
+    for idx, energy in enumerate(_CURVE_ENERGIES):
+        _mk_track(db, set_obj, src, idx, track_id=f"tidal:{idx}", bpm=124.0, key="8A", camelot="8A")
+        _llm_energy(db, f"tidal:{idx}", energy=energy)
+
+    aware_mae = _curve_mae(build_set(db, set_obj))
+
+    # Energy-blind baseline: drop the LLM tier so nothing resolves; pool rows are
+    # already None. Same pool, same curve, same builder.
+    db.query(TrackVibe).delete()
+    db.commit()
+    blind_mae = _curve_mae(build_set(db, set_obj))
+
+    assert aware_mae < blind_mae, (
+        f"resolved energy did not improve curve adherence: aware={aware_mae} blind={blind_mae}"
+    )
+
+
+def test_missing_energy_degrades_neutrally(db: Session, test_user: User):
+    """Tracks with no resolvable energy anywhere must not crash and must not be
+    unfairly penalized: a full pool with zero vibe data still builds a set."""
+    set_obj = _mk_set(db, test_user, duration=210 * 4)
+    src = _mk_source(db, set_obj)
+    for idx in range(6):
+        _mk_track(db, set_obj, src, idx)  # energy None, no TrackVibe rows
+
+    result = build_set(db, set_obj)
+
+    assert result.slot_count >= 1
+    assert all(s.track_id for s in result.slots)
+
+
+def test_missing_owner_resolves_empty_vibes_no_crash(db: Session, test_user: User):
+    """If the set's owner row is gone, vibe resolution degrades to an empty map
+    (pre-#543 behavior) instead of crashing the build."""
+    set_obj = _mk_set(db, test_user, duration=210 * 2)
+    src = _mk_source(db, set_obj)
+    for idx in range(3):
+        _mk_track(db, set_obj, src, idx)
+        _llm_energy(db, f"tidal:{idx}", energy=idx * 3)
+
+    # Point the set at a non-existent owner so db.get(User, ...) returns None.
+    set_obj.owner_id = 999_999
+    db.commit()
+
+    assert _pool_vibes(db, set_obj) == {}
+    # The build still succeeds (energy term falls back to its neutral constant).
+    result = build_set(db, set_obj)
+    assert result.slot_count >= 1
+    assert all(s.track_id for s in result.slots)
+
+
+def test_resolved_mood_continuity_affects_transition_scores(db: Session, test_user: User):
+    """Mood was dead the same way as energy. With resolved mood threaded in,
+    same-mood neighbors should score a higher mood-continuity transition than a
+    mood clash, which is observable in the persisted transition scores."""
+    set_obj = _mk_set(db, test_user, duration=210 * 3)
+    src = _mk_source(db, set_obj)
+    # Three tracks; two share a mood, one differs. BPM/key identical so mood is
+    # the differentiator.
+    for idx in range(3):
+        _mk_track(db, set_obj, src, idx, track_id=f"tidal:{idx}", bpm=124.0, key="8A", camelot="8A")
+    _llm_energy(db, "tidal:0", energy=5, mood="dark")
+    _llm_energy(db, "tidal:1", energy=5, mood="dark")
+    _llm_energy(db, "tidal:2", energy=5, mood="happy")
+
+    result = build_set(db, set_obj)
+
+    # At least one adjacent same-mood pair should exist and its transition should
+    # outscore the worst (mood-clash) transition.
+    assert result.slot_count >= 2
+    scores = [s.transition_score for s in result.slots[1:] if s.transition_score is not None]
+    assert scores, "expected transition scores"
+    # A purely energy/bpm/key-identical pool would have flat mood (0.5) everywhere;
+    # with mood resolved, the same-mood transition rises above the clash one.
+    assert max(scores) > min(scores)


### PR DESCRIPTION
## Why

Pass-1's deterministic builder **scored on energy it never received.** `_track_meta` read `energy=track.energy` off the `SetPoolTrack` row, but that column is **structurally always `None` in production** — no import source fills it, and #391's LLM-inferred energy lives in the `TrackVibe` cache, resolved read-time for the UI but **never surfaced to the builder**. So `0.30 * _energy_match(None, target)` was a constant for every candidate: the energy term contributed nothing to selection, and the per-slot `target_energy` curve had nothing to match against. `mood` was dead the same way. This is effectively a bug — the quick win of epic #539.

## What

Source **resolved energy/mood** from the existing own > community > LLM cascade (`vibe_resolver.build_pool_vibe_states`) into the candidate scoring path, so the existing `0.30` energy term goes live and tracks are matched to the curve.

- New `_pool_vibes(db, set_obj)` helper resolves the cascade once per build, keyed by pool-track id.
- `_track_meta` gains an optional `resolved` arg that overlays energy/mood (resolved wins; pool row is the fallback).
- Wired through both `build_set` and `recompute_transition_scores`.
- `_candidate_score` weights are **untouched** — no new terms — so this rebases cleanly under the sibling #545 (genre) work.

## Design decisions

- **Sourcing energy/mood:** consumed via the read-time vibe cascade (`build_pool_vibe_states` → `ResolvedVibe.energy`/`.mood`), the same own>community>LLM precedence the UI already uses (#391). The pool row remains the fallback, so existing callers that pass no resolved vibe — and any row that genuinely carries a value — keep working unchanged. This is consumer-side only; the energy **source** (external audio-features provider, #544) is out of scope, as is genre (#545).
- **`transitional_role`:** left as a documented neutral constant with a `TODO(#543)` in `_role_fit`, **not dropped.** The cascade only surfaces energy/mood (no own/community/LLM tier for role is exposed by the resolver), so the term is genuinely dead today — but deleting it would silently re-weight the other terms and collide with the #545 genre edit to the same function. Kept so it goes live for free once a role source is wired.
- **Owner threading:** the build path only carries `(db, set_obj)`; the cascade needs the acting DJ, so the owner is resolved as `db.get(User, set_obj.owner_id)` — the exact pattern the agent import/sensing tools use. A missing owner degrades neutrally to an empty vibe map (pre-#543 behavior, never a crash).
- **Weights:** unchanged. The fix only makes the existing `0.30` energy and `0.10` mood terms receive real data; it does not re-tune scoring.
- **Backward compatibility:** `_track_meta` is imported by many sibling setbuilder modules (sensing/structural/mutations/pass2). The new `resolved` param is **optional with a `None` default**, so every existing `_track_meta(track)` call is untouched.

## Testing

- [x] New regression test: two candidates identical except energy — the one closer to the slot's `target_energy` wins (arranged so the energy-correct track has the **higher** pool_id, so the only way it wins is the now-live energy term; would have failed before this change).
- [x] New A/B curve-adherence test: building with resolved energy tracks the curve measurably better (lower MAE) than the identical builder run energy-blind, on the same fixture pool with known energies.
- [x] New neutral-degradation tests: a pool with no resolvable energy still builds (no crash, no unfair penalty); a missing owner resolves to an empty vibe map and still builds.
- [x] New mood test: resolved mood moves transition scores (same-mood pair outscores a clash).
- [x] No regression to bpm/key/artist behavior — full setbuilder suite (218 tests) green; existing pass-1 tests that set `energy` on the pool row still pass via the fallback.
- [x] Full backend suite: **3309 passed**, coverage **89.44%** (gate 85%).
- [x] ruff check / ruff format --check / bandit all clean.
- [ ] CI green

No migration (consumer-side wiring only).

🤖 Co-authored by Claude Opus 4.8. Closes #543.