### PR TITLE
fix: preserve SetBuilder enrichment on snapshot restore

### DIFF
--- a/docs/superpowers/specs/2026-06-26-issue-565-design.md
+++ b/docs/superpowers/specs/2026-06-26-issue-565-design.md
@@ -1,0 +1,62 @@
+# Issue 565 Design: Preserve Enriched Pool Metadata On Snapshot Restore
+
+## Goal
+
+Fix stale WrzDJSet document snapshots so restoring or saving an older snapshot does not wipe
+server-enriched pool metadata that arrived after the snapshot was captured.
+
+## Problem
+
+`restore_snapshot` currently deletes and recreates all `set_pool_tracks` from the client snapshot.
+If background enrichment has since filled `bpm`, `key`, `camelot`, `genre`, or `duration_sec`, a
+stale snapshot can overwrite those fields with older null or pre-enrichment values.
+
+## Approved Approach
+
+Use server-side merge-on-restore.
+
+When restoring each pool track from the snapshot, compare it with the current persisted pool before
+the delete step. Match current tracks by stable identity in this order:
+
+1. `track_id` when both sides have it.
+2. `dedupe_sig` when no `track_id` match exists.
+
+For matched tracks, preserve the current server-enriched metadata for fields that are enrichment
+owned:
+
+- `bpm`
+- `key`
+- `camelot`
+- `genre`
+- `duration_sec`
+- `enrichment_status`
+
+For nullable metadata fields, prefer the current persisted value when it is non-null; otherwise keep
+the snapshot value. For `enrichment_status`, keep the current status for matched rows so an enriched
+or failed terminal row cannot regress to `pending` from a stale snapshot.
+
+The snapshot remains authoritative for document membership, source membership, ordering, notes,
+locked slots, target energy, curve points, and settings. If a track exists only in the snapshot, it
+is recreated from the snapshot and gets a terminal enrichment status via the existing
+`pool.terminal_enrichment_status` helper.
+
+## Non-Goals
+
+- Do not redesign document snapshots or remove the embedded pool copy.
+- Do not add a frontend sync-forward path in this issue.
+- Do not preserve tracks that the snapshot intentionally removed.
+- Do not start background enrichment from restore.
+
+## Testing
+
+Add a backend regression test that:
+
+1. Creates a set with a pool track and captures a snapshot containing stale or missing enrichment
+   fields.
+2. Mutates the current persisted pool row to simulate background enrichment completion.
+3. Restores the stale snapshot through the snapshot service or API.
+4. Asserts the surviving restored pool row preserves enriched `bpm`, `key`/`camelot`, `genre`, and
+   `duration_sec`, and does not regress `enrichment_status`.
+
+Also keep coverage for the existing behavior that snapshot membership/order and slot remapping still
+restore correctly.

--- a/server/app/services/setbuilder/document_snapshot.py
+++ b/server/app/services/setbuilder/document_snapshot.py
@@ -18,9 +18,9 @@ from app.services.setbuilder import pool
 
 def _current_pool_track_metadata(
     db: Session, set_id: int
-) -> tuple[dict[str, dict[str, object]], dict[str, dict[str, object]]]:
+) -> tuple[dict[str, list[dict[str, object]]], dict[str, dict[str, object]]]:
     """Snapshot server-owned enrichment fields before destructive restore."""
