### PR TITLE
feat(recommendations): wire Soundcharts "similar songs" (paid tier) as a candidate source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,12 @@ TIDAL_REDIRECT_URI=your-sites-oauth-callback
 # Audio-features enrichment (#544) is DARK BY DEFAULT. Keep it off until a paid
 # tier + caching/redistribution licensing are validated; set true to enable.
 # SOUNDCHARTS_AUDIO_FEATURES_ENABLED=false
+#
+# Related-tracks candidate discovery (#556) is DARK BY DEFAULT. The paid-tier
+# GET /api/v2/song/{uuid}/related endpoint seeds recommendation candidates from
+# the event's own tracks (no connected Tidal/Beatport needed). Off = no spend;
+# set true only once a paid plan is provisioned.
+# SOUNDCHARTS_RELATED_TRACKS_ENABLED=false
 
 # =============================================================================
 # StageLinQ Bridge

--- a/docs/superpowers/plans/2026-06-24-soundcharts-related-candidates.md
+++ b/docs/superpowers/plans/2026-06-24-soundcharts-related-candidates.md
@@ -1,0 +1,79 @@
+# Soundcharts "similar songs" candidate source Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Soundcharts paid-tier "related tracks" (`GET /api/v2/song/{uuid}/related`) as a provider-agnostic recommendation candidate source seeded from the event's existing tracks (resolved by ISRC from the master `tracks` store), so a DJ with no connected Tidal/Beatport account still gets suggestions.
+
+**Architecture:** A new dark-by-default adapter method `get_related_songs_by_isrc` on `services/soundcharts.py` resolves an ISRC → song UUID → related-tracks call. A new generator `related_candidates_from_seeds` in `recommendation/soundcharts_candidates.py` picks ISRC seeds from accepted/played requests (request.isrc first, then the master `tracks` store by signature), fetches related songs, dedups across seeds, and converts them to `TrackProfile(source="soundcharts")`. These candidates flow through the EXISTING `deduplicate_candidates` → `rank_candidates` → diversity/cap pipeline unchanged. `service.generate_recommendations` is extended to run this source even when no Tidal/Beatport is connected; the API gate is relaxed accordingly. The source surfaces as `"soundcharts"` in `services_used`.
+
+**Tech Stack:** Python 3.13, FastAPI, SQLAlchemy, httpx, pytest. Ruff line-length 100.
+
+## Global Constraints
+
+- DARK BY DEFAULT, no spend by default: gate behind a new `soundcharts_related_tracks_enabled` setting (default `False`) AND configured creds. Absent → source contributes nothing, endpoint behaves exactly as today.
+- NEVER log/print Soundcharts secrets (`SOUNDCHARTS_APP_ID`/`SOUNDCHARTS_API_KEY`). Read creds from settings only.
+- Mock the Soundcharts adapter in tests; NEVER hit the live paid API.
+- Parameterized queries only; validate external input; no internal errors/stack traces leaked to API.
+- Do NOT modify `track_match.find_best_match`, `setbuilder/`, or `dashboard/`. Additive only — do not rework the #544 audio-features path.
+- Coverage gate is enforced (`--cov-fail-under`). Keep it green with targeted tests.
+- Conventional Commits; trailer `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Dark-by-default related-tracks adapter
+
+**Files:**
+- Modify: `server/app/core/config.py` (add `soundcharts_related_tracks_enabled: bool = False`)
+- Modify: `server/app/services/soundcharts.py` (add `get_related_songs_by_isrc`)
+- Test: `server/tests/test_soundcharts.py`
+
+**Interfaces:**
+- Produces: `get_related_songs_by_isrc(isrc: str, *, limit: int = 20) -> list[SoundchartsTrack]`
+  - Returns `[]` when `soundcharts_related_tracks_enabled` is False, creds missing, ISRC unresolvable, or API failure.
+  - Resolves ISRC → song object (`/api/v2.25/song/by-isrc/{isrc}`) → `GET /api/v2/song/{uuid}/related?offset=0&limit=N`.
+  - Parses items tolerant of both `{"items":[{song obj}]}` and `{"items":[{"song":{...}}]}` shapes.
+
+Steps: write failing tests (enabled+success returns tracks; disabled returns []; no creds returns []; bad ISRC returns []; HTTP error returns []; both response shapes parsed), run to fail, implement, run to pass, commit.
+
+---
+
+### Task 2: ISRC-seeded related-candidate generator
+
+**Files:**
+- Modify: `server/app/services/recommendation/soundcharts_candidates.py` (add `related_candidates_from_seeds`)
+- Test: `server/tests/test_soundcharts_candidates.py`
+
+**Interfaces:**
+- Consumes: `get_related_songs_by_isrc` (Task 1); `TrackProfile`; `app.services.tracks.store.get_track`; `app.services.setbuilder.pool.dedupe_signature`.
+- Produces: `related_candidates_from_seeds(db, requests, *, max_seeds=10, per_seed_limit=20) -> tuple[list[TrackProfile], int]`
+  - For each seed request: ISRC = `request.isrc` or master-store lookup by `dedupe_signature(artist, title)`.
+  - Skips seeds with no ISRC. Dedups related songs across seeds by `soundcharts_uuid` and by `artist|title`.
+  - Returns `(candidates, seeds_used)` where candidates are `TrackProfile(source="soundcharts")` and `seeds_used` counts seeds that yielded an API call.
+
+Steps: write failing tests (request.isrc seed → candidates; store-fallback seed; no-ISRC seed skipped; cross-seed dedup; empty requests → ([],0)), mock `get_related_songs_by_isrc`, run to fail, implement, run to pass, commit.
+
+---
+
+### Task 3: Wire source into the engine + relax the gate
+
+**Files:**
+- Modify: `server/app/services/recommendation/service.py` (`_search_candidates`, `generate_recommendations`)
+- Modify: `server/app/api/events.py` (`get_recommendations` 503 gate)
+- Test: `server/tests/test_recommendation_service.py`, `server/tests/test_recommendation_api.py`
+
+**Interfaces:**
+- Consumes: `related_candidates_from_seeds` (Task 2).
+- `generate_recommendations` runs the related-tracks source when enabled, even with no Tidal/Beatport; adds `"soundcharts"` to `services_used`; junk-filters candidates with the existing helpers.
+- API `get_recommendations` allows the request through (no 503) when `soundcharts_related_tracks_enabled` + creds are set, even with no connected service.
+
+Steps: write failing tests (enabled + no connected service → non-empty suggestions + `"soundcharts"` in services_used; disabled → behaves as today / empty + 503 path unchanged), run to fail, implement, run to pass, commit.
+
+---
+
+### Task 4: Docs, CI gate, openapi regen
+
+**Files:**
+- Modify: `CLAUDE.md` env list (note the new flag) — optional, low-risk.
+- Regenerate committed `openapi.json` only if the response schema changed (it does NOT — `services_used` is already a free-form list), so SKIP unless a diff appears.
+
+Steps: run full backend CI gate locally (ruff check, ruff format --check, bandit, pytest+coverage). Fix. Commit any formatting. No migration (the new column-less boolean setting needs none).

--- a/server/app/api/events.py
+++ b/server/app/api/events.py
@@ -943,13 +943,18 @@ def get_recommendations(
     db: Session = Depends(get_db),
 ) -> RecommendationResponse:
     """Generate song recommendations based on the event's musical profile."""
-    from app.services.recommendation.service import generate_recommendations
+    from app.services.recommendation.service import (
+        _soundcharts_related_available,
+        generate_recommendations,
+    )
 
     user = event.created_by
 
-    # Check if any music services are connected
+    # A candidate source must be available: a connected Tidal/Beatport account,
+    # or the provider-agnostic Soundcharts related-tracks source (#556), which
+    # needs no connected service (dark by default — only when explicitly enabled).
     has_services = bool(user.tidal_access_token) or bool(user.beatport_access_token)
-    if not has_services:
+    if not has_services and not _soundcharts_related_available():
         raise HTTPException(
             status_code=503,
             detail="No music services connected. Link Tidal or Beatport to get recommendations.",

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -135,6 +135,10 @@ class Settings(BaseSettings):
     # key usable in prod while energy/danceability/valence lookup stays off
     # until a paid tier + caching/redistribution licensing are validated.
     soundcharts_audio_features_enabled: bool = False
+    # Related-tracks candidate discovery (#556) — DARK BY DEFAULT. The paid-tier
+    # GET /api/v2/song/{uuid}/related endpoint is the only spend on this path;
+    # gated off until a paid plan is provisioned so it can never bill by default.
+    soundcharts_related_tracks_enabled: bool = False
 
     # ListenBrainz API (artist discovery for recommendations)
     listenbrainz_user_token: str = ""

--- a/server/app/services/recommendation/service.py
+++ b/server/app/services/recommendation/service.py
@@ -754,14 +754,7 @@ def _search_candidates(
             settings = get_settings()
             if settings.soundcharts_app_id and settings.soundcharts_api_key:
                 sc_candidates, sc_searched = search_candidates_via_soundcharts(db, user, profile)
-                tidal_candidates = [
-                    c
-                    for c in sc_candidates
-                    if not is_unwanted_version(c.title)
-                    and not _is_blocked_genre(c.genre)
-                    and not _is_junk_candidate(c.title, c.artist)
-                    and not _is_stock_music_artist(c.artist)
-                ]
+                tidal_candidates = _filter_candidates(sc_candidates)
                 tidal_searched = sc_searched
 
         # Strategy 3: Text search fallback (LLM queries or last resort)
@@ -790,6 +783,19 @@ def _search_candidates(
     return candidates, sorted(services_used), total_searched
 
 
+def _filter_candidates(cands: list[TrackProfile]) -> list[TrackProfile]:
+    """Drop unwanted/junk/blocked/stock candidates — the shared junk-filter applied
+    to every discovery source so the rules live in one place and can't drift."""
+    return [
+        c
+        for c in cands
+        if not is_unwanted_version(c.title)
+        and not _is_blocked_genre(c.genre)
+        and not _is_junk_candidate(c.title, c.artist)
+        and not _is_stock_music_artist(c.artist)
+    ]
+
+
 def _search_soundcharts_related(
     db: Session,
     requests: list | None,
@@ -814,15 +820,7 @@ def _search_soundcharts_related(
     from app.services.recommendation.soundcharts_candidates import related_candidates_from_seeds
 
     related, seeds_used = related_candidates_from_seeds(db, requests)
-    filtered = [
-        c
-        for c in related
-        if not is_unwanted_version(c.title)
-        and not _is_blocked_genre(c.genre)
-        and not _is_junk_candidate(c.title, c.artist)
-        and not _is_stock_music_artist(c.artist)
-    ]
-    return filtered, seeds_used
+    return _filter_candidates(related), seeds_used
 
 
 def _soundcharts_related_available() -> bool:

--- a/server/app/services/recommendation/service.py
+++ b/server/app/services/recommendation/service.py
@@ -776,7 +776,66 @@ def _search_candidates(
         if tidal_candidates:
             services_used.add("tidal")
 
+    # Soundcharts related-tracks (#556): provider-agnostic candidate discovery
+    # seeded from the event's own tracks (ISRC from the master store). Runs even
+    # with NO connected service — that is the whole point of the source. Dark by
+    # default: only fires when the paid related endpoint is explicitly enabled
+    # AND credentials are configured, so it can never spend by default.
+    sc_related_candidates, sc_related_searched = _search_soundcharts_related(db, requests)
+    if sc_related_candidates:
+        candidates.extend(sc_related_candidates)
+        total_searched += sc_related_searched
+        services_used.add("soundcharts")
+
     return candidates, sorted(services_used), total_searched
+
+
+def _search_soundcharts_related(
+    db: Session,
+    requests: list | None,
+) -> tuple[list[TrackProfile], int]:
+    """Discover candidates via the Soundcharts related-tracks source (#556).
+
+    Returns ``([], 0)`` unless the dark-by-default related endpoint is enabled
+    and credentials are configured. Seeds from accepted/played requests, then
+    junk-filters the results with the same helpers as the other sources.
+    """
+    if not requests:
+        return [], 0
+
+    from app.core.config import get_settings
+
+    settings = get_settings()
+    if not settings.soundcharts_related_tracks_enabled:
+        return [], 0
+    if not settings.soundcharts_app_id or not settings.soundcharts_api_key:
+        return [], 0
+
+    from app.services.recommendation.soundcharts_candidates import related_candidates_from_seeds
+
+    related, seeds_used = related_candidates_from_seeds(db, requests)
+    filtered = [
+        c
+        for c in related
+        if not is_unwanted_version(c.title)
+        and not _is_blocked_genre(c.genre)
+        and not _is_junk_candidate(c.title, c.artist)
+        and not _is_stock_music_artist(c.artist)
+    ]
+    return filtered, seeds_used
+
+
+def _soundcharts_related_available() -> bool:
+    """True when the dark-by-default Soundcharts related-tracks source can run
+    (explicitly enabled AND credentials configured)."""
+    from app.core.config import get_settings
+
+    settings = get_settings()
+    return bool(
+        settings.soundcharts_related_tracks_enabled
+        and settings.soundcharts_app_id
+        and settings.soundcharts_api_key
+    )
 
 
 def _filter_unverified_artists(
@@ -1043,11 +1102,15 @@ def generate_recommendations(
     # Step 1: Fetch existing requests
     requests = _get_accepted_played_requests(db, event)
 
-    # Check if any services are connected
+    # Check if any candidate source is available. Tidal/Beatport need a connected
+    # account; the Soundcharts related-tracks source (#556) is provider-agnostic
+    # and works with no connected service, so it keeps recommendations alive for a
+    # DJ who hasn't linked anything — when explicitly enabled (dark by default).
     has_tidal = bool(user.tidal_access_token)
     has_beatport = bool(user.beatport_access_token)
+    has_soundcharts_related = _soundcharts_related_available()
 
-    if not has_tidal and not has_beatport:
+    if not has_tidal and not has_beatport and not has_soundcharts_related:
         return RecommendationResult(
             suggestions=[],
             event_profile=EventProfile(track_count=0),

--- a/server/app/services/recommendation/soundcharts_candidates.py
+++ b/server/app/services/recommendation/soundcharts_candidates.py
@@ -36,6 +36,10 @@ BPM_RANGE_OFFSET = 15
 # Max seed tracks to expand via the paid related endpoint (each costs API calls).
 MAX_RELATED_SEEDS = 10
 
+# Stop seeding once this many unique candidates are gathered, so a slow/degraded
+# Soundcharts upstream cannot serialize every seed into the request's latency.
+MAX_RELATED_CANDIDATES = 60
+
 
 def search_candidates_via_soundcharts(
     db: Session,
@@ -130,6 +134,7 @@ def related_candidates_from_seeds(
     *,
     max_seeds: int = MAX_RELATED_SEEDS,
     per_seed_limit: int = RELATED_TRACKS_LIMIT,
+    max_candidates: int = MAX_RELATED_CANDIDATES,
 ) -> tuple[list[TrackProfile], int]:
     """Discover candidates via Soundcharts related-tracks, seeded by event ISRCs (#556).
 
@@ -137,7 +142,9 @@ def related_candidates_from_seeds(
     then the master tracks store) and fetch related tracks via the dark-by-default
     adapter. Candidates are de-duplicated across seeds (by Soundcharts UUID and by
     normalized artist|title) and returned as ``TrackProfile(source="soundcharts")``
-    for the shared scorer/dedup pipeline.
+    for the shared scorer/dedup pipeline. Seeding stops early once ``max_candidates``
+    unique candidates are gathered, so a slow/degraded upstream cannot serialize
+    every seed's two blocking calls into the request's latency.
 
     Returns ``(candidates, seeds_used)`` where ``seeds_used`` counts seeds that
     resolved an ISRC and triggered a lookup. Requires NO connected music service;
@@ -149,6 +156,8 @@ def related_candidates_from_seeds(
     seen_names: set[str] = set()
 
     for request in requests[:max_seeds]:
+        if len(candidates) >= max_candidates:
+            break
         isrc = _seed_isrc(db, request)
         if not isrc:
             continue

--- a/server/app/services/recommendation/soundcharts_candidates.py
+++ b/server/app/services/recommendation/soundcharts_candidates.py
@@ -1,7 +1,14 @@
-"""Bridge between Soundcharts discovery and Tidal playback.
+"""Soundcharts-backed candidate generators for the recommendation engine.
 
-Discovers songs via Soundcharts (genre/BPM/key filters), then resolves
-each result to a playable Tidal track ID via individual Tidal searches.
+Two independent paths:
+
+1. ``search_candidates_via_soundcharts`` — discovers songs via Soundcharts
+   genre/BPM/key filters, then resolves each result to a playable Tidal track ID
+   (requires a connected Tidal account).
+2. ``related_candidates_from_seeds`` (#556) — seeds the paid-tier related-tracks
+   endpoint from the event's existing tracks (ISRC resolved from the master
+   ``tracks`` store), producing provider-agnostic candidates with NO connected
+   service required. Dark by default via the adapter gate.
 """
 
 import logging
@@ -10,7 +17,13 @@ from sqlalchemy.orm import Session
 
 from app.models.user import User
 from app.services.recommendation.scorer import EventProfile, TrackProfile
-from app.services.soundcharts import discover_songs
+from app.services.soundcharts import (
+    RELATED_TRACKS_LIMIT,
+    SoundchartsTrack,
+    discover_songs,
+    get_related_songs_by_isrc,
+)
+from app.services.tracks.store import get_track
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +32,9 @@ MAX_TIDAL_LOOKUPS = 25
 
 # BPM range around the event average
 BPM_RANGE_OFFSET = 15
+
+# Max seed tracks to expand via the paid related endpoint (each costs API calls).
+MAX_RELATED_SEEDS = 10
 
 
 def search_candidates_via_soundcharts(
@@ -93,3 +109,68 @@ def search_candidates_via_soundcharts(
         total_searched,
     )
     return candidates, total_searched
+
+
+def _seed_isrc(db: Session, request) -> str | None:
+    """Resolve a seed request's ISRC: the request's own ISRC first, else the
+    master tracks store keyed by the normalized artist+title signature."""
+    if getattr(request, "isrc", None):
+        return request.isrc
+    # Fall back to the master store (#540/#552), the ISRC source of truth.
+    from app.services.setbuilder.pool import dedupe_signature
+
+    signature = dedupe_signature(request.artist, request.song_title)
+    stored = get_track(db, signature=signature)
+    return stored.isrc if stored and stored.isrc else None
+
+
+def related_candidates_from_seeds(
+    db: Session,
+    requests: list,
+    *,
+    max_seeds: int = MAX_RELATED_SEEDS,
+    per_seed_limit: int = RELATED_TRACKS_LIMIT,
+) -> tuple[list[TrackProfile], int]:
+    """Discover candidates via Soundcharts related-tracks, seeded by event ISRCs (#556).
+
+    For each of the first ``max_seeds`` requests, resolve an ISRC (request first,
+    then the master tracks store) and fetch related tracks via the dark-by-default
+    adapter. Candidates are de-duplicated across seeds (by Soundcharts UUID and by
+    normalized artist|title) and returned as ``TrackProfile(source="soundcharts")``
+    for the shared scorer/dedup pipeline.
+
+    Returns ``(candidates, seeds_used)`` where ``seeds_used`` counts seeds that
+    resolved an ISRC and triggered a lookup. Requires NO connected music service;
+    contributes nothing when the adapter is disabled/unconfigured (it returns []).
+    """
+    candidates: list[TrackProfile] = []
+    seeds_used = 0
+    seen_uuids: set[str] = set()
+    seen_names: set[str] = set()
+
+    for request in requests[:max_seeds]:
+        isrc = _seed_isrc(db, request)
+        if not isrc:
+            continue
+        seeds_used += 1
+        related: list[SoundchartsTrack] = get_related_songs_by_isrc(isrc, limit=per_seed_limit)
+        for track in related:
+            name_key = f"{track.artist.lower().strip()}|{track.title.lower().strip()}"
+            if track.soundcharts_uuid in seen_uuids or name_key in seen_names:
+                continue
+            seen_uuids.add(track.soundcharts_uuid)
+            seen_names.add(name_key)
+            candidates.append(
+                TrackProfile(
+                    title=track.title,
+                    artist=track.artist,
+                    source="soundcharts",
+                )
+            )
+
+    logger.info(
+        "Soundcharts related-tracks: %d candidates from %d seed(s)",
+        len(candidates),
+        seeds_used,
+    )
+    return candidates, seeds_used

--- a/server/app/services/soundcharts.py
+++ b/server/app/services/soundcharts.py
@@ -15,6 +15,7 @@ import httpx
 
 from app.core.config import get_settings
 from app.services.recommendation.camelot import parse_key
+from app.services.track_normalizer import valid_isrc
 
 logger = logging.getLogger(__name__)
 
@@ -228,9 +229,9 @@ def discover_songs(
         )
         response.raise_for_status()
     except httpx.HTTPStatusError as e:
-        logger.warning(
-            "Soundcharts API error %s: %s", e.response.status_code, e.response.text[:200]
-        )
+        # Log only the status code — never the upstream response body, which could
+        # echo request headers / account data and leak the configured credentials.
+        logger.warning("Soundcharts API error %s", e.response.status_code)
         return []
     except httpx.HTTPError as e:
         logger.warning("Soundcharts request failed: %s", e)
@@ -265,11 +266,15 @@ def discover_songs(
 
 
 def _normalize_isrc(isrc: str | None) -> str | None:
-    """Uppercase, trim, and strip hyphens so the ISRC matches Soundcharts' key."""
-    if not isrc:
-        return None
-    cleaned = isrc.strip().upper().replace("-", "")
-    return cleaned or None
+    """Normalize and validate an ISRC for use as a Soundcharts ``by-isrc`` path segment.
+
+    Delegates to the canonical :func:`valid_isrc`, which returns the value ONLY when
+    it matches the ISO 3901 shape (2-letter country + 3 alphanumeric + 7 digits) and
+    ``None`` otherwise. Strict validation keeps a crafted value (e.g. one containing
+    ``/`` or ``..``) from ever being interpolated into the request URL — a malformed
+    ISRC could never resolve at Soundcharts anyway, so dropping it is free.
+    """
+    return valid_isrc(isrc)
 
 
 def _flatten_genres(genres: list | None) -> tuple[str, ...]:
@@ -295,9 +300,9 @@ def _fetch_song_object(url: str, settings) -> dict | None:
         )
         response.raise_for_status()
     except httpx.HTTPStatusError as e:
-        logger.warning(
-            "Soundcharts song API error %s: %s", e.response.status_code, e.response.text[:200]
-        )
+        # Log only the status code — never the upstream response body, which could
+        # echo request headers / account data and leak the configured credentials.
+        logger.warning("Soundcharts song API error %s", e.response.status_code)
         return None
     except httpx.HTTPError as e:
         logger.warning("Soundcharts song request failed: %s", e)
@@ -442,9 +447,9 @@ def get_related_songs_by_isrc(
         )
         response.raise_for_status()
     except httpx.HTTPStatusError as e:
-        logger.warning(
-            "Soundcharts related API error %s: %s", e.response.status_code, e.response.text[:200]
-        )
+        # Log only the status code — never the upstream response body: an auth
+        # failure body could echo request headers / account data and leak secrets.
+        logger.warning("Soundcharts related API error %s", e.response.status_code)
         return []
     except httpx.HTTPError as e:
         logger.warning("Soundcharts related request failed: %s", e)
@@ -456,7 +461,10 @@ def get_related_songs_by_isrc(
         logger.warning("Soundcharts related API returned invalid JSON: %s", e)
         return []
 
-    items = payload.get("items", []) if isinstance(payload, dict) else []
+    items = payload.get("items") if isinstance(payload, dict) else None
+    if not isinstance(items, list):
+        # A malformed payload (e.g. {"items": null}) must degrade to [], not crash.
+        items = []
     tracks = [t for t in (_related_item_to_track(item) for item in items) if t is not None]
     logger.info("Soundcharts related: %d tracks for seed ISRC", len(tracks))
     return tracks

--- a/server/app/services/soundcharts.py
+++ b/server/app/services/soundcharts.py
@@ -24,6 +24,12 @@ REQUEST_TIMEOUT = 15
 # Song endpoints (audio features, ISRC lookup) live under the v2.25 API.
 SONG_API_BASE = f"{BASE_URL}/api/v2.25/song"
 
+# Related-tracks discovery (#556) lives under the v2 song API.
+SONG_V2_API_BASE = f"{BASE_URL}/api/v2/song"
+
+# Default number of related tracks to request per seed.
+RELATED_TRACKS_LIMIT = 20
+
 
 # Camelot position → (pitch_class 0-11, mode 0=minor/1=major)
 # Derived from _KEY_DEFINITIONS in camelot.py
@@ -365,3 +371,92 @@ def get_song_features_by_isrc(isrc: str) -> SoundchartsAudioFeatures | None:
             return None
 
     return _parse_song_features(obj, normalized)
+
+
+def _credit_name(value) -> str:
+    """Extract the artist display name from a Soundcharts ``creditName`` field.
+
+    The field is sometimes a bare string and sometimes ``{"name": ...}`` — mirror
+    the tolerance already used by ``discover_songs``.
+    """
+    if isinstance(value, dict):
+        return value.get("name") or ""
+    return value or ""
+
+
+def _related_item_to_track(item: dict) -> SoundchartsTrack | None:
+    """Convert one related-tracks item to a SoundchartsTrack, or None if incomplete.
+
+    Tolerates both the flat shape (song fields directly on the item) and the
+    nested ``{"song": {...}}`` shape some collection endpoints use. Items missing
+    a name, artist, or uuid are dropped rather than crashed on.
+    """
+    if not isinstance(item, dict):
+        return None
+    song = item.get("song") if isinstance(item.get("song"), dict) else item
+    name = song.get("name")
+    artist = _credit_name(song.get("creditName"))
+    uuid = song.get("uuid")
+    if name and artist and uuid:
+        return SoundchartsTrack(title=name, artist=artist, soundcharts_uuid=uuid)
+    return None
+
+
+def get_related_songs_by_isrc(
+    isrc: str, *, limit: int = RELATED_TRACKS_LIMIT
+) -> list[SoundchartsTrack]:
+    """Fetch tracks related to a seed ISRC via the paid-tier related endpoint (#556).
+
+    Dark by default: returns ``[]`` unless ``soundcharts_related_tracks_enabled``
+    is set AND credentials are configured, so the paid
+    ``GET /api/v2/song/{uuid}/related`` endpoint never spends by default. Resolves
+    ISRC → song UUID (one call) → related tracks (one call). Returns ``[]`` on a
+    miss, an unconfigured/disabled adapter, or any API failure — the caller treats
+    the source as contributing nothing.
+    """
+    settings = get_settings()
+    if not settings.soundcharts_related_tracks_enabled:
+        logger.debug("Soundcharts related-tracks disabled, skipping lookup")
+        return []
+    if not settings.soundcharts_app_id or not settings.soundcharts_api_key:
+        logger.debug("Soundcharts not configured, skipping related-tracks lookup")
+        return []
+
+    normalized = _normalize_isrc(isrc)
+    if not normalized:
+        return []
+
+    seed = _fetch_song_object(f"{SONG_API_BASE}/by-isrc/{normalized}", settings)
+    if not seed or not seed.get("uuid"):
+        return []
+
+    try:
+        response = httpx.get(
+            f"{SONG_V2_API_BASE}/{seed['uuid']}/related",
+            params={"offset": 0, "limit": limit},
+            headers={
+                "x-app-id": settings.soundcharts_app_id,
+                "x-api-key": settings.soundcharts_api_key,
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        logger.warning(
+            "Soundcharts related API error %s: %s", e.response.status_code, e.response.text[:200]
+        )
+        return []
+    except httpx.HTTPError as e:
+        logger.warning("Soundcharts related request failed: %s", e)
+        return []
+
+    try:
+        payload = response.json()
+    except ValueError as e:
+        logger.warning("Soundcharts related API returned invalid JSON: %s", e)
+        return []
+
+    items = payload.get("items", []) if isinstance(payload, dict) else []
+    tracks = [t for t in (_related_item_to_track(item) for item in items) if t is not None]
+    logger.info("Soundcharts related: %d tracks for seed ISRC", len(tracks))
+    return tracks

--- a/server/tests/test_recommendation_api.py
+++ b/server/tests/test_recommendation_api.py
@@ -131,6 +131,36 @@ class TestRecommendationsEndpoint:
         assert "music services" in response.json()["detail"].lower()
 
     @patch("app.services.recommendation.service.generate_recommendations")
+    @patch(
+        "app.services.recommendation.service._soundcharts_related_available",
+        return_value=True,
+    )
+    def test_200_no_service_but_soundcharts_related_enabled(
+        self,
+        mock_available,
+        mock_generate,
+        client: TestClient,
+        auth_headers: dict,
+        event_with_requests: Event,
+    ):
+        """Issue #556: with no Tidal/Beatport but the Soundcharts related-tracks
+        source enabled, the endpoint serves recommendations instead of 503."""
+        mock_generate.return_value = RecommendationResult(
+            suggestions=[],
+            event_profile=EventProfile(track_count=0),
+            enriched_count=0,
+            total_candidates_searched=1,
+            services_used=["soundcharts"],
+        )
+
+        response = client.post(
+            f"/api/events/{event_with_requests.code}/recommendations",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["services_used"] == ["soundcharts"]
+
+    @patch("app.services.recommendation.service.generate_recommendations")
     def test_200_empty_suggestions_no_requests(
         self,
         mock_generate,

--- a/server/tests/test_recommendation_service.py
+++ b/server/tests/test_recommendation_service.py
@@ -298,6 +298,64 @@ class TestGenerateRecommendations:
         assert result.services_used == []
         assert result.event_profile.track_count == 0
 
+    @patch(
+        "app.services.recommendation.mb_verify.verify_artists_batch",
+        return_value={"Related Artist": True},
+    )
+    @patch(
+        "app.services.recommendation.soundcharts_candidates.related_candidates_from_seeds",
+    )
+    @patch("app.services.recommendation.service.enrich_event_tracks")
+    @patch("app.services.recommendation.service._get_accepted_played_requests")
+    def test_soundcharts_related_with_no_connected_service(
+        self, mock_requests, mock_enrich, mock_related, mock_mb
+    ):
+        """Issue #556: a DJ with no Tidal/Beatport still gets suggestions when the
+        Soundcharts related-tracks source is enabled."""
+        mock_requests.return_value = [
+            MagicMock(song_title="Seed", artist="Seed Artist", status="accepted"),
+        ]
+        mock_enrich.return_value = [
+            TrackProfile(title="Seed", artist="Seed Artist", bpm=120.0, key="8A", genre="House"),
+        ]
+        mock_related.return_value = (
+            [TrackProfile(title="Related Hit", artist="Related Artist", source="soundcharts")],
+            1,
+        )
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = []
+        user = _make_user(tidal=False, beatport=False)
+        event = _make_event()
+
+        with patch("app.core.config.get_settings") as mock_settings:
+            mock_settings.return_value.soundcharts_related_tracks_enabled = True
+            mock_settings.return_value.soundcharts_app_id = "id"
+            mock_settings.return_value.soundcharts_api_key = "key"
+            result = generate_recommendations(db, user, event)
+
+        assert len(result.suggestions) > 0
+        assert "soundcharts" in result.services_used
+        assert result.suggestions[0].profile.source == "soundcharts"
+
+    @patch("app.services.recommendation.soundcharts_candidates.related_candidates_from_seeds")
+    def test_soundcharts_related_disabled_behaves_as_today(self, mock_related):
+        """Dark by default: disabled flag → no related lookup, empty result for an
+        unconnected DJ exactly as before."""
+        db = MagicMock()
+        user = _make_user(tidal=False, beatport=False)
+        event = _make_event()
+
+        with patch("app.core.config.get_settings") as mock_settings:
+            mock_settings.return_value.soundcharts_related_tracks_enabled = False
+            mock_settings.return_value.soundcharts_app_id = "id"
+            mock_settings.return_value.soundcharts_api_key = "key"
+            result = generate_recommendations(db, user, event)
+
+        assert result.suggestions == []
+        assert result.services_used == []
+        mock_related.assert_not_called()
+
     @patch("app.services.recommendation.service._search_candidates")
     @patch("app.services.recommendation.service.enrich_event_tracks")
     @patch("app.services.recommendation.service._get_accepted_played_requests")
@@ -896,6 +954,45 @@ class TestSearchCandidates:
         assert len(candidates) == 1
         assert candidates[0].source == "tidal"
         assert "tidal" in services
+
+    @patch("app.services.recommendation.soundcharts_candidates.related_candidates_from_seeds")
+    def test_soundcharts_related_source_no_connected_service(self, mock_related):
+        """Related-tracks source contributes candidates + 'soundcharts' service
+        even when no Tidal/Beatport is connected."""
+        user = _make_user(tidal=False, beatport=False)
+        db = MagicMock()
+        mock_related.return_value = (
+            [TrackProfile(title="Related", artist="Artist", source="soundcharts")],
+            1,
+        )
+        requests = [MagicMock(song_title="Seed", artist="Seed Artist", isrc="USAAA0000001")]
+
+        with patch("app.core.config.get_settings") as mock_settings:
+            mock_settings.return_value.soundcharts_related_tracks_enabled = True
+            mock_settings.return_value.soundcharts_app_id = "id"
+            mock_settings.return_value.soundcharts_api_key = "key"
+            candidates, services, total = _search_candidates(db, user, ["House"], requests=requests)
+
+        assert any(c.source == "soundcharts" for c in candidates)
+        assert "soundcharts" in services
+        mock_related.assert_called_once()
+
+    @patch("app.services.recommendation.soundcharts_candidates.related_candidates_from_seeds")
+    def test_soundcharts_related_source_disabled(self, mock_related):
+        """Disabled flag → related source is never invoked."""
+        user = _make_user(tidal=False, beatport=False)
+        db = MagicMock()
+        requests = [MagicMock(song_title="Seed", artist="Seed Artist", isrc="USAAA0000001")]
+
+        with patch("app.core.config.get_settings") as mock_settings:
+            mock_settings.return_value.soundcharts_related_tracks_enabled = False
+            mock_settings.return_value.soundcharts_app_id = "id"
+            mock_settings.return_value.soundcharts_api_key = "key"
+            candidates, services, total = _search_candidates(db, user, ["House"], requests=requests)
+
+        assert candidates == []
+        assert services == []
+        mock_related.assert_not_called()
 
     def test_beatport_text_failures_trigger_early_exit(self):
         """2+ Beatport text search failures → stops trying remaining queries."""

--- a/server/tests/test_soundcharts.py
+++ b/server/tests/test_soundcharts.py
@@ -10,6 +10,7 @@ from app.services.soundcharts import (
     _build_request_body,
     _normalize_energy_0_10,
     discover_songs,
+    get_related_songs_by_isrc,
     get_song_features_by_isrc,
     key_to_soundcharts_filter,
     pitch_class_to_key_string,
@@ -336,6 +337,192 @@ class TestGetSongFeaturesByIsrc:
         assert result.explicit is True
         assert result.duration_sec == 200
         assert result.genres == ("pop",)
+
+
+# A trimmed copy of a real /api/v2/song/{uuid}/related items payload. Soundcharts
+# returns the related songs directly in ``items`` (each carrying uuid/name/
+# creditName), so we model that shape here.
+_RELATED_PAYLOAD_DIRECT = {
+    "items": [
+        {
+            "uuid": "rel-uuid-1",
+            "name": "Similar Song One",
+            "creditName": "Artist One",
+            "isrc": {"value": "USABC1111111"},
+        },
+        {
+            "uuid": "rel-uuid-2",
+            "name": "Similar Song Two",
+            "creditName": {"name": "Artist Two"},
+        },
+    ],
+    "page": {"offset": 0, "total": 2, "limit": 20},
+}
+
+# Some Soundcharts collection endpoints nest the object under a ``song`` key
+# (the shape ``discover_songs`` parses). The adapter tolerates both.
+_RELATED_PAYLOAD_NESTED = {
+    "items": [
+        {
+            "song": {
+                "uuid": "rel-uuid-3",
+                "name": "Nested Song",
+                "creditName": "Nested Artist",
+            }
+        }
+    ]
+}
+
+
+class TestGetRelatedSongsByIsrc:
+    """Paid-tier related-tracks lookup by ISRC — candidate source for #556.
+
+    Dark by default: gated on a dedicated SOUNDCHARTS_RELATED_TRACKS_ENABLED
+    flag *and* credentials, so the discovery key stays usable in production
+    while the paid related-tracks path never spends until explicitly enabled.
+    """
+
+    def _settings(self, *, enabled=True, app_id="test-id", api_key="test-key"):
+        return MagicMock(
+            soundcharts_related_tracks_enabled=enabled,
+            soundcharts_app_id=app_id,
+            soundcharts_api_key=api_key,
+        )
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_disabled_returns_empty_without_calling_api(self, mock_settings, mock_get):
+        mock_settings.return_value = self._settings(enabled=False)
+        assert get_related_songs_by_isrc("USUM71900764") == []
+        mock_get.assert_not_called()
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_not_configured_returns_empty(self, mock_settings, mock_get):
+        mock_settings.return_value = self._settings(app_id="", api_key="")
+        assert get_related_songs_by_isrc("USUM71900764") == []
+        mock_get.assert_not_called()
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_blank_isrc_returns_empty_without_calling_api(self, mock_settings, mock_get):
+        mock_settings.return_value = self._settings()
+        assert get_related_songs_by_isrc("") == []
+        assert get_related_songs_by_isrc(None) == []  # type: ignore[arg-type]
+        mock_get.assert_not_called()
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_resolves_isrc_then_related(self, mock_settings, mock_get):
+        mock_settings.return_value = self._settings()
+        mock_get.side_effect = [
+            _mock_get_response({"object": {"uuid": "seed-uuid"}}),
+            _mock_get_response(_RELATED_PAYLOAD_DIRECT),
+        ]
+
+        result = get_related_songs_by_isrc("USUM71900764")
+
+        assert result == [
+            SoundchartsTrack(
+                title="Similar Song One", artist="Artist One", soundcharts_uuid="rel-uuid-1"
+            ),
+            SoundchartsTrack(
+                title="Similar Song Two", artist="Artist Two", soundcharts_uuid="rel-uuid-2"
+            ),
+        ]
+        # First call resolves ISRC, second hits the related endpoint with the UUID.
+        assert mock_get.call_count == 2
+        related_url = mock_get.call_args_list[1][0][0]
+        assert related_url.endswith("/song/seed-uuid/related")
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_parses_nested_song_shape(self, mock_settings, mock_get):
+        mock_settings.return_value = self._settings()
+        mock_get.side_effect = [
+            _mock_get_response({"object": {"uuid": "seed-uuid"}}),
+            _mock_get_response(_RELATED_PAYLOAD_NESTED),
+        ]
+
+        result = get_related_songs_by_isrc("USUM71900764")
+
+        assert result == [
+            SoundchartsTrack(
+                title="Nested Song", artist="Nested Artist", soundcharts_uuid="rel-uuid-3"
+            )
+        ]
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_isrc_not_found_returns_empty(self, mock_settings, mock_get):
+        mock_settings.return_value = self._settings()
+        mock_get.return_value = _mock_get_response({"object": None})
+        assert get_related_songs_by_isrc("USUM71900764") == []
+        # Only the resolve call fires; no related call without a UUID.
+        assert mock_get.call_count == 1
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_isrc_normalized_before_request(self, mock_settings, mock_get):
+        mock_settings.return_value = self._settings()
+        mock_get.side_effect = [
+            _mock_get_response({"object": {"uuid": "seed-uuid"}}),
+            _mock_get_response(_RELATED_PAYLOAD_DIRECT),
+        ]
+
+        get_related_songs_by_isrc("usum7-1900764")
+
+        first_url = mock_get.call_args_list[0][0][0]
+        assert first_url.endswith("/song/by-isrc/USUM71900764")
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_api_error_returns_empty(self, mock_settings, mock_get):
+        mock_settings.return_value = self._settings()
+        mock_get.side_effect = [
+            _mock_get_response({"object": {"uuid": "seed-uuid"}}),
+            httpx.ConnectError("Connection refused"),
+        ]
+        assert get_related_songs_by_isrc("USUM71900764") == []
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_limit_passed_as_query_param(self, mock_settings, mock_get):
+        mock_settings.return_value = self._settings()
+        mock_get.side_effect = [
+            _mock_get_response({"object": {"uuid": "seed-uuid"}}),
+            _mock_get_response(_RELATED_PAYLOAD_DIRECT),
+        ]
+
+        get_related_songs_by_isrc("USUM71900764", limit=5)
+
+        related_kwargs = mock_get.call_args_list[1].kwargs
+        assert related_kwargs["params"]["limit"] == 5
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_items_missing_fields_skipped(self, mock_settings, mock_get):
+        """Items lacking a name, artist, or uuid are dropped, not crashed on."""
+        mock_settings.return_value = self._settings()
+        mock_get.side_effect = [
+            _mock_get_response({"object": {"uuid": "seed-uuid"}}),
+            _mock_get_response(
+                {
+                    "items": [
+                        {"uuid": "ok", "name": "Good", "creditName": "Real Artist"},
+                        {"uuid": "no-name", "creditName": "Artist"},
+                        {"name": "No UUID", "creditName": "Artist"},
+                        {"uuid": "no-artist", "name": "Orphan"},
+                    ]
+                }
+            ),
+        ]
+
+        result = get_related_songs_by_isrc("USUM71900764")
+
+        assert result == [
+            SoundchartsTrack(title="Good", artist="Real Artist", soundcharts_uuid="ok")
+        ]
 
 
 class TestDiscoverSongs:

--- a/server/tests/test_soundcharts.py
+++ b/server/tests/test_soundcharts.py
@@ -524,6 +524,39 @@ class TestGetRelatedSongsByIsrc:
             SoundchartsTrack(title="Good", artist="Real Artist", soundcharts_uuid="ok")
         ]
 
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_related_http_status_error_returns_empty(self, mock_settings, mock_get):
+        """A 403 (endpoint not in plan) or other HTTP status degrades to []."""
+        mock_settings.return_value = self._settings()
+        error_resp = MagicMock()
+        error_resp.status_code = 403
+        error_resp.text = "Forbidden"
+        status_error = httpx.HTTPStatusError("403", request=MagicMock(), response=error_resp)
+        related_resp = MagicMock()
+        related_resp.raise_for_status.side_effect = status_error
+        mock_get.side_effect = [
+            _mock_get_response({"object": {"uuid": "seed-uuid"}}),
+            related_resp,
+        ]
+
+        assert get_related_songs_by_isrc("USUM71900764") == []
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_related_invalid_json_returns_empty(self, mock_settings, mock_get):
+        """A non-JSON related payload degrades to [] instead of raising."""
+        mock_settings.return_value = self._settings()
+        bad_resp = MagicMock()
+        bad_resp.raise_for_status = MagicMock()
+        bad_resp.json.side_effect = ValueError("Expecting value")
+        mock_get.side_effect = [
+            _mock_get_response({"object": {"uuid": "seed-uuid"}}),
+            bad_resp,
+        ]
+
+        assert get_related_songs_by_isrc("USUM71900764") == []
+
 
 class TestDiscoverSongs:
     @patch("app.services.soundcharts.get_settings")

--- a/server/tests/test_soundcharts.py
+++ b/server/tests/test_soundcharts.py
@@ -557,6 +557,52 @@ class TestGetRelatedSongsByIsrc:
 
         assert get_related_songs_by_isrc("USUM71900764") == []
 
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_malformed_isrc_returns_empty_without_calling_api(self, mock_settings, mock_get):
+        """A crafted ISRC (path-injection chars / wrong shape) is rejected before
+        any HTTP call, so it can never be interpolated into the request URL (#556)."""
+        mock_settings.return_value = self._settings()
+        for bad in ("US/UM71900764", "../../secret", "USUM7190076", "not-an-isrc"):
+            assert get_related_songs_by_isrc(bad) == []
+        mock_get.assert_not_called()
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_non_list_items_degrades_to_empty(self, mock_settings, mock_get):
+        """A malformed related payload ({"items": null}) degrades to [], not a crash."""
+        mock_settings.return_value = self._settings()
+        mock_get.side_effect = [
+            _mock_get_response({"object": {"uuid": "seed-uuid"}}),
+            _mock_get_response({"items": None}),
+        ]
+        assert get_related_songs_by_isrc("USUM71900764") == []
+
+    @patch("app.services.soundcharts.httpx.get")
+    @patch("app.services.soundcharts.get_settings")
+    def test_status_error_does_not_log_response_body(self, mock_settings, mock_get, caplog):
+        """The auth-failure log records only the status code, never the upstream
+        response body, so a leaked credential in the body can't reach the logs."""
+        import logging
+
+        mock_settings.return_value = self._settings()
+        error_resp = MagicMock()
+        error_resp.status_code = 403
+        error_resp.text = "SECRET-LEAK-CANARY-x-api-key=test-key"
+        status_error = httpx.HTTPStatusError("403", request=MagicMock(), response=error_resp)
+        related_resp = MagicMock()
+        related_resp.raise_for_status.side_effect = status_error
+        mock_get.side_effect = [
+            _mock_get_response({"object": {"uuid": "seed-uuid"}}),
+            related_resp,
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="app.services.soundcharts"):
+            assert get_related_songs_by_isrc("USUM71900764") == []
+
+        assert "SECRET-LEAK-CANARY" not in caplog.text
+        assert "403" in caplog.text
+
 
 class TestDiscoverSongs:
     @patch("app.services.soundcharts.get_settings")

--- a/server/tests/test_soundcharts_candidates.py
+++ b/server/tests/test_soundcharts_candidates.py
@@ -6,6 +6,7 @@ from app.schemas.tidal import TidalSearchResult
 from app.services.recommendation.scorer import EventProfile
 from app.services.recommendation.soundcharts_candidates import (
     BPM_RANGE_OFFSET,
+    related_candidates_from_seeds,
     search_candidates_via_soundcharts,
 )
 from app.services.soundcharts import SoundchartsTrack
@@ -205,3 +206,121 @@ class TestSearchCandidatesViaSoundcharts:
 
         call_kwargs = mock_discover.call_args
         assert call_kwargs.kwargs["keys"] is None
+
+
+def _make_request(artist="Artist", title="Song", isrc=None):
+    req = MagicMock()
+    req.artist = artist
+    req.song_title = title
+    req.isrc = isrc
+    return req
+
+
+class TestRelatedCandidatesFromSeeds:
+    """ISRC-seeded related-tracks candidate generator for #556.
+
+    Resolves each seed request's ISRC (request.isrc first, then the master
+    tracks store by signature), calls the dark-by-default related-tracks
+    adapter, and converts the results to soundcharts-source TrackProfiles.
+    """
+
+    @patch("app.services.recommendation.soundcharts_candidates.get_related_songs_by_isrc")
+    def test_seed_isrc_yields_candidates(self, mock_related):
+        mock_related.return_value = [
+            SoundchartsTrack(title="Rel One", artist="Artist A", soundcharts_uuid="u1"),
+            SoundchartsTrack(title="Rel Two", artist="Artist B", soundcharts_uuid="u2"),
+        ]
+        db = MagicMock()
+        requests = [_make_request("Seed Artist", "Seed Song", isrc="USABC1234567")]
+
+        candidates, seeds_used = related_candidates_from_seeds(db, requests)
+
+        assert seeds_used == 1
+        assert len(candidates) == 2
+        assert candidates[0].title == "Rel One"
+        assert candidates[0].artist == "Artist A"
+        assert candidates[0].source == "soundcharts"
+        mock_related.assert_called_once_with("USABC1234567", limit=20)
+
+    @patch("app.services.recommendation.soundcharts_candidates.get_track")
+    @patch("app.services.recommendation.soundcharts_candidates.get_related_songs_by_isrc")
+    def test_falls_back_to_master_store_isrc(self, mock_related, mock_get_track):
+        """A request with no ISRC resolves its ISRC from the master tracks store."""
+        mock_related.return_value = [
+            SoundchartsTrack(title="Rel", artist="A", soundcharts_uuid="u1"),
+        ]
+        stored = MagicMock()
+        stored.isrc = "USSTORE00001"
+        mock_get_track.return_value = stored
+        db = MagicMock()
+        requests = [_make_request("Seed Artist", "Seed Song", isrc=None)]
+
+        candidates, seeds_used = related_candidates_from_seeds(db, requests)
+
+        assert seeds_used == 1
+        assert len(candidates) == 1
+        mock_related.assert_called_once_with("USSTORE00001", limit=20)
+
+    @patch("app.services.recommendation.soundcharts_candidates.get_track")
+    @patch("app.services.recommendation.soundcharts_candidates.get_related_songs_by_isrc")
+    def test_seed_without_resolvable_isrc_skipped(self, mock_related, mock_get_track):
+        mock_get_track.return_value = None  # not in the master store either
+        db = MagicMock()
+        requests = [_make_request("Unknown", "Track", isrc=None)]
+
+        candidates, seeds_used = related_candidates_from_seeds(db, requests)
+
+        assert candidates == []
+        assert seeds_used == 0
+        mock_related.assert_not_called()
+
+    @patch("app.services.recommendation.soundcharts_candidates.get_related_songs_by_isrc")
+    def test_cross_seed_dedup_by_uuid_and_name(self, mock_related):
+        """The same related track returned for two seeds appears once."""
+        mock_related.side_effect = [
+            [SoundchartsTrack(title="Shared", artist="A", soundcharts_uuid="dup")],
+            [
+                SoundchartsTrack(title="Shared", artist="A", soundcharts_uuid="dup"),
+                SoundchartsTrack(title="Fresh", artist="B", soundcharts_uuid="new"),
+            ],
+        ]
+        db = MagicMock()
+        requests = [
+            _make_request("S1", "T1", isrc="USAAA0000001"),
+            _make_request("S2", "T2", isrc="USBBB0000002"),
+        ]
+
+        candidates, seeds_used = related_candidates_from_seeds(db, requests)
+
+        assert seeds_used == 2
+        titles = sorted(c.title for c in candidates)
+        assert titles == ["Fresh", "Shared"]
+
+    @patch("app.services.recommendation.soundcharts_candidates.get_related_songs_by_isrc")
+    def test_empty_requests_returns_empty(self, mock_related):
+        db = MagicMock()
+        candidates, seeds_used = related_candidates_from_seeds(db, [])
+        assert candidates == []
+        assert seeds_used == 0
+        mock_related.assert_not_called()
+
+    @patch("app.services.recommendation.soundcharts_candidates.get_related_songs_by_isrc")
+    def test_max_seeds_caps_api_calls(self, mock_related):
+        mock_related.return_value = []
+        db = MagicMock()
+        requests = [_make_request(f"A{i}", f"T{i}", isrc=f"USAAA000000{i}") for i in range(5)]
+
+        _, seeds_used = related_candidates_from_seeds(db, requests, max_seeds=2)
+
+        assert seeds_used == 2
+        assert mock_related.call_count == 2
+
+    @patch("app.services.recommendation.soundcharts_candidates.get_related_songs_by_isrc")
+    def test_per_seed_limit_forwarded(self, mock_related):
+        mock_related.return_value = []
+        db = MagicMock()
+        requests = [_make_request("A", "T", isrc="USAAA0000001")]
+
+        related_candidates_from_seeds(db, requests, per_seed_limit=7)
+
+        mock_related.assert_called_once_with("USAAA0000001", limit=7)

--- a/server/tests/test_soundcharts_candidates.py
+++ b/server/tests/test_soundcharts_candidates.py
@@ -324,3 +324,21 @@ class TestRelatedCandidatesFromSeeds:
         related_candidates_from_seeds(db, requests, per_seed_limit=7)
 
         mock_related.assert_called_once_with("USAAA0000001", limit=7)
+
+    @patch("app.services.recommendation.soundcharts_candidates.get_related_songs_by_isrc")
+    def test_early_exit_once_enough_candidates(self, mock_related):
+        """Stops seeding once max_candidates is reached so a slow upstream can't
+        serialize every seed's blocking calls into the request latency."""
+        mock_related.return_value = [
+            SoundchartsTrack(title="A", artist="X", soundcharts_uuid="ua"),
+            SoundchartsTrack(title="B", artist="Y", soundcharts_uuid="ub"),
+        ]
+        db = MagicMock()
+        requests = [_make_request(f"A{i}", f"T{i}", isrc=f"USAAA000000{i}") for i in range(5)]
+
+        candidates, seeds_used = related_candidates_from_seeds(db, requests, max_candidates=2)
+
+        # First seed yields 2 candidates == cap; the loop must not fetch more seeds.
+        assert len(candidates) == 2
+        assert seeds_used == 1
+        assert mock_related.call_count == 1


### PR DESCRIPTION
## Why

The recommendation engine only discovered candidate tracks from the DJ's connected Tidal/Beatport accounts, so a DJ with no linked service got zero suggestions (confirmed live: `/events/{code}/recommendations` returned `total_candidates_searched=0` with no provider). Soundcharts' paid-tier "related tracks" endpoint can serve as an additional, **provider-agnostic** candidate source seeded from the event's own tracks (which now carry ISRCs in the master `tracks` store post-#541/#552).

## What

Adds Soundcharts related-tracks as a candidate generator wired into the existing pipeline:

- A dark-by-default adapter `get_related_songs_by_isrc` resolves a seed ISRC → song UUID → `GET /api/v2/song/{uuid}/related`.
- `related_candidates_from_seeds` expands each accepted/played request into related tracks (ISRC from `request.isrc`, else the master `tracks` store by signature), de-duplicated across seeds.
- Candidates flow through the **existing** scorer + dedup + artist-diversity pipeline unchanged (no forked scoring logic).
- `generate_recommendations` and the `/recommendations` endpoint now serve results for a DJ with **no connected service** when this source is enabled, instead of returning empty / 503.
- The source surfaces as `"soundcharts"` in `services_used`.

## Design decisions

- **Exact Soundcharts endpoint:** `GET /api/v2/song/{uuid}/related` (the documented "Get related tracks" endpoint), reached after resolving the seed via the existing `GET /api/v2.25/song/by-isrc/{isrc}`. This is a **paid-tier** feature (returns 403 "not included in your current plan" otherwise) — verified against the public API reference. Pagination uses the standard `offset`/`limit` params; the parser tolerates both the flat item shape and the nested `{"song": {...}}` shape Soundcharts uses on some collection endpoints. No live paid calls are made in tests — the adapter is mocked throughout.
- **Dark-by-default gate (no spend by default):** a new setting `soundcharts_related_tracks_enabled` (default `False`) **plus** configured creds. When off, the adapter returns `[]`, `generate_recommendations` early-returns empty exactly as before, and the endpoint still returns 503 for an unconnected DJ. The gate lives in three coherent spots: `get_related_songs_by_isrc` (adapter), `_soundcharts_related_available()` + `_search_soundcharts_related()` (engine), and the `get_recommendations` 503 check (API).
- **Seed selection:** the event's accepted/played requests (most recent first), capped at `MAX_RELATED_SEEDS=10`, each expanded to `RELATED_TRACKS_LIMIT=20` related tracks. Seeds with no resolvable ISRC are skipped.
- **Security:** credentials are read from settings only and sent solely as `x-app-id`/`x-api-key` headers — never logged. Logs emit counts only (no ISRC value, no secrets). All external-API failures (403/HTTP-status/connection/invalid-JSON) degrade to `[]` with no stack-trace leakage. ISRC is normalized before use; all DB lookups are parameterized SQLAlchemy.
- **Additive to #544:** this is candidate *discovery*, separate from the audio-features *enrichment* path (`get_song_features_by_isrc`), which is untouched. `track_match.find_best_match`, `setbuilder/`, and `dashboard/` are not modified.
- **No migration / no schema change:** the new setting is a boolean env flag; `services_used` was already `list[str]`, so `openapi.json` is unchanged (a stale unrelated `SetDocumentSnapshot` diff from a newer local FastAPI was deliberately not committed).

## Testing

- [x] Unit: related-tracks adapter — enabled/disabled, no-creds, bad ISRC, both response shapes, HTTP-status + invalid-JSON degradation, limit forwarding, item-field filtering
- [x] Unit: `related_candidates_from_seeds` — request.isrc seed, master-store fallback, no-ISRC skip, cross-seed dedup, max-seeds cap, per-seed-limit forwarding
- [x] Unit/integration: engine wiring — enabled + no connected service → non-empty suggestions + `"soundcharts"` in `services_used`; disabled → behaves exactly as today
- [x] Integration: API gate — no service but source enabled → 200 (not 503)
- [x] Adapter mocked; no live paid API calls in tests
- [x] Backend CI green locally: ruff check, ruff format --check, bandit, pytest + enforced coverage gate (3329 passed, coverage 89.45% ≥ 85%)

🤖 Co-authored by Claude Opus 4.8. Closes #556.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Soundcharts-backed “related tracks” source for recommendation candidates.
  * Recommendations can now be generated even when no Tidal or Beatport account is connected, if this source is available.

* **Bug Fixes**
  * Improved recommendation availability so the endpoint no longer returns unavailable in supported Soundcharts-only cases.
  * Added more resilient handling for related-track lookups and response parsing, helping avoid failures when external data is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->