### PR TITLE
[codex] Enrich pool imports in background

### DIFF
--- a/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/BuilderWorkspace.test.tsx
@@ -142,6 +142,7 @@ const POOL_TRACKS: PoolTrack[] = [
     genre: null,
     isrc: null,
     artwork_url: null,
+    enrichment_status: 'enriched',
     created_at: '2026-01-01T00:00:00Z',
   },
   {
@@ -159,6 +160,7 @@ const POOL_TRACKS: PoolTrack[] = [
     genre: null,
     isrc: null,
     artwork_url: null,
+    enrichment_status: 'enriched',
     created_at: '2026-01-01T00:00:00Z',
   },
   {
@@ -176,6 +178,7 @@ const POOL_TRACKS: PoolTrack[] = [
     genre: null,
     isrc: null,
     artwork_url: null,
+    enrichment_status: 'enriched',
     created_at: '2026-01-01T00:00:00Z',
   },
 ];
@@ -230,6 +233,7 @@ const EXTRA_POOL_TRACK: PoolTrack = {
   genre: null,
   isrc: null,
   artwork_url: null,
+  enrichment_status: 'enriched',
   created_at: '2026-01-01T00:00:00Z',
 };
 
@@ -248,6 +252,7 @@ const SYNTHETIC_POOL_TRACK: PoolTrack = {
   genre: null,
   isrc: null,
   artwork_url: null,
+  enrichment_status: 'pending',
   created_at: '2026-01-01T00:00:00Z',
 };
 

--- a/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
@@ -149,7 +149,13 @@ export default function PoolPanel({
   }, [setId, snapshot, snapshotVersion]);
 
   useEffect(() => {
-    if (snapshot || !loaded || !pool.enrichment.in_progress) return;
+    // Poll while background enrichment is running, regardless of whether a
+    // document snapshot is mounted: enrichment progress is orthogonal to the
+    // snapshot's content, and polling only triggers when in_progress is true —
+    // which means the live pool already carries the same just-imported tracks,
+    // so refreshing from the server is consistent (fixes a stuck banner after
+    // an import that follows a commit/recompute).
+    if (!loaded || !pool.enrichment.in_progress) return;
     let cancelled = false;
     const handle = setInterval(() => {
       api
@@ -165,7 +171,7 @@ export default function PoolPanel({
       cancelled = true;
       clearInterval(handle);
     };
-  }, [loaded, pool.enrichment.in_progress, setId, snapshot]);
+  }, [loaded, pool.enrichment.in_progress, setId]);
 
   useEffect(() => {
     if (!toast) return;

--- a/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/PoolPanel.tsx
@@ -46,6 +46,33 @@ const IMPORT_MENU: { kind: ImportKind; title: string; sub: string }[] = [
   { kind: 'manual', title: 'Add single track', sub: 'Search a service' },
 ];
 
+const EMPTY_POOL: PoolState = {
+  sources: [],
+  tracks: [],
+  enrichment: { total: 0, enriched: 0, failed: 0, pending: 0, in_progress: false },
+  runtime_sec: 0,
+};
+
+function deriveEnrichment(tracks: PoolState['tracks']): PoolState['enrichment'] {
+  const enriched = tracks.filter((track) => track.enrichment_status === 'enriched').length;
+  const failed = tracks.filter((track) => track.enrichment_status === 'failed').length;
+  const pending = tracks.filter((track) => track.enrichment_status === 'pending').length;
+  return { total: tracks.length, enriched, failed, pending, in_progress: pending > 0 };
+}
+
+function normalizePoolState(pool: PoolState | SetDocumentSnapshot['pool']): PoolState {
+  if ('enrichment' in pool) return pool;
+  const tracks = pool.tracks as PoolState['tracks'];
+  // Snapshots carry neither enrichment nor runtime; derive both the same way the
+  // server does so the restored PoolState stays whole (#538 + background enrichment).
+  return {
+    sources: pool.sources,
+    tracks,
+    enrichment: deriveEnrichment(tracks),
+    runtime_sec: poolRuntimeSec(tracks),
+  };
+}
+
 interface ContextMenuState {
   x: number;
   y: number;
@@ -70,7 +97,7 @@ export default function PoolPanel({
   confirmRemovals = false,
   requestConfirmation,
 }: PoolPanelProps) {
-  const [pool, setPool] = useState<PoolState>({ sources: [], tracks: [], runtime_sec: 0 });
+  const [pool, setPool] = useState<PoolState>(EMPTY_POOL);
   const [loaded, setLoaded] = useState(false);
   const [tab, setTab] = useState('all');
   const [q, setQ] = useState('');
@@ -97,9 +124,9 @@ export default function PoolPanel({
     setVibesLoaded(false);
     setLoaded(false);
     if (snapshot) {
-      // The document snapshot's pool carries no runtime field; derive it the same
-      // way the server does so the local PoolState stays whole (#538).
-      setPool({ ...snapshot.pool, runtime_sec: poolRuntimeSec(snapshot.pool.tracks) });
+      // normalizePoolState backfills both enrichment and runtime for a snapshot's
+      // partial pool, the same way the server derives them (#538 + enrichment).
+      setPool(normalizePoolState(snapshot.pool));
       setLoaded(true);
       return () => {
         cancelled = true;
@@ -120,6 +147,25 @@ export default function PoolPanel({
       cancelled = true;
     };
   }, [setId, snapshot, snapshotVersion]);
+
+  useEffect(() => {
+    if (snapshot || !loaded || !pool.enrichment.in_progress) return;
+    let cancelled = false;
+    const handle = setInterval(() => {
+      api
+        .getPool(setId)
+        .then((next) => {
+          if (!cancelled) setPool(next);
+        })
+        .catch(() => {
+          if (!cancelled) setToast('Failed to refresh enrichment progress');
+        });
+    }, 2500);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, [loaded, pool.enrichment.in_progress, setId, snapshot]);
 
   useEffect(() => {
     if (!toast) return;
@@ -324,6 +370,10 @@ export default function PoolPanel({
     });
   };
 
+  const enrichmentDone = pool.enrichment.enriched + pool.enrichment.failed;
+  const enrichmentPercent =
+    pool.enrichment.total > 0 ? Math.round((enrichmentDone / pool.enrichment.total) * 100) : 0;
+
   return (
     <div className={styles.poolPanel}>
       {/* Header: count + Add menu */}
@@ -383,6 +433,33 @@ export default function PoolPanel({
           )}
         </span>
       </div>
+
+      {pool.enrichment.in_progress && (
+        <div className={styles.poolEnrichment}>
+          <div className={styles.poolEnrichmentHeader}>
+            <span className={styles.poolEnrichmentText}>
+              Enriching {enrichmentDone}/{pool.enrichment.total}...
+            </span>
+            <span className={styles.poolEnrichmentMeta}>
+              {pool.enrichment.pending} pending
+              {pool.enrichment.failed > 0 ? ` · ${pool.enrichment.failed} failed` : ''}
+            </span>
+          </div>
+          <div
+            className={styles.poolEnrichmentBar}
+            role="progressbar"
+            aria-label="Pool enrichment progress"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={enrichmentPercent}
+          >
+            <div
+              className={styles.poolEnrichmentFill}
+              style={{ width: `${enrichmentPercent}%` }}
+            />
+          </div>
+        </div>
+      )}
 
       {/* Sources accordion */}
       <div className={styles.poolSources}>

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/ImportModal.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/ImportModal.test.tsx
@@ -34,7 +34,11 @@ const IMPORT_RESULT: PoolImportResult = {
     meta: null,
     created_at: '2026-06-09T00:00:00Z',
   },
-  pool: { sources: [], tracks: [] },
+  pool: {
+    sources: [],
+    tracks: [],
+    enrichment: { total: 0, enriched: 0, failed: 0, pending: 0, in_progress: false },
+  },
 } as unknown as PoolImportResult;
 
 function importResult(eventId: number, added: number, deduped: number): PoolImportResult {
@@ -61,6 +65,7 @@ function importResult(eventId: number, added: number, deduped: number): PoolImpo
         },
       ],
       tracks: [],
+      enrichment: { total: 0, enriched: 0, failed: 0, pending: 0, in_progress: false },
     },
   } as unknown as PoolImportResult;
 }

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
@@ -9,6 +9,7 @@ import { ApiError } from '@/lib/api';
 import type {
   PoolState,
   PoolVibesState,
+  SetDocumentSnapshot,
   TrackVibeState,
   VibeEnrichmentResult,
 } from '@/lib/api-types';
@@ -237,6 +238,38 @@ describe('PoolPanel', () => {
       await Promise.resolve();
     });
     expect(mockApi.getPool).toHaveBeenCalledTimes(2);
+  });
+
+  it('polls for enrichment progress even when a document snapshot is mounted', async () => {
+    // Regression: importing after a commit/recompute mounts a snapshot, which
+    // previously short-circuited the polling effect, leaving the enrichment
+    // banner stuck even though the background worker finished server-side.
+    vi.useFakeTimers();
+    const snapshot = {
+      curve_points: [],
+      settings: {},
+      slots: [],
+      pool: POOL, // one pending track → enrichment.in_progress
+    } as unknown as SetDocumentSnapshot;
+    mockApi.getPool.mockResolvedValue(ENRICHED_POOL);
+
+    render(<PoolPanel setId={1} snapshot={snapshot} />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // Snapshot path renders from the snapshot without an initial fetch...
+    expect(screen.getByText('Enriching 1/2...')).toBeTruthy();
+    expect(mockApi.getPool).not.toHaveBeenCalled();
+
+    // ...but the poll still fires while in_progress, refreshing to enriched.
+    await act(async () => {
+      vi.advanceTimersByTime(2500);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mockApi.getPool).toHaveBeenCalledWith(1);
+    expect(screen.queryByText(/Enriching/)).toBeNull();
   });
 
   it('writes a pool-track drag payload when dragging a track row', async () => {

--- a/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx
@@ -3,7 +3,7 @@
  * source filter + remove-by-source, multi-select removal, dedupe toast.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { ApiError } from '@/lib/api';
 import type {
@@ -69,6 +69,7 @@ const TRACKS = [
     isrc: null,
     duration_sec: null,
     artwork_url: null,
+    enrichment_status: 'enriched' as const,
     created_at: '2026-06-09T00:00:00Z',
   },
   {
@@ -86,11 +87,36 @@ const TRACKS = [
     isrc: null,
     duration_sec: null,
     artwork_url: null,
+    enrichment_status: 'pending' as const,
     created_at: '2026-06-09T00:00:00Z',
   },
 ];
 
-const POOL: PoolState = { sources: SOURCES, tracks: TRACKS, runtime_sec: 0 };
+const POOL: PoolState = {
+  sources: SOURCES,
+  tracks: TRACKS,
+  enrichment: { total: 2, enriched: 1, failed: 0, pending: 1, in_progress: true },
+  runtime_sec: 0,
+};
+
+const ENRICHED_POOL: PoolState = {
+  sources: SOURCES,
+  tracks: TRACKS.map((track) => ({ ...track, enrichment_status: 'enriched' as const })),
+  enrichment: { total: 2, enriched: 2, failed: 0, pending: 0, in_progress: false },
+  runtime_sec: 0,
+};
+
+function poolState(sources: PoolState['sources'], tracks: PoolState['tracks']): PoolState {
+  const enriched = tracks.filter((track) => track.enrichment_status === 'enriched').length;
+  const failed = tracks.filter((track) => track.enrichment_status === 'failed').length;
+  const pending = tracks.filter((track) => track.enrichment_status === 'pending').length;
+  return {
+    sources,
+    tracks,
+    enrichment: { total: tracks.length, enriched, failed, pending, in_progress: pending > 0 },
+    runtime_sec: 0,
+  };
+}
 
 // --- Vibe fixtures (issue #391) ---
 
@@ -158,6 +184,10 @@ beforeEach(() => {
   mockApi.getPool.mockResolvedValue(POOL);
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe('PoolPanel', () => {
   it('renders tracks with source chips and badges', async () => {
     render(<PoolPanel setId={1} />);
@@ -168,6 +198,45 @@ describe('PoolPanel', () => {
     // camelot + bpm badges
     expect(screen.getByText('8A')).toBeTruthy();
     expect(screen.getByText('126')).toBeTruthy();
+  });
+
+  it('renders enrichment progress while pool tracks are pending', async () => {
+    render(<PoolPanel setId={1} />);
+
+    expect(await screen.findByText('Enriching 1/2...')).toBeTruthy();
+    const bar = screen.getByRole('progressbar', { name: 'Pool enrichment progress' });
+    expect(bar).toHaveAttribute('aria-valuenow', '50');
+    expect(screen.getByText('1 pending')).toBeTruthy();
+  });
+
+  it('polls pool state while enrichment is pending and stops at completion', async () => {
+    vi.useFakeTimers();
+    mockApi.getPool
+      .mockResolvedValueOnce(POOL)
+      .mockResolvedValueOnce(ENRICHED_POOL)
+      .mockResolvedValue(ENRICHED_POOL);
+
+    render(<PoolPanel setId={1} />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByText('Enriching 1/2...')).toBeTruthy();
+    expect(mockApi.getPool).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(2500);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mockApi.getPool).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText(/Enriching/)).toBeNull();
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+      await Promise.resolve();
+    });
+    expect(mockApi.getPool).toHaveBeenCalledTimes(2);
   });
 
   it('writes a pool-track drag payload when dragging a track row', async () => {
@@ -202,7 +271,7 @@ describe('PoolPanel', () => {
   it('removes a source via the hover × and updates state from response', async () => {
     mockApi.removePoolSource.mockResolvedValue({
       removed: 1,
-      pool: { sources: [SOURCES[1]], tracks: [TRACKS[1]] },
+      pool: poolState([SOURCES[1]], [TRACKS[1]]),
     });
     render(<PoolPanel setId={1} />);
     await screen.findByText('Event Song');
@@ -216,7 +285,7 @@ describe('PoolPanel', () => {
   it('multi-select: select-all-visible then remove calls removePoolTracks', async () => {
     mockApi.removePoolTracks.mockResolvedValue({
       removed: 2,
-      pool: { sources: SOURCES, tracks: [] },
+      pool: poolState(SOURCES, []),
     });
     render(<PoolPanel setId={1} />);
     await screen.findByText('Event Song');
@@ -296,7 +365,7 @@ describe('PoolPanel', () => {
   it('context menu offers per-track and per-source removal', async () => {
     mockApi.removePoolTracks.mockResolvedValue({
       removed: 1,
-      pool: { sources: SOURCES, tracks: [TRACKS[1]] },
+      pool: poolState(SOURCES, [TRACKS[1]]),
     });
     render(<PoolPanel setId={1} />);
     const row = await screen.findByText('Event Song');

--- a/dashboard/app/(dj)/setbuilder/setbuilder.module.css
+++ b/dashboard/app/(dj)/setbuilder/setbuilder.module.css
@@ -1245,6 +1245,45 @@
   border-bottom: 1px solid var(--border-subtle);
 }
 
+.poolEnrichment {
+  padding: 8px 10px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: rgba(50, 215, 160, 0.08);
+}
+
+.poolEnrichmentHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 7px;
+  font-size: 12px;
+}
+
+.poolEnrichmentText {
+  color: var(--text);
+  font-weight: 700;
+}
+
+.poolEnrichmentMeta {
+  color: var(--text-secondary);
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.poolEnrichmentBar {
+  height: 5px;
+  overflow: hidden;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.poolEnrichmentFill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--color-primary);
+  transition: width 180ms ease;
+}
+
 .sourcesToggle {
   display: flex;
   align-items: center;

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -4953,9 +4953,15 @@ export interface components {
             collection_opens_at: string | null;
             /** Collection Phase Override */
             collection_phase_override: string | null;
-            /** Created At */
+            /**
+             * Created At
+             * Format: date-time
+             */
             created_at: string;
-            /** Expires At */
+            /**
+             * Expires At
+             * Format: date-time
+             */
             expires_at: string;
             /**
              * Frictionless Join
@@ -5537,7 +5543,10 @@ export interface components {
             source: string;
             /** Spotify Uri */
             spotify_uri: string | null;
-            /** Started At */
+            /**
+             * Started At
+             * Format: date-time
+             */
             started_at: string;
             /** Title */
             title: string;
@@ -5703,7 +5712,10 @@ export interface components {
             source: string;
             /** Spotify Uri */
             spotify_uri: string | null;
-            /** Started At */
+            /**
+             * Started At
+             * Format: date-time
+             */
             started_at: string;
             /** Title */
             title: string;
@@ -5811,6 +5823,22 @@ export interface components {
             pool_size: number;
             /** Ready */
             ready: boolean;
+        };
+        /**
+         * PoolEnrichmentSummary
+         * @description Set-level background enrichment progress for pool imports.
+         */
+        PoolEnrichmentSummary: {
+            /** Enriched */
+            enriched: number;
+            /** Failed */
+            failed: number;
+            /** In Progress */
+            in_progress: boolean;
+            /** Pending */
+            pending: number;
+            /** Total */
+            total: number;
         };
         /**
          * PoolImportEventIn
@@ -5922,22 +5950,6 @@ export interface components {
             label: string;
             /** Meta */
             meta: string | null;
-        };
-        /**
-         * PoolEnrichmentSummary
-         * @description Set-level background enrichment progress for pool imports.
-         */
-        PoolEnrichmentSummary: {
-            /** Enriched */
-            enriched: number;
-            /** Failed */
-            failed: number;
-            /** In Progress */
-            in_progress: boolean;
-            /** Pending */
-            pending: number;
-            /** Total */
-            total: number;
         };
         /**
          * PoolState
@@ -6257,7 +6269,10 @@ export interface components {
             artwork_url: string | null;
             /** Bpm */
             bpm: number | null;
-            /** Created At */
+            /**
+             * Created At
+             * Format: date-time
+             */
             created_at: string;
             /** Event Id */
             event_id: number;
@@ -6290,7 +6305,10 @@ export interface components {
             status: string;
             /** Sync Results Json */
             sync_results_json: string | null;
-            /** Updated At */
+            /**
+             * Updated At
+             * Format: date-time
+             */
             updated_at: string;
             /**
              * Vote Count

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -5924,10 +5924,27 @@ export interface components {
             meta: string | null;
         };
         /**
+         * PoolEnrichmentSummary
+         * @description Set-level background enrichment progress for pool imports.
+         */
+        PoolEnrichmentSummary: {
+            /** Enriched */
+            enriched: number;
+            /** Failed */
+            failed: number;
+            /** In Progress */
+            in_progress: boolean;
+            /** Pending */
+            pending: number;
+            /** Total */
+            total: number;
+        };
+        /**
          * PoolState
          * @description Full pool snapshot: sources + tracks + total candidate runtime.
          */
         PoolState: {
+            enrichment: components["schemas"]["PoolEnrichmentSummary"];
             /**
              * Runtime Sec
              * @default 0
@@ -5962,6 +5979,11 @@ export interface components {
             duration_sec: number | null;
             /** Energy */
             energy: number | null;
+            /**
+             * Enrichment Status
+             * @enum {string}
+             */
+            enrichment_status: "pending" | "enriched" | "failed";
             /** Genre */
             genre: string | null;
             /** Id */
@@ -6510,6 +6532,12 @@ export interface components {
             duration_sec: number | null;
             /** Energy */
             energy: number | null;
+            /**
+             * Enrichment Status
+             * @default pending
+             * @enum {string}
+             */
+            enrichment_status: "pending" | "enriched" | "failed";
             /** Genre */
             genre: string | null;
             /** Id */

--- a/docs/superpowers/specs/2026-06-24-pool-import-background-enrichment-design.md
+++ b/docs/superpowers/specs/2026-06-24-pool-import-background-enrichment-design.md
@@ -1,0 +1,75 @@
+# Pool import: background enrichment + progress
+
+**Issue:** #563 · **Date:** 2026-06-24 · **Branch:** `feat/pool-import-background-enrichment`
+
+## Problem
+
+Importing a playlist into a set pool blocks for tens of seconds (~44s for a 48-track Tidal
+playlist on a cold cache) and the UI appears frozen. Root cause: `pool.hydrate_candidates_from_store`
+enriches **inline, sequentially, synchronously** — each gap track triggers `enrich_track()` (up to two
+serial external searches: Beatport + Tidal). Not rate-limiting (no 429s; Soundcharts dark). The backend
+stays responsive (threadpool `def` route); the freeze is the **frontend awaiting the long fetch with no
+progress feedback**. Cache-aside (#541/#542) makes this worst-case first-touch only.
+
+## Goals
+- Import request returns fast (~1–2s) regardless of how many tracks need enrichment.
+- Gap tracks enrich in the background; the user sees tracks immediately and a progress bar to 100%.
+- Reuse the existing background pattern; respect provider rate limits; no correctness regressions.
+
+## Non-goals
+- Durable task queue (celery/arq) — out of scope; `BackgroundTasks` + fresh session matches current infra.
+- Soundcharts enablement (#544/#556 flags) and any change to the enrichment *cascade* itself.
+
+## Design
+
+### Backend
+
+**1. Import returns fast (the four import endpoints: tidal/beatport/event/url).**
+Split `hydrate_candidates_from_store` so the synchronous request path only does the **cheap** half:
+create pool rows from the raw candidates and hydrate tracks **already present** in the master `tracks`
+store (no external calls). Tracks with a store gap are inserted unenriched and marked `pending`. The
+endpoint returns `PoolImportResult` immediately and enqueues the background job.
+
+**2. Background enrich job (mirrors `collect.py` `_enrich_with_fresh_session`).**
+`background_tasks.add_task(enrich_pool_tracks, set_id, gap_track_ids)`. The job:
+- opens a **fresh `SessionLocal()`** (never the request session — #505),
+- enriches the gap tracks with **bounded concurrency** via `ThreadPoolExecutor(max_workers=POOL_ENRICH_CONCURRENCY)` (default 6; `enrich_track` is sync httpx, so threads are correct),
+- writes results through to the master store (existing `_enrich_and_writeback`) and updates the pool row,
+- sets each pool track's `enrichment_status` to `enriched` (or `failed` on per-track error — isolated + logged), committing per track so progress is observable as it runs.
+
+**3. Data model.** Add `SetPoolTrack.enrichment_status: Mapped[str]` — `"pending" | "enriched" | "failed"`,
+default `"pending"`, `server_default="pending"`. One Alembic migration. Tracks hydrated from the store at
+import time are written directly as `"enriched"`.
+
+**4. Progress surfacing.** `PoolState` gains a set-level summary
+`enrichment: { total, enriched, failed, pending, in_progress: bool }` derived from the set's pool-track
+statuses (the progress bar reads this). `PoolTrackOut` also gains `enrichment_status` so the UI *may* show a
+per-row pending/failed badge (optional, cheap). No new endpoint — the existing `GET /sets/{id}/pool` carries both.
+
+### Frontend
+- After import, the modal closes and tracks render immediately (they already come back in `PoolImportResult` / the pool refetch).
+- While `enrichment.in_progress` (pending > 0), the pool panel shows a **progress bar + "Enriching N/total…"**, polling `GET /sets/{id}/pool` every ~2.5s (stop when `pending == 0`).
+- Vanilla CSS / inline styles, dark theme (project rule). Reuse existing bar styling if present.
+
+## Data flow
+`import endpoint` → create rows + hydrate cache-hits (sync, fast) → return + `add_task` →
+`enrich_pool_tracks(fresh session, bounded pool)` → per track: `enrich_track` → store write-back → set status →
+frontend polls pool-state → bar fills → 100% when `pending == 0`.
+
+## Error handling
+- Per-track enrichment failure → `enrichment_status = "failed"`, logged, **counts as done** for progress so the bar always completes; surfaced as "no data" in the UI.
+- Background job must not touch the request's (closed) session — always a fresh `SessionLocal()`, closed in a `finally`.
+- Re-import / recompute mid-enrichment is safe: recompute tolerates partial data (#543 None-degrades-neutrally).
+
+## Testing
+- **Unit:** import endpoint returns without making external enrichment calls (mock `enrich_track`, assert not called inline); background `enrich_pool_tracks` uses a fresh session, enriches gaps, sets statuses, isolates a failing track (one `failed`, others `enriched`); concurrency bound respected.
+- **Schema/migration:** `alembic upgrade head && alembic check` clean; default `pending`.
+- **Progress:** pool-state returns correct enriched/total/pending counts across states.
+- **Frontend (vitest):** progress component renders bar from counts; polling starts when pending>0 and stops at 0; tracks render pre-enrichment.
+- Backend coverage ≥ enforced gate.
+
+## Rollout
+Single PR into `main`. Backward compatible. The migration **backfills**: any existing pool row that already
+has contract data (bpm or key present) is set to `enriched`; the rest stay `pending`. This avoids old pools
+spuriously showing an "enriching" bar, and the few genuinely-empty legacy rows simply enrich on their next
+import/recompute touch.

--- a/docs/superpowers/specs/2026-06-24-pool-import-background-enrichment-design.md
+++ b/docs/superpowers/specs/2026-06-24-pool-import-background-enrichment-design.md
@@ -69,7 +69,8 @@ frontend polls pool-state → bar fills → 100% when `pending == 0`.
 - Backend coverage ≥ enforced gate.
 
 ## Rollout
-Single PR into `main`. Backward compatible. The migration **backfills**: any existing pool row that already
-has contract data (bpm or key present) is set to `enriched`; the rest stay `pending`. This avoids old pools
-spuriously showing an "enriching" bar, and the few genuinely-empty legacy rows simply enrich on their next
-import/recompute touch.
+Single PR into `main`. Backward compatible. The migration **backfills**: any existing pool row whose full
+contract is present (bpm, key, genre, and duration_sec — mirroring `_has_provider_gap`) is set to
+`enriched`; partially-filled or empty rows stay `pending`. Matching the runtime gap rule keeps backfilled
+status consistent with what a fresh import would assign, and the `pending` legacy rows simply enrich on
+their next import/recompute touch.

--- a/docs/superpowers/specs/2026-06-24-pool-import-background-enrichment-design.md
+++ b/docs/superpowers/specs/2026-06-24-pool-import-background-enrichment-design.md
@@ -69,8 +69,9 @@ frontend polls pool-state → bar fills → 100% when `pending == 0`.
 - Backend coverage ≥ enforced gate.
 
 ## Rollout
-Single PR into `main`. Backward compatible. The migration **backfills**: any existing pool row whose full
-contract is present (bpm, key, genre, and duration_sec — mirroring `_has_provider_gap`) is set to
-`enriched`; partially-filled or empty rows stay `pending`. Matching the runtime gap rule keeps backfilled
-status consistent with what a fresh import would assign, and the `pending` legacy rows simply enrich on
-their next import/recompute touch.
+Single PR into `main`. Backward compatible. The migration **backfills terminal statuses only** — there is
+no background worker at migration time, so no legacy row may be left `pending` (it would report
+`in_progress` forever with nothing to clear it). Rows whose full contract is present (bpm, key, genre, and
+duration_sec — mirroring `_has_provider_gap`) become `enriched`; partial/empty rows become `failed`, which
+is exactly what the runtime worker now records when a pass can't close the gap. Legacy `failed` rows
+re-enrich on their next import/recompute touch.

--- a/server/alembic/versions/064_add_pool_track_enrichment_status.py
+++ b/server/alembic/versions/064_add_pool_track_enrichment_status.py
@@ -28,11 +28,13 @@ def upgrade() -> None:
             server_default="pending",
         ),
     )
-    # Mirror pool._has_provider_gap: a track is only "enriched" when every
-    # provider-fillable contract field (bpm/key/genre/duration_sec) is present.
-    # A weaker OR heuristic would mark partially-filled rows enriched, so the
-    # background worker (which only processes "pending") could never complete
-    # them — they'd be stuck looking enriched while a fresh import flags pending.
+    # Backfill terminal statuses only — there is no background worker at migration
+    # time, so a legacy row must never be left "pending" (it would report
+    # in_progress forever and make clients poll with nothing to clear it).
+    # Mirror pool._has_provider_gap: rows with the full contract (bpm/key/genre/
+    # duration_sec) are "enriched"; anything partial is "failed" — exactly what
+    # the runtime worker now records when a pass can't close the gap. Legacy rows
+    # re-enrich on their next import/recompute touch.
     op.execute(
         """
         UPDATE set_pool_tracks
@@ -42,7 +44,7 @@ def upgrade() -> None:
                  AND genre IS NOT NULL
                  AND duration_sec IS NOT NULL
             THEN 'enriched'
-            ELSE 'pending'
+            ELSE 'failed'
         END
         """
     )

--- a/server/alembic/versions/064_add_pool_track_enrichment_status.py
+++ b/server/alembic/versions/064_add_pool_track_enrichment_status.py
@@ -1,0 +1,43 @@
+"""Add pool-track enrichment status.
+
+Revision ID: 064
+Revises: 063
+Create Date: 2026-06-24
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "064"
+down_revision: str | None = "063"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "set_pool_tracks",
+        sa.Column(
+            "enrichment_status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="pending",
+        ),
+    )
+    op.execute(
+        """
+        UPDATE set_pool_tracks
+        SET enrichment_status = CASE
+            WHEN bpm IS NOT NULL OR "key" IS NOT NULL THEN 'enriched'
+            ELSE 'pending'
+        END
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("set_pool_tracks", "enrichment_status")

--- a/server/alembic/versions/064_add_pool_track_enrichment_status.py
+++ b/server/alembic/versions/064_add_pool_track_enrichment_status.py
@@ -28,11 +28,20 @@ def upgrade() -> None:
             server_default="pending",
         ),
     )
+    # Mirror pool._has_provider_gap: a track is only "enriched" when every
+    # provider-fillable contract field (bpm/key/genre/duration_sec) is present.
+    # A weaker OR heuristic would mark partially-filled rows enriched, so the
+    # background worker (which only processes "pending") could never complete
+    # them — they'd be stuck looking enriched while a fresh import flags pending.
     op.execute(
         """
         UPDATE set_pool_tracks
         SET enrichment_status = CASE
-            WHEN bpm IS NOT NULL OR "key" IS NOT NULL THEN 'enriched'
+            WHEN bpm IS NOT NULL
+                 AND "key" IS NOT NULL
+                 AND genre IS NOT NULL
+                 AND duration_sec IS NOT NULL
+            THEN 'enriched'
             ELSE 'pending'
         END
         """

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -7,7 +7,16 @@ missing-or-unowned sets return 404 to avoid leaking existence.
 
 from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    status,
+)
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
@@ -55,6 +64,7 @@ from app.schemas.setbuilder import (
     PlaybackSlotOutcomeOut,
     PlayHistoryFeedbackOut,
     PoolCoverageOut,
+    PoolEnrichmentSummary,
     PoolImportEventIn,
     PoolImportManualIn,
     PoolImportPlaylistIn,
@@ -1010,6 +1020,20 @@ def _pool_state(db: Session, set_id: int) -> PoolState:
         sources=[PoolSourceOut.model_validate(s) for s in sources],
         tracks=[PoolTrackOut.model_validate(t) for t in tracks],
         runtime_sec=pool.pool_runtime_sec(db, set_id),
+        enrichment=_pool_enrichment_summary(tracks),
+    )
+
+
+def _pool_enrichment_summary(tracks: list[SetPoolTrack]) -> PoolEnrichmentSummary:
+    enriched = sum(1 for track in tracks if track.enrichment_status == pool.POOL_ENRICHED)
+    failed = sum(1 for track in tracks if track.enrichment_status == pool.POOL_ENRICH_FAILED)
+    pending = sum(1 for track in tracks if track.enrichment_status == pool.POOL_ENRICH_PENDING)
+    return PoolEnrichmentSummary(
+        total=len(tracks),
+        enriched=enriched,
+        failed=failed,
+        pending=pending,
+        in_progress=pending > 0,
     )
 
 
@@ -1020,6 +1044,14 @@ def _import_result(db: Session, set_id: int, source, added: int, deduped: int) -
         source=PoolSourceOut.model_validate(source),
         pool=_pool_state(db, set_id),
     )
+
+
+def _queue_pool_enrichment(
+    db: Session, background_tasks: BackgroundTasks, set_id: int, source_id: int
+) -> None:
+    pending_ids = pool.pending_enrichment_track_ids(db, set_id, source_id=source_id)
+    if pending_ids:
+        background_tasks.add_task(pool.enrich_pool_tracks, set_id, pending_ids)
 
 
 @router.get("/sets/{set_id}/pool", response_model=PoolState)
@@ -1073,6 +1105,7 @@ def import_pool_event(
     set_id: int,
     payload: PoolImportEventIn,
     request: Request,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ) -> PoolImportResult:
@@ -1090,8 +1123,11 @@ def import_pool_event(
         label=event.name,
         meta="WrzDJ event requests",
     )
-    candidates = pool.hydrate_candidates_from_store(db, candidates, user=current_user)
+    candidates = pool.hydrate_candidates_from_store(
+        db, candidates, user=current_user, enrich_missing=False
+    )
     added, deduped = pool.import_candidates(db, set_obj, source, candidates)
+    _queue_pool_enrichment(db, background_tasks, set_obj.id, source.id)
     return _import_result(db, set_obj.id, source, added, deduped)
 
 
@@ -1101,6 +1137,7 @@ def import_pool_tidal(
     set_id: int,
     payload: PoolImportPlaylistIn,
     request: Request,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ) -> PoolImportResult:
@@ -1120,8 +1157,11 @@ def import_pool_tidal(
         label=payload.label or "Tidal playlist",
         meta="Tidal playlist",
     )
-    candidates = pool.hydrate_candidates_from_store(db, candidates, user=current_user)
+    candidates = pool.hydrate_candidates_from_store(
+        db, candidates, user=current_user, enrich_missing=False
+    )
     added, deduped = pool.import_candidates(db, set_obj, source, candidates)
+    _queue_pool_enrichment(db, background_tasks, set_obj.id, source.id)
     return _import_result(db, set_obj.id, source, added, deduped)
 
 
@@ -1131,6 +1171,7 @@ def import_pool_beatport(
     set_id: int,
     payload: PoolImportPlaylistIn,
     request: Request,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ) -> PoolImportResult:
@@ -1146,8 +1187,11 @@ def import_pool_beatport(
         label=payload.label or "Beatport playlist",
         meta="Beatport playlist",
     )
-    candidates = pool.hydrate_candidates_from_store(db, candidates, user=current_user)
+    candidates = pool.hydrate_candidates_from_store(
+        db, candidates, user=current_user, enrich_missing=False
+    )
     added, deduped = pool.import_candidates(db, set_obj, source, candidates)
+    _queue_pool_enrichment(db, background_tasks, set_obj.id, source.id)
     return _import_result(db, set_obj.id, source, added, deduped)
 
 
@@ -1181,6 +1225,7 @@ def import_pool_url(
     set_id: int,
     payload: PoolImportUrlIn,
     request: Request,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ) -> PoolImportResult:
@@ -1206,8 +1251,11 @@ def import_pool_url(
         label=name,
         meta=f"Public {parsed.provider} playlist",
     )
-    candidates = pool.hydrate_candidates_from_store(db, candidates, user=current_user)
+    candidates = pool.hydrate_candidates_from_store(
+        db, candidates, user=current_user, enrich_missing=False
+    )
     added, deduped = pool.import_candidates(db, set_obj, source, candidates)
+    _queue_pool_enrichment(db, background_tasks, set_obj.id, source.id)
     return _import_result(db, set_obj.id, source, added, deduped)
 
 

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -140,6 +140,9 @@ class Settings(BaseSettings):
     # gated off until a paid plan is provisioned so it can never bill by default.
     soundcharts_related_tracks_enabled: bool = False
 
+    # Setbuilder pool import background enrichment (#563).
+    pool_enrich_concurrency: int = 6
+
     # ListenBrainz API (artist discovery for recommendations)
     listenbrainz_user_token: str = ""
 

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -151,6 +151,12 @@ def create_app(*, lifespan_context=lifespan) -> FastAPI:
         docs_url=None if settings.is_production else "/docs",
         redoc_url=None if settings.is_production else "/redoc",
         openapi_url=None if settings.is_production else "/openapi.json",
+        # Emit one schema per model instead of FastAPI's default -Input/-Output
+        # split. Models reused as both request body and response (e.g.
+        # SetDocumentSnapshot, whose pool tracks carry a defaulted
+        # enrichment_status for snapshot backward-compat) would otherwise split,
+        # and the generated TS client + api-types.ts assume a single schema name.
+        separate_input_output_schemas=False,
     )
 
     application.state.limiter = limiter

--- a/server/app/models/set_pool.py
+++ b/server/app/models/set_pool.py
@@ -77,6 +77,9 @@ class SetPoolTrack(Base):
     duration_sec: Mapped[int | None] = mapped_column(Integer, nullable=True)
     artwork_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     dedupe_sig: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    enrichment_status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="pending", server_default="pending"
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow)
 
     set: Mapped["Set"] = relationship("Set", back_populates="pool_tracks")

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -60,6 +60,8 @@ class SetDetail(SetSummary):
 # ---------------------------------------------------------------------------
 # Pool (issue #388)
 
+PoolEnrichmentStatus = Literal["pending", "enriched", "failed"]
+
 
 class PoolSourceOut(BaseModel):
     """An import source row for the sources accordion."""
@@ -93,7 +95,18 @@ class PoolTrackOut(BaseModel):
     isrc: str | None
     duration_sec: int | None
     artwork_url: str | None
+    enrichment_status: PoolEnrichmentStatus
     created_at: datetime
+
+
+class PoolEnrichmentSummary(BaseModel):
+    """Set-level background enrichment progress for pool imports."""
+
+    total: int
+    enriched: int
+    failed: int
+    pending: int
+    in_progress: bool
 
 
 def _validate_pairing_tags(tags: list[str]) -> list[str]:
@@ -169,6 +182,7 @@ class PoolState(BaseModel):
 
     sources: list[PoolSourceOut]
     tracks: list[PoolTrackOut]
+    enrichment: PoolEnrichmentSummary
     # Total pool runtime in seconds (Σ duration_sec with the builder's avg
     # fallback), surfaced before generation so the build dialog can show pool
     # size vs. target and the resulting slot count (#538).
@@ -677,6 +691,7 @@ class SetDocumentPoolTrack(BaseModel):
     duration_sec: int | None = Field(None, ge=0, le=36000)
     artwork_url: str | None = Field(None, max_length=500)
     dedupe_sig: str = Field(..., min_length=1, max_length=64)
+    enrichment_status: PoolEnrichmentStatus = "pending"
     created_at: datetime
 
 

--- a/server/app/services/setbuilder/document_snapshot.py
+++ b/server/app/services/setbuilder/document_snapshot.py
@@ -13,6 +13,7 @@ from app.schemas.setbuilder import (
     SetDocumentSlot,
     SetDocumentSnapshot,
 )
+from app.services.setbuilder import pool
 
 
 def _remap_synthetic_pool_track_id(track_id: str | None, id_map: dict[int, int]) -> str | None:
@@ -150,7 +151,17 @@ def restore_snapshot(
             duration_sec=track.duration_sec,
             artwork_url=track.artwork_url,
             dedupe_sig=track.dedupe_sig,
-            enrichment_status=track.enrichment_status,
+            # Restore enqueues no background worker, so derive a terminal status
+            # from the track's contract fields rather than trusting the snapshot's
+            # stored value. A pre-change snapshot has no enrichment_status (it
+            # defaults to "pending"), which would otherwise report in_progress
+            # forever with nothing to clear it (mirrors the 064 backfill).
+            enrichment_status=pool.terminal_enrichment_status(
+                bpm=track.bpm,
+                key=track.key,
+                genre=track.genre,
+                duration_sec=track.duration_sec,
+            ),
             created_at=track.created_at,
         )
         db.add(restored_track)

--- a/server/app/services/setbuilder/document_snapshot.py
+++ b/server/app/services/setbuilder/document_snapshot.py
@@ -88,6 +88,7 @@ def build_snapshot(set_obj: Set) -> SetDocumentSnapshot:
                     duration_sec=track.duration_sec,
                     artwork_url=track.artwork_url,
                     dedupe_sig=track.dedupe_sig,
+                    enrichment_status=track.enrichment_status,
                     created_at=track.created_at,
                 )
                 for track in sorted(set_obj.pool_tracks, key=lambda t: t.id)
@@ -149,6 +150,7 @@ def restore_snapshot(
             duration_sec=track.duration_sec,
             artwork_url=track.artwork_url,
             dedupe_sig=track.dedupe_sig,
+            enrichment_status=track.enrichment_status,
             created_at=track.created_at,
         )
         db.add(restored_track)

--- a/server/app/services/setbuilder/pool.py
+++ b/server/app/services/setbuilder/pool.py
@@ -416,15 +416,36 @@ def _hydrate_authoritative_fields(candidate: PoolCandidate, row) -> tuple[PoolCa
     return dataclasses.replace(candidate, **updates), hydrated
 
 
+def _contract_gap(*, bpm: object, key: object, genre: object, duration_sec: object) -> bool:
+    """The single provider-contract gap rule (bpm/key/genre/duration all present).
+    Energy is excluded (it comes only from Soundcharts/Lexicon, dark per #543/#544).
+    The 064 migration backfill mirrors this in SQL."""
+    return bpm is None or not key or not genre or duration_sec is None
+
+
 def _has_provider_gap(candidate: PoolCandidate) -> bool:
-    """True if any provider-fillable field (bpm/key/genre/duration) is still
-    missing — the trigger for running the enrich cascade. Energy is excluded (it
-    comes only from Soundcharts/Lexicon, dark per #543/#544)."""
+    """True if any provider-fillable field is still missing — the trigger for
+    running the enrich cascade."""
+    return _contract_gap(
+        bpm=candidate.bpm,
+        key=candidate.key,
+        genre=candidate.genre,
+        duration_sec=candidate.duration_sec,
+    )
+
+
+def terminal_enrichment_status(
+    *, bpm: object, key: object, genre: object, duration_sec: object
+) -> str:
+    """Assign a terminal status from a track's contract fields, for paths that
+    set status without a background worker to run (snapshot restore; the 064
+    backfill mirrors this in SQL). Enriched iff the full contract is present,
+    else failed — never "pending", which would report in_progress with nothing
+    to clear it."""
     return (
-        candidate.bpm is None
-        or not candidate.key
-        or not candidate.genre
-        or candidate.duration_sec is None
+        POOL_ENRICH_FAILED
+        if _contract_gap(bpm=bpm, key=key, genre=genre, duration_sec=duration_sec)
+        else POOL_ENRICHED
     )
 
 

--- a/server/app/services/setbuilder/pool.py
+++ b/server/app/services/setbuilder/pool.py
@@ -14,6 +14,7 @@ import dataclasses
 import hashlib
 import logging
 from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 
 from sqlalchemy.orm import Session
@@ -31,6 +32,10 @@ from app.services.tracks.provenance import is_cache_authoritative
 from app.services.tracks.store import TrackIdentity, get_track, upsert_track
 
 logger = logging.getLogger(__name__)
+
+POOL_ENRICH_PENDING = "pending"
+POOL_ENRICHED = "enriched"
+POOL_ENRICH_FAILED = "failed"
 
 
 class PoolImportError(Exception):
@@ -214,6 +219,7 @@ def import_candidates(
                 duration_sec=c.duration_sec,
                 artwork_url=c.artwork_url,
                 dedupe_sig=sig,
+                enrichment_status=POOL_ENRICH_PENDING if _has_provider_gap(c) else POOL_ENRICHED,
             )
         )
         seen_sigs.add(sig)
@@ -259,6 +265,7 @@ def hydrate_candidates_from_store(
     *,
     user: User | None = None,
     commit: bool = True,
+    enrich_missing: bool = True,
 ) -> list[PoolCandidate]:
     """Resolve each candidate to the master `tracks` store and fill its gaps.
 
@@ -293,7 +300,9 @@ def hydrate_candidates_from_store(
     resolved: list[PoolCandidate] = []
     for candidate in candidates:
         try:
-            resolved.append(_hydrate_one(db, candidate, user, commit=commit))
+            resolved.append(
+                _hydrate_one(db, candidate, user, commit=commit, enrich_missing=enrich_missing)
+            )
         except Exception:
             # commit=False (agent turn): the session may be poisoned and the turn
             # owns the transaction — re-raise so the turn rolls back atomically
@@ -313,7 +322,12 @@ def hydrate_candidates_from_store(
 
 
 def _hydrate_one(
-    db: Session, candidate: PoolCandidate, user: User | None, *, commit: bool
+    db: Session,
+    candidate: PoolCandidate,
+    user: User | None,
+    *,
+    commit: bool,
+    enrich_missing: bool = True,
 ) -> PoolCandidate:
     """Resolve one candidate against the store and return a gap-filled copy.
 
@@ -361,7 +375,7 @@ def _hydrate_one(
 
     # Genuine remaining gaps in the provider-fillable fields: only a connected DJ
     # can run the cascade. Energy stays out of this gate by design.
-    if _has_provider_gap(candidate) and user is not None:
+    if enrich_missing and _has_provider_gap(candidate) and user is not None:
         return _enrich_and_writeback(
             db, candidate, user, title=title, artist=artist, sig=sig, isrc=isrc, commit=commit
         )
@@ -612,6 +626,138 @@ def _safe_upsert(
     except Exception:
         db.rollback()
         logger.warning("Pool store upsert failed for '%s' by '%s'.", title, artist)
+
+
+# ---------------------------------------------------------------------------
+# Background enrichment
+
+
+def pending_enrichment_track_ids(
+    db: Session, set_id: int, *, source_id: int | None = None
+) -> list[int]:
+    """Pool track IDs still awaiting provider enrichment."""
+    query = db.query(SetPoolTrack.id).filter(
+        SetPoolTrack.set_id == set_id,
+        SetPoolTrack.enrichment_status == POOL_ENRICH_PENDING,
+    )
+    if source_id is not None:
+        query = query.filter(SetPoolTrack.source_id == source_id)
+    return [row_id for (row_id,) in query.order_by(SetPoolTrack.id).all()]
+
+
+def enrich_pool_tracks(
+    set_id: int, track_ids: list[int], *, max_workers: int | None = None
+) -> None:
+    """Background pool enrichment entrypoint.
+
+    The scheduled task receives only scalar IDs. Each worker opens its own
+    SessionLocal so external provider calls never pin the request-scoped session
+    and SQLAlchemy sessions are not shared across threads.
+    """
+    unique_ids = list(dict.fromkeys(track_ids))
+    if not unique_ids:
+        return
+    if max_workers is None:
+        from app.core.config import get_settings
+
+        max_workers = get_settings().pool_enrich_concurrency
+    max_workers = max(1, int(max_workers))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        list(
+            executor.map(
+                lambda track_id: _enrich_pool_track_with_fresh_session(set_id, track_id),
+                unique_ids,
+            )
+        )
+
+
+def _enrich_pool_track_with_fresh_session(set_id: int, track_id: int) -> None:
+    from app.db.session import SessionLocal
+
+    session = SessionLocal()
+    try:
+        _enrich_pool_track(session, set_id, track_id)
+    finally:
+        session.close()
+
+
+def _enrich_pool_track(db: Session, set_id: int, track_id: int) -> None:
+    track = db.get(SetPoolTrack, track_id)
+    if track is None or track.set_id != set_id:
+        return
+    set_obj = db.get(Set, set_id)
+    user = db.get(User, set_obj.owner_id) if set_obj is not None else None
+    if user is None:
+        return
+
+    candidate = _candidate_from_pool_track(track)
+    try:
+        if _has_provider_gap(candidate):
+            candidate = _enrich_and_writeback(
+                db,
+                candidate,
+                user,
+                title=track.title,
+                artist=track.artist,
+                sig=track.dedupe_sig,
+                isrc=valid_isrc(track.isrc),
+                commit=True,
+            )
+        _apply_candidate_to_pool_track(track, candidate)
+        track.enrichment_status = POOL_ENRICHED
+        db.commit()
+    except Exception:
+        logger.exception(
+            "Pool background enrichment failed for set_id=%s track_id=%s", set_id, track_id
+        )
+        if not db.is_active or db.new or db.dirty or db.deleted:
+            db.rollback()
+        failed = db.get(SetPoolTrack, track_id)
+        if failed is not None and failed.set_id == set_id:
+            failed.enrichment_status = POOL_ENRICH_FAILED
+            try:
+                db.commit()
+            except Exception:
+                db.rollback()
+                logger.exception(
+                    "Could not persist pool enrichment failure for set_id=%s track_id=%s",
+                    set_id,
+                    track_id,
+                )
+
+
+def _candidate_from_pool_track(track: SetPoolTrack) -> PoolCandidate:
+    return PoolCandidate(
+        title=track.title,
+        artist=track.artist,
+        track_id=track.track_id,
+        album=track.album,
+        genre=track.genre,
+        bpm=track.bpm,
+        key=track.key,
+        energy=track.energy,
+        isrc=track.isrc,
+        duration_sec=track.duration_sec,
+        artwork_url=track.artwork_url,
+    )
+
+
+def _apply_candidate_to_pool_track(track: SetPoolTrack, candidate: PoolCandidate) -> None:
+    if candidate.album is not None:
+        track.album = candidate.album
+    if candidate.genre is not None:
+        track.genre = candidate.genre
+    if candidate.bpm is not None:
+        track.bpm = float(candidate.bpm)
+    if candidate.key:
+        track.key = candidate.key
+        track.camelot = camelot_code(candidate.key)
+    if candidate.energy is not None:
+        track.energy = candidate.energy
+    if candidate.duration_sec is not None:
+        track.duration_sec = candidate.duration_sec
+    if candidate.artwork_url is not None:
+        track.artwork_url = candidate.artwork_url
 
 
 # ---------------------------------------------------------------------------

--- a/server/app/services/setbuilder/pool.py
+++ b/server/app/services/setbuilder/pool.py
@@ -704,7 +704,14 @@ def _enrich_pool_track(db: Session, set_id: int, track_id: int) -> None:
                 commit=True,
             )
         _apply_candidate_to_pool_track(track, candidate)
-        track.enrichment_status = POOL_ENRICHED
+        # Only "enriched" if providers actually closed the contract gap. A no-op
+        # enrichment (no match / owner has no usable connected services) leaves
+        # the same gaps, so mark it "failed" (terminal) rather than "enriched" —
+        # otherwise the summary reports completion and a pending-only pass skips
+        # the row even though bpm/key/genre/duration are still missing.
+        track.enrichment_status = (
+            POOL_ENRICH_FAILED if _has_provider_gap(candidate) else POOL_ENRICHED
+        )
         db.commit()
     except Exception:
         logger.exception(

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1647,6 +1647,7 @@
           "last_seen": {
             "anyOf": [
               {
+                "format": "date-time",
                 "type": "string"
               },
               {
@@ -3758,6 +3759,7 @@
           "archived_at": {
             "anyOf": [
               {
+                "format": "date-time",
                 "type": "string"
               },
               {
@@ -3836,6 +3838,7 @@
           "collection_opens_at": {
             "anyOf": [
               {
+                "format": "date-time",
                 "type": "string"
               },
               {
@@ -3856,10 +3859,12 @@
             "title": "Collection Phase Override"
           },
           "created_at": {
+            "format": "date-time",
             "title": "Created At",
             "type": "string"
           },
           "expires_at": {
+            "format": "date-time",
             "title": "Expires At",
             "type": "string"
           },
@@ -3894,6 +3899,7 @@
           "live_starts_at": {
             "anyOf": [
               {
+                "format": "date-time",
                 "type": "string"
               },
               {
@@ -5440,6 +5446,7 @@
             "title": "Spotify Uri"
           },
           "started_at": {
+            "format": "date-time",
             "title": "Started At",
             "type": "string"
           },
@@ -5919,6 +5926,7 @@
           "ended_at": {
             "anyOf": [
               {
+                "format": "date-time",
                 "type": "string"
               },
               {
@@ -5962,6 +5970,7 @@
             "title": "Spotify Uri"
           },
           "started_at": {
+            "format": "date-time",
             "title": "Started At",
             "type": "string"
           },
@@ -6266,6 +6275,40 @@
           "ready"
         ],
         "title": "PoolCoverageOut",
+        "type": "object"
+      },
+      "PoolEnrichmentSummary": {
+        "description": "Set-level background enrichment progress for pool imports.",
+        "properties": {
+          "enriched": {
+            "title": "Enriched",
+            "type": "integer"
+          },
+          "failed": {
+            "title": "Failed",
+            "type": "integer"
+          },
+          "in_progress": {
+            "title": "In Progress",
+            "type": "boolean"
+          },
+          "pending": {
+            "title": "Pending",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "enriched",
+          "failed",
+          "in_progress",
+          "pending",
+          "total"
+        ],
+        "title": "PoolEnrichmentSummary",
         "type": "object"
       },
       "PoolImportEventIn": {
@@ -6589,6 +6632,9 @@
       "PoolState": {
         "description": "Full pool snapshot: sources + tracks + total candidate runtime.",
         "properties": {
+          "enrichment": {
+            "$ref": "#/components/schemas/PoolEnrichmentSummary"
+          },
           "runtime_sec": {
             "default": 0,
             "title": "Runtime Sec",
@@ -6610,6 +6656,7 @@
           }
         },
         "required": [
+          "enrichment",
           "runtime_sec",
           "sources",
           "tracks"
@@ -6695,6 +6742,15 @@
             ],
             "title": "Energy"
           },
+          "enrichment_status": {
+            "enum": [
+              "pending",
+              "enriched",
+              "failed"
+            ],
+            "title": "Enrichment Status",
+            "type": "string"
+          },
           "genre": {
             "anyOf": [
               {
@@ -6761,6 +6817,7 @@
           "created_at",
           "duration_sec",
           "energy",
+          "enrichment_status",
           "genre",
           "id",
           "isrc",
@@ -7585,6 +7642,7 @@
           "accepted_at": {
             "anyOf": [
               {
+                "format": "date-time",
                 "type": "string"
               },
               {
@@ -7620,6 +7678,7 @@
             "title": "Bpm"
           },
           "created_at": {
+            "format": "date-time",
             "title": "Created At",
             "type": "string"
           },
@@ -7737,6 +7796,7 @@
             "title": "Sync Results Json"
           },
           "updated_at": {
+            "format": "date-time",
             "title": "Updated At",
             "type": "string"
           },
@@ -8500,6 +8560,16 @@
             ],
             "title": "Energy"
           },
+          "enrichment_status": {
+            "default": "pending",
+            "enum": [
+              "pending",
+              "enriched",
+              "failed"
+            ],
+            "title": "Enrichment Status",
+            "type": "string"
+          },
           "genre": {
             "anyOf": [
               {
@@ -8575,6 +8645,7 @@
           "dedupe_sig",
           "duration_sec",
           "energy",
+          "enrichment_status",
           "genre",
           "id",
           "isrc",

--- a/server/tests/test_setbuilder_document_snapshot_api.py
+++ b/server/tests/test_setbuilder_document_snapshot_api.py
@@ -20,8 +20,12 @@ def _logical_snapshot(snapshot: dict) -> dict:
         "curve_points": [_without_keys(point, "id") for point in snapshot["curve_points"]],
         "pool": {
             "sources": [_without_keys(source, "id") for source in snapshot["pool"]["sources"]],
+            # enrichment_status is intentionally re-derived on restore (no worker runs
+            # there), so it is not part of the round-trip invariant; its derivation is
+            # covered by test_document_snapshot_restore_derives_terminal_enrichment_status.
             "tracks": [
-                _without_keys(track, "id", "source_id") for track in snapshot["pool"]["tracks"]
+                _without_keys(track, "id", "source_id", "enrichment_status")
+                for track in snapshot["pool"]["tracks"]
             ],
         },
     }
@@ -157,6 +161,33 @@ def test_document_snapshot_round_trips_destructive_builder_state(client, db, aut
     assert restore.status_code == 200, restore.json()
     restored = restore.json()
     assert _logical_snapshot(restored) == _logical_snapshot(original)
+
+
+def test_document_snapshot_restore_derives_terminal_enrichment_status(client, db, auth_headers):
+    # Regression: a restored pool track must never come back "pending" — restore
+    # enqueues no background worker, so a legacy snapshot (whose tracks default to
+    # "pending") would otherwise report in_progress forever. Status is re-derived
+    # from the contract fields: full contract -> enriched, any gap -> failed.
+    set_id = _create_seeded_set(client, db, auth_headers)
+    payload = client.get(f"/api/setbuilder/sets/{set_id}/document", headers=auth_headers).json()
+
+    tracks = sorted(payload["pool"]["tracks"], key=lambda t: t["track_id"])
+    complete, gappy = tracks[0], tracks[1]
+    # Make the first track contract-complete; both arrive as "pending" (legacy).
+    complete["genre"] = "House"
+    complete["enrichment_status"] = "pending"
+    gappy["enrichment_status"] = "pending"
+
+    restore = client.put(
+        f"/api/setbuilder/sets/{set_id}/document", json=payload, headers=auth_headers
+    )
+    assert restore.status_code == 200, restore.json()
+
+    restored = {t["track_id"]: t for t in restore.json()["pool"]["tracks"]}
+    assert restored[complete["track_id"]]["enrichment_status"] == "enriched"
+    assert restored[gappy["track_id"]]["enrichment_status"] == "failed"
+    # And never left pending.
+    assert all(t["enrichment_status"] != "pending" for t in restored.values())
 
 
 def test_document_snapshot_restore_ignores_client_primary_keys(client, db, auth_headers):

--- a/server/tests/test_setbuilder_pool_api.py
+++ b/server/tests/test_setbuilder_pool_api.py
@@ -1,13 +1,16 @@
 """API-boundary tests for WrzDJSet pool endpoints (issue #388)."""
 
 import pytest
+from fastapi import BackgroundTasks
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.models.event import Event
 from app.models.request import Request as SongRequest
 from app.models.request import RequestStatus
+from app.models.set import Set
 from app.models.user import User
+from app.services.setbuilder import pool as pool_module
 
 
 @pytest.fixture
@@ -228,6 +231,104 @@ class TestPlaylistImports:
         assert body["source"]["kind"] == "tidal"
         assert body["source"]["label"] == "Friday Warmup"
 
+    def test_import_tidal_gap_returns_pending_and_schedules_background_enrichment(
+        self, client, auth_headers, set_id, monkeypatch
+    ):
+        from app.services.setbuilder.pool import PoolCandidate
+
+        scheduled: list[tuple] = []
+
+        def fake_add_task(self, func, *args, **kwargs):
+            scheduled.append((func, args, kwargs))
+
+        def boom(*args, **kwargs):  # pragma: no cover - must not run inline
+            raise AssertionError("pool import must not call provider enrichment inline")
+
+        monkeypatch.setattr(BackgroundTasks, "add_task", fake_add_task)
+        monkeypatch.setattr(pool_module, "enrich_track", boom)
+        monkeypatch.setattr(
+            "app.services.setbuilder.pool.candidates_from_tidal",
+            lambda db, user, pid: [
+                PoolCandidate(track_id="tidal:slow-1", title="Slow Song", artist="Slow Artist")
+            ],
+        )
+
+        resp = client.post(
+            f"/api/setbuilder/sets/{set_id}/pool/import/tidal",
+            json={"playlist_id": "abc-123", "label": "Slow Playlist"},
+            headers=auth_headers,
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["pool"]["enrichment"] == {
+            "total": 1,
+            "enriched": 0,
+            "failed": 0,
+            "pending": 1,
+            "in_progress": True,
+        }
+        track = body["pool"]["tracks"][0]
+        assert track["enrichment_status"] == "pending"
+        assert track["bpm"] is None
+
+        assert len(scheduled) == 1
+        func, args, kwargs = scheduled[0]
+        assert func is pool_module.enrich_pool_tracks
+        assert args == (set_id, [track["id"]])
+        assert kwargs == {}
+
+    def test_pool_state_reports_enrichment_progress(self, client, db, auth_headers, set_id):
+        from app.models.set_pool import SetPoolTrack
+
+        source = pool_module.get_or_create_source(
+            db,
+            db.get(Set, set_id),
+            kind="manual",
+            external_ref=None,
+            label="Manual",
+        )
+        rows = [
+            SetPoolTrack(
+                set_id=set_id,
+                source_id=source.id,
+                title="Pending",
+                artist="Artist",
+                dedupe_sig="pending",
+                enrichment_status="pending",
+            ),
+            SetPoolTrack(
+                set_id=set_id,
+                source_id=source.id,
+                title="Enriched",
+                artist="Artist",
+                bpm=124.0,
+                dedupe_sig="enriched",
+                enrichment_status="enriched",
+            ),
+            SetPoolTrack(
+                set_id=set_id,
+                source_id=source.id,
+                title="Failed",
+                artist="Artist",
+                dedupe_sig="failed",
+                enrichment_status="failed",
+            ),
+        ]
+        db.add_all(rows)
+        db.commit()
+
+        resp = client.get(f"/api/setbuilder/sets/{set_id}/pool", headers=auth_headers)
+
+        assert resp.status_code == 200
+        assert resp.json()["enrichment"] == {
+            "total": 3,
+            "enriched": 1,
+            "failed": 1,
+            "pending": 1,
+            "in_progress": True,
+        }
+
     def test_hydration_failure_on_first_candidate_keeps_source_and_imports_rest(
         self, client, auth_headers, set_id, db, monkeypatch
     ):
@@ -252,10 +353,12 @@ class TestPlaylistImports:
         # Make ONLY the first candidate's hydration blow up mid-flow.
         real_hydrate_one = pool_mod._hydrate_one
 
-        def _explode_first(db_, candidate, user, *, commit):
+        def _explode_first(db_, candidate, user, *, commit, enrich_missing=True):
             if candidate.title == "Boom Song":
                 raise RuntimeError("simulated hydration failure")
-            return real_hydrate_one(db_, candidate, user, commit=commit)
+            return real_hydrate_one(
+                db_, candidate, user, commit=commit, enrich_missing=enrich_missing
+            )
 
         monkeypatch.setattr(pool_mod, "_hydrate_one", _explode_first)
 

--- a/server/tests/test_setbuilder_pool_service.py
+++ b/server/tests/test_setbuilder_pool_service.py
@@ -3,8 +3,10 @@
 import pytest
 from sqlalchemy.orm import Session
 
+from app.api import setbuilder as setbuilder_api
 from app.models.request import Request, RequestStatus
 from app.models.set import Set
+from app.models.set_pool import SetPoolTrack
 from app.models.user import User
 from app.services.setbuilder import pool
 from app.services.setbuilder.playlist_url import (
@@ -207,6 +209,74 @@ class TestImportCandidates:
             db, test_set, src, [_candidate("Song A", "Artist"), _candidate("Song A", "Artist")]
         )
         assert (added, deduped) == (1, 1)
+
+    def test_import_marks_complete_tracks_enriched_and_gaps_pending(self, db, test_set):
+        src = pool.get_or_create_source(
+            db, test_set, kind="tidal", external_ref="p", label="Playlist"
+        )
+        pool.import_candidates(
+            db,
+            test_set,
+            src,
+            [
+                _candidate(
+                    "Complete",
+                    "Artist",
+                    bpm=126.0,
+                    key="8A",
+                    genre="House",
+                    duration_sec=300,
+                ),
+                _candidate("Gap", "Artist"),
+            ],
+        )
+
+        _, tracks = pool.get_pool(db, test_set.id)
+        by_title = {track.title: track for track in tracks}
+        assert by_title["Complete"].enrichment_status == "enriched"
+        assert by_title["Gap"].enrichment_status == "pending"
+
+    def test_pool_state_includes_enrichment_summary(self, db, test_set):
+        src = pool.get_or_create_source(
+            db, test_set, kind="manual", external_ref=None, label="Manual"
+        )
+        db.add_all(
+            [
+                SetPoolTrack(
+                    set_id=test_set.id,
+                    source_id=src.id,
+                    title="Pending",
+                    artist="Artist",
+                    dedupe_sig="pending",
+                    enrichment_status="pending",
+                ),
+                SetPoolTrack(
+                    set_id=test_set.id,
+                    source_id=src.id,
+                    title="Enriched",
+                    artist="Artist",
+                    dedupe_sig="enriched",
+                    enrichment_status="enriched",
+                ),
+                SetPoolTrack(
+                    set_id=test_set.id,
+                    source_id=src.id,
+                    title="Failed",
+                    artist="Artist",
+                    dedupe_sig="failed",
+                    enrichment_status="failed",
+                ),
+            ]
+        )
+        db.commit()
+
+        state = setbuilder_api._pool_state(db, test_set.id)
+
+        assert state.enrichment.total == 3
+        assert state.enrichment.enriched == 1
+        assert state.enrichment.failed == 1
+        assert state.enrichment.pending == 1
+        assert state.enrichment.in_progress is True
 
 
 class TestRemoval:

--- a/server/tests/test_setbuilder_pool_store.py
+++ b/server/tests/test_setbuilder_pool_store.py
@@ -635,6 +635,56 @@ class TestBackgroundPoolEnrichment:
         assert row is not None
         assert row.bpm == 128.0
 
+    def test_enrich_pool_tracks_marks_failed_when_gap_remains(self, db, dj_user, monkeypatch):
+        """A no-op enrichment (provider found nothing) must terminate as 'failed',
+        not 'enriched' — otherwise the row looks complete while still gapped and a
+        pending-only pass would never revisit it."""
+        from app.models.set import Set
+        from app.models.set_pool import SetPoolTrack
+
+        set_obj = Set(owner_id=dj_user.id, name="No Match Set")
+        db.add(set_obj)
+        db.flush()
+        source = pool.get_or_create_source(
+            db,
+            set_obj,
+            kind="tidal",
+            external_ref="pl-nomatch",
+            label="NoMatch",
+        )
+        track = SetPoolTrack(
+            set_id=set_obj.id,
+            source_id=source.id,
+            track_id="tidal:nomatch",
+            title="Obscure Track",
+            artist="Obscure Artist",
+            dedupe_sig=dedupe_signature("Obscure Artist", "Obscure Track"),
+            enrichment_status="pending",
+        )
+        db.add(track)
+        db.commit()
+
+        def fake_enrich(db_, user_, title, artist):
+            # Provider cascade returns no usable contract data.
+            return TrackProfile(
+                title=title,
+                artist=artist,
+                bpm=None,
+                key=None,
+                genre=None,
+                duration_seconds=None,
+                source="none",
+            )
+
+        monkeypatch.setattr(pool, "enrich_track", fake_enrich)
+
+        pool.enrich_pool_tracks(set_obj.id, [track.id], max_workers=1)
+
+        db.expire_all()
+        refreshed = db.get(SetPoolTrack, track.id)
+        assert refreshed.enrichment_status == "failed"
+        assert refreshed.bpm is None
+
     def test_enrich_pool_tracks_uses_bounded_concurrency(self, monkeypatch):
         captured: dict[str, object] = {}
 

--- a/server/tests/test_setbuilder_pool_store.py
+++ b/server/tests/test_setbuilder_pool_store.py
@@ -140,6 +140,18 @@ class TestHydrateFromStore:
         assert row is not None
         assert row.bpm == 128.0
 
+    def test_gap_can_skip_inline_enrichment_for_background_imports(self, db, dj_user, monkeypatch):
+        def _boom(*args, **kwargs):  # pragma: no cover - must not run
+            raise AssertionError("background imports must not enrich inline")
+
+        monkeypatch.setattr(pool, "enrich_track", _boom)
+
+        candidate = pool.PoolCandidate(title="Slow Song", artist="Slow Artist")
+        out = hydrate_candidates_from_store(db, [candidate], user=dj_user, enrich_missing=False)
+
+        assert out == [candidate]
+        assert get_track(db, signature=dedupe_signature("Slow Artist", "Slow Song")) is None
+
     def test_enrich_writeback_persists_the_candidate_isrc(self, db, dj_user, monkeypatch):
         """#554 FIX 2: a Spotify-style candidate (valid ISRC, no bpm/key/genre) takes
         the enrich path; the resulting store row must carry the candidate's ISRC so a
@@ -526,3 +538,127 @@ class TestManualPickProvenance:
         db.refresh(row)
         assert row.bpm == 126.0
         assert row.provenance["bpm"]["source"] == "beatport"
+
+
+class TestBackgroundPoolEnrichment:
+    def _pending_track(self, db: Session, owner: User, *, title: str, artist: str):
+        from app.models.set import Set
+        from app.models.set_pool import SetPoolTrack
+
+        set_obj = Set(owner_id=owner.id, name=f"{title} Set")
+        db.add(set_obj)
+        db.flush()
+        source = pool.get_or_create_source(
+            db,
+            set_obj,
+            kind="tidal",
+            external_ref=f"pl-{title}",
+            label="Slow Playlist",
+        )
+        track = SetPoolTrack(
+            set_id=set_obj.id,
+            source_id=source.id,
+            track_id=f"tidal:{title}",
+            title=title,
+            artist=artist,
+            dedupe_sig=dedupe_signature(artist, title),
+            enrichment_status="pending",
+        )
+        db.add(track)
+        db.commit()
+        return set_obj, track
+
+    def test_enrich_pool_tracks_updates_rows_and_isolates_failures(self, db, dj_user, monkeypatch):
+        from app.models.set import Set
+        from app.models.set_pool import SetPoolTrack
+
+        set_obj = Set(owner_id=dj_user.id, name="Background Enrich Set")
+        db.add(set_obj)
+        db.flush()
+        source = pool.get_or_create_source(
+            db,
+            set_obj,
+            kind="tidal",
+            external_ref="pl-bg",
+            label="Background",
+        )
+        ok = SetPoolTrack(
+            set_id=set_obj.id,
+            source_id=source.id,
+            track_id="tidal:ok",
+            title="Good Track",
+            artist="Good Artist",
+            dedupe_sig=dedupe_signature("Good Artist", "Good Track"),
+            enrichment_status="pending",
+        )
+        bad = SetPoolTrack(
+            set_id=set_obj.id,
+            source_id=source.id,
+            track_id="tidal:bad",
+            title="Bad Track",
+            artist="Bad Artist",
+            dedupe_sig=dedupe_signature("Bad Artist", "Bad Track"),
+            enrichment_status="pending",
+        )
+        db.add_all([ok, bad])
+        db.commit()
+
+        def fake_enrich(db_, user_, title, artist):
+            if title == "Bad Track":
+                raise RuntimeError("provider failed")
+            return TrackProfile(
+                title=title,
+                artist=artist,
+                bpm=128.0,
+                key="5A",
+                genre="Trance",
+                duration_seconds=400,
+                source="beatport",
+            )
+
+        monkeypatch.setattr(pool, "enrich_track", fake_enrich)
+
+        pool.enrich_pool_tracks(set_obj.id, [ok.id, bad.id], max_workers=1)
+
+        db.expire_all()
+        refreshed_ok = db.get(SetPoolTrack, ok.id)
+        refreshed_bad = db.get(SetPoolTrack, bad.id)
+        assert refreshed_ok.enrichment_status == "enriched"
+        assert refreshed_ok.bpm == 128.0
+        assert refreshed_ok.camelot == "5A"
+        assert refreshed_ok.genre == "Trance"
+        assert refreshed_ok.duration_sec == 400
+        assert refreshed_bad.enrichment_status == "failed"
+        assert refreshed_bad.bpm is None
+
+        row = get_track(db, signature=dedupe_signature("Good Artist", "Good Track"))
+        assert row is not None
+        assert row.bpm == 128.0
+
+    def test_enrich_pool_tracks_uses_bounded_concurrency(self, monkeypatch):
+        captured: dict[str, object] = {}
+
+        class FakeExecutor:
+            def __init__(self, *, max_workers):
+                captured["max_workers"] = max_workers
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def map(self, func, items):
+                captured["items"] = list(items)
+                return []
+
+        monkeypatch.setattr(pool, "ThreadPoolExecutor", FakeExecutor)
+        monkeypatch.setattr(
+            pool,
+            "_enrich_pool_track_with_fresh_session",
+            lambda set_id, track_id: None,
+        )
+
+        pool.enrich_pool_tracks(99, [1, 2, 3], max_workers=4)
+
+        assert captured == {"max_workers": 4, "items": [1, 2, 3]}


### PR DESCRIPTION
## Summary

Implements the background pool-import enrichment design from `docs/superpowers/specs/2026-06-24-pool-import-background-enrichment-design.md`.

- Adds `SetPoolTrack.enrichment_status` with an Alembic migration/backfill.
- Changes event, Tidal, Beatport, and public URL pool imports to do only cheap store hydration inline, insert gap tracks as `pending`, and enqueue background enrichment.
- Adds bounded fresh-session background enrichment that updates the master track store, marks rows `enriched` or `failed`, and isolates per-track failures.
- Exposes set-level pool enrichment progress and per-track enrichment status through the existing pool state response.
- Adds PoolPanel progress UI with polling while enrichment is pending.

Closes #563.

## Validation

- `server/.venv/bin/ruff check .`
- `server/.venv/bin/ruff format --check .`
- `server/.venv/bin/bandit -r app -c pyproject.toml -q`
- `server/.venv/bin/pytest tests/test_setbuilder_pool_store.py tests/test_setbuilder_pool_service.py -q --tb=short --no-cov` - 65 passed
- `env DATABASE_URL=postgresql+psycopg://wrzdj:wrzdj@localhost:5433/wrzdj server/.venv/bin/alembic check` - no new upgrade operations detected
- `dashboard/npm run lint`
- `dashboard/npx tsc --noEmit`
- `dashboard/npm test -- --run 'app/(dj)/setbuilder/components/__tests__/PoolPanel.test.tsx'` - 18 passed

## Notes

- Full backend `pytest --tb=short -q` was attempted with a 120s timeout and did not complete in this local environment. The run collected 3350 tests and started executing before the timeout. Earlier API-boundary TestClient tests also stalled locally before reaching the test body, so the targeted pool service/store coverage is included above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pool imports now run missing track enrichment in the background and report real-time progress.
  * The pool view shows an “enriching…” indicator with totals for enriched, pending, and failed tracks.
* **Bug Fixes**
  * Enrichment status is preserved through save/restore and correctly reflected in pool state responses.
  * Imports no longer wait for enrichment to finish before returning results.
* **Tests**
  * Added/updated coverage for background enrichment scheduling, enrichment progress aggregation, and polling-based UI updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->