### PR TITLE
feat(setbuilder): make pass-1 actually use genre (genre-continuity term) (#545)

### DIFF
--- a/server/app/services/setbuilder/pass1_deterministic.py
+++ b/server/app/services/setbuilder/pass1_deterministic.py
@@ -16,7 +16,7 @@ from app.models.set import Set, SetSlot
 from app.models.set_pool import SetPoolTrack
 from app.models.user import User
 from app.services.recommendation.camelot import compatibility_score, parse_key
-from app.services.recommendation.scorer import _score_bpm
+from app.services.recommendation.scorer import _score_bpm, _score_genre
 from app.services.setbuilder.curve import BUILTIN_TEMPLATES, interpolate_energy, uniform_midpoints
 from app.services.setbuilder.vibe_resolver import ResolvedVibe, build_pool_vibe_states
 
@@ -35,6 +35,7 @@ class TrackMeta:
     key: str | None
     energy: int | None
     mood: str | None = None
+    genre: str | None = None
     transitional_role: str | None = None
 
 
@@ -207,6 +208,12 @@ def _track_meta(track: SetPoolTrack, resolved: ResolvedVibe | None = None) -> Tr
     are dead constants (#543). The pool row remains the fallback so callers that
     pass no resolved vibe (and any row that does carry its own value) still work.
 
+    ``genre`` is sourced straight off the pool row (#545) — it is a guaranteed
+    contract field hydrated from the global ``tracks`` row on upsert, NOT part of
+    the vibe cascade (which only carries energy/mood), so it reads like bpm/key
+    rather than via ``resolved``. Missing genre stays ``None`` and degrades
+    neutrally in ``_genre_continuity``.
+
     ``transitional_role`` has no resolver source yet — the cascade only carries
     energy/mood — so its scoring term stays a neutral constant (see ``_role_fit``
     TODO). Re-point energy/mood at the global ``tracks`` row when that lands.
@@ -226,6 +233,7 @@ def _track_meta(track: SetPoolTrack, resolved: ResolvedVibe | None = None) -> Tr
         key=track.camelot or track.key,
         energy=energy,
         mood=mood,
+        genre=track.genre,
     )
 
 
@@ -330,12 +338,17 @@ def _candidate_score(
     key_strictness: float,
     pairings: set[tuple[str, str]],
 ) -> float:
+    # Genre (#545) is funded by halving the role term (0.10->0.05, a neutral
+    # constant today with no resolver source) and the mood term (0.10->0.05, the
+    # weakest live signal); the dominant energy/bpm/key terms are untouched, so
+    # existing ordering is preserved and all terms still sum to 1.00.
     score = (
         0.30 * _energy_match(candidate.energy, target_energy)
         + 0.25 * _bpm_continuity(previous, candidate)
         + 0.20 * _camelot_continuity(previous, candidate, key_strictness)
-        + 0.10 * _role_fit(candidate.transitional_role, position, slot_count, target_energy)
-        + 0.10 * _mood_continuity(previous, candidate)
+        + 0.10 * _genre_continuity(previous, candidate)
+        + 0.05 * _role_fit(candidate.transitional_role, position, slot_count, target_energy)
+        + 0.05 * _mood_continuity(previous, candidate)
         + 0.05 * _artist_diversity(candidate, selected)
     ) * 100
     if previous and (previous.slot_track_id, candidate.slot_track_id) in pairings:
@@ -367,6 +380,23 @@ def _mood_continuity(previous: TrackMeta | None, current: TrackMeta) -> float:
     if previous is None or not previous.mood or not current.mood:
         return 0.5
     return 1.0 if previous.mood.strip().lower() == current.mood.strip().lower() else 0.35
+
+
+def _genre_continuity(previous: TrackMeta | None, current: TrackMeta) -> float:
+    """Reward staying within / smoothly moving between related genres (#545).
+
+    Delegates to the recommendation scorer's curated genre affinity
+    (``_score_genre``: exact 1.0 / substring 0.5 / same-family 0.4 / related
+    family 0.2-0.4 / unrelated 0.0) by treating the previous track's genre as a
+    single-element dominant-genre lane — DRY, no second genre taxonomy.
+
+    Degrades neutrally to ``0.5`` (the no-information midpoint used by the other
+    ``_*_continuity`` helpers) at the set start or when either side has no genre,
+    so a missing-genre track is never penalized.
+    """
+    if previous is None or not previous.genre or not current.genre:
+        return 0.5
+    return _score_genre(current.genre, [previous.genre])
 
 
 def _role_fit(role: str | None, position: int, slot_count: int, target: float) -> float:

--- a/server/app/services/setbuilder/pass1_deterministic.py
+++ b/server/app/services/setbuilder/pass1_deterministic.py
@@ -391,12 +391,15 @@ def _genre_continuity(previous: TrackMeta | None, current: TrackMeta) -> float:
     single-element dominant-genre lane — DRY, no second genre taxonomy.
 
     Degrades neutrally to ``0.5`` (the no-information midpoint used by the other
-    ``_*_continuity`` helpers) at the set start or when either side has no genre,
+    ``_*_continuity`` helpers) at the set start or when either side has no genre
+    — including whitespace-only genres, which the pool import stores verbatim —
     so a missing-genre track is never penalized.
     """
-    if previous is None or not previous.genre or not current.genre:
+    previous_genre = previous.genre.strip() if previous and previous.genre else ""
+    current_genre = current.genre.strip() if current.genre else ""
+    if not previous_genre or not current_genre:
         return 0.5
-    return _score_genre(current.genre, [previous.genre])
+    return _score_genre(current_genre, [previous_genre])
 
 
 def _role_fit(role: str | None, position: int, slot_count: int, target: float) -> float:

--- a/server/tests/test_setbuilder_pass1_genre.py
+++ b/server/tests/test_setbuilder_pass1_genre.py
@@ -73,9 +73,12 @@ def test_genre_flows_into_track_meta(db: Session, test_user: User):
     assert meta.genre == "Tech House"
 
 
-def test_genre_continuity_rewards_same_family_over_unrelated(db: Session, test_user: User):
+def test_genre_continuity_rewards_same_family_over_unrelated():
     """Same-family genres score higher continuity than unrelated ones, and a
-    missing genre on either side degrades to the neutral 0.5 (no penalty)."""
+    missing genre on either side degrades to the neutral 0.5 (no penalty).
+
+    Pure in-memory unit test over ``TrackMeta`` — no DB / user fixtures needed.
+    """
     house = TrackMeta(0, "a", "A", "Art", 124.0, "8A", 5, genre="Deep House")
     tech_house = TrackMeta(1, "b", "B", "Art", 124.0, "8A", 5, genre="Tech House")
     country = TrackMeta(2, "c", "C", "Art", 124.0, "8A", 5, genre="Country")
@@ -88,6 +91,24 @@ def test_genre_continuity_rewards_same_family_over_unrelated(db: Session, test_u
     # Missing genre on either side is neutral, never a penalty.
     assert _genre_continuity(house, no_genre) == 0.5
     assert _genre_continuity(no_genre, house) == 0.5
+
+
+def test_genre_continuity_treats_whitespace_only_genre_as_missing():
+    """Regression for the genre-continuity term (#545): a whitespace-only genre
+    is effectively missing and must degrade to the neutral 0.5 — never falsely
+    perfect-match another blank (1.0) nor get penalized against a real genre
+    (0.0). The pool import stores ``genre`` verbatim, so ``"   "`` is reachable.
+    """
+    house = TrackMeta(0, "a", "A", "Art", 124.0, "8A", 5, genre="House")
+    blank = TrackMeta(1, "b", "B", "Art", 124.0, "8A", 5, genre="   ")
+    other_blank = TrackMeta(2, "c", "C", "Art", 124.0, "8A", 5, genre="\t ")
+
+    # Blank current vs real previous: not penalized to 0.0.
+    assert _genre_continuity(house, blank) == 0.5
+    # Real current vs blank previous: not penalized to 0.0.
+    assert _genre_continuity(blank, house) == 0.5
+    # Two blanks: not a false perfect match (1.0).
+    assert _genre_continuity(blank, other_blank) == 0.5
 
 
 def test_genre_continuity_breaks_tie_toward_matching_genre(db: Session, test_user: User):

--- a/server/tests/test_setbuilder_pass1_genre.py
+++ b/server/tests/test_setbuilder_pass1_genre.py
@@ -1,0 +1,133 @@
+"""Regression tests: pass-1 must score on track GENRE continuity (#545).
+
+Before #545 the deterministic builder ignored ``genre`` entirely —
+``_track_meta`` never mapped it onto ``TrackMeta`` and ``_candidate_score`` had
+no genre term — so the contract guarantee that every pool track carries a genre
+was wasted. These tests seed otherwise-identical candidates that differ ONLY in
+genre relative to the running context and assert the genre-continuity term now
+orders them, while missing-genre tracks still degrade neutrally.
+"""
+
+from sqlalchemy.orm import Session
+
+from app.models.set import Set, SetSlot
+from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.models.user import User
+from app.services.setbuilder.pass1_deterministic import (
+    TrackMeta,
+    _genre_continuity,
+    _track_meta,
+    build_set,
+)
+
+
+def _mk_set(db: Session, user: User, *, duration: int) -> Set:
+    set_obj = Set(owner_id=user.id, name="Genre-driven", target_duration_sec=duration)
+    db.add(set_obj)
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def _mk_source(db: Session, set_obj: Set) -> SetPoolSource:
+    src = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(src)
+    db.commit()
+    db.refresh(src)
+    return src
+
+
+def _mk_track(db: Session, set_obj: Set, source: SetPoolSource, idx: int, **kw) -> SetPoolTrack:
+    """Pool track that carries a genre — bpm/key identical so genre is the only
+    differentiator unless overridden."""
+    defaults = dict(
+        set_id=set_obj.id,
+        source_id=source.id,
+        track_id=f"tidal:{idx}",
+        title=f"Track {idx}",
+        artist=f"Artist {idx}",
+        bpm=124.0,
+        key="8A",
+        camelot="8A",
+        energy=5,
+        genre="House",
+        duration_sec=210,
+        dedupe_sig=f"sig-{idx}",
+    )
+    defaults.update(kw)
+    track = SetPoolTrack(**defaults)
+    db.add(track)
+    db.commit()
+    db.refresh(track)
+    return track
+
+
+def test_genre_flows_into_track_meta(db: Session, test_user: User):
+    """``_track_meta`` maps the pool row's genre onto ``TrackMeta.genre``."""
+    set_obj = _mk_set(db, test_user, duration=210)
+    src = _mk_source(db, set_obj)
+    track = _mk_track(db, set_obj, src, 0, genre="Tech House")
+
+    meta = _track_meta(track)
+
+    assert meta.genre == "Tech House"
+
+
+def test_genre_continuity_rewards_same_family_over_unrelated(db: Session, test_user: User):
+    """Same-family genres score higher continuity than unrelated ones, and a
+    missing genre on either side degrades to the neutral 0.5 (no penalty)."""
+    house = TrackMeta(0, "a", "A", "Art", 124.0, "8A", 5, genre="Deep House")
+    tech_house = TrackMeta(1, "b", "B", "Art", 124.0, "8A", 5, genre="Tech House")
+    country = TrackMeta(2, "c", "C", "Art", 124.0, "8A", 5, genre="Country")
+    no_genre = TrackMeta(3, "d", "D", "Art", 124.0, "8A", 5, genre=None)
+
+    # No previous track => neutral, like the other *_continuity helpers.
+    assert _genre_continuity(None, house) == 0.5
+    # Same family (both "house") outscores an unrelated family.
+    assert _genre_continuity(house, tech_house) > _genre_continuity(house, country)
+    # Missing genre on either side is neutral, never a penalty.
+    assert _genre_continuity(house, no_genre) == 0.5
+    assert _genre_continuity(no_genre, house) == 0.5
+
+
+def test_genre_continuity_breaks_tie_toward_matching_genre(db: Session, test_user: User):
+    """Two otherwise-identical candidates compete for slot 1, following a locked
+    House track at slot 0. The candidate whose genre stays in the House family
+    must win — even though it has the HIGHER pool_id, which the deterministic
+    ``-pool_id`` tie-break would otherwise reject.
+
+    Before #545 genre was ignored, so both candidates scored identically and the
+    LOWER-pool_id (unrelated-genre) track would win. This makes it a true
+    regression test that would have failed before the fix.
+    """
+    set_obj = _mk_set(db, test_user, duration=210 * 2)  # two slots
+    src = _mk_source(db, set_obj)
+
+    # Slot 0 is locked to a House track so the running genre context is "House".
+    anchor = _mk_track(db, set_obj, src, 0, track_id="tidal:anchor", genre="House")
+    # Lower pool_id = the UNRELATED-genre candidate (would win the -pool_id tie).
+    far = _mk_track(db, set_obj, src, 1, track_id="tidal:country", genre="Country")
+    near = _mk_track(db, set_obj, src, 2, track_id="tidal:techhouse", genre="Tech House")
+    assert far.id < near.id
+
+    db.add(SetSlot(set_id=set_obj.id, position=0, track_id=anchor.track_id, locked=True))
+    db.commit()
+
+    result = build_set(db, set_obj)
+
+    assert result.slot_count == 2
+    assert result.slots[1].track_id == "tidal:techhouse"
+
+
+def test_missing_genre_pool_builds_without_penalty(db: Session, test_user: User):
+    """A full pool with zero genre data still builds a set and does not crash:
+    the genre term collapses to its neutral constant everywhere."""
+    set_obj = _mk_set(db, test_user, duration=210 * 4)
+    src = _mk_source(db, set_obj)
+    for idx in range(6):
+        _mk_track(db, set_obj, src, idx, genre=None)
+
+    result = build_set(db, set_obj)
+
+    assert result.slot_count >= 1
+    assert all(s.track_id for s in result.slots)


### PR DESCRIPTION
## Why

Genre is a **required** pool→builder contract field (#539 epic), but pass-1
ignored it entirely: `_track_meta` never mapped `genre` onto `TrackMeta` and
`_candidate_score` had no genre term. Guaranteeing genre is present is pointless
if the sequencing algorithm never uses it. This makes genre actually influence
the order.

## What

- `TrackMeta` gains a `genre` field, sourced straight off the `SetPoolTrack` row
  (the contract field, hydrated from the global `tracks` row on upsert). Genre is
  **not** part of the #543 vibe cascade (energy/mood only), so it reads like
  bpm/key, not via the `resolved` overlay. Missing genre stays `None`.
- New `_genre_continuity(previous, current)` term in `_candidate_score` rewards
  staying within / smoothly moving between related genres.
- Missing genre on either side (or set start) degrades to the neutral `0.5`
  midpoint — no crash, no unfair penalty — matching the house style of the other
  `_*_continuity` helpers.

## Design decisions

- **Approach: genre-continuity term** (not pre-filter / clustering). It composes
  cleanly with the existing per-transition scoring model (every other term —
  bpm/key/energy/mood/role/artist — is a continuity term), works inside the 2-opt
  refinement which scores transitions pairwise, and avoids the pool-starvation
  risk a hard genre pre-filter carries for small or multi-genre pools.
- **Genre-distance/affinity function: reuse `recommendation.scorer._score_genre`**
  — the same DRY import pattern pass-1 already uses for `_score_bpm`. It encodes
  exact (1.0) / substring (0.5) / same-family (0.4) / related-family (0.2–0.4) /
  unrelated (0.0) over a curated `GENRE_FAMILIES` + `FAMILY_AFFINITY` table. No
  second genre taxonomy is introduced. `_genre_continuity` treats the previous
  track's genre as a single-element dominant-genre lane and delegates, after
  handling the neutral cases explicitly.
- **Weight rebalance (one sentence):** genre takes **0.10**, funded by halving
  the role term (0.10→0.05, a neutral constant today with no resolver source) and
  the mood term (0.10→0.05, the weakest live signal), leaving the dominant
  energy/bpm/key terms (0.30/0.25/0.20) untouched so existing ordering is
  preserved and the six terms still sum to 1.00.

## Testing

- [x] New regression test `test_setbuilder_pass1_genre.py` — two otherwise-identical
      candidates differing only in genre relative to a locked House anchor order
      toward the in-family one, even though it has the higher pool_id the
      deterministic `-pool_id` tie-break would otherwise reject (would have FAILED
      before this change, when genre was ignored).
- [x] Genre flows into `TrackMeta`; `_genre_continuity` rewards same-family over
      unrelated and degrades neutrally on missing genre / set start.
- [x] Missing-genre pool still builds without crash or penalty.
- [x] Existing `test_setbuilder_pass1.py` / `_vibe` / `pass2` behavior preserved
      within the rebalanced weights.
- [x] Backend CI gate green locally: ruff check, ruff format --check, bandit,
      full pytest (3342 passed) with coverage 89.51% ≥ 85% enforced gate.

Closes #545

🤖 Co-authored by Claude Opus 4.8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved track selection to better keep songs in the same genre family when building sets.

* **Bug Fixes**
  * Made genre-based scoring more balanced, so genre continuity can influence choices without overpowering other signals.
  * Sets now build reliably even when some tracks don’t have genre information, while still returning valid results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->