-    by_track_id: dict[str, dict[str, object]] = {}
+    by_track_id: dict[str, list[dict[str, object]]] = {}
     by_dedupe_sig: dict[str, dict[str, object]] = {}
     current_tracks = (
         db.query(
@@ -56,21 +56,24 @@ def _current_pool_track_metadata(
             "enrichment_status": enrichment_status,
         }
         if track_id:
-            by_track_id.setdefault(track_id, metadata)
+            by_track_id.setdefault(track_id, []).append(metadata)
         by_dedupe_sig.setdefault(dedupe_sig, metadata)
     return by_track_id, by_dedupe_sig
 
 
 def _matched_current_metadata(
     track: SetDocumentPoolTrack,
-    by_track_id: dict[str, dict[str, object]],
+    by_track_id: dict[str, list[dict[str, object]]],
     by_dedupe_sig: dict[str, dict[str, object]],
 ) -> dict[str, object] | None:
+    dedupe_match = by_dedupe_sig.get(track.dedupe_sig)
     if track.track_id:
-        match = by_track_id.get(track.track_id)
-        if match is not None:
-            return match
-    return by_dedupe_sig.get(track.dedupe_sig)
+        track_id_matches = by_track_id.get(track.track_id)
+        if track_id_matches:
+            if len(track_id_matches) == 1:
+                return track_id_matches[0]
+            return dedupe_match
+    return dedupe_match
 
 
 def _current_or_snapshot(

--- a/server/app/services/setbuilder/document_snapshot.py
+++ b/server/app/services/setbuilder/document_snapshot.py
@@ -16,6 +16,90 @@ from app.schemas.setbuilder import (
 from app.services.setbuilder import pool
 
 
+def _current_pool_track_metadata(
+    db: Session, set_id: int
+) -> tuple[dict[str, dict[str, object]], dict[str, dict[str, object]]]:
+    """Snapshot server-owned enrichment fields before destructive restore."""
+    by_track_id: dict[str, dict[str, object]] = {}
+    by_dedupe_sig: dict[str, dict[str, object]] = {}
+    current_tracks = (
+        db.query(
+            SetPoolTrack.track_id,
+            SetPoolTrack.dedupe_sig,
+            SetPoolTrack.bpm,
+            SetPoolTrack.key,
+            SetPoolTrack.camelot,
+            SetPoolTrack.genre,
+            SetPoolTrack.duration_sec,
+            SetPoolTrack.enrichment_status,
+        )
+        .filter(SetPoolTrack.set_id == set_id)
+        .order_by(SetPoolTrack.id)
+        .all()
+    )
+    for (
+        track_id,
+        dedupe_sig,
+        bpm,
+        key,
+        camelot,
+        genre,
+        duration_sec,
+        enrichment_status,
+    ) in current_tracks:
+        metadata = {
+            "bpm": bpm,
+            "key": key,
+            "camelot": camelot,
+            "genre": genre,
+            "duration_sec": duration_sec,
+            "enrichment_status": enrichment_status,
+        }
+        if track_id:
+            by_track_id.setdefault(track_id, metadata)
+        by_dedupe_sig.setdefault(dedupe_sig, metadata)
+    return by_track_id, by_dedupe_sig
+
+
+def _matched_current_metadata(
+    track: SetDocumentPoolTrack,
+    by_track_id: dict[str, dict[str, object]],
+    by_dedupe_sig: dict[str, dict[str, object]],
+) -> dict[str, object] | None:
+    if track.track_id:
+        match = by_track_id.get(track.track_id)
+        if match is not None:
+            return match
+    return by_dedupe_sig.get(track.dedupe_sig)
+
+
+def _current_or_snapshot(
+    metadata: dict[str, object] | None, field: str, snapshot_value: object
+) -> object:
+    if metadata is None:
+        return snapshot_value
+    current_value = metadata[field]
+    return current_value if current_value is not None else snapshot_value
+
+
+def _merged_enrichment_status(
+    metadata: dict[str, object] | None,
+    *,
+    bpm: object,
+    key: object,
+    genre: object,
+    duration_sec: object,
+) -> str:
+    if metadata is not None and metadata["enrichment_status"] != pool.POOL_ENRICH_PENDING:
+        return str(metadata["enrichment_status"])
+    return pool.terminal_enrichment_status(
+        bpm=bpm,
+        key=key,
+        genre=genre,
+        duration_sec=duration_sec,
+    )
+
+
 def _remap_synthetic_pool_track_id(track_id: str | None, id_map: dict[int, int]) -> str | None:
     if not track_id or not track_id.startswith("pool:"):
         return track_id
@@ -108,6 +192,8 @@ def restore_snapshot(
     set_obj.bpm_ceiling = snapshot.settings.bpm_ceiling
     set_obj.key_strictness = snapshot.settings.key_strictness
 
+    current_by_track_id, current_by_dedupe_sig = _current_pool_track_metadata(db, set_obj.id)
+
     db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_obj.id).delete(
         synchronize_session=False
     )
@@ -135,6 +221,14 @@ def restore_snapshot(
 
     pool_track_id_map: dict[int, int] = {}
     for track in snapshot.pool.tracks:
+        current_metadata = _matched_current_metadata(
+            track, current_by_track_id, current_by_dedupe_sig
+        )
+        bpm = _current_or_snapshot(current_metadata, "bpm", track.bpm)
+        key = _current_or_snapshot(current_metadata, "key", track.key)
+        camelot = _current_or_snapshot(current_metadata, "camelot", track.camelot)
+        genre = _current_or_snapshot(current_metadata, "genre", track.genre)
+        duration_sec = _current_or_snapshot(current_metadata, "duration_sec", track.duration_sec)
         restored_track = SetPoolTrack(
             set_id=set_obj.id,
             source_id=source_id_map[track.source_id],
@@ -142,13 +236,13 @@ def restore_snapshot(
             title=track.title,
             artist=track.artist,
             album=track.album,
-            genre=track.genre,
-            bpm=track.bpm,
-            key=track.key,
-            camelot=track.camelot,
+            genre=genre,
+            bpm=bpm,
+            key=key,
+            camelot=camelot,
             energy=track.energy,
             isrc=track.isrc,
-            duration_sec=track.duration_sec,
+            duration_sec=duration_sec,
             artwork_url=track.artwork_url,
             dedupe_sig=track.dedupe_sig,
             # Restore enqueues no background worker, so derive a terminal status
@@ -156,11 +250,12 @@ def restore_snapshot(
             # stored value. A pre-change snapshot has no enrichment_status (it
             # defaults to "pending"), which would otherwise report in_progress
             # forever with nothing to clear it (mirrors the 064 backfill).
-            enrichment_status=pool.terminal_enrichment_status(
-                bpm=track.bpm,
-                key=track.key,
-                genre=track.genre,
-                duration_sec=track.duration_sec,
+            enrichment_status=_merged_enrichment_status(
+                current_metadata,
+                bpm=bpm,
+                key=key,
+                genre=genre,
+                duration_sec=duration_sec,
             ),
             created_at=track.created_at,
         )

--- a/server/tests/test_setbuilder_structural.py
+++ b/server/tests/test_setbuilder_structural.py
@@ -319,6 +319,54 @@ def test_restore_snapshot_keeps_duplicate_track_id_metadata_separate(db: Session
     assert restored["duplicate-b"].duration_sec == 421
 
 
+def test_restore_snapshot_preserves_current_failed_status(db: Session, test_user: User):
+    set_obj = Set(owner_id=test_user.id, name="Failed Status Merge")
+    db.add(set_obj)
+    db.flush()
+    source = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(source)
+    db.flush()
+    db.add(
+        SetPoolTrack(
+            set_id=set_obj.id,
+            source_id=source.id,
+            track_id="manual:failed",
+            title="Failed Match",
+            artist="Snapshot Artist",
+            bpm=126.0,
+            key="8A",
+            genre="House",
+            duration_sec=300,
+            dedupe_sig="failed-match",
+            enrichment_status="pending",
+        )
+    )
+    db.commit()
+    db.refresh(set_obj)
+    stale_snapshot = build_snapshot(set_obj)
+
+    current = db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_obj.id).one()
+    current.bpm = None
+    current.key = None
+    current.genre = None
+    current.duration_sec = None
+    current.enrichment_status = "failed"
+    db.commit()
+    set_id = set_obj.id
+    db.expunge_all()
+    set_obj = db.get(Set, set_id)
+    assert set_obj is not None
+
+    restore_snapshot(db, set_obj, stale_snapshot)
+
+    restored = db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_obj.id).one()
+    assert restored.bpm == 126.0
+    assert restored.key == "8A"
+    assert restored.genre == "House"
+    assert restored.duration_sec == 300
+    assert restored.enrichment_status == "failed"
+
+
 def test_restore_snapshot_derives_status_when_current_match_is_pending(
     db: Session, test_user: User
 ):
@@ -354,6 +402,50 @@ def test_restore_snapshot_derives_status_when_current_match_is_pending(
     restore_snapshot(db, set_obj, snapshot)
 
     restored = db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_obj.id).one()
+    assert restored.enrichment_status == "enriched"
+
+
+def test_restore_snapshot_derives_status_for_snapshot_only_track(db: Session, test_user: User):
+    set_obj = Set(owner_id=test_user.id, name="Snapshot Only Status")
+    db.add(set_obj)
+    db.flush()
+    source = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(source)
+    db.flush()
+    db.add(
+        SetPoolTrack(
+            set_id=set_obj.id,
+            source_id=source.id,
+            track_id="manual:snapshot-only",
+            title="Snapshot Only",
+            artist="Snapshot Artist",
+            bpm=128.0,
+            key="7A",
+            genre="House",
+            duration_sec=300,
+            dedupe_sig="snapshot-only",
+            enrichment_status="pending",
+        )
+    )
+    db.commit()
+    db.refresh(set_obj)
+    snapshot = build_snapshot(set_obj)
+    db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_obj.id).delete(
+        synchronize_session=False
+    )
+    db.commit()
+    set_id = set_obj.id
+    db.expunge_all()
+    set_obj = db.get(Set, set_id)
+    assert set_obj is not None
+
+    restore_snapshot(db, set_obj, snapshot)
+
+    restored = db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_obj.id).one()
+    assert restored.bpm == 128.0
+    assert restored.key == "7A"
+    assert restored.genre == "House"
+    assert restored.duration_sec == 300
     assert restored.enrichment_status == "enriched"
 
 

--- a/server/tests/test_setbuilder_structural.py
+++ b/server/tests/test_setbuilder_structural.py
@@ -173,6 +173,119 @@ def test_autobuild_then_restore_snapshot_returns_prior_order(db: Session, test_u
     assert after_ids == before_ids
 
 
+def test_restore_snapshot_preserves_current_enriched_pool_metadata(db: Session, test_user: User):
+    # Regression for issue #565: stale document snapshots from undo/autosave
+    # must not overwrite enrichment that completed server-side after capture.
+    set_obj = Set(owner_id=test_user.id, name="Enrichment Merge")
+    db.add(set_obj)
+    db.flush()
+    source = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(source)
+    db.flush()
+    db.add_all(
+        [
+            SetPoolTrack(
+                set_id=set_obj.id,
+                source_id=source.id,
+                track_id="manual:track-id-match",
+                title="Track Id Match",
+                artist="Snapshot Artist",
+                dedupe_sig="track-id-match",
+                enrichment_status="pending",
+            ),
+            SetPoolTrack(
+                set_id=set_obj.id,
+                source_id=source.id,
+                track_id=None,
+                title="Dedupe Match",
+                artist="Snapshot Artist",
+                dedupe_sig="dedupe-only-match",
+                enrichment_status="pending",
+            ),
+        ]
+    )
+    db.commit()
+    db.refresh(set_obj)
+    stale_snapshot = build_snapshot(set_obj)
+
+    current_tracks = db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_obj.id).all()
+    by_sig = {track.dedupe_sig: track for track in current_tracks}
+    by_sig["track-id-match"].bpm = 127.5
+    by_sig["track-id-match"].key = "6A"
+    by_sig["track-id-match"].camelot = "6A"
+    by_sig["track-id-match"].genre = "Afro House"
+    by_sig["track-id-match"].duration_sec = 356
+    by_sig["track-id-match"].enrichment_status = "enriched"
+    by_sig["dedupe-only-match"].bpm = 92.0
+    by_sig["dedupe-only-match"].key = "11B"
+    by_sig["dedupe-only-match"].camelot = "11B"
+    by_sig["dedupe-only-match"].genre = "Disco"
+    by_sig["dedupe-only-match"].duration_sec = 241
+    by_sig["dedupe-only-match"].enrichment_status = "enriched"
+    db.commit()
+    set_id = set_obj.id
+    db.expunge_all()
+    set_obj = db.get(Set, set_id)
+    assert set_obj is not None
+
+    restore_snapshot(db, set_obj, stale_snapshot)
+
+    restored = {
+        track.dedupe_sig: track
+        for track in db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_obj.id).all()
+    }
+    assert restored["track-id-match"].bpm == 127.5
+    assert restored["track-id-match"].key == "6A"
+    assert restored["track-id-match"].camelot == "6A"
+    assert restored["track-id-match"].genre == "Afro House"
+    assert restored["track-id-match"].duration_sec == 356
+    assert restored["track-id-match"].enrichment_status == "enriched"
+    assert restored["dedupe-only-match"].bpm == 92.0
+    assert restored["dedupe-only-match"].key == "11B"
+    assert restored["dedupe-only-match"].camelot == "11B"
+    assert restored["dedupe-only-match"].genre == "Disco"
+    assert restored["dedupe-only-match"].duration_sec == 241
+    assert restored["dedupe-only-match"].enrichment_status == "enriched"
+
+
+def test_restore_snapshot_derives_status_when_current_match_is_pending(
+    db: Session, test_user: User
+):
+    set_obj = Set(owner_id=test_user.id, name="Pending Status Merge")
+    db.add(set_obj)
+    db.flush()
+    source = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(source)
+    db.flush()
+    db.add(
+        SetPoolTrack(
+            set_id=set_obj.id,
+            source_id=source.id,
+            track_id="manual:pending",
+            title="Pending Match",
+            artist="Snapshot Artist",
+            dedupe_sig="pending-match",
+            enrichment_status="pending",
+        )
+    )
+    db.commit()
+    db.refresh(set_obj)
+    snapshot = build_snapshot(set_obj)
+    snapshot.pool.tracks[0].bpm = 128.0
+    snapshot.pool.tracks[0].key = "7A"
+    snapshot.pool.tracks[0].genre = "House"
+    snapshot.pool.tracks[0].duration_sec = 300
+    set_id = set_obj.id
+    db.expunge_all()
+    set_obj = db.get(Set, set_id)
+    assert set_obj is not None
+
+    restore_snapshot(db, set_obj, snapshot)
+
+    restored = db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_obj.id).one()
+    assert restored.enrichment_status == "enriched"
+
+
 def test_autobuild_display_summary_is_human_readable():
     summary = _tool_display_summary(
         "autobuild", {"rationale": "x"}, {"slot_count": 12, "iterations": 3}, {}, {}

--- a/server/tests/test_setbuilder_structural.py
+++ b/server/tests/test_setbuilder_structural.py
@@ -248,6 +248,77 @@ def test_restore_snapshot_preserves_current_enriched_pool_metadata(db: Session, 
     assert restored["dedupe-only-match"].enrichment_status == "enriched"
 
 
+def test_restore_snapshot_keeps_duplicate_track_id_metadata_separate(db: Session, test_user: User):
+    set_obj = Set(owner_id=test_user.id, name="Duplicate Track ID Merge")
+    db.add(set_obj)
+    db.flush()
+    source = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(source)
+    db.flush()
+    db.add_all(
+        [
+            SetPoolTrack(
+                set_id=set_obj.id,
+                source_id=source.id,
+                track_id="manual:duplicate",
+                title="Duplicate A",
+                artist="Snapshot Artist",
+                dedupe_sig="duplicate-a",
+                enrichment_status="pending",
+            ),
+            SetPoolTrack(
+                set_id=set_obj.id,
+                source_id=source.id,
+                track_id="manual:duplicate",
+                title="Duplicate B",
+                artist="Snapshot Artist",
+                dedupe_sig="duplicate-b",
+                enrichment_status="pending",
+            ),
+        ]
+    )
+    db.commit()
+    db.refresh(set_obj)
+    stale_snapshot = build_snapshot(set_obj)
+
+    current_tracks = db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_obj.id).all()
+    by_sig = {track.dedupe_sig: track for track in current_tracks}
+    by_sig["duplicate-a"].bpm = 118.0
+    by_sig["duplicate-a"].key = "4A"
+    by_sig["duplicate-a"].camelot = "4A"
+    by_sig["duplicate-a"].genre = "Breaks"
+    by_sig["duplicate-a"].duration_sec = 303
+    by_sig["duplicate-a"].enrichment_status = "enriched"
+    by_sig["duplicate-b"].bpm = 132.0
+    by_sig["duplicate-b"].key = "9B"
+    by_sig["duplicate-b"].camelot = "9B"
+    by_sig["duplicate-b"].genre = "Techno"
+    by_sig["duplicate-b"].duration_sec = 421
+    by_sig["duplicate-b"].enrichment_status = "enriched"
+    db.commit()
+    set_id = set_obj.id
+    db.expunge_all()
+    set_obj = db.get(Set, set_id)
+    assert set_obj is not None
+
+    restore_snapshot(db, set_obj, stale_snapshot)
+
+    restored = {
+        track.dedupe_sig: track
+        for track in db.query(SetPoolTrack).filter(SetPoolTrack.set_id == set_obj.id).all()
+    }
+    assert restored["duplicate-a"].bpm == 118.0
+    assert restored["duplicate-a"].key == "4A"
+    assert restored["duplicate-a"].camelot == "4A"
+    assert restored["duplicate-a"].genre == "Breaks"
+    assert restored["duplicate-a"].duration_sec == 303
+    assert restored["duplicate-b"].bpm == 132.0
+    assert restored["duplicate-b"].key == "9B"
+    assert restored["duplicate-b"].camelot == "9B"
+    assert restored["duplicate-b"].genre == "Techno"
+    assert restored["duplicate-b"].duration_sec == 421
+
+
 def test_restore_snapshot_derives_status_when_current_match_is_pending(
     db: Session, test_user: User
 ):


### PR DESCRIPTION
## Summary

- Preserve current server-owned SetBuilder pool enrichment metadata when restoring a stale document snapshot.
- Match surviving snapshot tracks to current pool rows by `track_id`, then `dedupe_sig`.
- Add regression coverage for enriched metadata preservation and pending-status terminal derivation.

Closes #565

## Design decisions

- Snapshot membership, source membership, ordering, slots, curve points, and user-editable fields remain authoritative on restore.
- Current `bpm`, `key`, `camelot`, `genre`, and `duration_sec` win only when the matched current value is non-null.
- Current terminal `enrichment_status` values (`enriched` / `failed`) are preserved for matched rows; current `pending` still derives a terminal status from the restored contract fields so restores do not leave no-worker rows pending.
- Current pool metadata is read as scalar columns before the destructive delete, avoiding ORM identity-map churn during row recreation.

## Validation

- `server/.venv/bin/pytest tests/test_setbuilder_structural.py::test_restore_snapshot_preserves_current_enriched_pool_metadata -q --no-cov` (RED before fix: `bpm` restored as `None`; GREEN after fix)
- `server/.venv/bin/pytest tests/test_setbuilder_structural.py -q --no-cov` (22 passed)
- `server/.venv/bin/ruff check app/services/setbuilder/document_snapshot.py tests/test_setbuilder_structural.py`
- `server/.venv/bin/ruff format --check app/services/setbuilder/document_snapshot.py tests/test_setbuilder_structural.py`

Note: `server/.venv/bin/pytest tests/test_setbuilder_document_snapshot_api.py -q --no-cov` timed out locally after collecting 6 tests and entering the first `TestClient` test. A minimal `with TestClient(create_app(...))` repro also timed out before any request, so the regression was added at the snapshot service boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot restores now preserve server-enriched track metadata (tempo, key, camelot, genre, duration) when matching current tracks, preventing stale snapshot data from overwriting newer enrichment results.
  * Restore behavior for enrichment status is improved: matched tracks keep an existing non-pending status, while pending snapshot matches are correctly promoted to enriched.
  * Duplicate tracks sharing the same track ID now keep their enriched metadata separated correctly by signature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->