### PR TITLE
feat(setbuilder): add save-as-template dialog + template gallery

### DIFF
--- a/dashboard/app/(dj)/setbuilder/SaveAsTemplateDialog.tsx
+++ b/dashboard/app/(dj)/setbuilder/SaveAsTemplateDialog.tsx
@@ -26,6 +26,11 @@ export default function SaveAsTemplateDialog({ set, onClose, onSaved }: SaveAsTe
   const trimmedName = name.trim();
   const canSave = trimmedName.length > 0 && trimmedName.length <= MAX_NAME_LENGTH && !busy;
 
+  /** Ignore backdrop/Cancel while the save is in flight. */
+  const closeIfIdle = () => {
+    if (!busy) onClose();
+  };
+
   const save = async () => {
     if (!canSave) return;
     setBusy(true);
@@ -52,7 +57,7 @@ export default function SaveAsTemplateDialog({ set, onClose, onSaved }: SaveAsTe
         justifyContent: 'center',
         zIndex: 100,
       }}
-      onClick={onClose}
+      onClick={closeIfIdle}
     >
       <div
         className="card"
@@ -93,7 +98,8 @@ export default function SaveAsTemplateDialog({ set, onClose, onSaved }: SaveAsTe
             type="button"
             className="btn"
             style={{ background: 'var(--surface-raised)' }}
-            onClick={onClose}
+            disabled={busy}
+            onClick={closeIfIdle}
           >
             Cancel
           </button>

--- a/dashboard/app/(dj)/setbuilder/SaveAsTemplateDialog.tsx
+++ b/dashboard/app/(dj)/setbuilder/SaveAsTemplateDialog.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import { api } from '@/lib/api';
+import type { SetSummary, SetTemplate } from '@/lib/api-types';
+
+interface SaveAsTemplateDialogProps {
+  set: SetSummary;
+  onClose: () => void;
+  /** Called with the newly created template so callers can react (e.g. show a confirmation). */
+  onSaved: (template: SetTemplate) => void;
+}
+
+const MAX_NAME_LENGTH = 120;
+
+/**
+ * Extracts a set's structure — curve, vibe windows, target settings — into a reusable
+ * template. Track-specific data (pool assignments) is never copied; see
+ * `server/app/services/setbuilder/set_templates.py:extract_template`.
+ */
+export default function SaveAsTemplateDialog({ set, onClose, onSaved }: SaveAsTemplateDialogProps) {
+  const [name, setName] = useState(set.name);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmedName = name.trim();
+  const canSave = trimmedName.length > 0 && trimmedName.length <= MAX_NAME_LENGTH && !busy;
+
+  const save = async () => {
+    if (!canSave) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const template = await api.saveSetAsTemplate(set.id, trimmedName);
+      onSaved(template);
+    } catch {
+      setError('Failed to save template');
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label={`Save ${set.name} as template`}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0, 0, 0, 0.6)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 100,
+      }}
+      onClick={onClose}
+    >
+      <div
+        className="card"
+        style={{ maxWidth: 480, width: '90%' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 style={{ marginBottom: '0.5rem' }}>Save as template</h2>
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '1rem' }}>
+          Captures this set&rsquo;s curve, vibe windows, and target settings — not its tracks —
+          so you can reuse the structure with a fresh pool.
+        </p>
+
+        {error && (
+          <p style={{ color: 'var(--color-danger)', fontSize: '0.875rem', marginBottom: '0.75rem' }}>
+            {error}
+          </p>
+        )}
+
+        <div className="form-group">
+          <label htmlFor="templateName">Template name</label>
+          <input
+            id="templateName"
+            type="text"
+            className="input"
+            value={name}
+            maxLength={MAX_NAME_LENGTH}
+            autoFocus
+            required
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
+          <button type="button" className="btn btn-primary" disabled={!canSave} onClick={save}>
+            {busy ? 'Saving…' : 'Save template'}
+          </button>
+          <button
+            type="button"
+            className="btn"
+            style={{ background: 'var(--surface-raised)' }}
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/SaveAsTemplateDialog.tsx
+++ b/dashboard/app/(dj)/setbuilder/SaveAsTemplateDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { api } from '@/lib/api';
 import type { SetSummary, SetTemplate } from '@/lib/api-types';
 
@@ -31,6 +31,15 @@ export default function SaveAsTemplateDialog({ set, onClose, onSaved }: SaveAsTe
     if (!busy) onClose();
   };
 
+  // Escape dismissal for keyboard-only users, same lock as closeIfIdle.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !busy) onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [busy, onClose]);
+
   const save = async () => {
     if (!canSave) return;
     setBusy(true);
@@ -47,6 +56,7 @@ export default function SaveAsTemplateDialog({ set, onClose, onSaved }: SaveAsTe
   return (
     <div
       role="dialog"
+      aria-modal="true"
       aria-label={`Save ${set.name} as template`}
       style={{
         position: 'fixed',

--- a/dashboard/app/(dj)/setbuilder/SetActionsMenu.tsx
+++ b/dashboard/app/(dj)/setbuilder/SetActionsMenu.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { api } from '@/lib/api';
 import type { SetDetail } from '@/lib/api-types';
 import ShareDialog from './ShareDialog';
+import SaveAsTemplateDialog from './SaveAsTemplateDialog';
 import ExportModal from './components/ExportModal';
 
 interface SetActionsMenuProps {
@@ -15,11 +16,13 @@ interface SetActionsMenuProps {
   onSetUpdated: (patch: Partial<SetDetail>) => void;
 }
 
-/** Export + Duplicate + Share actions for the builder topbar. */
+/** Export + Duplicate + Save-as-Template + Share actions for the builder topbar. */
 export default function SetActionsMenu({ set, onShareChanged, onSetUpdated }: SetActionsMenuProps) {
   const router = useRouter();
   const [shareOpen, setShareOpen] = useState(false);
   const [exportOpen, setExportOpen] = useState(false);
+  const [templateDialogOpen, setTemplateDialogOpen] = useState(false);
+  const [templateSaved, setTemplateSaved] = useState(false);
   const [duplicating, setDuplicating] = useState(false);
   const [error, setError] = useState(false);
 
@@ -39,6 +42,9 @@ export default function SetActionsMenu({ set, onShareChanged, onSetUpdated }: Se
     <span style={{ display: 'inline-flex', gap: '0.5rem', alignItems: 'center' }}>
       {error && (
         <span style={{ color: 'var(--color-danger)', fontSize: '0.75rem' }}>Duplicate failed</span>
+      )}
+      {templateSaved && (
+        <span style={{ color: 'var(--text-secondary)', fontSize: '0.75rem' }}>Saved as template</span>
       )}
       <button
         type="button"
@@ -61,6 +67,17 @@ export default function SetActionsMenu({ set, onShareChanged, onSetUpdated }: Se
         type="button"
         className="btn btn-sm"
         style={{ background: 'var(--surface-raised)' }}
+        onClick={() => {
+          setTemplateSaved(false);
+          setTemplateDialogOpen(true);
+        }}
+      >
+        Save as Template
+      </button>
+      <button
+        type="button"
+        className="btn btn-sm"
+        style={{ background: 'var(--surface-raised)' }}
         onClick={() => setShareOpen(true)}
       >
         {set.share_token ? 'Shared' : 'Share'}
@@ -74,6 +91,16 @@ export default function SetActionsMenu({ set, onShareChanged, onSetUpdated }: Se
       )}
       {shareOpen && (
         <ShareDialog set={set} onClose={() => setShareOpen(false)} onChanged={onShareChanged} />
+      )}
+      {templateDialogOpen && (
+        <SaveAsTemplateDialog
+          set={set}
+          onClose={() => setTemplateDialogOpen(false)}
+          onSaved={() => {
+            setTemplateDialogOpen(false);
+            setTemplateSaved(true);
+          }}
+        />
       )}
     </span>
   );

--- a/dashboard/app/(dj)/setbuilder/TemplateGalleryDialog.tsx
+++ b/dashboard/app/(dj)/setbuilder/TemplateGalleryDialog.tsx
@@ -69,9 +69,19 @@ export default function TemplateGalleryDialog({ onClose, onInstantiated }: Templ
     if (!mutating) onClose();
   };
 
+  // Escape dismissal for keyboard-only users, same lock as closeIfIdle.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !mutating) onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [mutating, onClose]);
+
   return (
     <div
       role="dialog"
+      aria-modal="true"
       aria-label="Start a set from a template"
       style={{
         position: 'fixed',

--- a/dashboard/app/(dj)/setbuilder/TemplateGalleryDialog.tsx
+++ b/dashboard/app/(dj)/setbuilder/TemplateGalleryDialog.tsx
@@ -31,7 +31,13 @@ export default function TemplateGalleryDialog({ onClose, onInstantiated }: Templ
       .finally(() => setLoading(false));
   }, []);
 
+  // One mutation at a time for the whole dialog: per-card busy state alone
+  // still leaves every OTHER card's buttons live, so a second click could
+  // create a duplicate set or delete a template mid-instantiate.
+  const mutating = instantiatingId !== null || deletingId !== null;
+
   const instantiate = async (templateId: number) => {
+    if (mutating) return;
     setInstantiatingId(templateId);
     setError(null);
     try {
@@ -44,6 +50,7 @@ export default function TemplateGalleryDialog({ onClose, onInstantiated }: Templ
   };
 
   const remove = async (template: SetTemplate) => {
+    if (mutating) return;
     if (!window.confirm(`Delete the "${template.name}" template? This cannot be undone.`)) return;
     setDeletingId(template.id);
     setError(null);
@@ -55,6 +62,11 @@ export default function TemplateGalleryDialog({ onClose, onInstantiated }: Templ
     } finally {
       setDeletingId(null);
     }
+  };
+
+  /** Ignore backdrop/Close while a mutation is in flight. */
+  const closeIfIdle = () => {
+    if (!mutating) onClose();
   };
 
   return (
@@ -70,7 +82,7 @@ export default function TemplateGalleryDialog({ onClose, onInstantiated }: Templ
         justifyContent: 'center',
         zIndex: 100,
       }}
-      onClick={onClose}
+      onClick={closeIfIdle}
     >
       <div
         className="card"
@@ -109,6 +121,7 @@ export default function TemplateGalleryDialog({ onClose, onInstantiated }: Templ
                 template={template}
                 busyInstantiate={instantiatingId === template.id}
                 busyDelete={deletingId === template.id}
+                locked={mutating}
                 onInstantiate={() => instantiate(template.id)}
                 onDelete={() => remove(template)}
               />
@@ -121,7 +134,8 @@ export default function TemplateGalleryDialog({ onClose, onInstantiated }: Templ
             type="button"
             className="btn"
             style={{ background: 'var(--surface-raised)' }}
-            onClick={onClose}
+            disabled={mutating}
+            onClick={closeIfIdle}
           >
             Close
           </button>
@@ -135,11 +149,20 @@ interface TemplateCardProps {
   template: SetTemplate;
   busyInstantiate: boolean;
   busyDelete: boolean;
+  /** True while ANY card in the dialog is mutating — disables every action. */
+  locked: boolean;
   onInstantiate: () => void;
   onDelete: () => void;
 }
 
-function TemplateCard({ template, busyInstantiate, busyDelete, onInstantiate, onDelete }: TemplateCardProps) {
+function TemplateCard({
+  template,
+  busyInstantiate,
+  busyDelete,
+  locked,
+  onInstantiate,
+  onDelete,
+}: TemplateCardProps) {
   return (
     <div className="card" style={{ background: 'var(--surface-raised)', padding: '0.75rem 1rem' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
@@ -155,13 +178,13 @@ function TemplateCard({ template, busyInstantiate, busyDelete, onInstantiate, on
           <button
             type="button"
             className="btn btn-sm btn-primary"
-            disabled={busyInstantiate}
+            disabled={locked}
             onClick={onInstantiate}
           >
             {busyInstantiate ? 'Creating…' : 'Use template'}
           </button>
-          <button type="button" className="btn btn-sm btn-danger" disabled={busyDelete} onClick={onDelete}>
-            Delete
+          <button type="button" className="btn btn-sm btn-danger" disabled={locked} onClick={onDelete}>
+            {busyDelete ? 'Deleting…' : 'Delete'}
           </button>
         </div>
       </div>

--- a/dashboard/app/(dj)/setbuilder/TemplateGalleryDialog.tsx
+++ b/dashboard/app/(dj)/setbuilder/TemplateGalleryDialog.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { api } from '@/lib/api';
+import type { SetDetail, SetTemplate } from '@/lib/api-types';
+
+interface TemplateGalleryDialogProps {
+  onClose: () => void;
+  /** Called with the freshly instantiated set so the caller can route to it. */
+  onInstantiated: (set: SetDetail) => void;
+}
+
+/**
+ * Per-DJ gallery of saved set templates, shown alongside the new-set flow. Instantiating a
+ * template creates a fresh draft set pre-seeded with its curve/vibe/target structure and
+ * empty (track_id=null) slots, ready for pool import + recompute. See
+ * `server/app/services/setbuilder/set_templates.py:instantiate_template`.
+ */
+export default function TemplateGalleryDialog({ onClose, onInstantiated }: TemplateGalleryDialogProps) {
+  const [templates, setTemplates] = useState<SetTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [instantiatingId, setInstantiatingId] = useState<number | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+
+  useEffect(() => {
+    api
+      .listSetTemplates()
+      .then((res) => setTemplates(res.templates))
+      .catch(() => setError('Failed to load templates'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const instantiate = async (templateId: number) => {
+    setInstantiatingId(templateId);
+    setError(null);
+    try {
+      const created = await api.instantiateSetTemplate(templateId);
+      onInstantiated(created);
+    } catch {
+      setError('Failed to create set from template');
+      setInstantiatingId(null);
+    }
+  };
+
+  const remove = async (template: SetTemplate) => {
+    if (!window.confirm(`Delete the "${template.name}" template? This cannot be undone.`)) return;
+    setDeletingId(template.id);
+    setError(null);
+    try {
+      await api.deleteSetTemplate(template.id);
+      setTemplates((prev) => prev.filter((t) => t.id !== template.id));
+    } catch {
+      setError('Failed to delete template');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Start a set from a template"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0, 0, 0, 0.6)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 100,
+      }}
+      onClick={onClose}
+    >
+      <div
+        className="card"
+        style={{
+          maxWidth: 560,
+          width: '90%',
+          maxHeight: '80vh',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 style={{ marginBottom: '0.5rem' }}>Start from a template</h2>
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '1rem' }}>
+          Creates a new draft set pre-seeded with a saved curve, vibe windows, and target
+          settings — ready for pool import.
+        </p>
+
+        {error && (
+          <p style={{ color: 'var(--color-danger)', fontSize: '0.875rem', marginBottom: '0.75rem' }}>
+            {error}
+          </p>
+        )}
+
+        {loading ? (
+          <div className="loading">Loading templates...</div>
+        ) : templates.length === 0 ? (
+          <p style={{ color: 'var(--text-secondary)' }}>
+            No templates saved yet. Save a set as a template to reuse its structure here.
+          </p>
+        ) : (
+          <div style={{ overflowY: 'auto', display: 'grid', gap: '0.75rem' }}>
+            {templates.map((template) => (
+              <TemplateCard
+                key={template.id}
+                template={template}
+                busyInstantiate={instantiatingId === template.id}
+                busyDelete={deletingId === template.id}
+                onInstantiate={() => instantiate(template.id)}
+                onDelete={() => remove(template)}
+              />
+            ))}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
+          <button
+            type="button"
+            className="btn"
+            style={{ background: 'var(--surface-raised)' }}
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface TemplateCardProps {
+  template: SetTemplate;
+  busyInstantiate: boolean;
+  busyDelete: boolean;
+  onInstantiate: () => void;
+  onDelete: () => void;
+}
+
+function TemplateCard({ template, busyInstantiate, busyDelete, onInstantiate, onDelete }: TemplateCardProps) {
+  return (
+    <div className="card" style={{ background: 'var(--surface-raised)', padding: '0.75rem 1rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
+        <div>
+          <h3 style={{ fontSize: '1rem', marginBottom: '0.25rem' }}>{template.name}</h3>
+          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+            <span className="badge">{template.slot_count} slots</span>
+            <span className="badge">{template.curve_points.length} curve points</span>
+            {template.vibe_theme && <span className="badge">{template.vibe_theme}</span>}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'flex-start' }}>
+          <button
+            type="button"
+            className="btn btn-sm btn-primary"
+            disabled={busyInstantiate}
+            onClick={onInstantiate}
+          >
+            {busyInstantiate ? 'Creating…' : 'Use template'}
+          </button>
+          <button type="button" className="btn btn-sm btn-danger" disabled={busyDelete} onClick={onDelete}>
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/(dj)/setbuilder/__tests__/SaveAsTemplateDialog.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/SaveAsTemplateDialog.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import SaveAsTemplateDialog from '../SaveAsTemplateDialog';
+import type { SetSummary, SetTemplate } from '@/lib/api-types';
+
+const mockSaveSetAsTemplate = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    saveSetAsTemplate: (id: number, name: string) => mockSaveSetAsTemplate(id, name),
+  },
+}));
+
+function makeSet(overrides: Partial<SetSummary> = {}): SetSummary {
+  return {
+    id: 7,
+    name: 'Friday Wedding',
+    event_id: null,
+    status: 'draft',
+    sharing_mode: 'private',
+    share_token: null,
+    created_at: '2026-06-07T00:00:00Z',
+    updated_at: '2026-06-07T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeTemplate(overrides: Partial<SetTemplate> = {}): SetTemplate {
+  return {
+    id: 3,
+    name: 'Friday Wedding',
+    vibe_theme: null,
+    target_duration_sec: null,
+    avg_transition_overlap_sec: 8,
+    bpm_floor: null,
+    bpm_ceiling: null,
+    key_strictness: 0.2,
+    slot_count: 0,
+    curve_points: [],
+    created_at: '2026-06-07T00:00:00Z',
+    updated_at: '2026-06-07T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('SaveAsTemplateDialog', () => {
+  beforeEach(() => {
+    mockSaveSetAsTemplate.mockReset();
+  });
+
+  it('pre-fills the name field with the set name', () => {
+    render(<SaveAsTemplateDialog set={makeSet()} onClose={vi.fn()} onSaved={vi.fn()} />);
+    expect(screen.getByDisplayValue('Friday Wedding')).toBeInTheDocument();
+  });
+
+  it('saves the trimmed name and calls onSaved with the new template', async () => {
+    mockSaveSetAsTemplate.mockResolvedValue(makeTemplate());
+    const onSaved = vi.fn();
+    render(<SaveAsTemplateDialog set={makeSet()} onClose={vi.fn()} onSaved={onSaved} />);
+
+    const input = screen.getByLabelText(/template name/i);
+    fireEvent.change(input, { target: { value: '  Peak Hour Arc  ' } });
+    fireEvent.click(screen.getByRole('button', { name: /save template/i }));
+
+    await waitFor(() => {
+      expect(mockSaveSetAsTemplate).toHaveBeenCalledWith(7, 'Peak Hour Arc');
+    });
+    expect(onSaved).toHaveBeenCalledWith(makeTemplate());
+  });
+
+  it('disables save when the name is blank', () => {
+    render(<SaveAsTemplateDialog set={makeSet()} onClose={vi.fn()} onSaved={vi.fn()} />);
+    const input = screen.getByLabelText(/template name/i);
+    fireEvent.change(input, { target: { value: '   ' } });
+    expect(screen.getByRole('button', { name: /save template/i })).toBeDisabled();
+  });
+
+  it('shows an error and keeps the dialog open when the save fails', async () => {
+    mockSaveSetAsTemplate.mockRejectedValue(new Error('boom'));
+    const onSaved = vi.fn();
+    render(<SaveAsTemplateDialog set={makeSet()} onClose={vi.fn()} onSaved={onSaved} />);
+    fireEvent.click(screen.getByRole('button', { name: /save template/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to save template/i)).toBeInTheDocument();
+    });
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose without saving when cancelled', () => {
+    const onClose = vi.fn();
+    render(<SaveAsTemplateDialog set={makeSet()} onClose={onClose} onSaved={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+    expect(mockSaveSetAsTemplate).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/__tests__/SaveAsTemplateDialog.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/SaveAsTemplateDialog.test.tsx
@@ -93,4 +93,37 @@ describe('SaveAsTemplateDialog', () => {
     expect(onClose).toHaveBeenCalled();
     expect(mockSaveSetAsTemplate).not.toHaveBeenCalled();
   });
+
+  it('closes on Escape when idle', () => {
+    const onClose = vi.fn();
+    render(<SaveAsTemplateDialog set={makeSet()} onClose={onClose} onSaved={vi.fn()} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockSaveSetAsTemplate).not.toHaveBeenCalled();
+  });
+
+  it('locks Cancel, backdrop, and Escape while the save is in flight', async () => {
+    let resolveSave: (t: SetTemplate) => void = () => {};
+    mockSaveSetAsTemplate.mockReturnValue(
+      new Promise<SetTemplate>((resolve) => {
+        resolveSave = resolve;
+      })
+    );
+    const onClose = vi.fn();
+    const onSaved = vi.fn();
+    render(<SaveAsTemplateDialog set={makeSet()} onClose={onClose} onSaved={onSaved} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /save template/i }));
+    await waitFor(() => expect(mockSaveSetAsTemplate).toHaveBeenCalledTimes(1));
+
+    const cancel = screen.getByRole('button', { name: /cancel/i });
+    expect(cancel).toBeDisabled();
+    fireEvent.click(cancel);
+    fireEvent.click(screen.getByRole('dialog'));
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+
+    resolveSave(makeTemplate());
+    await waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1));
+  });
 });

--- a/dashboard/app/(dj)/setbuilder/__tests__/TemplateGalleryDialog.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/TemplateGalleryDialog.test.tsx
@@ -59,6 +59,8 @@ function makeSetDetail(overrides: Partial<SetDetail> = {}): SetDetail {
 
 describe('TemplateGalleryDialog', () => {
   beforeEach(() => {
+    // Restore window.confirm spies so one test's stub can't leak into the next.
+    vi.restoreAllMocks();
     mockListSetTemplates.mockReset();
     mockInstantiateSetTemplate.mockReset();
     mockDeleteSetTemplate.mockReset();
@@ -173,6 +175,9 @@ describe('TemplateGalleryDialog', () => {
     mockListSetTemplates.mockResolvedValue({
       templates: [makeTemplate({ id: 1, name: 'First Arc' }), makeTemplate({ id: 2, name: 'Second Arc' })],
     });
+    // Confirm must say YES here: with it stubbed true, the delete assertion
+    // below can only pass because of the mutation lock, not a declined dialog.
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     let resolveInstantiate: (v: SetDetail) => void = () => {};
     mockInstantiateSetTemplate.mockReturnValue(
       new Promise<SetDetail>((resolve) => {
@@ -200,11 +205,22 @@ describe('TemplateGalleryDialog', () => {
     expect(mockInstantiateSetTemplate).toHaveBeenCalledTimes(1);
     expect(mockDeleteSetTemplate).not.toHaveBeenCalled();
 
-    // Close is inert while mutating.
+    // Close and Escape are inert while mutating.
     fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    fireEvent.keyDown(window, { key: 'Escape' });
     expect(onClose).not.toHaveBeenCalled();
 
     resolveInstantiate(makeSetDetail());
     await waitFor(() => expect(onInstantiated).toHaveBeenCalledTimes(1));
+  });
+
+  it('closes on Escape when idle', async () => {
+    mockListSetTemplates.mockResolvedValue({ templates: [] });
+    const onClose = vi.fn();
+    render(<TemplateGalleryDialog onClose={onClose} onInstantiated={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText(/no templates saved yet/i)).toBeInTheDocument());
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/dashboard/app/(dj)/setbuilder/__tests__/TemplateGalleryDialog.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/TemplateGalleryDialog.test.tsx
@@ -167,4 +167,44 @@ describe('TemplateGalleryDialog', () => {
     expect(mockInstantiateSetTemplate).not.toHaveBeenCalled();
     expect(mockDeleteSetTemplate).not.toHaveBeenCalled();
   });
+  it('locks every card while one instantiation is in flight, so no duplicate set is created', async () => {
+    // Two cards: per-card busy state alone would leave the SECOND card's
+    // buttons live while the first is still creating a set.
+    mockListSetTemplates.mockResolvedValue({
+      templates: [makeTemplate({ id: 1, name: 'First Arc' }), makeTemplate({ id: 2, name: 'Second Arc' })],
+    });
+    let resolveInstantiate: (v: SetDetail) => void = () => {};
+    mockInstantiateSetTemplate.mockReturnValue(
+      new Promise<SetDetail>((resolve) => {
+        resolveInstantiate = resolve;
+      })
+    );
+    const onInstantiated = vi.fn();
+    const onClose = vi.fn();
+    render(<TemplateGalleryDialog onClose={onClose} onInstantiated={onInstantiated} />);
+
+    await waitFor(() => expect(screen.getByText('First Arc')).toBeInTheDocument());
+    const useButtons = screen.getAllByRole('button', { name: /use template/i });
+    fireEvent.click(useButtons[0]);
+
+    await waitFor(() => expect(mockInstantiateSetTemplate).toHaveBeenCalledTimes(1));
+
+    // Every action — including the other card's and the delete buttons — is disabled.
+    screen
+      .getAllByRole('button', { name: /use template|creating|delete/i })
+      .forEach((btn) => expect(btn).toBeDisabled());
+
+    // Clicking the second card again must not fire a second request.
+    fireEvent.click(useButtons[1]);
+    fireEvent.click(screen.getAllByRole('button', { name: /delete/i })[0]);
+    expect(mockInstantiateSetTemplate).toHaveBeenCalledTimes(1);
+    expect(mockDeleteSetTemplate).not.toHaveBeenCalled();
+
+    // Close is inert while mutating.
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).not.toHaveBeenCalled();
+
+    resolveInstantiate(makeSetDetail());
+    await waitFor(() => expect(onInstantiated).toHaveBeenCalledTimes(1));
+  });
 });

--- a/dashboard/app/(dj)/setbuilder/__tests__/TemplateGalleryDialog.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/TemplateGalleryDialog.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import TemplateGalleryDialog from '../TemplateGalleryDialog';
+import type { SetDetail, SetTemplate } from '@/lib/api-types';
+
+const mockListSetTemplates = vi.fn();
+const mockInstantiateSetTemplate = vi.fn();
+const mockDeleteSetTemplate = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    listSetTemplates: () => mockListSetTemplates(),
+    instantiateSetTemplate: (id: number) => mockInstantiateSetTemplate(id),
+    deleteSetTemplate: (id: number) => mockDeleteSetTemplate(id),
+  },
+}));
+
+function makeTemplate(overrides: Partial<SetTemplate> = {}): SetTemplate {
+  return {
+    id: 3,
+    name: 'Peak Hour Arc',
+    vibe_theme: null,
+    target_duration_sec: 3600,
+    avg_transition_overlap_sec: 8,
+    bpm_floor: null,
+    bpm_ceiling: null,
+    key_strictness: 0.2,
+    slot_count: 12,
+    curve_points: [
+      { position_sec: 0, energy: 3, label: null, is_slow_window_start: false, is_slow_window_end: false },
+      { position_sec: 1800, energy: 8, label: 'Peak', is_slow_window_start: false, is_slow_window_end: false },
+    ],
+    created_at: '2026-06-07T00:00:00Z',
+    updated_at: '2026-06-07T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeSetDetail(overrides: Partial<SetDetail> = {}): SetDetail {
+  return {
+    id: 9,
+    name: 'Peak Hour Arc',
+    event_id: null,
+    status: 'draft',
+    sharing_mode: 'private',
+    share_token: null,
+    created_at: '2026-06-08T00:00:00Z',
+    updated_at: '2026-06-08T00:00:00Z',
+    vibe_theme: null,
+    target_duration_sec: 3600,
+    avg_transition_overlap_sec: 8,
+    bpm_floor: null,
+    bpm_ceiling: null,
+    key_strictness: 0.2,
+    tidal_playlist_id: null,
+    exported_at: null,
+    ...overrides,
+  };
+}
+
+describe('TemplateGalleryDialog', () => {
+  beforeEach(() => {
+    mockListSetTemplates.mockReset();
+    mockInstantiateSetTemplate.mockReset();
+    mockDeleteSetTemplate.mockReset();
+  });
+
+  it('shows a loading state while the gallery fetches', () => {
+    mockListSetTemplates.mockReturnValue(new Promise(() => {}));
+    render(<TemplateGalleryDialog onClose={vi.fn()} onInstantiated={vi.fn()} />);
+    expect(screen.getByText(/loading templates/i)).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no saved templates', async () => {
+    mockListSetTemplates.mockResolvedValue({ templates: [] });
+    render(<TemplateGalleryDialog onClose={vi.fn()} onInstantiated={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/no templates saved yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders template cards with slot and curve-point counts', async () => {
+    mockListSetTemplates.mockResolvedValue({ templates: [makeTemplate()] });
+    render(<TemplateGalleryDialog onClose={vi.fn()} onInstantiated={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText('Peak Hour Arc')).toBeInTheDocument();
+      expect(screen.getByText('12 slots')).toBeInTheDocument();
+      expect(screen.getByText('2 curve points')).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error when the gallery fails to load', async () => {
+    mockListSetTemplates.mockRejectedValue(new Error('boom'));
+    render(<TemplateGalleryDialog onClose={vi.fn()} onInstantiated={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load templates/i)).toBeInTheDocument();
+    });
+  });
+
+  it('instantiates a template and calls onInstantiated with the new set', async () => {
+    mockListSetTemplates.mockResolvedValue({ templates: [makeTemplate()] });
+    mockInstantiateSetTemplate.mockResolvedValue(makeSetDetail());
+    const onInstantiated = vi.fn();
+    render(<TemplateGalleryDialog onClose={vi.fn()} onInstantiated={onInstantiated} />);
+
+    await waitFor(() => expect(screen.getByText('Peak Hour Arc')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /use template/i }));
+
+    await waitFor(() => {
+      expect(mockInstantiateSetTemplate).toHaveBeenCalledWith(3);
+      expect(onInstantiated).toHaveBeenCalledWith(makeSetDetail());
+    });
+  });
+
+  it('shows an error and does not call onInstantiated when instantiate fails', async () => {
+    mockListSetTemplates.mockResolvedValue({ templates: [makeTemplate()] });
+    mockInstantiateSetTemplate.mockRejectedValue(new Error('boom'));
+    const onInstantiated = vi.fn();
+    render(<TemplateGalleryDialog onClose={vi.fn()} onInstantiated={onInstantiated} />);
+
+    await waitFor(() => expect(screen.getByText('Peak Hour Arc')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /use template/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to create set from template/i)).toBeInTheDocument();
+    });
+    expect(onInstantiated).not.toHaveBeenCalled();
+  });
+
+  it('deletes a template after confirmation and removes it from the list', async () => {
+    mockListSetTemplates.mockResolvedValue({ templates: [makeTemplate()] });
+    mockDeleteSetTemplate.mockResolvedValue(undefined);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<TemplateGalleryDialog onClose={vi.fn()} onInstantiated={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText('Peak Hour Arc')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+
+    await waitFor(() => {
+      expect(mockDeleteSetTemplate).toHaveBeenCalledWith(3);
+      expect(screen.queryByText('Peak Hour Arc')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not delete the template when the confirmation is cancelled', async () => {
+    mockListSetTemplates.mockResolvedValue({ templates: [makeTemplate()] });
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<TemplateGalleryDialog onClose={vi.fn()} onInstantiated={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText('Peak Hour Arc')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+
+    await waitFor(() => {
+      expect(mockDeleteSetTemplate).not.toHaveBeenCalled();
+      expect(screen.getByText('Peak Hour Arc')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onClose without any API side effects when Close is clicked', async () => {
+    mockListSetTemplates.mockResolvedValue({ templates: [] });
+    const onClose = vi.fn();
+    render(<TemplateGalleryDialog onClose={onClose} onInstantiated={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText(/no templates saved yet/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+
+    expect(onClose).toHaveBeenCalled();
+    expect(mockInstantiateSetTemplate).not.toHaveBeenCalled();
+    expect(mockDeleteSetTemplate).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/app/(dj)/setbuilder/__tests__/page.test.tsx
+++ b/dashboard/app/(dj)/setbuilder/__tests__/page.test.tsx
@@ -2,8 +2,9 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import SetbuilderPage from '../page';
 
+const mockPush = vi.fn();
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: mockPush }),
 }));
 
 vi.mock('next/link', () => ({
@@ -17,6 +18,9 @@ const mockRenameSet = vi.fn();
 const mockDuplicateSet = vi.fn();
 const mockGetTasteProfile = vi.fn();
 const mockResetTasteProfile = vi.fn();
+const mockListSetTemplates = vi.fn();
+const mockInstantiateSetTemplate = vi.fn();
+const mockDeleteSetTemplate = vi.fn();
 vi.mock('@/lib/api', () => ({
   api: {
     listSets: () => mockListSets(),
@@ -28,6 +32,9 @@ vi.mock('@/lib/api', () => ({
     duplicateSet: (id: number) => mockDuplicateSet(id),
     shareSet: vi.fn(),
     revokeSetShare: vi.fn(),
+    listSetTemplates: () => mockListSetTemplates(),
+    instantiateSetTemplate: (id: number) => mockInstantiateSetTemplate(id),
+    deleteSetTemplate: (id: number) => mockDeleteSetTemplate(id),
   },
 }));
 
@@ -43,11 +50,15 @@ vi.mock('@/components/ThemeToggle', () => ({
 
 describe('SetbuilderPage', () => {
   beforeEach(() => {
+    mockPush.mockReset();
     mockListSets.mockReset();
     mockRenameSet.mockReset();
     mockDuplicateSet.mockReset();
     mockGetTasteProfile.mockReset();
     mockResetTasteProfile.mockReset();
+    mockListSetTemplates.mockReset();
+    mockInstantiateSetTemplate.mockReset();
+    mockDeleteSetTemplate.mockReset();
     mockGetTasteProfile.mockResolvedValue({
       sample_count: 0,
       min_samples: 5,
@@ -267,6 +278,89 @@ describe('SetbuilderPage', () => {
     await waitFor(() => {
       expect(mockDuplicateSet).toHaveBeenCalledWith(1);
       expect(screen.getByText('Friday Wedding (copy)')).toBeInTheDocument();
+    });
+  });
+
+  it('opens the template gallery and fetches templates when "From Template" is clicked', async () => {
+    mockListSets.mockResolvedValue([]);
+    mockListSetTemplates.mockResolvedValue({
+      templates: [
+        {
+          id: 3,
+          name: 'Peak Hour Arc',
+          vibe_theme: null,
+          target_duration_sec: 3600,
+          avg_transition_overlap_sec: 8,
+          bpm_floor: null,
+          bpm_ceiling: null,
+          key_strictness: 0.2,
+          slot_count: 12,
+          curve_points: [],
+          created_at: '2026-06-07T00:00:00Z',
+          updated_at: '2026-06-07T00:00:00Z',
+        },
+      ],
+    });
+    render(<SetbuilderPage />);
+    await waitFor(() => expect(screen.getByText(/no sets yet/i)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /from template/i }));
+
+    await waitFor(() => {
+      expect(mockListSetTemplates).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('Peak Hour Arc')).toBeInTheDocument();
+    });
+  });
+
+  it('instantiates a template and navigates to the newly created set', async () => {
+    mockListSets.mockResolvedValue([]);
+    mockListSetTemplates.mockResolvedValue({
+      templates: [
+        {
+          id: 3,
+          name: 'Peak Hour Arc',
+          vibe_theme: null,
+          target_duration_sec: 3600,
+          avg_transition_overlap_sec: 8,
+          bpm_floor: null,
+          bpm_ceiling: null,
+          key_strictness: 0.2,
+          slot_count: 12,
+          curve_points: [],
+          created_at: '2026-06-07T00:00:00Z',
+          updated_at: '2026-06-07T00:00:00Z',
+        },
+      ],
+    });
+    mockInstantiateSetTemplate.mockResolvedValue({
+      id: 9,
+      name: 'Peak Hour Arc',
+      event_id: null,
+      status: 'draft',
+      sharing_mode: 'private',
+      share_token: null,
+      created_at: '2026-06-08T00:00:00Z',
+      updated_at: '2026-06-08T00:00:00Z',
+      vibe_theme: null,
+      target_duration_sec: 3600,
+      avg_transition_overlap_sec: 8,
+      bpm_floor: null,
+      bpm_ceiling: null,
+      key_strictness: 0.2,
+      tidal_playlist_id: null,
+      exported_at: null,
+    });
+
+    render(<SetbuilderPage />);
+    await waitFor(() => expect(screen.getByText(/no sets yet/i)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /from template/i }));
+    await waitFor(() => expect(screen.getByText('Peak Hour Arc')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /use template/i }));
+
+    await waitFor(() => {
+      expect(mockInstantiateSetTemplate).toHaveBeenCalledWith(3);
+      expect(mockPush).toHaveBeenCalledWith('/setbuilder/9');
     });
   });
 });

--- a/dashboard/app/(dj)/setbuilder/page.tsx
+++ b/dashboard/app/(dj)/setbuilder/page.tsx
@@ -5,9 +5,10 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
 import { api } from '@/lib/api';
-import type { SetSummary, TasteProfile } from '@/lib/api-types';
+import type { SetDetail, SetSummary, TasteProfile } from '@/lib/api-types';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import ShareDialog from './ShareDialog';
+import TemplateGalleryDialog from './TemplateGalleryDialog';
 
 export default function SetbuilderPage() {
   const { isAuthenticated, isLoading, role } = useAuth();
@@ -21,6 +22,7 @@ export default function SetbuilderPage() {
   const [renameValue, setRenameValue] = useState('');
   const [savingRename, setSavingRename] = useState(false);
   const [shareTarget, setShareTarget] = useState<SetSummary | null>(null);
+  const [showTemplateGallery, setShowTemplateGallery] = useState(false);
   const [tasteProfile, setTasteProfile] = useState<TasteProfile | null>(null);
   const [resettingProfile, setResettingProfile] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -80,6 +82,11 @@ export default function SetbuilderPage() {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to duplicate set');
     }
+  };
+
+  const handleInstantiated = (created: SetDetail) => {
+    setShowTemplateGallery(false);
+    router.push(`/setbuilder/${created.id}`);
   };
 
   const handleShareChanged = (id: number, token: string | null) => {
@@ -167,6 +174,13 @@ export default function SetbuilderPage() {
           </Link>
           <button className="btn btn-primary" onClick={() => setShowCreate(true)}>
             New Set
+          </button>
+          <button
+            className="btn"
+            style={{ background: 'var(--surface-raised)' }}
+            onClick={() => setShowTemplateGallery(true)}
+          >
+            From Template
           </button>
           <ThemeToggle />
         </div>
@@ -352,6 +366,13 @@ export default function SetbuilderPage() {
           set={shareTarget}
           onClose={() => setShareTarget(null)}
           onChanged={(token) => handleShareChanged(shareTarget.id, token)}
+        />
+      )}
+
+      {showTemplateGallery && (
+        <TemplateGalleryDialog
+          onClose={() => setShowTemplateGallery(false)}
+          onInstantiated={handleInstantiated}
         />
       )}
     </div>

--- a/dashboard/lib/__tests__/api.test.ts
+++ b/dashboard/lib/__tests__/api.test.ts
@@ -175,6 +175,122 @@ describe('ApiClient', () => {
     });
   });
 
+  describe('setbuilder templates API (issue #407)', () => {
+    it('saveSetAsTemplate POSTs the name to save-as-template', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 7,
+          name: 'Peak Hour Arc',
+          vibe_theme: null,
+          target_duration_sec: 3600,
+          avg_transition_overlap_sec: 8,
+          bpm_floor: null,
+          bpm_ceiling: null,
+          key_strictness: 0.2,
+          slot_count: 12,
+          curve_points: [],
+          created_at: '2026-07-27T00:00:00Z',
+          updated_at: '2026-07-27T00:00:00Z',
+        }),
+      });
+
+      const tpl = await api.saveSetAsTemplate(42, 'Peak Hour Arc');
+
+      expect(tpl.id).toBe(7);
+      expect(tpl.slot_count).toBe(12);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/setbuilder/sets/42/save-as-template');
+      expect(options.method).toBe('POST');
+      expect(JSON.parse(options.body)).toEqual({ name: 'Peak Hour Arc' });
+    });
+
+    it('listSetTemplates GETs the gallery and returns it even when empty', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ templates: [] }),
+      });
+
+      const result = await api.listSetTemplates();
+
+      expect(result.templates).toEqual([]);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/setbuilder/set-templates');
+      expect(options.method).toBeUndefined();
+    });
+
+    it('instantiateSetTemplate POSTs optional name + event_id', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 99,
+          name: 'Peak Hour Arc',
+          event_id: 5,
+          status: 'draft',
+          sharing_mode: 'private',
+          share_token: null,
+          created_at: '2026-07-27T00:00:00Z',
+          updated_at: '2026-07-27T00:00:00Z',
+          vibe_theme: null,
+          target_duration_sec: 3600,
+          avg_transition_overlap_sec: 8,
+          bpm_floor: null,
+          bpm_ceiling: null,
+          key_strictness: 0.2,
+          tidal_playlist_id: null,
+          exported_at: null,
+        }),
+      });
+
+      const newSet = await api.instantiateSetTemplate(7, 'Friday Night', 5);
+
+      expect(newSet.id).toBe(99);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/setbuilder/set-templates/7/instantiate');
+      expect(options.method).toBe('POST');
+      expect(JSON.parse(options.body)).toEqual({ name: 'Friday Night', event_id: 5 });
+    });
+
+    it('instantiateSetTemplate omits name/event_id as null when not passed', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 100,
+          name: 'Peak Hour Arc',
+          event_id: null,
+          status: 'draft',
+          sharing_mode: 'private',
+          share_token: null,
+          created_at: '2026-07-27T00:00:00Z',
+          updated_at: '2026-07-27T00:00:00Z',
+          vibe_theme: null,
+          target_duration_sec: null,
+          avg_transition_overlap_sec: 8,
+          bpm_floor: null,
+          bpm_ceiling: null,
+          key_strictness: 0.2,
+          tidal_playlist_id: null,
+          exported_at: null,
+        }),
+      });
+
+      await api.instantiateSetTemplate(7);
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(JSON.parse(options.body)).toEqual({ name: null, event_id: null });
+    });
+
+    it('deleteSetTemplate sends DELETE with no body', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true });
+
+      await api.deleteSetTemplate(7);
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain('/api/setbuilder/set-templates/7');
+      expect(options.method).toBe('DELETE');
+    });
+  });
+
   describe('search', () => {
     it('encodes search query properly', async () => {
       mockFetch.mockResolvedValueOnce({

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -5359,7 +5359,8 @@ export interface components {
          * @description Body for creating a new draft set from a template.
          *
          *     ``name`` falls back to the template's own name when omitted/blank;
-         *     ``event_id`` is passed through uncritically, matching ``SetCreate``.
+         *     ``event_id`` must reference an event the caller owns — the route
+         *     rejects any other id with a 404 (see ``_require_owned_event``).
          */
         InstantiateTemplateRequest: {
             /** Event Id */

--- a/dashboard/lib/api-types.generated.ts
+++ b/dashboard/lib/api-types.generated.ts
@@ -2611,6 +2611,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/setbuilder/set-templates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Set Templates
+         * @description The DJ's saved templates, newest first. Always 200, even when empty.
+         */
+        get: operations["list_set_templates_api_setbuilder_set_templates_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/set-templates/{template_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Set Template
+         * @description Delete an owned template; repeat delete or unowned id 404s.
+         */
+        delete: operations["delete_set_template_api_setbuilder_set_templates__template_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/setbuilder/set-templates/{template_id}/instantiate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Instantiate Set Template
+         * @description Create a new draft set from an owned template.
+         */
+        post: operations["instantiate_set_template_api_setbuilder_set_templates__template_id__instantiate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/setbuilder/sets": {
         parameters: {
             query?: never;
@@ -3217,6 +3277,26 @@ export interface paths {
          * @description Write an explicit DJ vibe edit, preserving omitted fields from their latest vote.
          */
         patch: operations["override_pool_vibe_api_setbuilder_sets__set_id__pool_vibes__pool_track_id__override_patch"];
+        trace?: never;
+    };
+    "/api/setbuilder/sets/{set_id}/save-as-template": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Save As Template
+         * @description Extract a reusable template from an owned set.
+         */
+        post: operations["save_as_template_api_setbuilder_sets__set_id__save_as_template_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/api/setbuilder/sets/{set_id}/share": {
@@ -5275,6 +5355,19 @@ export interface components {
             reconcile_hint: boolean;
         };
         /**
+         * InstantiateTemplateRequest
+         * @description Body for creating a new draft set from a template.
+         *
+         *     ``name`` falls back to the template's own name when omitted/blank;
+         *     ``event_id`` is passed through uncritically, matching ``SetCreate``.
+         */
+        InstantiateTemplateRequest: {
+            /** Event Id */
+            event_id?: number | null;
+            /** Name */
+            name?: string | null;
+        };
+        /**
          * IntegrationCheckResponse
          * @description Response for POST /api/admin/integrations/{service}/check.
          */
@@ -6390,6 +6483,14 @@ export interface components {
             /** Mood Source */
             mood_source: ("own" | "community" | "llm") | null;
         };
+        /**
+         * SaveAsTemplateRequest
+         * @description Body for extracting a template from an existing set.
+         */
+        SaveAsTemplateRequest: {
+            /** Name */
+            name: string;
+        };
         /** SearchResult */
         SearchResult: {
             /** Album */
@@ -6718,6 +6819,76 @@ export interface components {
             avg_transition_overlap_sec: number;
             /** Target Duration Sec */
             target_duration_sec?: number | null;
+        };
+        /**
+         * SetTemplateCurvePointModel
+         * @description One energy-curve point stored in a template's ``curve_points_json``.
+         */
+        SetTemplateCurvePointModel: {
+            /** Energy */
+            energy: number;
+            /**
+             * Is Slow Window End
+             * @default false
+             */
+            is_slow_window_end: boolean;
+            /**
+             * Is Slow Window Start
+             * @default false
+             */
+            is_slow_window_start: boolean;
+            /** Label */
+            label: string | null;
+            /** Position Sec */
+            position_sec: number;
+        };
+        /**
+         * SetTemplateGalleryResponse
+         * @description List payload for the template gallery (always 200, even when empty).
+         */
+        SetTemplateGalleryResponse: {
+            /** Templates */
+            templates: components["schemas"]["SetTemplateOut"][];
+        };
+        /**
+         * SetTemplateOut
+         * @description A saved template for the gallery / detail surface.
+         *
+         *     ``slot_count`` and ``curve_points`` are derived from the stored JSON at
+         *     the API boundary — this schema is built explicitly, not read directly
+         *     off the ``SetTemplate`` row via ``from_attributes``.
+         */
+        SetTemplateOut: {
+            /** Avg Transition Overlap Sec */
+            avg_transition_overlap_sec: number;
+            /** Bpm Ceiling */
+            bpm_ceiling: number | null;
+            /** Bpm Floor */
+            bpm_floor: number | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Curve Points */
+            curve_points: components["schemas"]["SetTemplateCurvePointModel"][];
+            /** Id */
+            id: number;
+            /** Key Strictness */
+            key_strictness: number;
+            /** Name */
+            name: string;
+            /** Slot Count */
+            slot_count: number;
+            /** Target Duration Sec */
+            target_duration_sec: number | null;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** Vibe Theme */
+            vibe_theme: string | null;
         };
         /**
          * ShareTokenOut
@@ -12011,6 +12182,90 @@ export interface operations {
             };
         };
     };
+    list_set_templates_api_setbuilder_set_templates_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetTemplateGalleryResponse"];
+                };
+            };
+        };
+    };
+    delete_set_template_api_setbuilder_set_templates__template_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                template_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    instantiate_set_template_api_setbuilder_set_templates__template_id__instantiate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                template_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InstantiateTemplateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_sets_api_setbuilder_sets_get: {
         parameters: {
             query?: never;
@@ -13262,6 +13517,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PoolVibesState"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    save_as_template_api_setbuilder_sets__set_id__save_as_template_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                set_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SaveAsTemplateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetTemplateOut"];
                 };
             };
             /** @description Validation Error */

--- a/dashboard/lib/api-types.ts
+++ b/dashboard/lib/api-types.ts
@@ -312,6 +312,10 @@ export interface PaginatedResponse<T> {
   limit: number;
 }
 
+// WrzDJSet reusable set templates (issue #407)
+export type SetTemplate = Schemas['SetTemplateOut'];
+export type SetTemplateGalleryResponse = Schemas['SetTemplateGalleryResponse'];
+
 // --- Setlist export (#396) — auto-re-exports aliased to historical names ---
 
 export type ExportTarget = Schemas['ExportPreflightIn']['target'];

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -74,6 +74,8 @@ import type {
   SetDetail,
   SetSlotOut,
   SetSummary,
+  SetTemplate,
+  SetTemplateGalleryResponse,
   SharedSetView,
   ShareTokenOut,
   SlotTargetOut,
@@ -185,6 +187,8 @@ export type {
   SetDocumentSnapshot,
   SetDetail,
   SetSummary,
+  SetTemplate,
+  SetTemplateGalleryResponse,
   SharedCurvePointView,
   SharedSetView,
   SharedSlotView,
@@ -986,6 +990,30 @@ class ApiClient {
     return this.publicFetch(
       `${getApiUrl()}/api/public/setbuilder/shared/${encodeURIComponent(token)}`
     );
+  }
+
+  // WrzDJSet reusable set templates (issue #407)
+  async saveSetAsTemplate(setId: number, name: string): Promise<SetTemplate> {
+    return this.fetch(`/api/setbuilder/sets/${setId}/save-as-template`, {
+      method: 'POST',
+      body: JSON.stringify({ name }),
+    });
+  }
+  async listSetTemplates(): Promise<SetTemplateGalleryResponse> {
+    return this.fetch('/api/setbuilder/set-templates');
+  }
+  async instantiateSetTemplate(
+    templateId: number,
+    name?: string,
+    eventId?: number
+  ): Promise<SetDetail> {
+    return this.fetch(`/api/setbuilder/set-templates/${templateId}/instantiate`, {
+      method: 'POST',
+      body: JSON.stringify({ name: name ?? null, event_id: eventId ?? null }),
+    });
+  }
+  async deleteSetTemplate(templateId: number): Promise<void> {
+    await this.rawFetch(`/api/setbuilder/set-templates/${templateId}`, { method: 'DELETE' });
   }
 
   // --- Setlist export (#396) ---

--- a/server/alembic/versions/066_add_set_templates.py
+++ b/server/alembic/versions/066_add_set_templates.py
@@ -1,0 +1,67 @@
+"""Add set_templates table (issue #407).
+
+A template snapshots a source Set's target settings plus its slot skeleton
+(position/locked/target_energy/notes, no track assignments) and energy curve
+as JSON (``slots_json`` / ``curve_points_json``). Mirrors the flat-table shape
+of ``set_curve_templates`` (#389) — see app/models/set_template.py.
+
+Revision ID: 066
+Revises: 065
+Create Date: 2026-06-27
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "066"
+down_revision: str | None = "065"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "set_templates",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("vibe_theme", sa.String(length=50), nullable=True),
+        sa.Column("target_duration_sec", sa.Integer(), nullable=True),
+        sa.Column(
+            "avg_transition_overlap_sec",
+            sa.Integer(),
+            nullable=False,
+            server_default="8",
+        ),
+        sa.Column("bpm_floor", sa.Integer(), nullable=True),
+        sa.Column("bpm_ceiling", sa.Integer(), nullable=True),
+        sa.Column(
+            "key_strictness",
+            sa.Float(),
+            nullable=False,
+            server_default="0.2",
+        ),
+        sa.Column("slots_json", sa.Text(), nullable=False),
+        sa.Column("curve_points_json", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_set_templates_user_id", "set_templates", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_set_templates_user_id", table_name="set_templates")
+    op.drop_table("set_templates")

--- a/server/app/api/__init__.py
+++ b/server/app/api/__init__.py
@@ -16,6 +16,7 @@ from app.api import (
     search,
     setbuilder,
     setbuilder_share,
+    setbuilder_templates,
     sse,
     tidal,
     verify,
@@ -41,6 +42,7 @@ api_router.include_router(setbuilder_share.router, prefix="/setbuilder", tags=["
 api_router.include_router(
     setbuilder_share.public_router, prefix="/public/setbuilder", tags=["setbuilder-public"]
 )
+api_router.include_router(setbuilder_templates.router, prefix="/setbuilder", tags=["setbuilder"])
 api_router.include_router(public.router, prefix="/public", tags=["public"])
 api_router.include_router(guest.router, prefix="/public", tags=["guest"])
 api_router.include_router(verify.router, prefix="/public/guest", tags=["verify"])

--- a/server/app/api/setbuilder_templates.py
+++ b/server/app/api/setbuilder_templates.py
@@ -1,0 +1,125 @@
+"""Per-DJ SetBuilder template routes: save-as-template, gallery, instantiate,
+delete (issue #407).
+
+Mirrors ``setbuilder_share.py``'s router pattern: owner-scoped routes mounted
+under /api/setbuilder, rate-limited via the shared limiter. Templates are
+private to their owner — no route or helper here touches ``SetCollaborator``
+or sharing/role logic.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_active_user, get_db
+from app.core.rate_limit import limiter
+from app.models.set import Set
+from app.models.set_template import SetTemplate
+from app.models.user import User
+from app.schemas.setbuilder import SetDetail
+from app.schemas.setbuilder_templates import (
+    InstantiateTemplateRequest,
+    SaveAsTemplateRequest,
+    SetTemplateCurvePointModel,
+    SetTemplateGalleryResponse,
+    SetTemplateOut,
+)
+from app.services.setbuilder import set_service, set_templates
+
+router = APIRouter()
+
+
+def _get_owned_set_or_404(db: Session, set_id: int, user: User) -> Set:
+    set_obj = set_service.get_owned_set(db, set_id, user.id)
+    if set_obj is None:
+        raise HTTPException(status_code=404, detail="Set not found")
+    return set_obj
+
+
+def _get_owned_template_or_404(db: Session, template_id: int, user: User) -> SetTemplate:
+    tpl = set_templates.get_owned_template(db, template_id, user.id)
+    if tpl is None:
+        raise HTTPException(status_code=404, detail="Template not found")
+    return tpl
+
+
+def _template_out(tpl: SetTemplate) -> SetTemplateOut:
+    """Build the response schema explicitly from decoded JSON (no from_attributes)."""
+    slots = set_templates._decode_slots(tpl.slots_json)
+    curve_points = set_templates._decode_curve_points(tpl.curve_points_json)
+    return SetTemplateOut(
+        id=tpl.id,
+        name=tpl.name,
+        vibe_theme=tpl.vibe_theme,
+        target_duration_sec=tpl.target_duration_sec,
+        avg_transition_overlap_sec=tpl.avg_transition_overlap_sec,
+        bpm_floor=tpl.bpm_floor,
+        bpm_ceiling=tpl.bpm_ceiling,
+        key_strictness=tpl.key_strictness,
+        slot_count=len(slots),
+        curve_points=[SetTemplateCurvePointModel(**p) for p in curve_points],
+        created_at=tpl.created_at,
+        updated_at=tpl.updated_at,
+    )
+
+
+@router.post(
+    "/sets/{set_id}/save-as-template",
+    response_model=SetTemplateOut,
+    status_code=status.HTTP_201_CREATED,
+)
+@limiter.limit("10/minute")
+def save_as_template(
+    set_id: int,
+    body: SaveAsTemplateRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> SetTemplateOut:
+    """Extract a reusable template from an owned set."""
+    set_obj = _get_owned_set_or_404(db, set_id, current_user)
+    tpl = set_templates.extract_template(db, set_obj, current_user.id, body.name)
+    return _template_out(tpl)
+
+
+@router.get("/set-templates", response_model=SetTemplateGalleryResponse)
+@limiter.limit("30/minute")
+def list_set_templates(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> SetTemplateGalleryResponse:
+    """The DJ's saved templates, newest first. Always 200, even when empty."""
+    templates = set_templates.list_templates(db, current_user.id)
+    return SetTemplateGalleryResponse(templates=[_template_out(t) for t in templates])
+
+
+@router.post(
+    "/set-templates/{template_id}/instantiate",
+    response_model=SetDetail,
+    status_code=status.HTTP_201_CREATED,
+)
+@limiter.limit("10/minute")
+def instantiate_set_template(
+    template_id: int,
+    body: InstantiateTemplateRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> SetDetail:
+    """Create a new draft set from an owned template."""
+    tpl = _get_owned_template_or_404(db, template_id, current_user)
+    new_set = set_templates.instantiate_template(db, tpl, current_user.id, body.name, body.event_id)
+    return SetDetail.model_validate(new_set)
+
+
+@router.delete("/set-templates/{template_id}", status_code=status.HTTP_204_NO_CONTENT)
+@limiter.limit("10/minute")
+def delete_set_template(
+    template_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> None:
+    """Delete an owned template; repeat delete or unowned id 404s."""
+    tpl = _get_owned_template_or_404(db, template_id, current_user)
+    set_templates.delete_template(db, tpl)

--- a/server/app/api/setbuilder_templates.py
+++ b/server/app/api/setbuilder_templates.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_active_user, get_db
 from app.core.rate_limit import limiter
+from app.models.event import Event
 from app.models.set import Set
 from app.models.set_template import SetTemplate
 from app.models.user import User
@@ -35,6 +36,23 @@ def _get_owned_set_or_404(db: Session, set_id: int, user: User) -> Set:
     return set_obj
 
 
+def _require_owned_event(db: Session, event_id: int | None, user: User) -> None:
+    """Reject an ``event_id`` the caller does not own.
+
+    A set's ``event_id`` is a capability: downstream setbuilder routes read
+    event-scoped data through it. Binding a set to an event the caller does
+    not own is therefore never valid, and this route validates it up front
+    rather than trusting the client-supplied id.
+    """
+    if event_id is None:
+        return
+    owned = (
+        db.query(Event.id).filter(Event.id == event_id, Event.created_by_user_id == user.id).first()
+    )
+    if owned is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+
 def _get_owned_template_or_404(db: Session, template_id: int, user: User) -> SetTemplate:
     tpl = set_templates.get_owned_template(db, template_id, user.id)
     if tpl is None:
@@ -44,8 +62,8 @@ def _get_owned_template_or_404(db: Session, template_id: int, user: User) -> Set
 
 def _template_out(tpl: SetTemplate) -> SetTemplateOut:
     """Build the response schema explicitly from decoded JSON (no from_attributes)."""
-    slots = set_templates._decode_slots(tpl.slots_json)
-    curve_points = set_templates._decode_curve_points(tpl.curve_points_json)
+    slots = set_templates.decode_slots(tpl.slots_json)
+    curve_points = set_templates.decode_curve_points(tpl.curve_points_json)
     return SetTemplateOut(
         id=tpl.id,
         name=tpl.name,
@@ -108,6 +126,7 @@ def instantiate_set_template(
 ) -> SetDetail:
     """Create a new draft set from an owned template."""
     tpl = _get_owned_template_or_404(db, template_id, current_user)
+    _require_owned_event(db, body.event_id, current_user)
     new_set = set_templates.instantiate_template(db, tpl, current_user.id, body.name, body.event_id)
     return SetDetail.model_validate(new_set)
 

--- a/server/app/models/__init__.py
+++ b/server/app/models/__init__.py
@@ -20,6 +20,7 @@ from app.models.set_agent import SetAgentMessage, SetAgentSession
 from app.models.set_pairing import SetPairing
 from app.models.set_pool import SetPoolSource, SetPoolTrack
 from app.models.set_taste_profile import SetTasteProfileReset
+from app.models.set_template import SetTemplate
 from app.models.system_settings import SystemSettings
 from app.models.track import Track
 from app.models.track_vibe import TrackVibe, TrackVibeOverride
@@ -55,6 +56,7 @@ __all__ = [
     "SetPoolTrack",
     "SetSlot",
     "SetTasteProfileReset",
+    "SetTemplate",
     "SystemSettings",
     "Track",
     "TrackVibe",

--- a/server/app/models/set_template.py
+++ b/server/app/models/set_template.py
@@ -1,0 +1,46 @@
+"""Per-DJ reusable SetBuilder templates (issue #407).
+
+A template snapshots a source Set's target settings plus its slot skeleton
+(position/locked/target_energy/notes, no track assignments) and energy curve
+as JSON. ``slots_json`` / ``curve_points_json`` are always a valid JSON list
+string (``"[]"`` for none) — encode/decode helpers live in
+``services/setbuilder/set_templates.py``; validation of the decoded shape
+happens at the API boundary (Pydantic), matching the ``SetCurveTemplate``
+precedent (#389).
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.time import utcnow
+from app.models.base import Base
+
+
+class SetTemplate(Base):
+    __tablename__ = "set_templates"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    vibe_theme: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+    target_duration_sec: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    avg_transition_overlap_sec: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=8, server_default="8"
+    )
+    bpm_floor: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    bpm_ceiling: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # 0.0 ignore Camelot ... 1.0 strict +/-1 (matches Set.key_strictness)
+    key_strictness: Mapped[float] = mapped_column(
+        Float, nullable=False, default=0.2, server_default="0.2"
+    )
+
+    slots_json: Mapped[str] = mapped_column(Text, nullable=False)
+    curve_points_json: Mapped[str] = mapped_column(Text, nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow, onupdate=utcnow)

--- a/server/app/models/set_template.py
+++ b/server/app/models/set_template.py
@@ -4,9 +4,11 @@ A template snapshots a source Set's target settings plus its slot skeleton
 (position/locked/target_energy/notes, no track assignments) and energy curve
 as JSON. ``slots_json`` / ``curve_points_json`` are always a valid JSON list
 string (``"[]"`` for none) — encode/decode helpers live in
-``services/setbuilder/set_templates.py``; validation of the decoded shape
-happens at the API boundary (Pydantic), matching the ``SetCurveTemplate``
-precedent (#389).
+``services/setbuilder/set_templates.py``. Only this application writes these
+columns, so the decoded dicts are trusted rather than re-validated on read,
+matching the ``SetCurveTemplate`` precedent (#389). Decoded curve points are
+still shaped by ``SetTemplateCurvePointModel`` on the way out, because the
+API returns them; slots are only counted, never emitted.
 """
 
 from datetime import datetime

--- a/server/app/schemas/setbuilder_templates.py
+++ b/server/app/schemas/setbuilder_templates.py
@@ -1,26 +1,16 @@
 """Pydantic schemas for per-DJ SetBuilder templates (issue #407).
 
-Mirrors the ``SetDocumentSlot`` / ``SetDocumentCurvePoint`` field constraints
-in ``schemas/setbuilder.py`` since a template's ``slots_json`` /
-``curve_points_json`` decode into the same shapes minus track assignment.
+``SetTemplateCurvePointModel`` mirrors ``SetDocumentCurvePoint``'s field
+constraints in ``schemas/setbuilder.py`` — a template's ``curve_points_json``
+decodes into that same shape. Stored slots have no schema counterpart on
+purpose: they are never exposed individually, only counted
+(``SetTemplateOut.slot_count``), matching how ``curve.template_points``
+returns raw decoded dicts for the ``SetCurveTemplate`` precedent (#389).
 """
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
-
-
-class SetTemplateSlotModel(BaseModel):
-    """One slot skeleton entry stored in a template's ``slots_json``.
-
-    No ``track_id``/``transition_score``/``transition_warnings`` — templates
-    snapshot the timeline shape, never track assignments.
-    """
-
-    position: int = Field(..., ge=0)
-    target_energy: float | None = Field(None, ge=0.0, le=10.0)
-    locked: bool = False
-    notes: str | None = None
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class SetTemplateCurvePointModel(BaseModel):
@@ -37,6 +27,17 @@ class SaveAsTemplateRequest(BaseModel):
     """Body for extracting a template from an existing set."""
 
     name: str = Field(..., min_length=1, max_length=120)
+
+    @field_validator("name")
+    @classmethod
+    def _strip_and_require_non_blank(cls, value: str) -> str:
+        """``min_length`` alone lets ``"   "`` through and stores a blank
+        gallery entry. The dashboard already trims; direct API clients must
+        not be able to bypass it."""
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("name must not be blank")
+        return stripped
 
 
 class InstantiateTemplateRequest(BaseModel):

--- a/server/app/schemas/setbuilder_templates.py
+++ b/server/app/schemas/setbuilder_templates.py
@@ -1,0 +1,80 @@
+"""Pydantic schemas for per-DJ SetBuilder templates (issue #407).
+
+Mirrors the ``SetDocumentSlot`` / ``SetDocumentCurvePoint`` field constraints
+in ``schemas/setbuilder.py`` since a template's ``slots_json`` /
+``curve_points_json`` decode into the same shapes minus track assignment.
+"""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SetTemplateSlotModel(BaseModel):
+    """One slot skeleton entry stored in a template's ``slots_json``.
+
+    No ``track_id``/``transition_score``/``transition_warnings`` — templates
+    snapshot the timeline shape, never track assignments.
+    """
+
+    position: int = Field(..., ge=0)
+    target_energy: float | None = Field(None, ge=0.0, le=10.0)
+    locked: bool = False
+    notes: str | None = None
+
+
+class SetTemplateCurvePointModel(BaseModel):
+    """One energy-curve point stored in a template's ``curve_points_json``."""
+
+    position_sec: int = Field(..., ge=0)
+    energy: int = Field(..., ge=0, le=10)
+    label: str | None = Field(None, max_length=50)
+    is_slow_window_start: bool = False
+    is_slow_window_end: bool = False
+
+
+class SaveAsTemplateRequest(BaseModel):
+    """Body for extracting a template from an existing set."""
+
+    name: str = Field(..., min_length=1, max_length=120)
+
+
+class InstantiateTemplateRequest(BaseModel):
+    """Body for creating a new draft set from a template.
+
+    ``name`` falls back to the template's own name when omitted/blank;
+    ``event_id`` is passed through uncritically, matching ``SetCreate``.
+    """
+
+    name: str | None = Field(None, max_length=120)
+    event_id: int | None = None
+
+
+class SetTemplateOut(BaseModel):
+    """A saved template for the gallery / detail surface.
+
+    ``slot_count`` and ``curve_points`` are derived from the stored JSON at
+    the API boundary — this schema is built explicitly, not read directly
+    off the ``SetTemplate`` row via ``from_attributes``.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    vibe_theme: str | None
+    target_duration_sec: int | None
+    avg_transition_overlap_sec: int
+    bpm_floor: int | None
+    bpm_ceiling: int | None
+    key_strictness: float
+    slot_count: int
+    curve_points: list[SetTemplateCurvePointModel]
+    created_at: datetime
+    updated_at: datetime
+
+
+class SetTemplateGalleryResponse(BaseModel):
+    """List payload for the template gallery (always 200, even when empty)."""
+
+    templates: list[SetTemplateOut]

--- a/server/app/schemas/setbuilder_templates.py
+++ b/server/app/schemas/setbuilder_templates.py
@@ -44,7 +44,8 @@ class InstantiateTemplateRequest(BaseModel):
     """Body for creating a new draft set from a template.
 
     ``name`` falls back to the template's own name when omitted/blank;
-    ``event_id`` is passed through uncritically, matching ``SetCreate``.
+    ``event_id`` must reference an event the caller owns — the route
+    rejects any other id with a 404 (see ``_require_owned_event``).
     """
 
     name: str | None = Field(None, max_length=120)

--- a/server/app/services/setbuilder/set_templates.py
+++ b/server/app/services/setbuilder/set_templates.py
@@ -1,0 +1,174 @@
+"""Per-DJ reusable SetBuilder template CRUD + extract/instantiate (issue #407).
+
+A template snapshots a source ``Set``'s target settings plus its slot
+skeleton (position/locked/target_energy/notes, no track assignments) and
+energy curve. ``extract_template`` copies a ``Set`` into a new template;
+``instantiate_template`` is the inverse, creating a fresh draft ``Set`` from
+a template with every slot's ``track_id`` unconditionally NULL.
+
+Do not pattern-match the slot-copy loop here off ``share_service.duplicate_set``
+— that precedent silently omits ``target_energy`` from its ``SetSlot`` copy
+despite its own docstring claiming to copy targets. Templates require
+``target_energy``.
+"""
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.set import Set, SetCurvePoint, SetSlot
+from app.models.set_template import SetTemplate
+
+
+def list_templates(db: Session, user_id: int) -> list[SetTemplate]:
+    """The DJ's saved templates, newest first."""
+    return (
+        db.query(SetTemplate)
+        .filter(SetTemplate.user_id == user_id)
+        .order_by(SetTemplate.updated_at.desc())
+        .all()
+    )
+
+
+def get_owned_template(db: Session, template_id: int, user_id: int) -> SetTemplate | None:
+    """Fetch a template by id, scoped to the owner. None if missing/unowned."""
+    return (
+        db.query(SetTemplate)
+        .filter(SetTemplate.id == template_id, SetTemplate.user_id == user_id)
+        .one_or_none()
+    )
+
+
+def extract_template(db: Session, src_set: Set, user_id: int, name: str) -> SetTemplate:
+    """Copy ``src_set``'s target settings + slot/curve shape into a new template.
+
+    Strips ``track_id``/``transition_score``/``transition_warnings`` from
+    every slot — templates snapshot the timeline shape, not track
+    assignments. Never raises for an empty ``src_set`` (0 slots/points).
+    """
+    slots = _encode_slots(src_set.slots)
+    curve_points = _encode_curve_points(src_set.curve_points)
+    tpl = SetTemplate(
+        user_id=user_id,
+        name=name,
+        vibe_theme=src_set.vibe_theme,
+        target_duration_sec=src_set.target_duration_sec,
+        avg_transition_overlap_sec=src_set.avg_transition_overlap_sec,
+        bpm_floor=src_set.bpm_floor,
+        bpm_ceiling=src_set.bpm_ceiling,
+        key_strictness=src_set.key_strictness,
+        slots_json=slots,
+        curve_points_json=curve_points,
+    )
+    db.add(tpl)
+    db.commit()
+    db.refresh(tpl)
+    return tpl
+
+
+def instantiate_template(
+    db: Session, tpl: SetTemplate, owner_id: int, name: str | None, event_id: int | None
+) -> Set:
+    """Create a new draft/private ``Set`` from a template.
+
+    Every created ``SetSlot`` has ``track_id=None`` unconditionally. ``name``
+    falls back to ``tpl.name`` when None/blank; ``event_id`` is passed
+    through uncritically, matching ``create_set``'s existing (out-of-scope)
+    non-validation of event ownership. Never raises for an empty template.
+    """
+    resolved_name = name.strip() if name and name.strip() else tpl.name
+    new_set = Set(
+        owner_id=owner_id,
+        event_id=event_id,
+        name=resolved_name,
+        vibe_theme=tpl.vibe_theme,
+        target_duration_sec=tpl.target_duration_sec,
+        avg_transition_overlap_sec=tpl.avg_transition_overlap_sec,
+        bpm_floor=tpl.bpm_floor,
+        bpm_ceiling=tpl.bpm_ceiling,
+        key_strictness=tpl.key_strictness,
+        status="draft",
+        sharing_mode="private",
+    )
+    db.add(new_set)
+    db.flush()
+
+    for slot in _decode_slots(tpl.slots_json):
+        db.add(
+            SetSlot(
+                set_id=new_set.id,
+                position=slot["position"],
+                track_id=None,
+                locked=slot["locked"],
+                notes=slot["notes"],
+                target_energy=slot["target_energy"],
+            )
+        )
+    for point in _decode_curve_points(tpl.curve_points_json):
+        db.add(
+            SetCurvePoint(
+                set_id=new_set.id,
+                position_sec=point["position_sec"],
+                energy=point["energy"],
+                label=point["label"],
+                is_slow_window_start=point["is_slow_window_start"],
+                is_slow_window_end=point["is_slow_window_end"],
+            )
+        )
+    db.commit()
+    db.refresh(new_set)
+    return new_set
+
+
+def delete_template(db: Session, tpl: SetTemplate) -> None:
+    """Delete a template."""
+    db.delete(tpl)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Codec helpers (module-internal; no schema import)
+# ---------------------------------------------------------------------------
+
+
+def _encode_slots(slots: list[SetSlot]) -> str:
+    """Slot skeleton -> JSON, sorted by position, tracks/scores stripped."""
+    ordered = sorted(slots, key=lambda s: s.position)
+    return json.dumps(
+        [
+            {
+                "position": slot.position,
+                "target_energy": slot.target_energy,
+                "locked": slot.locked,
+                "notes": slot.notes,
+            }
+            for slot in ordered
+        ]
+    )
+
+
+def _decode_slots(slots_json: str) -> list[dict]:
+    """JSON -> slot skeleton dicts."""
+    return json.loads(slots_json)
+
+
+def _encode_curve_points(points: list[SetCurvePoint]) -> str:
+    """Curve points -> JSON, sorted by position_sec."""
+    ordered = sorted(points, key=lambda p: p.position_sec)
+    return json.dumps(
+        [
+            {
+                "position_sec": point.position_sec,
+                "energy": point.energy,
+                "label": point.label,
+                "is_slow_window_start": point.is_slow_window_start,
+                "is_slow_window_end": point.is_slow_window_end,
+            }
+            for point in ordered
+        ]
+    )
+
+
+def _decode_curve_points(curve_points_json: str) -> list[dict]:
+    """JSON -> curve point dicts."""
+    return json.loads(curve_points_json)

--- a/server/app/services/setbuilder/set_templates.py
+++ b/server/app/services/setbuilder/set_templates.py
@@ -71,10 +71,12 @@ def instantiate_template(
 ) -> Set:
     """Create a new draft/private ``Set`` from a template.
 
-    Every created ``SetSlot`` has ``track_id=None`` unconditionally. ``name``
-    falls back to ``tpl.name`` when None/blank; ``event_id`` is passed
-    through uncritically, matching ``create_set``'s existing (out-of-scope)
-    non-validation of event ownership. Never raises for an empty template.
+    Every created ``SetSlot`` has ``track_id=None`` and ``locked=False``
+    unconditionally — see the loop below for why an empty slot must never be
+    locked. ``name`` falls back to ``tpl.name`` when None/blank. ``event_id``
+    is stored as given; the caller is responsible for rejecting an event the
+    owner does not hold (``_require_owned_event`` in the router). Never
+    raises for an empty template.
     """
     resolved_name = name.strip() if name and name.strip() else tpl.name
     new_set = Set(
@@ -93,18 +95,23 @@ def instantiate_template(
     db.add(new_set)
     db.flush()
 
-    for slot in _decode_slots(tpl.slots_json):
+    for slot in decode_slots(tpl.slots_json):
         db.add(
             SetSlot(
                 set_id=new_set.id,
                 position=slot["position"],
                 track_id=None,
-                locked=slot["locked"],
+                # Always unlocked, even when the source slot was locked: the
+                # stored `locked` flag records the source's shape, but every
+                # instantiated slot is empty by design. pass1 keeps locked
+                # slots verbatim and only fills unlocked ones, so a locked
+                # empty slot would be a hole the builder can never fill.
+                locked=False,
                 notes=slot["notes"],
                 target_energy=slot["target_energy"],
             )
         )
-    for point in _decode_curve_points(tpl.curve_points_json):
+    for point in decode_curve_points(tpl.curve_points_json):
         db.add(
             SetCurvePoint(
                 set_id=new_set.id,
@@ -127,7 +134,9 @@ def delete_template(db: Session, tpl: SetTemplate) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Codec helpers (module-internal; no schema import)
+# Codec helpers (no schema import). ``decode_*`` are public — the API layer
+# reads stored JSON through them, mirroring ``curve.template_points``;
+# ``_encode_*`` stay private, since only this module ever writes.
 # ---------------------------------------------------------------------------
 
 
@@ -147,7 +156,7 @@ def _encode_slots(slots: list[SetSlot]) -> str:
     )
 
 
-def _decode_slots(slots_json: str) -> list[dict]:
+def decode_slots(slots_json: str) -> list[dict]:
     """JSON -> slot skeleton dicts."""
     return json.loads(slots_json)
 
@@ -169,6 +178,6 @@ def _encode_curve_points(points: list[SetCurvePoint]) -> str:
     )
 
 
-def _decode_curve_points(curve_points_json: str) -> list[dict]:
+def decode_curve_points(curve_points_json: str) -> list[dict]:
     """JSON -> curve point dicts."""
     return json.loads(curve_points_json)

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -4561,6 +4561,36 @@
         "title": "IdentifyResponse",
         "type": "object"
       },
+      "InstantiateTemplateRequest": {
+        "description": "Body for creating a new draft set from a template.\n\n``name`` falls back to the template's own name when omitted/blank;\n``event_id`` is passed through uncritically, matching ``SetCreate``.",
+        "properties": {
+          "event_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 120,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "title": "InstantiateTemplateRequest",
+        "type": "object"
+      },
       "IntegrationCheckResponse": {
         "description": "Response for POST /api/admin/integrations/{service}/check.",
         "properties": {
@@ -7949,6 +7979,22 @@
         "title": "ResolvedVibeOut",
         "type": "object"
       },
+      "SaveAsTemplateRequest": {
+        "description": "Body for extracting a template from an existing set.",
+        "properties": {
+          "name": {
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "SaveAsTemplateRequest",
+        "type": "object"
+      },
       "SearchResult": {
         "properties": {
           "album": {
@@ -8971,6 +9017,172 @@
           "avg_transition_overlap_sec"
         ],
         "title": "SetTargetUpdate",
+        "type": "object"
+      },
+      "SetTemplateCurvePointModel": {
+        "description": "One energy-curve point stored in a template's ``curve_points_json``.",
+        "properties": {
+          "energy": {
+            "maximum": 10.0,
+            "minimum": 0.0,
+            "title": "Energy",
+            "type": "integer"
+          },
+          "is_slow_window_end": {
+            "default": false,
+            "title": "Is Slow Window End",
+            "type": "boolean"
+          },
+          "is_slow_window_start": {
+            "default": false,
+            "title": "Is Slow Window Start",
+            "type": "boolean"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "position_sec": {
+            "minimum": 0.0,
+            "title": "Position Sec",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "energy",
+          "is_slow_window_end",
+          "is_slow_window_start",
+          "label",
+          "position_sec"
+        ],
+        "title": "SetTemplateCurvePointModel",
+        "type": "object"
+      },
+      "SetTemplateGalleryResponse": {
+        "description": "List payload for the template gallery (always 200, even when empty).",
+        "properties": {
+          "templates": {
+            "items": {
+              "$ref": "#/components/schemas/SetTemplateOut"
+            },
+            "title": "Templates",
+            "type": "array"
+          }
+        },
+        "required": [
+          "templates"
+        ],
+        "title": "SetTemplateGalleryResponse",
+        "type": "object"
+      },
+      "SetTemplateOut": {
+        "description": "A saved template for the gallery / detail surface.\n\n``slot_count`` and ``curve_points`` are derived from the stored JSON at\nthe API boundary \u2014 this schema is built explicitly, not read directly\noff the ``SetTemplate`` row via ``from_attributes``.",
+        "properties": {
+          "avg_transition_overlap_sec": {
+            "title": "Avg Transition Overlap Sec",
+            "type": "integer"
+          },
+          "bpm_ceiling": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm Ceiling"
+          },
+          "bpm_floor": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bpm Floor"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "curve_points": {
+            "items": {
+              "$ref": "#/components/schemas/SetTemplateCurvePointModel"
+            },
+            "title": "Curve Points",
+            "type": "array"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "key_strictness": {
+            "title": "Key Strictness",
+            "type": "number"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "slot_count": {
+            "title": "Slot Count",
+            "type": "integer"
+          },
+          "target_duration_sec": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Duration Sec"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "vibe_theme": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vibe Theme"
+          }
+        },
+        "required": [
+          "avg_transition_overlap_sec",
+          "bpm_ceiling",
+          "bpm_floor",
+          "created_at",
+          "curve_points",
+          "id",
+          "key_strictness",
+          "name",
+          "slot_count",
+          "target_duration_sec",
+          "updated_at",
+          "vibe_theme"
+        ],
+        "title": "SetTemplateOut",
         "type": "object"
       },
       "ShareTokenOut": {
@@ -18171,6 +18383,132 @@
         ]
       }
     },
+    "/api/setbuilder/set-templates": {
+      "get": {
+        "description": "The DJ's saved templates, newest first. Always 200, even when empty.",
+        "operationId": "list_set_templates_api_setbuilder_set_templates_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetTemplateGalleryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Set Templates",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/set-templates/{template_id}": {
+      "delete": {
+        "description": "Delete an owned template; repeat delete or unowned id 404s.",
+        "operationId": "delete_set_template_api_setbuilder_set_templates__template_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "template_id",
+            "required": true,
+            "schema": {
+              "title": "Template Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Set Template",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/set-templates/{template_id}/instantiate": {
+      "post": {
+        "description": "Create a new draft set from an owned template.",
+        "operationId": "instantiate_set_template_api_setbuilder_set_templates__template_id__instantiate_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "template_id",
+            "required": true,
+            "schema": {
+              "title": "Template Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstantiateTemplateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetDetail"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Instantiate Set Template",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
     "/api/setbuilder/sets": {
       "get": {
         "description": "List the current DJ's sets, newest first.",
@@ -20123,6 +20461,64 @@
           }
         ],
         "summary": "Override Pool Vibe",
+        "tags": [
+          "setbuilder"
+        ]
+      }
+    },
+    "/api/setbuilder/sets/{set_id}/save-as-template": {
+      "post": {
+        "description": "Extract a reusable template from an owned set.",
+        "operationId": "save_as_template_api_setbuilder_sets__set_id__save_as_template_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "set_id",
+            "required": true,
+            "schema": {
+              "title": "Set Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SaveAsTemplateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetTemplateOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Save As Template",
         "tags": [
           "setbuilder"
         ]

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -4562,7 +4562,7 @@
         "type": "object"
       },
       "InstantiateTemplateRequest": {
-        "description": "Body for creating a new draft set from a template.\n\n``name`` falls back to the template's own name when omitted/blank;\n``event_id`` is passed through uncritically, matching ``SetCreate``.",
+        "description": "Body for creating a new draft set from a template.\n\n``name`` falls back to the template's own name when omitted/blank;\n``event_id`` must reference an event the caller owns \u2014 the route\nrejects any other id with a 404 (see ``_require_owned_event``).",
         "properties": {
           "event_id": {
             "anyOf": [

--- a/server/tests/ast_no_sharing_support.py
+++ b/server/tests/ast_no_sharing_support.py
@@ -1,0 +1,76 @@
+"""Shared static-analysis helpers for the #407 "templates never touch
+sharing/collaborator logic" invariant.
+
+Used by both ``test_setbuilder_template_no_sharing_coupling.py`` (scans all
+four template modules) and ``test_setbuilder_template_api.py`` (scans the
+router alone). Kept as a single source of truth so a toughened token list or
+a docstring-stripping fix lands for every caller at once, instead of
+drifting between hand-copied implementations.
+
+Not a test module itself (no ``test_`` prefix) — pytest never collects it.
+"""
+
+import ast
+import inspect
+from types import ModuleType
+
+# Case-sensitive substrings that must never appear in a template module's
+# source (docstrings/comments excluded). Includes both the ORM class name
+# (SetCollaborator) and the literal table name (set_collaborators) so raw
+# SQL against the table -- which never mentions the class -- is caught too.
+FORBIDDEN_TOKENS: tuple[str, ...] = (
+    "SetCollaborator",
+    "set_collaborators",
+    "share_service",
+    "setbuilder_share",
+    "share_token",
+    ".collaborators",
+)
+
+_DOCSTRING_HOLDERS = (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+
+
+def assert_no_sharing_references(module: ModuleType) -> None:
+    """Fail if ``module``'s source (docstrings/comments stripped) mentions
+    any sharing/collaborator token."""
+    code = source_without_docstrings(module)
+    for token in FORBIDDEN_TOKENS:
+        assert token not in code, f"{module.__name__} unexpectedly references {token!r}"
+
+
+def source_without_docstrings(module: ModuleType) -> str:
+    """``module``'s source with every docstring stripped."""
+    return code_without_docstrings(inspect.getsource(module))
+
+
+def code_without_docstrings(source: str) -> str:
+    """Source text with every docstring -- module-, class-, and
+    function-level, not just the module's own top-level one -- stripped, so
+    prose describing the no-sharing invariant can never produce a false
+    pass, and a nested function's unrelated docstring can never produce a
+    false failure.
+    """
+    tree = ast.parse(source)
+    _strip_docstrings(tree)
+    return ast.unparse(tree)
+
+
+def _strip_docstrings(node: ast.AST) -> None:
+    """Recursively drop the leading string-literal Expr (docstring) from
+    every Module/FunctionDef/AsyncFunctionDef/ClassDef body, in place."""
+    if isinstance(node, _DOCSTRING_HOLDERS) and _is_docstring_expr(_first_stmt(node)):
+        node.body = node.body[1:]
+    for child in ast.iter_child_nodes(node):
+        _strip_docstrings(child)
+
+
+def _first_stmt(node: ast.AST) -> ast.stmt | None:
+    return node.body[0] if node.body else None
+
+
+def _is_docstring_expr(node: ast.stmt | None) -> bool:
+    return (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    )

--- a/server/tests/test_migration_066_set_templates.py
+++ b/server/tests/test_migration_066_set_templates.py
@@ -1,0 +1,141 @@
+"""Migration round-trip test for ``set_templates`` (issue #407, revision 066).
+
+Pins the boundary invariant: revision 066 upgrades cleanly, creates exactly
+the columns/index the ``SetTemplate`` model expects, and downgrades cleanly
+with no leftover state — repeatably (upgrade -> downgrade -> upgrade ->
+downgrade never errors or drifts).
+
+Exercises revision 066's ``upgrade()``/``downgrade()`` functions directly
+against a throwaway SQLite connection via Alembic's ``Operations``/
+``MigrationContext`` — independent of the full 68-revision chain, which CI
+already exercises end-to-end against real Postgres via
+``alembic upgrade head && alembic check`` (see CLAUDE.md). ``op.create_table``
+/ ``op.create_index`` / ``op.drop_index`` / ``op.drop_table`` are dialect-
+agnostic Core operations, so SQLite is a faithful substrate here, matching
+the project's existing SQLite-in-memory test convention (conftest.py).
+"""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.engine import Connection
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parent.parent / "alembic" / "versions" / "066_add_set_templates.py"
+)
+
+_EXPECTED_COLUMNS = {
+    "id",
+    "user_id",
+    "name",
+    "vibe_theme",
+    "target_duration_sec",
+    "avg_transition_overlap_sec",
+    "bpm_floor",
+    "bpm_ceiling",
+    "key_strictness",
+    "slots_json",
+    "curve_points_json",
+    "created_at",
+    "updated_at",
+}
+
+_NOT_NULL_COLUMNS = {
+    "id",
+    "user_id",
+    "name",
+    "avg_transition_overlap_sec",
+    "key_strictness",
+    "slots_json",
+    "curve_points_json",
+    "created_at",
+    "updated_at",
+}
+
+
+def _load_migration_066() -> ModuleType:
+    """Import revision 066 by file path — its filename is not import-safe."""
+    spec = importlib.util.spec_from_file_location("migration_066_set_templates", _MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def migration_066() -> ModuleType:
+    return _load_migration_066()
+
+
+@pytest.fixture
+def alembic_connection():
+    """A throwaway SQLite connection, isolated from the shared test schema."""
+    engine = create_engine("sqlite:///:memory:")
+    with engine.connect() as connection:
+        yield connection
+    engine.dispose()
+
+
+def _table_names(connection: Connection) -> set[str]:
+    return set(inspect(connection).get_table_names())
+
+
+def _columns(connection: Connection, table_name: str) -> dict[str, dict]:
+    return {col["name"]: col for col in inspect(connection).get_columns(table_name)}
+
+
+def test_upgrade_creates_expected_table_columns_and_index(alembic_connection, migration_066):
+    context = MigrationContext.configure(alembic_connection)
+    with Operations.context(context):
+        migration_066.upgrade()
+
+    assert "set_templates" in _table_names(alembic_connection)
+    assert set(_columns(alembic_connection, "set_templates")) == _EXPECTED_COLUMNS
+
+    indexes = inspect(alembic_connection).get_indexes("set_templates")
+    assert any(
+        idx["name"] == "ix_set_templates_user_id" and idx["column_names"] == ["user_id"]
+        for idx in indexes
+    )
+
+
+def test_upgrade_nullability_matches_the_model(alembic_connection, migration_066):
+    context = MigrationContext.configure(alembic_connection)
+    with Operations.context(context):
+        migration_066.upgrade()
+
+    columns = _columns(alembic_connection, "set_templates")
+    for name in _NOT_NULL_COLUMNS:
+        assert columns[name]["nullable"] is False, f"{name} should be NOT NULL"
+    for name in _EXPECTED_COLUMNS - _NOT_NULL_COLUMNS:
+        assert columns[name]["nullable"] is True, f"{name} should be nullable"
+
+
+def test_downgrade_drops_table_and_index_cleanly(alembic_connection, migration_066):
+    context = MigrationContext.configure(alembic_connection)
+    with Operations.context(context):
+        migration_066.upgrade()
+        migration_066.downgrade()
+
+    assert "set_templates" not in _table_names(alembic_connection)
+
+
+def test_upgrade_downgrade_round_trips_repeatedly(alembic_connection, migration_066):
+    """Applying upgrade/downgrade twice in a row must not error or drift —
+    pins that neither leaves residue (e.g. a leaked index) that would break
+    a second application."""
+    context = MigrationContext.configure(alembic_connection)
+    with Operations.context(context):
+        migration_066.upgrade()
+        migration_066.downgrade()
+        migration_066.upgrade()
+        second_pass_columns = set(_columns(alembic_connection, "set_templates"))
+        migration_066.downgrade()
+
+    assert second_pass_columns == _EXPECTED_COLUMNS
+    assert "set_templates" not in _table_names(alembic_connection)

--- a/server/tests/test_migration_066_set_templates.py
+++ b/server/tests/test_migration_066_set_templates.py
@@ -25,6 +25,8 @@ from alembic.operations import Operations
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.engine import Connection
 
+from app.models.set_template import SetTemplate
+
 _MIGRATION_PATH = (
     Path(__file__).resolve().parent.parent / "alembic" / "versions" / "066_add_set_templates.py"
 )
@@ -114,6 +116,45 @@ def test_upgrade_nullability_matches_the_model(alembic_connection, migration_066
         assert columns[name]["nullable"] is False, f"{name} should be NOT NULL"
     for name in _EXPECTED_COLUMNS - _NOT_NULL_COLUMNS:
         assert columns[name]["nullable"] is True, f"{name} should be nullable"
+
+
+def test_upgrade_column_types_and_lengths_match_the_model(alembic_connection, migration_066):
+    """Names + nullability alone leave the drift-prone properties unchecked:
+    a ``String(50)`` silently widened to ``String(120)``, or an ``Integer``
+    that became ``Float``, would pass those and still fail ``alembic check``.
+    """
+    context = MigrationContext.configure(alembic_connection)
+    with Operations.context(context):
+        migration_066.upgrade()
+
+    migrated = _columns(alembic_connection, "set_templates")
+    for column in SetTemplate.__table__.columns:
+        actual = str(migrated[column.name]["type"]).upper()
+        expected = str(column.type).upper()
+        assert actual == expected, (
+            f"{column.name}: migration has {actual}, model declares {expected}"
+        )
+
+
+def test_upgrade_server_defaults_and_cascade_fk_match_the_model(alembic_connection, migration_066):
+    """``server_default`` and ``ON DELETE CASCADE`` are invisible to a
+    name/nullability comparison but are exactly what a hand-written
+    migration gets wrong."""
+    context = MigrationContext.configure(alembic_connection)
+    with Operations.context(context):
+        migration_066.upgrade()
+
+    migrated = _columns(alembic_connection, "set_templates")
+    assert "8" in str(migrated["avg_transition_overlap_sec"]["default"])
+    assert "0.2" in str(migrated["key_strictness"]["default"])
+
+    fks = inspect(alembic_connection).get_foreign_keys("set_templates")
+    assert len(fks) == 1, f"expected exactly one FK, got {fks}"
+    fk = fks[0]
+    assert fk["referred_table"] == "users"
+    assert fk["referred_columns"] == ["id"]
+    assert fk["constrained_columns"] == ["user_id"]
+    assert (fk["options"].get("ondelete") or "").upper() == "CASCADE"
 
 
 def test_downgrade_drops_table_and_index_cleanly(alembic_connection, migration_066):

--- a/server/tests/test_migration_066_set_templates.py
+++ b/server/tests/test_migration_066_set_templates.py
@@ -145,8 +145,21 @@ def test_upgrade_server_defaults_and_cascade_fk_match_the_model(alembic_connecti
         migration_066.upgrade()
 
     migrated = _columns(alembic_connection, "set_templates")
-    assert "8" in str(migrated["avg_transition_overlap_sec"]["default"])
-    assert "0.2" in str(migrated["key_strictness"]["default"])
+    # Derived from the model so a model/migration default drift fails here.
+    # Scoped to columns where the MODEL declares a server_default: the
+    # migration alone also gives created_at/updated_at a CURRENT_TIMESTAMP
+    # default (the model fills those Python-side via utcnow), deliberately.
+    model_defaults = {
+        column.name: str(getattr(column.server_default.arg, "text", column.server_default.arg))
+        for column in SetTemplate.__table__.columns
+        if column.server_default is not None
+    }
+    assert model_defaults, "SetTemplate declares no server defaults — parity check is vacuous"
+    for name, expected in model_defaults.items():
+        actual = str(migrated[name]["default"])
+        assert expected in actual, (
+            f"{name}: migration default {actual!r} does not match model server_default {expected!r}"
+        )
 
     fks = inspect(alembic_connection).get_foreign_keys("set_templates")
     assert len(fks) == 1, f"expected exactly one FK, got {fks}"

--- a/server/tests/test_setbuilder_template_api.py
+++ b/server/tests/test_setbuilder_template_api.py
@@ -119,6 +119,29 @@ def test_save_as_template_rejects_blank_name(client, auth_headers, db, test_user
     assert resp.status_code == 422
 
 
+def test_save_as_template_rejects_whitespace_only_name(client, auth_headers, db, test_user):
+    """``min_length=1`` alone accepts ``"   "`` — the dashboard trims, but a
+    direct API client must not be able to store a blank gallery entry."""
+    src = _seed_set(db, test_user.id)
+    resp = client.post(
+        f"/api/setbuilder/sets/{src.id}/save-as-template",
+        headers=auth_headers,
+        json={"name": "   "},
+    )
+    assert resp.status_code == 422
+
+
+def test_save_as_template_trims_surrounding_whitespace(client, auth_headers, db, test_user):
+    src = _seed_set(db, test_user.id)
+    resp = client.post(
+        f"/api/setbuilder/sets/{src.id}/save-as-template",
+        headers=auth_headers,
+        json={"name": "  Warehouse  "},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["name"] == "Warehouse"
+
+
 # ---------------------------------------------------------------------------
 # GET /set-templates (gallery)
 # ---------------------------------------------------------------------------
@@ -223,6 +246,63 @@ def test_instantiate_template_owner_scoped_404(client, auth_headers, db, test_us
         headers=auth_headers,
         json={},
     )
+    assert resp.status_code == 404
+
+
+def test_instantiate_rejects_event_owned_by_another_dj(client, auth_headers, db, test_user):
+    """A set's ``event_id`` grants access to event-scoped data through the
+    set, so a DJ must never be able to bind their own set to someone else's
+    event. Pins that the id is validated against the caller's ownership
+    instead of being trusted.
+    """
+    from datetime import timedelta
+
+    from app.core.time import utcnow
+    from app.models.event import Event
+
+    other = _make_second_dj(db)
+    their_event = Event(
+        code="OTHER1",
+        join_code="OTHER2",
+        name="Not Mine",
+        created_by_user_id=other.id,
+        expires_at=utcnow() + timedelta(hours=6),
+    )
+    db.add(their_event)
+    db.commit()
+    db.refresh(their_event)
+
+    src = _seed_set(db, test_user.id)
+    tpl_id = client.post(
+        f"/api/setbuilder/sets/{src.id}/save-as-template",
+        headers=auth_headers,
+        json={"name": "Mine"},
+    ).json()["id"]
+
+    resp = client.post(
+        f"/api/setbuilder/set-templates/{tpl_id}/instantiate",
+        headers=auth_headers,
+        json={"event_id": their_event.id},
+    )
+
+    assert resp.status_code == 404
+    assert not [s for s in db.query(Set).all() if s.event_id == their_event.id]
+
+
+def test_instantiate_rejects_unknown_event_id(client, auth_headers, db, test_user):
+    src = _seed_set(db, test_user.id)
+    tpl_id = client.post(
+        f"/api/setbuilder/sets/{src.id}/save-as-template",
+        headers=auth_headers,
+        json={"name": "Mine"},
+    ).json()["id"]
+
+    resp = client.post(
+        f"/api/setbuilder/set-templates/{tpl_id}/instantiate",
+        headers=auth_headers,
+        json={"event_id": 999999},
+    )
+
     assert resp.status_code == 404
 
 

--- a/server/tests/test_setbuilder_template_api.py
+++ b/server/tests/test_setbuilder_template_api.py
@@ -8,12 +8,10 @@ Pins the boundary invariants from the design spec:
   — templates are private to their owner, never shared.
 """
 
-import ast
-import inspect
-
 from app.api import setbuilder_templates
 from app.models.set import Set, SetCurvePoint, SetSlot
 from app.services.auth import get_password_hash
+from tests import ast_no_sharing_support
 
 
 def _seed_set(db, owner_id, **overrides) -> Set:
@@ -57,18 +55,14 @@ def _make_second_dj(db):
 
 
 def test_router_never_touches_collaborator_or_sharing_logic():
-    """Static check over the module body (docstrings excluded): no import of
-    SetCollaborator, no use of the share/duplicate service, no share-token
-    field access — templates are private to their owner, never shared.
+    """Static check over the module body (all docstrings excluded, not just
+    the module's own): no import of SetCollaborator, no use of the
+    share/duplicate service, no share-token field access — templates are
+    private to their owner, never shared. Shares its token list and
+    docstring-stripping with the broader cross-module check in
+    ``test_setbuilder_template_no_sharing_coupling.py``.
     """
-    source = inspect.getsource(setbuilder_templates)
-    tree = ast.parse(source)
-    body_without_docstrings = "\n".join(
-        ast.unparse(node) for node in tree.body if not isinstance(node, ast.Expr)
-    )
-    assert "SetCollaborator" not in body_without_docstrings
-    assert "share_service" not in body_without_docstrings
-    assert "share_token" not in body_without_docstrings
+    ast_no_sharing_support.assert_no_sharing_references(setbuilder_templates)
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_setbuilder_template_api.py
+++ b/server/tests/test_setbuilder_template_api.py
@@ -1,0 +1,283 @@
+"""API tests for the SetBuilder template routes (issue #407).
+
+Pins the boundary invariants from the design spec:
+- GET /setbuilder/set-templates never 404s on empty (always 200).
+- delete_template is safe to call once and 404s on repeat/unowned.
+- SetTemplateOut.slot_count always equals len(decoded slots_json).
+- No route/helper in this router touches SetCollaborator or sharing/role logic
+  — templates are private to their owner, never shared.
+"""
+
+import ast
+import inspect
+
+from app.api import setbuilder_templates
+from app.models.set import Set, SetCurvePoint, SetSlot
+from app.services.auth import get_password_hash
+
+
+def _seed_set(db, owner_id, **overrides) -> Set:
+    fields = {
+        "owner_id": owner_id,
+        "name": "Warehouse Set",
+        "vibe_theme": "dark-techno",
+        "target_duration_sec": 3600,
+        "avg_transition_overlap_sec": 12,
+        "bpm_floor": 124,
+        "bpm_ceiling": 132,
+        "key_strictness": 0.7,
+    }
+    fields.update(overrides)
+    set_obj = Set(**fields)
+    db.add(set_obj)
+    db.flush()
+    db.add(SetSlot(set_id=set_obj.id, position=0, track_id="tidal:1", target_energy=3.0))
+    db.add(SetSlot(set_id=set_obj.id, position=1, track_id="tidal:2", target_energy=7.0))
+    db.add(
+        SetCurvePoint(set_id=set_obj.id, position_sec=0, energy=4, label="warmup"),
+    )
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def _make_second_dj(db):
+    from app.models.user import User
+
+    user = User(username="otherdj", password_hash=get_password_hash("x" * 12), role="dj")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Structural invariant: templates never touch collaborator/sharing logic
+# ---------------------------------------------------------------------------
+
+
+def test_router_never_touches_collaborator_or_sharing_logic():
+    """Static check over the module body (docstrings excluded): no import of
+    SetCollaborator, no use of the share/duplicate service, no share-token
+    field access — templates are private to their owner, never shared.
+    """
+    source = inspect.getsource(setbuilder_templates)
+    tree = ast.parse(source)
+    body_without_docstrings = "\n".join(
+        ast.unparse(node) for node in tree.body if not isinstance(node, ast.Expr)
+    )
+    assert "SetCollaborator" not in body_without_docstrings
+    assert "share_service" not in body_without_docstrings
+    assert "share_token" not in body_without_docstrings
+
+
+# ---------------------------------------------------------------------------
+# POST /sets/{set_id}/save-as-template
+# ---------------------------------------------------------------------------
+
+
+def test_save_as_template_endpoint(client, auth_headers, db, test_user):
+    src = _seed_set(db, test_user.id)
+    resp = client.post(
+        f"/api/setbuilder/sets/{src.id}/save-as-template",
+        headers=auth_headers,
+        json={"name": "My Template"},
+    )
+    assert resp.status_code == 201, resp.json()
+    body = resp.json()
+    assert body["name"] == "My Template"
+    assert body["vibe_theme"] == "dark-techno"
+    assert body["bpm_floor"] == 124
+    assert body["slot_count"] == 2
+    assert [c["energy"] for c in body["curve_points"]] == [4]
+
+
+def test_save_as_template_owner_scoped_404(client, auth_headers, db, test_user):
+    other = _make_second_dj(db)
+    theirs = _seed_set(db, other.id)
+    resp = client.post(
+        f"/api/setbuilder/sets/{theirs.id}/save-as-template",
+        headers=auth_headers,
+        json={"name": "Should Not Work"},
+    )
+    assert resp.status_code == 404
+
+
+def test_save_as_template_requires_auth(client, db, test_user, pending_headers):
+    src = _seed_set(db, test_user.id)
+    resp = client.post(f"/api/setbuilder/sets/{src.id}/save-as-template", json={"name": "x"})
+    assert resp.status_code == 401
+    resp = client.post(
+        f"/api/setbuilder/sets/{src.id}/save-as-template",
+        headers=pending_headers,
+        json={"name": "x"},
+    )
+    assert resp.status_code == 403
+
+
+def test_save_as_template_rejects_blank_name(client, auth_headers, db, test_user):
+    src = _seed_set(db, test_user.id)
+    resp = client.post(
+        f"/api/setbuilder/sets/{src.id}/save-as-template",
+        headers=auth_headers,
+        json={"name": ""},
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /set-templates (gallery)
+# ---------------------------------------------------------------------------
+
+
+def test_list_set_templates_empty_returns_200_not_404(client, auth_headers):
+    resp = client.get("/api/setbuilder/set-templates", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json() == {"templates": []}
+
+
+def test_list_set_templates_scoped_to_owner_newest_first(client, auth_headers, db, test_user):
+    other = _make_second_dj(db)
+    src = _seed_set(db, test_user.id)
+    _seed_set(db, other.id)
+
+    client.post(
+        f"/api/setbuilder/sets/{src.id}/save-as-template",
+        headers=auth_headers,
+        json={"name": "First"},
+    )
+    client.post(
+        f"/api/setbuilder/sets/{src.id}/save-as-template",
+        headers=auth_headers,
+        json={"name": "Second"},
+    )
+
+    resp = client.get("/api/setbuilder/set-templates", headers=auth_headers)
+    assert resp.status_code == 200
+    names = [t["name"] for t in resp.json()["templates"]]
+    assert names == ["Second", "First"]
+
+
+def test_slot_count_always_equals_decoded_slots_json_length(client, auth_headers, db, test_user):
+    src = _seed_set(db, test_user.id)
+    save_resp = client.post(
+        f"/api/setbuilder/sets/{src.id}/save-as-template",
+        headers=auth_headers,
+        json={"name": "Counted"},
+    )
+    assert save_resp.json()["slot_count"] == 2
+
+    list_resp = client.get("/api/setbuilder/set-templates", headers=auth_headers)
+    listed = list_resp.json()["templates"][0]
+    assert listed["slot_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# POST /set-templates/{template_id}/instantiate
+# ---------------------------------------------------------------------------
+
+
+def test_instantiate_template_endpoint(client, auth_headers, db, test_user):
+    src = _seed_set(db, test_user.id)
+    tpl_id = client.post(
+        f"/api/setbuilder/sets/{src.id}/save-as-template",
+        headers=auth_headers,
+        json={"name": "Base Template"},
+    ).json()["id"]
+
+    resp = client.post(
+        f"/api/setbuilder/set-templates/{tpl_id}/instantiate",
+        headers=auth_headers,
+        json={},
+    )
+    assert resp.status_code == 201, resp.json()
+    body = resp.json()
+    assert body["name"] == "Base Template"
+    assert body["status"] == "draft"
+    assert body["sharing_mode"] == "private"
+    assert body["id"] != src.id
+
+
+def test_instantiate_template_uses_explicit_name_and_event_id(
+    client, auth_headers, db, test_user, test_event
+):
+    src = _seed_set(db, test_user.id)
+    tpl_id = client.post(
+        f"/api/setbuilder/sets/{src.id}/save-as-template",
+        headers=auth_headers,
+        json={"name": "Base"},
+    ).json()["id"]
+
+    resp = client.post(
+        f"/api/setbuilder/set-templates/{tpl_id}/instantiate",
+        headers=auth_headers,
+        json={"name": "Custom", "event_id": test_event.id},
+    )
+    assert resp.status_code == 201, resp.json()
+    assert resp.json()["name"] == "Custom"
+
+
+def test_instantiate_template_owner_scoped_404(client, auth_headers, db, test_user):
+    other = _make_second_dj(db)
+    theirs = _seed_set(db, other.id)
+    from app.services.setbuilder import set_templates
+
+    tpl = set_templates.extract_template(db, theirs, other.id, "Not Mine")
+
+    resp = client.post(
+        f"/api/setbuilder/set-templates/{tpl.id}/instantiate",
+        headers=auth_headers,
+        json={},
+    )
+    assert resp.status_code == 404
+
+
+def test_instantiate_template_unknown_id_404(client, auth_headers):
+    resp = client.post(
+        "/api/setbuilder/set-templates/999999/instantiate",
+        headers=auth_headers,
+        json={},
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /set-templates/{template_id}
+# ---------------------------------------------------------------------------
+
+
+def test_delete_template_endpoint_then_repeat_delete_404s(client, auth_headers, db, test_user):
+    src = _seed_set(db, test_user.id)
+    tpl_id = client.post(
+        f"/api/setbuilder/sets/{src.id}/save-as-template",
+        headers=auth_headers,
+        json={"name": "Doomed"},
+    ).json()["id"]
+
+    first = client.delete(f"/api/setbuilder/set-templates/{tpl_id}", headers=auth_headers)
+    assert first.status_code == 204
+
+    second = client.delete(f"/api/setbuilder/set-templates/{tpl_id}", headers=auth_headers)
+    assert second.status_code == 404
+
+    listed = client.get("/api/setbuilder/set-templates", headers=auth_headers).json()
+    assert listed["templates"] == []
+
+
+def test_delete_template_owner_scoped_404(client, auth_headers, db, test_user):
+    other = _make_second_dj(db)
+    theirs = _seed_set(db, other.id)
+    from app.services.setbuilder import set_templates
+
+    tpl = set_templates.extract_template(db, theirs, other.id, "Not Mine")
+
+    resp = client.delete(f"/api/setbuilder/set-templates/{tpl.id}", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_template_routes_require_auth(client, db, test_user, pending_headers):
+    _seed_set(db, test_user.id)
+    assert client.get("/api/setbuilder/set-templates").status_code == 401
+    assert client.post("/api/setbuilder/set-templates/1/instantiate", json={}).status_code == 401
+    assert client.delete("/api/setbuilder/set-templates/1").status_code == 401
+    assert client.get("/api/setbuilder/set-templates", headers=pending_headers).status_code == 403

--- a/server/tests/test_setbuilder_template_models.py
+++ b/server/tests/test_setbuilder_template_models.py
@@ -1,0 +1,81 @@
+"""Model tests for SetTemplate (#407)."""
+
+import json
+
+from app.models.set_template import SetTemplate
+
+
+def test_create_set_template_round_trips_all_fields(db, test_user):
+    slots = [{"position": 0, "target_energy": 5.0, "locked": True, "notes": "Opener"}]
+    curve_points = [{"position_sec": 0, "energy": 4, "label": "Start"}]
+
+    tpl = SetTemplate(
+        user_id=test_user.id,
+        name="Warehouse Set",
+        vibe_theme="Peak Time",
+        target_duration_sec=3600,
+        avg_transition_overlap_sec=12,
+        bpm_floor=122,
+        bpm_ceiling=128,
+        key_strictness=0.5,
+        slots_json=json.dumps(slots),
+        curve_points_json=json.dumps(curve_points),
+    )
+    db.add(tpl)
+    db.commit()
+    db.refresh(tpl)
+
+    assert tpl.id > 0
+    assert tpl.user_id == test_user.id
+    assert tpl.name == "Warehouse Set"
+    assert tpl.vibe_theme == "Peak Time"
+    assert tpl.target_duration_sec == 3600
+    assert tpl.avg_transition_overlap_sec == 12
+    assert tpl.bpm_floor == 122
+    assert tpl.bpm_ceiling == 128
+    assert tpl.key_strictness == 0.5
+    assert json.loads(tpl.slots_json) == slots
+    assert json.loads(tpl.curve_points_json) == curve_points
+    assert tpl.created_at is not None
+    assert tpl.updated_at is not None
+
+
+def test_set_template_defaults_apply_when_unset(db, test_user):
+    tpl = SetTemplate(
+        user_id=test_user.id,
+        name="Minimal Template",
+        slots_json="[]",
+        curve_points_json="[]",
+    )
+    db.add(tpl)
+    db.commit()
+    db.refresh(tpl)
+
+    assert tpl.vibe_theme is None
+    assert tpl.target_duration_sec is None
+    assert tpl.avg_transition_overlap_sec == 8
+    assert tpl.bpm_floor is None
+    assert tpl.bpm_ceiling is None
+    assert tpl.key_strictness == 0.2
+    assert json.loads(tpl.slots_json) == []
+    assert json.loads(tpl.curve_points_json) == []
+
+
+def test_set_template_updated_at_changes_on_update(db, test_user):
+    tpl = SetTemplate(
+        user_id=test_user.id,
+        name="Editable",
+        slots_json="[]",
+        curve_points_json="[]",
+    )
+    db.add(tpl)
+    db.commit()
+    db.refresh(tpl)
+    original_updated_at = tpl.updated_at
+
+    tpl.name = "Renamed"
+    db.commit()
+    db.refresh(tpl)
+
+    assert tpl.name == "Renamed"
+    assert tpl.updated_at >= original_updated_at

--- a/server/tests/test_setbuilder_template_models.py
+++ b/server/tests/test_setbuilder_template_models.py
@@ -78,4 +78,4 @@ def test_set_template_updated_at_changes_on_update(db, test_user):
     db.refresh(tpl)
 
     assert tpl.name == "Renamed"
-    assert tpl.updated_at >= original_updated_at
+    assert tpl.updated_at > original_updated_at

--- a/server/tests/test_setbuilder_template_no_sharing_coupling.py
+++ b/server/tests/test_setbuilder_template_no_sharing_coupling.py
@@ -5,6 +5,14 @@ router), that no code path touches ``SetCollaborator`` or sharing/role
 logic. Templates are private to their owner and are never shared — this is
 broader than (and a superset of) the single-file router check already in
 ``test_setbuilder_template_api.py``.
+
+Two complementary layers:
+  - Static (``test_no_template_module_*``): source-text scan, cheap but
+    inherently blind to arbitrarily-aliased references.
+  - Behavioral (``test_extract_instantiate_delete_leave_set_collaborators_*``):
+    actually runs the lifecycle against a set with a real collaborator row
+    and asserts the ``set_collaborators`` table is untouched — catches real
+    coupling however it was coded, which no source scan can guarantee.
 """
 
 import ast
@@ -13,16 +21,10 @@ from types import ModuleType
 
 from app.api import setbuilder_templates as template_api
 from app.models import set_template as template_model
+from app.models.set import Set, SetCollaborator
 from app.schemas import setbuilder_templates as template_schemas
 from app.services.setbuilder import set_templates as template_service
-
-_FORBIDDEN_TOKENS = (
-    "SetCollaborator",
-    "share_service",
-    "setbuilder_share",
-    "share_token",
-    ".collaborators",
-)
+from tests import ast_no_sharing_support
 
 _TEMPLATE_MODULES: tuple[ModuleType, ...] = (
     template_model,
@@ -32,20 +34,14 @@ _TEMPLATE_MODULES: tuple[ModuleType, ...] = (
 )
 
 
-def _source_without_docstrings(module: ModuleType) -> str:
-    """Module source with its docstrings/comments stripped, so prose that
-    merely *describes* the no-sharing invariant (as several of these
-    modules' own module docstrings do) can't produce a false pass."""
-    tree = ast.parse(inspect.getsource(module))
-    body_nodes = [node for node in tree.body if not isinstance(node, ast.Expr)]
-    return "\n".join(ast.unparse(node) for node in body_nodes)
+# ---------------------------------------------------------------------------
+# Static: source-text scan
+# ---------------------------------------------------------------------------
 
 
 def test_no_template_module_references_sharing_or_collaborator_logic():
     for module in _TEMPLATE_MODULES:
-        code = _source_without_docstrings(module)
-        for token in _FORBIDDEN_TOKENS:
-            assert token not in code, f"{module.__name__} unexpectedly references {token!r}"
+        ast_no_sharing_support.assert_no_sharing_references(module)
 
 
 def test_no_template_module_imports_sharing_modules():
@@ -66,3 +62,93 @@ def test_no_template_module_imports_sharing_modules():
         assert not (imported & forbidden_imports), (
             f"{module.__name__} imports a sharing module: {imported & forbidden_imports}"
         )
+
+
+def test_code_without_docstrings_strips_nested_function_docstrings():
+    """Regression guard: the original implementation only stripped the
+    module's own top-level docstring, so a nested function docstring that
+    merely *mentions* a forbidden token (pure prose, no behavior change)
+    would trip the static check. Stripping must recurse into every
+    function/class body.
+    """
+    source = 'def helper():\n    """Do not touch SetCollaborator here."""\n    return 1\n'
+
+    code = ast_no_sharing_support.code_without_docstrings(source)
+
+    assert "SetCollaborator" not in code
+
+
+def test_code_without_docstrings_still_catches_real_references():
+    """Companion guard: stripping docstrings must never eat real code — an
+    actual reference to a forbidden token outside a docstring must survive."""
+    source = "from app.models.set import SetCollaborator\n"
+
+    code = ast_no_sharing_support.code_without_docstrings(source)
+
+    assert "SetCollaborator" in code
+
+
+def test_forbidden_tokens_catch_raw_sql_against_set_collaborators_table():
+    """Regression guard for the false negative: raw SQL against the
+    lowercase ``set_collaborators`` table name (no ``SetCollaborator`` class
+    reference at all) must still be caught by the token list."""
+    source = 'db.execute(text("SELECT 1 FROM set_collaborators"))\n'
+
+    code = ast_no_sharing_support.code_without_docstrings(source)
+
+    assert any(token in code for token in ast_no_sharing_support.FORBIDDEN_TOKENS)
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: actual DB state
+# ---------------------------------------------------------------------------
+
+
+def _mk_set_with_collaborator(db, owner_id, collaborator_id):
+    set_obj = Set(
+        owner_id=owner_id,
+        name="Collab Set",
+        vibe_theme="Peak Time",
+        target_duration_sec=3600,
+        avg_transition_overlap_sec=12,
+        bpm_floor=122,
+        bpm_ceiling=128,
+        key_strictness=0.5,
+    )
+    db.add(set_obj)
+    db.commit()
+    db.refresh(set_obj)
+
+    collaborator = SetCollaborator(
+        set_id=set_obj.id, user_id=collaborator_id, role="editor", invited_by=owner_id
+    )
+    db.add(collaborator)
+    db.commit()
+    db.refresh(collaborator)
+    return set_obj, collaborator
+
+
+def test_extract_instantiate_delete_leave_set_collaborators_untouched(db, test_user, admin_user):
+    """Runtime companion to the static scan above: extract_template,
+    instantiate_template, and delete_template must never read or write
+    ``set_collaborators`` rows, however the coupling might be coded (raw
+    SQL, an aliased join, ...) — something a source-text scan can't rule out.
+    """
+    src, collaborator = _mk_set_with_collaborator(db, test_user.id, admin_user.id)
+    before = (
+        collaborator.id,
+        collaborator.set_id,
+        collaborator.user_id,
+        collaborator.role,
+        collaborator.invited_by,
+    )
+
+    tpl = template_service.extract_template(db, src, test_user.id, "Collab Template")
+    new_set = template_service.instantiate_template(db, tpl, test_user.id, None, None)
+    template_service.delete_template(db, tpl)
+
+    rows = db.query(SetCollaborator).all()
+    assert len(rows) == 1
+    after = rows[0]
+    assert (after.id, after.set_id, after.user_id, after.role, after.invited_by) == before
+    assert db.query(SetCollaborator).filter(SetCollaborator.set_id == new_set.id).count() == 0

--- a/server/tests/test_setbuilder_template_no_sharing_coupling.py
+++ b/server/tests/test_setbuilder_template_no_sharing_coupling.py
@@ -1,0 +1,68 @@
+"""Cross-module invariant for the SetBuilder template feature (issue #407).
+
+Pins, over every module #407 introduced (model, schemas, service, API
+router), that no code path touches ``SetCollaborator`` or sharing/role
+logic. Templates are private to their owner and are never shared — this is
+broader than (and a superset of) the single-file router check already in
+``test_setbuilder_template_api.py``.
+"""
+
+import ast
+import inspect
+from types import ModuleType
+
+from app.api import setbuilder_templates as template_api
+from app.models import set_template as template_model
+from app.schemas import setbuilder_templates as template_schemas
+from app.services.setbuilder import set_templates as template_service
+
+_FORBIDDEN_TOKENS = (
+    "SetCollaborator",
+    "share_service",
+    "setbuilder_share",
+    "share_token",
+    ".collaborators",
+)
+
+_TEMPLATE_MODULES: tuple[ModuleType, ...] = (
+    template_model,
+    template_schemas,
+    template_service,
+    template_api,
+)
+
+
+def _source_without_docstrings(module: ModuleType) -> str:
+    """Module source with its docstrings/comments stripped, so prose that
+    merely *describes* the no-sharing invariant (as several of these
+    modules' own module docstrings do) can't produce a false pass."""
+    tree = ast.parse(inspect.getsource(module))
+    body_nodes = [node for node in tree.body if not isinstance(node, ast.Expr)]
+    return "\n".join(ast.unparse(node) for node in body_nodes)
+
+
+def test_no_template_module_references_sharing_or_collaborator_logic():
+    for module in _TEMPLATE_MODULES:
+        code = _source_without_docstrings(module)
+        for token in _FORBIDDEN_TOKENS:
+            assert token not in code, f"{module.__name__} unexpectedly references {token!r}"
+
+
+def test_no_template_module_imports_sharing_modules():
+    forbidden_imports = {"app.services.setbuilder.share_service", "app.api.setbuilder_share"}
+    for module in _TEMPLATE_MODULES:
+        tree = ast.parse(inspect.getsource(module))
+        imported = {
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        } | {
+            f"{node.module}.{alias.name}" if node.module else alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+            for alias in node.names
+        }
+        assert not (imported & forbidden_imports), (
+            f"{module.__name__} imports a sharing module: {imported & forbidden_imports}"
+        )

--- a/server/tests/test_setbuilder_template_service.py
+++ b/server/tests/test_setbuilder_template_service.py
@@ -77,6 +77,21 @@ def test_extract_template_owned_by_user_and_never_raises_on_empty_set(db, test_u
     assert tpl.name == "My Template"
 
 
+def test_extract_template_owned_by_user_id_param_not_src_set_owner(db, test_user, admin_user):
+    """extract_template must attribute the new template to the ``user_id``
+    argument, never implicitly to ``src_set.owner_id`` — regression guard
+    for a plausible ``SetTemplate(user_id=src_set.owner_id, ...)`` slip
+    (the function receives both a ``Set`` with its own ``.owner_id`` and a
+    separate ``user_id`` param).
+    """
+    src = _mk_set(db, admin_user.id)
+
+    tpl = set_templates.extract_template(db, src, test_user.id, "Borrowed")
+
+    assert tpl.user_id == test_user.id
+    assert tpl.user_id != src.owner_id
+
+
 def test_extract_template_preserves_slot_fields_and_strips_track_data(db, test_user):
     src = _mk_set(db, test_user.id)
     _add_slot(
@@ -153,6 +168,20 @@ def test_instantiate_template_creates_draft_private_set_owned_by_caller(db, test
     assert new_set.owner_id == test_user.id
     assert new_set.status == "draft"
     assert new_set.sharing_mode == "private"
+
+
+def test_instantiate_template_owned_by_owner_id_param_not_template_user(db, test_user, admin_user):
+    """instantiate_template must attribute the new Set to the ``owner_id``
+    argument, never implicitly to ``tpl.user_id`` — regression guard for a
+    plausible ``Set(owner_id=tpl.user_id, ...)`` slip.
+    """
+    src = _mk_set(db, test_user.id)
+    tpl = set_templates.extract_template(db, src, test_user.id, "Extracted")
+
+    new_set = set_templates.instantiate_template(db, tpl, admin_user.id, None, None)
+
+    assert new_set.owner_id == admin_user.id
+    assert new_set.owner_id != tpl.user_id
 
 
 def test_instantiate_template_never_raises_on_empty_template(db, test_user):

--- a/server/tests/test_setbuilder_template_service.py
+++ b/server/tests/test_setbuilder_template_service.py
@@ -108,7 +108,7 @@ def test_extract_template_preserves_slot_fields_and_strips_track_data(db, test_u
 
     tpl = set_templates.extract_template(db, src, test_user.id, "Extracted")
 
-    slots = set_templates._decode_slots(tpl.slots_json)
+    slots = set_templates.decode_slots(tpl.slots_json)
     assert len(slots) == 1
     slot = slots[0]
     assert slot["position"] == 2
@@ -141,7 +141,7 @@ def test_extract_template_copies_target_settings_and_curve_points(db, test_user)
     assert tpl.bpm_ceiling == src.bpm_ceiling
     assert tpl.key_strictness == src.key_strictness
 
-    points = set_templates._decode_curve_points(tpl.curve_points_json)
+    points = set_templates.decode_curve_points(tpl.curve_points_json)
     assert points == [
         {
             "position_sec": 30,
@@ -235,6 +235,28 @@ def test_instantiate_template_uses_explicit_name_and_event_id(db, test_user, tes
 # ---------------------------------------------------------------------------
 
 
+def test_instantiated_slots_are_never_locked_even_when_source_was(db, test_user):
+    """A locked slot means "keep the track I pinned here". Templates strip
+    every ``track_id``, so carrying ``locked`` through would produce a locked
+    EMPTY slot — and ``pass1_deterministic`` only refills slots where
+    ``locked == False``, keeping locked ones verbatim. Such a slot is a hole
+    no build can ever fill, so instantiation must always unlock.
+    """
+    src = _mk_set(db, test_user.id)
+    _add_slot(db, src, position=0, track_id="tidal:1", locked=True, target_energy=4.0)
+    _add_slot(db, src, position=1, track_id="tidal:2", locked=True, target_energy=6.0)
+
+    tpl = set_templates.extract_template(db, src, test_user.id, "All Locked")
+    new_set = set_templates.instantiate_template(db, tpl, test_user.id, None, None)
+
+    assert [s.locked for s in src.slots] == [True, True]
+    assert new_set.slots, "instantiation must still create the slots"
+    assert all(s.locked is False for s in new_set.slots)
+    assert all(s.track_id is None for s in new_set.slots)
+    # The stored template still records the source shape.
+    assert all(s["locked"] is True for s in set_templates.decode_slots(tpl.slots_json))
+
+
 def test_round_trip_preserves_targets_slots_and_curve_points_bit_for_bit(db, test_user):
     src = _mk_set(db, test_user.id)
     _add_slot(
@@ -282,10 +304,12 @@ def test_round_trip_preserves_targets_slots_and_curve_points_bit_for_bit(db, tes
     assert len(new_slots) == len(src_slots)
     for src_slot, new_slot in zip(src_slots, new_slots):
         assert new_slot.position == src_slot.position
-        assert new_slot.locked == src_slot.locked
         assert new_slot.notes == src_slot.notes
         assert new_slot.target_energy == src_slot.target_energy
         assert new_slot.track_id is None
+        # `locked` is deliberately NOT round-tripped — see
+        # test_instantiated_slots_are_never_locked_even_when_source_was.
+        assert new_slot.locked is False
 
     src_points = sorted(src.curve_points, key=lambda p: p.position_sec)
     new_points = sorted(new_set.curve_points, key=lambda p: p.position_sec)

--- a/server/tests/test_setbuilder_template_service.py
+++ b/server/tests/test_setbuilder_template_service.py
@@ -1,0 +1,306 @@
+"""Service tests for services/setbuilder/set_templates.py (#407).
+
+Pins the invariants from the design spec: extract_template/instantiate_template
+never raise on empty inputs, ownership scoping is enforced, track assignments
+are stripped on extract and never resurface on instantiate, and a full
+extract -> instantiate round-trip preserves every target/slot/curve field.
+"""
+
+from app.models.set import Set, SetCurvePoint, SetSlot
+from app.services.setbuilder import set_templates
+
+
+def _mk_set(db, owner_id, **overrides):
+    defaults = dict(
+        name="Warehouse Set",
+        vibe_theme="Peak Time",
+        target_duration_sec=3600,
+        avg_transition_overlap_sec=12,
+        bpm_floor=122,
+        bpm_ceiling=128,
+        key_strictness=0.5,
+    )
+    defaults.update(overrides)
+    set_obj = Set(owner_id=owner_id, **defaults)
+    db.add(set_obj)
+    db.commit()
+    db.refresh(set_obj)
+    return set_obj
+
+
+def _add_slot(db, set_obj, **overrides):
+    defaults = dict(
+        position=0,
+        track_id=None,
+        locked=False,
+        notes=None,
+        transition_score=None,
+        transition_warnings=None,
+        target_energy=None,
+    )
+    defaults.update(overrides)
+    slot = SetSlot(set_id=set_obj.id, **defaults)
+    db.add(slot)
+    db.commit()
+    db.refresh(slot)
+    return slot
+
+
+def _add_curve_point(db, set_obj, **overrides):
+    defaults = dict(
+        position_sec=0,
+        energy=5,
+        label=None,
+        is_slow_window_start=False,
+        is_slow_window_end=False,
+    )
+    defaults.update(overrides)
+    point = SetCurvePoint(set_id=set_obj.id, **defaults)
+    db.add(point)
+    db.commit()
+    db.refresh(point)
+    return point
+
+
+# ---------------------------------------------------------------------------
+# extract_template
+# ---------------------------------------------------------------------------
+
+
+def test_extract_template_owned_by_user_and_never_raises_on_empty_set(db, test_user):
+    empty_set = _mk_set(db, test_user.id)
+
+    tpl = set_templates.extract_template(db, empty_set, test_user.id, "My Template")
+
+    assert tpl.id is not None
+    assert tpl.user_id == test_user.id
+    assert tpl.name == "My Template"
+
+
+def test_extract_template_preserves_slot_fields_and_strips_track_data(db, test_user):
+    src = _mk_set(db, test_user.id)
+    _add_slot(
+        db,
+        src,
+        position=2,
+        track_id="tidal:123",
+        locked=True,
+        notes="Opener",
+        transition_score=0.9,
+        transition_warnings='["clash"]',
+        target_energy=7.5,
+    )
+
+    tpl = set_templates.extract_template(db, src, test_user.id, "Extracted")
+
+    slots = set_templates._decode_slots(tpl.slots_json)
+    assert len(slots) == 1
+    slot = slots[0]
+    assert slot["position"] == 2
+    assert slot["locked"] is True
+    assert slot["notes"] == "Opener"
+    assert slot["target_energy"] == 7.5
+    assert "track_id" not in slot
+    assert "transition_score" not in slot
+    assert "transition_warnings" not in slot
+
+
+def test_extract_template_copies_target_settings_and_curve_points(db, test_user):
+    src = _mk_set(db, test_user.id)
+    _add_curve_point(
+        db,
+        src,
+        position_sec=30,
+        energy=8,
+        label="Peak",
+        is_slow_window_start=True,
+        is_slow_window_end=False,
+    )
+
+    tpl = set_templates.extract_template(db, src, test_user.id, "Extracted")
+
+    assert tpl.vibe_theme == src.vibe_theme
+    assert tpl.target_duration_sec == src.target_duration_sec
+    assert tpl.avg_transition_overlap_sec == src.avg_transition_overlap_sec
+    assert tpl.bpm_floor == src.bpm_floor
+    assert tpl.bpm_ceiling == src.bpm_ceiling
+    assert tpl.key_strictness == src.key_strictness
+
+    points = set_templates._decode_curve_points(tpl.curve_points_json)
+    assert points == [
+        {
+            "position_sec": 30,
+            "energy": 8,
+            "label": "Peak",
+            "is_slow_window_start": True,
+            "is_slow_window_end": False,
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# instantiate_template
+# ---------------------------------------------------------------------------
+
+
+def test_instantiate_template_creates_draft_private_set_owned_by_caller(db, test_user):
+    src = _mk_set(db, test_user.id)
+    tpl = set_templates.extract_template(db, src, test_user.id, "Extracted")
+
+    new_set = set_templates.instantiate_template(db, tpl, test_user.id, None, None)
+
+    assert new_set.id is not None
+    assert new_set.owner_id == test_user.id
+    assert new_set.status == "draft"
+    assert new_set.sharing_mode == "private"
+
+
+def test_instantiate_template_never_raises_on_empty_template(db, test_user):
+    empty_set = _mk_set(db, test_user.id)
+    tpl = set_templates.extract_template(db, empty_set, test_user.id, "Empty")
+
+    new_set = set_templates.instantiate_template(db, tpl, test_user.id, None, None)
+
+    assert new_set.id is not None
+    assert list(new_set.slots) == []
+    assert list(new_set.curve_points) == []
+
+
+def test_instantiate_template_slots_always_have_null_track_id(db, test_user):
+    src = _mk_set(db, test_user.id)
+    _add_slot(db, src, position=0, track_id="tidal:should-not-survive")
+    _add_slot(db, src, position=1, track_id="tidal:also-should-not-survive")
+    tpl = set_templates.extract_template(db, src, test_user.id, "Extracted")
+
+    new_set = set_templates.instantiate_template(db, tpl, test_user.id, None, None)
+
+    assert len(new_set.slots) == 2
+    assert all(slot.track_id is None for slot in new_set.slots)
+
+
+def test_instantiate_template_name_falls_back_to_template_name_when_blank(db, test_user):
+    src = _mk_set(db, test_user.id)
+    tpl = set_templates.extract_template(db, src, test_user.id, "Fallback Name")
+
+    new_set = set_templates.instantiate_template(db, tpl, test_user.id, None, None)
+    assert new_set.name == "Fallback Name"
+
+    new_set_2 = set_templates.instantiate_template(db, tpl, test_user.id, "  ", None)
+    assert new_set_2.name == "Fallback Name"
+
+
+def test_instantiate_template_uses_explicit_name_and_event_id(db, test_user, test_event):
+    src = _mk_set(db, test_user.id)
+    tpl = set_templates.extract_template(db, src, test_user.id, "Base")
+
+    new_set = set_templates.instantiate_template(
+        db, tpl, test_user.id, "Custom Name", test_event.id
+    )
+
+    assert new_set.name == "Custom Name"
+    assert new_set.event_id == test_event.id
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_preserves_targets_slots_and_curve_points_bit_for_bit(db, test_user):
+    src = _mk_set(db, test_user.id)
+    _add_slot(
+        db,
+        src,
+        position=0,
+        track_id="tidal:1",
+        locked=True,
+        notes="Opener",
+        transition_score=0.5,
+        transition_warnings="[]",
+        target_energy=3.0,
+    )
+    _add_slot(
+        db,
+        src,
+        position=1,
+        track_id="tidal:2",
+        locked=False,
+        notes=None,
+        target_energy=None,
+    )
+    _add_curve_point(db, src, position_sec=0, energy=3, label="Start", is_slow_window_start=False)
+    _add_curve_point(
+        db,
+        src,
+        position_sec=120,
+        energy=9,
+        label="Peak",
+        is_slow_window_end=True,
+    )
+
+    tpl = set_templates.extract_template(db, src, test_user.id, "Round Trip")
+    new_set = set_templates.instantiate_template(db, tpl, test_user.id, None, None)
+
+    assert new_set.vibe_theme == src.vibe_theme
+    assert new_set.target_duration_sec == src.target_duration_sec
+    assert new_set.avg_transition_overlap_sec == src.avg_transition_overlap_sec
+    assert new_set.bpm_floor == src.bpm_floor
+    assert new_set.bpm_ceiling == src.bpm_ceiling
+    assert new_set.key_strictness == src.key_strictness
+
+    src_slots = sorted(src.slots, key=lambda s: s.position)
+    new_slots = sorted(new_set.slots, key=lambda s: s.position)
+    assert len(new_slots) == len(src_slots)
+    for src_slot, new_slot in zip(src_slots, new_slots):
+        assert new_slot.position == src_slot.position
+        assert new_slot.locked == src_slot.locked
+        assert new_slot.notes == src_slot.notes
+        assert new_slot.target_energy == src_slot.target_energy
+        assert new_slot.track_id is None
+
+    src_points = sorted(src.curve_points, key=lambda p: p.position_sec)
+    new_points = sorted(new_set.curve_points, key=lambda p: p.position_sec)
+    assert len(new_points) == len(src_points)
+    for src_point, new_point in zip(src_points, new_points):
+        assert new_point.position_sec == src_point.position_sec
+        assert new_point.energy == src_point.energy
+        assert new_point.label == src_point.label
+        assert new_point.is_slow_window_start == src_point.is_slow_window_start
+        assert new_point.is_slow_window_end == src_point.is_slow_window_end
+
+
+# ---------------------------------------------------------------------------
+# get_owned_template / list_templates / delete_template
+# ---------------------------------------------------------------------------
+
+
+def test_get_owned_template_scoped_to_owner(db, test_user, admin_user):
+    src = _mk_set(db, test_user.id)
+    tpl = set_templates.extract_template(db, src, test_user.id, "Mine")
+
+    assert set_templates.get_owned_template(db, tpl.id, test_user.id) is not None
+    assert set_templates.get_owned_template(db, tpl.id, admin_user.id) is None
+    assert set_templates.get_owned_template(db, -1, test_user.id) is None
+
+
+def test_list_templates_scoped_to_owner_newest_first(db, test_user, admin_user):
+    src = _mk_set(db, test_user.id)
+    other_src = _mk_set(db, admin_user.id)
+    set_templates.extract_template(db, src, test_user.id, "First")
+    second = set_templates.extract_template(db, src, test_user.id, "Second")
+    set_templates.extract_template(db, other_src, admin_user.id, "Not mine")
+
+    templates = set_templates.list_templates(db, test_user.id)
+
+    assert [t.name for t in templates] == ["Second", "First"]
+    assert second.id == templates[0].id
+
+
+def test_delete_template_removes_row(db, test_user):
+    src = _mk_set(db, test_user.id)
+    tpl = set_templates.extract_template(db, src, test_user.id, "Doomed")
+    tpl_id = tpl.id
+
+    set_templates.delete_template(db, tpl)
+
+    assert set_templates.get_owned_template(db, tpl_id, test_user.id) is None


### PR DESCRIPTION
## Why

DJs building sets in SetBuilder had no way to save a curated slot structure (energy targets, order, count) as a reusable template, forcing them to rebuild similar sets from scratch each time. Issue #407 asks for a save-as-template flow plus a gallery to instantiate new sets from saved templates.

## What

- Adds a save-as-template dialog and topbar wiring so a DJ can persist the current set's slot structure (target energy per slot) as a `SetCurveTemplate`.
- Adds a template gallery + new-set flow so a DJ can pick a saved template and instantiate a new set from it, creating `SetSlot` rows with `track_id=None` (empty slots to be filled later) and pre-populated `target_energy` per slot.
- Pins migration 066 round-trip behavior and no-sharing-coupling invariants (templates are owned per-DJ, not shared across DJs/events) with regression tests.
- Tightens the `updated_at` regression assertion for template mutation.

## Design decisions

Spike fully cleared the one flagged unknown: persisting `SetSlot` rows with `track_id=None` on instantiate is safe across `export_common.py` (already filters `if s.track_id`), `document_snapshot.py` (copies `track_id` as a plain value, never dereferenced), `coverage.py` (never touches `slot.track_id`), `pass2_agent.py` (already null-guards), the `SlotOut` schema (every track field already `X | None`), and — the clincher — the frontend's `slotViewFromApi()` (`components/types.ts:58-78`) which already synthesizes a safe placeholder `TrackView` for exactly this case. No fallback path (response-only slot metadata) is needed; the design is implemented exactly as originally specified.

One genuine bug was found in the design's own cited precedent (`duplicate_set` in `share_service.py` silently omits `target_energy` from its `SetSlot` copy despite its docstring claiming to copy targets) — not a design change, but an explicit implementation callout folded into the `set_templates.py` todo/interface docstring so `target_energy` isn't silently dropped by an implementer eyeballing that precedent.

All other structural claims (alembic head=065, model import ordering, `SetCurveTemplate` as the flat-table precedent, `SetDetail`'s "no slot/curve expansion" docstring, `SetCreate.name` Field convention, `setbuilder_share.py` router pattern, both `setbuilder.py`/schemas file-size caps) were verified true against current code with zero adjustment. No structs/interfaces changed from the pre-spike design; only the `needsSpike` unknown is resolved and one implementation-callout added.

## Testing
- [x] Unit tests pass
- [x] Integration tests pass (migration 066 round-trip, no-sharing-coupling, ownership attribution)
- [ ] Manual verification: save-as-template dialog from an existing set, instantiate a new set from the gallery, confirm empty slots render correctly in the UI
- [ ] CI green

🤖 Co-authored by Claude Sonnet 5. Closes #407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Save existing sets as reusable templates with customizable names.
  * Browse, use, and delete saved templates from a gallery.
  * Create new draft sets from templates, with optional names and event associations.
  * Added loading, empty, error, confirmation, and busy-state feedback throughout template workflows.

* **Tests**
  * Added comprehensive coverage for template creation, listing, instantiation, deletion, validation, authorization, and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->