### PR TITLE
feat: add SetBuilder taste profile

### DIFF
--- a/dashboard/app/(dj)/setbuilder/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/page.test.tsx
@@ -15,9 +15,13 @@ vi.mock('next/link', () => ({
 const mockListSets = vi.fn();
 const mockRenameSet = vi.fn();
 const mockDuplicateSet = vi.fn();
+const mockGetTasteProfile = vi.fn();
+const mockResetTasteProfile = vi.fn();
 vi.mock('@/lib/api', () => ({
   api: {
     listSets: () => mockListSets(),
+    getSetbuilderTasteProfile: () => mockGetTasteProfile(),
+    resetSetbuilderTasteProfile: () => mockResetTasteProfile(),
     createSet: vi.fn(),
     deleteSet: vi.fn(),
     renameSet: (id: number, name: string) => mockRenameSet(id, name),
@@ -42,6 +46,18 @@ describe('SetbuilderPage', () => {
     mockListSets.mockReset();
     mockRenameSet.mockReset();
     mockDuplicateSet.mockReset();
+    mockGetTasteProfile.mockReset();
+    mockResetTasteProfile.mockReset();
+    mockGetTasteProfile.mockResolvedValue({
+      sample_count: 0,
+      min_samples: 5,
+      active: false,
+      average_energy_delta: null,
+      energy_adjustment: 0,
+      top_moods: [],
+      summary: 'No learned taste profile yet.',
+      reset_at: null,
+    });
   });
 
   it('renders the empty state when there are no sets', async () => {
@@ -76,6 +92,63 @@ describe('SetbuilderPage', () => {
     render(<SetbuilderPage />);
     await waitFor(() => {
       expect(screen.getByText('Friday Wedding')).toBeInTheDocument();
+    });
+  });
+
+  it('renders the compact learned taste profile card', async () => {
+    mockListSets.mockResolvedValue([]);
+    mockGetTasteProfile.mockResolvedValue({
+      sample_count: 8,
+      min_samples: 5,
+      active: true,
+      average_energy_delta: 2,
+      energy_adjustment: 1.5,
+      top_moods: [{ mood: 'Peak', count: 5 }],
+      summary: 'Learned from 8 edits: energy +1.5; top mood Peak.',
+      reset_at: null,
+    });
+
+    render(<SetbuilderPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Taste profile')).toBeInTheDocument();
+      expect(screen.getAllByText(/energy \+1\.5/i).length).toBeGreaterThan(0);
+      expect(screen.getByText('Peak')).toBeInTheDocument();
+    });
+  });
+
+  it('resets the learned taste profile after confirmation', async () => {
+    mockListSets.mockResolvedValue([]);
+    mockGetTasteProfile.mockResolvedValue({
+      sample_count: 8,
+      min_samples: 5,
+      active: true,
+      average_energy_delta: 2,
+      energy_adjustment: 1.5,
+      top_moods: [{ mood: 'Peak', count: 5 }],
+      summary: 'Learned from 8 edits: energy +1.5; top mood Peak.',
+      reset_at: null,
+    });
+    mockResetTasteProfile.mockResolvedValue({
+      sample_count: 0,
+      min_samples: 5,
+      active: false,
+      average_energy_delta: null,
+      energy_adjustment: 0,
+      top_moods: [],
+      summary: 'No learned taste profile yet.',
+      reset_at: '2026-06-26T18:00:00Z',
+    });
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<SetbuilderPage />);
+    await waitFor(() => expect(screen.getByText('Taste profile')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /reset profile/i }));
+
+    await waitFor(() => {
+      expect(mockResetTasteProfile).toHaveBeenCalledTimes(1);
+      expect(screen.getByText(/no learned taste profile yet/i)).toBeInTheDocument();
     });
   });
 

--- a/dashboard/app/(dj)/setbuilder/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/page.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import SetbuilderPage from '../page';
 
 vi.mock('next/navigation', () => ({
@@ -60,6 +60,10 @@ describe('SetbuilderPage', () => {
     });
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('renders the empty state when there are no sets', async () => {
     mockListSets.mockResolvedValue([]);
     render(<SetbuilderPage />);
@@ -92,6 +96,29 @@ describe('SetbuilderPage', () => {
     render(<SetbuilderPage />);
     await waitFor(() => {
       expect(screen.getByText('Friday Wedding')).toBeInTheDocument();
+    });
+  });
+
+  it('keeps the sets list visible when the taste profile fails to load', async () => {
+    mockListSets.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Friday Wedding',
+        event_id: null,
+        status: 'draft',
+        sharing_mode: 'private',
+        share_token: null,
+        created_at: '2026-06-07T00:00:00Z',
+        updated_at: '2026-06-07T00:00:00Z',
+      },
+    ]);
+    mockGetTasteProfile.mockRejectedValue(new Error('profile unavailable'));
+
+    render(<SetbuilderPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Friday Wedding')).toBeInTheDocument();
+      expect(screen.queryByText('Failed to load sets')).not.toBeInTheDocument();
     });
   });
 

--- a/dashboard/app/(dj)/setbuilder/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
 import { api } from '@/lib/api';
-import type { SetSummary } from '@/lib/api-types';
+import type { SetSummary, TasteProfile } from '@/lib/api-types';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import ShareDialog from './ShareDialog';
 
@@ -21,6 +21,8 @@ export default function SetbuilderPage() {
   const [renameValue, setRenameValue] = useState('');
   const [savingRename, setSavingRename] = useState(false);
   const [shareTarget, setShareTarget] = useState<SetSummary | null>(null);
+  const [tasteProfile, setTasteProfile] = useState<TasteProfile | null>(null);
+  const [resettingProfile, setResettingProfile] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -33,9 +35,11 @@ export default function SetbuilderPage() {
 
   useEffect(() => {
     if (isAuthenticated) {
-      api
-        .listSets()
-        .then(setSets)
+      Promise.all([api.listSets(), api.getSetbuilderTasteProfile()])
+        .then(([loadedSets, profile]) => {
+          setSets(loadedSets);
+          setTasteProfile(profile);
+        })
         .catch(() => setError('Failed to load sets'))
         .finally(() => setLoading(false));
     }
@@ -79,6 +83,21 @@ export default function SetbuilderPage() {
   const handleShareChanged = (id: number, token: string | null) => {
     setSets((prev) => prev.map((s) => (s.id === id ? { ...s, share_token: token } : s)));
     setShareTarget((prev) => (prev && prev.id === id ? { ...prev, share_token: token } : prev));
+  };
+
+  const handleResetProfile = async () => {
+    if (!window.confirm('Reset your learned SetBuilder taste profile? Existing track edits stay saved.')) {
+      return;
+    }
+    setResettingProfile(true);
+    try {
+      const profile = await api.resetSetbuilderTasteProfile();
+      setTasteProfile(profile);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to reset taste profile');
+    } finally {
+      setResettingProfile(false);
+    }
   };
 
   const startRename = (s: SetSummary) => {
@@ -150,6 +169,56 @@ export default function SetbuilderPage() {
           <ThemeToggle />
         </div>
       </div>
+
+      {tasteProfile && (
+        <div
+          className="card"
+          style={{
+            marginBottom: '1rem',
+            display: 'grid',
+            gap: '0.75rem',
+            padding: '1rem',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              gap: '1rem',
+              alignItems: 'flex-start',
+              flexWrap: 'wrap',
+            }}
+          >
+            <div>
+              <h2 style={{ fontSize: '1rem', marginBottom: '0.35rem' }}>Taste profile</h2>
+              <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', margin: 0 }}>
+                {tasteProfile.summary}
+              </p>
+            </div>
+            <button
+              type="button"
+              className="btn btn-sm"
+              style={{ background: 'var(--surface-raised)' }}
+              onClick={handleResetProfile}
+              disabled={resettingProfile || tasteProfile.sample_count === 0}
+            >
+              {resettingProfile ? 'Resetting...' : 'Reset profile'}
+            </button>
+          </div>
+          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+            <span className="badge">
+              {tasteProfile.active
+                ? `Energy ${tasteProfile.energy_adjustment >= 0 ? '+' : ''}${tasteProfile.energy_adjustment.toFixed(1)}`
+                : `${tasteProfile.sample_count}/${tasteProfile.min_samples} samples`}
+            </span>
+            {tasteProfile.top_moods.map((mood) => (
+              <span key={mood.mood} className="badge">
+                {mood.mood}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
 
       {showCreate && (
         <div className="card" style={{ marginBottom: '2rem' }}>

--- a/dashboard/app/(dj)/setbuilder/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/page.tsx
@@ -35,13 +35,15 @@ export default function SetbuilderPage() {
 
   useEffect(() => {
     if (isAuthenticated) {
-      Promise.all([api.listSets(), api.getSetbuilderTasteProfile()])
-        .then(([loadedSets, profile]) => {
-          setSets(loadedSets);
-          setTasteProfile(profile);
-        })
+      api
+        .listSets()
+        .then(setSets)
         .catch(() => setError('Failed to load sets'))
         .finally(() => setLoading(false));
+      api
+        .getSetbuilderTasteProfile()
+        .then(setTasteProfile)
+        .catch(() => setTasteProfile(null));
     }
   }, [isAuthenticated]);
 

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -132,6 +132,47 @@ describe('ApiClient', () => {
       expect(chatUrl).toContain('/api/setbuilder/sets/42/agent/chat');
       expect(JSON.parse(chatOptions.body)).toEqual({ message: 'Swap these' });
     });
+
+    it('loads and resets the SetBuilder taste profile', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            sample_count: 5,
+            min_samples: 5,
+            active: true,
+            average_energy_delta: 2,
+            energy_adjustment: 1.5,
+            top_moods: [{ mood: 'Peak', count: 4 }],
+            summary: 'Learned from 5 edits: energy +1.5; top mood Peak.',
+            reset_at: null,
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            sample_count: 0,
+            min_samples: 5,
+            active: false,
+            average_energy_delta: null,
+            energy_adjustment: 0,
+            top_moods: [],
+            summary: 'No learned taste profile yet.',
+            reset_at: '2026-06-26T18:00:00Z',
+          }),
+        });
+
+      const profile = await api.getSetbuilderTasteProfile();
+      const reset = await api.resetSetbuilderTasteProfile();
+
+      expect(profile.active).toBe(true);
+      expect(reset.sample_count).toBe(0);
+      const [getUrl] = mockFetch.mock.calls[0];
+      expect(getUrl).toContain('/api/setbuilder/taste-profile');
+      const [resetUrl, resetOptions] = mockFetch.mock.calls[1];
+      expect(resetUrl).toContain('/api/setbuilder/taste-profile/reset');
+      expect(resetOptions.method).toBe('POST');
+    });
   });
 
   describe('search', () => {

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -3387,6 +3387,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/setbuilder/taste-profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Taste Profile
+         * @description Return the current DJ's learned SetBuilder taste profile.
+         */
+        get: operations["get_taste_profile_api_setbuilder_taste_profile_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/taste-profile/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reset Taste Profile
+         * @description Reset learned profile training history without deleting override rows.
+         */
+        post: operations["reset_taste_profile_api_setbuilder_taste_profile_reset_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/tidal/auth/cancel": {
         parameters: {
             query?: never;
@@ -6903,6 +6943,38 @@ export interface components {
             total_requests: number;
             /** Total Users */
             total_users: number;
+        };
+        /**
+         * TasteProfileMoodOut
+         * @description One mood preference learned from explicit vibe edits.
+         */
+        TasteProfileMoodOut: {
+            /** Count */
+            count: number;
+            /** Mood */
+            mood: string;
+        };
+        /**
+         * TasteProfileOut
+         * @description Current DJ's read-time SetBuilder taste profile.
+         */
+        TasteProfileOut: {
+            /** Active */
+            active: boolean;
+            /** Average Energy Delta */
+            average_energy_delta: number | null;
+            /** Energy Adjustment */
+            energy_adjustment: number;
+            /** Min Samples */
+            min_samples: number;
+            /** Reset At */
+            reset_at: string | null;
+            /** Sample Count */
+            sample_count: number;
+            /** Summary */
+            summary: string;
+            /** Top Moods */
+            top_moods: components["schemas"]["TasteProfileMoodOut"][];
         };
         /** TemplatePlaylistRequest */
         TemplatePlaylistRequest: {
@@ -13535,6 +13607,46 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_taste_profile_api_setbuilder_taste_profile_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TasteProfileOut"];
+                };
+            };
+        };
+    };
+    reset_taste_profile_api_setbuilder_taste_profile_reset_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TasteProfileOut"];
                 };
             };
         };

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -204,6 +204,9 @@ export interface SetDetail extends SetSummary {
   exported_at: string | null;
 }
 
+export type TasteProfileMood = Schemas['TasteProfileMoodOut'];
+export type TasteProfile = Schemas['TasteProfileOut'];
+
 // WrzDJSet energy curve editor (#389)
 export type CurvePoint = Schemas['CurvePointModel'];
 export type BuiltinCurveTemplate = Schemas['BuiltinTemplateOut'];

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -84,6 +84,7 @@ import type {
   SortDirection,
   SystemSettings,
   SystemStats,
+  TasteProfile,
   TidalEventSettings,
   TidalSearchResult,
   TidalSyncResult,
@@ -197,6 +198,7 @@ export type {
   SyncResultEntry,
   SystemSettings,
   SystemStats,
+  TasteProfile,
   TidalEventSettings,
   TidalSearchResult,
   TidalSyncResult,
@@ -755,6 +757,12 @@ class ApiClient {
   }
   async deleteSet(setId: number): Promise<void> {
     await this.rawFetch(`/api/setbuilder/sets/${setId}`, { method: 'DELETE' });
+  }
+  async getSetbuilderTasteProfile(): Promise<TasteProfile> {
+    return this.fetch('/api/setbuilder/taste-profile');
+  }
+  async resetSetbuilderTasteProfile(): Promise<TasteProfile> {
+    return this.fetch('/api/setbuilder/taste-profile/reset', { method: 'POST' });
   }
 
   // WrzDJSet energy curve editor (#389)

--- a/docs/superpowers/specs/2026-06-26-issue-409-design.md
+++ b/docs/superpowers/specs/2026-06-26-issue-409-design.md
@@ -24,7 +24,10 @@ The profile should include:
 Apply the profile conservatively:
 
 - Only use the profile when there are enough samples to be meaningful.
+- Train only on fields whose explicit before/after values differ; carried-forward values are not
+  new preference signals.
 - Cap energy adjustment to a small range so learned taste cannot dominate track-specific data.
+- Do not reapply the learned bias to the DJ's own explicit per-track energy override.
 - Keep the existing own -> community -> LLM per-track precedence intact. Taste is a calibration layer,
   not a new higher-priority source.
 

--- a/docs/superpowers/specs/2026-06-26-issue-409-design.md
+++ b/docs/superpowers/specs/2026-06-26-issue-409-design.md
@@ -1,0 +1,60 @@
+# Issue 409 Design: Per-DJ Taste Profile From Vibe Overrides
+
+## Goal
+
+Use accumulated `TrackVibeOverride` rows as a per-DJ taste profile that can personalize WrzDJSet
+scoring and agent context without changing the meaning of explicit per-track overrides.
+
+## Approved Approach
+
+Compute the taste profile at read time from override history.
+
+Use a new setbuilder service that summarizes the current DJ's historical override deltas. The first
+implementation should avoid a materialized profile table and avoid destructive resets. A reset
+stores a timestamp marker in a small owner-scoped table so older override history is ignored for
+profile training, while explicit per-track overrides remain intact.
+
+The profile should include:
+
+- Sample count used for training.
+- Average energy bias from rows with both `energy_override` and `energy_was`.
+- Mood preference counts or top moods from explicit mood overrides.
+- A short text summary suitable for agent context and UI.
+
+Apply the profile conservatively:
+
+- Only use the profile when there are enough samples to be meaningful.
+- Cap energy adjustment to a small range so learned taste cannot dominate track-specific data.
+- Keep the existing own -> community -> LLM per-track precedence intact. Taste is a calibration layer,
+  not a new higher-priority source.
+
+## Integration Points
+
+- Vibe resolution: add an explicit helper that takes the existing resolved value plus the profile and
+  returns a taste-adjusted energy for scoring paths. Preserve source/provenance for the original
+  resolved value.
+- Pass 1 scoring: use taste-adjusted energy for energy-match scoring when the profile is active.
+- Pass 2 context: include the concise profile summary in `_set_context` so critique/chat can explain
+  taste-aware decisions.
+- Transparency UI/API: add an owner-scoped endpoint that returns the profile summary and supports
+  reset. Surface it as a compact taste-profile card on the SetBuilder list page.
+
+## Non-Goals
+
+- Do not train per-genre or per-era models in the first pass unless it falls out naturally from
+  existing fields.
+- Do not delete `TrackVibeOverride` rows during reset.
+- Do not make taste bias affect other DJs, community consensus, or normal WrzDJ request enrichment.
+- Do not add an LLM call to compute the profile.
+
+## Testing
+
+Add backend tests for:
+
+- Profile computation from `TrackVibeOverride` deltas.
+- Minimum-sample gating and energy-bias cap.
+- Reset excluding older history without deleting explicit overrides.
+- Pass-1 scoring using taste-adjusted energy only when the profile is active.
+- Agent context including the profile summary.
+
+Add frontend tests for the profile transparency/reset surface if UI is implemented in the dashboard.

--- a/server/alembic/versions/065_add_set_taste_profile_resets.py
+++ b/server/alembic/versions/065_add_set_taste_profile_resets.py
@@ -1,0 +1,53 @@
+"""Add SetBuilder taste-profile reset markers (issue #409).
+
+Revision ID: 065
+Revises: 064
+Create Date: 2026-06-26
+
+Profiles are computed at read time from TrackVibeOverride history. Resetting a
+profile stores a marker instead of deleting override rows.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "065"
+down_revision: str | None = "064"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "set_taste_profile_resets",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "reset_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_set_taste_profile_resets_user_id",
+        "set_taste_profile_resets",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_set_taste_profile_resets_user_reset_at",
+        "set_taste_profile_resets",
+        ["user_id", "reset_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_set_taste_profile_resets_user_reset_at",
+        table_name="set_taste_profile_resets",
+    )
+    op.drop_index("ix_set_taste_profile_resets_user_id", table_name="set_taste_profile_resets")
+    op.drop_table("set_taste_profile_resets")

--- a/server/app/api/setbuilder.py
+++ b/server/app/api/setbuilder.py
@@ -90,6 +90,8 @@ from app.schemas.setbuilder import (
     SlotOut,
     SlotTargetOut,
     SlotTargetUpdate,
+    TasteProfileMoodOut,
+    TasteProfileOut,
     TemplateWindowOut,
     TrackVibeStateOut,
     TransitionScoreOut,
@@ -121,6 +123,7 @@ from app.services.setbuilder import (
     pool,
     reorder,
     set_service,
+    taste_profile,
     vibe_enrichment,
     vibe_resolver,
 )
@@ -169,6 +172,43 @@ def _agent_message_out(message) -> AgentChatMessageOut:  # noqa: ANN001
         ],
         created_at=message.created_at,
     )
+
+
+def _taste_profile_out(profile: taste_profile.TasteProfile) -> TasteProfileOut:
+    return TasteProfileOut(
+        sample_count=profile.sample_count,
+        min_samples=profile.min_samples,
+        active=profile.active,
+        average_energy_delta=profile.average_energy_delta,
+        energy_adjustment=profile.energy_adjustment,
+        top_moods=[
+            TasteProfileMoodOut(mood=mood.mood, count=mood.count) for mood in profile.top_moods
+        ],
+        summary=profile.summary,
+        reset_at=profile.reset_at,
+    )
+
+
+@router.get("/taste-profile", response_model=TasteProfileOut)
+@limiter.limit("30/minute")
+def get_taste_profile(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> TasteProfileOut:
+    """Return the current DJ's learned SetBuilder taste profile."""
+    return _taste_profile_out(taste_profile.build_taste_profile(db, current_user.id))
+
+
+@router.post("/taste-profile/reset", response_model=TasteProfileOut)
+@limiter.limit("10/minute")
+def reset_taste_profile(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> TasteProfileOut:
+    """Reset learned profile training history without deleting override rows."""
+    return _taste_profile_out(taste_profile.reset_taste_profile(db, current_user.id))
 
 
 @router.post("/sets", response_model=SetDetail, status_code=status.HTTP_201_CREATED)

--- a/server/app/models/__init__.py
+++ b/server/app/models/__init__.py
@@ -19,6 +19,7 @@ from app.models.set import Set, SetCollaborator, SetCurvePoint, SetSlot
 from app.models.set_agent import SetAgentMessage, SetAgentSession
 from app.models.set_pairing import SetPairing
 from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.models.set_taste_profile import SetTasteProfileReset
 from app.models.system_settings import SystemSettings
 from app.models.track import Track
 from app.models.track_vibe import TrackVibe, TrackVibeOverride
@@ -53,6 +54,7 @@ __all__ = [
     "SetPoolSource",
     "SetPoolTrack",
     "SetSlot",
+    "SetTasteProfileReset",
     "SystemSettings",
     "Track",
     "TrackVibe",

--- a/server/app/models/set_taste_profile.py
+++ b/server/app/models/set_taste_profile.py
@@ -1,0 +1,22 @@
+"""Read-time SetBuilder taste-profile reset markers (#409)."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.time import utcnow
+from app.models.base import Base
+
+
+class SetTasteProfileReset(Base):
+    """Owner-scoped marker; older vibe overrides are ignored for profile training."""
+
+    __tablename__ = "set_taste_profile_resets"
+    __table_args__ = (Index("ix_set_taste_profile_resets_user_reset_at", "user_id", "reset_at"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    reset_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=utcnow)

--- a/server/app/schemas/setbuilder.py
+++ b/server/app/schemas/setbuilder.py
@@ -57,6 +57,26 @@ class SetDetail(SetSummary):
     exported_at: datetime | None
 
 
+class TasteProfileMoodOut(BaseModel):
+    """One mood preference learned from explicit vibe edits."""
+
+    mood: str
+    count: int
+
+
+class TasteProfileOut(BaseModel):
+    """Current DJ's read-time SetBuilder taste profile."""
+
+    sample_count: int
+    min_samples: int
+    active: bool
+    average_energy_delta: float | None
+    energy_adjustment: float
+    top_moods: list[TasteProfileMoodOut]
+    summary: str
+    reset_at: datetime | None
+
+
 # ---------------------------------------------------------------------------
 # Pool (issue #388)
 

--- a/server/app/services/setbuilder/pass1_deterministic.py
+++ b/server/app/services/setbuilder/pass1_deterministic.py
@@ -18,7 +18,9 @@ from app.models.user import User
 from app.services.recommendation.camelot import compatibility_score, parse_key
 from app.services.recommendation.scorer import _score_bpm, _score_genre
 from app.services.setbuilder import targeting
+from app.services.setbuilder import taste_profile as taste_profile_service
 from app.services.setbuilder.curve import BUILTIN_TEMPLATES, interpolate_energy, uniform_midpoints
+from app.services.setbuilder.taste_profile import TasteProfile
 from app.services.setbuilder.vibe_resolver import ResolvedVibe, build_pool_vibe_states
 
 AVG_TRACK_LENGTH_SEC = 210
@@ -41,7 +43,7 @@ class TrackMeta:
     artist: str
     bpm: float | None
     key: str | None
-    energy: int | None
+    energy: float | None
     mood: str | None = None
     genre: str | None = None
     transitional_role: str | None = None
@@ -74,7 +76,8 @@ def build_set(db: Session, set_obj: Set, *, commit: bool = True) -> BuildResult:
     # duration-driven loop decides how many slots actually fit the target.
     targets = _target_energies(db, set_obj, max_slots)
     vibes = _pool_vibes(db, set_obj)
-    metas = [_track_meta(t, vibes.get(t.id)) for t in pool_tracks]
+    profile = taste_profile_service.build_taste_profile(db, set_obj.owner_id)
+    metas = [_track_meta(t, vibes.get(t.id), profile) for t in pool_tracks]
     by_track_id = {m.slot_track_id: m for m in metas}
     # Real per-track durations (avg fallback for missing/<=0), keyed the same way
     # the chooser identifies tracks, so the loop can accumulate actual playtime.
@@ -149,7 +152,8 @@ def recompute_transition_scores(
     if slots is None:
         slots = _ordered_slots(db, set_obj.id)
     vibes = _pool_vibes(db, set_obj)
-    pool_metas = [_track_meta(t, vibes.get(t.id)) for t in _pool_tracks(db, set_obj.id)]
+    profile = taste_profile_service.build_taste_profile(db, set_obj.owner_id)
+    pool_metas = [_track_meta(t, vibes.get(t.id), profile) for t in _pool_tracks(db, set_obj.id)]
     tracks_by_id = {meta.slot_track_id: meta for meta in pool_metas}
     scores: list[TransitionScore] = []
     for idx, slot in enumerate(slots):
@@ -229,7 +233,11 @@ def _saved_pairings(db: Session, set_id: int) -> set[tuple[str, str]]:
     return pairings
 
 
-def _track_meta(track: SetPoolTrack, resolved: ResolvedVibe | None = None) -> TrackMeta:
+def _track_meta(
+    track: SetPoolTrack,
+    resolved: ResolvedVibe | None = None,
+    profile: TasteProfile | None = None,
+) -> TrackMeta:
     """Build a scoring meta for a pool track.
 
     Energy and mood are sourced from the read-time vibe cascade (own > community
@@ -253,7 +261,7 @@ def _track_meta(track: SetPoolTrack, resolved: ResolvedVibe | None = None) -> Tr
     mood = None
     if resolved is not None:
         if resolved.energy is not None:
-            energy = resolved.energy
+            energy = taste_profile_service.taste_adjusted_energy(resolved, profile)
         mood = resolved.mood
     return TrackMeta(
         pool_id=track.id,

--- a/server/app/services/setbuilder/pass1_deterministic.py
+++ b/server/app/services/setbuilder/pass1_deterministic.py
@@ -8,6 +8,7 @@ tie-breakers, greedy fill first, then a capped 2-opt-style swap refinement.
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 
 from sqlalchemy.orm import Session
@@ -26,6 +27,7 @@ from app.services.setbuilder.vibe_resolver import ResolvedVibe, build_pool_vibe_
 AVG_TRACK_LENGTH_SEC = 210
 MAX_SWAP_ITERATIONS = 50
 PAIRING_BOOST_POINTS = 20.0
+logger = logging.getLogger(__name__)
 
 # Hard fallback cap for the generated set when no explicit ``target_duration_sec``
 # is set (#538). Without this, ``_slot_count`` returned ``len(tracks)`` and a big
@@ -65,6 +67,19 @@ class BuildResult:
     transition_scores: list[TransitionScore]
 
 
+def _taste_profile_or_none(db: Session, set_obj: Set) -> TasteProfile | None:
+    try:
+        return taste_profile_service.build_taste_profile(db, set_obj.owner_id)
+    except Exception:
+        if not db.is_active:
+            db.rollback()
+        logger.warning(
+            "SetBuilder taste profile read failed; continuing without personalization",
+            exc_info=True,
+        )
+        return None
+
+
 def build_set(db: Session, set_obj: Set, *, commit: bool = True) -> BuildResult:
     """Build and persist a deterministic ordered set from the set pool."""
     pool_tracks = _pool_tracks(db, set_obj.id)
@@ -76,7 +91,7 @@ def build_set(db: Session, set_obj: Set, *, commit: bool = True) -> BuildResult:
     # duration-driven loop decides how many slots actually fit the target.
     targets = _target_energies(db, set_obj, max_slots)
     vibes = _pool_vibes(db, set_obj)
-    profile = taste_profile_service.build_taste_profile(db, set_obj.owner_id)
+    profile = _taste_profile_or_none(db, set_obj)
     metas = [_track_meta(t, vibes.get(t.id), profile) for t in pool_tracks]
     by_track_id = {m.slot_track_id: m for m in metas}
     # Real per-track durations (avg fallback for missing/<=0), keyed the same way
@@ -152,7 +167,7 @@ def recompute_transition_scores(
     if slots is None:
         slots = _ordered_slots(db, set_obj.id)
     vibes = _pool_vibes(db, set_obj)
-    profile = taste_profile_service.build_taste_profile(db, set_obj.owner_id)
+    profile = _taste_profile_or_none(db, set_obj)
     pool_metas = [_track_meta(t, vibes.get(t.id), profile) for t in _pool_tracks(db, set_obj.id)]
     tracks_by_id = {meta.slot_track_id: meta for meta in pool_metas}
     scores: list[TransitionScore] = []

--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -390,7 +390,17 @@ def _critique_from_payload(payload: dict[str, Any]) -> SetCritique:
 def _set_context(db: Session, set_obj: Set) -> str:
     slots = _ordered_slots(db, set_obj.id)
     tracks = {_pass1_track_meta(t).slot_track_id: t for t in _pool_tracks(db, set_obj.id)}
-    taste_profile = build_taste_profile(db, set_obj.owner_id)
+    try:
+        taste_profile = build_taste_profile(db, set_obj.owner_id)
+    except Exception as exc:
+        if not db.is_active:
+            db.rollback()
+        logger.warning(
+            "SetBuilder taste profile read failed for agent context: %s",
+            exc,
+            exc_info=True,
+        )
+        taste_profile = None
     rows = []
     for slot in slots:
         track = tracks.get(slot.track_id or "")

--- a/server/app/services/setbuilder/pass2_agent.py
+++ b/server/app/services/setbuilder/pass2_agent.py
@@ -72,6 +72,7 @@ from app.services.setbuilder.pass1_deterministic import (
     recompute_transition_scores,
 )
 from app.services.setbuilder.pass1_deterministic import _track_meta as _pass1_track_meta
+from app.services.setbuilder.taste_profile import build_taste_profile, profile_context
 
 logger = logging.getLogger(__name__)
 
@@ -389,6 +390,7 @@ def _critique_from_payload(payload: dict[str, Any]) -> SetCritique:
 def _set_context(db: Session, set_obj: Set) -> str:
     slots = _ordered_slots(db, set_obj.id)
     tracks = {_pass1_track_meta(t).slot_track_id: t for t in _pool_tracks(db, set_obj.id)}
+    taste_profile = build_taste_profile(db, set_obj.owner_id)
     rows = []
     for slot in slots:
         track = tracks.get(slot.track_id or "")
@@ -418,6 +420,7 @@ def _set_context(db: Session, set_obj: Set) -> str:
             "set_id": set_obj.id,
             "name": set_obj.name,
             "key_strictness": set_obj.key_strictness,
+            "taste_profile": profile_context(taste_profile),
             "slots": rows,
         },
         separators=(",", ":"),

--- a/server/app/services/setbuilder/taste_profile.py
+++ b/server/app/services/setbuilder/taste_profile.py
@@ -45,7 +45,9 @@ def build_taste_profile(db: Session, user_id: int) -> TasteProfile:
     deltas = [
         float(row.energy_override - row.energy_was)
         for row in rows
-        if row.energy_override is not None and row.energy_was is not None
+        if row.energy_override is not None
+        and row.energy_was is not None
+        and row.energy_override != row.energy_was
     ]
     sample_count = len(deltas)
     average_delta = round(sum(deltas) / sample_count, 2) if deltas else None
@@ -78,13 +80,27 @@ def taste_adjusted_energy(
     """Apply the active profile's capped energy calibration to a resolved vibe value."""
     if resolved.energy is None:
         return None
-    if profile is None or not profile.active or profile.energy_adjustment == 0:
+    if (
+        resolved.energy_source == "own"
+        or profile is None
+        or not profile.active
+        or profile.energy_adjustment == 0
+    ):
         return float(resolved.energy)
     return round(max(0.0, min(10.0, float(resolved.energy) + profile.energy_adjustment)), 2)
 
 
-def profile_context(profile: TasteProfile) -> dict:
+def profile_context(profile: TasteProfile | None) -> dict:
     """Compact JSON-safe profile summary for pass-2 agent context."""
+    if profile is None:
+        return {
+            "active": False,
+            "sample_count": 0,
+            "min_samples": MIN_TASTE_SAMPLES,
+            "energy_adjustment": 0.0,
+            "top_moods": [],
+            "summary": "Taste profile unavailable.",
+        }
     return {
         "active": profile.active,
         "sample_count": profile.sample_count,
@@ -137,6 +153,9 @@ def _top_moods(rows: list[TrackVibeOverride]) -> list[TasteMood]:
     for row in rows:
         mood = (row.mood_override or "").strip()
         if not mood:
+            continue
+        previous_mood = (row.mood_was or "").strip()
+        if previous_mood and mood.casefold() == previous_mood.casefold():
             continue
         key = mood.lower()
         display_by_key.setdefault(key, mood)

--- a/server/app/services/setbuilder/taste_profile.py
+++ b/server/app/services/setbuilder/taste_profile.py
@@ -1,0 +1,175 @@
+"""Per-DJ taste profile derived from TrackVibeOverride history (#409)."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy import and_, or_
+from sqlalchemy.orm import Session
+
+from app.core.time import utcnow
+from app.models.set_taste_profile import SetTasteProfileReset
+from app.models.track_vibe import TRACK_VIBE_SOURCE_EXPLICIT_EDIT, TrackVibeOverride
+from app.services.setbuilder.vibe_resolver import ResolvedVibe
+
+MIN_TASTE_SAMPLES = 5
+MAX_PROFILE_ROWS = 250
+ENERGY_ADJUSTMENT_CAP = 1.5
+TOP_MOOD_LIMIT = 3
+
+
+@dataclass(frozen=True)
+class TasteMood:
+    mood: str
+    count: int
+
+
+@dataclass(frozen=True)
+class TasteProfile:
+    sample_count: int
+    min_samples: int
+    active: bool
+    average_energy_delta: float | None
+    energy_adjustment: float
+    top_moods: list[TasteMood]
+    summary: str
+    reset_at: datetime | None
+
+
+def build_taste_profile(db: Session, user_id: int) -> TasteProfile:
+    """Compute the current DJ's taste profile from recent explicit vibe edits."""
+    reset = _latest_reset(db, user_id)
+    rows = _training_rows(db, user_id, reset.reset_at if reset else None)
+    deltas = [
+        float(row.energy_override - row.energy_was)
+        for row in rows
+        if row.energy_override is not None and row.energy_was is not None
+    ]
+    sample_count = len(deltas)
+    average_delta = round(sum(deltas) / sample_count, 2) if deltas else None
+    active = sample_count >= MIN_TASTE_SAMPLES
+    adjustment = _cap(average_delta or 0.0) if active else 0.0
+    moods = _top_moods(rows)
+    return TasteProfile(
+        sample_count=sample_count,
+        min_samples=MIN_TASTE_SAMPLES,
+        active=active,
+        average_energy_delta=average_delta,
+        energy_adjustment=adjustment,
+        top_moods=moods,
+        summary=_summary(sample_count, active, adjustment, moods),
+        reset_at=reset.reset_at if reset else None,
+    )
+
+
+def reset_taste_profile(db: Session, user_id: int) -> TasteProfile:
+    """Store a reset marker and return the now-current read-time profile."""
+    db.add(SetTasteProfileReset(user_id=user_id, reset_at=utcnow()))
+    db.commit()
+    return build_taste_profile(db, user_id)
+
+
+def taste_adjusted_energy(
+    resolved: ResolvedVibe,
+    profile: TasteProfile | None,
+) -> float | None:
+    """Apply the active profile's capped energy calibration to a resolved vibe value."""
+    if resolved.energy is None:
+        return None
+    if profile is None or not profile.active or profile.energy_adjustment == 0:
+        return float(resolved.energy)
+    return round(max(0.0, min(10.0, float(resolved.energy) + profile.energy_adjustment)), 2)
+
+
+def profile_context(profile: TasteProfile) -> dict:
+    """Compact JSON-safe profile summary for pass-2 agent context."""
+    return {
+        "active": profile.active,
+        "sample_count": profile.sample_count,
+        "min_samples": profile.min_samples,
+        "energy_adjustment": profile.energy_adjustment,
+        "top_moods": [{"mood": mood.mood, "count": mood.count} for mood in profile.top_moods],
+        "summary": profile.summary,
+    }
+
+
+def _latest_reset(db: Session, user_id: int) -> SetTasteProfileReset | None:
+    return (
+        db.query(SetTasteProfileReset)
+        .filter(SetTasteProfileReset.user_id == user_id)
+        .order_by(SetTasteProfileReset.reset_at.desc(), SetTasteProfileReset.id.desc())
+        .first()
+    )
+
+
+def _training_rows(
+    db: Session,
+    user_id: int,
+    reset_at: datetime | None,
+) -> list[TrackVibeOverride]:
+    filters = [
+        TrackVibeOverride.user_id == user_id,
+        TrackVibeOverride.source == TRACK_VIBE_SOURCE_EXPLICIT_EDIT,
+        or_(
+            and_(
+                TrackVibeOverride.energy_override != None,
+                TrackVibeOverride.energy_was != None,
+            ),
+            TrackVibeOverride.mood_override != None,
+        ),
+    ]
+    if reset_at is not None:
+        filters.append(TrackVibeOverride.created_at > reset_at)
+    return (
+        db.query(TrackVibeOverride)
+        .filter(*filters)
+        .order_by(TrackVibeOverride.created_at.desc(), TrackVibeOverride.id.desc())
+        .limit(MAX_PROFILE_ROWS)
+        .all()
+    )
+
+
+def _top_moods(rows: list[TrackVibeOverride]) -> list[TasteMood]:
+    display_by_key: dict[str, str] = {}
+    counts: Counter[str] = Counter()
+    for row in rows:
+        mood = (row.mood_override or "").strip()
+        if not mood:
+            continue
+        key = mood.lower()
+        display_by_key.setdefault(key, mood)
+        counts[key] += 1
+    return [
+        TasteMood(mood=display_by_key[key], count=count)
+        for key, count in counts.most_common(TOP_MOOD_LIMIT)
+    ]
+
+
+def _summary(
+    sample_count: int,
+    active: bool,
+    adjustment: float,
+    moods: list[TasteMood],
+) -> str:
+    if sample_count == 0:
+        return "No learned taste profile yet."
+    mood_text = _mood_summary(moods)
+    if not active:
+        return (
+            f"Learning from {sample_count}/{MIN_TASTE_SAMPLES} energy edits; "
+            f"no scoring adjustment yet{mood_text}."
+        )
+    return f"Learned from {sample_count} energy edits: energy {adjustment:+.1f}{mood_text}."
+
+
+def _mood_summary(moods: list[TasteMood]) -> str:
+    if not moods:
+        return ""
+    joined = ", ".join(f"{mood.mood} ({mood.count})" for mood in moods)
+    return f"; top moods {joined}"
+
+
+def _cap(value: float) -> float:
+    return round(max(-ENERGY_ADJUSTMENT_CAP, min(ENERGY_ADJUSTMENT_CAP, value)), 1)

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -9719,6 +9719,92 @@
         "title": "SystemStats",
         "type": "object"
       },
+      "TasteProfileMoodOut": {
+        "description": "One mood preference learned from explicit vibe edits.",
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "mood": {
+            "title": "Mood",
+            "type": "string"
+          }
+        },
+        "required": [
+          "count",
+          "mood"
+        ],
+        "title": "TasteProfileMoodOut",
+        "type": "object"
+      },
+      "TasteProfileOut": {
+        "description": "Current DJ's read-time SetBuilder taste profile.",
+        "properties": {
+          "active": {
+            "title": "Active",
+            "type": "boolean"
+          },
+          "average_energy_delta": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Average Energy Delta"
+          },
+          "energy_adjustment": {
+            "title": "Energy Adjustment",
+            "type": "number"
+          },
+          "min_samples": {
+            "title": "Min Samples",
+            "type": "integer"
+          },
+          "reset_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reset At"
+          },
+          "sample_count": {
+            "title": "Sample Count",
+            "type": "integer"
+          },
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          },
+          "top_moods": {
+            "items": {
+              "$ref": "#/components/schemas/TasteProfileMoodOut"
+            },
+            "title": "Top Moods",
+            "type": "array"
+          }
+        },
+        "required": [
+          "active",
+          "average_energy_delta",
+          "energy_adjustment",
+          "min_samples",
+          "reset_at",
+          "sample_count",
+          "summary",
+          "top_moods"
+        ],
+        "title": "TasteProfileOut",
+        "type": "object"
+      },
       "TemplatePlaylistRequest": {
         "properties": {
           "playlist_id": {
@@ -20576,6 +20662,60 @@
           }
         ],
         "summary": "Put Vibe Windows",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/taste-profile": {
+      "get": {
+        "description": "Return the current DJ's learned SetBuilder taste profile.",
+        "operationId": "get_taste_profile_api_setbuilder_taste_profile_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TasteProfileOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Taste Profile",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/taste-profile/reset": {
+      "post": {
+        "description": "Reset learned profile training history without deleting override rows.",
+        "operationId": "reset_taste_profile_api_setbuilder_taste_profile_reset_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TasteProfileOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Reset Taste Profile",
         "tags": [
           "setbuilder"
         ]

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -53,10 +53,11 @@ dev = [
     "pygments>=2.20.0",      # CVE-2026-4539 (transitive from bandit/pip-audit via rich)
     "msgpack>=1.2.1",       # GHSA-6v7p-g79w-8964 (OOB read on Unpacker reuse; transitive from pip-audit via cachecontrol)
     "pip>=26.1.2",           # CVE-2026-3219, CVE-2026-6357, PYSEC-2026-196 (transitive from pip-audit)
+    "setuptools>=83.0.0",    # PYSEC-2026-3447 (path traversal via PackageIndex.download)
 ]
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=83.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/server/tests/test_setbuilder_taste_profile.py
+++ b/server/tests/test_setbuilder_taste_profile.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.api import setbuilder as setbuilder_api
 from app.core.time import utcnow
-from app.models.set import Set
+from app.models.set import Set, SetSlot
 from app.models.set_pool import SetPoolSource, SetPoolTrack
 from app.models.set_taste_profile import SetTasteProfileReset
 from app.models.track_vibe import (
@@ -17,7 +17,7 @@ from app.models.track_vibe import (
     TrackVibeOverride,
 )
 from app.models.user import User
-from app.services.setbuilder.pass1_deterministic import build_set
+from app.services.setbuilder.pass1_deterministic import build_set, recompute_transition_scores
 from app.services.setbuilder.pass2_agent import _set_context
 from app.services.setbuilder.taste_profile import (
     ENERGY_ADJUSTMENT_CAP,
@@ -203,6 +203,44 @@ def test_pass1_ignores_taste_profile_below_sample_gate(db: Session, test_user: U
 
     assert result.slot_count == 1
     assert result.slots[0].track_id == "tidal:first"
+
+
+def test_pass1_continues_with_neutral_profile_when_profile_read_fails(
+    monkeypatch, db: Session, test_user: User
+):
+    set_obj = _mk_set(db, test_user)
+    source = _mk_source(db, set_obj)
+    _mk_pool_track(db, set_obj, source, idx=0, track_id="tidal:first")
+    monkeypatch.setattr(
+        "app.services.setbuilder.pass1_deterministic.taste_profile_service.build_taste_profile",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("profile unavailable")),
+    )
+
+    result = build_set(db, set_obj)
+
+    assert result.slot_count == 1
+    assert result.slots[0].track_id == "tidal:first"
+
+
+def test_transition_rescore_continues_with_neutral_profile_when_profile_read_fails(
+    monkeypatch, db: Session, test_user: User
+):
+    set_obj = _mk_set(db, test_user)
+    source = _mk_source(db, set_obj)
+    track = _mk_pool_track(db, set_obj, source, idx=0, track_id="tidal:first")
+    slot = SetSlot(set_id=set_obj.id, position=0, track_id=track.track_id)
+    db.add(slot)
+    db.commit()
+    db.refresh(slot)
+    monkeypatch.setattr(
+        "app.services.setbuilder.pass1_deterministic.taste_profile_service.build_taste_profile",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("profile unavailable")),
+    )
+
+    scores = recompute_transition_scores(db, set_obj)
+
+    assert scores[0].position == 0
+    assert scores[0].score == 100.0
 
 
 def test_pass2_context_includes_compact_taste_summary(db: Session, test_user: User):

--- a/server/tests/test_setbuilder_taste_profile.py
+++ b/server/tests/test_setbuilder_taste_profile.py
@@ -22,9 +22,12 @@ from app.services.setbuilder.pass2_agent import _set_context
 from app.services.setbuilder.taste_profile import (
     ENERGY_ADJUSTMENT_CAP,
     MIN_TASTE_SAMPLES,
+    TasteProfile,
     build_taste_profile,
+    taste_adjusted_energy,
 )
 from app.services.setbuilder.vibe_enrichment import PROMPT_VERSION, SCHEMA_VERSION
+from app.services.setbuilder.vibe_resolver import ResolvedVibe
 
 
 def _override(
@@ -35,6 +38,7 @@ def _override(
     energy: int | None,
     energy_was: int | None,
     mood: str | None = None,
+    mood_was: str | None = None,
     source: str = TRACK_VIBE_SOURCE_EXPLICIT_EDIT,
     created_at=None,
 ) -> TrackVibeOverride:
@@ -44,6 +48,7 @@ def _override(
         energy_override=energy,
         energy_was=energy_was,
         mood_override=mood,
+        mood_was=mood_was,
         source=source,
         created_at=created_at or utcnow(),
     )
@@ -172,6 +177,37 @@ def test_profile_ignores_upvotes_and_reset_excludes_older_history(db: Session, t
     assert profile.top_moods[0].mood == "cooldown"
 
 
+def test_profile_ignores_unchanged_carried_forward_fields(db: Session, test_user: User):
+    _override(db, test_user.id, 0, energy=8, energy_was=6, mood="Peak", mood_was="Warm")
+    for idx in range(1, MIN_TASTE_SAMPLES):
+        _override(db, test_user.id, idx, energy=8, energy_was=8, mood="Peak", mood_was="Peak")
+
+    profile = build_taste_profile(db, test_user.id)
+
+    assert profile.sample_count == 1
+    assert profile.active is False
+    assert profile.average_energy_delta == 2.0
+    assert len(profile.top_moods) == 1
+    assert profile.top_moods[0].mood == "Peak"
+    assert profile.top_moods[0].count == 1
+
+
+def test_taste_adjustment_does_not_double_apply_to_own_override():
+    profile = TasteProfile(
+        sample_count=MIN_TASTE_SAMPLES,
+        min_samples=MIN_TASTE_SAMPLES,
+        active=True,
+        average_energy_delta=2.0,
+        energy_adjustment=ENERGY_ADJUSTMENT_CAP,
+        top_moods=[],
+        summary="Active profile",
+        reset_at=None,
+    )
+    own = ResolvedVibe(energy=8, energy_source="own", mood=None, mood_source=None)
+
+    assert taste_adjusted_energy(own, profile) == 8.0
+
+
 def test_pass1_uses_taste_adjusted_energy_when_profile_is_active(db: Session, test_user: User):
     set_obj = _mk_set(db, test_user)
     source = _mk_source(db, set_obj)
@@ -254,6 +290,20 @@ def test_pass2_context_includes_compact_taste_summary(db: Session, test_user: Us
     assert context["taste_profile"]["sample_count"] == MIN_TASTE_SAMPLES
     assert "Peak" in context["taste_profile"]["summary"]
     assert "+1.5" in context["taste_profile"]["summary"]
+
+
+def test_pass2_context_continues_when_profile_read_fails(monkeypatch, db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user)
+    monkeypatch.setattr(
+        "app.services.setbuilder.pass2_agent.build_taste_profile",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("profile unavailable")),
+    )
+
+    context = json.loads(_set_context(db, set_obj))
+
+    assert context["taste_profile"]["active"] is False
+    assert context["taste_profile"]["sample_count"] == 0
+    assert context["taste_profile"]["summary"] == "Taste profile unavailable."
 
 
 def test_taste_profile_api_get_and_reset_keeps_override_rows(db: Session, test_user: User):

--- a/server/tests/test_setbuilder_taste_profile.py
+++ b/server/tests/test_setbuilder_taste_profile.py
@@ -1,0 +1,234 @@
+"""Tests for per-DJ SetBuilder taste profiles from TrackVibeOverride rows (#409)."""
+
+import json
+from datetime import timedelta
+
+from sqlalchemy.orm import Session
+
+from app.api import setbuilder as setbuilder_api
+from app.core.time import utcnow
+from app.models.set import Set
+from app.models.set_pool import SetPoolSource, SetPoolTrack
+from app.models.set_taste_profile import SetTasteProfileReset
+from app.models.track_vibe import (
+    TRACK_VIBE_SOURCE_EXPLICIT_EDIT,
+    TRACK_VIBE_SOURCE_UPVOTE,
+    TrackVibe,
+    TrackVibeOverride,
+)
+from app.models.user import User
+from app.services.setbuilder.pass1_deterministic import build_set
+from app.services.setbuilder.pass2_agent import _set_context
+from app.services.setbuilder.taste_profile import (
+    ENERGY_ADJUSTMENT_CAP,
+    MIN_TASTE_SAMPLES,
+    build_taste_profile,
+)
+from app.services.setbuilder.vibe_enrichment import PROMPT_VERSION, SCHEMA_VERSION
+
+
+def _override(
+    db: Session,
+    user_id: int,
+    idx: int,
+    *,
+    energy: int | None,
+    energy_was: int | None,
+    mood: str | None = None,
+    source: str = TRACK_VIBE_SOURCE_EXPLICIT_EDIT,
+    created_at=None,
+) -> TrackVibeOverride:
+    row = TrackVibeOverride(
+        track_id=f"taste:{idx}",
+        user_id=user_id,
+        energy_override=energy,
+        energy_was=energy_was,
+        mood_override=mood,
+        source=source,
+        created_at=created_at or utcnow(),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _mk_set(db: Session, user: User, *, duration: int = 210) -> Set:
+    set_obj = Set(owner_id=user.id, name="Taste Set", target_duration_sec=duration)
+    db.add(set_obj)
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def _mk_source(db: Session, set_obj: Set) -> SetPoolSource:
+    source = SetPoolSource(set_id=set_obj.id, kind="manual", label="Manual")
+    db.add(source)
+    db.commit()
+    db.refresh(source)
+    return source
+
+
+def _mk_pool_track(
+    db: Session,
+    set_obj: Set,
+    source: SetPoolSource,
+    *,
+    idx: int,
+    track_id: str,
+) -> SetPoolTrack:
+    track = SetPoolTrack(
+        set_id=set_obj.id,
+        source_id=source.id,
+        track_id=track_id,
+        title=f"Track {idx}",
+        artist=f"Artist {idx}",
+        bpm=124.0,
+        key="8A",
+        camelot="8A",
+        energy=None,
+        duration_sec=210,
+        dedupe_sig=f"sig-{idx}",
+    )
+    db.add(track)
+    db.commit()
+    db.refresh(track)
+    return track
+
+
+def _llm_energy(db: Session, track_id: str, *, energy: int, mood: str | None = None) -> None:
+    db.add(
+        TrackVibe(
+            track_id=track_id,
+            energy=energy,
+            mood=mood,
+            confidence=0.9,
+            llm_provider="anthropic_apikey",
+            llm_model="claude-haiku-4-5",
+            prompt_version=PROMPT_VERSION,
+            schema_version=SCHEMA_VERSION,
+        )
+    )
+    db.commit()
+
+
+def test_profile_requires_min_samples_and_caps_energy_bias(db: Session, test_user: User):
+    for idx in range(MIN_TASTE_SAMPLES - 1):
+        _override(db, test_user.id, idx, energy=10, energy_was=3, mood="Peak")
+
+    inactive = build_taste_profile(db, test_user.id)
+
+    assert inactive.sample_count == MIN_TASTE_SAMPLES - 1
+    assert inactive.active is False
+    assert inactive.average_energy_delta == 7.0
+    assert inactive.energy_adjustment == 0.0
+
+    _override(db, test_user.id, 99, energy=10, energy_was=3, mood="Peak")
+    active = build_taste_profile(db, test_user.id)
+
+    assert active.sample_count == MIN_TASTE_SAMPLES
+    assert active.active is True
+    assert active.average_energy_delta == 7.0
+    assert active.energy_adjustment == ENERGY_ADJUSTMENT_CAP
+    assert active.top_moods[0].mood == "Peak"
+    assert active.top_moods[0].count == MIN_TASTE_SAMPLES
+    assert "+1.5" in active.summary
+
+
+def test_profile_ignores_upvotes_and_reset_excludes_older_history(db: Session, test_user: User):
+    older = utcnow() - timedelta(days=2)
+    newer = utcnow()
+    for idx in range(MIN_TASTE_SAMPLES):
+        _override(db, test_user.id, idx, energy=10, energy_was=4, mood="old", created_at=older)
+    _override(
+        db,
+        test_user.id,
+        100,
+        energy=10,
+        energy_was=4,
+        mood="upvote",
+        source=TRACK_VIBE_SOURCE_UPVOTE,
+        created_at=newer,
+    )
+    db.add(SetTasteProfileReset(user_id=test_user.id, reset_at=utcnow() - timedelta(days=1)))
+    db.commit()
+    for idx in range(MIN_TASTE_SAMPLES):
+        _override(
+            db,
+            test_user.id,
+            200 + idx,
+            energy=2,
+            energy_was=4,
+            mood="cooldown",
+            created_at=newer,
+        )
+
+    profile = build_taste_profile(db, test_user.id)
+
+    assert db.query(TrackVibeOverride).count() == (MIN_TASTE_SAMPLES * 2) + 1
+    assert profile.sample_count == MIN_TASTE_SAMPLES
+    assert profile.average_energy_delta == -2.0
+    assert profile.energy_adjustment == -1.5
+    assert profile.top_moods[0].mood == "cooldown"
+
+
+def test_pass1_uses_taste_adjusted_energy_when_profile_is_active(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user)
+    source = _mk_source(db, set_obj)
+    first = _mk_pool_track(db, set_obj, source, idx=0, track_id="tidal:first")
+    second = _mk_pool_track(db, set_obj, source, idx=1, track_id="tidal:second")
+    assert first.id < second.id
+    _llm_energy(db, "tidal:first", energy=8)
+    _llm_energy(db, "tidal:second", energy=6)
+    for idx in range(MIN_TASTE_SAMPLES):
+        _override(db, test_user.id, idx, energy=8, energy_was=6)
+
+    result = build_set(db, set_obj)
+
+    assert result.slot_count == 1
+    assert result.slots[0].track_id == "tidal:second"
+
+
+def test_pass1_ignores_taste_profile_below_sample_gate(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user)
+    source = _mk_source(db, set_obj)
+    _mk_pool_track(db, set_obj, source, idx=0, track_id="tidal:first")
+    _mk_pool_track(db, set_obj, source, idx=1, track_id="tidal:second")
+    _llm_energy(db, "tidal:first", energy=8)
+    _llm_energy(db, "tidal:second", energy=6)
+    for idx in range(MIN_TASTE_SAMPLES - 1):
+        _override(db, test_user.id, idx, energy=8, energy_was=6)
+
+    result = build_set(db, set_obj)
+
+    assert result.slot_count == 1
+    assert result.slots[0].track_id == "tidal:first"
+
+
+def test_pass2_context_includes_compact_taste_summary(db: Session, test_user: User):
+    set_obj = _mk_set(db, test_user)
+    for idx in range(MIN_TASTE_SAMPLES):
+        _override(db, test_user.id, idx, energy=8, energy_was=6, mood="Peak")
+
+    context = json.loads(_set_context(db, set_obj))
+
+    assert context["taste_profile"]["active"] is True
+    assert context["taste_profile"]["sample_count"] == MIN_TASTE_SAMPLES
+    assert "Peak" in context["taste_profile"]["summary"]
+    assert "+1.5" in context["taste_profile"]["summary"]
+
+
+def test_taste_profile_api_get_and_reset_keeps_override_rows(db: Session, test_user: User):
+    for idx in range(MIN_TASTE_SAMPLES):
+        _override(db, test_user.id, idx, energy=8, energy_was=6, mood="Peak")
+
+    profile = setbuilder_api.get_taste_profile(request=None, db=db, current_user=test_user)
+
+    assert profile.active is True
+    assert profile.sample_count == MIN_TASTE_SAMPLES
+
+    reset = setbuilder_api.reset_taste_profile(request=None, db=db, current_user=test_user)
+
+    assert reset.active is False
+    assert reset.sample_count == 0
+    assert db.query(TrackVibeOverride).count() == MIN_TASTE_SAMPLES

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -2252,6 +2252,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2829,6 +2838,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "setuptools" },
 ]
 
 [package.metadata]
@@ -2866,6 +2876,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.33.0" },
     { name = "resend", specifier = ">=2.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "setuptools", marker = "extra == 'dev'", specifier = ">=83.0.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "spotipy", specifier = ">=2.23.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },


### PR DESCRIPTION
Closes #409

## Summary
- Derive a per-DJ SetBuilder taste profile at read time from explicit `TrackVibeOverride` history.
- Apply gated, capped energy calibration in pass 1 scoring while preserving existing vibe precedence/provenance.
- Add pass 2 taste context plus SetBuilder API/client/UI surfaces for viewing and resetting the learned profile.

## Design decisions
- Compute the profile at read time from recent explicit edit rows only; upvote-derived overrides do not train the profile.
- Store reset markers in `set_taste_profile_resets` instead of deleting override rows.
- Keep personalization conservative: activate only after 5 energy samples, cap energy adjustment to +/-1.5, and limit profile reads to the latest 250 rows.
- Treat taste as a scoring calibration layer only; own/community/LLM resolution precedence remains unchanged.

## Verification
- `/home/adam/github/WrzDJ/server/.venv/bin/pytest tests/test_setbuilder_pass1_vibe.py tests/test_setbuilder_pass2.py tests/test_setbuilder_taste_profile.py -q --no-cov` -> 137 passed.
- Backend pre-commit hook -> ruff check, ruff format check, and bandit completed successfully.
- `alembic upgrade head` and `alembic check` passed against local Docker Postgres at `localhost:5433`.
- `npm test -- --run "app/(dj)/setbuilder/__tests__/page.test.tsx" "lib/__tests__/api.test.ts"` -> 178 passed.
- `npm run lint` and `npx tsc --noEmit` passed.

## Notes
- Local FastAPI `TestClient` requests currently hang under the shared Python 3.13 venv even for unrelated `/health` requests, so the new route behavior is covered through direct route/service tests rather than full TestClient calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new learned taste profile view in SetBuilder, showing profile status, energy bias, sample count, top moods, and a short summary.
  * Added the ability to reset the learned profile from the SetBuilder page.

* **Bug Fixes**
  * SetBuilder now uses learned taste history when suggesting and scoring tracks, while ignoring it until enough samples are available.
  * Resetting a profile now immediately updates the displayed profile state without removing underlying history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->